### PR TITLE
Corrupt Element Inserter

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3902,6 +3902,8 @@ STR_5560    :{SMALLFONT}{BLACK}Sets the inspection time to 'Every 10 minutes' on
 STR_5561    :Failed to load language file
 STR_5562    :WARNING!
 STR_5563    :This feature is currently unstable, take extra caution.
+STR_5564    :Insert Corrupt Element
+STR_5565    :{SMALLFONT}{BLACK}Inserts a corrupt map element at top of tile. This will hide any element above the corrupt element.
 
 #####################
 # Rides/attractions # 

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2151,6 +2151,9 @@ enum {
 	STR_WARNING_IN_CAPS = 5562,
 	STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE = 5563,
 
+	STR_INSERT_CORRUPT = 5564,
+	STR_INSERT_CORRUPT_TIP = 5565,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -1184,7 +1184,7 @@ void window_guest_overview_tool_down(rct_window* w, int widgetIndex, int x, int 
 		window_error_open(0x785,-1);
 		return;
 	}
-
+	
 	if (!map_can_construct_at(tile_x, tile_y, dest_z / 8, (dest_z / 8) + 1, 15)){
 		if (RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) != 0x3A5 ){
 			if (RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) != 0x49B){


### PR DESCRIPTION
Implemented an insert corrupt element button on the tile inspector.

This can be used to hide any element above the current element. People at NE use 8cars a lot for hiding entrances and track with this.