### PR TITLE
Cleaned up peep_on_enter_ride

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -68,6 +68,9 @@ static bool peep_has_ridden(rct_peep *peep, int rideIndex);
 static void peep_set_has_ridden_ride_type(rct_peep *peep, int rideType);
 static bool peep_has_ridden_ride_type(rct_peep *peep, int rideType);
 static void peep_on_enter_or_exit_ride(rct_peep *peep, int rideIndex, int flags);
+static void peep_update_favourite_ride(rct_peep *peep, rct_ride *ride);
+static sint8 peep_calculate_ride_satisfaction(rct_peep *peep, rct_ride *ride);
+static void peep_update_ride_nausea_growth(rct_peep *peep, rct_ride *ride);
 static bool sub_69AF1E(rct_peep *peep, int rideIndex, int shopItem, money32 price);
 static bool peep_should_use_cash_machine(rct_peep *peep, int rideIndex);
 static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNum, int flags);
@@ -7532,43 +7535,72 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
 
 static void peep_set_has_ridden(rct_peep *peep, int rideIndex)
 {
-	peep->rides_been_on[rideIndex >> 5] |= 1 << (rideIndex & 0x1F);
+	peep->rides_been_on[rideIndex / 32] |= 1 << (rideIndex % 32);
+	rct_ride *ride = GET_RIDE(rideIndex);
+	peep_set_has_ridden_ride_type(peep, ride->type);
 }
 
 static bool peep_has_ridden(rct_peep *peep, int rideIndex)
 {
-	return peep->rides_been_on[rideIndex >> 5] & (1 << (rideIndex & 0x1F));
+	return peep->rides_been_on[rideIndex / 32] & (1 << (rideIndex % 32));
 }
 
 static void peep_set_has_ridden_ride_type(rct_peep *peep, int rideType)
 {
-	peep->rides_been_on[rideType >> 5] |= 1 << (rideType & 0x1F);
+	peep->ride_types_been_on[rideType / 32] |= 1 << (rideType % 32);
 }
 
 static bool peep_has_ridden_ride_type(rct_peep *peep, int rideType)
 {
-	return peep->rides_been_on[rideType >> 5] & (1 << (rideType & 0x1F));
+	return peep->ride_types_been_on[rideType / 32] & (1 << (rideType % 32));
 }
 
 /**
  *
  *  rct2: 0x0069545B
- *  Updates the happiness and nausea growth rates for peeps upon entering a ride,
- *  and contains the logic for determining if the ride will become the peep's favourite.
- *  The ride itself has its satisfaction value updated.
+ *  Updates various peep stats upon entering a ride, as well as updating the
+ *  ride's satisfaction value.
  */
 static void peep_on_enter_ride(rct_peep *peep, int rideIndex)
 {
 	rct_ride *ride = GET_RIDE(rideIndex);
 
-	// Check to see if this should become the peep's favourite ride.
-	// For this, a "ride rating" is calculated based on the excitement of the ride and the peep's current happiness.
-	// As this value cannot exceed 255, the happier the peep is, the more irrelevant the ride's excitement becomes.
-	// Due to the minimum happiness requirement, an excitement rating of more than 3.8 has no further effect.
-	
-	// If the ride rating is higher than any ride the peep has already been on and the happiness criteria is met,
-	// the ride becomes the peep's favourite.
+	// Calculate how satisfying the ride is for the peep. Can range from -140 to +140.
+	sint8 satisfaction = peep_calculate_ride_satisfaction(peep, ride);
 
+	// Update the satisfaction stat of the ride.
+	uint8 rideSatisfaction = 0;
+	if (satisfaction >= 40)
+		rideSatisfaction = 3;
+	else if (satisfaction >= 20)
+		rideSatisfaction = 2;
+	else if (satisfaction >= 0)
+		rideSatisfaction = 1;
+
+	ride_update_satisfaction(ride, rideSatisfaction);
+
+	// Update various peep stats.
+	if (peep->no_of_rides < 255)
+		peep->no_of_rides++;
+
+	peep_set_has_ridden(peep, peep->current_ride);
+	peep_update_favourite_ride(peep, ride);
+	peep->happiness_growth_rate = clamp(0, peep->happiness_growth_rate + satisfaction, 255);
+	peep_update_ride_nausea_growth(peep, ride);
+}
+
+/*
+ * Check to see if the specified ride should become the peep's favourite.
+ * For this, a "ride rating" is calculated based on the excitement of the ride and the peep's current happiness.
+ * As this value cannot exceed 255, the happier the peep is, the more irrelevant the ride's excitement becomes.
+ * Due to the minimum happiness requirement, an excitement rating of more than 3.8 has no further effect.
+ *
+ * If the ride rating is higher than any ride the peep has already been on and the happiness criteria is met,
+ * the ride becomes the peep's favourite. (This doesn't happen right away, but will be updated once the peep
+ * exits the ride.)
+ */
+static void peep_update_favourite_ride(rct_peep *peep, rct_ride *ride)
+{
 	peep->flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
 	uint8 peepRideRating = clamp(0, (ride->excitement / 4) + peep->happiness, 255);
 	if (peepRideRating >= peep->favourite_ride_rating) {
@@ -7577,17 +7609,19 @@ static void peep_on_enter_ride(rct_peep *peep, int rideIndex)
 			peep->flags |= PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
 		}
 	}
+}
 
-	/**
-	 * The satisfaction values calculated here are used to determine how happy the peep is with the ride,
-	 * and also affects the satisfaction stat of the ride itself. The factors that affect satisfaction include:
-	 * - The price of the ride compared to the ride's value
-	 * - How closely the intensity and nausea of the ride matches the peep's preferences
-	 * - How long the peep was waiting in the queue
-	 * - If the peep has been on the ride before, or on another ride of the same type
-	 */
-
-	uint8 rawSatisfaction = 0;
+/**
+ * The satisfaction values calculated here are used to determine how happy the peep is with the ride,
+ * and also affects the satisfaction stat of the ride itself. The factors that affect satisfaction include:
+ * - The price of the ride compared to the ride's value
+ * - How closely the intensity and nausea of the ride matches the peep's preferences
+ * - How long the peep was waiting in the queue
+ * - If the peep has been on the ride before, or on another ride of the same type
+ */
+static sint8 peep_calculate_ride_satisfaction(rct_peep *peep, rct_ride *ride)
+{
+	sint8 satisfaction = 0;
 
 	// Calculate satisfaction based on the price and value of the ride.
 	uint8 valueSatisfaction = 1;
@@ -7610,13 +7644,13 @@ static void peep_on_enter_ride(rct_peep *peep, int rideIndex)
 
 	switch (valueSatisfaction) {
 	case 2:
-		rawSatisfaction += 40;
+		satisfaction += 40;
 		break;
 	case 1:
-		rawSatisfaction += 15;
+		satisfaction += 15;
 		break;
 	case 0:
-		rawSatisfaction -= 45;
+		satisfaction -= 45;
 		break;
 	}
 
@@ -7676,78 +7710,64 @@ static void peep_on_enter_ride(rct_peep *peep, int rideIndex)
 	if (highestSatisfaction == 3) {
 		switch (lowestSatisfaction) {
 		case 3:
-			rawSatisfaction += 20;
+			satisfaction += 20;
 		case 2:
-			rawSatisfaction += 15;
+			satisfaction += 15;
 		case 1:
-			rawSatisfaction += 35;
+			satisfaction += 35;
 			break;
 		case 0:
-			rawSatisfaction -= 35;
+			satisfaction -= 35;
 		}
 	}
 	else if (highestSatisfaction == 2) {
 		switch (lowestSatisfaction) {
 		case 2:
-			rawSatisfaction += 15;
+			satisfaction += 15;
 		case 1:
-			rawSatisfaction += 20;
+			satisfaction += 20;
 			break;
 		case 0:
-			rawSatisfaction -= 50;
+			satisfaction -= 50;
 		}
 	}
 	else if (highestSatisfaction == 1 && lowestSatisfaction == 1) {
-		rawSatisfaction += 10;
+		satisfaction += 10;
 	}
 	else {
-		rawSatisfaction -= 60;
+		satisfaction -= 60;
 	}
-	
+
 	// Calculate satisfaction based on how long the peep has been in the queue for.
 	// (For comparison: peeps start thinking "I've been queueing for a long time" at 3500 and
 	// start leaving the queue at 4300.)
 	if (peep->time_in_queue >= 4500)
-		rawSatisfaction -= 35;
+		satisfaction -= 35;
 	else if (peep->time_in_queue >= 2250)
-		rawSatisfaction -= 10;
+		satisfaction -= 10;
 	else if (peep->time_in_queue <= 750)
-		rawSatisfaction += 10;
+		satisfaction += 10;
 
 	// Peeps get a small boost in satisfaction if they've been on a ride of the same type before,
 	// and this boost is doubled if they've already been on this particular ride.
 	if (peep_has_ridden_ride_type(peep, ride->type))
-		rawSatisfaction += 10;
-	peep_set_has_ridden_ride_type(peep, ride->type);
+		satisfaction += 10;
 
 	if (peep_has_ridden(peep, peep->current_ride))
-		rawSatisfaction += 10;
-	peep_set_has_ridden(peep, peep->current_ride);
+		satisfaction += 10;
 
-	if (peep->no_of_rides < 255)
-		peep->no_of_rides++;
+	return satisfaction;
+}
 
-	// Update the satisfaction stat of the ride itself.
-	uint8 satisfaction = 0;
-	if (rawSatisfaction >= 40)
-		satisfaction = 3;
-	else if (rawSatisfaction >= 20)
-		satisfaction = 2;
-	else if (rawSatisfaction >= 0)
-		satisfaction = 1;
-	
-	ride_update_satisfaction(ride, satisfaction);
-
-	// Update the happiness growth rate of the peep. The largest possible change is +/- 1
-	peep->happiness_growth_rate = clamp(0, rawSatisfaction + peep->happiness_growth_rate, 255);
-
-	/*
-	 * Update the nausea growth of the peep. This is calculated based on:
-	 * - The nausea rating of the ride
-	 * - Their new happiness growth rate (the higher, the less nauseous)
-	 * - How hungry the peep is (+0% nausea at 50% hunger up to +100% nausea at 100% hunger)
-	 * - The peep's nausea tolerance (Final modifier: none: 100%, low: 50%, average: 25%, high: 12.5%)
-	 */
+/*
+ * Update the nausea growth of the peep based on a ride. This is calculated based on:
+ * - The nausea rating of the ride
+ * - Their new happiness growth rate (the higher, the less nauseous)
+ * - How hungry the peep is (+0% nausea at 50% hunger up to +100% nausea at 100% hunger)
+ * - The peep's nausea tolerance (Final modifier: none: 100%, low: 50%, average: 25%, high: 12.5%)
+ */
+static void peep_update_ride_nausea_growth(rct_peep *peep, rct_ride *ride)
+{
 	uint32 nauseaMultiplier = clamp(64, 256 - peep->happiness_growth_rate, 200);
 	uint32 nauseaGrowthRateChange = (ride->nausea * nauseaMultiplier) / 512;
 	nauseaGrowthRateChange *= max(128, peep->hunger) / 64;

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -7535,24 +7535,24 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
 
 static void peep_set_has_ridden(rct_peep *peep, int rideIndex)
 {
-	peep->rides_been_on[rideIndex / 32] |= 1 << (rideIndex % 32);
+	peep->rides_been_on[rideIndex / 8] |= 1 << (rideIndex % 8);
 	rct_ride *ride = GET_RIDE(rideIndex);
 	peep_set_has_ridden_ride_type(peep, ride->type);
 }
 
 static bool peep_has_ridden(rct_peep *peep, int rideIndex)
 {
-	return peep->rides_been_on[rideIndex / 32] & (1 << (rideIndex % 32));
+	return peep->rides_been_on[rideIndex / 8] & (1 << (rideIndex % 8));
 }
 
 static void peep_set_has_ridden_ride_type(rct_peep *peep, int rideType)
 {
-	peep->ride_types_been_on[rideType / 32] |= 1 << (rideType % 32);
+	peep->ride_types_been_on[rideType / 8] |= 1 << (rideType % 8);
 }
 
 static bool peep_has_ridden_ride_type(rct_peep *peep, int rideType)
 {
-	return peep->ride_types_been_on[rideType / 32] & (1 << (rideType % 32));
+	return peep->ride_types_been_on[rideType / 8] & (1 << (rideType % 8));
 }
 
 /**

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -542,7 +542,7 @@ typedef struct {
 	uint8 umbrella_colour;			// 0xF7
 	uint8 hat_colour;				// 0xF8
 	uint8 favourite_ride;			// 0xF9
-	uint8 var_FA;
+	uint8 favourite_ride_rating;	// 0xFA
 	uint8 pad_FB;
 	uint32 item_standard_flags;		// 0xFC
 } rct_peep;

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -5441,7 +5441,7 @@ void game_command_demolish_ride(int *eax, int *ebx, int *ecx, int *edx, int *esi
 			uint16 spriteIndex;
 			rct_peep *peep;
 			FOR_ALL_GUESTS(spriteIndex, peep){
-				uint8 ride_id_bit = ride_id & 0x3;
+				uint8 ride_id_bit = ride_id % 8;
 				uint8 ride_id_offset = ride_id / 8;
 				peep->rides_been_on[ride_id_offset] &= ~(1 << ride_id_bit); // clear ride from potentially being in rides_been_on
 				if(peep->state == PEEP_STATE_WATCHING){

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -1514,7 +1514,7 @@ void window_guest_rides_update(rct_window *w)
 	uint8 curr_list_position = 0;
 	for (uint8 ride_id = 0; ride_id < 255; ++ride_id){
 		// Offset to the ride_id bit in peep_rides_been_on
-		uint8 ride_id_bit = ride_id & 0x7;
+		uint8 ride_id_bit = ride_id % 8;
 		uint8 ride_id_offset = ride_id / 8;
 		if (peep->rides_been_on[ride_id_offset] & (1 << ride_id_bit)){
 			rct_ride* ride = GET_RIDE(ride_id);


### PR DESCRIPTION
I originally thought that this would be a rather straight forward clean up, but that has proved not to be the case.

My main concern is the bit of the code which calculates `intensitySatisfaction` and `nauseaSatisfaction`. In commit b0437746 I noticed that the max and min intensity were the wrong way around, but what I failed to notice was that it was actually the *variable names themselves* that were wrong, and so my commit effectively broke the logic which was previous correctly (just mislabeled).

I now believe that everything is the right way around, but that section definitely needs somebody to look over it to confirm that the logic is now right. In general, the closer the ride's intensity and nausea is to the peep's preferred intensity and nausea, the more `rawSatisfaction` should be increased.

As part of this commit, I've identified the purpose of `peep->var_FA` and named it `favourite_ride_rating` (the logic relating to that is near the start of the function). I'm not sure if there's a better name for it, I'm open to suggestions.