### PR TITLE
Zero the buffer for g2.dat

### DIFF
--- a/src/cmdline_sprite.c
+++ b/src/cmdline_sprite.c
@@ -260,6 +260,7 @@ bool sprite_file_import(const char *path, rct_g1_element *outElement, uint8 **ou
 	}
 
 	uint8 *buffer = malloc((height * 2) + (width * height * 16));
+	memset(buffer, 0, (height * 2) + (width * height * 16));
 	uint16 *yOffsets = (uint16*)buffer;
 
 	// A larger range is needed for proper dithering


### PR DESCRIPTION
Some leftover data caused the g2.dat generated on different platforms to
have mismatching cheksums. Zeroing the buffer makes them
checksum-identical.