### PR TITLE
add limits.h include for CHAR_BIT

### DIFF
--- a/src/drawing/rect.c
+++ b/src/drawing/rect.c
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
+#include <limits.h>
 #include "../addresses.h"
 #include "../common.h"
 #include "drawing.h"


### PR DESCRIPTION
This adds `limits.h` as an include to `src/drawing/rect.c` as it defines `CHAR_BIT` which is used in this file. This is needed to be able to compile on clang, but it's also correct on gcc since the file uses a value defined in the included file.