### PR TITLE
Fixed resize gripper not showing up on guest and staff windows.

### DIFF
--- a/src/window_peep.c
+++ b/src/window_peep.c
@@ -152,7 +152,7 @@ void window_peep_open(rct_peep* peep){
 		window->min_height = 157;
 		window->max_width = 500;
 		window->max_height = 450;
-		window->flags = 8;
+		window->flags = 1 << 8;
 		window->no_list_items = 0;
 		window->selected_list_item = -1;
 		window->colours[0] = 1;

--- a/src/window_staff_peep.c
+++ b/src/window_staff_peep.c
@@ -198,7 +198,7 @@ rct_window* sub_6BEF1B(rct_peep* peep)
 	w->max_width = 500;
 	w->max_height = 450;
 
-	w->flags = 8;
+	w->flags = 1 << 8;
 
 	w->colours[0] = 1;
 	w->colours[1] = 4;


### PR DESCRIPTION
Bug related to pull request #312.
