### PR TITLE
Disable drawing if the window is minimized or otherwise hidden

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -393,8 +393,11 @@ static void openrct2_loop()
 				invalidate_sprite_2(&g_sprite_list[i]);
 			}
 
-			rct2_draw();
-			platform_draw();
+			if ((SDL_GetWindowFlags(gWindow) & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_HIDDEN)) == 0) {
+				rct2_draw();
+				platform_draw();
+			}
+
 			fps++;
 			if (SDL_GetTicks() - secondTick >= 1000) {
 				fps = 0;
@@ -426,8 +429,10 @@ static void openrct2_loop()
 
 			rct2_update();
 
-			rct2_draw();
-			platform_draw();
+			if ((SDL_GetWindowFlags(gWindow) & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_HIDDEN)) == 0) {
+				rct2_draw();
+				platform_draw();
+			}
 		}
 	} while (!_finished);
 }


### PR DESCRIPTION
There is no point in drawing anything if the window is not visible.

This also happens to fix #2096, although the draw buffer corruption (?) that crashes `redraw_rain()` should probably still be looked into. It doesn't appear to affect any of the other draw functions.