### PR TITLE
Low level optimizations

### DIFF
--- a/src/drawing/sprite.c
+++ b/src/drawing/sprite.c
@@ -359,8 +359,13 @@ void gfx_rle_sprite_to_buffer(const uint8* source_bits_pointer, uint8* dest_bits
 			}
 			else
 			{
-				for (; no_pixels > 0; no_pixels -= zoom_amount, source_pointer += zoom_amount, dest_pointer++){
-					*dest_pointer = *source_pointer;
+				if (zoom_amount == 1) {
+					memcpy(dest_pointer, source_pointer, no_pixels);
+				}
+				else {
+					for (; no_pixels > 0; no_pixels -= zoom_amount, source_pointer += zoom_amount, dest_pointer++) {
+						*dest_pointer = *source_pointer;
+					}
 				}
 			}
 		}
@@ -498,7 +503,6 @@ void gfx_draw_sprite_palette_set(rct_drawpixelinfo *dpi, int image_id, int x, in
 
 	//Its used super often so we will define it to a separate variable.
 	int zoom_level = dpi->zoom_level;
-	int zoom_amount = 1 << zoom_level;
 	int zoom_mask = 0xFFFFFFFF << zoom_level;
 
 	if (zoom_level && g1_source->flags & G1_FLAG_RLE_COMPRESSION){
@@ -552,8 +556,8 @@ void gfx_draw_sprite_palette_set(rct_drawpixelinfo *dpi, int image_id, int x, in
 	//If the image no longer has anything to draw
 	if (height <= 0)return;
 
-	dest_start_y /= zoom_amount;
-	dest_end_y /= zoom_amount;
+	dest_start_y >>= zoom_level;
+	dest_end_y >>= zoom_level;
 
 	//This will be the width of the drawn image
 	int width = g1_source->width;
@@ -591,12 +595,12 @@ void gfx_draw_sprite_palette_set(rct_drawpixelinfo *dpi, int image_id, int x, in
 		if (width <= 0)return;
 	}
 
-	dest_start_x /= zoom_amount;
-	dest_end_x /= zoom_amount;
+	dest_start_x >>= zoom_level;
+	dest_end_x >>= zoom_level;
 
 	uint8* dest_pointer = (uint8*)dpi->bits;
 	//Move the pointer to the start point of the destination
-	dest_pointer += ((dpi->width / zoom_amount) + dpi->pitch)*dest_start_y + dest_start_x;
+	dest_pointer += ((dpi->width >> zoom_level) + dpi->pitch) * dest_start_y + dest_start_x;
 
 	if (g1_source->flags & G1_FLAG_RLE_COMPRESSION){
 		//We have to use a different method to move the source pointer for

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1559,7 +1559,7 @@ static void sub_68B3FB(int x, int y)
 	RCT2_GLOBAL(0x9DE574, uint16_t) = x;
 	RCT2_GLOBAL(0x9DE576, uint16_t) = y;
 
-	rct_map_element* map_element = map_get_first_element_at(x / 32, y / 32);
+	rct_map_element* map_element = map_get_first_element_at(x >> 5, y >> 5);
 
 	int dx = 0;
 	switch (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32_t)) {
@@ -1580,7 +1580,7 @@ static void sub_68B3FB(int x, int y)
 		dx = x - y;
 		break;
 	}
-	dx /= 2;
+	dx >>= 1;
 	// Display little yellow arrow when building footpaths?
 	if ((RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & 4) &&
 		RCT2_GLOBAL(0x9DE56A, uint16) == RCT2_GLOBAL(RCT2_ADDRESS_MAP_ARROW_X, uint16) &&
@@ -1805,9 +1805,9 @@ void viewport_paint_setup()
 		.y = (dpi->y - 16) & 0xFFE0
 	};
 
-	sint16 half_x = mapTile.x / 2;
+	sint16 half_x = mapTile.x >> 1;
 
-	uint16 num_vertical_quadrants = (dpi->height + 2128) / 32;
+	uint16 num_vertical_quadrants = (dpi->height + 2128) >> 5;
 
 	switch (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32)){
 	case 0:
@@ -1821,19 +1821,12 @@ void viewport_paint_setup()
 			map_element_paint_setup(mapTile.x, mapTile.y);
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
-			mapTile.x -= 32;
-			mapTile.y += 32;
+			sprite_paint_setup(mapTile.x - 32, mapTile.y + 32);
 
-			sprite_paint_setup(mapTile.x, mapTile.y);
-
-			mapTile.x += 32;
-
-			map_element_paint_setup(mapTile.x, mapTile.y);
-			sprite_paint_setup(mapTile.x, mapTile.y);
+			map_element_paint_setup(mapTile.x, mapTile.y + 32);
+			sprite_paint_setup(mapTile.x, mapTile.y + 32);
 
 			mapTile.x += 32;
-			mapTile.y -= 32;
-
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
 			mapTile.y += 32;
@@ -1850,19 +1843,12 @@ void viewport_paint_setup()
 			map_element_paint_setup(mapTile.x, mapTile.y);
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
-			mapTile.x -= 32;
-			mapTile.y -= 32;
+			sprite_paint_setup(mapTile.x - 32, mapTile.y - 32);
 
-			sprite_paint_setup(mapTile.x, mapTile.y);
+			map_element_paint_setup(mapTile.x - 32, mapTile.y);
+			sprite_paint_setup(mapTile.x - 32, mapTile.y);
 
 			mapTile.y += 32;
-
-			map_element_paint_setup(mapTile.x, mapTile.y);
-			sprite_paint_setup(mapTile.x, mapTile.y);
-
-			mapTile.x += 32;
-			mapTile.y += 32;
-
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
 			mapTile.x -= 32;
@@ -1879,18 +1865,12 @@ void viewport_paint_setup()
 			map_element_paint_setup(mapTile.x, mapTile.y);
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
-			mapTile.x += 32;
-			mapTile.y -= 32;
+			sprite_paint_setup(mapTile.x + 32, mapTile.y - 32);
 
-			sprite_paint_setup(mapTile.x, mapTile.y);
-
-			mapTile.x -= 32;
-
-			map_element_paint_setup(mapTile.x, mapTile.y);
-			sprite_paint_setup(mapTile.x, mapTile.y);
+			map_element_paint_setup(mapTile.x, mapTile.y - 32);
+			sprite_paint_setup(mapTile.x, mapTile.y - 32);
 
 			mapTile.x -= 32;
-			mapTile.y += 32;
 
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
@@ -1908,17 +1888,11 @@ void viewport_paint_setup()
 			map_element_paint_setup(mapTile.x, mapTile.y);
 			sprite_paint_setup(mapTile.x, mapTile.y);
 
-			mapTile.x += 32;
-			mapTile.y += 32;
+			sprite_paint_setup(mapTile.x + 32, mapTile.y + 32);
 
-			sprite_paint_setup(mapTile.x, mapTile.y);
+			map_element_paint_setup(mapTile.x + 32, mapTile.y);
+			sprite_paint_setup(mapTile.x + 32, mapTile.y);
 
-			mapTile.y -= 32;
-
-			map_element_paint_setup(mapTile.x, mapTile.y);
-			sprite_paint_setup(mapTile.x, mapTile.y);
-
-			mapTile.x -= 32;
 			mapTile.y -= 32;
 
 			sprite_paint_setup(mapTile.x, mapTile.y);


### PR DESCRIPTION
* Just memcpy if we don't have to use a pallete and zoom_amount == 1
* Replace some divide operations by right-shifts
* Optimize / simplify sub_68B3FB