### PR TITLE
Partially fix compilation on OS X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,9 +54,9 @@ pushd build
 	echo OPENRCT2_CMAKE_OPTS = $OPENRCT2_CMAKE_OPTS
 	if [[ $TARGET == "docker32" ]]
 	then
-		PARENT=`readlink -f ../`
-		chmod a+rwx `pwd`
-		chmod g+s `pwd`
+		PARENT=$(readlink -f ../)
+		chmod a+rwx $(pwd)
+		chmod g+s $(pwd)
 		docker run -u travis -v $PARENT:/work/openrct2 -w /work/openrct2/build -i -t openrct2/openrct2:32bit-only bash -c "cmake ../ $OPENRCT2_CMAKE_OPTS && make"
 	else
 		cmake -DCMAKE_BUILD_TYPE=Debug $OPENRCT2_CMAKE_OPTS ..

--- a/install.sh
+++ b/install.sh
@@ -197,7 +197,11 @@ fi
 
 download_libs
 # mind the gap (trailing space)
-sha256sum $cachedir/orctlibs.zip | cut -f1 -d\  > $libVFile
+if [[ `uname` == "Darwin" ]]; then
+	shasum -a 256 $cachedir/orctlibs.zip | cut -f1 -d\  > $libVFile
+else
+	sha256sum $cachedir/orctlibs.zip | cut -f1 -d\  > $libVFile
+fi
 echo "Downloaded library with sha256sum: $(cat $libVFile)"
 # Local libs are required for all targets
 install_local_libs

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ cachedir=.cache
 liburl=https://openrct.net/launcher/libs/orctlibs.zip
 mkdir -p $cachedir
 
-echo `uname`
+echo $(uname)
 
 # Sets default target to "linux", if none specified
 TARGET=${TARGET-linux}
@@ -104,7 +104,7 @@ function install_local_libs {
 
 echo TARGET = $TARGET
 
-if [[ `uname` == "Darwin" ]]; then
+if [[ $(uname) == "Darwin" ]]; then
     echo "Installation of OpenRCT2 assumes you have homebrew and use it to install packages."
 
     echo "Check if brew is installed"
@@ -162,7 +162,7 @@ if [[ `uname` == "Darwin" ]]; then
             popd
         popd
     fi
-elif [[ `uname` == "Linux" ]]; then
+elif [[ $(uname) == "Linux" ]]; then
 	if [[ -z "$TRAVIS" ]]; then
 	    sudo apt-get install -y binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake
 		if [[ -z "$DISABLE_G2_BUILD" ]]; then
@@ -197,7 +197,7 @@ fi
 
 download_libs
 # mind the gap (trailing space)
-if [[ `uname` == "Darwin" ]]; then
+if [[ $(uname) == "Darwin" ]]; then
 	shasum -a 256 $cachedir/orctlibs.zip | cut -f1 -d\  > $libVFile
 else
 	sha256sum $cachedir/orctlibs.zip | cut -f1 -d\  > $libVFile

--- a/src/rct2.h
+++ b/src/rct2.h
@@ -91,6 +91,9 @@ typedef utf16* utf16string;
 #ifdef __linux__
 	#define OPENRCT2_PLATFORM		"Linux"
 #endif
+#ifdef __APPLE__
+	#define OPENRCT2_PLATFORM		"OS X"
+#endif
 #ifndef OPENRCT2_PLATFORM
 	#error Unknown platform!
 #endif


### PR DESCRIPTION
Currently, building on OS X appears to be broken -- this is a step towards fixing the build process. The changes are made are relatively minor, and will still result in a broken compilation process:a fter my changes, the process errors on the inline assembly in addresses.h, stating "brackets expression not supported on this target". If anyone else could look at that, that'd be grand.

As for my changes: first off, OS X does not provide a `sha256sum` tool, which install.sh assumes to exist. Instead, we should use `shasum -a 256`.

Secondly, `clang` does not support the `var-tracking-assignments` flag. I checked why it was introduced using `git blame`, but there does not seem to be a proper reason? Dropping it results in compilation continuing.

Finally, `limits.h` was not included in rect.c, resulting in `CHAR_BITS` not being defined.