### PR TITLE
Fix double payment in game_do_command

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -515,7 +515,6 @@ int game_do_command_p(int command, int *eax, int *ebx, int *ecx, int *edx, int *
 			if (!(flags & 0x20)) {
 				// Update money balance
 				finance_payment(cost, RCT2_GLOBAL(0x0141F56C, uint8));
-				RCT2_CALLPROC_X(0x0069C674, 0, cost, 0, 0, 0, 0, 0);
 				if (RCT2_GLOBAL(0x0141F568, uint8) == RCT2_GLOBAL(0x013CA740, uint8)) {
 					// Create a +/- money text effect
 					if (cost != 0)


### PR DESCRIPTION
As pointed out by @vanderkleij, we called the original payment code after the new one in the game_do_command function. It was only used in the footpath tool, so it was barely noticeable.
