### PR TITLE
Object selection columns

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3780,3 +3780,5 @@ STR_5443    :Speed{MOVE_X}{87}{STRINGID}
 STR_5444    :Speed:
 STR_5445    :Speed
 STR_5446    :Get
+STR_5447    :Type {STRINGID}
+STR_5448    :Ride / Vehicle {STRINGID}

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -1550,6 +1550,9 @@ enum {
 	STR_UP = 5375,
 	STR_DOWN = 5376,
 
+	STR_OBJECTS_SORT_TYPE = 5447,
+	STR_OBJECTS_SORT_RIDE = 5448,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/object.h
+++ b/src/object.h
@@ -80,7 +80,7 @@ typedef struct {
 
 typedef struct {
 	uint8 category[2];
-
+	uint8 ride_type;
 } rct_ride_filters;
 
 typedef struct {

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -795,10 +795,21 @@ static uint32 install_object_entry(rct_object_entry* entry, rct_object_entry* in
 
 static void load_object_filter(rct_object_entry* entry, uint8* chunk, rct_object_filters* filter)
 {
+	rct_ride_type *rideType;
+	rct_ride_filters *rideFilter;
+
 	switch (entry->flags & 0xF) {
 	case OBJECT_TYPE_RIDE:
-		filter->ride.category[0] = ((rct_ride_type*)chunk)->category[0];
-		filter->ride.category[1] = ((rct_ride_type*)chunk)->category[1];
+		rideType = ((rct_ride_type*)chunk);
+		rideFilter = &(filter->ride);
+
+		rideFilter->category[0] = rideType->category[0];
+		rideFilter->category[1] = rideType->category[1];
+		for (int i = 0; i < 3; i++) {
+			rideFilter->ride_type = rideType->ride_type[i];
+			if (rideFilter->ride_type != 255)
+				break;
+		}
 		break;
 	case OBJECT_TYPE_SMALL_SCENERY:
 	case OBJECT_TYPE_LARGE_SCENERY:


### PR DESCRIPTION
Add ride type and ride name columns to object selection. This could be extended in some way to the other types of objects but this PR will for now only add sortable columns to rides.

plugin.dat information increased to store ride type.
Ride tab animations have also been implemented.