### PR TITLE
Use wget to get orctlibs.zip in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ function download_sdl {
 
 function download_libs {
 	if [[ ! -f $cachedir/orctlibs.zip ]]; then
-		curl $liburl -o $cachedir/orctlibs.zip;
+		wget $liburl -O $cachedir/orctlibs.zip;
 	fi
 	if [[ ! -d $cachedir/orctlibs ]]; then
 		mkdir -p $cachedir/orctlibs


### PR DESCRIPTION
Most systems do not have curl installed by default but do have wget.
The rest of the script already uses wget so this also makes it more consistent.