### PR TITLE
Merge the two Dutch translations

### DIFF
--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -512,23 +512,23 @@ STR_0510    :
 STR_0511    :
 STR_0512    :
 STR_0513    :
-STR_0514    :Trains suspended beneath the roller coaster track swing out to the side around corners
+STR_0514    :Treinen hangen onder de baan en zwaaien naar buiten in bochten
 STR_0515    :
-STR_0516    :A gentle roller coaster for people who haven't yet got the courage to face the larger rides
-STR_0517    :Passengers ride in miniature trains along a narrow-gauge railway track
-STR_0518    :Passengers travel in electric trains along a monorail track
-STR_0519    :Passengers ride in small cars hanging beneath the single-rail track, swinging freely from side to side around corners
+STR_0516    :Een rustige achtbaan voor bezoekers die nog niet in engere attracties durven
+STR_0517    :Passagiers rijden in miniatuurtreinen over een smalspoorweg
+STR_0518    :Passagiers rijden in elektrische treinen over een monorailbaan
+STR_0519    :Passagiers zitten in kleine karretjes die onder een enkele rail hangen en naar buiten zwaaien in de bochten
 STR_0520    :
 STR_0521    :
 STR_0522    :
-STR_0523    :Riders travel slowly in powered vehicles along a track-based route
+STR_0523    :Bezoekers rijden langzaam over een baan in aangedreven karretjes
 STR_0524    :
 STR_0525    :
 STR_0526    :
-STR_0527    :A smooth steel-tracked roller coaster capable of vertical loops
+STR_0527    :Een soepele stalen achtbaan die verticale loopings kan maken
 STR_0528    :
 STR_0529    :
-STR_0530    :Cars hang from a steel cable which runs continuously from one end of the ride to the other and back again
+STR_0530    :Stoeltjes hangen aan een continu draaiende stalen kabel die van het ene uiteinde van de baan naar het andere loopt, en daarna weer terug
 STR_0531    :
 STR_0532    :
 STR_0533    :
@@ -552,7 +552,7 @@ STR_0550    :
 STR_0551    :
 STR_0552    :
 STR_0553    :
-STR_0554    :The car is accelerated out of the station along a long level track using Linear Induction Motors, then heads straight up a vertical spike of track, freefalling back down to return to the station
+STR_0554    :Het karretje wordt het station uitgelanceerd over een lange rechte baan door middel van lineaire inductiemotoren, om daarna recht omhoog te gaan en weer terug te vallen richting het station
 STR_0555    :
 STR_0556    :
 STR_0557    :
@@ -561,22 +561,22 @@ STR_0559    :
 STR_0560    :
 STR_0561    :
 STR_0562    :
-STR_0563    :Sitting in comfortable trains with only simple lap restraints riders enjoy giant smooth drops and twisting track as well as plenty of 'air time' over the hills
-STR_0564    :Running on wooden track, this coaster is fast, rough, noisy, and gives an 'out of control' riding experience with plenty of 'air time'
-STR_0565    :A simple wooden roller coaster capable of only gentle slopes and turns, where the cars are only kept on the track by side friction wheels and gravity
-STR_0566    :Individual roller coaster cars zip around a tight zig-zag layout of track with sharp corners and short sharp drops
-STR_0567    :Sitting in seats suspended either side of the track, riders are pitched head-over-heels while they plunge down steep drops and travel through various inversions
+STR_0563    :Bezoekers zitten in comfortabele treinen met enkel een schootbeugel en gaan door soepel door grote afdalingen en kronkelende stukken baan, met veel 'airtime' in de heuvels
+STR_0564    :Deze over een houten baan lopende achtbaan is snel, ruw, luidruchting en geeft het gevoel van controleverlies met veel 'airtime'
+STR_0565    :Een simpele houten achtbaan die enkel in staat is rustige hellingen en bochten te bedwingen, de karretjes worden enkel op de baan gehouden door middel van zijfrictiewielen en zwaartekracht
+STR_0566    :Losse karretjes rijden over een kronkelende baan scherpe bochten en korte felle afdalingen
+STR_0567    :Bezoekers zitten in stoelen aan beide kanten van de baan, en draaien alle kanten op terwijl ze door de diepe afdalingen gaan en door diverse omkeringen. 
 STR_0568    :
-STR_0569    :Riding in special harnesses beLaag the track, riders experience the feeling of flight as they swoop through the air
+STR_0569    :Bezoekers zitten in een speciaal tuig onder de baan en krijgen zo de ervaring dat ze vliegen
 STR_0570    :
 STR_0571    :
 STR_0572    :
 STR_0573    :
 STR_0574    :
-STR_0575    :Powered trains hanging from a single rail transport people around the park
+STR_0575    :Aangedreven treinen hangen aan een enkele rail en vervoeren mensen door het park heen
 STR_0576    :
 STR_0577    :
-STR_0578    :Cars run along track enclosed by circular hoops, traversing steep drops and heartline twists
+STR_0578    :Karretjes lopen in een baan omgeven door hoepels en gaan door steile afdalingen en heartline-twists
 STR_0579    :
 STR_0580    :
 STR_0581    :
@@ -584,7 +584,7 @@ STR_0582    :
 STR_0583    :
 STR_0584    :
 STR_0585    :
-STR_0586    :Boat shaped cars run on roller coaster track to allow twisting curves and steep drops, splashing down into sections of water for gentle river sections
+STR_0586    :Bootvormige karretjes lopen over achtbaanrails waardoor ze hellende bochten en diepe afdalingen kunnen maken, waarna ze in bakken water neerplonzen en rustig een stukje kunnen varen
 STR_0587    :
 STR_0588    :
 STR_0589    :
@@ -597,7 +597,7 @@ STR_0595    :
 STR_0596    :
 STR_0597    :
 STR_0598    :
-STR_0599    :A compact roller coaster with individual cars and smooth twisting drops
+STR_0599    :Een compacte achtbaan met individuele karretjes en steile, kronkelende afdalingen
 STR_0600    :
 STR_0601    :
 STR_0602    :
@@ -926,7 +926,7 @@ STR_0924    :{SMALLFONT}{BLACK}Spiraal naar beneden
 STR_0925    :{SMALLFONT}{BLACK}Spiraal naar boven
 STR_0926    :Kan dit niet verwijderen...
 STR_0927    :Kan dit hier niet bouwen...
-STR_0928    :{SMALLFONT}{BLACK}Kettinglift, om karretjes een heuvel op te trekken
+STR_0928    :{SMALLFONT}{BLACK}Kettinglift, om karretjes omhoog te trekken
 STR_0929    :S-bocht (links)
 STR_0930    :S-bocht (rechts)
 STR_0931    :Verticale looping (links)
@@ -1818,8 +1818,8 @@ STR_1816    :{SMALLFONT}{BLACK}Selecteer het type informatie dat je in de gasten
 STR_1817    :({COMMA16})
 STR_1818    :{WINDOW_COLOUR_2}Alle bezoekers
 STR_1819    :{WINDOW_COLOUR_2}Alle bezoekers (samengevat)
-STR_1820    :{WINDOW_COLOUR_2}Bezoekers die {STRINGID}
-STR_1821    :{WINDOW_COLOUR_2}Bezoekers die {STRINGID} denken
+STR_1820    :{WINDOW_COLOUR_2}Bezoekers met de volgende status: {STRINGID}
+STR_1821    :{WINDOW_COLOUR_2}Bezoekers met de volgende gedachte: {STRINGID}
 STR_1822    :{WINDOW_COLOUR_2}Bezoekers met gedachten over {POP16}{STRINGID}
 STR_1823    :{SMALLFONT}{BLACK}Toon de gedachten van bezoekers over deze attractie
 STR_1824    :{SMALLFONT}{BLACK}Toon de bezoekers in deze attractie
@@ -2021,7 +2021,7 @@ STR_2019    :Actiefoto's
 STR_2020    :Paraplu's
 STR_2021    :Blikjes frisdrank
 STR_2022    :Hamburgers
-STR_2023    :Zakjes fries
+STR_2023    :Zakjes friet
 STR_2024    :IJsjes
 STR_2025    :Suikerspinnen
 STR_2026    :Lege blikjes
@@ -2299,7 +2299,7 @@ STR_2297    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgeven aan {BLACK}{COMMA16}
 STR_2298    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} attracties
 STR_2299    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} stuk voedsel
 STR_2300    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} stuks voedsel
-STR_2301    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} drankjr
+STR_2301    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} drankje
 STR_2302    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} drankjes
 STR_2303    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} souvenir
 STR_2304    :{BLACK}{CURRENCY2DP}{WINDOW_COLOUR_2} uitgegeven aan {BLACK}{COMMA16} souvenirs
@@ -2444,83 +2444,83 @@ STR_2442    :{BLACK}({STRINGID} resterend)
 STR_2443    :{WINDOW_COLOUR_2}Kosten per week: {BLACK}{CURRENCY2DP}
 STR_2444    :{WINDOW_COLOUR_2}Totale kosten: {BLACK}{CURRENCY2DP}
 STR_2445    :Start deze marketingcampagne
-STR_2446    :{YELLOW}Your marketing campaign for free entry to the park has finished
-STR_2447    :{YELLOW}Your marketing campaign for free rides on {STRINGID} has finished
-STR_2448    :{YELLOW}Your marketing campaign for half-price entry to the park has finished
-STR_2449    :{YELLOW}Your marketing campaign for free {STRINGID} has finished
-STR_2450    :{YELLOW}Your advertising campaign for the park has finished
-STR_2451    :{YELLOW}Your advertising campaign for {STRINGID} has finished
+STR_2446    :{YELLOW}Je advertentiecampagne voor gratis entree tot het park is afgelopen
+STR_2447    :{YELLOW}Je advertentiecampagne voor gratis ritjes op {STRINGID} is afgelopen
+STR_2448    :{YELLOW}Je advertentiecampagne voor 50% korting op de entree is afgelopen
+STR_2449    :{YELLOW}Je advertentiecampagne voor gratis {STRINGID} is afgelopen
+STR_2450    :{YELLOW}Je advertentiecampagne voor het park is afgelopen
+STR_2451    :{YELLOW}Je advertentiecampagne voor {STRINGID} is afgelopen
 STR_2452    :{WINDOW_COLOUR_2}Saldo (zonder lening): {BLACK}{CURRENCY2DP}
 STR_2453    :{WINDOW_COLOUR_2}Saldo (zonder lening): {RED}{CURRENCY2DP}
 STR_2454    :{SMALLFONT}{BLACK}{CURRENCY2DP} -
 STR_2455    :{SMALLFONT}{BLACK}+{CURRENCY2DP} -
 STR_2456    :{SMALLFONT}{BLACK}{CURRENCY2DP} -
-STR_2457    :{SMALLFONT}{BLACK}Show financial accounts
-STR_2458    :{SMALLFONT}{BLACK}Show graph of cash (less loan) over time
-STR_2459    :{SMALLFONT}{BLACK}Show graph of park value over time
-STR_2460    :{SMALLFONT}{BLACK}Show graph of weekly profit
-STR_2461    :{SMALLFONT}{BLACK}Show marketing campaigns
-STR_2462    :{SMALLFONT}{BLACK}Show view of park entrance
-STR_2463    :{SMALLFONT}{BLACK}Show graph of park ratings over time
-STR_2464    :{SMALLFONT}{BLACK}Show graph of guest numbers over time
-STR_2465    :{SMALLFONT}{BLACK}Show park entrance price and information
-STR_2466    :{SMALLFONT}{BLACK}Show park statistics
-STR_2467    :{SMALLFONT}{BLACK}Show objectives for this game
-STR_2468    :{SMALLFONT}{BLACK}Show recent awards this park has received
-STR_2469    :{SMALLFONT}{BLACK}Select level of research & development
-STR_2470    :{SMALLFONT}{BLACK}Research new transport rides
-STR_2471    :{SMALLFONT}{BLACK}Research new gentle rides
-STR_2472    :{SMALLFONT}{BLACK}Research new roller coasters
-STR_2473    :{SMALLFONT}{BLACK}Research new thrill rides
-STR_2474    :{SMALLFONT}{BLACK}Research new water rides
-STR_2475    :{SMALLFONT}{BLACK}Research new shops and stalls
-STR_2476    :{SMALLFONT}{BLACK}Research new scenery and themeing
-STR_2477    :{SMALLFONT}{BLACK}Select operating mode for this ride/attraction
-STR_2478    :{SMALLFONT}{BLACK}Show graph of velocity against time
-STR_2479    :{SMALLFONT}{BLACK}Show graph of altitude against time
-STR_2480    :{SMALLFONT}{BLACK}Show graph of vertical acceleration against time
-STR_2481    :{SMALLFONT}{BLACK}Show graph of lateral acceleration against time
-STR_2482    :{SMALLFONT}{BLACK}Profit: {CURRENCY} per week,  Park Value: {CURRENCY}
-STR_2483    :{WINDOW_COLOUR_2}Weekly profit: {BLACK}+{CURRENCY2DP}
-STR_2484    :{WINDOW_COLOUR_2}Weekly profit: {RED}{CURRENCY2DP}
+STR_2457    :{SMALLFONT}{BLACK}Laat financiële posten zien
+STR_2458    :{SMALLFONT}{BLACK}Toon grafiek van saldoverloop (zonder lening)
+STR_2459    :{SMALLFONT}{BLACK}Toon grafiek van parkwaardeverloop
+STR_2460    :{SMALLFONT}{BLACK}Toon grafiek van wekelijke winst
+STR_2461    :{SMALLFONT}{BLACK}Toon marketingcampagnes
+STR_2462    :{SMALLFONT}{BLACK}Toon beeld van de parkingang
+STR_2463    :{SMALLFONT}{BLACK}Toon grafiek van parkwaarderingverloop
+STR_2464    :{SMALLFONT}{BLACK}Toon grafiek met verloop van het aantal bezoekers
+STR_2465    :{SMALLFONT}{BLACK}Toon de entreeprijs en -informatie
+STR_2466    :{SMALLFONT}{BLACK}Toon parkstatistieken
+STR_2467    :{SMALLFONT}{BLACK}Toon doelstellingen voor dit spel
+STR_2468    :{SMALLFONT}{BLACK}Toon recente prijzen die het park heeft gekregen
+STR_2469    :{SMALLFONT}{BLACK}Selecteer niveau van onderzoek en ontwikkeling
+STR_2470    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe transportattracties
+STR_2471    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe rustige attracties
+STR_2472    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe achtbanen
+STR_2473    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe spannende attracties
+STR_2474    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe waterattracties
+STR_2475    :{SMALLFONT}{BLACK}Onderzoek naar nieuwe winkels en kraampjes
+STR_2476    :{SMALLFONT}{BLACK}Onderzoek naar nieuw decor en nieuwe thema's
+STR_2477    :{SMALLFONT}{BLACK}Selecteer werkmodus voor deze attractie
+STR_2478    :{SMALLFONT}{BLACK}Toon grafiek van snelheidsverloop
+STR_2479    :{SMALLFONT}{BLACK}Toon grafiek van hoogteverloop
+STR_2480    :{SMALLFONT}{BLACK}Toon grafiek met verloop van verticale versnelling
+STR_2481    :{SMALLFONT}{BLACK}Toon grafiek met verloop van zijwaartse versnelling
+STR_2482    :{SMALLFONT}{BLACK}Winst: {CURRENCY} per week,  parkwaarde: {CURRENCY}
+STR_2483    :{WINDOW_COLOUR_2}Wekelijkse winst: {BLACK}+{CURRENCY2DP}
+STR_2484    :{WINDOW_COLOUR_2}Wekelijkse winst: {RED}{CURRENCY2DP}
 STR_2485    :Besturing
 STR_2486    :Algemeen
 STR_2487    :'Echte' namen van bezoekers tonen
-STR_2488    :{SMALLFONT}{BLACK}Toggle between showing 'real' names of guests and guest numbers
+STR_2488    :{SMALLFONT}{BLACK}Wissel tussen het tonen van 'echte' namen van bezoekers en bezoekernummers
 STR_2489    :Sneltoetsen...
 STR_2490    :Sneltoetsen
 STR_2491    :Toetsen herstellen
-STR_2492    :{SMALLFONT}{BLACK}Set all keyboard shortcuts back to default settings
-STR_2493    :Close top-most window
-STR_2494    :Close all floating windows
-STR_2495    :Cancel construction mode
+STR_2492    :{SMALLFONT}{BLACK}Alle sneltoetsen terugzetten op de standaardinstellingen
+STR_2493    :Sluit bovenste venster
+STR_2494    :Sluit alle openstaande vensters
+STR_2495    :Bouwmodus annuleren
 STR_2496    :Spel pauzeren
-STR_2497    :Zoom view out
-STR_2498    :Zoom view in
-STR_2499    :Rotate view
-STR_2500    :Rotate construction object
-STR_2501    :Underground view toggle
-STR_2502    :Remove base land toggle
-STR_2503    :Remove vertical land toggle
-STR_2504    :See-through rides toggle
-STR_2505    :See-through scenery toggle
-STR_2506    :Invisible supports toggle
-STR_2507    :Invisible people toggle
-STR_2508    :Height marks on land toggle
-STR_2509    :Height marks on ride tracks toggle
-STR_2510    :Height marks on paths toggle
+STR_2497    :Beeld uitzoomen
+STR_2498    :Beeld inzoomen
+STR_2499    :Beeld draaien
+STR_2500    :Object draaien
+STR_2501    :Ondergrondszicht
+STR_2502    :Bovenkant land onzichtbaar
+STR_2503    :Zijkant land onzichtbaar
+STR_2504    :Doorzichtige attracties
+STR_2505    :Doorzichtig decor
+STR_2506    :Onzichtbare ondersteuningen
+STR_2507    :Onzichtbare bezoekers
+STR_2508    :Toon hoogtemarkeringen op land
+STR_2509    :Toon hoogtemarkeringen op attracties
+STR_2510    :Toon hoogtemarkeringen op paden
 STR_2511    :Land aanpassen
 STR_2512    :Water aanpassen
 STR_2513    :Decor bouwen
-STR_2514    :Build paths
-STR_2515    :Build new ride
-STR_2516    :Show financial information
-STR_2517    :Show research information
-STR_2518    :Show rides list
-STR_2519    :Show park information
-STR_2520    :Show guest list
-STR_2521    :Show staff list
-STR_2522    :Show recent messages
+STR_2514    :Voetpaden bouwen
+STR_2515    :Nieuwe attractie bouwen
+STR_2516    :Financiële informatie tonen
+STR_2517    :Onderzoeksinformatie tonen
+STR_2518    :Lijst met attracties tonen
+STR_2519    :Parkinformatie tonen
+STR_2520    :Lijst met bezoekers tonen
+STR_2521    :Lijst met werknemers tonen
+STR_2522    :Recente berichten tonen
 STR_2523    :Kaart tonen
 STR_2524    :Screenshot
 STR_2525    :???
@@ -2784,7 +2784,7 @@ STR_2782    :SHIFT +
 STR_2783    :CTRL + 
 STR_2784    :Sneltoets wijzigen
 STR_2785    :{WINDOW_COLOUR_2}Voer een nieuwe sneltoets in voor:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
-STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
+STR_2786    :{SMALLFONT}{BLACK}Klik op de beschrijving op een nieuwe sneltoets in te stellen
 STR_2787    :{WINDOW_COLOUR_2}Parkwaarde: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Gefeliciteerd!{NEWLINE}{BLACK}Je hebt je doel bereikt met een bedrijfswaarde van {CURRENCY}!
 STR_2789    :{WINDOW_COLOUR_2}Je hebt je doel niet bereikt!
@@ -2792,11 +2792,11 @@ STR_2790    :Naam invoeren voor scenario-overzicht
 STR_2791    :Naam invoeren
 STR_2792    :Voer je naam in voor het scenario-overzicht:
 STR_2793    :{SMALLFONT}(Voltooid door {STRINGID})
-STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
+STR_2794    :{WINDOW_COLOUR_2}Voltooid door: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} met een bedrijfswaarde van: {BLACK}{CURRENCY}
 STR_2795    :Sorteren
-STR_2796    :{SMALLFONT}{BLACK}Sort the ride list into order using the information type displayed
+STR_2796    :{SMALLFONT}{BLACK}Sorteer de lijst met attracties op basis van het aangegeven informatietype
 STR_2797    :Beeld verschuiven als aanwijzer op de rand staat
-STR_2798    :{SMALLFONT}{BLACK}Select whether to scroll the view when the mouse pointer is at the screen edge
+STR_2798    :{SMALLFONT}{BLACK}Selecteer of het beeld moet verschuiven als de muisaanwijzer op de rand van het beeld staat
 STR_2799    :{SMALLFONT}{BLACK}Instellingen voor sneltoetsen bekijken of aanpassen
 STR_2800    :{WINDOW_COLOUR_2}Totale bezoeken: {BLACK}{COMMA32}
 STR_2801    :{WINDOW_COLOUR_2}Entree-inkomsten: {BLACK}{CURRENCY2DP}
@@ -2804,14 +2804,14 @@ STR_2802    :Kaart
 STR_2803    :{SMALLFONT}{BLACK}Parkkaart tonen waarop deze bezoekers gemarkeerd zijn
 STR_2804    :{SMALLFONT}{BLACK}Parkkaart tonen waarop deze werknemers gemarkeerd zijn
 STR_2805    :{SMALLFONT}{BLACK}Parkkaart tonen
-STR_2806    :{RED}Guests are complaining about the disgusting state of the paths in your park{NEWLINE}Check where your handymen are and consider organizing them better
-STR_2807    :{RED}Guests are complaining about the amount of litter in your park{NEWLINE}Check where your handymen are and consider organizing them better
-STR_2808    :{RED}Guests are complaining about the vandalism in your park{NEWLINE}Check where your security guards are and consider organizing them better
-STR_2809    :{RED}Guests are hungry and can't find anywhere to buy food
-STR_2810    :{RED}Guests are thirsty and can't find anywhere to buy drinks
-STR_2811    :{RED}Guests are complaining because they can't find the restrooms in your park
-STR_2812    :{RED}Guests are getting lost or stuck{NEWLINE}Check whether the layout of your footpaths needs improving to help the guests find their way around
-STR_2813    :{RED}Your park entrance fee is too Hoog!{NEWLINE}Reduce your entrance fee or improve the value of the park to attract more guests
+STR_2806    :{RED}Bezoekers klagen over de smerige voetpaden in je park{NEWLINE}Controleer waar je klusjesmannen zijn en overweeg om ze beter te organiseren
+STR_2807    :{RED}Bezoekers klagen over de hoeveelheid rommel{NEWLINE}Controleer waar je klusjesmannen zijn en overweeg om ze beter te organiseren
+STR_2808    :{RED}Bezoekers klagen over het vandalisme in je park{NEWLINE}Controleer waar je bewakers zijn en overweeg om ze beter te organiseren
+STR_2809    :{RED}Bezoekers hebben honger en kunnen geen plek vinden om voedsel te kopen
+STR_2810    :{RED}Bezoekers hebben dorst en kunnen geen plek vinden om drinken te kopen
+STR_2811    :{RED}Bezoekers klagen omdat ze de toiletten in je park niet kunnen vinden
+STR_2812    :{RED}Bezoekers raken verdwaald of komen vast te zitten{NEWLINE}Controleer of de indeling van je voetpaden voor verbetering vatbaar is
+STR_2813    :{RED}Je entreeprijs is te hoog!{NEWLINE}Verlaag de entreeprijs of verbeter het park om meer bezoekers te trekken
 STR_2814    :{WINDOW_COLOUR_2}Rommeligste park
 STR_2815    :{WINDOW_COLOUR_2}Netste park
 STR_2816    :{WINDOW_COLOUR_2}Beste achtbanen
@@ -2829,39 +2829,39 @@ STR_2827    :{WINDOW_COLOUR_2}Beste unieke attracties
 STR_2828    :{WINDOW_COLOUR_2}Meest duizelingwekkende kleurenschema
 STR_2829    :{WINDOW_COLOUR_2}Vreemdste indeling
 STR_2830    :{WINDOW_COLOUR_2}Beste rustige attracties
-STR_2831    :{TOPAZ}Your park has received an award for being 'The most untidy park in the country'!
-STR_2832    :{TOPAZ}Your park has received an award for being 'The tidiest park in the country'!
-STR_2833    :{TOPAZ}Your park has received an award for being 'The park with the best roller coasters'!
-STR_2834    :{TOPAZ}Your park has received an award for being 'The best value park in the country'!
-STR_2835    :{TOPAZ}Your park has received an award for being 'The most beautiful park in the country'!
-STR_2836    :{TOPAZ}Your park has received an award for being 'The worst value park in the country'!
-STR_2837    :{TOPAZ}Your park has received an award for being 'The safest park in the country'!
-STR_2838    :{TOPAZ}Your park has received an award for being 'The park with the best staff'!
-STR_2839    :{TOPAZ}Your park has received an award for being 'The park with the best food in the country'!
-STR_2840    :{TOPAZ}Your park has received an award for being 'The park with the worst food in the country'!
-STR_2841    :{TOPAZ}Your park has received an award for being 'The park with the best restroom facilities in the country'!
-STR_2842    :{TOPAZ}Your park has received an award for being 'The most disappointing park in the country'!
-STR_2843    :{TOPAZ}Your park has received an award for being 'The park with the best water rides in the country'!
-STR_2844    :{TOPAZ}Your park has received an award for being 'The park with the best custom-designed rides'!
-STR_2845    :{TOPAZ}Your park has received an award for being 'The park with the most dazzling choice of color schemes'!
-STR_2846    :{TOPAZ}Your park has received an award for being 'The park with the most confusing layout'!
-STR_2847    :{TOPAZ}Your park has received an award for being 'The park with the best gentle rides'!
+STR_2831    :{TOPAZ}Je park heeft een prijs gekregen: 'Rommeligste park van het land'!
+STR_2832    :{TOPAZ}Je park heeft een prijs gekregen: 'Netste park van het land'!
+STR_2833    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste achtbanen'!
+STR_2834    :{TOPAZ}Je park heeft een prijs gekregen: 'Beste park van het land'!
+STR_2835    :{TOPAZ}Je park heeft een prijs gekregen: 'Mooiste park van het land'!
+STR_2836    :{TOPAZ}Je park heeft een prijs gekregen: 'Slechtste park van het land'!
+STR_2837    :{TOPAZ}Je park heeft een prijs gekregen: 'Veiligste park'!
+STR_2838    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste werknemers'!
+STR_2839    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met het beste eten van het land'!
+STR_2840    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met het slechtste eten van het land'!
+STR_2841    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste toiletten van het land'!
+STR_2842    :{TOPAZ}Je park heeft een prijs gekregen: 'Meest teleurstellende park'!
+STR_2843    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste waterattracties'!
+STR_2844    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste unieke attracties'!
+STR_2845    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met het meest duizelingwekkende kleurenschema'!
+STR_2846    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de vreemdste indeling'!
+STR_2847    :{TOPAZ}Je park heeft een prijs gekregen: 'Park met de beste rustige attracties'!
 STR_2848    :{WINDOW_COLOUR_2}Geen recente prijzen
-STR_2849    :New scenario installed successfully
-STR_2850    :New track design installed successfully
-STR_2851    :Scenario already installed
-STR_2852    :Track design already installed
-STR_2853    :Forbidden by the local authority!
-STR_2854    :{RED}Guests can't get to the entrance of {STRINGID} !{NEWLINE}Construct a path to the entrance
-STR_2855    :{RED}{STRINGID} has no path leading from its exit !{NEWLINE}Construct a path from the ride exit
+STR_2849    :Nieuw scenario is succesvol geïnstalleerd
+STR_2850    :Nieuw baanontwerp is succesvol geïnstalleerd
+STR_2851    :Scenario al is geïnstalleerd
+STR_2852    :Baanontwerp is al geïnstalleerd
+STR_2853    :Niet toegestaan door de gemeente!
+STR_2854    :{RED}Bezoekers kunnen niet bij de ingang van {STRINGID} komen!{NEWLINE}Maak een pad naar de ingang
+STR_2855    :{RED}{STRINGID} heeft geen pad vanaf de uitgang!{NEWLINE}Maak een pad vanaf de uitgang
 STR_2856    :{WINDOW_COLOUR_2}Tutorial
-STR_2857    :{WINDOW_COLOUR_2}(Press a key or mouse button to take control)
-STR_2858    :Can't start marketing campaign...
-STR_2859    :Another instance of RollerCoaster Tycoon 2 is already running
-STR_2860    :Infogrames Interactive credits...
-STR_2861    :{WINDOW_COLOUR_2}Licensed to Infogrames Interactive Inc.
-STR_2862    :Music acknowledgements...
-STR_2863    :Music acknowledgements
+STR_2857    :{WINDOW_COLOUR_2}(Druk op een toets of muisknop om de controle over te nemen)
+STR_2858    :Kan marketingcampagne niet starten...
+STR_2859    :RollerCoaster Tycoon 2 draait al
+STR_2860    :Credits voor Infogrames Interactive...
+STR_2861    :{WINDOW_COLOUR_2}In licentie geven aan Infogrames Interactive Inc.
+STR_2862    :Muziekdankwoord...
+STR_2863    :Muziekdankwoord
 STR_2864    :{WINDOW_COLOUR_2}March - Children of the Regiment:   (Fucik) geen copyright
 STR_2865    :{WINDOW_COLOUR_2}Heyken's Serenade:   (J.Heyken) British Standard Music Coy; GEMA, BRITICO
 STR_2866    :{WINDOW_COLOUR_2}In Continental Mood:   (Onbekende componist) Copyright Control
@@ -2967,7 +2967,7 @@ STR_2965    :{WINDOW_COLOUR_2}
 STR_2966    :
 STR_2967    :
 STR_2968    :
-STR_2969    :Het gebruik van dit product is onderhevig aan de bepalen in de gebruikersovereenkomst
+STR_2969    :Het gebruik van dit product is onderhevig aan de bepalingen in de gebruikersovereenkomst
 STR_2970    :die te raadplegen is in de {OPENQUOTES}ReadMe{ENDQUOTES} of de handleiding.
 STR_2971    :Standaard kleurenschema
 STR_2972    :Alternatief kleurenschema 1
@@ -2984,11 +2984,11 @@ STR_2982    :Baniertekst
 STR_2983    :Voer een nieuwe tekst in voer deze banier:
 STR_2984    :Kan de tekst op deze banier niet veranderen...
 STR_2985    :Banier
-STR_2986    :{SMALLFONT}{BLACK}Change text on banner
-STR_2987    :{SMALLFONT}{BLACK}Set this banner as a 'no-entry' sign for guests
-STR_2988    :{SMALLFONT}{BLACK}Demolish this banner
-STR_2989    :{SMALLFONT}{BLACK}Select main color
-STR_2990    :{SMALLFONT}{BLACK}Select text color
+STR_2986    :{SMALLFONT}{BLACK}Tekst op deze banier aanpassen
+STR_2987    :{SMALLFONT}{BLACK}Deze banier gebruiken als bord voor 'geen toegang' voor de bezoekers
+STR_2988    :{SMALLFONT}{BLACK}Deze banier vernietigen
+STR_2989    :{SMALLFONT}{BLACK}Hoofdkleur selecteren
+STR_2990    :{SMALLFONT}{BLACK}Tekstkleur selecteren
 STR_2991    :Bord
 STR_2992    :Bordtekst
 STR_2993    :Voer een nieuwe tekst in voor dit bord:
@@ -3010,43 +3010,43 @@ STR_3008    :{PEARLAQUA}ABC
 STR_3009    :{PALESILVER}ABC
 STR_3010    :Kan dit bestand niet laden...
 STR_3011    :Bestand bevat ongeldige gegevens
-STR_3012    :Dodgems beat style
+STR_3012    :Botsautostijl
 STR_3013    :Kermisorgelstijl
-STR_3014    :Roman fanfare style
-STR_3015    :Oriental style
-STR_3016    :Martian style
-STR_3017    :Jungle drums style
-STR_3018    :Egyptian style
-STR_3019    :Toyland style
+STR_3014    :Romeinsefanfarestijl
+STR_3015    :Oosterse stijl
+STR_3016    :Marsstijl
+STR_3017    :Jungledrumsstijl
+STR_3018    :Egyptische stijl
+STR_3019    :Speelgoedlandstijl
 STR_3020    :
-STR_3021    :Space style
-STR_3022    :Horror style
-STR_3023    :Techno style
-STR_3024    :Gentle style
-STR_3025    :Summer style
-STR_3026    :Water style
-STR_3027    :Wild west style
-STR_3028    :Jurassic style
-STR_3029    :Rock style
-STR_3030    :Ragtime style
-STR_3031    :Fantasy style
-STR_3032    :Rock style 2
-STR_3033    :Ice style
-STR_3034    :Snow style
+STR_3021    :Ruimtestijl
+STR_3022    :Horrorstijl
+STR_3023    :Technostijl
+STR_3024    :Rustige stijl
+STR_3025    :Zomerstijl
+STR_3026    :Waterstijl
+STR_3027    :Wildweststijl
+STR_3028    :Jurastijl
+STR_3029    :Rockstijl
+STR_3030    :Ragtimestijl
+STR_3031    :Fantasiestijl
+STR_3032    :Rockstijl 2
+STR_3033    :IJsstijl
+STR_3034    :Sneeuwstijl
 STR_3035    :Extra muziek 1
 STR_3036    :Extra muziek 2
-STR_3037    :Medieval style
-STR_3038    :Urban style
-STR_3039    :Organ style
-STR_3040    :Mechanical style
-STR_3041    :Modern style
-STR_3042    :Pirates style
-STR_3043    :Rock style 3
-STR_3044    :Candy style
-STR_3045    :{SMALLFONT}{BLACK}Select style of music to play
+STR_3037    :Middeleeuwse stijl
+STR_3038    :Stadsstijl
+STR_3039    :Orgelstijl
+STR_3040    :Mechanische stijl
+STR_3041    :Moderne stijl
+STR_3042    :Piratenstijl
+STR_3043    :Rockstijl 3
+STR_3044    :Snoepstijl
+STR_3045    :{SMALLFONT}{BLACK}Selecteer welke muziekstijl er moet worden gespeeld
 STR_3046    :Deze attractie kan niet worden aangepast
-STR_3047    :Local authority forbids demolition or modifications to this ride
-STR_3048    :Marketing campaigns forbidden by local authority
+STR_3047    :De gemeente staat de sloop van en wijzigingen aan deze attractie niet toe
+STR_3048    :Marketingcampagnes worden niet toegestaan door de gemeente
 STR_3049    :Golfhole A
 STR_3050    :Golfhole B
 STR_3051    :Golfhole C
@@ -3071,10 +3071,10 @@ STR_3069    :Bovensegment
 STR_3070    :Van helling naar vlak
 STR_3071    :{WINDOW_COLOUR_2}Dezelfde prijs in het hele park
 STR_3072    :{SMALLFONT}{BLACK}Select whether this price is used throughout the entire park
-STR_3073    :{RED}WAARSCHUWING: Your park rating has dropped beLaag 700 !{NEWLINE}If you haven't raised the park rating in 4 weeks, your park will be closed down
-STR_3074    :{RED}WAARSCHUWING: Your park rating is still beLaag 700 !{NEWLINE}You have 3 weeks to raise the park rating
-STR_3075    :{RED}WAARSCHUWING: Your park rating is still beLaag 700 !{NEWLINE}You have only 2 weeks to raise the park rating, or your park will be closed down
-STR_3076    :{RED}FINAL WARNING: Your park rating is still beLaag 700 !{NEWLINE}In just 7 days your park will be closed down unless you can raise the rating
+STR_3073    :{RED}WAARSCHUWING: Je parkwaardering is onder de 700 gekomen!{NEWLINE}Als je niet binnen 4 weken de waardering boven de 700 hebt gekregen, wordt je park gesloten
+STR_3074    :{RED}WAARSCHUWING: Je parkwaardering is nog steeds lager dan 700!{NEWLINE}Je hebt nog 3 weken om de waardering te verhogen
+STR_3075    :{RED}WAARSCHUWING: Je parkwaardering is nog steeds lager dan 700!{NEWLINE}Je hebt nog maar 2 weken om de waardering te verhogen, anders wordt je park gesloten
+STR_3076    :{RED}LAATSTE WAARSCHUWING: Je parkwaardering is nog steeds lager dan 700!{NEWLINE}Je hebt nog maar 7 dagen om die te verhogen, anders wordt je park gesloten
 STR_3077    :{RED}SLUITINGSBERICHT: Je park is gesloten!
 STR_3078    :Standaardingang
 STR_3079    :Houten ingang
@@ -3088,20 +3088,20 @@ STR_3086    :Abstracte ingang
 STR_3087    :Sneeuw/ijs-ingang
 STR_3088    :Pagode-ingang
 STR_3089    :Ruimte-ingang
-STR_3090    :{SMALLFONT}{BLACK}Select style of entrance, exit, and station
+STR_3090    :{SMALLFONT}{BLACK}Selecteer de stijl van de ingang, uitgang, en het station
 STR_3091    :Je mag dit segment niet verwijderen!
-STR_3092    :You are not allowed to move or modify the station for this ride!
+STR_3092    :Je mag het station van deze attractie niet verplaatsen of veranderen!
 STR_3093    :{WINDOW_COLOUR_2}Favoriet: {BLACK}{STRINGID}
 STR_3094    :n.v.t.
-STR_3095    :{WINDOW_COLOUR_2}Lift hill chain speed:
+STR_3095    :{WINDOW_COLOUR_2}Snelheid kettingheuvel:
 STR_3096    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{VELOCITY}
-STR_3097    :{SMALLFONT}{BLACK}Select lift hill chain speed
-STR_3098    :Can't change lift hill speed...
-STR_3099    :{SMALLFONT}{BLACK}Select color
-STR_3100    :{SMALLFONT}{BLACK}Select second color
-STR_3101    :{SMALLFONT}{BLACK}Select third color
-STR_3102    :{SMALLFONT}{BLACK}Re-paint colored scenery on landscape
-STR_3103    :Can't re-paint this...
+STR_3097    :{SMALLFONT}{BLACK}Selecteer de snelheid van de kettingheuvel
+STR_3098    :Kan de snelheid van de kettingheuvel niet veranderen...
+STR_3099    :{SMALLFONT}{BLACK}Kleur selecteren
+STR_3100    :{SMALLFONT}{BLACK}Tweede kleur selecteren
+STR_3101    :{SMALLFONT}{BLACK}Derde kleur selecteren
+STR_3102    :{SMALLFONT}{BLACK}Gekleurd decor opnieuw verven
+STR_3103    :Kan dit niet opnieuw ververen...
 STR_3104    :{SMALLFONT}{BLACK}Toon een lijst van attracties
 STR_3105    :{SMALLFONT}{BLACK}Toon een lijst van winkels en kraampjes
 STR_3106    :{SMALLFONT}{BLACK}Toon een lijst van informatiekiosken en andere faciliteiten
@@ -3109,50 +3109,50 @@ STR_3107    :Sluiten
 STR_3108    :Testen
 STR_3109    :Openen
 STR_3110    :{WINDOW_COLOUR_2}Blokken: {BLACK}{COMMA16}
-STR_3111    :{SMALLFONT}{BLACK}Click on design to build it
-STR_3112    :{SMALLFONT}{BLACK}Click on design to rename or delete it
-STR_3113    :Select a different design
-STR_3114    :{SMALLFONT}{BLACK}Go back to design selection window
-STR_3115    :{SMALLFONT}{BLACK}Save track design
-STR_3116    :{SMALLFONT}{BLACK}Save track design (Not possible until ride has been tested and statistics have been generated)
-STR_3117    :{BLACK}Calling mechanic...
-STR_3118    :{BLACK}{STRINGID} is heading for the ride
-STR_3119    :{BLACK}{STRINGID} is fixing the ride
-STR_3120    :{SMALLFONT}{BLACK}Locate nearest available mechanic, or mechanic fixing ride
-STR_3121    :Unable to locate mechanic, or all nearby mechanics are busy
-STR_3122    :{WINDOW_COLOUR_2}Favorite ride of: {BLACK}{COMMA16} guest
-STR_3123    :{WINDOW_COLOUR_2}Favorite ride of: {BLACK}{COMMA16} guests
+STR_3111    :{SMALLFONT}{BLACK}Klik op het ontwerp om het te bouwen
+STR_3112    :{SMALLFONT}{BLACK}Klik op het ontwerp om het te verwijderen of om het een andere naam te geven
+STR_3113    :Een ander ontwerp selecteren
+STR_3114    :{SMALLFONT}{BLACK}Terug naar ontwerpselectie
+STR_3115    :{SMALLFONT}{BLACK}Baanontwerp opslaan
+STR_3116    :{SMALLFONT}{BLACK}Baanontwerp opslaan (Niet mogelijk voordat de attractie is getest en de statistieken zijn gegenereerd)
+STR_3117    :{BLACK}Monteur wordt gebeld...
+STR_3118    :{BLACK}{STRINGID} gaat naar deze attractie
+STR_3119    :{BLACK}{STRINGID} is bezig deze attractie te repareren
+STR_3120    :{SMALLFONT}{BLACK}Vind de dichstbijzijnde monteur, of de monteur die de attractie aan het repareren is
+STR_3121    :Kan geen monteur vinden, of alle monteurs in de buurt zijn bezig
+STR_3122    :{WINDOW_COLOUR_2}Favoriet van: {BLACK}{COMMA16} bezoeker
+STR_3123    :{WINDOW_COLOUR_2}Favoriet van: {BLACK}{COMMA16} bezoekers
 STR_3124    :{STRINGID} defect
-STR_3125    :{WINDOW_COLOUR_2}Excitement Factor: {BLACK}+{COMMA16}%
-STR_3126    :{WINDOW_COLOUR_2}Intensity Factor: {BLACK}+{COMMA16}%
-STR_3127    :{WINDOW_COLOUR_2}Nausea Factor: {BLACK}+{COMMA16}%
+STR_3125    :{WINDOW_COLOUR_2}Spanningsfactor: {BLACK}+{COMMA16}%
+STR_3126    :{WINDOW_COLOUR_2}Intensiteitsfactor: {BLACK}+{COMMA16}%
+STR_3127    :{WINDOW_COLOUR_2}Misselijkheidsfactor: {BLACK}+{COMMA16}%
 STR_3128    :Baanontwerp opslaan
 STR_3129    :Baanontwerp en decor opslaan
 STR_3130    :Opslaan
 STR_3131    :Annuleren
-STR_3132    :{BLACK}Click items of scenery to select them to be saved with track design...
-STR_3133    :Unable to build this on a slope
-STR_3134    :{RED}(Design includes scenery which is unavailable)
-STR_3135    :{RED}(Vehicle design unavailable - Ride performance may be affected)
-STR_3136    :Warning: This design will be built with an alternative vehicle type and may not perform as expected
+STR_3132    :{BLACK}Klik op decoritems om ze op te slaan met het baanontwerp...
+STR_3133    :Kan dit niet bouwen op een helling
+STR_3134    :{RED}(Ontwerp bevat decor dat niet beschikbaar is)
+STR_3135    :{RED}(Karretjestype niet beschikbaar - dit kan van invloed zijn op de baanprestaties)
+STR_3136    :Waarschuwing: Dit ontwerp zal worden gebouwd met een ander type karretje, wat onverwachte effecten met zich mee kan brengen
 STR_3137    :Decor naast baan selecteren
 STR_3138    :Alles deselecteren
-STR_3139    :Cable lift unable to work in this operating mode
-STR_3140    :Cable lift hill must start immediately after station
-STR_3141    :Multi-circuit per ride not possible with cable lift hill
+STR_3139    :Kabellift kan niet functioneren in deze werkmodus
+STR_3140    :Kabellift moet meteen na het station beginnen
+STR_3141    :Meerdere circuits zijn niet mogelijk met een kabellift
 STR_3142    :{WINDOW_COLOUR_2}Capaciteit: {BLACK}{STRINGID}
-STR_3143    :{SMALLFONT}{BLACK}Show people on map
-STR_3144    :{SMALLFONT}{BLACK}Show rides and stalls on map
-STR_3145    :{SMALLFONT}{BLACK}Scroll {STRINGID} left
-STR_3146    :{SMALLFONT}{BLACK}Scroll {STRINGID} right
-STR_3147    :{SMALLFONT}{BLACK}Scroll {STRINGID} left fast
-STR_3148    :{SMALLFONT}{BLACK}Scroll {STRINGID} right fast
-STR_3149    :{SMALLFONT}{BLACK}Scroll {STRINGID} left/right
-STR_3150    :{SMALLFONT}{BLACK}Scroll {STRINGID} up
-STR_3151    :{SMALLFONT}{BLACK}Scroll {STRINGID} down
-STR_3152    :{SMALLFONT}{BLACK}Scroll {STRINGID} up fast
-STR_3153    :{SMALLFONT}{BLACK}Scroll {STRINGID} down fast
-STR_3154    :{SMALLFONT}{BLACK}Scroll {STRINGID} up/down
+STR_3143    :{SMALLFONT}{BLACK}Laat bezoekers zien op kaart
+STR_3144    :{SMALLFONT}{BLACK}Laat attracties en kraampjes zien op kaart
+STR_3145    :{SMALLFONT}{BLACK}Scroll {STRINGID} naar links
+STR_3146    :{SMALLFONT}{BLACK}Scroll {STRINGID} naar rechts
+STR_3147    :{SMALLFONT}{BLACK}Scroll {STRINGID} snel naar links
+STR_3148    :{SMALLFONT}{BLACK}Scroll {STRINGID} snel naar rechts
+STR_3149    :{SMALLFONT}{BLACK}Scroll {STRINGID} links/rechts
+STR_3150    :{SMALLFONT}{BLACK}Scroll {STRINGID} omhoog
+STR_3151    :{SMALLFONT}{BLACK}Scroll {STRINGID} omlaag
+STR_3152    :{SMALLFONT}{BLACK}Scroll {STRINGID} snel omhoog
+STR_3153    :{SMALLFONT}{BLACK}Scroll {STRINGID} snel omlaag
+STR_3154    :{SMALLFONT}{BLACK}Scroll {STRINGID} omhoog/omlaag
 STR_3155    :
 STR_3156    :
 STR_3157    :kaart
@@ -3167,77 +3167,77 @@ STR_3165    :
 STR_3166    :{BLACK}(ID: 
 STR_3167    :{WINDOW_COLOUR_2}Bevat {BLACK}{COMMA16} objecten
 STR_3168    :{WINDOW_COLOUR_2}Tekst: {BLACK}{STRINGID}
-STR_3169    :Data for the folLaaging object not found: 
-STR_3170    :Not enough space for graphics
-STR_3171    :Too many objects of this type selected
-STR_3172    :The folLaaging object must be selected first: 
-STR_3173    :This object is currently in use
-STR_3174    :This object is required by another object
-STR_3175    :This object is always required
-STR_3176    :Unable to select this object
-STR_3177    :Unable to de-select this object
-STR_3178    :At least one path object must be selected
-STR_3179    :At least one ride vehicle/attraction object must be selected
-STR_3180    :Invalid selection of objects
-STR_3181    :Object Selection - {STRINGID}
-STR_3182    :Park entrance type must be selected
-STR_3183    :Water type must be selected
-STR_3184    :Ride Vehicles/Attractions
-STR_3185    :Small Scenery
-STR_3186    :Large Scenery
-STR_3187    :Walls/Fences
-STR_3188    :Path Signs
-STR_3189    :Footpaths
-STR_3190    :Path Extras
-STR_3191    :Scenery Groups
-STR_3192    :Park Entrance
+STR_3169    :Data voor de volgende objecten niet gevonden: 
+STR_3170    :Niet genoeg ruimte voor graphics
+STR_3171    :Te veel objecten van dit type geselecteerd
+STR_3172    :De volgende objecten moeten eerst geselecteerd worden:
+STR_3173    :Dit object is momenteel in gebruik
+STR_3174    :Een ander object is afhankelijk van dit object
+STR_3175    :Dit object is altijd benodigd
+STR_3176    :Kan object niet selecteren
+STR_3177    :Kan object niet deselecteren
+STR_3178    :Er moet minstens 1 voetpad worden geselecteerd
+STR_3179    :Er moet minstens 1 attractie worden geselecteerd
+STR_3180    :Ongeldige selectie van objecten
+STR_3181    :Objectselectie - {STRINGID}
+STR_3182    :Er moet een parkingang worden geselecteerd
+STR_3183    :Er moet een watertyoe worden geselecteerd
+STR_3184    :Attracties/voertuigen
+STR_3185    :Klein decor
+STR_3186    :Groot decor
+STR_3187    :Muren/hekken
+STR_3188    :Borden voor paden
+STR_3189    :Voetpaden
+STR_3190    :Extra's voor paden
+STR_3191    :Decorgroepen
+STR_3192    :Parkingang
 STR_3193    :Water
-STR_3194    :Scenario Description
-STR_3195    :Invention List
-STR_3196    :{WINDOW_COLOUR_2}Research Group: {BLACK}{STRINGID}
-STR_3197    :{WINDOW_COLOUR_2}Items pre-invented at start of game:
-STR_3198    :{WINDOW_COLOUR_2}Items to invent during game:
-STR_3199    :Random Shuffle
-STR_3200    :{SMALLFONT}{BLACK}Randomly shuffle the list of items to invent during the game
-STR_3201    :Object Selection
-STR_3202    :Landscape Editor
-STR_3203    :Invention List Set Up
-STR_3204    :Options Selection
-STR_3205    :Objective Selection
-STR_3206    :Save Scenario
-STR_3207    :Roller Coaster Designer
-STR_3208    :Track Designs Manager
-STR_3209    :Back to Previous Step:
-STR_3210    :Forward to Next Step:
-STR_3211    :{WINDOW_COLOUR_2}Map size:
+STR_3194    :Scenariobeschrijving
+STR_3195    :Lijst van uitvindingen
+STR_3196    :{WINDOW_COLOUR_2}Onderzoeksgroep: {BLACK}{STRINGID}
+STR_3197    :{WINDOW_COLOUR_2}Items die aan het begin al zijn uitgevonden:
+STR_3198    :{WINDOW_COLOUR_2}Items die tijdens het spel kunnen worden uitgevonden:
+STR_3199    :Willekeurige volgorde
+STR_3200    :{SMALLFONT}{BLACK}Zet de lijst van tijdens het spel uit te vinden items in een willekeurige volgorde
+STR_3201    :Objectselectie
+STR_3202    :Landschap bewerken
+STR_3203    :Uitvindingen instellen
+STR_3204    :Opties selecteren
+STR_3205    :Doel selecteren
+STR_3206    :Scenario opslaan
+STR_3207    :Achtbaanontwerper
+STR_3208    :Baanontwerpbeheer
+STR_3209    :Terug naar de vorige stap:
+STR_3210    :Verder naar de volgende stap:
+STR_3211    :{WINDOW_COLOUR_2}Kaartgrootte:
 STR_3212    :{POP16}{COMMA16} x {PUSH16}{COMMA16}
-STR_3213    :Can't decrease map size any further
-STR_3214    :Can't increase map size any further
-STR_3215    :Too close to edge of map
-STR_3216    :{SMALLFONT}{BLACK}Select park-owned land etc.
-STR_3217    :Land Owned
-STR_3218    :Construction Rights Owned
-STR_3219    :Land For Sale
-STR_3220    :Construction Rights For Sale
-STR_3221    :{SMALLFONT}{BLACK}Set land to be owned by the park
-STR_3222    :{SMALLFONT}{BLACK}Set construction rights only to be owned by the park
-STR_3223    :{SMALLFONT}{BLACK}Set land to be available to purchase by the park
-STR_3224    :{SMALLFONT}{BLACK}Set construction rights to be available to purchase by the park
-STR_3225    :{SMALLFONT}{BLACK}Toggle on/off building a random cluster of objects around the selected position
-STR_3226    :{SMALLFONT}{BLACK}Build park entrance
-STR_3227    :Too many park entrances!
-STR_3228    :{SMALLFONT}{BLACK}Set starting positions for people
-STR_3229    :Block Brakes cannot be used directly after station
-STR_3230    :Block Brakes cannot be used directly after each other
-STR_3231    :Block Brakes cannot be used directly after the top of this lift hill
-STR_3232    :Options - Financial
-STR_3233    :Options - Guests
-STR_3234    :Options - Park
-STR_3235    :{SMALLFONT}{BLACK}Show financial options
-STR_3236    :{SMALLFONT}{BLACK}Show guest options
-STR_3237    :{SMALLFONT}{BLACK}Show park options
+STR_3213    :Kan kaart niet verder verkleinen
+STR_3214    :Kan kaart niet verder vergroten
+STR_3215    :Te dicht bij de rand van de kaart
+STR_3216    :{SMALLFONT}{BLACK}Selecteer parkland, etc.
+STR_3217    :Eigendom van het park
+STR_3218    :Bouwrechten voor het park
+STR_3219    :Te koop
+STR_3220    :Bouwrechten te koop
+STR_3221    :{SMALLFONT}{BLACK}Instellen welk land van het park is
+STR_3222    :{SMALLFONT}{BLACK}Instellen voor welk land het park bouwrechten heeft
+STR_3223    :{SMALLFONT}{BLACK}Instellen welk land gekocht kan worden door het park
+STR_3224    :{SMALLFONT}{BLACK}Instellen voor welk land bouwrechten te koop zijn
+STR_3225    :{SMALLFONT}{BLACK}Een willekeurig cluster van dit object neerzetten rondom de geselecteerde plek
+STR_3226    :{SMALLFONT}{BLACK}Parkingang bouwen
+STR_3227    :Teveel parkingangen!
+STR_3228    :{SMALLFONT}{BLACK}Geef startposities voor bezoekers aan
+STR_3229    :Blokremmen kunnen niet direct na het station geplaatst worden
+STR_3230    :Blokremmen kunnen niet direct achter elkaar gebruikt worden
+STR_3231    :Blokremmen kunnen niet direct achter de top van een kettingheuvel geplaatst worden
+STR_3232    :Opties - Financiëel
+STR_3233    :Opties - Bezoekers
+STR_3234    :Opties - Park
+STR_3235    :{SMALLFONT}{BLACK}Toon financiële opties
+STR_3236    :{SMALLFONT}{BLACK}Toon bezoekersopties
+STR_3237    :{SMALLFONT}{BLACK}Toon parkopties
 STR_3238    :Zonder geld
-STR_3239    :{SMALLFONT}{BLACK}Make this park a 'no money' park with no financial restrictions
+STR_3239    :{SMALLFONT}{BLACK}Schakel geld compleet uit, zodat het park geen financiële beperkingen heeft
 STR_3240    :{WINDOW_COLOUR_2}Startsaldo:
 STR_3241    :{WINDOW_COLOUR_2}Startlening
 STR_3242    :{WINDOW_COLOUR_2}Maximale lening:
@@ -3246,47 +3246,47 @@ STR_3244    :Marketingcampagnes niet toestaan
 STR_3245    :{SMALLFONT}{BLACK}Geen advertenties, promoties of andere marketingacties toestaan
 STR_3246    :{WINDOW_COLOUR_2}{CURRENCY}
 STR_3247    :{WINDOW_COLOUR_2}{COMMA16}%
-STR_3248    :Can't increase initial cash any further!
-STR_3249    :Can't reduce initial cash any further!
-STR_3250    :Can't increase initial loan any further!
-STR_3251    :Can't reduce initial loan any further!
-STR_3252    :Can't increase maximum loan size any further!
-STR_3253    :Can't reduce maximum loan size any further!
-STR_3254    :Can't increase interest rate any further!
-STR_3255    :Can't reduce interest rate any further!
-STR_3256    :Guests prefer less intense rides
-STR_3257    :{SMALLFONT}{BLACK}Select whether guests should generally prefer less intense rides only
-STR_3258    :Guests prefer more intense rides
-STR_3259    :{SMALLFONT}{BLACK}Select whether guests should generally prefer more intense rides only
-STR_3260    :{WINDOW_COLOUR_2}Cash per guest (average):
-STR_3261    :{WINDOW_COLOUR_2}Guests initial happiness:
-STR_3262    :{WINDOW_COLOUR_2}Guests initial hunger:
-STR_3263    :{WINDOW_COLOUR_2}Guests initial thirst:
-STR_3264    :Can't increase this any further!
-STR_3265    :Can't reduce this any further!
-STR_3266    :{SMALLFONT}{BLACK}Select how this park charges for entrance and rides
-STR_3267    :Forbid tree removal
-STR_3268    :{SMALLFONT}{BLACK}Forbid tall trees being removed
-STR_3269    :Forbid landscape changes
-STR_3270    :{SMALLFONT}{BLACK}Forbid any changes to the landscape
-STR_3271    :Forbid Hoog construction
-STR_3272    :{SMALLFONT}{BLACK}Forbid any tall construction
-STR_3273    :Park rating Hooger difficult level
-STR_3274    :{SMALLFONT}{BLACK}Make the park rating value more challenging
-STR_3275    :Guest generation Hooger difficult level
-STR_3276    :{SMALLFONT}{BLACK}Make it more difficult to attract guests to the park
-STR_3277    :{WINDOW_COLOUR_2}Cost to buy land:
-STR_3278    :{WINDOW_COLOUR_2}Cost to buy construction rights:
+STR_3248    :Kan het startsaldo niet verder verhogen!
+STR_3249    :Kan het startsaldo niet verder verlagen!
+STR_3250    :Kan de startlening niet verder verhogen!
+STR_3251    :Kan de startlening niet verder verlagen!
+STR_3252    :Kan de maximumlening niet verder verhogen!
+STR_3253    :Kan de maximumlening niet verder verlagen!
+STR_3254    :Kan de rente niet verder verhogen!
+STR_3255    :Kan de rente niet verder verlagen!
+STR_3256    :Bezoekers houden meer van rustigere attracties
+STR_3257    :{SMALLFONT}{BLACK}Selecteer of bezoekers in het algemeen meer van rustigere attracties houden
+STR_3258    :Bezoekers houden meer van spannende attracties
+STR_3259    :{SMALLFONT}{BLACK}Selecteer of bezoekers in het algemeen meer van spannende attracties houden
+STR_3260    :{WINDOW_COLOUR_2}Geld per bezoeker (gemiddeld):
+STR_3261    :{WINDOW_COLOUR_2}Aanvankelijke stemming bezoekers:
+STR_3262    :{WINDOW_COLOUR_2}Aanvankelijke honger bezoekers:
+STR_3263    :{WINDOW_COLOUR_2}Aanvankelijke dorst bezoekers:
+STR_3264    :Kan dit niet verder verhogen!
+STR_3265    :Kan dit niet verder verlagen!
+STR_3266    :{SMALLFONT}{BLACK}Selecteer hoe dit park geld vraagt voor entree en attracties
+STR_3267    :Verbied verwijderen bomen
+STR_3268    :{SMALLFONT}{BLACK}Verbied het verwijderen van bomen
+STR_3269    :Verbied veranderen landschap
+STR_3270    :{SMALLFONT}{BLACK}Verbied het veranderen van het landschap
+STR_3271    :Verbied hoog bouwen
+STR_3272    :{SMALLFONT}{BLACK}Verbied bouwen boven boomhoogte
+STR_3273    :Hogere moeilijkheid parkwaardering
+STR_3274    :{SMALLFONT}{BLACK}Maak het krijgen van een goede parkwaardering uitdagender
+STR_3275    :Hogere moeilijkheid bezoekersgeneratie
+STR_3276    :{SMALLFONT}{BLACK}Maak het moeilijker om bezoekers aan te trekken
+STR_3277    :{WINDOW_COLOUR_2}Prijs landaankoop:
+STR_3278    :{WINDOW_COLOUR_2}Prijs bouwrechten:
 STR_3279    :Gratis entree / Per rit betalen
 STR_3280    :Betaalde toegang / Attracties gratis
 STR_3281    :{WINDOW_COLOUR_2}Entreeprijs:
-STR_3282    :{SMALLFONT}{BLACK}Select objective and park name
-STR_3283    :{SMALLFONT}{BLACK}Select rides to be preserved
+STR_3282    :{SMALLFONT}{BLACK}Doel en parknaam selecteren
+STR_3283    :{SMALLFONT}{BLACK}Beschermde attracties selecteren
 STR_3284    :Doelselectie
 STR_3285    :Beschermde attracties
-STR_3286    :{SMALLFONT}{BLACK}Select objective for this scenario
+STR_3286    :{SMALLFONT}{BLACK}Selecteer doel voor dit scenario
 STR_3287    :{WINDOW_COLOUR_2}Doel:
-STR_3288    :{SMALLFONT}{BLACK}Select climate
+STR_3288    :{SMALLFONT}{BLACK}Selecteer klimaat:
 STR_3289    :{WINDOW_COLOUR_2}Klimaat:
 STR_3290    :Koel en nat
 STR_3291    :Warm
@@ -3295,75 +3295,75 @@ STR_3293    :Koud
 STR_3294    :Aanpassen...
 STR_3295    :{SMALLFONT}{BLACK}Parknaam veranderen
 STR_3296    :{SMALLFONT}{BLACK}Scenarionaam veranderen
-STR_3297    :{SMALLFONT}{BLACK}Change detail notes about park / scenario
+STR_3297    :{SMALLFONT}{BLACK}Details van dit park/scenario aanpassen
 STR_3298    :{WINDOW_COLOUR_2}Parknaam: {BLACK}{STRINGID}
-STR_3299    :{WINDOW_COLOUR_2}Park/Scenario Details:
-STR_3300    :{WINDOW_COLOUR_2}Scenario Name: {BLACK}{STRINGID}
-STR_3301    :{WINDOW_COLOUR_2}Objective Date:
+STR_3299    :{WINDOW_COLOUR_2}Parkdetails:
+STR_3300    :{WINDOW_COLOUR_2}Scenarionaam: {BLACK}{STRINGID}
+STR_3301    :{WINDOW_COLOUR_2}Datum doel:
 STR_3302    :{WINDOW_COLOUR_2}{MONTHYEAR}
-STR_3303    :{WINDOW_COLOUR_2}Number of guests:
-STR_3304    :{WINDOW_COLOUR_2}Park value:
-STR_3305    :{WINDOW_COLOUR_2}Monthly income:
-STR_3306    :{WINDOW_COLOUR_2}Monthly profit:
-STR_3307    :{WINDOW_COLOUR_2}Minimum length:
-STR_3308    :{WINDOW_COLOUR_2}Excitement rating:
+STR_3303    :{WINDOW_COLOUR_2}Aantal bezoekers:
+STR_3304    :{WINDOW_COLOUR_2}Parkwaarde:
+STR_3305    :{WINDOW_COLOUR_2}Maandelijkse inkomsten:
+STR_3306    :{WINDOW_COLOUR_2}Maandelijkse winst:
+STR_3307    :{WINDOW_COLOUR_2}Minimumlengte:
+STR_3308    :{WINDOW_COLOUR_2}Spanningswaarde:
 STR_3309    :{WINDOW_COLOUR_2}{COMMA16}
 STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
-STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
+STR_3312    :{WINDOW_COLOUR_2}Attracties met monumentenstatus:
 STR_3313    :Scenarionaam
-STR_3314    :Enter name for scenario:-
-STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3314    :Voer een naam in voor het scenario:
+STR_3315    :Details park/scenario
+STR_3316    :Geef een beschrijving voor dit scenario:
 STR_3317    :Nog geen details
-STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
-STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
-STR_3320    :Unable to save scenario file...
-STR_3321    :New objects installed successfully
-STR_3322    :{WINDOW_COLOUR_2}Objective: {BLACK}{STRINGID}
-STR_3323    :Missing object data, ID: 
-STR_3324    :Requires Add-On Pack: 
-STR_3325    :Requires an Add-On Pack
-STR_3326    :{WINDOW_COLOUR_2}(no image)
-STR_3327    :Starting positions for people not set
-STR_3328    :Can't advance to next editor stage...
-STR_3329    :Park entrance not yet built
-STR_3330    :Park must own some land
-STR_3331    :Path from park entrance to map edge either not complete or too complex - Path must be single-width with as few junctions and corners as possible
-STR_3332    :Park entrance is the wrong way round or has no path leading to the map edge
-STR_3333    :Export plug-in objects with saved games
-STR_3334    :{SMALLFONT}{BLACK}Select whether to save any additional plug-in object data required (add-in data not supplied with the main product) in saved game or scenario files, allowing them to be loaded by someone who doesn't have the additional object data
-STR_3335    :Roller Coaster Designer - Select Ride Types & Vehicles
-STR_3336    :Track Designs Manager - Select Ride Type
+STR_3318    :{SMALLFONT}{BLACK}Selecteer in welke groep dit scenario moet verschijnen
+STR_3319    :{WINDOW_COLOUR_2}Scenariogroep:
+STR_3320    :Kan scenariobestand niet opslaan...
+STR_3321    :Nieuwe objecten successvol geïnstalleerd
+STR_3322    :{WINDOW_COLOUR_2}Doel: {BLACK}{STRINGID}
+STR_3323    :Ontbrekende objectdata, ID: 
+STR_3324    :Vereist uitbreidingspakket:
+STR_3325    :Vereist een uitbreidingspakket
+STR_3326    :{WINDOW_COLOUR_2}(geen plaatje)
+STR_3327    :Startpositie voor bezoekers niet aangegeven
+STR_3328    :Kan niet verder naar volgende stap...
+STR_3329    :Parkingang nog niet gebouwd
+STR_3330    :Park moet land bezitten
+STR_3331    :Pad van de parkingang naar de rand van de kaart is incompleet of te complex - het pad mag maar één blok breed zijn en moet zo min mogelijk kruisingen en bochten bevatten
+STR_3332    :Parkingang staan achterstevoren of heeft geen pad naar de rand van de kaart
+STR_3333    :Niet-standaard objecten meeleveren in opgeslagen spellen
+STR_3334    :{SMALLFONT}{BLACK}Selecteer of toegevoegde (niet-standaard) objecten in opgeslagen spellen en scenario's moeten worden meegeleverd, zodat ze geopend kunnen worden door iemand die deze objecten nog niet heeft
+STR_3335    :Achtbaanontwerper - Attractietypes en -voertuigen selecteren
+STR_3336    :Baanontwerpbeheer - Attractietype selecteren
 STR_3337    :Six Flags-park
-STR_3338    :{BLACK}Custom-designed layout
-STR_3339    :{BLACK}{COMMA16} design available, or custom-designed layout
-STR_3340    :{BLACK}{COMMA16} designs available, or custom-designed layout
-STR_3341    :{SMALLFONT}{BLACK}Game tools
-STR_3342    :Scenario Editor
-STR_3343    :Convert Saved Game to Scenario
-STR_3344    :Roller Coaster Designer
-STR_3345    :Track Designs Manager
-STR_3346    :Can't save track design...
-STR_3347    :Ride is too large, contains too many elements, or scenery is too spread out
+STR_3338    :{BLACK}Eigen ontwerp
+STR_3339    :{BLACK}{COMMA16} ontwerp beschikbaar, of maak een eigen ontwerp
+STR_3340    :{BLACK}{COMMA16} ontwerpen beschikbaar, of maak een eigen ontwerp
+STR_3341    :{SMALLFONT}{BLACK}Hulpmiddelen
+STR_3342    :Scenariobewerker
+STR_3343    :Opgeslagen spel omzetten naar scenario
+STR_3344    :Achtbaanontwerper
+STR_3345    :Baanontwerpbeheer
+STR_3346    :Kan baanontwerp niet opslaan
+STR_3347    :Attractie is te groot, bevat teveel elementen, of het decor is te ver verspreid
 STR_3348    :Naam wijzigen
 STR_3349    :Verwijderen
-STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
-STR_3352    :Can't rename track design...
-STR_3353    :New name contains invalid characters
-STR_3354    :Another file exists with this name, or file is write-protected
-STR_3355    :File is write-protected or locked
-STR_3356    :Delete File
-STR_3357    :{WINDOW_COLOUR_2}Are you sure you want to permanently delete {STRINGID} ?
-STR_3358    :Can't delete track design...
-STR_3359    :{BLACK}No track designs of this type
-STR_3360    :Warschuwing!
-STR_3361    :Too many track designs of this type - Some will not be listed.
+STR_3350    :Naam baanontwerp
+STR_3351    :Voer een nieuwe naam in voor dit baanontwerp:
+STR_3352    :Kan het baanontwerp geen andere naam geven...
+STR_3353    :Nieuwe naam bevat ongeldige tekens
+STR_3354    :Er bestaat al een bestand met deze naam, of het bestand is beveiligd tegen schrijven
+STR_3355    :Bestand is beveiligd tegen schrijven of vergrendeld
+STR_3356    :Bestand verwijderen
+STR_3357    :{WINDOW_COLOUR_2}Weet je zeker dat je {STRINGID} permanent wilt verwijderen?
+STR_3358    :Kan het baanontwerp niet verwijderen...
+STR_3359    :{BLACK}Geen baanontwerpen van dit type
+STR_3360    :Waarschuwing!
+STR_3361    :Te veel baanontwerpen van dit type - sommige staan niet in de lijst
 STR_3362    :Mixing via softwarebuffer forceren
-STR_3363    :{SMALLFONT}{BLACK}Select this option to improve performance if the game pauses slightly when sounds start or interference is heard
+STR_3363    :{SMALLFONT}{BLACK}Selecteer deze optie om de prestaties te verbeteren als het spel vertraagt bij het afspelen van geluiden of als er ruis hoorbaar is
 STR_3364    :Meer opties
-STR_3365    :{SMALLFONT}{BLACK}allow selection of individual items of scenery in addition to scenery groups
+STR_3365    :{SMALLFONT}{BLACK}Maakt naast selectie van decorgroepen ook selectie van losse items mogelijk
 STR_3366    :{BLACK}= Attractie
 STR_3367    :{BLACK}= Eetkraampje
 STR_3368    :{BLACK}= Drankkraampje
@@ -3372,70 +3372,70 @@ STR_3370    :{BLACK}= Infokiosk
 STR_3371    :{BLACK}= Eerste hulp
 STR_3372    :{BLACK}= PIN
 STR_3373    :{BLACK}= Toilet
-STR_3374    :Warning: Too many objects selected!
-STR_3375    :Not all objects in this scenery group could be selected
-STR_3376    :Install new track design...
-STR_3377    :{SMALLFONT}{BLACK}Install a new track design file
+STR_3374    :Waarschuwing: teveel objecten geselecteerd!
+STR_3375    :Niet alle objecten in deze decorgroep kunnen worden geselecteerd
+STR_3376    :Nieuw baanontwerp installeren...
+STR_3377    :{SMALLFONT}{BLACK}Bestand met nieuw baanontwerp installeren
 STR_3378    :Installeren
 STR_3379    :Annuleren
-STR_3380    :Unable to install this track design...
-STR_3381    :File is not compatible or contains invalid data
-STR_3382    :File copy failed
-STR_3383    :Select new name for track design
-STR_3384    :An existing track design already has this name - Please select a new name for this design:
-STR_3385    :Beginners Tutorial
-STR_3386    :Custom Rides Tutorial
-STR_3387    :Roller Coaster Building Tutorial
-STR_3388    :Unable to switch to selected mode
-STR_3389    :Unable to select additional item of scenery...
-STR_3390    :Too many items selected
-STR_3391    :{SMALLFONT}{BLACK}Here is our park - Let's have a quick look around...
-STR_3392    :{SMALLFONT}{BLACK}Holding down the RIGHT mouse button and moving the mouse is the quickest way to move the view...
-STR_3393    :{SMALLFONT}{BLACK}To view more of the park, you can zoom the view out using the icon at the top of the screen...
-STR_3394    :{SMALLFONT}{BLACK}You can also rotate the view in 90 degree steps...
-STR_3395    :{SMALLFONT}{BLACK}Building anything at this scale is a bit difficult, so let's zoom the view back in again...
-STR_3396    :{SMALLFONT}{BLACK}Let's build a simple ride to get the park started...
-STR_3397    :{SMALLFONT}{BLACK}The white 'ghost' image shows where the ride will be built. We'll move the pointer to select the position then click to build it...
-STR_3398    :{SMALLFONT}{BLACK}Rides need an entrance and an exit. We'll move the pointer to a square on the edge of the ride and then click to build first the entrance and then the exit...
-STR_3399    :{SMALLFONT}{BLACK}We need to build footpaths to allow guests to reach our new ride...
-STR_3400    :{SMALLFONT}{BLACK}For the path to the ride entrance we'll use a special 'queue line' path...
-STR_3401    :{SMALLFONT}{BLACK}For the exit path, just an 'ordinary' path will do...
-STR_3402    :{SMALLFONT}{BLACK}Right, lets open the ride! To open the ride we click the flag icon on the ride window and select 'open'...
-STR_3403    :{SMALLFONT}{BLACK}But where are the guests?
-STR_3404    :{SMALLFONT}{BLACK}Oh - The park is still closed! Right - Let's open it...
-STR_3405    :{SMALLFONT}{BLACK}While we're waiting for our first guests, let's build some scenery...
-STR_3406    :{SMALLFONT}{BLACK}Here's our empty park. We're going to build a simple custom-designed ride...
-STR_3407    :{SMALLFONT}{BLACK}First we need to choose a starting position...
-STR_3408    :{SMALLFONT}{BLACK}The section of track we've just built is a 'station platform', to allow guests to get on and off the ride...
-STR_3409    :{SMALLFONT}{BLACK}We'll extend the platform a bit by adding a couple more station platform sections...
-STR_3410    :{SMALLFONT}{BLACK}The icons at the top of the construction window let you choose different track pieces to add...
-STR_3411    :{SMALLFONT}{BLACK}We'll select a left-hand curve...
-STR_3412    :{SMALLFONT}{BLACK}The curve hasn't been built yet, but the white ghost image shows where it will be built. Clicking the large 'build this' icon actually builds the track...
-STR_3413    :{SMALLFONT}{BLACK}Now we want to build straight track, so we click the straight track icon...
-STR_3414    :{SMALLFONT}{BLACK}Now that the circuit is complete, we need to build the ride entrance and exit...
-STR_3415    :{SMALLFONT}{BLACK}Let's test our ride to check it works...
-STR_3416    :{SMALLFONT}{BLACK}White it's being tested, we'll build the queue line and exit path...
-STR_3417    :{SMALLFONT}{BLACK}OK - Let's open the park and the ride...
-STR_3418    :{SMALLFONT}{BLACK}Our new ride isn't very exciting - Perhaps we should add some scenery?
-STR_3419    :{SMALLFONT}{BLACK}To build scenery above other scenery or in mid-air, hold down the SHIFT key and move the mouse to select the height...
-STR_3420    :{SMALLFONT}{BLACK}Some types of scenery can be re-painted after it's built...
-STR_3421    :{SMALLFONT}{BLACK}Let's add some music to the ride...
-STR_3422    :{SMALLFONT}{BLACK}Let's build a roller coaster !
-STR_3423    :{SMALLFONT}{BLACK}There are loads of pre-designed coasters, but we're going to build our own custom design...
-STR_3424    :{SMALLFONT}{BLACK}That's the station platform built. Now we need a lift hill...
-STR_3425    :{SMALLFONT}{BLACK}Roller coaster trains aren't powered, so a 'chain lift' is needed to pull the train up the first hill...
-STR_3426    :{SMALLFONT}{BLACK}That's the lift hill complete - Now for the first drop...
-STR_3427    :{SMALLFONT}{BLACK}Those curves are a bad idea - The riders will be flung to the sides by the lateral G forces as the train hurtles around...
-STR_3428    :{SMALLFONT}{BLACK}Banking the curves will improve the ride - Riders will be pushed down into their seats instead of flung to the sides...
-STR_3429    :{SMALLFONT}{BLACK}No - That won't work! Look at the height marks - The second hill is taller than the lift hill...
-STR_3430    :{SMALLFONT}{BLACK}To ensure the train makes it around, each hill should be slightly smaller than the previous one...
-STR_3431    :{SMALLFONT}{BLACK}That's better - Our train should make it up that hill now! Let's try some more twisted track...
-STR_3432    :{SMALLFONT}{BLACK}We need to slow the train before the final curve and station, so let's add some brakes...
-STR_3433    :{SMALLFONT}{BLACK}And finally we'll add 'block brakes', which allow two trains to operate more safely on the circuit...
-STR_3434    :{SMALLFONT}{BLACK}Let's test the ride and see if it works!
-STR_3435    :{SMALLFONT}{BLACK}Great - It worked! Let's add the footpaths and let guests onto our new roller coaster...
-STR_3436    :{SMALLFONT}{BLACK}While waiting for our first riders, we could customize the ride a bit...
-STR_3437    :{SMALLFONT}{BLACK}Clear large areas of scenery from landscape
+STR_3380    :Kan dit baanontwerp niet installeren...
+STR_3381    :Bestand is niet compatible of bevat ongeldige gegevens
+STR_3382    :Kopiëren van bestand mislukt
+STR_3383    :Selecteer nieuwe naam voor dit baanontwerp
+STR_3384    :Er bestaat al een baanontwerp met deze naam - verzin een andere naam voor dit ontwerp:
+STR_3385    :Tutorial voor beginners
+STR_3386    :Toturial voor eigen ontwerpen
+STR_3387    :Toturial voor achtbanen bouwen
+STR_3388    :Kan niet naar de geselecteerde modus overschakelen
+STR_3389    :Kan extra decorstukken niet selecteren...
+STR_3390    :Te veel items geselecteerd
+STR_3391    :{SMALLFONT}{BLACK}Dit is ons park - laten we eventjes kort rondkijken...
+STR_3392    :{SMALLFONT}{BLACK}De snelste manier om het beeld te verschuiven is de RECHTERmuisknop inhouden en met de muis bewegen...
+STR_3393    :{SMALLFONT}{BLACK}Als je meer van het park wil zien, kan je uitzoomen met het knopje bovenaan het scherm...
+STR_3394    :{SMALLFONT}{BLACK}Je kunt het beeld ook draaien in stappen van 90 graden...
+STR_3395    :{SMALLFONT}{BLACK}Dingen bouwen vanaf deze hoogte is een beetje lastig, laten we terug inzoomen...
+STR_3396    :{SMALLFONT}{BLACK}Laten we een simpele attractie bouwen om met dit park te beginnen...
+STR_3397    :{SMALLFONT}{BLACK}Het witte 'spookplaatje' laat zien waar de attractie zal worden gebouwd. Beweeg de muis er naar toe en klik om het te bouwen...
+STR_3398    :{SMALLFONT}{BLACK}Attracties hebben een ingang en een uitgang nodig. Beweeg de muis naar een tegeltje aan de rand van de attractie en klik om de ingang te bouwen. Klik nog een keer ergens om de uitgang te bouwen...
+STR_3399    :{SMALLFONT}{BLACK}We moeten een voetpad bouwen zodat bezoekers onze nieuwe attractie kunnen bereiken...
+STR_3400    :{SMALLFONT}{BLACK}Voor het pad naar de ingang gebruiken we een speciaal wachtrij-voetpad...
+STR_3401    :{SMALLFONT}{BLACK}Voor de uitgang maakt het niet uit welk pad je gebruikt. Een normaal pad is goed...
+STR_3402    :{SMALLFONT}{BLACK}Oké dan, laten we de attractie openen! Om de attractie te openen klikken we op het knopje met de vlag in het attractievenster en selecteren we 'openen'...
+STR_3403    :{SMALLFONT}{BLACK}Maar waar zijn de bezoekers?!
+STR_3404    :{SMALLFONT}{BLACK}Oh, juist - het park is nog gesloten! Laten we ons park openen...
+STR_3405    :{SMALLFONT}{BLACK}Terwijl we op onze eerste bezoekers wachten kunnen we wat decorstukken neerzetten...
+STR_3406    :{SMALLFONT}{BLACK}Dit is ons lege park. We gaan een simpele zelfontworpen attractie bouwen...
+STR_3407    :{SMALLFONT}{BLACK}Ten eerste hebben we een startpositie nodig...
+STR_3408    :{SMALLFONT}{BLACK}Het stuk baan dat we net gebouwd hebben is een 'station', en zorgt ervoor dat bezoekers in en uit kunnen stappen...
+STR_3409    :{SMALLFONT}{BLACK}We verlengen het perron een beetje door nog wat stationssegmenten aan te leggen...
+STR_3410    :{SMALLFONT}{BLACK}De knopjes aan de bovenkant van het bouwvenster laten je tusen verschillende soorten baanstukjes kiezen...
+STR_3411    :{SMALLFONT}{BLACK}We gaan een bocht naar links bouwen...
+STR_3412    :{SMALLFONT}{BLACK}De bocht is nog niet gebouwd, maar het witte spookplaatje laat zien waar het gebouwd gaat worden. Als je op de grote knop klikt wordt het gebouwd...
+STR_3413    :{SMALLFONT}{BLACK}Nu willen we een recht stuk bouwen, dus klikken we op het knopje voor 'recht stuk'...
+STR_3414    :{SMALLFONT}{BLACK}De baan is af, we kunnen nu de ingang en uitgang bouwen...
+STR_3415    :{SMALLFONT}{BLACK}Laten we testen of onze attractie werkt...
+STR_3416    :{SMALLFONT}{BLACK}Terwijl de attractie wordt getest kunnen we een wachtrij en uitgangspad bouwen...
+STR_3417    :{SMALLFONT}{BLACK}Goed - laten we het park en onze attractie openen...
+STR_3418    :{SMALLFONT}{BLACK}Onze nieuwe attractie is niet heel erg spannend - misschien moeten we wat decor toevoegen?
+STR_3419    :{SMALLFONT}{BLACK}Om decor te bouwen boven ander decor (of midden in de lucht) hou je de SHIFT-toets ingedrukt en beweeg je de muis om de hoogte te bepalen...
+STR_3420    :{SMALLFONT}{BLACK}Sommige types decor kunnen opnieuw geverfd worden nadat ze zijn gebouwd...
+STR_3421    :{SMALLFONT}{BLACK}Laten we wat muziek draaien in onze attractie...
+STR_3422    :{SMALLFONT}{BLACK}Laten we een achtbaan bouwen!
+STR_3423    :{SMALLFONT}{BLACK}Er zijn veel kant-en-klare achtbanen, maar wij gaan ons eigen ontwerp bouwen...
+STR_3424    :{SMALLFONT}{BLACK}Zo, het station is af. Nu hebben we een liftheuvel nodig...
+STR_3425    :{SMALLFONT}{BLACK}Achtbaankarretjes zijn niet aangedreven, dus is een 'kettinglift' nodig om ze eerst een heuvel op te trekken...
+STR_3426    :{SMALLFONT}{BLACK}Goed, de liftheuvel is klaar - nu de eerste afdaling...
+STR_3427    :{SMALLFONT}{BLACK}Die bochten zijn een slecht idee - de passagiers zullen naar de zijkanten gesmeten worden wanneer de trein er doorheen raast...
+STR_3428    :{SMALLFONT}{BLACK}De bochten een banking (schuinleggen) geven zal de rit prettiger maken - de passagiers zullen in hun stoelen geduwd worden in plaats van naar de zijkanten...
+STR_3429    :{SMALLFONT}{BLACK}Dit gaat niet werken! Kijk naar de hoogtemarkeringen - De tweede heuvel is hoger dan de liftheuvel...
+STR_3430    :{SMALLFONT}{BLACK}Om ervoor te zorgen dat de trein terug naar het station komt, moet elke heuvel iets lager zijn dan de heuvel daarvoor...
+STR_3431    :{SMALLFONT}{BLACK}Dat ziet er beter uit! Onze trein zou het nu moeten halen! Laten we wat meer bochtige stukjes toevoegen...
+STR_3432    :{SMALLFONT}{BLACK}We moeten de trein afremmen voordat we de laatste bocht en het station inkomen, dus laten we wat remmen toevoegen...
+STR_3433    :{SMALLFONT}{BLACK}En tenslotte voegen we 'blokremmen' toe. Die zorgen ervoor dat twee treinen tegelijk (en veilig) op de baan kunnen zitten...
+STR_3434    :{SMALLFONT}{BLACK}Laten we kijken of onze achtbaan werkt!
+STR_3435    :{SMALLFONT}{BLACK}Fantastisch - hij werkt! Laten we wat voetpaden aanleggen zodat bezoekers bij onze nieuwe achtbaan kunnen komen...
+STR_3436    :{SMALLFONT}{BLACK}Terwijl we wachten op onze eerste bezoekers, kunnen we onze achtbaan een beetje aanpassen...
+STR_3437    :{SMALLFONT}{BLACK}Grote gebieden met decor van het landschap verwijderen
 STR_3438    :Kan hier niet al het decor verwijderen...
 STR_3439    :Decor verwijderen
 STR_3440    :Pagina 1


### PR DESCRIPTION
Also includes many new strings. Dutch is nearing completion now.

I restored most of my own translations. Some explanation:
- Lift chain hill and cable lift are two different things. The first is the well-known method to pull cars up, the second is a unique part of the Giga Coaster that pulls the train up at 24 km/h, using, you guessed it, a cable. The Goliath in the Six Flags Holland scenario uses it (the same goes for the real-life version!).
- I kept 'Autorondrit' as the translation for 'Car ride', since it seems to be a more 'official' term, if you like, than 'Rit in een karretje' (as it was translated in RCT1)
- I kept 'Tutorial', since it's mostly used untranslated (in Dutch RCT forums for example, most of which are sadly long gone).
- I kept 'Smalspoorweg' as the translation for 'Miniature Railway', but I would be fine with 'Miniatuurspoorweg' if most native Dutch speakers find it better.

(There may be some other things. If you wonder why I translated something in a particular way, feel free to ask it.)
