### PR TITLE
Don't apply select by track type to research, fixes #1733

### DIFF
--- a/src/management/research.c
+++ b/src/management/research.c
@@ -183,12 +183,12 @@ void research_finish_item(sint32 entryIndex)
 			RCT2_ADDRESS(0x01357644, uint32)[ebx] = RCT2_ADDRESS(0x0097C5D4, uint32)[ebx];
 		}
 		RCT2_ADDRESS(0x001357424, uint32)[rideEntryIndex >> 5] |= 1 << (rideEntryIndex & 0x1F);
-		if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+		if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)) {
 			for (i = 0; i < 128; i++) {
 				rideEntry2 = GET_RIDE_ENTRY(i);
 				if (rideEntry2 == (rct_ride_type*)-1)
 					continue;
-				if ((rideEntry2->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) && !rideTypeShouldLoseSeparateFlag(rideEntry2))
+				if ((rideEntry2->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE))
 					continue;
 
 				if (rideEntry2->ride_type[0] == base_ride_type || rideEntry2->ride_type[1] == base_ride_type || rideEntry2->ride_type[2] == base_ride_type)
@@ -198,7 +198,7 @@ void research_finish_item(sint32 entryIndex)
 
 		// I don't think 0x009AC06C is ever not 0, so probably redundant
 		if (RCT2_GLOBAL(0x009AC06C, uint8) == 0) {
-			RCT2_GLOBAL(0x013CE952, rct_string_id) = ((rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME) && !rideTypeShouldLoseSeparateFlag(rideEntry)) ?
+			RCT2_GLOBAL(0x013CE952, rct_string_id) = ((rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)) ?
 				rideEntry->name : base_ride_type + 2;
 			if (!gSilentResearch)
 				news_item_add_to_queue(NEWS_ITEM_RESEARCH, 2249, entryIndex);
@@ -352,7 +352,7 @@ void research_remove_non_separate_vehicle_types()
 			researchItem->entryIndex >= 0x10000			
 		) {
 			rct_ride_type *rideEntry = GET_RIDE_ENTRY(researchItem->entryIndex & 0xFF);
-			if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+			if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME))) {
 				// Check if ride type already exists further up for a vehicle type that isn't displayed as a ride
 				researchItem2 = researchItem - 1;
 				do {
@@ -361,7 +361,7 @@ void research_remove_non_separate_vehicle_types()
 						researchItem2->entryIndex >= 0x10000
 					) {
 						rideEntry = GET_RIDE_ENTRY(researchItem2->entryIndex & 0xFF);
-						if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+						if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME))) {
 
 							if (((researchItem->entryIndex >> 8) & 0xFF) == ((researchItem2->entryIndex >> 8) & 0xFF)) {
 								// Remove item

--- a/src/windows/editor_inventions_list.c
+++ b/src/windows/editor_inventions_list.c
@@ -197,14 +197,14 @@ static void research_rides_setup(){
 		rct_ride_type* ride_entry = GET_RIDE_ENTRY(object_index);
 
 		uint8 master_found = 0;
-		if (!(ride_entry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(ride_entry)){
+		if (!(ride_entry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)){
 
 			for (uint8 rideType = 0; rideType < object_entry_group_counts[OBJECT_TYPE_RIDE]; rideType++){
 				rct_ride_type* master_ride = GET_RIDE_ENTRY(rideType);
 				if (master_ride == NULL || (uint32)master_ride == 0xFFFFFFFF)
 					continue;
 
-				if (master_ride->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE && !rideTypeShouldLoseSeparateFlag(master_ride))
+				if (master_ride->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)
 					continue;
 
 				// If master ride not in use
@@ -317,7 +317,7 @@ static rct_string_id research_item_get_name(uint32 researchItem)
 	if (rideEntry == NULL || rideEntry == (rct_ride_type*)0xFFFFFFFF)
 		return 0;
 
-	if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME && !rideTypeShouldLoseSeparateFlag(rideEntry))
+	if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)
 		return rideEntry->name;
 
 	return ((researchItem >> 8) & 0xFF) + 2;


### PR DESCRIPTION
Due to the way RCT2 handles non-separate ride types during research - treating them as one - opening games with alternative selection on would cause vehicles that are normally separate to be available at the beginning, yet still be invented.

This PR makes alternative selection no longer affect research, solving #1733.