### PR TITLE
Wrap download arguments in quotes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,9 @@ libVFile="./libversion"
 
 function download {
 	if command -v curl > /dev/null 2>&1; then
-		curl -L -o $2 $1
+		curl -L -o "$2" "$1"
 	elif command -v wget > /dev/null 2>&1; then
-		wget -O $2 $1
+		wget -O "$2" "$1"
 	else
 		echo "Please install either wget or curl to continue"
 		exit 1


### PR DESCRIPTION
I noticed that someone mentioned on Gitter that the download function in install.sh did not accept arguments with spaces or special characters, so I put them in quotes and did a quick test.