### PR TITLE
Use MacPorts if Homebrew isn't installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ if [[ `uname` == "Darwin" ]]; then
     echo "Check if wget is installed"
     which -s wget
     if [ $? -eq 1 ]; then
-	echo "wget is not installed, installing wget.."
+        echo "wget is not installed, installing wget.."
         eval "$package_command install wget"
     fi
 


### PR DESCRIPTION
Rewrote the install script of OSX users so that it installs with either MacPorts or Homebrew/
Also install wget if it's not installed already.
