### PR TITLE
Require a restart after changing hardware rendering

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3896,6 +3896,7 @@ STR_5554    :{SMALLFONT}{BLACK}Enable mountain tool
 STR_5555    :Show vehicles from other track types
 STR_5556    :Kick Player
 STR_5557    :Stay connected after desynchronisation (Multiplayer)
+STR_5558    :A restart is required for this setting to take effect
 
 #####################
 # Rides/attractions # 

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2143,6 +2143,9 @@ enum {
 	STR_KICK_PLAYER = 5556,
 	STR_STAY_CONNECTED_AFTER_DESYNC = 5557,
 
+    STR_RESTART_REQUIRED = 5558,
+
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -90,6 +90,8 @@ extern int gNumResolutions;
 extern resolution *gResolutions;
 extern SDL_Window *gWindow;
 
+extern bool gHardwareDisplay;
+
 extern bool gSteamOverlayActive;
 
 // Platform shared definitions

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -493,7 +493,16 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 			break;
 		case WIDX_HARDWARE_DISPLAY_CHECKBOX:
 			gConfigGeneral.hardware_display ^= 1;
+#ifdef _WIN32
+			// Windows is apparently able to switch to hardware rendering on the fly although
+			// using the same window in an unaccelerated and accelerated context is unsupported by SDL2
+			gHardwareDisplay = gConfigGeneral.hardware_display;
 			platform_refresh_video();
+#else
+			// Linux requires a restart. This could be improved in the future by recreating the window,
+			// https://github.com/OpenRCT2/OpenRCT2/issues/2015
+			window_error_open(STR_RESTART_REQUIRED, STR_NONE);
+#endif
 			config_save_default();
 			window_invalidate(w);
 			break;


### PR DESCRIPTION
Require a restart after changing hardware rendering setting, decouple setting from active status