### PR TITLE
Fix #426

### DIFF
--- a/src/rct2.c
+++ b/src/rct2.c
@@ -229,6 +229,7 @@ void check_file_path(int pathId)
 	{
 	case PATH_ID_GAMECFG:
 	case PATH_ID_SCORES:
+	case PATH_ID_TRACKSIDX:
 		// Do nothing; these will be created later if they do not exist yet
 		break;
 


### PR DESCRIPTION
Fixes #426 
Fixes none generation of tracks.idx.
There is no reason to check for tracks.idx with check_file_path as it is created later on so may as well skip the check. Note this is not how rct2 has done it. 
