### PR TITLE
Fix import of Merry-go-round colours

### DIFF
--- a/src/rct1.c
+++ b/src/rct1.c
@@ -2112,9 +2112,16 @@ static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 			dst->track_colour_supports[i] = RCT1ColourConversionTable[src->track_colour_supports[i]];
 		}
 	}
-	for (int i = 0; i < 12; i++) {
-		dst->vehicle_colours[i].body_colour = RCT1ColourConversionTable[src->vehicle_colours[i].body];
-		dst->vehicle_colours[i].trim_colour = RCT1ColourConversionTable[src->vehicle_colours[i].trim];
+
+	if(s4->game_version == 108166 && dst->type == RIDE_TYPE_MERRY_GO_ROUND) {
+		// The merry-go-round in the base game was always yellow with red
+		dst->vehicle_colours[0].body_colour = 18;
+		dst->vehicle_colours[0].trim_colour = 28;
+	} else {
+		for (int i = 0; i < 12; i++) {
+			dst->vehicle_colours[i].body_colour = RCT1ColourConversionTable[src->vehicle_colours[i].body];
+			dst->vehicle_colours[i].trim_colour = RCT1ColourConversionTable[src->vehicle_colours[i].trim];
+		}
 	}
 
 	// Maintenance

--- a/src/rct1.c
+++ b/src/rct1.c
@@ -2101,7 +2101,7 @@ static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 
 	// Colours
 	dst->colour_scheme_type = src->colour_scheme;
-	if (s4->game_version == 108166) {
+	if (s4->game_version < 110000) {
 		dst->track_colour_main[0] = RCT1ColourConversionTable[src->track_primary_colour];
 		dst->track_colour_additional[0] = RCT1ColourConversionTable[src->track_secondary_colour];
 		dst->track_colour_supports[0] = RCT1ColourConversionTable[src->track_support_colour];
@@ -2113,8 +2113,8 @@ static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 		}
 	}
 
-	if(s4->game_version == 108166 && dst->type == RIDE_TYPE_MERRY_GO_ROUND) {
-		// The merry-go-round in the base game was always yellow with red
+	if(s4->game_version < 120000 && dst->type == RIDE_TYPE_MERRY_GO_ROUND) {
+		// The merry-go-round in pre-LL versions was always yellow with red
 		dst->vehicle_colours[0].body_colour = 18;
 		dst->vehicle_colours[0].trim_colour = 28;
 	} else {

--- a/src/rct1.c
+++ b/src/rct1.c
@@ -2033,6 +2033,8 @@ static void rct1_import_map_elements(rct1_s4 *s4)
 
 static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 {
+	int gameVersion = sawyercoding_detect_rct1_version(s4->game_version) & FILE_VERSION_MASK;
+
 	rct_ride_type *rideEntry;
 
 	memset(dst, 0, sizeof(rct_ride));
@@ -2101,7 +2103,7 @@ static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 
 	// Colours
 	dst->colour_scheme_type = src->colour_scheme;
-	if (s4->game_version < 110000) {
+	if (gameVersion == FILE_VERSION_RCT1) {
 		dst->track_colour_main[0] = RCT1ColourConversionTable[src->track_primary_colour];
 		dst->track_colour_additional[0] = RCT1ColourConversionTable[src->track_secondary_colour];
 		dst->track_colour_supports[0] = RCT1ColourConversionTable[src->track_support_colour];
@@ -2113,7 +2115,7 @@ static void rct1_import_ride(rct1_s4 *s4, rct_ride *dst, rct1_ride *src)
 		}
 	}
 
-	if(s4->game_version < 120000 && dst->type == RIDE_TYPE_MERRY_GO_ROUND) {
+	if(gameVersion < FILE_VERSION_RCT1_LL && dst->type == RIDE_TYPE_MERRY_GO_ROUND) {
 		// The merry-go-round in pre-LL versions was always yellow with red
 		dst->vehicle_colours[0].body_colour = 18;
 		dst->vehicle_colours[0].trim_colour = 28;

--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -468,14 +468,20 @@ int sawyercoding_detect_file_type(char *src, int length)
 		actualChecksum = rol32(actualChecksum, 3);
 	}
 
-	switch (checksum - actualChecksum) {
-	case +108156:	return FILE_VERSION_RCT1 | FILE_TYPE_SV4;
-	case -108156:	return FILE_VERSION_RCT1 | FILE_TYPE_SC4;
-	case +110001:	return FILE_VERSION_RCT1_AA | FILE_TYPE_SV4;
-	case -110001:	return FILE_VERSION_RCT1_AA | FILE_TYPE_SC4;
-	case +120001:	return FILE_VERSION_RCT1_LL | FILE_TYPE_SV4;
-	case -120001:	return FILE_VERSION_RCT1_LL | FILE_TYPE_SC4;
-	}
+	return sawyercoding_detect_rct1_version(checksum - actualChecksum);
+}
+
+int sawyercoding_detect_rct1_version(int gameVersion)
+{
+	int fileType = (gameVersion) > 0 ? FILE_TYPE_SV4 : FILE_TYPE_SC4;
+	gameVersion=abs(gameVersion);
+
+	if (gameVersion >= 108000 && gameVersion < 110000)
+		return (FILE_VERSION_RCT1 | fileType);
+	else if (gameVersion >= 110000 && gameVersion < 120000)
+		return (FILE_VERSION_RCT1_AA | fileType);
+	else if (gameVersion >= 120000 && gameVersion < 130000)
+		return (FILE_VERSION_RCT1_LL | fileType);
 
 	return -1;
 }

--- a/src/util/sawyercoding.h
+++ b/src/util/sawyercoding.h
@@ -59,5 +59,6 @@ int sawyercoding_encode_td6(char* src, char* dst, int length);
 int sawyercoding_validate_track_checksum(char* src, int length);
 
 int sawyercoding_detect_file_type(char *src, int length);
+int sawyercoding_detect_rct1_version(int gameVersion);
 
 #endif


### PR DESCRIPTION
Merry-go-rounds in RCT1 versions before Loopy Landscapes had no colours defined, but were always yellow and red. This PR fixes the import of them.

SC4 versions:
RCT1: 108xyz
AA: 110xyz
LL: 120xyz

The xyz is used for the revision number. I deliberately ignored that part since they might differ slightly. For example: Sprightly Park and Heide-Park are both AA scenarios, but Sprightly Park has version 110011 and Heide-Park has version 110018.