### PR TITLE
Early out and report error if langauge files are missing

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3899,6 +3899,7 @@ STR_5557    :Stay connected after desynchronisation (Multiplayer)
 STR_5558    :A restart is required for this setting to take effect
 STR_5559    :10 min. inspections
 STR_5560    :{SMALLFONT}{BLACK}Sets the inspection time to 'Every 10 minutes' on all rides
+STR_5561    :Failed to load language file
 
 
 #####################

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2146,6 +2146,7 @@ enum {
 	STR_STAY_CONNECTED_AFTER_DESYNC = 5557,
 
     STR_RESTART_REQUIRED = 5558,
+    STR_LANGUAGE_LOAD_FAILED = 5561,
 
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -225,7 +225,11 @@ bool openrct2_initialise()
 		audio_init();
 		audio_get_devices();
 	}
-	language_open(gConfigGeneral.language);
+	if (!language_open(gConfigGeneral.language))
+	{
+		log_fatal("Failed to open language, exiting.");
+		return false;
+	}
 	http_init();
 
 	themes_set_default();

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -1010,11 +1010,27 @@ static void window_options_dropdown(rct_window *w, int widgetIndex, int dropdown
 			}
 			break;
 		case WIDX_LANGUAGE_DROPDOWN:
-			if (dropdownIndex != gCurrentLanguage - 1) {
-				language_open(dropdownIndex + 1);
-				gConfigGeneral.language = dropdownIndex + 1;
-				config_save_default();
-				gfx_invalidate_screen();
+			{
+				int fallbackLanguage = gCurrentLanguage;
+				if (dropdownIndex != gCurrentLanguage - 1) {
+					if (!language_open(dropdownIndex + 1))
+					{
+						// Failed to open language file, try to recover by falling
+						// back to previously used language
+						if (language_open(fallbackLanguage))
+						{
+							// It worked, so we can say it with error message in-game
+							window_error_open(STR_LANGUAGE_LOAD_FAILED, STR_NONE);
+						}
+						// report error to console regardless
+						log_error("Failed to open language file.");
+						dropdownIndex = fallbackLanguage - 1;
+					} else {
+						gConfigGeneral.language = dropdownIndex + 1;
+						config_save_default();
+						gfx_invalidate_screen();
+					}
+				}
 			}
 			break;
 		case WIDX_DATE_FORMAT_DROPDOWN:


### PR DESCRIPTION
This is a common problem if you don't set up your paths properly on
Linux, so be nice and try to provide helpful message why we failed to
load instead of crashing on user a moment later.