### PR TITLE
Fix Bug #2201

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2908,10 +2908,10 @@ void screen_get_map_xy_side_with_z(sint16 screenX, sint16 screenY, sint16 z, sin
  *
  * @returns rotation in range 0-3 (inclusive)
  */
-int get_current_rotation()
+uint32 get_current_rotation()
 {
-	int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	int rotation_masked = rotation & 3;
+	uint32 rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	uint32 rotation_masked = rotation & 3;
 #if DEBUG_LEVEL_1
 	if (rotation != rotation_masked) {
 	    log_error("Found wrong rotation %d! Will return %d instead.", rotation, rotation_masked);

--- a/src/interface/viewport.h
+++ b/src/interface/viewport.h
@@ -144,6 +144,6 @@ void screen_get_map_xy_quadrant_with_z(sint16 screenX, sint16 screenY, sint16 z,
 void screen_get_map_xy_side(sint16 screenX, sint16 screenY, sint16 *mapX, sint16 *mapY, uint8 *side);
 void screen_get_map_xy_side_with_z(sint16 screenX, sint16 screenY, sint16 z, sint16 *mapX, sint16 *mapY, uint8 *side);
 
-int get_current_rotation();
+uint32 get_current_rotation();
 
 #endif


### PR DESCRIPTION
Current Rotation should be unsigned, otherwise `(get_current_rotation() + direction) % 4` will return invalid values for example in interface/window.c