### PR TITLE
Include Wine on Linux install; stop forcing install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,14 @@ if [[ `uname` == "Darwin" ]]; then
         popd
     fi
 elif [[ `uname` == "Linux" ]]; then
-    sudo apt-get install -y binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake wine
+	if [[ -z "$TRAVIS" ]]; then
+	    sudo apt-get install -y binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake
+		if [[ -z "$DISABLE_G2_BUILD" ]]; then
+			sudo apt-get install -y wine
+		fi
+	else
+		sudo apt-get install -y --force-yes binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake
+	fi
 fi
 
 if [[ ! -f $cachedir/SDL2-devel-${SDL2_PV}-mingw.tar.gz ]]; then

--- a/src/title.c
+++ b/src/title.c
@@ -646,9 +646,6 @@ static uint8 *title_script_load()
 
 bool title_refresh_sequence()
 {
-	if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) != SCREEN_FLAGS_TITLE_DEMO)
-		return;
-
 	_scriptCurrentPreset = gCurrentPreviewTitleSequence;
 	title_sequence *title = &gConfigTitleSequences.presets[_scriptCurrentPreset];
 
@@ -719,8 +716,11 @@ bool title_refresh_sequence()
 		_scriptWaitCounter = 0;
 		gTitleScriptCommand = -1;
 		gTitleScriptSave = 0xFF;
-		title_update_showcase();
-		gfx_invalidate_screen();
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) == SCREEN_FLAGS_TITLE_DEMO) {
+			title_update_showcase();
+			gfx_invalidate_screen();
+		}
 
 		return true;
 	}
@@ -738,8 +738,12 @@ bool title_refresh_sequence()
 	gCurrentPreviewTitleSequence = 0;
 	window_invalidate_by_class(WC_OPTIONS);
 	window_invalidate_by_class(WC_TITLE_EDITOR);
-	title_update_showcase();
-	gfx_invalidate_screen();
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) == SCREEN_FLAGS_TITLE_DEMO) {
+		title_update_showcase();
+		gfx_invalidate_screen();
+	}
+
 	return false;
 }
 

--- a/src/title.c
+++ b/src/title.c
@@ -646,6 +646,9 @@ static uint8 *title_script_load()
 
 bool title_refresh_sequence()
 {
+	if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) != SCREEN_FLAGS_TITLE_DEMO)
+		return;
+
 	_scriptCurrentPreset = gCurrentPreviewTitleSequence;
 	title_sequence *title = &gConfigTitleSequences.presets[_scriptCurrentPreset];
 


### PR DESCRIPTION
Since Wine is needed to build g2.dat, include it in the installation script.
Stop forcing installation: it can severely bork up the package manager and is only useful on already broken systems.