### PR TITLE
Implement mountain tool + enhanced functionality.

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3892,6 +3892,7 @@ STR_5550    :{POP16}{POP16}Year {COMMA16}, {PUSH16}{PUSH16}{MONTH} {PUSH16}{PUSH
 STR_5551    :Year/Day/Month
 STR_5552    :{POP16}{POP16}Year {COMMA16}, {PUSH16}{PUSH16}{PUSH16}{STRINGID} {MONTH}
 STR_5553    :Pause game when Steam overlay is open
+STR_5554    :{SMALLFONT}{BLACK}Enable mountain tool
 
 #####################
 # Rides/attractions # 

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2128,6 +2128,8 @@ enum {
 
 	STR_STEAM_OVERLAY_PAUSE = 5553,
 
+	STR_ENABLE_MOUNTAIN_TOOL_TIP = 5554,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1792,7 +1792,7 @@ void top_toolbar_tool_update_land(sint16 x, sint16 y){
 	rct_xy16 mapTile = { .x = x, .y = y };
 
 	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
-	if (tool_size == 1){
+	if (tool_size == 1 && !gLandMountainMode){
 		int direction;
 		screen_pos_to_map_pos(&mapTile.x, &mapTile.y, &direction);
 
@@ -2498,7 +2498,7 @@ static void window_top_toolbar_tool_update(rct_window* w, int widgetIndex, int x
 		top_toolbar_tool_update_scenery_clear(x, y);
 		break;
 	case WIDX_LAND:
-		if (LandPaintMode)
+		if (gLandPaintMode)
 			top_toolbar_tool_update_land_paint(x, y);
 		else
 			top_toolbar_tool_update_land(x, y);
@@ -2576,7 +2576,7 @@ money32 selection_raise_land(uint8 flags)
 	uint32 yBounds = (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) & 0xFFFF) | (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) << 16);
 
 	RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_CANT_RAISE_LAND_HERE;
-	if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) == 0) {
+	if (gLandMountainMode) {
 		return game_do_command(centreX, flags, centreY, xBounds, GAME_COMMAND_EDIT_LAND_SMOOTH, 1, yBounds);
 	} else {
 		return game_do_command(centreX, flags, centreY, xBounds, GAME_COMMAND_RAISE_LAND, RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16), yBounds);
@@ -2598,7 +2598,7 @@ money32 selection_lower_land(uint8 flags)
 	uint32 yBounds = (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) & 0xFFFF) | (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) << 16);
 
 	RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_CANT_LOWER_LAND_HERE;
-	if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) == 0) {
+	if (gLandMountainMode) {
 		return game_do_command(centreX, flags, centreY, xBounds, GAME_COMMAND_EDIT_LAND_SMOOTH, 0xFFFF, yBounds);
 	} else {
 		return game_do_command(centreX, flags, centreY, xBounds, GAME_COMMAND_LOWER_LAND, RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16), yBounds);
@@ -2746,7 +2746,7 @@ static void window_top_toolbar_tool_drag(rct_window* w, int widgetIndex, int x, 
 		break;
 	case WIDX_LAND:
 		// Custom setting to only change land style instead of raising or lowering land
-		if (LandPaintMode) {
+		if (gLandPaintMode) {
 			if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16)&(1 << 0)){
 				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_CANT_CHANGE_LAND_TYPE;
 				game_do_command(

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -2100,7 +2100,7 @@ static int map_get_corner_height(rct_map_element *mapElement, int direction)
  *  rct2: 0x0068C222 slope 4, style 2
  *  rct2: 0x0068C2EA slope 8, style 3
  */
-static money32 smooth_land_tile(int direction, uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+static money32 smooth_land_tile(int direction, uint8 flags, int x, int y, int targetBaseZ, int minBaseZ)
 {
 	// Check if inside map bounds
 	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
@@ -2109,7 +2109,7 @@ static money32 smooth_land_tile(int direction, uint8 flags, int x, int y, uint8 
 
 	// Get height of tile
 	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
-	uint8 baseZ = map_get_corner_height(mapElement, direction);
+	int baseZ = map_get_corner_height(mapElement, direction);
 
 	// Check if tile is same height as target tile
 	if (baseZ == targetBaseZ) {
@@ -2205,11 +2205,11 @@ money32 smooth_land(int flags, int centreX, int centreY, int mapLeft, int mapTop
 	x = mapLeft;
 	y = mapTop;
 	int size = ((mapRight - mapLeft) >> 5) + 1;
-	sint8 initialMinZ = -2;
+	int initialMinZ = -2;
 
 	for (; size <= 256; size += 2) {
 		initialMinZ += 2;
-		sint8 minZ = (initialMinZ << 1) & 0xFF;
+		int minZ = initialMinZ * 2;
 		x -= 32;
 		y -= 32;
 

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -2051,12 +2051,12 @@ void game_command_lower_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, i
 	);
 }
 
-static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
+static int map_get_corner_height(rct_map_element *mapElement, int direction)
 {
 	int z = mapElement->base_height;
 	int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-	switch (slopeMask) {
-	case 1:
+	switch (direction) {
+	case 0:
 		if (slope & 1) {
 			z += 2;
 			if (slope == 27) {
@@ -2064,7 +2064,7 @@ static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
 			}
 		}
 		break;
-	case 2:
+	case 1:
 		if (slope & 2) {
 			z += 2;
 			if (slope == 23) {
@@ -2072,7 +2072,7 @@ static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
 			}
 		}
 		break;
-	case 4:
+	case 2:
 		if (slope & 4) {
 			z += 2;
 			if (slope == 30) {
@@ -2080,7 +2080,7 @@ static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
 			}
 		}
 		break;
-	case 8:
+	case 3:
 		if (slope & 8) {
 			z += 2;
 			if (slope == 29) {
@@ -2094,9 +2094,12 @@ static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
 
 /**
  *
- *  rct2: 0x0068C3B2
+ *  rct2: 0x0068C3B2 slope 1, style 0
+ *  rct2: 0x0068C47A slope 2, style 1
+ *  rct2: 0x0068C222 slope 4, style 2
+ *  rct2: 0x0068C2EA slope 8, style 3
  */
-static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+static money32 smooth_land_tile(int direction, uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
 {
 	// Check if inside map bounds
 	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
@@ -2105,7 +2108,7 @@ static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 mi
 
 	// Get height of tile
 	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
-	uint8 baseZ = map_get_corner_height(mapElement, 1);
+	uint8 baseZ = map_get_corner_height(mapElement, direction);
 
 	// Check if tile is same height as target tile
 	if (baseZ == targetBaseZ) {
@@ -2121,7 +2124,7 @@ static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 mi
 		}
 		targetBaseZ = mapElement->base_height;
 		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_lower_styles[0][slope];
+		style = map_element_lower_styles[direction][slope];
 		if (style & 0x20) {
 			targetBaseZ -= 2;
 			style &= ~0x20;
@@ -2133,7 +2136,7 @@ static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 mi
 		}
 		targetBaseZ = mapElement->base_height;
 		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_raise_styles[0][slope];
+		style = map_element_raise_styles[direction][slope];
 		if ((style & 0x20) != 0) {
 			targetBaseZ += 2;
 			style &= ~0x20;
@@ -2143,180 +2146,12 @@ static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 mi
 	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
 }
 
-/**
- *
- *  rct2: 0x0068C47A
- */
-static money32 sub_68C47A(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+money32 smooth_land(int flags, int centreX, int centreY, int mapLeft, int mapTop, int mapRight, int mapBottom, int command)
 {
-	// Check if inside map bounds
-	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
-		return MONEY32_UNDEFINED;
-	}
-
-	// Get height of tile
-	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
-	uint8 baseZ = map_get_corner_height(mapElement, 2);
-
-	// Check if tile is same height as target tile
-	if (baseZ == targetBaseZ) {
-		// No need to raise or lower
-		return MONEY32_UNDEFINED;
-	}
-
-	uint8 style;
-	if (targetBaseZ <= baseZ) {
-		baseZ = baseZ - targetBaseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_lower_styles[1][slope];
-		if (style & 0x20) {
-			targetBaseZ -= 2;
-			style &= ~0x20;
-		}
-	} else {
-		baseZ = targetBaseZ - baseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_raise_styles[1][slope];
-		if ((style & 0x20) != 0) {
-			targetBaseZ += 2;
-			style &= ~0x20;
-		}
-	}
-
-	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
-}
-
-/**
- *
- *  rct2: 0x0068C222
- */
-static money32 sub_68C222(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
-{
-	// Check if inside map bounds
-	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
-		return MONEY32_UNDEFINED;
-	}
-
-	// Get height of tile
-	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
-	uint8 baseZ = map_get_corner_height(mapElement, 4);
-
-	// Check if tile is same height as target tile
-	if (baseZ == targetBaseZ) {
-		// No need to raise or lower
-		return MONEY32_UNDEFINED;
-	}
-
-	uint8 style;
-	if (targetBaseZ <= baseZ) {
-		baseZ = baseZ - targetBaseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_lower_styles[2][slope];
-		if (style & 0x20) {
-			targetBaseZ -= 2;
-			style &= ~0x20;
-		}
-	} else {
-		baseZ = targetBaseZ - baseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_raise_styles[2][slope];
-		if ((style & 0x20) != 0) {
-			targetBaseZ += 2;
-			style &= ~0x20;
-		}
-	}
-
-	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
-}
-
-/**
- *
- *  rct2: 0x0068C2EA
- */
-static money32 sub_68C2EA(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
-{
-	// Check if inside map bounds
-	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
-		return MONEY32_UNDEFINED;
-	}
-
-	// Get height of tile
-	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
-	uint8 baseZ = map_get_corner_height(mapElement, 8);
-
-	// Check if tile is same height as target tile
-	if (baseZ == targetBaseZ) {
-		// No need to raise or lower
-		return MONEY32_UNDEFINED;
-	}
-
-	uint8 style;
-	if (targetBaseZ <= baseZ) {
-		baseZ = baseZ - targetBaseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_lower_styles[3][slope];
-		if (style & 0x20) {
-			targetBaseZ -= 2;
-			style &= ~0x20;
-		}
-	} else {
-		baseZ = targetBaseZ - baseZ;
-		if (baseZ <= minBaseZ) {
-			return MONEY32_UNDEFINED;
-		}
-		targetBaseZ = mapElement->base_height;
-		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-		style = map_element_raise_styles[3][slope];
-		if ((style & 0x20) != 0) {
-			targetBaseZ += 2;
-			style &= ~0x20;
-		}
-	}
-
-	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
-}
-
-/**
- *
- *  rct2: 0x0068BC01
- */
-void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
-{
-	// RCT2_CALLFUNC_X(0x0068BC01, eax, ebx, ecx, edx, esi, edi, ebp); return;
-
-	int flags = *ebx & 0xFF;
-	int centreX = *eax & 0xFFFF;
-	int centreY = *ecx & 0xFFFF;
+	int commandType;
 	int centreZ = map_element_height(centreX, centreY);
-	int mapLeftRight = *edx;
-	int mapTopBottom = *ebp;
-	int mapLeft = mapLeftRight & 0xFFFF;
-	int mapTop = mapTopBottom & 0xFFFF;
-	int mapRight = mapLeftRight >> 16;
-	int mapBottom = mapTopBottom >> 16;
-
-	int subCommand = *edi;
-	int subGameCommandType = *edi == 1 ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
+	int mapLeftRight = mapLeft | (mapRight << 16);
+	int mapTopBottom = mapTop | (mapBottom << 16);
 
 	// Play sound (only once)
 	if ((flags & GAME_COMMAND_FLAG_APPLY) && RCT2_GLOBAL(0x009A8C28, uint8) == 1) {
@@ -2327,7 +2162,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 
 	// First raise / lower the centre tile
 	money32 result;
-	result = game_do_command(centreX, flags, centreY, mapLeftRight, subGameCommandType, 4, mapTopBottom);
+	commandType = command == 1 ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
+	result = game_do_command(centreX, flags, centreY, mapLeftRight, commandType, 4, mapTopBottom);
 	if (result != MONEY32_UNDEFINED) {
 		totalCost += result;
 	}
@@ -2340,8 +2176,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 	mapElement = map_get_surface_element_at(x >> 5, y >> 5);
 	int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
 	if (slope != 0) {
-		int command = subCommand == 0xFFFF ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
-		result = game_do_command(centreX, flags, centreY, mapLeftRight, command, 4, mapTopBottom);
+		commandType = command == 0xFFFF ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
+		result = game_do_command(centreX, flags, centreY, mapLeftRight, commandType, 4, mapTopBottom);
 		if (result != MONEY32_UNDEFINED) {
 			totalCost += result;
 		}
@@ -2350,51 +2186,41 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 		y = mapTop;
 		mapElement = map_get_surface_element_at(x >> 5, y >> 5);
 		slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
-
-		*ebx = totalCost * 4;
-		RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_LANDSCAPING * 4;
-		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint32) = centreX;
-		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint32) = centreY;
-		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint32) = centreZ;
-		return;
-	}
-
-	x = mapLeft;
-	y = mapTop;
-	int bx = ((mapRight - mapLeft) >> 5) - 1;
-	sint8 byte_F1AD5C = -2;
-
-	for (;;) {
-		byte_F1AD5C += 2;
-		bx += 2;
-		x -= 32;
-		y -= 32;
-		if (bx > 64) {
-			*ebx = totalCost * 4;
+		if (slope != 0) {
 			RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_LANDSCAPING * 4;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint32) = centreX;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint32) = centreY;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint32) = centreZ;
-			return;
+			return totalCost * 4;
 		}
+	}
 
-		sint8 minZ = (byte_F1AD5C << 1) & 0xFF;
+	x = mapLeft;
+	y = mapTop;
+	int size = ((mapRight - mapLeft) >> 5) + 1;
+	sint8 initialMinZ = -2;
+
+	for (; size <= 64; size += 2) {
+		initialMinZ += 2;
+		sint8 minZ = (initialMinZ << 1) & 0xFF;
+		x -= 32;
+		y -= 32;
 
 		// Corner (North-West)
 		mapElement = map_get_surface_element_at(mapLeft >> 5, mapTop >> 5);
-		z = map_get_corner_height(mapElement, 4);
-		result = sub_68C3B2(flags, x, y, z, minZ);
+		z = map_get_corner_height(mapElement, 2);
+		result = smooth_land_tile(0, flags, x, y, z, minZ);
 		if (result != MONEY32_UNDEFINED) {
 			totalCost += result;
 		}
 		y += 32;
 
 		// Side (West)
-		for (int i = 0; i < bx; i++) {
+		for (int i = 0; i < size; i++) {
 			int y2 = clamp(mapTop, y, mapBottom);
 			mapElement = map_get_surface_element_at(mapLeft >> 5, y2 >> 5);
-			z = map_get_corner_height(mapElement, 4);
-			result = sub_68C47A(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 2);
+			result = smooth_land_tile(1, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2405,8 +2231,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 					minZ += 2;
 				}
 			}
-			z = map_get_corner_height(mapElement, 8);
-			result = sub_68C3B2(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 3);
+			result = smooth_land_tile(0, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2416,19 +2242,19 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 
 		// Corner (South-West)
 		mapElement = map_get_surface_element_at(mapLeft >> 5, mapBottom >> 5);
-		z = map_get_corner_height(mapElement, 8);
-		result = sub_68C47A(flags, x, y, z, minZ);
+		z = map_get_corner_height(mapElement, 3);
+		result = smooth_land_tile(1, flags, x, y, z, minZ);
 		if (result != MONEY32_UNDEFINED) {
 			totalCost += result;
 		}
 		x += 32;
 
 		// Side (South)
-		for (int i = 0; i < bx; i++) {
+		for (int i = 0; i < size; i++) {
 			int x2 = clamp(mapLeft, x, mapRight);
 			mapElement = map_get_surface_element_at(x2 >> 5, mapBottom >> 5);
-			z = map_get_corner_height(mapElement, 8);
-			result = sub_68C222(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 3);
+			result = smooth_land_tile(2, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2439,8 +2265,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 					minZ += 2;
 				}
 			}
-			z = map_get_corner_height(mapElement, 1);
-			result = sub_68C47A(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 0);
+			result = smooth_land_tile(1, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2450,19 +2276,19 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 
 		// Corner (South-East)
 		mapElement = map_get_surface_element_at(mapRight >> 5, mapBottom >> 5);
-		z = map_get_corner_height(mapElement, 1);
-		result = sub_68C222(flags, x, y, z, minZ);
+		z = map_get_corner_height(mapElement, 0);
+		result = smooth_land_tile(2, flags, x, y, z, minZ);
 		if (result != MONEY32_UNDEFINED) {
 			totalCost += result;
 		}
 		y -= 32;
 
 		// Side (East)
-		for (int i = 0; i < bx; i++) {
+		for (int i = 0; i < size; i++) {
 			int y2 = clamp(mapTop, y, mapBottom);
 			mapElement = map_get_surface_element_at(mapRight >> 5, y2 >> 5);
-			z = map_get_corner_height(mapElement, 1);
-			result = sub_68C2EA(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 0);
+			result = smooth_land_tile(3, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2473,8 +2299,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 					minZ += 2;
 				}
 			}
-			z = map_get_corner_height(mapElement, 2);
-			result = sub_68C222(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 1);
+			result = smooth_land_tile(2, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2484,19 +2310,19 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 
 		// Corner (North-East)
 		mapElement = map_get_surface_element_at(mapRight >> 5, mapTop >> 5);
-		z = map_get_corner_height(mapElement, 2);
-		result = sub_68C2EA(flags, x, y, z, minZ);
+		z = map_get_corner_height(mapElement, 1);
+		result = smooth_land_tile(3, flags, x, y, z, minZ);
 		if (result != MONEY32_UNDEFINED) {
 			totalCost += result;
 		}
 		x -= 32;
 
 		// Side (North)
-		for (int i = 0; i < bx; i++) {
+		for (int i = 0; i < size; i++) {
 			int x2 = clamp(mapLeft, x, mapRight);
 			mapElement = map_get_surface_element_at(x2 >> 5, mapTop >> 5);
-			z = map_get_corner_height(mapElement, 2);
-			result = sub_68C3B2(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 1);
+			result = smooth_land_tile(0, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2507,8 +2333,8 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 					minZ += 2;
 				}
 			}
-			z = map_get_corner_height(mapElement, 4);
-			result = sub_68C2EA(flags, x, y, z, minZ);
+			z = map_get_corner_height(mapElement, 2);
+			result = smooth_land_tile(3, flags, x, y, z, minZ);
 			if (result != MONEY32_UNDEFINED) {
 				totalCost += result;
 			}
@@ -2517,7 +2343,28 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 		}
 	}
 
-	*ebx = totalCost;
+	RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_LANDSCAPING * 4;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint32) = centreX;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint32) = centreY;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint32) = centreZ;
+	return totalCost * 4;
+}
+
+/**
+ *
+ *  rct2: 0x0068BC01
+ */
+void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
+{
+	int flags = *ebx & 0xFF;
+	int centreX = *eax & 0xFFFF;
+	int centreY = *ecx & 0xFFFF;
+	int mapLeft = *edx & 0xFFFF;
+	int mapTop = *ebp & 0xFFFF;
+	int mapRight = *edx >> 16;
+	int mapBottom = *ebp >> 16;
+	int command = *edi;
+	*ebx = smooth_land(flags, centreX, centreY, mapLeft, mapTop, mapRight, mapBottom, command);
 }
 
 /**

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -2051,13 +2051,473 @@ void game_command_lower_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, i
 	);
 }
 
+static int map_get_corner_height(rct_map_element *mapElement, int slopeMask)
+{
+	int z = mapElement->base_height;
+	int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+	switch (slopeMask) {
+	case 1:
+		if (slope & 1) {
+			z += 2;
+			if (slope == 27) {
+				z += 2;
+			}
+		}
+		break;
+	case 2:
+		if (slope & 2) {
+			z += 2;
+			if (slope == 23) {
+				z += 2;
+			}
+		}
+		break;
+	case 4:
+		if (slope & 4) {
+			z += 2;
+			if (slope == 30) {
+				z += 2;
+			}
+		}
+		break;
+	case 8:
+		if (slope & 8) {
+			z += 2;
+			if (slope == 29) {
+				z += 2;
+			}
+		}
+		break;
+	}
+	return z;
+}
+
+/**
+ *
+ *  rct2: 0x0068C3B2
+ */
+static money32 sub_68C3B2(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+{
+	// Check if inside map bounds
+	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
+		return MONEY32_UNDEFINED;
+	}
+
+	// Get height of tile
+	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+	uint8 baseZ = map_get_corner_height(mapElement, 1);
+
+	// Check if tile is same height as target tile
+	if (baseZ == targetBaseZ) {
+		// No need to raise or lower
+		return MONEY32_UNDEFINED;
+	}
+
+	uint8 style;
+	if (targetBaseZ <= baseZ) {
+		baseZ = baseZ - targetBaseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_lower_styles[0][slope];
+		if (style & 0x20) {
+			targetBaseZ -= 2;
+			style &= ~0x20;
+		}
+	} else {
+		baseZ = targetBaseZ - baseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_raise_styles[0][slope];
+		if ((style & 0x20) != 0) {
+			targetBaseZ += 2;
+			style &= ~0x20;
+		}
+	}
+
+	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
+}
+
+/**
+ *
+ *  rct2: 0x0068C47A
+ */
+static money32 sub_68C47A(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+{
+	// Check if inside map bounds
+	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
+		return MONEY32_UNDEFINED;
+	}
+
+	// Get height of tile
+	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+	uint8 baseZ = map_get_corner_height(mapElement, 2);
+
+	// Check if tile is same height as target tile
+	if (baseZ == targetBaseZ) {
+		// No need to raise or lower
+		return MONEY32_UNDEFINED;
+	}
+
+	uint8 style;
+	if (targetBaseZ <= baseZ) {
+		baseZ = baseZ - targetBaseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_lower_styles[1][slope];
+		if (style & 0x20) {
+			targetBaseZ -= 2;
+			style &= ~0x20;
+		}
+	} else {
+		baseZ = targetBaseZ - baseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_raise_styles[1][slope];
+		if ((style & 0x20) != 0) {
+			targetBaseZ += 2;
+			style &= ~0x20;
+		}
+	}
+
+	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
+}
+
+/**
+ *
+ *  rct2: 0x0068C222
+ */
+static money32 sub_68C222(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+{
+	// Check if inside map bounds
+	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
+		return MONEY32_UNDEFINED;
+	}
+
+	// Get height of tile
+	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+	uint8 baseZ = map_get_corner_height(mapElement, 4);
+
+	// Check if tile is same height as target tile
+	if (baseZ == targetBaseZ) {
+		// No need to raise or lower
+		return MONEY32_UNDEFINED;
+	}
+
+	uint8 style;
+	if (targetBaseZ <= baseZ) {
+		baseZ = baseZ - targetBaseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_lower_styles[2][slope];
+		if (style & 0x20) {
+			targetBaseZ -= 2;
+			style &= ~0x20;
+		}
+	} else {
+		baseZ = targetBaseZ - baseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_raise_styles[2][slope];
+		if ((style & 0x20) != 0) {
+			targetBaseZ += 2;
+			style &= ~0x20;
+		}
+	}
+
+	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
+}
+
+/**
+ *
+ *  rct2: 0x0068C2EA
+ */
+static money32 sub_68C2EA(uint8 flags, int x, int y, uint8 targetBaseZ, uint8 minBaseZ)
+{
+	// Check if inside map bounds
+	if (x < 0 || y < 0 || x >= (256 * 32) || y >= (256 * 32)) {
+		return MONEY32_UNDEFINED;
+	}
+
+	// Get height of tile
+	rct_map_element *mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+	uint8 baseZ = map_get_corner_height(mapElement, 8);
+
+	// Check if tile is same height as target tile
+	if (baseZ == targetBaseZ) {
+		// No need to raise or lower
+		return MONEY32_UNDEFINED;
+	}
+
+	uint8 style;
+	if (targetBaseZ <= baseZ) {
+		baseZ = baseZ - targetBaseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_lower_styles[3][slope];
+		if (style & 0x20) {
+			targetBaseZ -= 2;
+			style &= ~0x20;
+		}
+	} else {
+		baseZ = targetBaseZ - baseZ;
+		if (baseZ <= minBaseZ) {
+			return MONEY32_UNDEFINED;
+		}
+		targetBaseZ = mapElement->base_height;
+		int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+		style = map_element_raise_styles[3][slope];
+		if ((style & 0x20) != 0) {
+			targetBaseZ += 2;
+			style &= ~0x20;
+		}
+	}
+
+	return game_do_command(x, flags, y, targetBaseZ | (style << 8), GAME_COMMAND_SET_LAND_HEIGHT, 0, 0);
+}
+
 /**
  *
  *  rct2: 0x0068BC01
  */
 void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
 {
-	RCT2_CALLFUNC_X(0x0068BC01, eax, ebx, ecx, edx, esi, edi, ebp);
+	// RCT2_CALLFUNC_X(0x0068BC01, eax, ebx, ecx, edx, esi, edi, ebp); return;
+
+	int flags = *ebx & 0xFF;
+	int centreX = *eax & 0xFFFF;
+	int centreY = *ecx & 0xFFFF;
+	int centreZ = map_element_height(centreX, centreY);
+	int mapLeftRight = *edx;
+	int mapTopBottom = *ebp;
+	int mapLeft = mapLeftRight & 0xFFFF;
+	int mapTop = mapTopBottom & 0xFFFF;
+	int mapRight = mapLeftRight >> 16;
+	int mapBottom = mapTopBottom >> 16;
+
+	int subCommand = *edi;
+	int subGameCommandType = *edi == 1 ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
+
+	// Play sound (only once)
+	if ((flags & GAME_COMMAND_FLAG_APPLY) && RCT2_GLOBAL(0x009A8C28, uint8) == 1) {
+		sound_play_panned(SOUND_PLACE_ITEM, 0x8001, centreX, centreY, centreZ);
+	}
+
+	money32 totalCost = 0;
+
+	// First raise / lower the centre tile
+	money32 result;
+	result = game_do_command(centreX, flags, centreY, mapLeftRight, subGameCommandType, 4, mapTopBottom);
+	if (result != MONEY32_UNDEFINED) {
+		totalCost += result;
+	}
+
+	int x, y, z;
+	rct_map_element *mapElement;
+
+	x = mapLeft;
+	y = mapTop;
+	mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+	int slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+	if (slope != 0) {
+		int command = subCommand == 0xFFFF ? GAME_COMMAND_RAISE_LAND : GAME_COMMAND_LOWER_LAND;
+		result = game_do_command(centreX, flags, centreY, mapLeftRight, command, 4, mapTopBottom);
+		if (result != MONEY32_UNDEFINED) {
+			totalCost += result;
+		}
+
+		x = mapLeft;
+		y = mapTop;
+		mapElement = map_get_surface_element_at(x >> 5, y >> 5);
+		slope = mapElement->properties.surface.slope & MAP_ELEMENT_SLOPE_MASK;
+
+		*ebx = totalCost * 4;
+		RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_LANDSCAPING * 4;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint32) = centreX;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint32) = centreY;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint32) = centreZ;
+		return;
+	}
+
+	x = mapLeft;
+	y = mapTop;
+	int bx = ((mapRight - mapLeft) >> 5) - 1;
+	sint8 byte_F1AD5C = -2;
+
+	for (;;) {
+		byte_F1AD5C += 2;
+		bx += 2;
+		x -= 32;
+		y -= 32;
+		if (bx > 64) {
+			*ebx = totalCost * 4;
+			RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_LANDSCAPING * 4;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint32) = centreX;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint32) = centreY;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint32) = centreZ;
+			return;
+		}
+
+		sint8 minZ = (byte_F1AD5C << 1) & 0xFF;
+
+		// Corner (North-West)
+		mapElement = map_get_surface_element_at(mapLeft >> 5, mapTop >> 5);
+		z = map_get_corner_height(mapElement, 4);
+		result = sub_68C3B2(flags, x, y, z, minZ);
+		if (result != MONEY32_UNDEFINED) {
+			totalCost += result;
+		}
+		y += 32;
+
+		// Side (West)
+		for (int i = 0; i < bx; i++) {
+			int y2 = clamp(mapTop, y, mapBottom);
+			mapElement = map_get_surface_element_at(mapLeft >> 5, y2 >> 5);
+			z = map_get_corner_height(mapElement, 4);
+			result = sub_68C47A(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+			minZ -= 2;
+			if (y >= mapTop) {
+				minZ += 2;
+				if (y > mapBottom) {
+					minZ += 2;
+				}
+			}
+			z = map_get_corner_height(mapElement, 8);
+			result = sub_68C3B2(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+
+			y += 32;
+		}
+
+		// Corner (South-West)
+		mapElement = map_get_surface_element_at(mapLeft >> 5, mapBottom >> 5);
+		z = map_get_corner_height(mapElement, 8);
+		result = sub_68C47A(flags, x, y, z, minZ);
+		if (result != MONEY32_UNDEFINED) {
+			totalCost += result;
+		}
+		x += 32;
+
+		// Side (South)
+		for (int i = 0; i < bx; i++) {
+			int x2 = clamp(mapLeft, x, mapRight);
+			mapElement = map_get_surface_element_at(x2 >> 5, mapBottom >> 5);
+			z = map_get_corner_height(mapElement, 8);
+			result = sub_68C222(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+			minZ -= 2;
+			if (x >= mapLeft) {
+				minZ += 2;
+				if (x > mapRight) {
+					minZ += 2;
+				}
+			}
+			z = map_get_corner_height(mapElement, 1);
+			result = sub_68C47A(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+
+			x += 32;
+		}
+
+		// Corner (South-East)
+		mapElement = map_get_surface_element_at(mapRight >> 5, mapBottom >> 5);
+		z = map_get_corner_height(mapElement, 1);
+		result = sub_68C222(flags, x, y, z, minZ);
+		if (result != MONEY32_UNDEFINED) {
+			totalCost += result;
+		}
+		y -= 32;
+
+		// Side (East)
+		for (int i = 0; i < bx; i++) {
+			int y2 = clamp(mapTop, y, mapBottom);
+			mapElement = map_get_surface_element_at(mapRight >> 5, y2 >> 5);
+			z = map_get_corner_height(mapElement, 1);
+			result = sub_68C2EA(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+			minZ -= 2;
+			if (y <= mapBottom) {
+				minZ += 2;
+				if (y < mapTop) {
+					minZ += 2;
+				}
+			}
+			z = map_get_corner_height(mapElement, 2);
+			result = sub_68C222(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+
+			y -= 32;
+		}
+
+		// Corner (North-East)
+		mapElement = map_get_surface_element_at(mapRight >> 5, mapTop >> 5);
+		z = map_get_corner_height(mapElement, 2);
+		result = sub_68C2EA(flags, x, y, z, minZ);
+		if (result != MONEY32_UNDEFINED) {
+			totalCost += result;
+		}
+		x -= 32;
+
+		// Side (North)
+		for (int i = 0; i < bx; i++) {
+			int x2 = clamp(mapLeft, x, mapRight);
+			mapElement = map_get_surface_element_at(x2 >> 5, mapTop >> 5);
+			z = map_get_corner_height(mapElement, 2);
+			result = sub_68C3B2(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+			minZ -= 2;
+			if (x <= mapRight) {
+				minZ += 2;
+				if (x < mapLeft) {
+					minZ += 2;
+				}
+			}
+			z = map_get_corner_height(mapElement, 4);
+			result = sub_68C2EA(flags, x, y, z, minZ);
+			if (result != MONEY32_UNDEFINED) {
+				totalCost += result;
+			}
+
+			x -= 32;
+		}
+	}
+
+	*ebx = totalCost;
 }
 
 /**

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -58,7 +58,8 @@ rct_map_element **gMapElementTilePointers = (rct_map_element**)RCT2_ADDRESS_TILE
 rct_xy16 *gMapSelectionTiles = (rct_xy16*)0x009DE596;
 rct2_peep_spawn *gPeepSpawns = (rct2_peep_spawn*)RCT2_ADDRESS_PEEP_SPAWNS;
 
-bool LandPaintMode;
+bool gLandMountainMode;
+bool gLandPaintMode;
 bool LandRightsMode;
 bool gClearSmallScenery;
 bool gClearLargeScenery;
@@ -2148,6 +2149,12 @@ static money32 smooth_land_tile(int direction, uint8 flags, int x, int y, uint8 
 
 money32 smooth_land(int flags, int centreX, int centreY, int mapLeft, int mapTop, int mapRight, int mapBottom, int command)
 {
+	// Cap bounds to map
+	mapLeft = max(mapLeft, 32);
+	mapTop = max(mapTop, 32);
+	mapRight = min(mapRight, 255 * 32);
+	mapBottom = min(mapBottom, 255 * 32);
+
 	int commandType;
 	int centreZ = map_element_height(centreX, centreY);
 	int mapLeftRight = mapLeft | (mapRight << 16);
@@ -2200,7 +2207,7 @@ money32 smooth_land(int flags, int centreX, int centreY, int mapLeft, int mapTop
 	int size = ((mapRight - mapLeft) >> 5) + 1;
 	sint8 initialMinZ = -2;
 
-	for (; size <= 64; size += 2) {
+	for (; size <= 256; size += 2) {
 		initialMinZ += 2;
 		sint8 minZ = (initialMinZ << 1) & 0xFF;
 		x -= 32;
@@ -2359,10 +2366,10 @@ void game_command_smooth_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 	int flags = *ebx & 0xFF;
 	int centreX = *eax & 0xFFFF;
 	int centreY = *ecx & 0xFFFF;
-	int mapLeft = *edx & 0xFFFF;
-	int mapTop = *ebp & 0xFFFF;
-	int mapRight = *edx >> 16;
-	int mapBottom = *ebp >> 16;
+	int mapLeft = (sint16)(*edx & 0xFFFF);
+	int mapTop = (sint16)(*ebp & 0xFFFF);
+	int mapRight = (sint16)(*edx >> 16);
+	int mapBottom = (sint16)(*ebp >> 16);
 	int command = *edi;
 	*ebx = smooth_land(flags, centreX, centreY, mapLeft, mapTop, mapRight, mapBottom, command);
 }

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -262,8 +262,10 @@ extern rct_map_element **gMapElementTilePointers;
 
 extern rct_xy16 *gMapSelectionTiles;
 extern rct2_peep_spawn *gPeepSpawns;
+// Used in the land tool window to enable mountain tool / land smoothing
+extern bool gLandMountainMode;
 // Used in the land tool window to allow dragging and changing land styles
-extern bool LandPaintMode;
+extern bool gLandPaintMode;
 // Used in the land rights tool window to either buy land rights or construction rights
 extern bool LandRightsMode;
 // Used in the clear scenery tool


### PR DESCRIPTION
Implements the mountain tool and land smooth game command. I have also updated the land tool window so that there is now a toggle button for mountain tool that you click instead of using size 0. This means you can now use the mountain tool in sizes of 1 to 64.