### PR TITLE
Fixes unselectable fifth row. Fix #431.

### DIFF
--- a/src/window_new_ride.c
+++ b/src/window_new_ride.c
@@ -870,7 +870,7 @@ static ride_list_item window_new_ride_scroll_get_ride_list_item_at(rct_window *w
 
 	int column = x / 116;
 	int row = y / 116;
-	if (row >= 5)
+	if (column >= 5)
 		return result;
 
 	int index = column + (row * 5);


### PR DESCRIPTION
Error was caused by checking for the wrong maximum value. There can only be 5 columns not 5 rows.
