### PR TITLE
Identify peep->var_C6

### DIFF
--- a/src/management/marketing.c
+++ b/src/management/marketing.c
@@ -116,7 +116,7 @@ void marketing_set_guest_campaign(rct_peep *peep, int campaign)
 		peep->voucher_type = VOUCHER_TYPE_RIDE_FREE;
 		peep->voucher_arguments = gMarketingCampaignRideIndex[campaign];
 		peep->guest_heading_to_ride_id = gMarketingCampaignRideIndex[campaign];
-		peep->var_C6 = 240;
+		peep->peep_is_lost_countdown = 240;
 		break;
 	case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
 		peep->item_standard_flags |= PEEP_ITEM_VOUCHER;
@@ -131,7 +131,7 @@ void marketing_set_guest_campaign(rct_peep *peep, int campaign)
 		break;
 	case ADVERTISING_CAMPAIGN_RIDE:
 		peep->guest_heading_to_ride_id = gMarketingCampaignRideIndex[campaign];
-		peep->var_C6 = 240;
+		peep->peep_is_lost_countdown = 240;
 		break;
 	}
 }

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -290,12 +290,12 @@ static void peep_update_hunger(rct_peep *peep){
 static void peep_leave_park(rct_peep* peep){
 	peep->guest_heading_to_ride_id = 0xFF;
 	if (peep->flags & PEEP_FLAGS_LEAVING_PARK){
-		if (peep->var_C6 < 60){
+		if (peep->peep_is_lost_countdown < 60){
 			return;
 		}
 	}
 	else{
-		peep->var_C6 = 254;
+		peep->peep_is_lost_countdown = 254;
 		peep->flags |= PEEP_FLAGS_LEAVING_PARK;
 		peep->flags &= ~PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
 	}
@@ -899,16 +899,18 @@ void peep_check_if_lost(rct_peep* peep){
 * Check if cant find ride.
 */
 void peep_check_cant_find_ride(rct_peep* peep){
-	if (peep->guest_heading_to_ride_id == 0xFF) return;
+	if (peep->guest_heading_to_ride_id == 0xFF)
+		return;
 
-	if (peep->var_C6 == 30 || peep->var_C6 == 60){
+	// Peeps will think "I can't find ride X" twice before giving up completely.
+	if (peep->peep_is_lost_countdown == 30 || peep->peep_is_lost_countdown == 60) {
 		peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_CANT_FIND, peep->guest_heading_to_ride_id);
-
 		peep->happiness_growth_rate = max(peep->happiness_growth_rate - 30, 0);
 	}
 
-	peep->var_C6--;
-	if (peep->var_C6 != 0)return;
+	peep->peep_is_lost_countdown--;
+	if (peep->peep_is_lost_countdown != 0)
+		return;
 
 	peep->guest_heading_to_ride_id = 0xFF;
 	rct_window* w = window_find_by_number(WC_PEEP, peep->sprite_index);
@@ -924,15 +926,17 @@ void peep_check_cant_find_ride(rct_peep* peep){
 * Check if cant find exit.
 */
 void peep_check_cant_find_exit(rct_peep* peep){
-	if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK))return;
+	if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK))
+		return;
 
-	if (peep->var_C6 == 1){
+	// Peeps who can't find the park exit will continue to get less happy until they find it.
+	if (peep->peep_is_lost_countdown == 1) {
 		peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_CANT_FIND_EXIT, 0xFF);
-
 		peep->happiness_growth_rate = max(peep->happiness_growth_rate - 30, 0);
 	}
 
-	if (--peep->var_C6 == 0) peep->var_C6 = 90;
+	if (--peep->peep_is_lost_countdown == 0)
+		peep->peep_is_lost_countdown = 90;
 }
 
 /* rct2: 0x6939EB
@@ -6884,7 +6888,7 @@ uint8 sub_69A60A(rct_peep* peep){
 	}
 
 	if (peep->flags & PEEP_FLAGS_LEAVING_PARK &&
-		peep->var_C6 < 90){
+		peep->peep_is_lost_countdown < 90){
 		return 16;
 	}
 
@@ -7819,7 +7823,7 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 
 	if (peep_should_go_on_ride_again(peep, ride)) {
 		peep->guest_heading_to_ride_id = rideIndex;
-		peep->var_C6 = 200;
+		peep->peep_is_lost_countdown = 200;
 		sub_69A98C(peep);
 
 		rct_window *w = window_find_by_number(WC_PEEP, peep->sprite_index);
@@ -8666,7 +8670,7 @@ static void peep_pick_ride_to_go_on(rct_peep *peep)
 
 	// Head to that ride
 	peep->guest_heading_to_ride_id = mostExcitingRideIndex;
-	peep->var_C6 = 200;
+	peep->peep_is_lost_countdown = 200;
 	sub_69A98C(peep);
 
 	// Invalidate windows
@@ -8777,7 +8781,7 @@ static void peep_head_for_nearest_ride_type(rct_peep *peep, int rideType)
 
 	// Head to that ride
 	peep->guest_heading_to_ride_id = closestRideIndex;
-	peep->var_C6 = 200;
+	peep->peep_is_lost_countdown = 200;
 	sub_69A98C(peep);
 
 	// Invalidate windows
@@ -8889,7 +8893,7 @@ static void peep_head_for_nearest_ride_with_flags(rct_peep *peep, int rideTypeFl
 
 	// Head to that ride
 	peep->guest_heading_to_ride_id = closestRideIndex;
-	peep->var_C6 = 200;
+	peep->peep_is_lost_countdown = 200;
 	sub_69A98C(peep);
 
 	// Invalidate windows

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -494,8 +494,8 @@ typedef struct {
 		uint8 guest_heading_to_ride_id;		// 0xC5
 	};
 	union {
-		uint8 staff_orders;			// 0xC6
-		uint8 var_C6;
+		uint8 staff_orders;				// 0xC6
+		uint8 peep_is_lost_countdown;	// 0xC6
 	};
 	uint8 photo1_ride_ref;			// 0xC7
 	uint32 flags;					// 0xC8

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -142,12 +142,12 @@ void game_command_hire_new_staff_member(int* eax, int* ebx, int* ecx, int* edx, 
 		newPeep->paid_on_food = 0;
 		newPeep->paid_on_souvenirs = 0;
 
-		newPeep->var_C6 = 0;
+		newPeep->staff_orders = 0;
 		if (staff_type == 0) {
-			newPeep->var_C6 = 7;
+			newPeep->staff_orders = 7;
 		}
 		else if (staff_type == 1) {
-			newPeep->var_C6 = 3;
+			newPeep->staff_orders = 3;
 		}
 
 		uint16 idSearchSpriteIndex;

--- a/src/windows/staff_list.c
+++ b/src/windows/staff_list.c
@@ -656,7 +656,7 @@ void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int sc
 
 				staffOrderIcon_x = 0x7D;
 				if (peep->staff_type != 3) {
-					staffOrders = peep->var_C6;
+					staffOrders = peep->staff_orders;
 					staffOrderSprite = RCT2_ADDRESS(0x00992A08, uint32)[selectedTab];
 
 					while (staffOrders != 0) {


### PR DESCRIPTION
This commit identifies `peep->var_C6` as a counter that is set when a peep decides to either go on a ride, go to a shop or exit the park.

If the peep is not currently doing any of the things above, then the counter isn't touched. As soon as the peep has a destination in mind, it gets set to a value between 200 and 255 and is decremented each time `peep_update` is called, until they either reach their destination or the counter hits zero.

When the counter starts getting low, the peep will think "I can't find [x]", and if the counter gets to zero, the peep will give up. The exception is if they're looking for the park exit: in that case, their happiness will decrease and the counter will be reset to 90.