### PR TITLE
type and const fixes for sawyercoding

### DIFF
--- a/src/scenario.c
+++ b/src/scenario.c
@@ -851,7 +851,7 @@ int scenario_write_packed_objects(SDL_RWops* rw)
  */
 int scenario_write_available_objects(FILE *file)
 {
-	char *buffer, *dstBuffer;
+	uint8 *buffer, *dstBuffer;
 	int i, encodedLength;
 	sawyercoding_chunk_header chunkHeader;
 
@@ -860,16 +860,16 @@ int scenario_write_available_objects(FILE *file)
 
 	// Initialise buffers
 	buffer = malloc(bufferLength);
-  if (buffer == NULL) {
-    log_error("out of memory");
-    return 0;
-  }
+	if (buffer == NULL) {
+		log_error("out of memory");
+		return 0;
+	}
 	dstBuffer = malloc(bufferLength + sizeof(sawyercoding_chunk_header));
-  if (dstBuffer == NULL) {
-    free(buffer);
-    log_error("out of memory");
-  	return 0;
-  }
+	if (dstBuffer == NULL) {
+		free(buffer);
+		log_error("out of memory");
+		return 0;
+	}
 
 	// Write entries
 	rct_object_entry_extended *srcEntry = (rct_object_entry_extended*)0x00F3F03C;
@@ -1123,7 +1123,7 @@ int scenario_save_network(SDL_RWops* rw)
 
 bool scenario_save_s6(SDL_RWops* rw, rct_s6_data *s6)
 {
-	char *buffer;
+	uint8 *buffer;
 	sawyercoding_chunk_header chunkHeader;
 	int encodedLength;
 	long fileSize;

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- 
+
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- 
+
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
@@ -175,7 +175,7 @@ typedef struct {
 	uint32 dword_0135789C;
 	uint32 dword_013578A0;
 	uint32 dword_013578A4[201];
-	
+
 	// SC6[8]
 	uint16 last_guests_in_park;
 	uint8 pad_01357BCA[3];
@@ -283,7 +283,7 @@ typedef struct {
 	uint16 park_entrance_y[4];
 	uint16 park_entrance_z[4];
 	uint8 park_entrance_direction[4];
-	uint8 scenario_filename[256];
+	char scenario_filename[256];
 	uint8 saved_expansion_pack_names[3256];
 	rct_banner banners[250];
 	char custom_strings[0x8000];

--- a/src/util/sawyercoding.h
+++ b/src/util/sawyercoding.h
@@ -1,9 +1,9 @@
 /*****************************************************************************
  * Copyright (c) 2014 Ted John
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
- * 
+ *
  * This file is part of OpenRCT2.
- * 
+ *
  * OpenRCT2 is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
- 
+
 #ifndef _SAWYERCODING_H_
 #define _SAWYERCODING_H_
 
@@ -48,16 +48,16 @@ enum {
 };
 
 int sawyercoding_validate_checksum(SDL_RWops* rw);
-uint32 sawyercoding_calculate_checksum(uint8* buffer, uint32 length);
-int sawyercoding_read_chunk(SDL_RWops* rw, uint8 *buffer);
-int sawyercoding_write_chunk_buffer(uint8 *dst_file, uint8* buffer, sawyercoding_chunk_header chunkHeader);
-int sawyercoding_decode_sv4(char *src, char *dst, int length);
-int sawyercoding_decode_sc4(char *src, char *dst, int length);
-int sawyercoding_encode_sv4(char *src, char *dst, int length);
-int sawyercoding_decode_td6(char *src, char *dst, int length);
-int sawyercoding_encode_td6(char* src, char* dst, int length);
-int sawyercoding_validate_track_checksum(char* src, int length);
+uint32 sawyercoding_calculate_checksum(const uint8* buffer, size_t length);
+size_t sawyercoding_read_chunk(SDL_RWops* rw, uint8 *buffer);
+size_t sawyercoding_write_chunk_buffer(uint8 *dst_file, uint8* buffer, sawyercoding_chunk_header chunkHeader);
+size_t sawyercoding_decode_sv4(const uint8 *src, uint8 *dst, size_t length);
+size_t sawyercoding_decode_sc4(const uint8 *src, uint8 *dst, size_t length);
+size_t sawyercoding_encode_sv4(const uint8 *src, uint8 *dst, size_t length);
+size_t sawyercoding_decode_td6(const uint8 *src, uint8 *dst, size_t length);
+size_t sawyercoding_encode_td6(const uint8 *src, uint8 *dst, size_t length);
+int sawyercoding_validate_track_checksum(const uint8* src, size_t length);
 
-int sawyercoding_detect_file_type(char *src, int length);
+int sawyercoding_detect_file_type(const uint8 *src, size_t length);
 
 #endif


### PR DESCRIPTION
Just some minor type and const fixes.

Signedness of `char` is undefined by standard, so force all the types to be much more binary-like `uint8`, at least for sawyercoding.