### PR TITLE
Fixes the portuguese (br) language name

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -43,7 +43,7 @@ enum {
 	RCT2_LANGUAGE_ID_CHINESE_SIMPLIFIED,
 	RCT2_LANGUAGE_ID_CHINESE_TRADITIONAL,
 	RCT2_LANGUAGE_ID_12,
-	RCT2_LANGUAGE_ID_PORTUGESE,
+	RCT2_LANGUAGE_ID_PORTUGUESE,
 	RCT2_LANGUAGE_ID_END = 255
 };
 
@@ -80,7 +80,7 @@ const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] = {
 	{ "es-ES",		"Spanish",					"Espa\xC3\xB1ol",			"spanish_sp",				FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_SPANISH				},	// LANGUAGE_SPANISH
 	{ "sv-SE",		"Swedish",					"Svenska",					"swedish",					FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_SWEDISH				},	// LANGUAGE_SWEDISH
 	{ "it-IT",		"Italian",					"Italiano",					"italian",					FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_ITALIAN				},	// LANGUAGE_ITALIAN
-	{ "pt-BR",		"Portuguese (BR)",			"Portug\xC3\xAAs (BR)",		"portuguese_br",			FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_PORTUGESE				},	// LANGUAGE_PORTUGUESE_BR
+	{ "pt-BR",		"Portuguese (BR)",			"Portugu\xC3\xAAs (BR)",		"portuguese_br",			FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_PORTUGUESE				},	// LANGUAGE_PORTUGUESE_BR
 	{ "zh-Hant",	"Chinese (Traditional)",	"Chinese (Traditional)",	"chinese_traditional",		&TTFFontMingLiu,		RCT2_LANGUAGE_ID_CHINESE_TRADITIONAL	},	// LANGUAGE_CHINESE_TRADITIONAL
 	{ "zh-Hans",	"Chinese (Simplified)",		"Chinese (Simplified)",		"chinese_simplified",		&TTFFontSimSun,			RCT2_LANGUAGE_ID_CHINESE_SIMPLIFIED		},	// LANGUAGE_CHINESE_SIMPLIFIED
 	{ "fi-FI",		"Finnish",					"Suomi",					"finnish",					FONT_OPENRCT2_SPRITE,	RCT2_LANGUAGE_ID_ENGLISH_UK				},	// LANGUAGE_FINNISH


### PR DESCRIPTION
The Brazilian Portuguese language is being listed as "Portugês (BR)" in the GUI and as ```PORTUGESE``` in the code. This PR fixes it to "Português (BR)" and ```PORTUGUESE```, respectively.