### PR TITLE
cmake for packaging and release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ else (WIN32)
 	# this will install the launcher script and replace the path to package in it
 	configure_file(distribution/openrct2.sh openrct2.sh)
 	install(PROGRAMS ${CMAKE_BINARY_DIR}/openrct2.sh DESTINATION bin)
+	add_custom_target(g2 ALL DEPENDS ${PROJECT} COMMAND ./openrct2 sprite build ${CMAKE_BINARY_DIR}/g2.dat ${CMAKE_CURRENT_SOURCE_DIR}/resources WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+	install(FILES ${CMAKE_BINARY_DIR}/g2.dat DESTINATION data)
 endif (WIN32)
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ else (WIN32)
 	configure_file(distribution/openrct2.sh openrct2.sh)
 	install(PROGRAMS ${CMAKE_BINARY_DIR}/openrct2.sh DESTINATION bin)
 	add_custom_target(g2 ALL DEPENDS ${PROJECT} COMMAND ./openrct2 sprite build ${CMAKE_BINARY_DIR}/g2.dat ${CMAKE_CURRENT_SOURCE_DIR}/resources WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+	add_custom_target(g2-echo ALL DEPENDS ${PROJECT} COMMAND echo ./openrct2 sprite build ${CMAKE_BINARY_DIR}/g2.dat ${CMAKE_CURRENT_SOURCE_DIR}/resources WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 	install(FILES ${CMAKE_BINARY_DIR}/g2.dat DESTINATION data)
 endif (WIN32)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ if (WIN32)
 	add_library(${PROJECT} SHARED ${ORCT2_SOURCES} ${SPEEX_SOURCES})
 else (WIN32)
 	add_executable(${PROJECT} ${ORCT2_SOURCES})
+	# this will install the launcher script and replace the path to package in it
+	configure_file(distribution/openrct2.sh openrct2.sh)
+	install(PROGRAMS ${CMAKE_BINARY_DIR}/openrct2.sh DESTINATION bin)
 endif (WIN32)
 
 if (APPLE)
@@ -129,3 +132,6 @@ endif (APPLE)
 set_target_properties(${PROJECT} PROPERTIES PREFIX "")
 
 TARGET_LINK_LIBRARIES(${PROJECT} ${SDL2_LIBRARIES} ${ORCTLIBS_LIB} ${JANSSON_LIBRARIES} ${HTTPLIBS} ${NETWORKLIBS} ${SPEEX_LIBRARIES} ${DLLIB})
+install(TARGETS ${PROJECT} RUNTIME DESTINATION data)
+install(DIRECTORY data DESTINATION data)
+install(FILES openrct2.exe DESTINATION data)

--- a/build.sh
+++ b/build.sh
@@ -59,8 +59,10 @@ pushd build
 		chmod g+s $(pwd)
 		docker run -u travis -v $PARENT:/work/openrct2 -w /work/openrct2/build -i -t openrct2/openrct2:32bit-only bash -c "cmake ../ $OPENRCT2_CMAKE_OPTS && make"
 	else
-		cmake -DCMAKE_BUILD_TYPE=Debug $OPENRCT2_CMAKE_OPTS ..
+		cmake -DCMAKE_BUILD_TYPE=Debug $OPENRCT2_CMAKE_OPTS -DCMAKE_INSTALL_PREFIX=package ..
 		make
+		make install
+		tree -lpFh package
 	fi
 popd
 

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,8 @@ if [[ ! -d build ]]; then
 	mkdir -p build
 fi
 
+source transfer.sh
+
 # keep in sync with version in install.sh
 sha256sum=69ff98c9544838fb16384bc78af9dc1c452b9d01d919e43f5fec686d02c9bdd8
 libVFile="./libversion"
@@ -63,6 +65,12 @@ pushd build
 		make
 		make install
 		tree -lpFh package
+		if [[ -f openrct2 ]]; then
+			transfer openrct2
+		fi
+		tree -lpFh ../
+		sha256sum package/data/g2.dat
+		transfer package/data/g2.dat
 	fi
 popd
 

--- a/distribution/openrct2.sh
+++ b/distribution/openrct2.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+cd ${CMAKE_INSTALL_PREFIX}/data
+exec ./openrct2 "$@"

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ elif [[ $(uname) == "Linux" ]]; then
 			"linux")
 				sudo dpkg --add-architecture i386
 				sudo apt-get update
-				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 clang
+				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 clang tree
 				download https://launchpad.net/ubuntu/+archive/primary/+files/libjansson4_2.7-1ubuntu1_i386.deb libjansson4_2.7-1ubuntu1_i386.deb
 				download https://launchpad.net/ubuntu/+archive/primary/+files/libjansson-dev_2.7-1ubuntu1_i386.deb libjansson-dev_2.7-1ubuntu1_i386.deb
 				sudo dpkg -i libjansson4_2.7-1ubuntu1_i386.deb
@@ -183,7 +183,7 @@ elif [[ $(uname) == "Linux" ]]; then
 				;;
 			"windows")
 				sudo apt-get update
-				sudo apt-get install -y --force-yes binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake
+				sudo apt-get install -y --force-yes binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake tree
 				;;
 			"docker32")
 				docker pull openrct2/openrct2:32bit-only

--- a/transfer.sh
+++ b/transfer.sh
@@ -1,0 +1,60 @@
+#
+# Defines transfer alias and provides easy command line file and folder sharing.
+#
+# Authors:
+#   Remco Verhoef <remco@dutchcoders.io>
+#
+
+curl --version 2>&1 > /dev/null
+if [ $? -ne 0 ]; then
+  echo "Could not find curl."
+  return 1
+fi
+
+transfer() { 
+    # check arguments
+    if [ $# -eq 0 ]; 
+    then 
+        echo "No arguments specified. Usage:\necho transfer /tmp/test.md\ncat /tmp/test.md | transfer test.md"
+        return 1
+    fi
+
+    # get temporarily filename, output is written to this file show progress can be showed
+    tmpfile=$( mktemp -t transferXXX )
+    
+    # upload stdin or file
+    file=$1
+
+    if tty -s; 
+    then 
+        basefile=$(basename "$file" | sed -e 's/[^a-zA-Z0-9._-]/-/g') 
+
+        if [ ! -e $file ];
+        then
+            echo "File $file doesn't exists."
+            return 1
+        fi
+        
+        if [ -d $file ];
+        then
+            # zip directory and transfer
+            zipfile=$( mktemp -t transferXXX.zip )
+            cd $(dirname $file) && zip -r -q - $(basename $file) >> $zipfile
+            curl --progress-bar --upload-file "$zipfile" "https://transfer.sh/$basefile.zip" >> $tmpfile
+            rm -f $zipfile
+        else
+            # transfer file
+            curl --progress-bar --upload-file "$file" "https://transfer.sh/$basefile" >> $tmpfile
+        fi
+    else 
+        # transfer pipe
+        curl --progress-bar --upload-file "-" "https://transfer.sh/$file" >> $tmpfile
+    fi
+   
+    # cat output link
+    cat $tmpfile
+
+    # cleanup
+    rm -f $tmpfile
+}
+


### PR DESCRIPTION
Changes to cmake that allow installation and subsequently packaging of OpenRCT2.

Takes care of #2190.

- [x] make cmake-generated project installable with `make install`
- [x] make sure `g2.dat` is built when doing `make` step.
  - [x] check if `g2.dat` is built properly, as it doesn't look quite right now
- [x] add launcher script that changes directory on behalf of user, so `openrct2` (the binary) can find `openrct2.exe` and other files
- [ ] create a menu entry for desktop environments.
  - [ ] make sure the entry has our icon
- [ ] add a step packaging all artifacts into an archive
- [x] ~~add certificate bundle and make a note that user can replace it with their system one~~ openrct2 uses system certificates on linux, see #2389 

I made travis more verbose for this pull request, so you can easily see what does the project structure look like after it was installed. Before this is merged, I will remove this commit so it be merged cleanly.

I'd like to request your comments now.

So far the proposed contents of a release package look like this (taken from https://travis-ci.org/janisozaur/OpenRCT2/jobs/90907970):
```
package
├── [drwxrwxr-x 4.0K]  bin/
│   └── [-rwxr-xr-x   95]  openrct2.sh*
└── [drwxrwxr-x 4.0K]  data/
    ├── [drwxr-xr-x 4.0K]  data/
    │   ├── [drwxr-xr-x 4.0K]  language/
    │   │   ├── [-rw-r--r-- 151K]  chinese_simplified.txt
    │   │   ├── [-rw-r--r-- 157K]  chinese_traditional.txt
    │   │   ├── [-rw-r--r-- 221K]  dutch.txt
    │   │   ├── [-rw-r--r-- 155K]  english_uk.txt
    │   │   ├── [-rw-r--r-- 155K]  english_us.txt
    │   │   ├── [-rw-r--r-- 160K]  finnish.txt
    │   │   ├── [-rw-r--r-- 158K]  french.txt
    │   │   ├── [-rw-r--r-- 166K]  german.txt
    │   │   ├── [-rw-r--r-- 139K]  hungarian.txt
    │   │   ├── [-rw-r--r-- 151K]  italian.txt
    │   │   ├── [-rw-r--r-- 174K]  korean.txt
    │   │   ├── [-rw-r--r-- 142K]  polish.txt
    │   │   ├── [-rw-r--r-- 161K]  portuguese_br.txt
    │   │   ├── [-rw-r--r-- 142K]  russian.txt
    │   │   ├── [-rw-r--r-- 139K]  spanish_sp.txt
    │   │   └── [-rw-r--r-- 140K]  swedish.txt
    │   └── [drwxr-xr-x 4.0K]  title/
    │       ├── [drwxr-xr-x 4.0K]  openrct2/
    │       │   ├── [-rw-r--r-- 1.9M]  achilleshiel.sv6
    │       │   ├── [-rw-r--r-- 2.3M]  faas.sv6
    │       │   ├── [-rw-r--r-- 1.1M]  mci.sv6
    │       │   ├── [-rw-r--r-- 1.4M]  pfckrutonium1.sv6
    │       │   ├── [-rw-r--r-- 1.6M]  pfckrutonium2.sv6
    │       │   ├── [-rw-r--r-- 1.5M]  poke.sv6
    │       │   ├── [-rw-r--r-- 540K]  rid6.sv6
    │       │   ├── [-rw-r--r-- 1.3K]  script.txt
    │       │   ├── [-rw-r--r-- 1010K]  shotguns.sv6
    │       │   └── [-rw-r--r-- 3.1M]  triggerdeath.sv6
    │       └── [drwxr-xr-x 4.0K]  rct2/
    │           └── [-rw-r--r--  306]  script.txt
    ├── [-rw-r--r--  40K]  g2.dat
    ├── [-rwxr-xr-x 6.1M]  openrct2*
    └── [-rw-r--r-- 6.4M]  openrct2.exe
```

This is based on Graham Edgecombe's [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/?h=openrct2-git)