### PR TITLE
Platform, memory fixes

### DIFF
--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -524,7 +524,8 @@ rct_track_td6* load_track_design(const char *path)
 
 	char* track_name_pointer = (char*)path;
 	while (*track_name_pointer++ != '\0');
-	while (*--track_name_pointer != '\\');
+	const char separator = platform_get_path_separator();
+	while (*--track_name_pointer != separator);
 	char* default_name = RCT2_ADDRESS(0x009E3504, char);
 	// Copy the track name for use as the default name of this ride
 	while (*++track_name_pointer != '.')*default_name++ = *track_name_pointer;
@@ -580,10 +581,11 @@ rct_track_td6* load_track_design(const char *path)
 		copy(&track_design->track_spine_colour, &src, version == 1 ? 140 : 67);
 
 	uint8* track_elements = RCT2_ADDRESS(0x9D821B, uint8);
+	int len = decodedLength - (src - decoded);
 	// Read the actual track data.
-	copy(track_elements, &src, 24572);
+	copy(track_elements, &src, len);
 
-	uint8* final_track_element_location = track_elements + 24572;
+	uint8* final_track_element_location = track_elements + len;
 	free(decoded);
 
 	// td4 files require some work to be recognised as td6.


### PR DESCRIPTION
The length decoded does not always equal 24572, sometimes the buffer only has 19072 left available, that's a case at least for:
```
Tracks/Crazy Cabs.TD6
Tracks/Crazy Castle.TD6
Tracks/Crazy Knights.TD6
Tracks/Danglefeet.TD6
Tracks/Demon Drop.TD6
Tracks/Dizzymouse.TD6
Tracks/Evil Vultures.TD6
Tracks/Exterminator.TD6
Tracks/Fright Flight.TD6
Tracks/Fungicide.TD6
Tracks/Garden Golf.TD6
Tracks/Gold Rush.TD6
Tracks/Golden Eagle.TD6
Tracks/Hedgehog.TD6
Tracks/Helixius.TD6
Tracks/Icicle Bob.TD6
Tracks/Ionizer.TD6
Tracks/Jellycopters.TD6
Tracks/Jellyfish.TD6
Tracks/Krypton Dips.TD6
Tracks/Liberty Loop.TD6
Tracks/Lobotomizer.TD6
Tracks/Lunar Launcher.TD6
Tracks/Manic Miner.TD6
Tracks/Mine Mania.TD6
Tracks/Mini Maze.TD6
Tracks/Minidiver.TD6
Tracks/Mummy's Curse.TD6
Tracks/Mystic Flight.TD6
Tracks/Octivator.TD6
Tracks/Pendulator.TD6
Tracks/Pony Tales.TD6
Tracks/Rat Race.TD6
Tracks/Rattlesnake.TD6
Tracks/Raven Racer.TD6
Tracks/Raving Rockets.TD6
Tracks/Red Baron.TD6
Tracks/Roman Racers.TD6
Tracks/Silvertwist.TD6
Tracks/Spiral Hedges.TD6
Tracks/Splashtastic.TD6
Tracks/Steel Squeak.TD6
Tracks/Swither.TD6
Tracks/Toxic Toboggan.TD6
Tracks/Triple Corkscrew.TD6
Tracks/Twicky Twister.TD6
Tracks/Velocerator.TD6
Tracks/Venomous.TD6
Tracks/Wheely Reel.TD6
Tracks/Wicked Whizzer.TD6
Tracks/Wings of Apollo.TD6
```