### PR TITLE
Add console option to reset all user strings

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -4,6 +4,7 @@
 #include "../addresses.h"
 #include "../drawing/drawing.h"
 #include "../localisation/localisation.h"
+#include "../localisation/user.h"
 #include "../platform/platform.h"
 #include "../world/park.h"
 #include "../util/sawyercoding.h"
@@ -816,6 +817,7 @@ static int cc_load_object(const utf8 **argv, int argc) {
 
 	return 0;
 }
+
 static int cc_object_count(const utf8 **argv, int argc) {
 	const utf8* object_type_names[] = { "Rides", "Small scenery", "Large scenery", "Walls", "Banners", "Paths", "Path Additions", "Scenery groups", "Park entrances", "Water" };
 	for (int i = 0; i < 10; i++) {
@@ -831,6 +833,13 @@ static int cc_object_count(const utf8 **argv, int argc) {
 
 	return 0;
 }
+
+static int cc_reset_user_strings(const utf8 **argv, int argc)
+{
+	reset_user_strings();
+	return 0;
+}
+
 static int cc_open(const utf8 **argv, int argc) {
 	if (argc > 0) {
 		bool title = (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TITLE_DEMO) != 0;
@@ -920,7 +929,8 @@ console_command console_command_table[] = {
 									"This is a safer method opposed to \"open object_selection\".", 
 									"load_object <objectfilenodat>" },
 	{ "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
-	{ "twitch", cc_twitch, "Twitch API" }
+	{ "twitch", cc_twitch, "Twitch API" },
+	{ "reset_user_strings", cc_reset_user_strings, "Resets all user-defined strings, to fix incorrectly occurring 'Chosen name in use already' errors.", "reset_user_strings" }
 };
 
 static int cc_windows(const utf8 **argv, int argc) {

--- a/src/localisation/user.c
+++ b/src/localisation/user.c
@@ -20,6 +20,7 @@
 
 #include "../addresses.h"
 #include "localisation.h"
+#include "../ride/ride.h"
 
 utf8 *gUserStrings = (char*)0x0135A8F4;
 
@@ -94,7 +95,10 @@ bool is_user_string_id(rct_string_id stringId)
 void reset_user_strings()
 {
 	char *userString = gUserStrings;
+
 	for (int i = 0; i < MAX_USER_STRINGS; i++, userString += USER_STRING_MAX_LENGTH) {
 		userString[0] = 0;
 	}
+
+	ride_reset_all_names();
 }

--- a/src/localisation/user.c
+++ b/src/localisation/user.c
@@ -90,3 +90,11 @@ bool is_user_string_id(rct_string_id stringId)
 {
 	return stringId >= 0x8000 && stringId < 0x9000;
 }
+
+void reset_user_strings()
+{
+	char *userString = gUserStrings;
+	for (int i = 0; i < MAX_USER_STRINGS; i++, userString += USER_STRING_MAX_LENGTH) {
+		userString[0] = 0;
+	}
+}

--- a/src/localisation/user.h
+++ b/src/localisation/user.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * Copyright (c) 2015 Michael Steenbeek
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * This file is part of OpenRCT2.
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+void reset_user_strings();

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -6643,3 +6643,30 @@ bool shop_item_is_food_or_drink(int shopItem)
 		return false;
 	}
 }
+
+void ride_reset_all_names()
+{
+	int i;
+	rct_ride *ride;
+	char rideNameBuffer[256];
+
+	FOR_ALL_RIDES(i, ride)
+	{
+		ride->name = STR_NONE;
+
+		struct {
+			uint16 type_name;
+			uint16 number;
+		} name_args;
+		name_args.type_name = 2 + ride->type;
+		name_args.number = 0;
+		do {
+			name_args.number++;
+			format_string(rideNameBuffer, 1, &name_args);
+		} while (ride_name_exists(rideNameBuffer));
+
+		ride->name = 1;
+		ride->name_arguments_type_name = name_args.type_name;
+		ride->name_arguments_number = name_args.number;
+	}
+}

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -1034,5 +1034,6 @@ bool ride_type_is_intamin(int rideType);
 void sub_6C94D8();
 
 bool shop_item_is_food_or_drink(int shopItem);
+void ride_reset_all_names();
 
 #endif


### PR DESCRIPTION
SV4 files that have been imported by RCT2 or OpenRCT2 don't have their names reset properly. As a result, the original names of the rides are unusable, since those will trigger a 'Chosen name in use already'. This PR adds a console option to reset all user strings, making the original names available again.

Besides this, the SV4/SC4 import code should free user strings when it removes rides.