### PR TITLE
Fixed drawing issues when zoomed.

### DIFF
--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -854,6 +854,8 @@ void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi){
 		ebx |= (peep->hat_colour << 19) | 0x20000000;
 		gfx_draw_sprite( clip_dpi, ebx, x, y, 0);
 	}
+
+	rct2_free(clip_dpi);
 }
 
 /* rct2: 0x69869b */
@@ -1017,6 +1019,8 @@ void window_guest_overview_paint(){
 
 	x = widget->right - widget->left - w->list_information_type;
 	gfx_draw_string_left(dpi_marquee, 1193, (void*)0x13CE952, 0, x, 0);
+
+	rct2_free(dpi_marquee);
 }
 
 /* rct2: 0x696749*/

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1036,6 +1036,7 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
 		spriteIndex |= 0x80000000;
 
 		gfx_draw_sprite(dpi, spriteIndex, x, y, vehicleColour.additional_2);
+		rct2_free(dpi);
 	}
 }
 
@@ -4129,6 +4130,8 @@ static void window_ride_colour_paint()
 			// ?
 			if (terniaryColour != 0)
 				gfx_draw_sprite(clippedDpi, ((spriteIndex + 20) & 0x7FFFF) + terniaryColour, 34, 20, terniaryColour);
+
+			rct2_free(clippedDpi);
 		}
 	}
 }

--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -1004,6 +1004,8 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi){
 		ebx |= (peep->hat_colour << 19) | 0x20000000;
 		gfx_draw_sprite(clip_dpi, ebx, x, y, 0);
 	}
+
+	rct2_free(clip_dpi);
 }
 
 /* rct2: 0x6BE7C6 */

--- a/src/windows/track_place.c
+++ b/src/windows/track_place.c
@@ -669,6 +669,8 @@ static void window_track_place_paint()
 		subsituteElement->flags = 0;
 		gfx_draw_sprite(clippedDpi, 0, 0, 0, 0);
 		*subsituteElement = tmpElement;
+
+		rct2_free(clippedDpi);
 	}
 
 	// Price


### PR DESCRIPTION
Fixes #652.

I finally found a fix to most of the issues. This will require some testing as I am not sure if i picked up every issue and I am away for a little while. The main issue was due to chris using a slightly different calculations for RLE sprites and bitmap sprites. I've also fixed a small memory leak that was happening due to the clip dpi function. I've noticed that viewports are leaking memory might be worthwhile investigating it (At least i think its a memory leak I'm noticing the amount of RAM being used is increasing rapidly when more viewports are open and it does not reduce when they close.
