### PR TITLE
Save settings in config.ini if changed in-game. Added new settings.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,7 @@ general_configuration_t gGeneral_config_default = {
 	0,		// always_show_gridlines
 	1,		// landscape_smoothing
 	0,		// show_height_as_units
+	1,		// save_plugin_data
 };
 sound_configuration_t gSound_config;
 
@@ -165,6 +166,14 @@ void config_load()
 			}
 			else {
 				RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) &= !CONFIG_FLAG_SHOW_HEIGHT_AS_UNITS;
+			}
+
+			// save plugin data
+			if (gGeneral_config.save_plugin_data){
+				RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) |= CONFIG_FLAG_SAVE_PLUGIN_DATA;
+			}
+			else {
+				RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) &= !CONFIG_FLAG_SAVE_PLUGIN_DATA;
 			}
 
 			//sound configuration
@@ -356,6 +365,13 @@ void config_write_ini_general(FILE *fp)
 	}
 	else {
 		fprintf(fp, "show_height_as_units = false\n");
+	}
+
+	if (gGeneral_config.save_plugin_data){
+		fprintf(fp, "save_plugin_data = true\n");
+	}
+	else {
+		fprintf(fp, "save_plugin_data = false\n");
 	}
 }
 
@@ -577,6 +593,14 @@ static void config_general(char *setting, char *value){
 		}
 		else {
 			gGeneral_config.show_height_as_units = 0;
+		}
+	}
+	else if (strcmp(setting, "save_plugin_data") == 0){
+		if (strcmp(value, "true") == 0){
+			gGeneral_config.save_plugin_data = 1;
+		}
+		else {
+			gGeneral_config.save_plugin_data = 0;
 		}
 	}
 }

--- a/src/config.h
+++ b/src/config.h
@@ -139,6 +139,7 @@ typedef struct general_configuration {
 	sint8 always_show_gridlines;
 	sint8 landscape_smoothing;
 	sint8 show_height_as_units;
+	sint8 save_plugin_data;
 } general_configuration_t;
 
 static const struct { char *key; int value; } _currencyLookupTable[] = {

--- a/src/window_options.c
+++ b/src/window_options.c
@@ -270,6 +270,8 @@ static void window_options_mouseup()
 		break;
 	case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
 		RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) ^= CONFIG_FLAG_SAVE_PLUGIN_DATA;
+		gGeneral_config.save_plugin_data = !(RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8)
+												& CONFIG_FLAG_SAVE_PLUGIN_DATA);
 		config_save();
 		window_invalidate(w);
 		break;


### PR DESCRIPTION
Up until now, config.ini was only read at startup but the settings were never saved. This set of patches fixes this.

Moreover the following settings have been added to config.ini:
- always_show_gridlines
- landscape_smoothing
- show_height_as_units
- save_plugin_data
