### PR TITLE
Fixes to safe_strncpy

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -188,7 +188,7 @@ void console_draw(rct_drawpixelinfo *dpi)
 		int lineLength = min(sizeof(lineBuffer) - (size_t)utf8_get_codepoint_length(FORMAT_GREEN), (size_t)(nextLine - ch));
 		lineCh = lineBuffer;
 		lineCh = utf8_write_codepoint(lineCh, FORMAT_GREEN);
-		safe_strncpy(lineCh, ch, lineLength);
+		safe_strncpy(lineCh, ch, CONSOLE_BUFFER_SIZE);
 		lineCh[lineLength] = 0;
 
 		gfx_draw_string(dpi, lineBuffer, 255, x, y);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -183,6 +183,10 @@ int strcicmp(char const *a, char const *b)
 
 char *safe_strncpy(char * destination, const char * source, size_t size)
 {
+	if (size == 0)
+	{
+		return destination;
+	}
 	char *result = destination;
 	bool terminated = false;
 	for (size_t i = 0; i < size; i++)
@@ -198,7 +202,7 @@ char *safe_strncpy(char * destination, const char * source, size_t size)
 	}
 	if (!terminated)
 	{
-		destination[size - 1] = '\0';
+		result[size - 1] = '\0';
 		log_warning("Truncating string %s to %d bytes.", destination, size);
 	}
 	return result;


### PR DESCRIPTION
* don't touch memory at all if size passed is 0
* use original address instead of now-changed `destination`
* fix one of the calls having improper size passed