### PR TITLE
Use C++'s std::abs instead of C's to get floats

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -26,6 +26,7 @@ extern "C" {
 	#include "audio.h"
 }
 #include "mixer.h"
+#include <cmath>
 
 Mixer gMixer;
 
@@ -393,7 +394,7 @@ void Channel::SetPan(float pan)
 	if (pan < 0) {
 		Channel::pan = 0;
 	}
-	double decibels = (abs(Channel::pan - 0.5) * 2.0) * 100.0;
+	double decibels = (std::abs(Channel::pan - 0.5) * 2.0) * 100.0;
 	double attenuation = pow(10, decibels / 20.0);
 	if (Channel::pan <= 0.5) {
 		volume_l = 1.0;


### PR DESCRIPTION
C's abs() will only work on int values, only std::abs will get floats, this resolves clang's warning
```
/home/travis/build/OpenRCT2/OpenRCT2/src/audio/mixer.cpp:396:21: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
        double decibels = (abs(C...
                           ^
/home/travis/build/OpenRCT2/OpenRCT2/src/audio/mixer.cpp:396:21: note: use function 'std::abs' instead
        double decibels = (abs(Channel::...
                           ^~~
                           std::abs
/home/travis/build/OpenRCT2/OpenRCT2/src/audio/mixer.cpp:396:21: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
1 warning generated.
```

https://travis-ci.org/OpenRCT2/OpenRCT2/jobs/90459641