### PR TITLE
Fixed bug in toolbar widget drawing. Added pause and zoom out disable.

### DIFF
--- a/src/widget.c
+++ b/src/widget.c
@@ -318,11 +318,11 @@ static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetInd
 	b = w->y + widget->bottom;
 
 	// Get the colour and image
-	colour = w->colours[widget->colour] << 19;
+	colour = w->colours[widget->colour];
 	image = widget->image + 2;
 
 	// Draw coloured image
-	gfx_draw_sprite(dpi, image | colour, l, t, 0);
+	gfx_draw_sprite(dpi, image | (colour << 19), l, t, 0);
 }
 
 /**

--- a/src/window_game_top_toolbar.c
+++ b/src/window_game_top_toolbar.c
@@ -153,8 +153,27 @@ void window_game_top_toolbar_open()
 		WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_5
 	);
 	window->widgets = window_game_top_toolbar_widgets;
-	window->enabled_widgets |= (1 | 2 | 4 | 8 | 0x10 | 0x20 | 0x40 | 0x80 | 0x100 | 0x200 | 0x400 | 0x800 |
-		0x1000 | 0x2000 | 0x4000 | 0x8000 | 0x10000 | 0x20000);
+
+	window->enabled_widgets |= 
+		(1 << WIDX_PAUSE) | 
+		(1 << WIDX_FILE_MENU) |
+		(1 << WIDX_ZOOM_OUT) | 
+		(1 << WIDX_ZOOM_IN) |
+		(1 << WIDX_ROTATE) | 
+		(1 << WIDX_VIEW_MENU) |
+		(1 << WIDX_MAP) | 
+		(1 << WIDX_LAND) |
+		(1 << WIDX_WATER) | 
+		(1 << WIDX_SCENERY) |
+		(1 << WIDX_PATH) | 
+		(1 << WIDX_CONSTRUCT_RIDE) |
+		(1 << WIDX_RIDES) | 
+		(1 << WIDX_PARK) |
+		(1 << WIDX_STAFF) | 
+		(1 << WIDX_CLEAR_SCENERY) |
+		(1ULL << WIDX_FASTFORWARD) | 
+		(1ULL << WIDX_RESEARCH);
+
 	window_init_scroll_widgets(window);
 	window->colours[0] = 7;
 	window->colours[1] = 12;
@@ -187,6 +206,8 @@ static void window_game_top_toolbar_mouseup()
 	switch (widgetIndex) {
 	case WIDX_PAUSE:
 		game_do_command(0, 1, 0, 0, GAME_COMMAND_TOGGLE_PAUSE, 0, 0);
+		// Not sure where this was done in the original code
+		w->pressed_widgets ^= (1 << WIDX_PAUSE);
 		break;
 	case WIDX_FASTFORWARD:
 		// This is an excellent place to add in debugging statements and
@@ -532,6 +553,18 @@ static void window_game_top_toolbar_invalidate()
 		w->pressed_widgets |= (1 << WIDX_FASTFORWARD);
 	else
 		w->pressed_widgets &= ~(1 << WIDX_FASTFORWARD);
+
+	// Zoomed out/in disable. Not sure where this code is in the original.
+	if (window_get_main()->viewport->zoom == 0){
+		w->disabled_widgets |= (1 << WIDX_ZOOM_IN);
+	}
+	else if (window_get_main()->viewport->zoom == 3){
+		w->disabled_widgets |= (1 << WIDX_ZOOM_OUT);
+	}
+	else
+	{
+		w->disabled_widgets &= ~((1 << WIDX_ZOOM_IN) | (1 << WIDX_ZOOM_OUT));
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #311.

I'm not completely sure where this code is in the original but this seems like the most logical place. This fixes the zoom in/out disabled icon issue and also the pause button not staying depressed.
