### PR TITLE
Fix bottom tooltip

### DIFF
--- a/src/window_game_bottom_toolbar.c
+++ b/src/window_game_bottom_toolbar.c
@@ -221,7 +221,7 @@ static void window_game_bottom_toolbar_tooltip()
 	#ifdef _MSC_VER
 	__asm mov tool_tip_index, ax
 	#else
-	__asm__ ( "mov %[tool_tip_index], dx " : [tool_tip_index] "+m" (tool_tip_index) );
+	__asm__ ( "mov %[tool_tip_index], ax " : [tool_tip_index] "+m" (tool_tip_index) );
 	#endif
 
 	#ifdef _MSC_VER


### PR DESCRIPTION
Thats me back from holiday and right back into finding the bugs. This should fix the issues with tooltips as found in #196. It was caused by using the wrong register for the function call. Additional issues were caused by  a signed int that was meant to be unsigned. 
