### PR TITLE
Prevent accessing memory we don't own

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -522,7 +522,8 @@ config_section_definition *config_get_section_def(const utf8 *name, int size)
 
 	for (i = 0; i < countof(_sectionDefinitions); i++) {
 		const_utf8string sectionName = _sectionDefinitions[i].section_name;
-		if (sectionName[size] == 0 && _strnicmp(sectionName, name, size) == 0)
+		const int sectionNameSize = strnlen(sectionName, size);
+		if (sectionNameSize == size && sectionName[size] == 0 && _strnicmp(sectionName, name, size) == 0)
 			return &_sectionDefinitions[i];
 	}
 
@@ -535,8 +536,11 @@ config_property_definition *config_get_property_def(config_section_definition *s
 
 	for (i = 0; i < section->property_definitions_count; i++) {
 		const_utf8string propertyName = section->property_definitions[i].property_name;
-		if (propertyName[size] == 0 && _strnicmp(propertyName, name, size) == 0)
+		const int propertyNameSize = strnlen(propertyName, size);
+		if (propertyNameSize == size && propertyName[size] == 0 && _strnicmp(propertyName, name, size) == 0)
+		{
 			return &section->property_definitions[i];
+		}
 	}
 
 	return NULL;


### PR DESCRIPTION
In case where `strlen(propertyName) < strlen(name)` we are accessing
memory from stack mapping region possibly outside our ownership.

Prevent such behaviour by clamping the check to valid range only.