### PR TITLE
Allow user data path to be specified by command line

### DIFF
--- a/projects/openrct2.vcxproj
+++ b/projects/openrct2.vcxproj
@@ -82,6 +82,7 @@
     <ClCompile Include="..\src\openrct2.c" />
     <ClCompile Include="..\src\peep\peep.c" />
     <ClCompile Include="..\src\peep\staff.c" />
+    <ClCompile Include="..\src\platform\linux.c" />
     <ClCompile Include="..\src\platform\shared.c" />
     <ClCompile Include="..\src\platform\unix.c" />
     <ClCompile Include="..\src\platform\osx.c" />

--- a/projects/openrct2.vcxproj.filters
+++ b/projects/openrct2.vcxproj.filters
@@ -543,6 +543,9 @@
     <ClCompile Include="..\src\ride\track_paint.c">
       <Filter>Source\Ride</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\platform\linux.c">
+      <Filter>Source\Platform</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\management\award.h">

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -73,6 +73,7 @@ int cmdline_run(const char **argv, int argc)
 	//
 	int version = 0, headless = 0, verbose = 0, width = 0, height = 0, port = 0;
 	char *server = NULL;
+	char *userDataPath = NULL;
 
 	argparse_option_t options[] = {
 		OPT_HELP(),
@@ -82,6 +83,7 @@ int cmdline_run(const char **argv, int argc)
 		OPT_INTEGER('m', "mode", &sprite_mode, "the type of sprite conversion. 0 = default, 1 = simple closest pixel match, 2 = dithering"),
 		OPT_STRING(0, "server", &server, "server to connect to"),
 		OPT_INTEGER(0, "port", &port, "port"),
+		OPT_STRING(0, "user-data-path", &userDataPath, "path to the user data directory (containing config.ini)"),
 		OPT_END()
 	};
 
@@ -99,6 +101,10 @@ int cmdline_run(const char **argv, int argc)
 
 	if (verbose)
 		_log_levels[DIAGNOSTIC_LEVEL_VERBOSE] = 1;
+
+	if (userDataPath != NULL) {
+		safe_strncpy(gCustomUserDataPath, userDataPath, sizeof(gCustomUserDataPath));
+	}
 
 #ifndef DISABLE_NETWORK
 	if (port != 0) {

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -52,6 +52,7 @@
 int gOpenRCT2StartupAction = STARTUP_ACTION_TITLE;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
 utf8 gExePath[MAX_PATH];
+utf8 gCustomUserDataPath[MAX_PATH] = { 0 };
 
 // This should probably be changed later and allow a custom selection of things to initialise like SDL_INIT
 bool gOpenRCT2Headless = false;
@@ -187,6 +188,7 @@ bool openrct2_initialise()
 {
 	utf8 userPath[MAX_PATH];
 
+	platform_resolve_user_data_path();
 	platform_get_user_directory(userPath, NULL);
 	if (!platform_ensure_directory_exists(userPath)) {
 		log_fatal("Could not create user directory (do you have write access to your documents folder?)");

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -31,8 +31,9 @@ enum {
 };
 
 extern int gOpenRCT2StartupAction;
-extern char gOpenRCT2StartupActionPath[512];
-extern char gExePath[MAX_PATH];
+extern utf8 gOpenRCT2StartupActionPath[512];
+extern utf8 gExePath[MAX_PATH];
+extern utf8 gCustomUserDataPath[MAX_PATH];
 extern bool gOpenRCT2Headless;
 extern bool gOpenRCT2ShowChangelog;
 

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -575,6 +575,7 @@ void platform_resolve_user_data_path()
 		return;
 	}
 
+	const char separator[2] = { platform_get_path_separator(), 0 };
 	char buffer[MAX_PATH];
 	buffer[0] = '\0';
 	log_verbose("buffer = '%s'", buffer);
@@ -590,11 +591,15 @@ void platform_resolve_user_data_path()
 			exit(-1);
 			return;
 		}
+
+		strncat(buffer, homedir, MAX_PATH);
+		strncat(buffer, separator, MAX_PATH);
+		strncat(buffer, ".config", MAX_PATH);
 	}
-	char separator[2] = { platform_get_path_separator(), 0 };
-	strncat(buffer, homedir, MAX_PATH);
-	strncat(buffer, separator, MAX_PATH);
-	strncat(buffer, ".config", MAX_PATH);
+	else
+	{
+		strncat(buffer, homedir, MAX_PATH);
+	}
 	strncat(buffer, separator, MAX_PATH);
 	strncat(buffer, "OpenRCT2", MAX_PATH);
 	strncat(buffer, separator, MAX_PATH);
@@ -610,6 +615,7 @@ void platform_resolve_user_data_path()
 
 void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory)
 {
+	const char separator[2] = { platform_get_path_separator(), 0 };
 	char buffer[MAX_PATH];
 	safe_strncpy(buffer, _userDataDirectoryPath, sizeof(buffer));
 	if (subDirectory != NULL && subDirectory[0] != 0) {

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -564,8 +564,10 @@ wchar_t *regular_to_wchar(const char* src)
  */
 void platform_resolve_user_data_path()
 {
+	const char separator[2] = { platform_get_path_separator(), 0 };
+
 	if (gCustomUserDataPath[0] != 0) {
-		safe_strncpy(_userDataDirectoryPath, gCustomUserDataPath, sizeof(_userDataDirectoryPath));
+		realpath(gCustomUserDataPath, _userDataDirectoryPath);
 
 		// Ensure path ends with separator
 		int len = strlen(_userDataDirectoryPath);
@@ -575,7 +577,6 @@ void platform_resolve_user_data_path()
 		return;
 	}
 
-	const char separator[2] = { platform_get_path_separator(), 0 };
 	char buffer[MAX_PATH];
 	buffer[0] = '\0';
 	log_verbose("buffer = '%s'", buffer);

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -138,6 +138,7 @@ void platform_show_cursor();
 void platform_get_cursor_position(int *x, int *y);
 void platform_set_cursor_position(int x, int y);
 unsigned int platform_get_ticks();
+void platform_resolve_user_data_path();
 void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory);
 void platform_show_messagebox(utf8 *message);
 int platform_open_common_file_dialog(int type, utf8 *title, utf8 *filename, utf8 *filterPattern, utf8 *filterName);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -183,6 +183,9 @@ int strcicmp(char const *a, char const *b)
 
 char *safe_strncpy(char * destination, const char * source, size_t size)
 {
+	assert(destination != NULL);
+	assert(source != NULL);
+
 	if (size == 0)
 	{
 		return destination;


### PR DESCRIPTION
See #2182

Added ```--user-data-path``` command argument so that you can specify where your user directory is allowing OpenRCT2 to be played completely off an external drive.

Also changed default path under linux to be ~/.config/OpenRCT2.

@janisozaur can you test this on linux please?