### PR TITLE
Fix the broken MinGW-w64 link at the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ A third-party offers [downloadable precompiled builds](https://openrct2.com/down
 - RollerCoaster Tycoon 2
 
 ### Mac OS X / Linux:
-- [MinGW-w64](mingw-w64.sourceforge.net)
+- [MinGW-w64](http://mingw-w64.sourceforge.net/)
 - [Wine](http://www.winehq.org)
 - RollerCoaster Tycoon 2
 - libsdl2 compiled with MinGW-w64


### PR DESCRIPTION
Previously this lead to a 404 page on GitHub. Now the link leads you to the correct page at Sourceforge. Probably the one who added this was using Chrome and then forgot to add https:// to the link.
