### PR TITLE
[RFC] Separate external libraries and language files into VS projects

### DIFF
--- a/projects/language/language.vcxproj
+++ b/projects/language/language.vcxproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0468FC1E-5881-4DB9-9DDE-1892290B31D9}</ProjectGuid>
+    <RootNamespace>language</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)..\build\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)..\build\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /Y "$(SolutionDir)\..\Data\Language\*.*" "$(TargetDir)\Data\Language\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="..\..\data\language\dutch.txt" />
+    <Text Include="..\..\data\language\english_uk.txt" />
+    <Text Include="..\..\data\language\english_us.txt" />
+    <Text Include="..\..\data\language\french.txt" />
+    <Text Include="..\..\data\language\german.txt" />
+    <Text Include="..\..\data\language\hungarian.txt" />
+    <Text Include="..\..\data\language\polish.txt" />
+    <Text Include="..\..\data\language\spanish_sp.txt" />
+    <Text Include="..\..\data\language\swedish.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/language/language.vcxproj.filters
+++ b/projects/language/language.vcxproj.filters
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Resource Files\Language">
+      <UniqueIdentifier>{96ec0470-f3e0-443e-8715-171ad8676bb6}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\..\data\language\dutch.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\english_uk.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\english_us.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\german.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\french.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\hungarian.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\polish.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\spanish_sp.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+    <Text Include="..\..\data\language\swedish.txt">
+      <Filter>Resource Files\Language</Filter>
+    </Text>
+  </ItemGroup>
+</Project>

--- a/projects/libs/libs.vcxproj
+++ b/projects/libs/libs.vcxproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}</ProjectGuid>
+    <RootNamespace>libs</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)..\build\libs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\libs\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)..\build\libs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\libs\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>1Byte</StructMemberAlignment>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>1Byte</StructMemberAlignment>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\lib\argparse\argparse.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\libspeex\resample.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\lodepng\lodepng.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\lib\argparse\argparse.h" />
+    <ClInclude Include="..\..\lib\libspeex\arch.h" />
+    <ClInclude Include="..\..\lib\libspeex\config.h" />
+    <ClInclude Include="..\..\lib\libspeex\os_support.h" />
+    <ClInclude Include="..\..\lib\libspeex\speex\speex_resampler.h" />
+    <ClInclude Include="..\..\lib\libspeex\speex\speex_types.h" />
+    <ClInclude Include="..\..\lib\libspeex\stack_alloc.h" />
+    <ClInclude Include="..\..\lib\lodepng\lodepng.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/libs/libs.vcxproj.filters
+++ b/projects/libs/libs.vcxproj.filters
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="argparse">
+      <UniqueIdentifier>{f28d7721-061f-44b8-bbd5-42dc9483b387}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libspeex">
+      <UniqueIdentifier>{69f22202-b887-4e7c-bf7c-eb581571398d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libspeex\speex">
+      <UniqueIdentifier>{45966214-8043-431c-8eb3-920c00bf749d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="lodepng">
+      <UniqueIdentifier>{7f953e55-d294-4158-b309-67f41fa82760}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\lib\argparse\argparse.c">
+      <Filter>argparse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\libspeex\resample.c">
+      <Filter>libspeex</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\lodepng\lodepng.c">
+      <Filter>lodepng</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\lib\argparse\argparse.h">
+      <Filter>argparse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\arch.h">
+      <Filter>libspeex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\config.h">
+      <Filter>libspeex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\os_support.h">
+      <Filter>libspeex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\stack_alloc.h">
+      <Filter>libspeex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\speex\speex_resampler.h">
+      <Filter>libspeex\speex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\libspeex\speex\speex_types.h">
+      <Filter>libspeex\speex</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\lodepng\lodepng.h">
+      <Filter>lodepng</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/openrct2.sln
+++ b/projects/openrct2.sln
@@ -1,9 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openrct2", "openrct2.vcxproj", "{D24D94F6-2A74-480C-B512-629C306CE92F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0468FC1E-5881-4DB9-9DDE-1892290B31D9} = {0468FC1E-5881-4DB9-9DDE-1892290B31D9}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "language", "language\language.vcxproj", "{0468FC1E-5881-4DB9-9DDE-1892290B31D9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libs", "libs\libs.vcxproj", "{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +22,14 @@ Global
 		{D24D94F6-2A74-480C-B512-629C306CE92F}.Debug|Win32.Build.0 = Debug|Win32
 		{D24D94F6-2A74-480C-B512-629C306CE92F}.Release|Win32.ActiveCfg = Release|Win32
 		{D24D94F6-2A74-480C-B512-629C306CE92F}.Release|Win32.Build.0 = Release|Win32
+		{0468FC1E-5881-4DB9-9DDE-1892290B31D9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0468FC1E-5881-4DB9-9DDE-1892290B31D9}.Debug|Win32.Build.0 = Debug|Win32
+		{0468FC1E-5881-4DB9-9DDE-1892290B31D9}.Release|Win32.ActiveCfg = Release|Win32
+		{0468FC1E-5881-4DB9-9DDE-1892290B31D9}.Release|Win32.Build.0 = Release|Win32
+		{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}.Debug|Win32.Build.0 = Debug|Win32
+		{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}.Release|Win32.ActiveCfg = Release|Win32
+		{074DC930-05C6-4B7F-B5DD-DD237E6E44DB}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/projects/openrct2.vcxproj
+++ b/projects/openrct2.vcxproj
@@ -18,33 +18,6 @@
     <None Include="..\openrct2.exe" />
   </ItemGroup>
   <ItemGroup>
-    <Text Include="..\data\language\dutch.txt" />
-    <Text Include="..\data\language\english_uk.txt" />
-    <Text Include="..\data\language\english_us.txt" />
-    <Text Include="..\data\language\german.txt" />
-    <Text Include="..\data\language\french.txt" />
-    <Text Include="..\data\language\hungarian.txt" />
-    <Text Include="..\data\language\polish.txt" />
-    <Text Include="..\data\language\spanish_sp.txt" />
-    <Text Include="..\data\language\swedish.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\lib\argparse\argparse.h" />
-    <ClInclude Include="..\lib\libspeex\arch.h" />
-    <ClInclude Include="..\lib\libspeex\config.h" />
-    <ClInclude Include="..\lib\libspeex\os_support.h" />
-    <ClInclude Include="..\lib\libspeex\speex\speex_resampler.h" />
-    <ClInclude Include="..\lib\libspeex\speex\speex_types.h" />
-    <ClInclude Include="..\lib\libspeex\stack_alloc.h" />
-    <ClInclude Include="..\lib\lodepng\lodepng.h" />
-    <ClCompile Include="..\lib\argparse\argparse.c">
-      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
-    </ClCompile>
-    <ClCompile Include="..\lib\libspeex\resample.c;..\lib\lodepng\lodepng.c">
-      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="..\src\audio\audio.c" />
     <ClCompile Include="..\src\audio\mixer.cpp" />
     <ClCompile Include="..\src\cmdline.c" />
@@ -229,6 +202,11 @@
     <ClInclude Include="..\src\world\scenery.h" />
     <ClInclude Include="..\src\world\sprite.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="libs\libs.vcxproj">
+      <Project>{074dc930-05c6-4b7f-b5dd-dd237e6e44db}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D24D94F6-2A74-480C-B512-629C306CE92F}</ProjectGuid>
     <RootNamespace>openrct2</RootNamespace>
@@ -277,6 +255,7 @@
       <SDLCheck>true</SDLCheck>
       <StructMemberAlignment>1Byte</StructMemberAlignment>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -306,9 +285,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>winmm.lib;sdl2.lib;Dsound.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy /Y "$(ProjectDir)\..\Data\Language\*.*" "$(TargetDir)\Data\Language\"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projects/openrct2.vcxproj.filters
+++ b/projects/openrct2.vcxproj.filters
@@ -5,26 +5,11 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Libraries">
-      <UniqueIdentifier>{29bd2abb-0a50-4c58-9031-bee3f966b249}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Libraries\lodepng">
-      <UniqueIdentifier>{e9219aff-1bb5-4065-8204-427a97344a43}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Libraries\libspeex">
-      <UniqueIdentifier>{3c824fc4-8242-4127-a4b4-248435ff9058}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source">
       <UniqueIdentifier>{4c8348c7-dfe9-4368-9d87-29733fe5950a}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source\Audio">
       <UniqueIdentifier>{8e15cd5b-d7a7-4bda-a58a-e1158ad6ffb4}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source\Data">
-      <UniqueIdentifier>{ee2e3a6f-1209-407b-8000-a6a4b88d28d9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source\Data\Language">
-      <UniqueIdentifier>{b344ca0f-b412-4924-be08-54bb6f83c3dd}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source\Drawing">
       <UniqueIdentifier>{8a9b8831-4ba9-4104-b13f-949981e10c22}</UniqueIdentifier>
@@ -53,49 +38,14 @@
     <Filter Include="Source\Windows">
       <UniqueIdentifier>{81716f5d-b396-4a82-a450-76fee56d982b}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Libraries\libspeex\speex">
-      <UniqueIdentifier>{209155b8-2f61-4e25-ab86-c8aa36357abd}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source\Peep">
       <UniqueIdentifier>{51e38783-5334-464c-8f90-61d725dc8013}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Libraries\argparse">
-      <UniqueIdentifier>{7e9587b2-333f-42ca-8a56-b77070828b17}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\openrct2.exe">
       <Filter>Resource Files</Filter>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Text Include="..\data\language\dutch.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\english_uk.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\english_us.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\german.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\french.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\hungarian.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\polish.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\spanish_sp.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
-    <Text Include="..\data\language\swedish.txt">
-      <Filter>Source\Data\Language</Filter>
-    </Text>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\management\award.c">
@@ -384,19 +334,13 @@
     <ClCompile Include="..\lib\lodepng\lodepng.c" />
     <ClCompile Include="..\lib\lodepng\lodepng.c" />
     <ClCompile Include="..\lib\lodepng\lodepng.c" />
-    <ClCompile Include="..\lib\lodepng\lodepng.c" />
-    <ClCompile Include="..\lib\libspeex\resample.c;..\lib\lodepng\lodepng.c" />
-    <ClCompile Include="..\lib\libspeex\resample.c;..\lib\lodepng\lodepng.c" />
     <ClCompile Include="..\src\cmdline.c">
       <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="..\src\openrct2.c">
       <Filter>Source</Filter>
     </ClCompile>
-    <ClCompile Include="..\lib\argparse\argparse.c">
-      <Filter>Libraries\argparse</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lib\libspeex\resample.c;..\lib\lodepng\lodepng.c" />
+    <ClCompile Include="..\lib\lodepng\lodepng.c" />
     <ClCompile Include="..\lib\libspeex\resample.c;..\lib\lodepng\lodepng.c" />
     <ClCompile Include="..\src\world\fountain.c">
       <Filter>Source\World</Filter>
@@ -479,6 +423,7 @@
     <ClCompile Include="..\src\windows\editor_scenario_options.c">
       <Filter>Source\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\lib\lodepng\lodepng.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\management\award.h">
@@ -634,27 +579,6 @@
     <ClInclude Include="..\src\localisation\format_codes.h">
       <Filter>Source\Localisation</Filter>
     </ClInclude>
-    <ClInclude Include="..\lib\lodepng\lodepng.h">
-      <Filter>Libraries\lodepng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\arch.h">
-      <Filter>Libraries\libspeex</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\config.h">
-      <Filter>Libraries\libspeex</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\os_support.h">
-      <Filter>Libraries\libspeex</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\stack_alloc.h">
-      <Filter>Libraries\libspeex</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\speex\speex_resampler.h">
-      <Filter>Libraries\libspeex\speex</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\libspeex\speex\speex_types.h">
-      <Filter>Libraries\libspeex\speex</Filter>
-    </ClInclude>
     <ClInclude Include="..\src\peep\peep.h">
       <Filter>Source\Peep</Filter>
     </ClInclude>
@@ -669,9 +593,6 @@
     </ClInclude>
     <ClInclude Include="..\src\openrct2.h">
       <Filter>Source</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib\argparse\argparse.h">
-      <Filter>Libraries\argparse</Filter>
     </ClInclude>
     <ClInclude Include="..\src\world\banner.h">
       <Filter>Source\World</Filter>


### PR DESCRIPTION
No source files were moved, the only changes were to VS solution and project files. The proposed solution structure looks like this:
![](http://puu.sh/dAaQU/3a1a167805.png)
- language project simply hold the language files. The PostBuildEvent which copies the files has been moved there.
- "libs" project holds speex, argparse and lodepng files. They are compiled to a static library (to build/libs) and linked with openrct2.dll.

Benefits:
- project - wide search will now skip language files and these libraries, which makes search results easier to navigate
- optimizations are now enabled for the libs project
