### PR TITLE
Opening or testing a ride will only that ride's close construction window

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -4452,7 +4452,7 @@ int ride_is_valid_for_test(int rideIndex, int goingToBeOpen, int isApplying)
 
 	ride = GET_RIDE(rideIndex);
 
-	window_close_by_class(WC_RIDE_CONSTRUCTION);
+	window_close_by_number(WC_RIDE_CONSTRUCTION, rideIndex);
 
 	stationIndex = ride_mode_check_station_present(ride);
 	if (stationIndex == -1)return 0;
@@ -4575,7 +4575,7 @@ int ride_is_valid_for_open(int rideIndex, int goingToBeOpen, int isApplying)
 
 	ride = GET_RIDE(rideIndex);
 
-	window_close_by_class(WC_RIDE_CONSTRUCTION);
+	window_close_by_number(WC_RIDE_CONSTRUCTION, rideIndex);
 
 	stationIndex = ride_mode_check_station_present(ride);
 	if (stationIndex == -1)return 0;


### PR DESCRIPTION
This is often seen in multiplayer when another player opens/tests a ride and everyone else has their ride construction window closed. Can be tested in single player by opening a construction window for one ride and opening/testing a different ride.