### PR TITLE
Basic analysis of window_map_mousedown

### DIFF
--- a/src/window_map.c
+++ b/src/window_map.c
@@ -338,7 +338,14 @@ static void window_map_mouseup()
 */
 static void window_map_mousedown(int widgetIndex, rct_window*w, rct_widget* widget)
 {
-	RCT2_CALLPROC_EBPSAFE(0x0068D040);
+	// The normal map window doesn't have widget 8 or 9.
+	// I assume these widgets refer to the Scenario Editor's map window.
+	if (widgetIndex == 8) {
+		RCT2_CALLPROC_EBPSAFE(0x0068D641);
+	}
+	else if (widgetIndex == 9) {
+		RCT2_CALLPROC_EBPSAFE(0x0068D6B4);
+	}
 }
 
 /**


### PR DESCRIPTION
- This function doesn't appear to be relevant to the normal map window, as
  it doesn't have the required widgets. Considering that the Scenario
  Editor has a more complex map window, I assume that this function does
  processing referred to that instance instead.
