### PR TITLE
Fix double track names in list; use track categories when in select-by-track-type-mode

### DIFF
--- a/src/object_list.c
+++ b/src/object_list.c
@@ -19,6 +19,7 @@
  *****************************************************************************/
 
 #include "addresses.h"
+#include "config.h"
 #include "localisation/localisation.h"
 #include "object.h"
 #include "platform/platform.h"
@@ -738,29 +739,9 @@ static uint32 install_object_entry(rct_object_entry* entry, rct_object_entry* in
 
 	load_object_filter(entry, chunk, filter);
 
-
-	// When made of two parts i.e Wooden Roller Coaster (Dream Woodie Cars)
-	if ((objectType == OBJECT_TYPE_RIDE) && (!((((rct_ride_type*)chunk)->flags) & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME) || 
-			rideTypeShouldLoseSeparateFlag((rct_ride_type*)chunk))) {
-		rct_ride_type* ride_type = (rct_ride_type*)chunk;
-		rct_string_id obj_string = ride_type->ride_type[0];
-		if (obj_string == 0xFF){
-			obj_string = ride_type->ride_type[1];
-			if (obj_string == 0xFF) {
-				obj_string = ride_type->ride_type[2];
-			}
-		}
-
-		format_string(installed_entry_pointer, obj_string + 2, 0);
-		strcat(installed_entry_pointer, "\t (");
-		strcat(installed_entry_pointer, language_get_string((rct_string_id)RCT2_GLOBAL(RCT2_ADDRESS_CURR_OBJECT_BASE_STRING_ID, uint32)));
-		strcat(installed_entry_pointer, ")");
-		while (*installed_entry_pointer++);
-	}
-	else{
-		strcpy(installed_entry_pointer, language_get_string((rct_string_id)RCT2_GLOBAL(RCT2_ADDRESS_CURR_OBJECT_BASE_STRING_ID, uint32)));
-		while (*installed_entry_pointer++);
-	}
+	// Always extract only the vehicle type, since the track type is always displayed in the left column, to prevent duplicate track names.
+	strcpy(installed_entry_pointer, language_get_string((rct_string_id)RCT2_GLOBAL(RCT2_ADDRESS_CURR_OBJECT_BASE_STRING_ID, uint32)));
+	while (*installed_entry_pointer++);
 
 	// This is deceptive. Due to setting the total no images earlier to 0xF26E
 	// this is actually the no_images in this entry.
@@ -805,6 +786,7 @@ static void load_object_filter(rct_object_entry* entry, uint8* chunk, rct_object
 
 		rideFilter->category[0] = rideType->category[0];
 		rideFilter->category[1] = rideType->category[1];
+
 		for (int i = 0; i < 3; i++) {
 			rideFilter->ride_type = rideType->ride_type[i];
 			if (rideFilter->ride_type != 255)

--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -31,6 +31,7 @@
 #include "error.h"
 #include "../interface/themes.h"
 #include "dropdown.h"
+#include "../rct1.h"
 
 enum {
 	FILTER_RCT2 = (1 << 0),
@@ -2085,11 +2086,16 @@ static bool filter_chunks(rct_object_entry *entry, rct_object_filters *filter)
 {
 	switch (entry->flags & 0x0F) {
 	case OBJECT_TYPE_RIDE:
-		if (_filter_flags & (1 << (filter->ride.category[0] + 5)))
-			return true;
-		if (_filter_flags & (1 << (filter->ride.category[1] + 5)))
-			return true;
-
+		if(!gConfigInterface.select_by_track_type) {
+			if (_filter_flags & (1 << (filter->ride.category[0] + 5)))
+				return true;
+			if (_filter_flags & (1 << (filter->ride.category[1] + 5)))
+				return true;
+		}
+		else {
+			if (_filter_flags & (1 << (gRideCategories[filter->ride.ride_type] + 5)))
+				return true;
+		}
 		return false;
 	}
 	return true;


### PR DESCRIPTION
Currently, the American Style Steam Trains will show up as:
`Miniature Railway     Miniature Railway(American Style Steam Trains)`
This is fixed by the patch.

Also, when the user has select-by-track-type (RCT1 style) enabled, it will now use the same categories as in the New Ride window, making it more consistent.