### PR TITLE
Grant MMX to non-windows platforms

### DIFF
--- a/src/rct2.c
+++ b/src/rct2.c
@@ -524,10 +524,10 @@ void get_system_info()
 	else
 		RCT2_GLOBAL(0x1423C18, sint32) = 1;
 
-	RCT2_GLOBAL(0x01423C20, uint32) = (SDL_HasMMX() == SDL_TRUE);
 #else
 	STUB();
 #endif // _WIN32
+	RCT2_GLOBAL(0x01423C20, uint32) = (SDL_HasMMX() == SDL_TRUE);
 }
 
 


### PR DESCRIPTION
As there is still of un-reversed code, especially the
peep/rides/terrain drawing, a likely potential candidate for using MMX,
these instruction can potentially be useful in making things
speedier even when not using Windows.

I tested it by running a park for a while and saw no regression. I
haven't went in as deep as to actually verify if MMX is used or not.