### PR TITLE
Don't install recommended packages on travis

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -170,7 +170,7 @@ elif [[ `uname` == "Linux" ]]; then
 			"linux")
 				sudo dpkg --add-architecture i386
 				sudo apt-get update
-				sudo apt-get install -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386
+				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386
 				wget https://launchpad.net/ubuntu/+archive/primary/+files/libjansson4_2.7-1ubuntu1_i386.deb
 				wget https://launchpad.net/ubuntu/+archive/primary/+files/libjansson-dev_2.7-1ubuntu1_i386.deb
 				sudo dpkg -i libjansson4_2.7-1ubuntu1_i386.deb


### PR DESCRIPTION
Old:
```
15 upgraded, 255 newly installed, 16 to remove and 82 not upgraded.
Need to get 62.7 MB of archives.
After this operation, 267 MB of additional disk space will be used.
```

New:
```
14 upgraded, 252 newly installed, 13 to remove and 83 not upgraded.
Need to get 61.1 MB of archives.
After this operation, 258 MB of additional disk space will be used.
```

The difference may look small, but when you see the list of affected
packages, you will notice that java installer is now skipped, which
shaves quite a big chunk of time wasted.

Skipped packages:
* `libsasl2-modules`
* `libtxc-dxtn-s2tc0`
* `libx11-doc`
* `oracle-java8-installer`