### PR TITLE
Cleanup .gitattributes formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,13 +10,13 @@
 *.dbproj merge=union
 
 # Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain
+*.doc    diff=astextplain
+*.DOC    diff=astextplain
+*.docx   diff=astextplain
+*.DOCX   diff=astextplain
+*.dot    diff=astextplain
+*.DOT    diff=astextplain
+*.pdf    diff=astextplain
+*.PDF    diff=astextplain
+*.rtf    diff=astextplain
+*.RTF    diff=astextplain


### PR DESCRIPTION
Hello. I cleaned up the `.gitattributes` file to have more consistent formatting. I think spaces are ideal when a file is organized like this one is, but I can change it if something else would be preferred.
