### PR TITLE
Added missing va_end call

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -310,8 +310,8 @@ void console_printf(const char *format, ...)
 {
 	va_list list;
 	va_start(list, format);
-	
 	vsprintf(_consolePrintfBuffer, format, list);
+	va_end(list);
 	console_writeline(_consolePrintfBuffer);
 }
 


### PR DESCRIPTION
This PR adds a missing `va_end` call after using the `list` variable.