### PR TITLE
Disable tutorial button

### DIFF
--- a/src/windows/title_menu.c
+++ b/src/windows/title_menu.c
@@ -99,7 +99,8 @@ void window_title_menu_open()
 		WF_STICK_TO_BACK | WF_TRANSPARENT
 	);
 	window->widgets = window_title_menu_widgets;
-	window->enabled_widgets |= (8 | 4 | 2 | 1);
+	window->enabled_widgets |= (8 | 2 | 1);
+	window->disabled_widgets |= (4); // Disable tutorial button
 	window_init_scroll_widgets(window);
 }
 


### PR DESCRIPTION
Since the tutorial isn't implmented, disable the button for it.
Currently the button allows the user to choose a tutorial, but then displays an error. This is bad UX. By disabling the button, it doesn't give the user the impression that tutorials work.