### PR TITLE
Fixes issue where sound stops working after cancel is pressed

### DIFF
--- a/src/window_save_prompt.c
+++ b/src/window_save_prompt.c
@@ -250,7 +250,6 @@ static void window_save_prompt_mouseup()
 			case WQIDX_CLOSE:
 			case WQIDX_CANCEL:
 				window_close(w);
-				window_save_prompt_close();
 				break;
 		}
 		return;
@@ -260,7 +259,6 @@ static void window_save_prompt_mouseup()
 				if (!save_game()) {
 					// user pressed cancel
 					window_close(w);
-					window_save_prompt_close();
 					return;
 				}
 				break;
@@ -269,7 +267,6 @@ static void window_save_prompt_mouseup()
 			case WIDX_CLOSE:
 			case WIDX_CANCEL:
 				window_close(w);
-				window_save_prompt_close();
 				return;
 		}
 	}


### PR DESCRIPTION
Tiny fix to get sounds working after you click cancel on the exit box. Turns out the save_prompt_close function was getting called twice once explicitly and once as part of window_close. The second call caused a variable to roll over to 0xFF instead of stay at zero.
