### PR TITLE
Remapped keypad enter to return keycode.

### DIFF
--- a/src/platform/osinterface.c
+++ b/src/platform/osinterface.c
@@ -414,6 +414,11 @@ void osinterface_process_messages()
 			}
 			break;
 		case SDL_KEYDOWN:
+			if (e.key.keysym.sym == SDLK_KP_ENTER){
+				// Map Keypad enter to regular enter.
+				e.key.keysym.scancode = SDL_SCANCODE_RETURN;
+			}
+
 			gLastKeyPressed = e.key.keysym.sym;
 			gKeysPressed[e.key.keysym.scancode] = 1;
 			if (e.key.keysym.sym == SDLK_RETURN && e.key.keysym.mod & KMOD_ALT)


### PR DESCRIPTION
Fixes #651

I couldn't decide where to make the change but decided that it was probably best to perform this in osinterface. I've only remapped the scancode so functions in osinterface that use the virtual keycode will not be changed by this (prevents ALT+ KEYPAD ENTER) not sure if that is the desired result or not but then it would be an awkward keypress. I haven't remapped the other keypad buttons as they were recognized as different in rct2.
