### PR TITLE
Properly merge #1672: incorrect plural form for last inspection time, fixes #1513, closes #1672

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3817,3 +3817,4 @@ STR_5478    :Controls
 STR_5479    :Toolbar
 STR_5480    :Show toolbar buttons for:
 STR_5481    :Themes
+STR_5482    :{WINDOW_COLOUR_2}Time since last inspection: {BLACK}1 minute

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -1834,6 +1834,8 @@ enum {
 	STR_SHOW_TOOLBAR_BUTTONS_FOR = 5480,
 	STR_THEMES_GROUP = 5481,
 
+	STR_TIME_SINCE_LAST_INSPECTION_MINUTE = 5482,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -3584,9 +3584,15 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	// Last inspection
 	lastInspection = ride->last_inspection;
-	stringId = lastInspection <= 240 ?
-		STR_TIME_SINCE_LAST_INSPECTION_MINUTES :
-		STR_TIME_SINCE_LAST_INSPECTION_MORE_THAN_4_HOURS;
+
+	// Use singular form for 1 minute of time or less
+	if (lastInspection <= 1)
+		stringId = STR_TIME_SINCE_LAST_INSPECTION_MINUTE;
+	else if (lastInspection <= 240)
+		stringId = STR_TIME_SINCE_LAST_INSPECTION_MINUTES;
+	else
+		stringId = STR_TIME_SINCE_LAST_INSPECTION_MORE_THAN_4_HOURS;
+
 	gfx_draw_string_left(dpi, stringId, &lastInspection, 0, x, y);
 	y += 12;
 


### PR DESCRIPTION
Issue fixed by @mdlayher, merged by me.