### PR TITLE
Include <fcntl.h> instead of the non-standard <sys/fcntl.h>

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -79,7 +79,7 @@ extern "C" {
 	#include <netdb.h>
 	#include <netinet/tcp.h>
 	#include <sys/socket.h>
-	#include <sys/fcntl.h>
+	#include <fcntl.h>
 	typedef int SOCKET;
 	#define SOCKET_ERROR -1
 	#define INVALID_SOCKET -1


### PR DESCRIPTION
Having another fcntl.h header in the sys subdirectory is non-standard, though many systems do this. Android, for example does not, and hence '#include \<sys/fcntl.h\> would fail'.