### PR TITLE
Re-add PLUGIN.DAT

### DIFF
--- a/src/rct2.h
+++ b/src/rct2.h
@@ -150,6 +150,7 @@ enum {
 
 enum {
 	PATH_ID_G1,
+	PATH_ID_PLUGIN,
 	PATH_ID_CSS1,
 	PATH_ID_CSS2,
 	PATH_ID_CSS4,
@@ -206,6 +207,7 @@ enum {
 static const char * const file_paths[] =
 {
 	"Data\\G1.DAT",
+	"Data\\PLUGIN.DAT",
 	"Data\\CSS1.DAT",
 	"Data\\CSS2.DAT",
 	"Data\\CSS4.DAT",


### PR DESCRIPTION
#1775 makes the game crash when the "Play Intro" setting is enabled. Adding PLUGIN.DAT back to the file list fixes this, although I'm not sure if there's a better solution.
The sound effect that's causing the crash is on line 65 of intro.c: sound_prepare(SOUND_LIFT_7, &_prepared_sound, 0, 1)
