### PR TITLE
Fix errors/warnings in VS build

### DIFF
--- a/projects/openrct2.vcxproj
+++ b/projects/openrct2.vcxproj
@@ -190,7 +190,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(SolutionDir)..\lodepng;$(SolutionDir)..\sdl\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)..\lodepng;$(SolutionDir)..\sdl\include;$(SolutionDir)..\libspeex;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)..\sdl\lib\x86;$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)..\build\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(Configuration)\</IntDir>

--- a/src/input.c
+++ b/src/input.c
@@ -1062,7 +1062,7 @@ static void input_mouseover(int x, int y, rct_window *w, int widgetIndex)
 {
 	rct_windowclass windowClass = 255;
 	rct_windownumber windowNumber = 0;
-	rct_widget *widget;
+	rct_widget *widget = NULL;
 
 	if (w != NULL) {
 		windowClass = w->classification;

--- a/src/language.c
+++ b/src/language.c
@@ -134,7 +134,8 @@ static int language_open_file(const char *filename)
 
 	language_strings = calloc(STR_COUNT, sizeof(char*));
 
-	char *dst, *token;
+	char *dst = NULL;
+	char *token = NULL;
 	char tokenBuffer[64];
 	int i, stringIndex = 0, mode = 0, string_no;
 	for (i = 0; i < language_buffer_size; i++) {

--- a/src/park.c
+++ b/src/park.c
@@ -467,7 +467,7 @@ static void get_random_peep_spawn(rct2_peep_spawn *spawn)
 
 static rct_peep *park_generate_new_guest()
 {
-	rct_peep *peep;
+	rct_peep *peep = NULL;
 	rct2_peep_spawn spawn;
 	get_random_peep_spawn(&spawn);
 


### PR DESCRIPTION
- Added libspeex to 'Debug' target, previously only 'Release' had it.
- Initialize some pointers with NULL when an uninitialized code path is
  unlikely, but possible.
