### PR TITLE
Replace calls to 6ACC28 with the existing decompiled function

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -32,6 +32,7 @@
 #include "viewport.h"
 #include "widget.h"
 #include "window.h"
+#include "window_ride.h"
 #include "window_tooltip.h"
 
 POINT _dragPosition;
@@ -789,7 +790,7 @@ static void game_handle_input_mouse(int x, int y, int state)
 						eax = RCT2_ADDRESS(0x0099BA64, uint8)[16 * map_element->properties.track.type];
 						if (!(eax & 0x10)){//If not station track
 							//Open ride window in overview mode.
-							RCT2_CALLPROC_X(0x6ACC28, map_element->properties.track.ride_index, ebx, ecx, (int)map_element, esi, edi, ebp);
+							window_ride_main_open(map_element->properties.track.ride_index);
 							break;
 						}
 					}

--- a/src/news_item.c
+++ b/src/news_item.c
@@ -28,6 +28,7 @@
 #include "string_ids.h"
 #include "sprite.h"
 #include "window.h"
+#include "window_ride.h"
 
 void window_game_bottom_toolbar_invalidate_news_item();
 static int news_item_get_new_history_slot();
@@ -291,7 +292,7 @@ void news_item_open_subject(int type, int subject) {
 
 	switch (type) {
 	case NEWS_ITEM_RIDE:
-		RCT2_CALLPROC_X(0x006ACC28, subject, 0, 0, 0, 0, 0, 0);
+		window_ride_main_open(subject);
 		break;
 	case NEWS_ITEM_PEEP_ON_RIDE:
 	case NEWS_ITEM_PEEP:

--- a/src/window_ride.c
+++ b/src/window_ride.c
@@ -28,6 +28,7 @@
 #include "widget.h"
 #include "window.h"
 #include "window_dropdown.h"
+#include "window_ride.h"
 
 #pragma region Widgets
 

--- a/src/window_ride.h
+++ b/src/window_ride.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * Copyright (c) 2014 Ted John
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * This file is part of OpenRCT2.
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+#ifndef _WINDOW_RIDE_H_
+#define _WINDOW_RIDE_H_
+
+void window_ride_main_open(int rideIndex);
+
+#endif // _WINDOW_RIDE_H_


### PR DESCRIPTION
Already have window_ride_main_open, but not using it everywhere. I wouldn't be surprised if this is happening in a bunch of other places, I'll hack up a quick script to check
