### PR TITLE
Fix loadlandscape breaking enabled tabs

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -160,7 +160,7 @@ void editor_convert_save_to_scenario()
 	}
 
 	RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) = SCREEN_FLAGS_SCENARIO_EDITOR;
-	s6Info->var_000 = 4;
+	s6Info->editor_step = EDITOR_STEP_OBJECTIVE_SELECTION;
 	s6Info->category = SCENARIO_CATEGORY_BUILDYOUROWN;
 	viewport_init_all();
 	news_item_init_queue();
@@ -347,10 +347,10 @@ static int editor_read_s6(const char *path)
 			// Read second chunk
 			sawyercoding_read_chunk(rw, (uint8*)s6Info);
 
-			if (s6Info->var_000 == 255)
-				s6Info->var_000 = 1;
+			if (s6Info->editor_step == 255)
+				s6Info->editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
 		} else {
-			s6Info->var_000 = 1;
+			s6Info->editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
 			s6Info->category = SCENARIO_CATEGORY_BUILDYOUROWN;
 			format_string(s6Info->details, STR_NO_DETAILS_YET, NULL);
 		}

--- a/src/interface/viewport_interaction.c
+++ b/src/interface/viewport_interaction.c
@@ -19,6 +19,7 @@
  *****************************************************************************/
 
 #include "../addresses.h"
+#include "../editor.h"
 #include "../game.h"
 #include "../localisation/localisation.h"
 #include "../ride/ride.h"
@@ -56,7 +57,7 @@ int viewport_interaction_get_item_left(int x, int y, viewport_interaction_info *
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
 	// 
-	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->var_000 != 6)
+	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
 	rct_xy16 mapCoord = { 0 };
@@ -179,7 +180,7 @@ int viewport_interaction_get_item_right(int x, int y, viewport_interaction_info 
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
 	// 
-	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->var_000 != 6)
+	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
 	rct_xy16 mapCoord = { 0 };

--- a/src/rct1.c
+++ b/src/rct1.c
@@ -20,6 +20,7 @@
 
 #include "addresses.h"
 #include "config.h"
+#include "editor.h"
 #include "interface/viewport.h"
 #include "interface/window.h"
 #include "localisation/localisation.h"
@@ -234,7 +235,7 @@ void rct1_fix_landscape()
 	rct_s6_header *s6Header = (rct_s6_header*)0x009E34E4;
 	rct_s6_info *s6Info = (rct_s6_info*)0x0141F570;
 
-	s6Info->var_000 = 1;
+	s6Info->editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
 	s6Info->category = 4;
 	format_string(s6Info->details, STR_NO_DETAILS_YET, NULL);
 	s6Info->name[0] = 0;

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -24,6 +24,7 @@
 #include "../cheats.h"
 #include "../common.h"
 #include "../config.h"
+#include "../editor.h"
 #include "../game.h"
 #include "../input.h"
 #include "../interface/window.h"
@@ -1776,7 +1777,7 @@ void ride_update_all()
 
 	// Remove all rides if scenario editor
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR) {
-		if (s6Info->var_000 <= 2)
+		if (s6Info->editor_step <= EDITOR_STEP_INVENTIONS_LIST_SET_UP)
 			FOR_ALL_RIDES(i, ride)
 				ride->type = RIDE_TYPE_NULL;
 		return;

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -49,7 +49,7 @@ typedef struct {
  * size: 0x198
  */
 typedef struct {
-	uint8 var_000;
+	uint8 editor_step;
 	uint8 category;				// 0x01
 	uint8 objective_type;		// 0x02
 	uint8 objective_arg_1;		// 0x03

--- a/src/scenario_list.c
+++ b/src/scenario_list.c
@@ -89,7 +89,7 @@ static void scenario_list_add(const char *path)
 		return;
 
 	// Ignore scenarios where first header byte is not 255
-	if (s6Info.var_000 != 255)
+	if (s6Info.editor_step != 255)
 		return;
 
 	// Check if scenario already exists in list, likely if in scores

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -119,6 +119,8 @@ static EMPTY_ARGS_VOID_POINTER *next_button_mouseup_events[] = {
 	NULL
 };
 
+static void sub_6DFED0();
+
 /**
 * Creates the main editor top toolbar window.
 * rct2: 0x0066F052 (part of 0x0066EF38)
@@ -140,6 +142,7 @@ void window_editor_bottom_toolbar_open()
 		(1 << WIDX_NEXT_IMAGE);
 
 	window_init_scroll_widgets(window);
+	sub_6DFED0();
 }
 
 /**
@@ -369,7 +372,7 @@ void window_editor_bottom_toolbar_jump_forward_to_save_scenario()
 	}
 
 	// 
-	s6Info->var_000 = 255;
+	s6Info->editor_step = 255;
 
 	// Ensure path has .SC6 extension
 	path_set_extension(path, ".SC6");
@@ -388,7 +391,7 @@ void window_editor_bottom_toolbar_jump_forward_to_save_scenario()
 		title_load();
 	} else {
 		window_error_open(STR_SCENARIO_SAVE_FAILED, -1);
-		s6Info->var_000 = 4;
+		s6Info->editor_step = EDITOR_STEP_OBJECTIVE_SELECTION;
 	}
 }
 

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -819,7 +819,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
 		rct_s6_info *s6Info = (rct_s6_info*)0x0141F570;
 		int parkFlagsBackup = RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32);
 		RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) &= ~PARK_FLAGS_18;
-		s6Info->var_000 = 255;
+		s6Info->editor_step = 255;
 		rw = SDL_RWFromFile(path, "wb+");
 		int success = 0;
 		if (rw != NULL) {
@@ -834,7 +834,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
 			title_load();
 		} else {
 			window_error_open(STR_SAVE_SCENARIO, STR_SCENARIO_SAVE_FAILED);
-			s6Info->var_000 = 4;
+			s6Info->editor_step = EDITOR_STEP_OBJECTIVE_SELECTION;
 		}
 		break;
 	}


### PR DESCRIPTION
Issue was caused by not calling sub_6DFED0 when loading the landscape. I assume in vanilla this would happen as part of the loading but due to the way loadsave now works it doesn't happen. In the process I also labelled the offset for editor step.

Fixes issue 5 of https://www.reddit.com/r/openrct2/comments/3ol63s/a_number_of_bugs_ive_found/