### PR TITLE
RCT_CALLFUNC now saves flags register.

### DIFF
--- a/src/addresses.h
+++ b/src/addresses.h
@@ -709,12 +709,12 @@ static int RCT2_CALLFUNC_X(int address, int *_eax, int *_ebx, int *_ecx, int *_e
 				/* Pop ebx reg into ecx*/ \n\
 				pop ecx		\n\
 				mov eax, [%[_ebx]] \n\
-				mov[eax], ecx \n\
+				mov [eax], ecx \n\
 				\n\
 				/* Pop ebp reg into ecx */\n\
 				pop ecx \n\
 				mov eax, [%[_ebp]] \n\
-				mov[eax], ecx \n\
+				mov [eax], ecx \n\
 				\n\
 				pop eax \n\
 				/* Get resulting eax register*/ \n\


### PR DESCRIPTION
This is a slight enhancment as mentioned in #422. I've added a little comment on how to use the flags register as well.
I have not tested this on anything other than Visual Studio so there is a chance it will not work.
