### PR TITLE
Full fix for #195 (border flash bug)

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -377,9 +377,11 @@ rct_window *window_create(int x, int y, int width, int height, uint32 *event_han
 	w->var_4B9 = -1;
 	w->flags = flags;
 
-	// Play sound
-	if (!(flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT)))
+	// Play sounds and flash the window
+	if (!(flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))){
+		w->flags |= WF_WHITE_BORDER_MASK;
 		sound_play_panned(SOUND_WINDOW_OPEN, x + (width / 2));
+	}
 
 	w->number = 0;
 	w->x = x;

--- a/src/window_guest_list.c
+++ b/src/window_guest_list.c
@@ -176,7 +176,7 @@ void window_guest_list_open()
 	window->min_height = 330;
 	window->max_width = 500;
 	window->max_height = 450;
-	window->flags = WF_RESIZABLE;
+	window->flags |= WF_RESIZABLE;
 	window->colours[0] = 1;
 	window->colours[1] = 15;
 	window->colours[2] = 15;

--- a/src/window_ride_list.c
+++ b/src/window_ride_list.c
@@ -160,7 +160,7 @@ void window_ride_list_open()
 		window->min_height = 240;
 		window->max_width = 400;
 		window->max_height = 450;
-		window->flags = WF_RESIZABLE;
+		window->flags |= WF_RESIZABLE;
 		window->colours[0] = 1;
 		window->colours[1] = 26;
 		window->colours[2] = 26;


### PR DESCRIPTION
It was caused by a missed line in assembly. Also, two windows had flag assignment instead of bit set.
