### PR TITLE
Add separate key buffer for handling shortcuts

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -850,8 +850,8 @@ int get_next_key()
 {
 	int i;
 	for (i = 0; i < 221; i++) {
-		if (gKeysState[i]) {
-			gKeysState[i] = 0;
+		if (gKeysPressed[i]) {
+			gKeysPressed[i] = 0;
 			return i;
 		}
 	}

--- a/src/osinterface.c
+++ b/src/osinterface.c
@@ -31,6 +31,7 @@ typedef void(*update_palette_func)(char*, int, int);
 
 openrct2_cursor gCursorState;
 unsigned char* gKeysState;
+unsigned char* gKeysPressed;
 unsigned int gLastKeyPressed;
 
 static void osinterface_create_window();
@@ -48,6 +49,9 @@ static void *_screenBuffer;
 void osinterface_init()
 {
 	osinterface_create_window();
+
+	gKeysPressed = malloc(sizeof(unsigned char) * 256);
+	memset(gKeysPressed, 0, sizeof(unsigned char) * 256);
 
 	// RCT2_CALLPROC(0x00404584); // dinput_init()
 }
@@ -253,6 +257,7 @@ void osinterface_process_messages()
 			break;
 		case SDL_KEYDOWN:
 			gLastKeyPressed = e.key.keysym.sym;
+			gKeysPressed[e.key.keysym.scancode] = 1;
 			break;
 		default:
 			break;
@@ -278,6 +283,8 @@ static void osinterface_close_window()
 
 void osinterface_free()
 {
+	free(gKeysPressed);
+
 	osinterface_close_window();
 	SDL_Quit();
 }

--- a/src/osinterface.h
+++ b/src/osinterface.h
@@ -38,6 +38,7 @@ typedef struct {
 
 extern openrct2_cursor gCursorState;
 extern unsigned char* gKeysState;
+extern unsigned char* gKeysPressed;
 extern unsigned int gLastKeyPressed;
 
 void osinterface_init();


### PR DESCRIPTION
This way, the key state remains 1 while a key is pressed, which makes things like panning with arrow keys work properly. (No longer have to rely on key repeat.)
