### PR TITLE
Fix more warnings

### DIFF
--- a/src/drawing/font.h
+++ b/src/drawing/font.h
@@ -22,7 +22,7 @@ enum {
 };
 
 typedef struct {
-	utf8 *filename;
+	const utf8 *filename;
 	int ptSize;
 	int offset_x;
 	int offset_y;

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -938,7 +938,7 @@ console_command console_command_table[] = {
 	{ "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
 	{ "twitch", cc_twitch, "Twitch API" },
 	{ "reset_user_strings", cc_reset_user_strings, "Resets all user-defined strings, to fix incorrectly occurring 'Chosen name in use already' errors.", "reset_user_strings" },
-	{ "fix_banner_count", cc_fix_banner_count, "Fixes incorrectly appearing 'Too many banners' error by marking every banner entry without a map element as null..", "fix_banner_count" }
+	{ "fix_banner_count", cc_fix_banner_count, "Fixes incorrectly appearing 'Too many banners' error by marking every banner entry without a map element as null.", "fix_banner_count" }
 };
 
 static int cc_windows(const utf8 **argv, int argc) {
@@ -1038,7 +1038,7 @@ void console_execute_silent(const utf8 *src)
 	bool validCommand = false;
 	for (int i = 0; i < countof(console_command_table); i++) {
 		if (strcmp(argv[0], console_command_table[i].command) == 0) {
-			console_command_table[i].func(argv + 1, argc - 1);
+			console_command_table[i].func((const utf8 **)(argv + 1), argc - 1);
 			validCommand = true;
 			break;
 		}

--- a/src/interface/screenshot.c
+++ b/src/interface/screenshot.c
@@ -299,7 +299,7 @@ int screenshot_dump_png()
 	}
 
 	free(png);
-	if (pixels != dpi->bits) {
+	if ((utf8*)pixels != (utf8*)dpi->bits) {
 		free(pixels);
 	}
 	return index;

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -75,7 +75,7 @@ __declspec(dllexport) int StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInsta
 
 	// Get command line arguments in standard form
 	argv = CommandLineToArgvA(lpCmdLine, &argc);
-	runGame = cmdline_run(argv, argc);
+	runGame = cmdline_run((const char **)argv, argc);
 	GlobalFree(argv);
 
 	if (runGame)


### PR DESCRIPTION
Fixes a load of `warning: deprecated conversion from string constant to ‘utf8* {aka char*}’` and three other warnings, leaving only the overflow in #1914 if I'm not mistaken.