### PR TITLE
Fix load fail

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -609,39 +609,6 @@ static void load_landscape()
 	}
 }
 
-/* rct2: 0x675827 */
-void set_load_objects_fail_reason(){
-	rct_object_entry* object = RCT2_ADDRESS(0x13CE952, rct_object_entry);
-	int expansion = (object->flags & 0xFF) >> 4;
-	if (expansion == 0
-		|| expansion == 8
-		|| RCT2_GLOBAL(0x9AB4C0, uint16) & (1 << expansion)){
-
-		char* string_buffer = RCT2_ADDRESS(0x9BC677, char);
-
-		format_string(string_buffer, 3323, 0); //Missing object data, ID:
-
-		RCT2_CALLPROC_X(0x6AB344, 0, 0, 0, 0, 0, (int)string_buffer, 0x13CE952);
-		RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
-		RCT2_GLOBAL(0x9AC31C, uint16) = 3165;
-		return;
-	}
-
-	char* exapansion_name = &RCT2_ADDRESS(RCT2_ADDRESS_EXPANSION_NAMES, char)[128 * expansion];
-	if (*exapansion_name == '\0'){
-		RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
-		RCT2_GLOBAL(0x9AC31C, uint16) = 3325;
-		return;
-	}
-
-	char* string_buffer = RCT2_ADDRESS(0x9BC677, char);
-
-	format_string(string_buffer, 3324, 0); // Requires expansion pack
-	strcat(string_buffer, exapansion_name);
-	RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
-	RCT2_GLOBAL(0x9AC31C, uint16) = 3165;
-}
-
 /**
  * 
  *  rct2: 0x00675E1B
@@ -709,7 +676,8 @@ int game_load_save(const char *path)
 			RCT2_GLOBAL(0x9DE518, uint32) &= ~(1<<5);
 		}
 		title_load();
-		return 0;// In the original this would call end_update but we get the same by returning 0
+		rct2_endupdate();
+		return 0;//This never gets called
 	}
 
 	// The rest is the same as in scenario load and play

--- a/src/object.h
+++ b/src/object.h
@@ -48,6 +48,7 @@ extern int object_entry_group_counts[];
 extern int object_entry_group_encoding[];
 
 void object_list_load();
+void set_load_objects_fail_reason();
 int object_read_and_load_entries(FILE *file);
 int object_load_packed(FILE *file);
 void object_unload_all();

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -22,6 +22,7 @@
 #include "addresses.h"
 #include "object.h"
 #include "util/sawyercoding.h"
+#include "localisation/localisation.h"
 
 #define OBJECT_ENTRY_GROUP_COUNT 11
 #define OBJECT_ENTRY_COUNT 721
@@ -167,6 +168,39 @@ static int check_object_entry(rct_object_entry *entry)
 {
 	uint32 *dwords = (uint32*)entry;
 	return (0xFFFFFFFF & dwords[0] & dwords[1] & dwords[2] & dwords[3]) + 1 != 0;
+}
+
+/* rct2: 0x675827 */
+void set_load_objects_fail_reason(){
+	rct_object_entry* object = RCT2_ADDRESS(0x13CE952, rct_object_entry);
+	int expansion = (object->flags & 0xFF) >> 4;
+	if (expansion == 0
+		|| expansion == 8
+		|| RCT2_GLOBAL(0x9AB4C0, uint16) & (1 << expansion)){
+
+		char* string_buffer = RCT2_ADDRESS(0x9BC677, char);
+
+		format_string(string_buffer, 3323, 0); //Missing object data, ID:
+
+		RCT2_CALLPROC_X(0x6AB344, 0, 0, 0, 0, 0, (int)string_buffer, 0x13CE952);
+		RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
+		RCT2_GLOBAL(0x9AC31C, uint16) = 3165;
+		return;
+	}
+
+	char* exapansion_name = &RCT2_ADDRESS(RCT2_ADDRESS_EXPANSION_NAMES, char)[128 * expansion];
+	if (*exapansion_name == '\0'){
+		RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
+		RCT2_GLOBAL(0x9AC31C, uint16) = 3325;
+		return;
+	}
+
+	char* string_buffer = RCT2_ADDRESS(0x9BC677, char);
+
+	format_string(string_buffer, 3324, 0); // Requires expansion pack
+	strcat(string_buffer, exapansion_name);
+	RCT2_GLOBAL(0x9AC31B, uint8) = 0xFF;
+	RCT2_GLOBAL(0x9AC31C, uint16) = 3165;
 }
 
 /**

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -19,6 +19,7 @@
  *****************************************************************************/
 
 #include <windows.h>
+#include "title.h"
 #include "addresses.h"
 #include "game.h"
 #include "interface/viewport.h"
@@ -110,7 +111,7 @@ int scenario_load(const char *path)
 					object_list_load();
 			}
 
-			object_read_and_load_entries(file);
+			uint8 load_success = object_read_and_load_entries(file);
 
 			// Read flags (16 bytes). Loads:
 			//	RCT2_ADDRESS_CURRENT_MONTH_YEAR
@@ -147,7 +148,12 @@ int scenario_load(const char *path)
 			sawyercoding_read_chunk(file, (uint8*)RCT2_ADDRESS_COMPLETED_COMPANY_VALUE);
 
 			fclose(file);
-
+			if (!load_success){
+				set_load_objects_fail_reason();
+				title_load();
+				rct2_endupdate();
+				return 0;//This never gets called
+			}
 			// Check expansion pack
 			// RCT2_CALLPROC_EBPSAFE(0x006757E6);
 

--- a/src/windows/error.c
+++ b/src/windows/error.c
@@ -103,6 +103,9 @@ void window_error_open(rct_string_id title, rct_string_id message)
 		dst += get_string_length(dst);
 	}
 
+	printf(_window_error_text+1);
+	printf("\r\n");
+
 	// Check if there is any text to display
 	if (dst == _window_error_text + 1)
 		return;


### PR DESCRIPTION
This fixes the issue where the game crashes when the objects that are being loaded are not correct (invalid checksum or missing). 
Fixes #434, #437, #225.

I've also modified the error window so that it copies any error messages onto the cmd prompt.
