### PR TITLE
Fix missing comma

### DIFF
--- a/src/language.c
+++ b/src/language.c
@@ -40,7 +40,7 @@ const char *language_filenames[LANGUAGE_COUNT] = {
 	"english_us",		// LANGUAGE_ENGLISH_US
 	"dutch",			// LANGUAGE_DUTCH
 	"french",			// LANGUAGE_FRENCH
-	"hungarian"			// LANGUAGE_HUNGARIAN
+	"hungarian",		// LANGUAGE_HUNGARIAN
 	"polish"			// LANGUAGE_POLISH
 };
 


### PR DESCRIPTION
Fix a missing comma that prevented loading Hungarian and Polish language files
