### PR TITLE
include correct headers

### DIFF
--- a/src/drawing/rect.c
+++ b/src/drawing/rect.c
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
-#include <limits.h>
 #include "../addresses.h"
 #include "../common.h"
 #include "../interface/colour.h"

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -31,7 +31,8 @@ extern "C" {
 
 #ifndef DISABLE_NETWORK
 
-#include <math.h>
+#include <cmath>
+#include <cerrno>
 #include <algorithm>
 #include <set>
 #include <string>

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -76,6 +76,7 @@ extern "C" {
 		#define SHUT_RDWR SD_BOTH
 	#endif
 #else
+	#include <errno.h>
 	#include <arpa/inet.h>
 	#include <netdb.h>
 	#include <netinet/tcp.h>
@@ -94,6 +95,7 @@ extern "C" {
 #include <list>
 #include <set>
 #include <memory>
+#include <string>
 #include <vector>
 #include <SDL.h>
 

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -40,14 +40,14 @@
 #include "util/util.h"
 #include "world/mapgen.h"
 
-#ifdef __linux__
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/mman.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#endif // __linux__
+#endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 
 int gOpenRCT2StartupAction = STARTUP_ACTION_TITLE;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
@@ -59,11 +59,11 @@ bool gOpenRCT2Headless = false;
 
 bool gOpenRCT2ShowChangelog;
 
-#if defined(__linux__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 void *gDataSegment;
 void *gTextSegment;
 int gExeFd;
-#endif // defined(__linux__)
+#endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 
 /** If set, will end the OpenRCT2 game loop. Intentially private to this module so that the flag can not be set back to 0. */
 int _finished;
@@ -498,9 +498,9 @@ void openrct2_reset_object_tween_locations()
  */
 static bool openrct2_setup_rct2_segment()
 {
-	// Linux will run OpenRCT2 as a native application and then load in the Windows PE, mapping the appropriate addresses as
+	// POSIX OSes will run OpenRCT2 as a native application and then load in the Windows PE, mapping the appropriate addresses as
 	// necessary. Windows does not need to do this as OpenRCT2 runs as a DLL loaded from the Windows PE.
-#ifdef __linux__
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 	#define RDATA_OFFSET 0x004A4000
 	#define DATASEG_OFFSET 0x005E2000
 
@@ -577,7 +577,7 @@ static bool openrct2_setup_rct2_segment()
 		err = errno;
 		log_error("Failed to unmap file! errno = %d", err);
 	}
-#endif // __linux__
+#endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 
 	// Check that the expected data is at various addresses.
 	// Start at 0x9a6000, which is start of .data, to skip the region containing addresses to DLL
@@ -601,7 +601,7 @@ static bool openrct2_setup_rct2_segment()
 static bool openrct2_release_rct2_segment()
 {
 	bool result = true;
-#if defined(__linux__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 	int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
 	int err;
 	err = munmap(gDataSegment, len);
@@ -626,7 +626,7 @@ static bool openrct2_release_rct2_segment()
 		log_error("Failed to close file! errno = %d", err);
 		result = false;
 	}
-#endif // defined(__linux__)
+#endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 	return result;
 }
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -162,9 +162,8 @@ bool platform_check_steam_overlay_attached();
 	HWND windows_get_window_handle();
 #endif // _WIN32
 
-#ifdef __linux__
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
-#include <limits.h>
 #define STUB() log_warning("Function %s at %s:%d is a stub.\n", __PRETTY_FUNCTION__, __FILE__, __LINE__)
 #define _strcmpi _stricmp
 #define _stricmp(x, y) strcasecmp((x), (y))
@@ -181,7 +180,7 @@ bool platform_check_steam_overlay_attached();
 #error Unknown endianess!
 #endif // RCT2_ENDIANESS
 
-#endif // __linux__
+#endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 
 #if !(_POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700)
 	char *strndup(const char *src, size_t size);

--- a/src/rct2.h
+++ b/src/rct2.h
@@ -28,6 +28,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
This fixes so that each files includes the headers that it needs. This usually works anyway on `gcc` but `clang` is more stricter about this.

It also changes `_stricmp` to `strcasecmp` which I believe to be right based on this: http://stackoverflow.com/questions/1784767/g-error-stricmp-was-not-declared-in-this-scope-but-ok-for-strcmp