### PR TITLE
Fixed #2082. Sub_6D31A6 now working.

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -1188,11 +1188,14 @@ int sub_6C683D(int* x, int* y, int* z, int direction, int type, uint16 extra_par
 			mapElement->properties.track.colour &= 0x0F;
 			mapElement->properties.track.colour |= (extra_params & 0xFF) << 4;
 		}
+		
 		if (flags & (1 << 3)) {
+			// Cable lift hill track
 			mapElement->properties.track.colour |= (1 << 3);
 		}
 		if (flags & (1 << 4)) {
-			mapElement->properties.track.colour &= 0xF7;
+			// Clear Cable lift hill track
+			mapElement->properties.track.colour &= ~(1 << 3);
 		}
 	}
 
@@ -4306,13 +4309,6 @@ bool ride_create_vehicles(rct_ride *ride, int rideIndex, rct_xy_element *element
  */
 static bool sub_6D31A6(rct_ride *ride, bool isApplying)
 {
-	return !(RCT2_CALLPROC_X(0x006D31A6, 0, isApplying ? 1 : 0, 0, 0, 0, (int)ride, 0) & 0x100);
-
-	// TODO This implementation does not work because track_block_get_previous called from track_circuit_iterator_previous seems
-	//      to be ending prematurely and not iterating the complete track. This can be reproduced by constructing a giga coaster
-	//      with a lift hill (pre-designed one will do) and testing it. This means other methods that use
-	//      track_block_get_previous could be faulty. It might a particuarly track block that causes it.
-
 	uint16 xy;
 	int stationIndex;
 	for (stationIndex = 0; stationIndex < 4; stationIndex++) {
@@ -4328,18 +4324,22 @@ static bool sub_6D31A6(rct_ride *ride, bool isApplying)
 	int y = (xy >> 8) * 32;
 	int z = ride->station_heights[stationIndex];
 
+	bool success = false;
 	rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);
 	do {
-		if (mapElement->type != MAP_ELEMENT_TYPE_TRACK) continue;
+		if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_TRACK) continue;
 		if (mapElement->base_height != z) continue;
 
 		int trackType = mapElement->properties.track.type;
 		if (!(RCT2_ADDRESS(0x0099BA64, uint8)[trackType * 16] & 0x10)) {
 			continue;
 		}
-
+		success = true;
 		break;
 	} while (!map_element_is_last_for_tile(mapElement++));
+
+	if (!success)
+		return false;
 
 	enum {
 		STATE_FIND_CABLE_LIFT,
@@ -4393,6 +4393,8 @@ static bool sub_6D31A6(rct_ride *ride, bool isApplying)
 			z = mapElement->base_height * 8;
 			int direction = mapElement->type & 3;
 			trackType = mapElement->properties.track.type;
+			x = it.current.x;
+			y = it.current.y;
 			sub_6C683D(&x, &y, &z, direction, trackType, 0, &mapElement, flags);
 		}
 	}

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -1190,12 +1190,10 @@ int sub_6C683D(int* x, int* y, int* z, int direction, int type, uint16 extra_par
 		}
 		
 		if (flags & (1 << 3)) {
-			// Cable lift hill track
-			mapElement->properties.track.colour |= (1 << 3);
+			track_element_set_cable_lift(mapElement);
 		}
 		if (flags & (1 << 4)) {
-			// Clear Cable lift hill track
-			mapElement->properties.track.colour &= ~(1 << 3);
+			track_element_clear_cable_lift(mapElement);
 		}
 	}
 
@@ -4306,8 +4304,10 @@ bool ride_create_vehicles(rct_ride *ride, int rideIndex, rct_xy_element *element
 /**
  *
  *  rct2: 0x006D31A6
+ *  Checks and initialises the cable lift track
+ *  returns false if unable to find appropriate track.
  */
-static bool sub_6D31A6(rct_ride *ride, bool isApplying)
+static bool ride_initialise_cable_lift_track(rct_ride *ride, bool isApplying)
 {
 	uint16 xy;
 	int stationIndex;
@@ -4426,7 +4426,7 @@ bool ride_create_cable_lift(int rideIndex, bool isApplying)
 		return false;
 	}
 
-	if (!sub_6D31A6(ride, isApplying)) {
+	if (!ride_initialise_cable_lift_track(ride, isApplying)) {
 		return false;
 	}
 

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -4824,3 +4824,15 @@ bool track_element_is_lift_hill(rct_map_element *trackElement)
 {
 	return trackElement->type & 0x80;
 }
+
+bool track_element_is_cable_lift(rct_map_element *trackElement) {
+	return trackElement->properties.track.colour & TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT;
+}
+
+void track_element_set_cable_lift(rct_map_element *trackElement) {
+	trackElement->properties.track.colour |= TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT;
+}
+
+void track_element_clear_cable_lift(rct_map_element *trackElement) {
+	trackElement->properties.track.colour &= ~TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT;
+}

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -4754,8 +4754,8 @@ bool track_circuit_iterator_previous(track_circuit_iterator *it)
 		it->last = it->current;
 
 		if (track_block_get_previous(it->last.x, it->last.y, it->last.element, &trackBeginEnd)) {
-			it->current.x = trackBeginEnd.begin_x;
-			it->current.y = trackBeginEnd.begin_y;
+			it->current.x = trackBeginEnd.end_x;
+			it->current.y = trackBeginEnd.end_y;
 			it->current.element = trackBeginEnd.begin_element;
 			it->currentZ = trackBeginEnd.begin_z;
 			it->currentDirection = trackBeginEnd.begin_direction;

--- a/src/ride/track.h
+++ b/src/ride/track.h
@@ -109,6 +109,12 @@ enum{
 	TRACK_ELEMENT_FLAG_TERMINAL_STATION = (1<<3),
 };
 
+enum {
+	// Not anything to do with colour but uses
+	// that field in the map element
+	TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT = (1 << 3),
+};
+
 #define TRACK_ELEMENT_FLAG_MAGNITUDE_MASK 0x0F
 #define TRACK_ELEMENT_FLAG_COLOUR_MASK 0x30
 #define TRACK_ELEMENT_FLAG_STATION_NO_MASK 0x02
@@ -541,5 +547,9 @@ void track_get_back(rct_xy_element *input, rct_xy_element *output);
 void track_get_front(rct_xy_element *input, rct_xy_element *output);
 
 bool track_element_is_lift_hill(rct_map_element *trackElement);
+
+bool track_element_is_cable_lift(rct_map_element *trackElement);
+void track_element_set_cable_lift(rct_map_element *trackElement);
+void track_element_clear_cable_lift(rct_map_element *trackElement);
 
 #endif


### PR DESCRIPTION
Fixed #2082. Sub_6D31A6 now working.
Small mistake in track previous meant the x/y coordinates didn't match the map element. There were also a few other issues that presented themselves once that was fixed.