### PR TITLE
Remove unused code

### DIFF
--- a/src/addresses.h
+++ b/src/addresses.h
@@ -75,10 +75,6 @@
 // When all sounds reversed replace with gConfigSound.ride_music
 #define RCT2_ADDRESS_CONFIG_MUSIC					0x009AAC72
 
-// Is supposed to be set to 0 whenever the screen resolution is changed
-// it will then count up 255 ticks before saving the config
-// In OpenRCT2 this value is only set to 0 on startup
-#define RCT2_ADDRESS_CONFIG_SAVE_TIMER				0x009AAC73
 #define RCT2_ADDRESS_CONFIG_FLAGS					0x009AAC74
 
 // MAX vehicle sounds not used anymore

--- a/src/game.c
+++ b/src/game.c
@@ -329,12 +329,6 @@ void game_update()
 	// Input
 	RCT2_GLOBAL(0x0141F568, uint8) = RCT2_GLOBAL(0x0013CA740, uint8);
 	game_handle_input();
-
-	if (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8) != 255) {
-		RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8)++;
-		if (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8) == 255)
-			config_save_default();
-	}
 }
 
 void game_logic_update()

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -340,7 +340,6 @@ void scenario_begin()
 
 	gfx_invalidate_screen();
 	RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_AGE, uint16) = 0;
-	RCT2_GLOBAL(0x009DEA5C, uint16) = 62000; // (doesn't appear to ever be read)
 	gGameSpeed = 1;
 }
 

--- a/src/title.c
+++ b/src/title.c
@@ -214,7 +214,6 @@ static int title_load_park(const char *path)
 	news_item_init_queue();
 	gfx_invalidate_screen();
 	RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_AGE, sint16) = 0;
-	RCT2_GLOBAL(0x009DEA5C, sint16) = 0x0D6D8;
 	gGameSpeed = 1;
 	return 1;
 }
@@ -490,12 +489,6 @@ void title_update()
 
 	// Input
 	game_handle_input();
-
-	if (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8) != 255) {
-		RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8)++;
-		if (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_SAVE_TIMER, uint8) == 255)
-			config_save_default();
-	}
 }
 
 static uint8 *generate_random_script()


### PR DESCRIPTION
0x009DEA5C is set but never read
0x009AAC73 is normally set to 0 when the screen resolution is changed to
delay saving the config. This is no longer neccesary in OpenRCT2