### PR TITLE
Possible fix to #543

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -477,7 +477,7 @@ int object_get_length(rct_object_entry *entry)
 
 rct_object_entry *object_get_next(rct_object_entry *entry)
 {
-	char *pos = (char*)entry;
+	uint8 *pos = (char*)entry;
 
 	// Skip sizeof(rct_object_entry)
 	pos += 16;


### PR DESCRIPTION
Will need confirmation from @Gymnasiast but this should fix the crash at startup. Issue was only occurring when you had a custom object that was composed of a very large amount theme objects (>127). 
