### PR TITLE
Fix confusing errors appearing when building a flat ride partially outside the park #2129

### DIFF
--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -1296,7 +1296,7 @@ int track_place_scenery(rct_track_scenery* scenery_start, uint8 rideIndex, int o
 						if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 105;
 						if (RCT2_GLOBAL(0x00F440D4, uint8) == 1)bl = 0;
 
-						RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+						RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 						cost = game_do_command(mapCoord.x, bl | (bh << 8), mapCoord.y, z | (entry_index << 8), GAME_COMMAND_PLACE_PATH_FROM_TRACK, 0, 0);
 					}
 					else{
@@ -1425,7 +1425,7 @@ int track_place_maze(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 				rotation += maze->unk_2;
 				rotation &= 3;
 
-				RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 
 				bl = 1;
 				if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 0x69;
@@ -1444,7 +1444,7 @@ int track_place_maze(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 				rotation += maze->unk_2;
 				rotation &= 3;
 
-				RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 
 				bl = 1;
 				if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 0x69;
@@ -1466,7 +1466,7 @@ int track_place_maze(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 				if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 0x69;
 				if (RCT2_GLOBAL(0x00F440D4, uint8) == 1)bl = 0;
 
-				RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 
 				cost = game_do_command(mapCoord.x, bl | (maze_entry & 0xFF) << 8, mapCoord.y, rideIndex | (maze_entry & 0xFF00), GAME_COMMAND_PLACE_MAZE_DESIGN, z, 0);
 				break;
@@ -1641,7 +1641,7 @@ int track_place_ride(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 			if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 105;
 			if (RCT2_GLOBAL(0x00F440D4, uint8) == 1)bl = 0;
 
-			RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 			money32 cost = game_do_command(x, bl | (rotation << 8), y, edx, GAME_COMMAND_PLACE_TRACK, edi, 0);
 			RCT2_GLOBAL(0x00F440D5, money32) += cost;
 
@@ -1847,7 +1847,7 @@ int track_place_ride(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 					if (RCT2_GLOBAL(0x00F440D4, uint8) == 4)bl = 105;
 					if (RCT2_GLOBAL(0x00F440D4, uint8) == 1)bl = 0;
 
-					RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+					RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 					money32 cost = game_do_command(x, bl | (rotation << 8), y, rideIndex | (is_exit << 8), GAME_COMMAND_PLACE_RIDE_ENTRANCE_OR_EXIT, di, 0);
 					RCT2_GLOBAL(0x00F440D5, money32) += cost;
 
@@ -1866,7 +1866,7 @@ int track_place_ride(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8** trac
 				z += RCT2_GLOBAL(0x00F44146, sint16);
 				z /= 16;
 
-				RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 				money32 cost = game_do_command(x, 0 | (rotation << 8), y, z | (is_exit << 8), GAME_COMMAND_PLACE_RIDE_ENTRANCE_OR_EXIT, -1, 0);
 				RCT2_GLOBAL(0x00F440D5, money32) += cost;
 
@@ -3940,22 +3940,6 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		}
 	}
 
-	uint16 *hmm = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ?
-		(uint16*)0x0099443C :
-		(uint16*)0x0099423C;
-	if (hmm[type] & 0x100) {
-		if ((originZ & 0x0F) != 8) {
-			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = 954;
-			return MONEY32_UNDEFINED;
-		}
-	}
-	else {
-		if ((originZ & 0x0F) != 0) {
-			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = 954;
-			return MONEY32_UNDEFINED;
-		}
-	}
-
 	if (type == TRACK_ELEM_ON_RIDE_PHOTO) {
 		if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_RIDE_PHOTO) {
 			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = STR_ONLY_ONE_ON_RIDE_PHOTO_PER_RIDE;
@@ -4015,6 +3999,21 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 
 		if (!map_is_location_owned(x, y, z) && !gCheatsSandboxMode) {
 			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = STR_LAND_NOT_OWNED_BY_PARK;
+			return MONEY32_UNDEFINED;
+		}
+	}
+
+	uint16 *hmm = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ?
+		(uint16*)0x0099443C :
+		(uint16*)0x0099423C;
+	if (hmm[type] & 0x100) {
+		if ((originZ & 0x0F) != 8) {
+			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = 954;
+			return MONEY32_UNDEFINED;
+		}
+	} else {
+		if ((originZ & 0x0F) != 0) {
+			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = 954;
 			return MONEY32_UNDEFINED;
 		}
 	}

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -4002,11 +4002,11 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 			return MONEY32_UNDEFINED;
 		}
 	}
-
-	uint16 *hmm = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ?
-		(uint16*)0x0099443C :
-		(uint16*)0x0099423C;
-	if (hmm[type] & 0x100) {
+	
+	uint16 *trackFlags = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ?
+		RCT2_ADDRESS(0x0099443C, uint16) :
+		RCT2_ADDRESS(0x0099423C, uint16);
+	if (trackFlags[type] & 0x100) {
 		if ((originZ & 0x0F) != 8) {
 			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, rct_string_id) = 954;
 			return MONEY32_UNDEFINED;

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -3282,7 +3282,7 @@ void ride_construction_toolupdate_construct(int screenX, int screenY)
 		return;
 	}
 
-	z = RCT2_GLOBAL(0x00F44163, uint16);
+	z = _trackPlaceZ;
 	if (z == 0)
 		z = map_get_highest_z(x >> 5, y >> 5);
 
@@ -3313,7 +3313,7 @@ void ride_construction_toolupdate_construct(int screenX, int screenY)
 	window_ride_construction_select_map_tiles(ride, trackType, trackDirection, x, y);
 
 	RCT2_GLOBAL(RCT2_ADDRESS_MAP_ARROW_Z, uint16) = z;
-	if (RCT2_GLOBAL(0x00F44163, uint16) == 0) {
+	if (_trackPlaceZ == 0) {
 		// Raise z above all slopes and water
 		highestZ = 0;
 		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & 2) {
@@ -3480,20 +3480,21 @@ void ride_construction_tooldown_construct(int screenX, int screenY)
 			selectedTile++;
 		}
 	}
+
 	RCT2_GLOBAL(0x00F440E2, uint16) = z;
 
 	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 | 2 | 4);
 	if (!ride_get_place_position_from_screen_position(screenX, screenY, &x, &y))
 		return;
 
-	z = RCT2_GLOBAL(0x00F44163, uint16);
+	z = _trackPlaceZ;
 	if (z == 0)
 		z = map_get_highest_z(x >> 5, y >> 5);
 
 	tool_cancel();
 
 	rct_ride *ride = GET_RIDE(_currentRideIndex);
-	if (RCT2_GLOBAL(0x00F44163, uint16) == 0) {
+	if (_trackPlaceZ == 0) {
 		const rct_preview_track *trackBlock = get_track_def_from_ride(ride, _currentTrackPieceType);
 		int bx = 0;
 		do {
@@ -3507,7 +3508,7 @@ void ride_construction_tooldown_construct(int screenX, int screenY)
 			z -= 16;
 		}
 	} else {
-		z = RCT2_GLOBAL(0x00F44163, uint16);
+		z = _trackPlaceZ;
 	}
 
 	if (ride->type == RIDE_TYPE_MAZE) {

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -3525,7 +3525,7 @@ void ride_construction_tooldown_construct(int screenX, int screenY)
 
 			RCT2_GLOBAL(0x009A8C29, uint8) |= 1;
 
-			RCT2_GLOBAL(0x00141E9AE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+			RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TITLE, rct_string_id) = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 			RCT2_GLOBAL(0x00F44074, money32) = game_do_command(
 				_currentTrackBeginX,
 				GAME_COMMAND_FLAG_APPLY | (4 << 8),


### PR DESCRIPTION
This fix ensures that the "land not owned" errors will appear when trying to build fully outside the owned land and partially in it, regardless of the cursor location. I also replaced some string ids with enum values. See the commit messages for details of the fix.