### PR TITLE
Fix for sub_6E7F34 in viewport.c

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -334,7 +334,6 @@ void sub_6E7F34(rct_window* w, rct_viewport* viewport, sint16 x_diff, sint16 y_d
 	RCT2_CALLPROC_X(0x6E7FF3, 0, 0, 0, x_diff, (int)viewport, (int)w, y_diff);
 }
 
-/* There is a bug in this. */
 void sub_6E7DE1(sint16 x, sint16 y, rct_window* w, rct_viewport* viewport){
 	//RCT2_CALLPROC_X(0x6E7DE1, x, y, 0, 0, w, viewport, 0);
 	//return;


### PR DESCRIPTION
I'd like @duncanspumpkin to review this as he disabled these functions and I'm not sure if this fix is correct and has removed all the issues. I'm also not sure if the argument should still be named `previous_x`. The second commit is an unrelated logic fix that didn't cause any noticeable change.

The strange thing is, when I set `previous_x` and `previous_y` to 0 at the top of `sub_6E7F34`, everything still seems to work correctly. But the old `RCT2_CALLPROC_X(0x6E7F34, 0, 0, 0, 0, (int)viewport, (int)w, 0);` was doing pretty much the same but caused large glitches, so I'm still not completely sure what's going on there.
