### PR TITLE
Fixes for MinGW/GCC

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -83,7 +83,7 @@ int gfx_load_g1()
 	}
 
 	// Unsuccessful
-	RCT2_ERR("Unable to load g1.dat");
+	RCT2_ERROR("Unable to load g1.dat");
 	return 0;
 }
 

--- a/src/peep.c
+++ b/src/peep.c
@@ -18,6 +18,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *****************************************************************************/
 
+#include <windows.h>
 #include "addresses.h"
 #include "news_item.h"
 #include "peep.h"

--- a/src/rct2.h
+++ b/src/rct2.h
@@ -50,9 +50,8 @@ typedef unsigned long long uint64;
 #ifdef _MSC_VER
 #define RCT2_ERROR(format,...) fprintf(stderr, "ERROR %s:%s():%d: " format "\n", __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__);
 #else
-#define RCT2_ERROR(format,...) fprintf(stderr, "ERROR %s:%s():%d: " format "\n", __FILE__, __func__, __LINE__, __VA_ARGS__);
+#define RCT2_ERROR(format,...) fprintf(stderr, "ERROR %s:%s():%d: " format "\n", __FILE__, __func__, __LINE__, ## __VA_ARGS__);
 #endif
-#define RCT2_ERR(msg) RCT2_ERROR("%s",msg)
 
 #ifndef _MSC_VER
 // use similar struct packing as MSVC for our structs

--- a/src/sawyercoding.c
+++ b/src/sawyercoding.c
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
+#include <windows.h>
 #include <string.h>
 #include "addresses.h"
 #include "rct2.h"

--- a/src/scenario_list.c
+++ b/src/scenario_list.c
@@ -169,7 +169,7 @@ static int scenario_scores_load()
 	// Try and load the scores file
 	file = fopen(get_file_path(PATH_ID_SCORES), "rb");
 	if (file == NULL) {
-		RCT2_ERR("Unable to load scenario scores.");
+		RCT2_ERROR("Unable to load scenario scores.");
 		return 0;
 	}
 
@@ -177,7 +177,7 @@ static int scenario_scores_load()
 	rct_scenario_scores_header header;
 	if (fread(&header, 16, 1, file) != 1) {
 		fclose(file);
-		RCT2_ERR("Invalid header in scenario scores file.");
+		RCT2_ERROR("Invalid header in scenario scores file.");
 		return 0;
 	}
 	gScenarioListCount = header.scenario_count;
@@ -210,7 +210,7 @@ int scenario_scores_save()
 	
 	file = fopen(get_file_path(PATH_ID_SCORES), "wb");
 	if (file == NULL) {
-		RCT2_ERR("Unable to save scenario scores.");
+		RCT2_ERROR("Unable to save scenario scores.");
 		return 0;
 	}
 

--- a/src/window_save_prompt.c
+++ b/src/window_save_prompt.c
@@ -247,7 +247,7 @@ static void window_save_prompt_mouseup()
 		switch (widgetIndex) {
 			case WIDX_SAVE:
 				// TODO to avoid data loss, treat SAVE as CANCEL
-				RCT2_ERROR("%s", "TODO\n");
+				RCT2_ERROR("TODO");
 				window_close(w);
 				window_save_prompt_close();
 				return;


### PR DESCRIPTION
This PR fixes compilation with MinGW/GCC. It also modifies the RCT2_ERROR macro in a way that it also accepts only one parameter which supersedes RCT2_ERR. Looks like MSVC simply ignores a trailing comma but GCC would abort without further care.
