### PR TITLE
Fix track bugs.

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -4488,7 +4488,7 @@ int ride_get_refund_price(int ride_id)
 				z,
 				0);
 			map_element_iterator_restart_for_tile(&it);
-			break;
+			continue;
 		}
 
 		RCT2_GLOBAL(0x00F4413A, money32) += game_do_command(
@@ -4527,7 +4527,6 @@ int ride_get_refund_price(int ride_id)
 			z,
 			0);
 		map_element_iterator_restart_for_tile(&it);
-		break;
 	}
 	RCT2_GLOBAL(RCT2_ADDRESS_GAME_PAUSED, uint8) = oldpaused;
 	return RCT2_GLOBAL(0x00F4413A, int);

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -3562,7 +3562,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 			offsetX = -trackBlock->y;
 			offsetY = trackBlock->x;
 			bl = rol8(bl, 3);
-			bh |= bl;
+			bh = bl;
 			bh = ror8(bh, 4);
 			bl &= 0x88;
 			bh &= 0x77;

--- a/src/windows/game_bottom_toolbar.c
+++ b/src/windows/game_bottom_toolbar.c
@@ -544,7 +544,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo *dpi, rc
 
 	// Text
 	stringId = 1926;
-	// memcpy((char*)language_get_string(1926), &newsItem->colour, 256);
+	// memcpy((char*)language_get_string(1926) + 1, &newsItem->colour, 256);
 	memcpy((void*)0x009B5F2C, &newsItem->colour, 256);
 	x = w->x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
 	y = w->y + middleOutsetWidget->top + 11;


### PR DESCRIPTION
Fixed issue with ride demolishing where only the first tile of a ride would get demolished causing issues when the ride entries were removed.
Fixed issue with rotation 3 track pieces where invalid memory would be accessed.

Fixes #1506
Fixes #1556