### PR TITLE
disable network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ add_definitions(-DCURL_STATICLIB)
 #uncomment the line bellow if you don't want to build openrct2 with twitch integration
 #add_definitions(-DDISABLE_HTTP -DDISABLE_TWITCH)
 
+option(DISABLE_NETWORK "Disable multiplayer functionality. Mainly for testing.")
+if (DISABLE_NETWORK)
+	add_definitions(-DDISABLE_NETWORK)
+endif (DISABLE_NETWORK)
+
 set(ORCTLIBS_INCLUDE /usr/local/cross-tools/orctlibs/include) 
 set(JANSSON_INCLUDE /usr/local/cross-tools/orctlibs/include/jansson) 
 set(ORCTLIBS_LIB_DIR /usr/local/cross-tools/orctlibs/lib)
@@ -44,7 +49,10 @@ file(GLOB_RECURSE ORCT2_SOURCES "src/*.c" "src/*.cpp" "lib/*.c")
 if (UNIX)
 	# force 32bit build for now and set necessary flags to compile code as is
 	set(CMAKE_C_FLAGS "-m32 -masm=intel -std=gnu99")
-	set(CMAKE_LDFLAGS_FLAGS "-m32")
+	set(CMAKE_CXX_FLAGS "-m32 -std=gnu++11 -masm=intel")
+	set(LIB32 /usr/lib32)
+	set(CMAKE_SHARED_LINKER_FLAGS "-m32 -Wl,-melf_i386 -L${LIB32} -lSDL2_ttf")
+	set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
 
 	# find and include SDL2
 	INCLUDE(FindPkgConfig)

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,9 @@ mkdir -p $cachedir
 if [[ ! -d build ]]; then
 	mkdir -p build
 fi
+if [[ ! -d build_nonet ]]; then
+	mkdir -p build_nonet
+fi
 
 libversion=2
 libVFile="./libversion"
@@ -56,6 +59,10 @@ fi
 
 pushd build
 	cmake -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=Debug  ..
+	make
+popd
+pushd build_nonet
+	cmake -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON ..
 	make
 popd
 

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -46,9 +46,11 @@ typedef int (*cmdline_action)(const char **argv, int argc);
 
 int gExitCode = 0;
 
+#ifndef DISABLE_NETWORK
 int gNetworkStart = NETWORK_MODE_NONE;
 char gNetworkStartHost[128];
 int gNetworkStartPort = NETWORK_DEFAULT_PORT;
+#endif // DISABLE_NETWORK
 
 static void print_launch_information();
 static int cmdline_call_action(const char **argv, int argc);
@@ -96,6 +98,7 @@ int cmdline_run(const char **argv, int argc)
 	if (verbose)
 		_log_levels[DIAGNOSTIC_LEVEL_VERBOSE] = 1;
 
+#ifndef DISABLE_NETWORK
 	if (port != 0) {
 		gNetworkStart = NETWORK_MODE_SERVER;
 		gNetworkStartPort = port;
@@ -105,6 +108,7 @@ int cmdline_run(const char **argv, int argc)
 		gNetworkStart = NETWORK_MODE_CLIENT;
 		strncpy(gNetworkStartHost, server, sizeof(gNetworkStartHost));
 	}
+#endif // DISABLE_NETWORK
 
 	if (argc != 0) {
 		gExitCode = cmdline_call_action(argv, argc);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -18,14 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
+#include "network.h"
+
+extern "C" {
+#include "../addresses.h"
+}
+
 #ifndef DISABLE_NETWORK
 
 #include <math.h>
 #include <algorithm>
 #include <set>
-#include "network.h"
 extern "C" {
-#include "../addresses.h"
 #include "../config.h"
 #include "../game.h"
 #include "../interface/chat.h"
@@ -566,7 +570,7 @@ void Network::Server_Send_MAP(NetworkConnection* connection)
 	int size = (int)SDL_RWtell(rw);
 	int chunksize = 1000;
 	for (int i = 0; i < size; i += chunksize) {
-		int datasize = min(chunksize, size - i);
+		int datasize = std::min(chunksize, size - i);
 		std::unique_ptr<NetworkPacket> packet = std::move(NetworkPacket::Allocate());
 		*packet << (uint32)NETWORK_COMMAND_MAP << (uint32)size << (uint32)i;
 		packet->Write(&buffer[i], datasize);
@@ -1099,4 +1103,19 @@ void network_send_gamecmd(uint32 eax, uint32 ebx, uint32 ecx, uint32 edx, uint32
 	}
 }
 
+#else
+int network_get_mode() { return NETWORK_MODE_NONE; }
+void network_tick() {}
+uint32 network_get_server_tick() { return RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TICKS, uint32); }
+void network_send_gamecmd(uint32 eax, uint32 ebx, uint32 ecx, uint32 edx, uint32 esi, uint32 edi, uint32 ebp, uint8 callback) {}
+void network_send_map() {}
+void network_update() {}
+int network_begin_client(const char *host, int port) { return 1; }
+int network_begin_server(int port) { return 1; }
+int network_get_num_players() { return 1; }
+const char* network_get_player_name(unsigned int index) { return "local (OpenRCT2 compiled without MP)"; }
+uint32 network_get_player_flags(unsigned int index) { return 0; }
+int network_get_player_ping(unsigned int index) { return 0; }
+void network_send_chat(const char* text) {}
+void network_close() {}
 #endif /* DISABLE_NETWORK */

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -21,15 +21,28 @@
 #ifndef _NETWORK_H_
 #define _NETWORK_H_
 
-#ifndef DISABLE_NETWORK
-
-#define NETWORK_DEFAULT_PORT 11753
-
 enum {
 	NETWORK_MODE_NONE,
 	NETWORK_MODE_CLIENT,
 	NETWORK_MODE_SERVER
 };
+
+enum {
+	NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
+};
+
+#define NETWORK_DEFAULT_PORT 11753
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+#include "../common.h"
+#include "../platform/platform.h"
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#ifndef DISABLE_NETWORK
 
 enum {
 	NETWORK_AUTH_NONE,
@@ -40,20 +53,13 @@ enum {
 	NETWORK_AUTH_BADPASSWORD
 };
 
-enum {
-	NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
-};
-
 #ifdef __cplusplus
 
 #include <list>
+#include <set>
 #include <memory>
 #include <vector>
 #include <SDL.h>
-extern "C" {
-#include "../common.h"
-#include "../platform/platform.h"
-}
 
 template <std::size_t size>
 struct ByteSwapT { };
@@ -215,17 +221,20 @@ private:
 	int Server_Handle_READY(NetworkConnection& connection, NetworkPacket& packet);
 };
 
-extern "C" {
-#endif
+#endif // __cplusplus
+#endif /* DISABLE_NETWORK */
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 int network_init();
 void network_close();
 int network_begin_client(const char *host, int port);
 int network_begin_server(int port);
 
+int network_get_mode();
 void network_update();
 void network_tick();
-int network_get_mode();
 int network_get_authstatus();
 uint32 network_get_server_tick();
 uint8 network_get_player_id();
@@ -242,8 +251,6 @@ void network_print_error();
 
 #ifdef __cplusplus
 }
-#endif
-
-#endif /* DISABLE_NETWORK */
+#endif // __cplusplus
 
 #endif

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -245,9 +245,11 @@ void openrct2_launch()
 
 			RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) = SCREEN_FLAGS_PLAYING;
 
+#ifndef DISABLE_NETWORK
 			if (gNetworkStart == NETWORK_MODE_SERVER) {
 				network_begin_server(gNetworkStartPort);
 			}
+#endif // DISABLE_NETWORK
 			break;
 		case STARTUP_ACTION_EDIT:
 			if (strlen(gOpenRCT2StartupActionPath) == 0) {
@@ -258,9 +260,11 @@ void openrct2_launch()
 			break;
 		}
 
+#ifndef DISABLE_NETWORK
 		if (gNetworkStart == NETWORK_MODE_CLIENT) {
 			network_begin_client(gNetworkStartHost, gNetworkStartPort);
 		}
+#endif // DISABLE_NETWORK
 
 		openrct2_loop();
 	}


### PR DESCRIPTION
add a cmake option to completely disable multiplayer code. This is most useful for testing, or when MP crashes.