### PR TITLE
Replace call by address with function name

### DIFF
--- a/src/news_item.c
+++ b/src/news_item.c
@@ -165,7 +165,9 @@ static int news_item_get_new_history_slot()
 }
 
 /**
- * 
+ * Get the (x,y,z) coordinates of the subject of a news item.
+ * If the new item is no longer valid, return 0x8000 in the x-coordinate
+ *
  *  rct2: 0x0066BA74
  */
 void news_item_get_subject_location(int type, int subject, int *x, int *y, int *z)

--- a/src/news_item.h
+++ b/src/news_item.h
@@ -56,5 +56,5 @@ typedef struct {
 void news_item_init_queue();
 void news_item_update_current();
 void news_item_close_current();
-
+void news_item_get_subject_location(int type, int subject, int *x, int *y, int *z);
 #endif

--- a/src/window_game_bottom_toolbar.c
+++ b/src/window_game_bottom_toolbar.c
@@ -179,15 +179,16 @@ static void window_game_bottom_toolbar_mouseup()
 			break;
 
 		{
-			uint32 eax, ebx, ecx, edx, esi, edi, ebp;
-			ecx = newsItem->assoc;
-			edx = newsItem->type;
-			RCT2_CALLFUNC_X(0x0066BA74, &eax, &ebx, &ecx, &edx, &esi, &edi, &ebp);
-			if ((eax & 0xFFFF) == 0x8000)
+			int x, y, z;
+			int subject = newsItem->assoc;
+
+			news_item_get_subject_location(newsItem->type, subject, &x, &y, &z);
+
+			if (x == 0x8000)
 				break;
 
 			if ((mainWindow = window_get_main()) != NULL)
-				window_scroll_to_location(mainWindow, eax & 0xFFFF, ecx & 0xFFFF, edx & 0xFFFF);
+				window_scroll_to_location(mainWindow, x, y, z);
 		}
 		break;
 	case WIDX_RIGHT_OUTSET:
@@ -278,12 +279,12 @@ static void window_game_bottom_toolbar_invalidate()
 		w->disabled_widgets &= ~(1 << WIDX_NEWS_SUBJECT);
 		w->disabled_widgets &= ~(1 << WIDX_NEWS_LOCATE);
 
-		int eax, ebx, ecx, edx, esi, edi, ebp;
-		ecx = newsItem->assoc;
-		edx = newsItem->type;
-		RCT2_CALLFUNC_X(0x0066BA74, &eax, &ebx, &ecx, &edx, &esi, &edi, &ebp);
+		// Find out if the news item is no longer valid
+		int x, y, z;
+		int subject = newsItem->assoc;
+		news_item_get_subject_location(newsItem->type, subject, &x, &y, &z);
 
-		if ((eax & 0xFFFF) == 0x8000)
+		if (x == 0x8000)
 			w->disabled_widgets |= (1 << WIDX_NEWS_LOCATE);
 
 		if (!(((char*)0x0097BE7C)[newsItem->type] & 2)) {


### PR DESCRIPTION
This is the first pull request I've ever submitted, so apologies if I've done something wrong! I've gone for some low-hanging fruit and changed the call to news_item_get_subject_location from using its address via RCT2_CALLFUNC_X to just calling it by name, and also added a short description of the function. 
