### PR TITLE
Improvements for a9091b41b6

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -101,7 +101,7 @@ void pause_sounds() {
 		RCT2_CALLPROC_EBPSAFE(0x006BCA9F);
 		RCT2_CALLPROC_EBPSAFE(0x006BD07F);
 	}
-	sounds_is_paused = 1;
+	g_sounds_disabled = 1;
 }
 
 /**
@@ -110,5 +110,5 @@ void pause_sounds() {
 */
 void unpause_sounds() {
 	RCT2_GLOBAL(0x009AF59C, uint8)--;
-	sounds_is_paused = 0;
+	g_sounds_disabled = 0;
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -63,7 +63,9 @@ void sound_stop(rct_sound *sound);
 void pause_sounds();
 void unpause_sounds();
 
-int sounds_is_paused;
+// 0x009AF59C probably does the same job
+// once it's confirmed and calls in pause_sounds() are reversed, it can be used instead of this
+int g_sounds_disabled;
 
 typedef enum {
 	SOUND_LIFT_1 = 0,

--- a/src/climate.c
+++ b/src/climate.c
@@ -85,14 +85,9 @@ void climate_reset(int climate)
 
 
 //for cheats
-void climate_freeze()
+void toggle_climate_lock()
 {
-	if (climate_frozen == 1){
-		climate_frozen = 0;
-	}
-	else{
-		climate_frozen = 1;
-	}
+	g_climate_locked = !g_climate_locked;
 }
 
 /**
@@ -111,7 +106,7 @@ void climate_update()
 		cur_rain = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_RAIN_LEVEL, sint8),
 		next_rain = _climateNextRainLevel;
 
-	if (climate_frozen == 1) //for cheats
+	if (g_climate_locked) //for cheats
 		return;
 
 	if (screen_flags & (~SCREEN_FLAGS_PLAYING)) // only normal play mode gets climate

--- a/src/climate.h
+++ b/src/climate.h
@@ -41,8 +41,9 @@ typedef struct {
 extern int gClimateNextWeather;
 extern const rct_weather climate_weather_data[6];
 
-int climate_frozen;
-void climate_freeze();
+// cheats
+int g_climate_locked;
+void toggle_climate_lock();
 
 int climate_celsius_to_fahrenheit(int celsius);
 void climate_reset(int climate);

--- a/src/game.c
+++ b/src/game.c
@@ -1688,20 +1688,22 @@ void handle_shortcut_command(int shortcutIndex)
 
 	// New
 	case SHORTCUT_REDUCE_GAME_SPEED:
-		_gameSpeed = max(1, _gameSpeed - 1);
+		game_reduce_game_speed();
 		break;
 	case SHORTCUT_INCREASE_GAME_SPEED:
-		_gameSpeed = min(8, _gameSpeed + 1);
+		game_increase_game_speed();
 		break;
 	}
 }
-void game_change_game_speed(int amount)
+
+void game_increase_game_speed()
 {
-	//Sending 0 will reset to default
-	if (amount == 0)
-		_gameSpeed = 1;
-	else
-		_gameSpeed = max(1, min(8, _gameSpeed + amount));
+	_gameSpeed = min(8, _gameSpeed + 1);
+}
+
+void game_reduce_game_speed()
+{
+	_gameSpeed = max(1, _gameSpeed - 1);
 }
 
 /**

--- a/src/game.h
+++ b/src/game.h
@@ -29,7 +29,9 @@ void update_rain_animation();
 void update_water_animation();
 
 int game_do_command(int eax, int ebx, int ecx, int edx, int esi, int edi, int ebp);
-void game_change_game_speed(int amount); //for cheats
+
+void game_increase_game_speed();
+void game_reduce_game_speed();
 
 void game_load_or_quit_no_save_prompt();
 int game_load_save();

--- a/src/window_options.c
+++ b/src/window_options.c
@@ -79,7 +79,7 @@ static rct_widget window_options_widgets[] = {
 	{ WWT_DROPDOWN,			0,	155,	299,	61,		72,		0x366,			STR_NONE },	// sound quality
 	{ WWT_DROPDOWN_BUTTON,	0,	288,	298,	62,		71,		0x36C,			STR_NONE },
 	{ WWT_CHECKBOX,			0,	10,		299,	76,		87,		STR_SOUND_FORCED_SOFTWARE_BUFFER_MIXING, STR_SOUND_FORCED_SOFTWARE_BUFFER_MIXING_TIP },
-	{ WWT_CHECKBOX,			0,	10,		229,	88,		99,		STR_SOUND,		STR_NONE }, // pause/unpause sound
+	{ WWT_CHECKBOX,			0,	10,		229,	88,		99,		STR_SOUND,		STR_NONE }, // enable/disable sound
 	{ WWT_GROUPBOX,			0,	3,		306,	112,	188,	STR_UNITS,		STR_NONE }, 
 	{ WWT_DROPDOWN,			0,	155,	299,	126,	137,	0x367,			STR_NONE },	// currency
 	{ WWT_DROPDOWN_BUTTON,	0,	288,	298,	127,	136,	0x36C,			STR_NONE },//
@@ -178,7 +178,7 @@ void window_options_open()
 		(1 << WIDX_TEMPERATURE_DROPDOWN) |
 		(1 << WIDX_HOTKEY_DROPDOWN) |
 		(1 << WIDX_SCREEN_EDGE_SCROLLING) |
-		(1 << WIDX_REAL_NAME_CHECKBOX) |
+		(1ULL << WIDX_REAL_NAME_CHECKBOX) |
 		(1 << WIDX_CONSTRUCTION_MARKER) |
 		(1 << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
 		(1 << WIDX_HEIGHT_LABELS) |
@@ -287,11 +287,11 @@ static void window_options_mouseup()
 		window_invalidate(w);
 		break;
 	case WIDX_SOUND_PAUSED_CHECKBOX:
-		if (sounds_is_paused == 0){
-			pause_sounds();
+		if (g_sounds_disabled){
+			unpause_sounds();
 		}
 		else{
-			unpause_sounds();
+			pause_sounds();
 		}
 		window_invalidate(w);
 		break;
@@ -571,7 +571,7 @@ static void window_options_update(rct_window *w)
 		RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_CONSTRUCTION_MARKER, uint8);
 	
 	//Sound pause checkbox
-	if (sounds_is_paused)
+	if (!g_sounds_disabled)
 		w->pressed_widgets |= (1 << WIDX_SOUND_PAUSED_CHECKBOX);
 	else
 		w->pressed_widgets &= ~(1 << WIDX_SOUND_PAUSED_CHECKBOX);
@@ -590,9 +590,9 @@ static void window_options_update(rct_window *w)
 
 	// real name checkbox
 	if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
-		w->pressed_widgets |= (1 << WIDX_REAL_NAME_CHECKBOX);
+		w->pressed_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
 	else
-		w->pressed_widgets &= ~(1 << WIDX_REAL_NAME_CHECKBOX);
+		w->pressed_widgets &= ~(1ULL << WIDX_REAL_NAME_CHECKBOX);
 	
 	// landscape tile smoothing checkbox
 	if ((RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_DISABLE_SMOOTH_LANDSCAPE))
@@ -614,7 +614,7 @@ static void window_options_update(rct_window *w)
 
 	// unknown park flag can disable real name checkbox
 	if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & 0x8000)
-		w->disabled_widgets |= (1 << WIDX_REAL_NAME_CHECKBOX);
+		w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
 
 	// save plugin data checkbox: visible or not
 	if (RCT2_GLOBAL(0x00F42BDA, uint8) == 1)

--- a/src/window_water.c
+++ b/src/window_water.c
@@ -150,8 +150,7 @@ static void window_water_mouseup()
 	case WIDX_DECREMENT:
 		// Decrement land tool size
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16)--;
-		//limit = 1;
-		limit = 0;
+		limit = 1;
 		if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) < limit)
 			RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = limit;
 


### PR DESCRIPTION
- renamed variables and functions
- simplified logic copied from other functions
- removed "fast staff" button
- commented the macros in window_cheats.c (they are actually a pretty good idea for making a grid of buttons)
- changed water tool bottom limit back to 1 (it doesn't work the same way as the land tool)
- used 1ULL for bit shift by 32
