### PR TITLE
mixer fix

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -31,7 +31,7 @@ typedef struct {
 extern int gAudioDeviceCount;
 extern audio_device *gAudioDevices;
 
-#define AUDIO_MAX_VEHICLE_SOUNDS 50
+#define AUDIO_MAX_VEHICLE_SOUNDS 14
 
 void audio_init();
 void audio_quit();

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -364,7 +364,7 @@ void vehicle_sounds_update()
 						vehicle_sound->sound1_id = sprite->vehicle.sound1_id;
 #ifndef USE_MIXER
 						RCT2_GLOBAL(0x014241BC, uint32) = 1;
-						sound_prepare(sprite->vehicle.var_BB, &vehicle_sound->sound1, 1, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SOUND_SW_BUFFER, uint32));
+						sound_prepare(sprite->vehicle.sound1_id, &vehicle_sound->sound1, 1, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SOUND_SW_BUFFER, uint32));
 						RCT2_GLOBAL(0x014241BC, uint32) = 0;
 #endif
 						vehicle_sound->sound1_pan = vehicle_sound_params->pan;
@@ -461,7 +461,7 @@ void vehicle_sounds_update()
 						vehicle_sound->sound2_id = sprite->vehicle.sound2_id;
 #ifndef USE_MIXER
 						RCT2_GLOBAL(0x014241BC, uint32) = 1;
-						sound_prepare(sprite->vehicle.var_BD, &vehicle_sound->sound2, 1, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SOUND_SW_BUFFER, uint32));
+						sound_prepare(sprite->vehicle.sound2_id, &vehicle_sound->sound2, 1, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SOUND_SW_BUFFER, uint32));
 						RCT2_GLOBAL(0x014241BC, uint32) = 0;
 #endif
 						vehicle_sound->sound2_pan = vehicle_sound_params->pan;

--- a/src/window_options.c
+++ b/src/window_options.c
@@ -505,7 +505,11 @@ static void window_options_dropdown()
 	case WIDX_SOUND_DROPDOWN:
 		audio_init2(dropdownIndex);
 		if (dropdownIndex < gAudioDeviceCount) {
-			Mixer_Init(gAudioDevices[dropdownIndex].name);
+			int devicenum = dropdownIndex;
+			if (devicenum == 0) {
+				devicenum = 1;
+			}
+			Mixer_Init(gAudioDevices[devicenum].name);
 		}
 		/*#ifdef _MSC_VER
 		__asm movzx ax, dropdownIndex		


### PR DESCRIPTION
fixed the vehicle.c compile error, stop sounds on close, default audio device fix, locks for audio to prevent a popping, max vehicle sounds set lower because it was using too much cpu
