### PR TITLE
Fixed #1948

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -53,6 +53,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * (halfbro)
 * (Myrtle)
 * (nean)
+* Michael Pham (nightroan)
 
 ## Toolchain
 * (Balletie) - OSX

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -5594,6 +5594,8 @@ void game_command_set_ride_price(int *eax, int *ebx, int *ecx, int *edx, int *es
 	//edx ride_number
 	//ebp ride_type
 
+	*ebx = 0; // for cost check - changing ride price does not cost anything
+
 	RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_PARK_RIDE_TICKETS * 4;
 	if (flags & 0x1) {
 		if (!secondary_price) {


### PR DESCRIPTION
There's a 'enum' collision of GAME_COMMAND_FLAG_NETWORKED and MONEY32_UNDEFINED. Was this on purpose? Both of these flags have the same value and are stored in the same variable (ebx).

There may be other unreported multiplayer issues related to this.