### PR TITLE
Fixed typo in window_staff_peep_stats_update

### DIFF
--- a/src/window_staff_peep.c
+++ b/src/window_staff_peep.c
@@ -691,7 +691,7 @@ void window_staff_peep_stats_update(rct_window* w)
 	window_invalidate_by_id(0x697, w->number);
 
 	rct_peep* peep = GET_PEEP(w->number);
-	if (peep->var_45 && 10) {
+	if (peep->var_45 & 0x10) {
 		peep->var_45 &= 0xEF;
 		window_invalidate(w);
 	}


### PR DESCRIPTION
Fixed typo from c50b9d12149bc36799dd56215a8372ed055e57c.
