### PR TITLE
Decompilation of viewport_surface_paint_setup

### DIFF
--- a/src/addresses.h
+++ b/src/addresses.h
@@ -221,7 +221,7 @@
 // Types:
 // 0-3   Corners
 // 4     Whole tile
-// 5     ?
+// 5     Water tool
 // 6-9   Quarters
 // 10-13 Edges
 #define RCT2_ADDRESS_MAP_SELECTION_TYPE				0x009DE594

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1629,12 +1629,19 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	regs.ah = mapElement->properties.surface.terrain;
 	//callcode_push1(0x66065D, saved_esi, &regs); return;
 	regs.al &= 3;
-	regs.ah = (uint8)regs.ah >> 5;
+	regs.ah = (uint8)regs.ah >> 5; //I really wish registers was unsigned.
 	regs.al <<= 3;
 	regs.al |= regs.ah;
 	regs.eax &= 0xFF;
 	RCT2_GLOBAL(0x9E3264, uint32) = regs.eax;
-	callcode_push1(0x660671, saved_esi, &regs); return;
+	//callcode_push1(0x660671, saved_esi, &regs); return;
+	regs.bl = mapElement->properties.surface.slope;
+	regs.di = (regs.bx & 0xF) << regs.cl;
+	regs.ebx &= 0x10;
+	regs.si = (uint16)regs.di >> 4;
+	regs.di = (regs.di | regs.si) & 0xF;
+	regs.bx |= regs.di;
+	callcode_push1(0x660692, saved_esi, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1884,6 +1884,37 @@ static inline int helper(rct_map_element *mapElement, uint8 shift)
 	return ebx;
 }
 
+static void loc_660E42(unsigned int ebx, unsigned int dx) //dx is already shifted
+{
+	unsigned int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint16); //ebp
+	
+	RCT2_CALLPROC_X(
+				(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
+				0 | (0x10 << 8),
+				0xA40,
+				0,
+				dx,
+				0x20,
+				0x20,
+				rotation
+	);
+	ebx ^= 2;
+	ebx += RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint8);
+	ebx &= 3;
+	ebx += 0x20380C27;
+	
+	RCT2_CALLPROC_X(
+				(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
+				0 | (0x13 << 8),
+				ebx,
+				0,
+				dx,
+				0x20,
+				0x20,
+				rotation
+	);
+}
+
 /**
  * rct2: 0x66062C
  * edx = height
@@ -2219,7 +2250,69 @@ loc_660D93:
 		}
 	}
 //loc_660DB2:
-	callcode_push1(0x660DB2, saved_esi, &regs); return;
+	//callcode_push1(0x660DB2, saved_esi, &regs); return;
+	
+	if((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR) && (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_OWNERSHIP))
+	{
+		//callcode_push1(0x660DCE, saved_esi, &regs); return;
+		
+		/* 	RCT2_ADDRESS_PEEP_SPAWNS = x coordinate of first peep spawn.
+		 *	0x13573F4 = y coordinate of first peep spawn.
+		 *	0x13573F8 = x coordinate of second peep spawn.
+		 *	0x13573FA = y coordinate of second peep spawn.
+		 */
+		//Check both peep spawn locations
+		if((RCT2_GLOBAL(RCT2_ADDRESS_PEEP_SPAWNS, uint16) & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
+		(RCT2_GLOBAL(0x13573F4, uint16) & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
+		{
+			loc_660E42(RCT2_GLOBAL(0x13573F7, uint8), RCT2_GLOBAL(0x13573F6, uint8) << 4);
+		}
+		else if((RCT2_GLOBAL(0x13573F8, uint16) & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
+		(RCT2_GLOBAL(0x13573FA, uint16) & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
+		{
+			loc_660E42(RCT2_GLOBAL(0x13573FD, uint8), RCT2_GLOBAL(0x13573FC, uint8) << 4);
+		}
+	}
+	
+//loc_660E9A:
+	//callcode_push1(0x660E9A, saved_esi, &regs); return;
+	assert(0x100 == VIEWPORT_FLAG_LAND_OWNERSHIP);
+	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_OWNERSHIP)
+	{
+		assert(saved_esi == (int)mapElement);
+		if(mapElement->properties.surface.ownership & 0x20)
+		{
+			//0x660EAE
+			//Draw blue square if land is owned
+			sub_68818E(0, RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0xA41, 0);
+		}
+		else
+		{
+			//loc_660ECB:
+			if(mapElement->properties.surface.ownership & 0x80)
+			{
+				//0x660ED4
+				//Put a sign if land is for sale
+				paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
+				unsigned int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint16);
+				
+				RCT2_CALLPROC_X(
+					(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
+					0x10 | (0 << 8),
+					0x59AB,
+					0x10,
+					map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10) + 3,
+					1,
+					1,
+					rotation
+				);
+				
+				RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
+			}
+		}
+	}
+loc_660F24:
+	callcode_push1(0x660F24, saved_esi, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1703,7 +1703,7 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	int saved_esi, saved_ecx;
 	
 	//Uncomment this to use vanilla code.
-	RCT2_CALLFUNC_Y(0x66062C, &regs); return;
+	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
 	
 	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo *); //dpi = edi	
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
@@ -1879,44 +1879,44 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	regs.ax += RCT2_ADDRESS(0x97B494, uint16)[regs.esi*2];
 	RCT2_GLOBAL(0x9E3240, rct_map_element *) = NULL;
 	regs.bp += RCT2_ADDRESS(0x97B496, uint16)[regs.esi*2];
-	if(regs.ax >= 0x2000 || regs.bp >= 0x2000)
-		goto loc_660A3C;
-	rct_map_element *mapElement2 = map_get_surface_element_at(regs.ax/32, regs.bp/32); //mapElement2 = esi
-	regs.esi = (int)mapElement2;
-	RCT2_GLOBAL(0x9E3240, rct_map_element *) = mapElement2;
-	regs.al = (mapElement2->type & 3) << 3;
-	regs.ah = mapElement2->properties.surface.terrain >> 5;
-	regs.al |= regs.ah;
-	regs.eax &= 0xFF;
-	RCT2_GLOBAL(0x9E3254, uint32) = regs.eax;
-	regs.ebx = helper(mapElement2, &regs);
-	RCT2_GLOBAL(0x9E3268, uint32) = regs.ebx;
-	regs.ax = regs.dx;
-	regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
-	regs.ax = (uint16)regs.ax >> 4;
-	mapElement2 = RCT2_GLOBAL(0x9E3240, rct_map_element *);
-	regs.esi = (int)mapElement2;
-	
-	//SAVE
-	saved_ecx = regs.ecx;
-	
-	regs.ah = mapElement2->base_height >> 1;
-	regs.cx = regs.ax;
-	regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
-	regs.cl += RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
-	regs.ah += RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
-	regs.ch += RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
-	RCT2_GLOBAL(0x9E327C, uint16) = regs.ax;
-	RCT2_GLOBAL(0x9E3284, uint16) = regs.cx;
-	
-	//RESTORE
-	regs.ecx = saved_ecx;
-	
-loc_660A3C:
+	if(regs.ax < 0x2000 && regs.bp < 0x2000)
+	{
+		rct_map_element *mapElement2 = map_get_surface_element_at(regs.ax/32, regs.bp/32); //mapElement2 = esi
+		regs.esi = (int)mapElement2;
+		RCT2_GLOBAL(0x9E3240, rct_map_element *) = mapElement2;
+		regs.al = (mapElement2->type & 3) << 3;
+		regs.ah = mapElement2->properties.surface.terrain >> 5;
+		regs.al |= regs.ah;
+		regs.eax &= 0xFF;
+		RCT2_GLOBAL(0x9E3254, uint32) = regs.eax;
+		regs.ebx = helper(mapElement2, &regs);
+		RCT2_GLOBAL(0x9E3268, uint32) = regs.ebx;
+		regs.ax = regs.dx;
+		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+		regs.ax = (uint16)regs.ax >> 4;
+		mapElement2 = RCT2_GLOBAL(0x9E3240, rct_map_element *);
+		regs.esi = (int)mapElement2;
+		
+		//SAVE
+		saved_ecx = regs.ecx;
+		
+		regs.ah = mapElement2->base_height >> 1;
+		regs.cx = regs.ax;
+		regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
+		regs.cl += RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
+		regs.ah += RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
+		regs.ch += RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E327C, uint16) = regs.ax;
+		RCT2_GLOBAL(0x9E3284, uint16) = regs.cx;
+		
+		//RESTORE
+		regs.ecx = saved_ecx;
+	}
+//loc_660A3C:
 	//RESTORE
 	regs.esi = saved_esi;
 	
-	RCT2_CALLFUNC_Y(0x660A3C, &regs); return;
+	RCT2_CALLFUNC_Y(0x660A3D, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2091,96 +2091,101 @@ loc_660AAB:
 	
 	assert(height == regs.dx);
 	if(height == regs.di)
-		goto loc_660B25;
-	//callcode_push3(0x660ACB, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	regs.bl = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx];
-	regs.edi = 0;
-	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_GRIDLINES)
-		regs.edi = 4;
-	//callcode_push3(0x660AE3, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	
-	regs.esi = saved_esi; //mov esi, [esp+0Ch+var_4]; mapElement = esi
-	assert(regs.esi = (int)mapElement);
-	mapElement = (rct_map_element *)regs.esi;
-	if(mapElement->properties.surface.terrain & 0xE0)
-		goto loc_660C9F;
-	if(mapElement->type & 3)
-		goto loc_660C9F;
-	if(RCT2_GLOBAL(0x9E3296, uint16) != 0)
-		goto loc_660C9F;
-	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
-		goto loc_660C9F;
-	regs.si = mapElement->properties.surface.grass_length;
-	regs.esi &= 7;
-	//callcode_push3(0x660B1E, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	switch(regs.esi)
 	{
-		case 0:
-			//Mowed grass
-			regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-			regs.ebx += RCT2_ADDRESS(0x97B898, uint32)[(regs.edi+regs.ebp*8)/4];
-			break;
-		case 1: case 2: case 3:
-			//Clear grass
-			goto loc_660C9F;
-		case 4: case 5:
-			//Clumpy grass
-			regs.bp = RCT2_GLOBAL(0x9DE56A, uint16);
-			regs.ax = RCT2_GLOBAL(0x9DE56E, uint16);
-			regs.ebp &= 0x20;
-			regs.ax &= 0x20;
-			regs.ax <<= 1;
-			regs.bp |= regs.ax;
-			regs.ebp /= 32;
-			regs.ebx += RCT2_ADDRESS(0x97B858, uint32)[(regs.edi+regs.ebp*8)/4];
-			break;
-		case 6:
-			//Very clumpy grass
-			regs.bp = RCT2_GLOBAL(0x9DE56A, uint16);
-			regs.ax = RCT2_GLOBAL(0x9DE56E, uint16);
-			regs.ebp &= 0x20;
-			regs.ax &= 0x20;
-			regs.ax <<= 1;
-			regs.bp |= regs.ax;
-			regs.ebp /= 32;
-			regs.ebx += RCT2_ADDRESS(0x97B878, uint32)[(regs.edi+regs.ebp*8)/4];
-			break;
-		default:
-			assert(false); //should not happen.
-			return;
-		
+		//goto loc_660B25;
+		callcode_push3(0x660B25, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	}
-//loc_660CDE:
-	//callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	regs.al = 0;
-	regs.cl = 0;
-	regs.di = 0x20;
-	regs.si = 0x20;
-	regs.ah = 0xFF;
-	regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	RCT2_CALLPROC_X(
-			(int)RCT2_ADDRESS(0x98196C, uint32*)[regs.ebp],
-			regs.eax, 
-			regs.ebx,
-			regs.ecx,
-			regs.edx,
-			regs.esi,
-			regs.edi,
-			regs.ebp
-	);
-	RCT2_GLOBAL(0x9E329A, uint8) = 1;
+	else
+	{
+		bool do_loc_660C9F = false;
+		
+		//callcode_push3(0x660ACB, saved_esi, saved_ebx, saved_ecx, &regs); return;
+		regs.bl = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx];
+		regs.edi = 0;
+		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_GRIDLINES)
+			regs.edi = 4;
+		//callcode_push3(0x660AE3, saved_esi, saved_ebx, saved_ecx, &regs); return;
+		
+		regs.esi = saved_esi; //mov esi, [esp+0Ch+var_4]; mapElement = esi
+		assert(regs.esi = (int)mapElement);
+		mapElement = (rct_map_element *)regs.esi;
+		if(mapElement->properties.surface.terrain & 0xE0)
+			goto loc_660C9F;
+		if(mapElement->type & 3)
+			goto loc_660C9F;
+		if(RCT2_GLOBAL(0x9E3296, uint16) != 0)
+			goto loc_660C9F;
+		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
+			goto loc_660C9F;
+		switch(mapElement->properties.surface.grass_length & 7) //si
+		{
+			case 0:
+				//Mowed grass
+				regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+				regs.ebx += RCT2_ADDRESS(0x97B898, uint32)[(regs.edi+regs.ebp*8)/4];
+				break;
+			case 1: case 2: case 3:
+				//Clear grass
+				goto loc_660C9F;
+			case 4: case 5:
+				//Clumpy grass
+				regs.ebp = (RCT2_GLOBAL(0x9DE56A, uint16) & 0x20) | ((RCT2_GLOBAL(0x9DE56E, uint16) & 0x20) << 1);
+				regs.ebp /= 32;
+				regs.ebx += RCT2_ADDRESS(0x97B858, uint32)[(regs.edi+regs.ebp*8)/4];
+				break;
+			case 6:
+				//Very clumpy grass
+				regs.ebp = (RCT2_GLOBAL(0x9DE56A, uint16) & 0x20) | ((RCT2_GLOBAL(0x9DE56E, uint16) & 0x20) << 1);
+				regs.ebp /= 32;
+				regs.ebx += RCT2_ADDRESS(0x97B878, uint32)[(regs.edi+regs.ebp*8)/4];
+				break;
+			default:
+				assert(false); //should not happen.
+				return;
+			
+		}
+		puts("hi"); fflush(stdout);
+	//loc_660CDE:
+		//callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
+		regs.al = 0;
+		//regs.cl = 0;
+		regs.di = 0x20;
+		regs.si = 0x20;
+		regs.ah = 0xFF;
+		int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
+		RCT2_CALLPROC_X(
+				(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
+				regs.eax, 
+				regs.ebx,
+				0,
+				regs.edx,
+				regs.esi,
+				regs.edi,
+				rotation
+		);
+		RCT2_GLOBAL(0x9E329A, uint8) = 1;
+		
+		//RESTORE
+		regs.ecx = saved_ecx;
+		regs.ebx = saved_ebx;
+	}
+loc_660D02:
+	callcode_push1(0x660D02, saved_esi, &regs); return;
 	
-	//RESTORE
-	regs.ecx = saved_ecx;
-	regs.ebx = saved_ebx;
-	callcode_push1(0x660D02, saved_esi, &regs);
-	return;
 	
 loc_660C9F:
-	callcode_push3(0x660C9F, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	
-loc_660B25:
-	callcode_push3(0x660B25, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	//callcode_push3(0x660C9F, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32) & 1)
+		regs.ebp = RCT2_ADDRESS(0x97B84A, uint8)[regs.ebp];
+	regs.ebx += RCT2_ADDRESS(0x97B750, uint32)[(regs.edi+regs.ebp*8)/4];
+	if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 0xC)
+		regs.ebx = 0xA3F;
+	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
+	{
+		regs.ebx &= 0xDC07FFFF;
+		regs.ebx |= 0x41880000;
+	}
+	callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2369,7 +2369,44 @@ loc_660FB8:
 		}
 	}
 //loc_661132:
-	callcode_push1(0x661132, saved_esi, &regs); return;
+	//callcode_push1(0x661132, saved_esi, &regs); return;
+	if(RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & 2)
+	{
+		//Check if this tile is selected by ride placement.
+		for(int i = 0; ; i++) //i = edi
+		{
+			rct_xy16 selectedTilePos = gMapSelectionTiles[i]; //selectedTilePos = eax;
+			if(selectedTilePos.x == -1)
+				goto loc_661194;
+			if(selectedTilePos.x == RCT2_GLOBAL(0x9DE56A, sint16) && selectedTilePos.y == RCT2_GLOBAL(0x9DE56E, sint16))
+				break;
+		}
+		//This map selection flag changes quite a bit and causes the highlight to flicker between white and yellow when moving the object.
+		uint32 imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000BE3) | ((RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & 8)?0x1580000:0x1280000);
+		sub_68818E(0, imageId, 0);
+	}
+loc_661194:
+	//callcode_push1(0x661194, saved_esi, &regs); return;
+	if(RCT2_GLOBAL(0x9E3296, uint16) == 0 &&
+	RCT2_GLOBAL(0x9E329A, uint8) != 0 &&
+	!(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & (VIEWPORT_FLAG_UNDERGROUND_INSIDE|VIEWPORT_FLAG_GRIDLINES)) &&
+	!(RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_DISABLE_SMOOTH_LANDSCAPE))
+	{
+		callcode_push1(0x6611BB, saved_esi, &regs); return;
+		regs.edi = (int)mapElement;
+		
+		saved_edx = regs.edx;
+		
+		regs.edx >>= 4;
+		RCT2_CALLFUNC_Y(0x65E9FC, &regs);
+		RCT2_CALLFUNC_Y(0x65EAB2, &regs);
+		RCT2_CALLFUNC_Y(0x65E890, &regs);
+		RCT2_CALLFUNC_Y(0x65E946, &regs);
+		
+		regs.edx = saved_edx;
+	}
+//loc_6611D8
+	callcode_push1(0x6611D8, saved_esi, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1703,7 +1703,7 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	int saved_esi, saved_ecx;
 	
 	//Uncomment this to use vanilla code.
-	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
+	RCT2_CALLFUNC_Y(0x66062C, &regs); return;
 	
 	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo *); //dpi = edi	
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
@@ -1741,19 +1741,19 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	{	
 		//callcode_push1(0x6606DA, saved_esi, &regs); return;
 		
-		rct_map_element *mapElement2 = map_get_surface_element_at(x/32, y/32);
+		rct_map_element *mapElement2 = map_get_surface_element_at(x/32, y/32); //mapElement2 = esi
 		
 		regs.esi = (int)mapElement2;
 		
 		//callcode_push1(0x6606F9, saved_esi, &regs); return;
 		
 		RCT2_GLOBAL(0x9E3248, rct_map_element *) = mapElement2;
-		regs.al = mapElement2->type & 3;
+		regs.al = (mapElement2->type & 3) << 3;
+		
 		regs.ah = mapElement2->properties.surface.terrain >> 5;
 		regs.al |= regs.ah;
 		//callcode_push1(0x66070E, saved_esi, &regs); return;
 		
-		//Now, there's another landscape smoothing bug in the following lines of code.
 		regs.eax &= 0xFF;
 		RCT2_GLOBAL(0x9E325C, uint32) = regs.eax;
 
@@ -1787,7 +1787,136 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 		regs.ecx = saved_ecx;
 	}
 //loc_660781:
-	callcode_push1(0x660781, saved_esi, &regs); return;
+	//callcode_push1(0x660781, saved_esi, &regs); return;
+	regs.ax = RCT2_GLOBAL(0x9DE568, uint16);
+	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	regs.bp = RCT2_GLOBAL(0x9DE56C, uint16);
+	regs.ax += RCT2_ADDRESS(0x97B474, uint16)[regs.esi*2];
+	RCT2_GLOBAL(0x9E3244, rct_map_element *) = NULL;
+	regs.bp += RCT2_ADDRESS(0x97B476, uint16)[regs.esi*2];
+	//callcode_push1(0x6607AE, saved_esi, &regs); return;
+	if(regs.ax < 0x2000 && regs.bp < 0x2000)
+	{
+		rct_map_element *mapElement2 = map_get_surface_element_at(regs.ax/32, regs.bp/32); //mapElement2 = esi
+		regs.esi = (int)mapElement2;
+		//rct2: loc_6607E2
+		//callcode_push1(0x6607E2, saved_esi, &regs); return;
+		RCT2_GLOBAL(0x9E3244, rct_map_element *) = mapElement2;
+		regs.al = (mapElement2->type & 3) << 3;
+		regs.ah = mapElement2->properties.surface.terrain >> 5;
+		regs.al |= regs.ah;
+		regs.eax &= 0xFF;
+		RCT2_GLOBAL(0x9E3258, uint32) = regs.eax;
+		regs.ebx = helper(mapElement2, &regs);
+		RCT2_GLOBAL(0x9E326C, uint32) = regs.ebx;
+		regs.ax = regs.dx;
+		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+		regs.ax = (uint16)regs.ax >> 4;
+		mapElement2 = RCT2_GLOBAL(0x9E3244, rct_map_element *);
+		regs.esi = (int)mapElement2;
+		
+		//SAVE
+		saved_ecx = regs.ecx;
+		
+		regs.ah = mapElement2->base_height >> 1;
+		regs.cx = regs.ax;
+		regs.al += RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
+		regs.cl += RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
+		regs.ah += RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
+		regs.ch += RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E327E, uint16) = regs.ax;
+		RCT2_GLOBAL(0x9E3286, uint16) = regs.cx;
+		
+		//RESTORE
+		regs.ecx = saved_ecx;
+	}
+//loc_66086A:
+	//callcode_push1(0x66086A, saved_esi, &regs); return;
+	regs.ax = RCT2_GLOBAL(0x9DE568, uint16);
+	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	regs.bp = RCT2_GLOBAL(0x9DE56C, uint16);
+	regs.ax += RCT2_ADDRESS(0x97B484, uint16)[regs.esi*2];
+	RCT2_GLOBAL(0x9E324C, rct_map_element *) = NULL;
+	regs.bp += RCT2_ADDRESS(0x97B486, uint16)[regs.esi*2];
+	if(regs.ax < 0x2000 && regs.bp < 0x2000)
+	{
+		rct_map_element *mapElement2 = map_get_surface_element_at(regs.ax/32, regs.bp/32); //mapElement2 = esi
+		regs.esi = (int)mapElement2;
+		RCT2_GLOBAL(0x9E324C, rct_map_element *) = mapElement2;
+		regs.al = (mapElement2->type & 3) << 3;
+		regs.ah = mapElement2->properties.surface.terrain >> 5;
+		regs.al |= regs.ah;
+		regs.eax &= 0xFF;
+		RCT2_GLOBAL(0x9E3260, uint32) = regs.eax;
+		regs.ebx = helper(mapElement2, &regs);
+		RCT2_GLOBAL(0x9E3274, uint32) = regs.ebx;
+		regs.ax = regs.dx;
+		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+		regs.ax = (uint16)regs.ax >> 4;
+		mapElement2 = RCT2_GLOBAL(0x9E324C, rct_map_element *);
+		regs.esi = (int)mapElement2;
+		
+		//SAVE
+		saved_ecx = regs.ecx;
+		
+		regs.ah = mapElement2->base_height >> 1;
+		regs.cx = regs.ax;
+		regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
+		regs.cl += RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
+		regs.ah += RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
+		regs.ch += RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E3282, uint16) = regs.ax;
+		RCT2_GLOBAL(0x9E328A, uint16) = regs.cx;
+		
+		//RESTORE
+		regs.ecx = saved_ecx;
+	}
+//loc_660953:
+	//callcode_push1(0x660953, saved_esi, &regs); return;
+	regs.ax = RCT2_GLOBAL(0x9DE568, uint16);
+	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	regs.bp = RCT2_GLOBAL(0x9DE56C, uint16);
+	regs.ax += RCT2_ADDRESS(0x97B494, uint16)[regs.esi*2];
+	RCT2_GLOBAL(0x9E3240, rct_map_element *) = NULL;
+	regs.bp += RCT2_ADDRESS(0x97B496, uint16)[regs.esi*2];
+	if(regs.ax >= 0x2000 || regs.bp >= 0x2000)
+		goto loc_660A3C;
+	rct_map_element *mapElement2 = map_get_surface_element_at(regs.ax/32, regs.bp/32); //mapElement2 = esi
+	regs.esi = (int)mapElement2;
+	RCT2_GLOBAL(0x9E3240, rct_map_element *) = mapElement2;
+	regs.al = (mapElement2->type & 3) << 3;
+	regs.ah = mapElement2->properties.surface.terrain >> 5;
+	regs.al |= regs.ah;
+	regs.eax &= 0xFF;
+	RCT2_GLOBAL(0x9E3254, uint32) = regs.eax;
+	regs.ebx = helper(mapElement2, &regs);
+	RCT2_GLOBAL(0x9E3268, uint32) = regs.ebx;
+	regs.ax = regs.dx;
+	regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+	regs.ax = (uint16)regs.ax >> 4;
+	mapElement2 = RCT2_GLOBAL(0x9E3240, rct_map_element *);
+	regs.esi = (int)mapElement2;
+	
+	//SAVE
+	saved_ecx = regs.ecx;
+	
+	regs.ah = mapElement2->base_height >> 1;
+	regs.cx = regs.ax;
+	regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
+	regs.cl += RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
+	regs.ah += RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
+	regs.ch += RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
+	RCT2_GLOBAL(0x9E327C, uint16) = regs.ax;
+	RCT2_GLOBAL(0x9E3284, uint16) = regs.cx;
+	
+	//RESTORE
+	regs.ecx = saved_ecx;
+	
+loc_660A3C:
+	//RESTORE
+	regs.esi = saved_esi;
+	
+	RCT2_CALLFUNC_Y(0x660A3C, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1709,12 +1709,13 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	
 	//callcode_push1(0x660698, saved_esi, &regs); return;
 	
-	//Something's not quite right in these few lines of code, causing landscape smoothing to not be as smooth as it should be.
 	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
 	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[regs.esi*2]; //x = ax
 	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[regs.esi*2]; //y = bp
 	RCT2_GLOBAL(0x9E3248, rct_map_element *) = NULL;
-	
+
+	regs.ax = x;
+	regs.bp = y;
 	//callcode_push1(0x6606C5, saved_esi, &regs); return;
 	
 	if(x >= 0x2000 || y >= 0x2000)
@@ -1733,6 +1734,8 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	regs.ah = mapElement2->properties.surface.terrain >> 5;
 	regs.al |= regs.ah;
 	//callcode_push1(0x66070E, saved_esi, &regs); return;
+	
+	//Now, there's another landscape smoothing bug in the following lines of code.
 	regs.eax &= 0xFF;
 	RCT2_GLOBAL(0x9E325C, uint32) = regs.eax;
 	
@@ -1756,11 +1759,12 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	//callcode_push1(0x66073F, saved_esi, &regs); return;
 	regs.ax = regs.dx;
 	regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+	//callcode_push1(0x660748, saved_esi, &regs); return;
 	regs.ax = (uint16)regs.ax >> 4;
 	assert(regs.ax == height/16);
 	mapElement2 = RCT2_GLOBAL(0x9E3248, rct_map_element *);
 	
-	//regs.esi = (int)mapElement2;
+	regs.esi = (int)mapElement2;
 	//callcode_push1(0x660752, saved_esi, &regs); return;
 	
 	//SAVE

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1609,9 +1609,9 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	
 	//Uncomment this to use vanilla code.
 	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
+	
 	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo *); //dpi = edi	
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
-	regs.ax = dpi->zoom_level;
 	RCT2_GLOBAL(0x9DE57C, uint16) |= 1;
 	RCT2_GLOBAL(0x9E3250, rct_map_element *) = mapElement;
 	RCT2_GLOBAL(0x9E3296, uint16) = dpi->zoom_level;
@@ -1624,24 +1624,15 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	//SAVE
 	saved_esi = regs.esi;
 	
-	//callcode_push1(0x660658, saved_esi, &regs); return;
-	regs.al = mapElement->type;
-	regs.ah = mapElement->properties.surface.terrain;
-	//callcode_push1(0x66065D, saved_esi, &regs); return;
-	regs.al &= 3;
-	regs.ah = (uint8)regs.ah >> 5; //I really wish registers was unsigned.
-	regs.al <<= 3;
-	regs.al |= regs.ah;
-	regs.eax &= 0xFF;
-	RCT2_GLOBAL(0x9E3264, uint32) = regs.eax;
+	RCT2_GLOBAL(0x9E3264, uint32) = ((mapElement->type & 3) << 3) | (mapElement->properties.surface.terrain >> 5);
+	
 	//callcode_push1(0x660671, saved_esi, &regs); return;
-	regs.bl = mapElement->properties.surface.slope;
-	regs.di = (regs.bx & 0xF) << regs.cl;
-	regs.ebx &= 0x10;
-	regs.si = (uint16)regs.di >> 4;
-	regs.di = (regs.di | regs.si) & 0xF;
-	regs.bx |= regs.di;
-	callcode_push1(0x660692, saved_esi, &regs); return;
+	
+	uint16 unk = (mapElement->properties.surface.slope & 0xF) << regs.cl; //unk = di
+	
+	RCT2_GLOBAL(0x9E3278, uint32) = (mapElement->properties.surface.slope & 0x10) | ((unk | (unk >> 4)) & 0xF);
+	
+	callcode_push1(0x660698, saved_esi, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2099,11 +2099,9 @@ loc_660AAB:
 		regs.edi = 4;
 	//callcode_push3(0x660AE3, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	
-	//This code causes a segfault.
-	
 	regs.esi = saved_esi; //mov esi, [esp+0Ch+var_4]; mapElement = esi
 	assert(regs.esi = (int)mapElement);
-	mapElement = regs.esi;
+	mapElement = (rct_map_element *)regs.esi;
 	if(mapElement->properties.surface.terrain & 0xE0)
 		goto loc_660C9F;
 	if(mapElement->type & 3)
@@ -2114,7 +2112,7 @@ loc_660AAB:
 		goto loc_660C9F;
 	regs.si = mapElement->properties.surface.grass_length;
 	regs.esi &= 7;
-	callcode_push3(0x660C28, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	callcode_push3(0x660B1E, saved_esi, saved_ebx, saved_ecx, &regs); return;
 loc_660C9F:
 	callcode_push3(0x660C9F, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2108,16 +2108,79 @@ loc_660AAB:
 		goto loc_660C9F;
 	if(RCT2_GLOBAL(0x9E3296, uint16) != 0)
 		goto loc_660C9F;
-	if(RCT2_GLOBAL(0x141E9E4, uint16) & 0x1001)
+	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
 		goto loc_660C9F;
 	regs.si = mapElement->properties.surface.grass_length;
 	regs.esi &= 7;
-	callcode_push3(0x660B1E, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	//callcode_push3(0x660B1E, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	switch(regs.esi)
+	{
+		case 0:
+			//Mowed grass
+			regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+			regs.ebx += RCT2_ADDRESS(0x97B898, uint32)[(regs.edi+regs.ebp*8)/4];
+			break;
+		case 1: case 2: case 3:
+			//Clear grass
+			goto loc_660C9F;
+		case 4: case 5:
+			//Clumpy grass
+			regs.bp = RCT2_GLOBAL(0x9DE56A, uint16);
+			regs.ax = RCT2_GLOBAL(0x9DE56E, uint16);
+			regs.ebp &= 0x20;
+			regs.ax &= 0x20;
+			regs.ax <<= 1;
+			regs.bp |= regs.ax;
+			regs.ebp /= 32;
+			regs.ebx += RCT2_ADDRESS(0x97B858, uint32)[(regs.edi+regs.ebp*8)/4];
+			break;
+		case 6:
+			//Very clumpy grass
+			regs.bp = RCT2_GLOBAL(0x9DE56A, uint16);
+			regs.ax = RCT2_GLOBAL(0x9DE56E, uint16);
+			regs.ebp &= 0x20;
+			regs.ax &= 0x20;
+			regs.ax <<= 1;
+			regs.bp |= regs.ax;
+			regs.ebp /= 32;
+			regs.ebx += RCT2_ADDRESS(0x97B878, uint32)[(regs.edi+regs.ebp*8)/4];
+			break;
+		default:
+			assert(false); //should not happen.
+			return;
+		
+	}
+//loc_660CDE:
+	//callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	regs.al = 0;
+	regs.cl = 0;
+	regs.di = 0x20;
+	regs.si = 0x20;
+	regs.ah = 0xFF;
+	regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	RCT2_CALLPROC_X(
+			(int)RCT2_ADDRESS(0x98196C, uint32*)[regs.ebp],
+			regs.eax, 
+			regs.ebx,
+			regs.ecx,
+			regs.edx,
+			regs.esi,
+			regs.edi,
+			regs.ebp
+	);
+	RCT2_GLOBAL(0x9E329A, uint8) = 1;
+	
+	//RESTORE
+	regs.ecx = saved_ecx;
+	regs.ebx = saved_ebx;
+	callcode_push1(0x660D02, saved_esi, &regs);
+	return;
+	
 loc_660C9F:
 	callcode_push3(0x660C9F, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	
 loc_660B25:
-	callcode_push3(0x660AC6, saved_esi, saved_ebx, saved_ecx, &regs); return;
+	callcode_push3(0x660B25, saved_esi, saved_ebx, saved_ecx, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1632,7 +1632,34 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	
 	RCT2_GLOBAL(0x9E3278, uint32) = (mapElement->properties.surface.slope & 0x10) | ((unk | (unk >> 4)) & 0xF);
 	
-	callcode_push1(0x660698, saved_esi, &regs); return;
+	//callcode_push1(0x660698, saved_esi, &regs); return;
+	
+	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[regs.esi*2]; //x = ax
+	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[regs.esi*2]; //y = bp
+	RCT2_GLOBAL(0x9E3248, uint32) = 0;
+	
+	//callcode_push1(0x6606C5, saved_esi, &regs); return;
+	
+	if(x >= 0x2000 || y >= 0x2000)
+		goto loc_660781;
+	
+	//callcode_push1(0x6606DA, saved_esi, &regs); return;
+	
+	rct_map_element *mapElement2 = map_get_surface_element_at(x/32, y/32);
+	
+	regs.esi = (int)mapElement2;
+	
+	//callcode_push1(0x6606F9, saved_esi, &regs); return;
+	
+	RCT2_GLOBAL(0x9E3248, rct_map_element *) = mapElement2;
+	regs.al = mapElement2->type & 3;
+	regs.ah = mapElement2->properties.surface.terrain >> 5;
+	regs.al |= regs.ah;
+	callcode_push1(0x66070E, saved_esi, &regs); return;
+	
+loc_660781:
+	callcode_push1(0x660781, saved_esi, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1680,7 +1680,7 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	regs.edi = 0;
 	regs.ebp = ebp;
 	
-	int saved_esi;
+	int saved_esi, saved_ecx;
 	
 	//Uncomment this to use vanilla code.
 	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
@@ -1709,10 +1709,11 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	
 	//callcode_push1(0x660698, saved_esi, &regs); return;
 	
+	//Something's not quite right in these few lines of code, causing landscape smoothing to not be as smooth as it should be.
 	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
 	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[regs.esi*2]; //x = ax
 	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[regs.esi*2]; //y = bp
-	RCT2_GLOBAL(0x9E3248, uint32) = 0;
+	RCT2_GLOBAL(0x9E3248, rct_map_element *) = NULL;
 	
 	//callcode_push1(0x6606C5, saved_esi, &regs); return;
 	
@@ -1731,7 +1732,51 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	regs.al = mapElement2->type & 3;
 	regs.ah = mapElement2->properties.surface.terrain >> 5;
 	regs.al |= regs.ah;
-	callcode_push1(0x66070E, saved_esi, &regs); return;
+	//callcode_push1(0x66070E, saved_esi, &regs); return;
+	regs.eax &= 0xFF;
+	RCT2_GLOBAL(0x9E325C, uint32) = regs.eax;
+	
+	/*
+	regs.bl = mapElement2->properties.surface.slope;
+	regs.di = regs.bx;
+	regs.di &= 0xF;
+	regs.di <<= regs.cl;
+	regs.ebx &= 0x10;
+	regs.si = regs.di;
+	regs.si = (uint16)regs.si >> 4;
+	regs.di |= regs.si;
+	regs.di &= 0xF;
+	regs.bx |= regs.di;
+	RCT2_GLOBAL(0x9E3270, uint32) = regs.ebx;
+	*/
+	
+	unk = (mapElement2->properties.surface.slope & 0xF) << regs.cl; //unk = di
+	
+	RCT2_GLOBAL(0x9E3270, uint32) = (mapElement2->properties.surface.slope & 0x10) | ((unk | (unk >> 4)) & 0xF);
+	//callcode_push1(0x66073F, saved_esi, &regs); return;
+	regs.ax = regs.dx;
+	regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
+	regs.ax = (uint16)regs.ax >> 4;
+	assert(regs.ax == height/16);
+	mapElement2 = RCT2_GLOBAL(0x9E3248, rct_map_element *);
+	
+	//regs.esi = (int)mapElement2;
+	//callcode_push1(0x660752, saved_esi, &regs); return;
+	
+	//SAVE
+	saved_ecx = regs.ecx;
+	
+	regs.ah = mapElement2->base_height >> 1;
+	regs.cx = regs.ax;
+	regs.al += RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
+	regs.cl += RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
+	regs.ah += RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
+	regs.ch += RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
+	RCT2_GLOBAL(0x9E3280, uint16) = regs.ax;
+	RCT2_GLOBAL(0x9E3288, uint16) = regs.cx;
+	
+	//RESTORE
+	regs.ecx = saved_ecx;
 	
 loc_660781:
 	callcode_push1(0x660781, saved_esi, &regs); return;

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1908,6 +1908,38 @@ static inline int helper(rct_map_element *mapElement, uint8 shift)
 }
 
 /**
+ *	rct2: 0x65E9FC
+ */
+static void viewport_surface_smooth_west_edge(int eax, int ebx, int ecx, int edx, int esi, int edi, int ebp)
+{
+	RCT2_CALLPROC_X(0x65E9FC, eax, ebx, ecx, edx, esi, edi, ebp);
+}
+
+/**
+ *	rct2: 0x65EAB2
+ */
+static void viewport_surface_smooth_north_edge(int eax, int ebx, int ecx, int edx, int esi, int edi, int ebp)
+{
+	RCT2_CALLPROC_X(0x65EAB2, eax, ebx, ecx, edx, esi, edi, ebp);
+}
+
+/**
+ *	rct2: 0x65E890
+ */
+static void viewport_surface_smooth_south_edge(int eax, int ebx, int ecx, int edx, int esi, int edi, int ebp)
+{
+	RCT2_CALLPROC_X(0x65E890, eax, ebx, ecx, edx, esi, edi, ebp);
+}
+
+/**
+ *	rct2: 0x65E946
+ */
+static void viewport_surface_smooth_east_edge(int eax, int ebx, int ecx, int edx, int esi, int edi, int ebp)
+{
+	RCT2_CALLPROC_X(0x65E946, eax, ebx, ecx, edx, esi, edi, ebp);
+}
+
+/**
  * rct2: 0x66062C
  * edx = height
  * esi = mapElement
@@ -1935,7 +1967,7 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
 	RCT2_GLOBAL(0x9DE57C, uint16) |= 1;
 	RCT2_GLOBAL(0x9E3250, rct_map_element *) = mapElement;
-	//0x9E3296: possibly zoom level for current viewport
+	//This global does not appear to be used outside of this function. I'm just keeping this here just in case.
 	RCT2_GLOBAL(0x9E3296, uint16) = dpi->zoom_level;
 	
 	regs.ecx = rotation;
@@ -1954,87 +1986,48 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	RCT2_GLOBAL(0x9E3278, uint32) = regs.ebx;
 	
 	//callcode_push1(0x660698, saved_esi, &regs); return;
-	
-	//regs.esi = rotation;
 	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[rotation * 2]; //x = ax
 	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[rotation * 2]; //y = bp
 	RCT2_GLOBAL(0x9E3248, rct_map_element *) = NULL;
-
-	regs.ax = x;
-	regs.bp = y;
-	//callcode_push1(0x6606C5, saved_esi, &regs); return;
-	
 	if(x < 0x2000 && y < 0x2000)
 	{	
-		//callcode_push1(0x6606DA, saved_esi, &regs); return;
-		
 		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E3248, rct_map_element *) = surfaceElement;
-		
 		RCT2_GLOBAL(0x9E325C, uint32) = ((surfaceElement->type & 3) << 3) | (surfaceElement->properties.surface.terrain >> 5);
 
 		regs.ebx = helper(surfaceElement, regs.cl);	
 		RCT2_GLOBAL(0x9E3270, uint32) = regs.ebx;
-		
-		regs.ax = height/16;
 		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
-		surfaceElement = RCT2_GLOBAL(0x9E3248, rct_map_element *);
 		
-		//SAVE
-		saved_ecx = regs.ecx;
-		
-		regs.ah = surfaceElement->base_height / 2;
-		regs.cl = regs.al + RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
-		regs.ch = regs.ah + RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
-		regs.al += RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
-		regs.ah += RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
-		RCT2_GLOBAL(0x9E3280, uint16) = regs.ax;
-		RCT2_GLOBAL(0x9E3288, uint16) = regs.cx;
-		
-		//RESTORE
-		regs.ecx = saved_ecx;
+		RCT2_GLOBAL(0x9E3280, uint8) = height / 16 + RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E3281, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E3288, uint8) = height / 16 + RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E3289, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
 	}
 //loc_660781:
 	//callcode_push1(0x660781, saved_esi, &regs); return;
-	//regs.esi = rotation;
 	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B474, uint16)[rotation * 2];
 	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B476, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E3244, rct_map_element *) = NULL;
-	//callcode_push1(0x6607AE, saved_esi, &regs); return;
 	if(x < 0x2000 && y < 0x2000)
 	{
 		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
-		//rct2: loc_6607E2
-		//callcode_push1(0x6607E2, saved_esi, &regs); return;
 		RCT2_GLOBAL(0x9E3244, rct_map_element *) = surfaceElement;
-		
 		RCT2_GLOBAL(0x9E3258, uint32) = ((surfaceElement->type & 3) << 3) | (surfaceElement->properties.surface.terrain >> 5);
 		
 		regs.ebx = helper(surfaceElement, regs.cl);
 		RCT2_GLOBAL(0x9E326C, uint32) = regs.ebx;
-		regs.ax = height/16;
 		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
-		surfaceElement = RCT2_GLOBAL(0x9E3244, rct_map_element *);
 		
-		//SAVE
-		saved_ecx = regs.ecx;
-		
-		regs.ah = surfaceElement->base_height / 2;
-		regs.cl = regs.al + RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
-		regs.ch = regs.ah + RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
-		regs.al += RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
-		regs.ah += RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
-		RCT2_GLOBAL(0x9E327E, uint16) = regs.ax;
-		RCT2_GLOBAL(0x9E3286, uint16) = regs.cx;
-		
-		//RESTORE
-		regs.ecx = saved_ecx;
+		RCT2_GLOBAL(0x9E327E, uint8) = height / 16 + RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E327F, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4C4, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E3286, uint8) = height / 16 + RCT2_ADDRESS(0x97B504, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E3287, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
 	}
 //loc_66086A:
 	//callcode_push1(0x66086A, saved_esi, &regs); return;
-	//regs.esi = rotation;
 	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B484, uint16)[rotation * 2];
 	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B486, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E324C, rct_map_element *) = NULL;
@@ -2043,32 +2036,19 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E324C, rct_map_element *) = surfaceElement;
-		
 		RCT2_GLOBAL(0x9E3260, uint32) = ((surfaceElement->type & 3) << 3) | (surfaceElement->properties.surface.terrain >> 5);
 		
 		regs.ebx = helper(surfaceElement, regs.cl);
 		RCT2_GLOBAL(0x9E3274, uint32) = regs.ebx;
-		regs.ax = height/16;
 		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
-		surfaceElement = RCT2_GLOBAL(0x9E324C, rct_map_element *);
 		
-		//SAVE
-		saved_ecx = regs.ecx;
-		
-		regs.ah = surfaceElement->base_height / 2;
-		regs.cl = regs.al + RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
-		regs.ch = regs.ah + RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
-		regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
-		regs.ah += RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
-		RCT2_GLOBAL(0x9E3282, uint16) = regs.ax;
-		RCT2_GLOBAL(0x9E328A, uint16) = regs.cx;
-		
-		//RESTORE
-		regs.ecx = saved_ecx;
+		RCT2_GLOBAL(0x9E3282, uint8) = height / 16 + RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E3283, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4A4, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E328A, uint8) = height / 16 + RCT2_ADDRESS(0x97B4E4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E328B, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
 	}
 //loc_660953:
 	//callcode_push1(0x660953, saved_esi, &regs); return;
-	//regs.esi = rotation;
 	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B494, uint16)[rotation * 2];
 	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B496, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E3240, rct_map_element *) = NULL;
@@ -2077,28 +2057,16 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E3240, rct_map_element *) = surfaceElement;
-		
 		RCT2_GLOBAL(0x9E3254, uint32) = ((surfaceElement->type & 3) << 3) | (surfaceElement->properties.surface.terrain >> 5);
 		
 		regs.ebx = helper(surfaceElement, regs.cl);
 		RCT2_GLOBAL(0x9E3268, uint32) = regs.ebx;
-		regs.ax = height/16;
 		regs.edi = RCT2_GLOBAL(0x9E3278, uint32);
-		surfaceElement = RCT2_GLOBAL(0x9E3240, rct_map_element *);
 		
-		//SAVE
-		saved_ecx = regs.ecx;
-		
-		regs.ah = surfaceElement->base_height / 2;
-		regs.cl = regs.al + RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
-		regs.ch = regs.ah + RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
-		regs.al += RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
-		regs.ah += RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
-		RCT2_GLOBAL(0x9E327C, uint16) = regs.ax;
-		RCT2_GLOBAL(0x9E3284, uint16) = regs.cx;
-		
-		//RESTORE
-		regs.ecx = saved_ecx;
+		RCT2_GLOBAL(0x9E327C, uint8) = height / 16 + RCT2_ADDRESS(0x97B4C4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E327D, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B4E4, uint8)[regs.ebx];
+		RCT2_GLOBAL(0x9E3284, uint8) = height / 16 + RCT2_ADDRESS(0x97B4A4, uint8)[regs.edi];
+		RCT2_GLOBAL(0x9E3285, uint8) = surfaceElement->base_height / 2 + RCT2_ADDRESS(0x97B504, uint8)[regs.ebx];
 	}
 //loc_660A3C:
 	//RESTORE
@@ -2107,7 +2075,7 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	//Handle height marks on land
 	//RCT2_CALLFUNC_Y(0x660A3D, &regs); return;
 	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_HEIGHTS) &&
-	RCT2_GLOBAL(0x9E3296, uint16) == 0)
+	dpi->zoom_level == 0)
 	{
 		//RCT2_CALLFUNC_Y(0x660A52, &regs); return;
 		uint16 elementHeight = 3 + map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10); //elementHeight = dx
@@ -2151,8 +2119,8 @@ loc_660AAB:
 		
 		if((mapElement->properties.surface.terrain & 0xE0) ||
 		(mapElement->type & 3) ||
-		(RCT2_GLOBAL(0x9E3296, uint16) != 0) ||
-		(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001))
+		(dpi->zoom_level != 0) ||
+		(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & (VIEWPORT_FLAG_UNDERGROUND_INSIDE|VIEWPORT_FLAG_HIDE_BASE)))
 			goto loc_660C9F;
 		switch(mapElement->properties.surface.grass_length & 7) //si
 		{
@@ -2387,21 +2355,24 @@ loc_660FB8:
 	}
 loc_661194:
 	//callcode_push1(0x661194, saved_esi, &regs); return;
-	if(RCT2_GLOBAL(0x9E3296, uint16) == 0 &&
+	if(dpi->zoom_level == 0 &&
 	RCT2_GLOBAL(0x9E329A, uint8) != 0 &&
-	!(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & (VIEWPORT_FLAG_UNDERGROUND_INSIDE|VIEWPORT_FLAG_GRIDLINES)) &&
+	!(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & (VIEWPORT_FLAG_UNDERGROUND_INSIDE|VIEWPORT_FLAG_HIDE_BASE)) &&
 	!(RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_DISABLE_SMOOTH_LANDSCAPE))
 	{
-		callcode_push1(0x6611BB, saved_esi, &regs); return;
-		regs.edi = (int)mapElement;
+		//callcode_push1(0x6611BB, saved_esi, &regs); return;
 		
 		saved_edx = regs.edx;
 		
+		//The smoothing functions don't appear to take any parameters. I have no idea what this is for.
+		regs.edi = (int)mapElement;
 		regs.edx >>= 4;
-		RCT2_CALLFUNC_Y(0x65E9FC, &regs);
-		RCT2_CALLFUNC_Y(0x65EAB2, &regs);
-		RCT2_CALLFUNC_Y(0x65E890, &regs);
-		RCT2_CALLFUNC_Y(0x65E946, &regs);
+		
+		//Smooth each edge of land tile
+		viewport_surface_smooth_west_edge(regs.eax, regs.ebx, regs.ecx, regs.edx, regs.esi, regs.edi, regs.ebp); //smooth west edge of tile
+		viewport_surface_smooth_north_edge(regs.eax, regs.ebx, regs.ecx, regs.edx, regs.esi, regs.edi, regs.ebp); //smooth north edge of tile
+		viewport_surface_smooth_south_edge(regs.eax, regs.ebx, regs.ecx, regs.edx, regs.esi, regs.edi, regs.ebp); //smooth south edge of tile
+		viewport_surface_smooth_east_edge(regs.eax, regs.ebx, regs.ecx, regs.edx, regs.esi, regs.edi, regs.ebp); //smooth east edge of tile
 		
 		regs.edx = saved_edx;
 	}

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2079,88 +2079,85 @@ loc_660AAB:
 	
 	regs.ebp = RCT2_GLOBAL(0x9E3264, uint32);
 	regs.ebx = RCT2_GLOBAL(0x9E3278, uint32);
-	regs.di = RCT2_GLOBAL(0x9E323C, uint8);
 	
 	//SAVE
 	saved_ebx = regs.ebx;
 	saved_ecx = regs.ecx;
 	
-	regs.di <<= 4;
-	
 	//callcode_push3(0x660AC6, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	
 	assert(height == regs.dx);
-	if(height == regs.di)
+	if(height == (RCT2_GLOBAL(0x9E323C, uint8) * 16))
 	{
 		//goto loc_660B25;
 		callcode_push3(0x660B25, saved_esi, saved_ebx, saved_ecx, &regs); return;
 	}
 	else
-	{
-		bool do_loc_660C9F = false;
-		
+	{		
 		//callcode_push3(0x660ACB, saved_esi, saved_ebx, saved_ecx, &regs); return;
-		regs.bl = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx];
-		regs.edi = 0;
-		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_GRIDLINES)
-			regs.edi = 4;
-		//callcode_push3(0x660AE3, saved_esi, saved_ebx, saved_ecx, &regs); return;
+		unsigned int imageId = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx]; //imageId = ebx;
 		
-		regs.esi = saved_esi; //mov esi, [esp+0Ch+var_4]; mapElement = esi
-		assert(regs.esi = (int)mapElement);
-		mapElement = (rct_map_element *)regs.esi;
-		if(mapElement->properties.surface.terrain & 0xE0)
-			goto loc_660C9F;
-		if(mapElement->type & 3)
-			goto loc_660C9F;
-		if(RCT2_GLOBAL(0x9E3296, uint16) != 0)
-			goto loc_660C9F;
-		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
+		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_GRIDLINES)
+			regs.edi = 1;
+		else
+			regs.edi = 0;
+		
+		assert(saved_esi == (int)mapElement);
+		
+		if(/*(mapElement->properties.surface.terrain & 0xE0) ||*/
+		   (mapElement->type & 3) ||
+		   (RCT2_GLOBAL(0x9E3296, uint16) != 0) ||
+		   (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001))
 			goto loc_660C9F;
 		switch(mapElement->properties.surface.grass_length & 7) //si
 		{
 			case 0:
 				//Mowed grass
 				regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-				regs.ebx += RCT2_ADDRESS(0x97B898, uint32)[(regs.edi+regs.ebp*8)/4];
+				imageId += RCT2_ADDRESS(0x97B898, uint32)[regs.edi + regs.ebp*2];
 				break;
 			case 1: case 2: case 3:
+	loc_660C9F:
 				//Clear grass
-				goto loc_660C9F;
+				if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32) & 1)
+					regs.ebp = RCT2_ADDRESS(0x97B84A, uint8)[regs.ebp];
+				imageId += RCT2_ADDRESS(0x97B750, uint32)[regs.edi + regs.ebp*2];
+				if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 0xC)
+					imageId = 0xA3F;
+				if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
+				{
+					imageId &= 0xDC07FFFF;
+					imageId |= 0x41880000;
+				}
+				break;
 			case 4: case 5:
 				//Clumpy grass
 				regs.ebp = (RCT2_GLOBAL(0x9DE56A, uint16) & 0x20) | ((RCT2_GLOBAL(0x9DE56E, uint16) & 0x20) << 1);
-				regs.ebp /= 32;
-				regs.ebx += RCT2_ADDRESS(0x97B858, uint32)[(regs.edi+regs.ebp*8)/4];
+				regs.ebp /= 16;
+				imageId += RCT2_ADDRESS(0x97B858, uint32)[regs.edi + regs.ebp];
 				break;
 			case 6:
 				//Very clumpy grass
 				regs.ebp = (RCT2_GLOBAL(0x9DE56A, uint16) & 0x20) | ((RCT2_GLOBAL(0x9DE56E, uint16) & 0x20) << 1);
-				regs.ebp /= 32;
-				regs.ebx += RCT2_ADDRESS(0x97B878, uint32)[(regs.edi+regs.ebp*8)/4];
+				regs.ebp /= 16;
+				imageId += RCT2_ADDRESS(0x97B878, uint32)[regs.edi + regs.ebp];
 				break;
 			default:
 				assert(false); //should not happen.
 				return;
 			
 		}
-		puts("hi"); fflush(stdout);
 	//loc_660CDE:
 		//callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
-		regs.al = 0;
-		//regs.cl = 0;
-		regs.di = 0x20;
-		regs.si = 0x20;
-		regs.ah = 0xFF;
 		int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
 		RCT2_CALLPROC_X(
 				(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
-				regs.eax, 
-				regs.ebx,
+				0 | (0xFF << 8),
+				imageId,
 				0,
-				regs.edx,
-				regs.esi,
-				regs.edi,
+				height,
+				0x20,
+				0x20,
 				rotation
 		);
 		RCT2_GLOBAL(0x9E329A, uint8) = 1;
@@ -2172,20 +2169,6 @@ loc_660AAB:
 loc_660D02:
 	callcode_push1(0x660D02, saved_esi, &regs); return;
 	
-	
-loc_660C9F:
-	//callcode_push3(0x660C9F, saved_esi, saved_ebx, saved_ecx, &regs); return;
-	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32) & 1)
-		regs.ebp = RCT2_ADDRESS(0x97B84A, uint8)[regs.ebp];
-	regs.ebx += RCT2_ADDRESS(0x97B750, uint32)[(regs.edi+regs.ebp*8)/4];
-	if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 0xC)
-		regs.ebx = 0xA3F;
-	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001)
-	{
-		regs.ebx &= 0xDC07FFFF;
-		regs.ebx |= 0x41880000;
-	}
-	callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
 }
 
 /**

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1607,13 +1607,18 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	
 	int saved_esi;
 	
+	//Uncomment this to use vanilla code.
 	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
-	rct_drawpixelinfo *dpi = RCT2_ADDRESS(0x140E9A8, rct_drawpixelinfo); //dpi = edi
+	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo *); //dpi = edi	
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
+	regs.ax = dpi->zoom_level;
 	RCT2_GLOBAL(0x9DE57C, uint16) |= 1;
 	RCT2_GLOBAL(0x9E3250, rct_map_element *) = mapElement;
-	RCT2_GLOBAL(0x9E3296, uint16) = dpi->zoom_level; //This line of code seems to cause an assertion failure in drawing.c:553. Strangely, it does not happen in vanilla code. I'll investigate this more later.
+	RCT2_GLOBAL(0x9E3296, uint16) = dpi->zoom_level;
+	
 	regs.ecx = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	
+	//regs.edi = (int)dpi;
 	//RCT2_CALLFUNC_Y(0x660657, &regs); return;
 	
 	//SAVE

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1032,16 +1032,17 @@ int sub_98197C(sint8 al, sint8 ah, int image_id, sint8 cl, int height, sint16 le
  * rct2: 0x6861AC, 0x686337, 0x6864D0, 0x68666B, 0x98196C
  * returns contents of carry flag
  * imageId = ebx
+ * height = dx
  * rotation = ebp
  */
-static int sub_98196C(uint8 al, uint8 ah, uint32 imageId, uint8 cl, uint16 dx, uint16 si, uint16 di, uint16 rotation)
+static int sub_98196C(uint8 al, uint8 ah, uint32 imageId, uint8 cl, uint16 height, uint16 si, uint16 di, uint16 rotation)
 {
 	int flags = RCT2_CALLPROC_X(
 		(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
 		al | (ah << 8),
 		imageId,
 		cl,
-		dx,
+		height,
 		si,
 		di,
 		rotation
@@ -1928,6 +1929,8 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	//Uncomment this to use vanilla code.
 	//RCT2_CALLFUNC_Y(0x66062C, &regs); return;
 	
+	unsigned int rotation = get_current_rotation();
+	
 	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo *); //dpi = edi	
 	RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8) = 1;
 	RCT2_GLOBAL(0x9DE57C, uint16) |= 1;
@@ -1935,7 +1938,7 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	//0x9E3296: possibly zoom level for current viewport
 	RCT2_GLOBAL(0x9E3296, uint16) = dpi->zoom_level;
 	
-	regs.ecx = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
+	regs.ecx = rotation;
 	
 	//regs.edi = (int)dpi;
 	//RCT2_CALLFUNC_Y(0x660657, &regs); return;
@@ -1952,9 +1955,9 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	
 	//callcode_push1(0x660698, saved_esi, &regs); return;
 	
-	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[regs.esi*2]; //x = ax
-	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[regs.esi*2]; //y = bp
+	//regs.esi = rotation;
+	uint16 x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B464, uint16)[rotation * 2]; //x = ax
+	uint16 y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B466, uint16)[rotation * 2]; //y = bp
 	RCT2_GLOBAL(0x9E3248, rct_map_element *) = NULL;
 
 	regs.ax = x;
@@ -1965,7 +1968,7 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	{	
 		//callcode_push1(0x6606DA, saved_esi, &regs); return;
 		
-		rct_map_element *surfaceElement = map_get_surface_element_at(x/32, y/32); //surfaceElement = esi
+		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E3248, rct_map_element *) = surfaceElement;
 		
@@ -1994,14 +1997,14 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	}
 //loc_660781:
 	//callcode_push1(0x660781, saved_esi, &regs); return;
-	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B474, uint16)[regs.esi*2];
-	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B476, uint16)[regs.esi*2];
+	//regs.esi = rotation;
+	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B474, uint16)[rotation * 2];
+	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B476, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E3244, rct_map_element *) = NULL;
 	//callcode_push1(0x6607AE, saved_esi, &regs); return;
 	if(x < 0x2000 && y < 0x2000)
 	{
-		rct_map_element *surfaceElement = map_get_surface_element_at(x/32, y/32); //surfaceElement = esi
+		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		//rct2: loc_6607E2
 		//callcode_push1(0x6607E2, saved_esi, &regs); return;
@@ -2031,13 +2034,13 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	}
 //loc_66086A:
 	//callcode_push1(0x66086A, saved_esi, &regs); return;
-	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B484, uint16)[regs.esi*2];
-	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B486, uint16)[regs.esi*2];
+	//regs.esi = rotation;
+	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B484, uint16)[rotation * 2];
+	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B486, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E324C, rct_map_element *) = NULL;
 	if(x < 0x2000 && y < 0x2000)
 	{
-		rct_map_element *surfaceElement = map_get_surface_element_at(x/32, y/32); //surfaceElement = esi
+		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E324C, rct_map_element *) = surfaceElement;
 		
@@ -2065,13 +2068,13 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	}
 //loc_660953:
 	//callcode_push1(0x660953, saved_esi, &regs); return;
-	regs.esi = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B494, uint16)[regs.esi*2];
-	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B496, uint16)[regs.esi*2];
+	//regs.esi = rotation;
+	x = RCT2_GLOBAL(0x9DE568, uint16) + RCT2_ADDRESS(0x97B494, uint16)[rotation * 2];
+	y = RCT2_GLOBAL(0x9DE56C, uint16) + RCT2_ADDRESS(0x97B496, uint16)[rotation * 2];
 	RCT2_GLOBAL(0x9E3240, rct_map_element *) = NULL;
 	if(x < 0x2000 && y < 0x2000)
 	{
-		rct_map_element *surfaceElement = map_get_surface_element_at(x/32, y/32); //surfaceElement = esi
+		rct_map_element *surfaceElement = map_get_surface_element_at(x / 32, y / 32); //surfaceElement = esi
 		
 		RCT2_GLOBAL(0x9E3240, rct_map_element *) = surfaceElement;
 		
@@ -2103,12 +2106,12 @@ void viewport_surface_paint_setup(int height, rct_map_element *mapElement)
 	
 	//Handle height marks on land
 	//RCT2_CALLFUNC_Y(0x660A3D, &regs); return;
-	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_HEIGHTS) && RCT2_GLOBAL(0x9E3296, uint16)==0)
+	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_HEIGHTS) &&
+	RCT2_GLOBAL(0x9E3296, uint16) == 0)
 	{
 		//RCT2_CALLFUNC_Y(0x660A52, &regs); return;
 		uint16 elementHeight = 3 + map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10); //elementHeight = dx
 		unsigned int imageId = (elementHeight >> 4) + 0x20781689 + RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_HEIGHT_MARKERS, uint16) - RCT2_GLOBAL(0x1359208, uint16); //imageId = ebx
-		unsigned int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
 		
 		sub_98196C(0x10, 0, imageId, 0x10, elementHeight, 1, 1, rotation);
 	}
@@ -2147,21 +2150,21 @@ loc_660AAB:
 		assert(saved_esi == (int)mapElement);
 		
 		if((mapElement->properties.surface.terrain & 0xE0) ||
-		   (mapElement->type & 3) ||
-		   (RCT2_GLOBAL(0x9E3296, uint16) != 0) ||
-		   (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001))
+		(mapElement->type & 3) ||
+		(RCT2_GLOBAL(0x9E3296, uint16) != 0) ||
+		(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x1001))
 			goto loc_660C9F;
 		switch(mapElement->properties.surface.grass_length & 7) //si
 		{
 			case 0:
 				//Mowed grass
-				regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-				imageId += RCT2_ADDRESS(0x97B898, uint32)[regs.edi + regs.ebp*2];
+				regs.ebp = rotation;
+				imageId += RCT2_ADDRESS(0x97B898, uint32)[regs.edi + rotation * 2];
 				break;
 			case 1: case 2: case 3:
 	loc_660C9F:
 				//Clear grass
-				if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32) & 1)
+				if(rotation & 1)
 					regs.ebp = RCT2_ADDRESS(0x97B84A, uint8)[regs.ebp];
 				imageId += RCT2_ADDRESS(0x97B750, uint32)[regs.edi + regs.ebp*2];
 				if(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 0xC)
@@ -2190,8 +2193,6 @@ loc_660AAB:
 			
 		}
 	//loc_660CDE:
-		int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
-		
 		sub_98196C(0, 0xFF, imageId, 0, height, 0x20, 0x20, rotation);
 		RCT2_GLOBAL(0x9E329A, uint8) = 1;
 		
@@ -2226,134 +2227,111 @@ loc_660D93:
 //loc_660DB2:
 	//callcode_push1(0x660DB2, saved_esi, &regs); return;
 	
-	if((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR) && (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_OWNERSHIP))
+	if((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR) &&
+	(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_OWNERSHIP))
 	{
-		//callcode_push1(0x660DCE, saved_esi, &regs); return;
+		//0x660DCE
 		//Check if this square is one of the two peep spawn locations
+		rct2_peep_spawn *peepSpawn1 = RCT2_ADDRESS(RCT2_ADDRESS_PEEP_SPAWNS, rct2_peep_spawn);
+		rct2_peep_spawn *peepSpawn2 = RCT2_ADDRESS(RCT2_ADDRESS_PEEP_SPAWNS, rct2_peep_spawn) + 1;
 		
-		rct2_peep_spawn *spawn = RCT2_ADDRESS(RCT2_ADDRESS_PEEP_SPAWNS, rct2_peep_spawn);
-		
-		if((spawn->x & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
-		(spawn->y & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
+		if((peepSpawn1->x & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
+		(peepSpawn1->y & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
 		{
-			unsigned int rotation = get_current_rotation();
-			unsigned int dx = RCT2_GLOBAL(0x13573F6, uint8) << 4;
-			unsigned int imageId = (((RCT2_GLOBAL(0x13573F7, uint8) ^ 2) + rotation) & 3) + 0x20380C27;
+			unsigned int imageId = (((peepSpawn1->direction ^ 2) + rotation) & 3) + 0x20380C27;
 			
-			//Add blue square
-			sub_98196C(0, 0x10, 0xA40, 0, dx, 0x20, 0x20, rotation);
-			//Add blue arrow
-			sub_98196C(0, 0x13, imageId, 0, dx, 0x20, 0x20, rotation);
+			//Add blue highlight and blue arrow
+			sub_98196C(0, 0x10, 0xA40, 0, peepSpawn1->z * 16, 0x20, 0x20, rotation);
+			sub_98196C(0, 0x13, imageId, 0, peepSpawn1->z * 16, 0x20, 0x20, rotation);
 		}
-		else
+		else if((peepSpawn2->x & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
+		(peepSpawn2->y & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
 		{
-			spawn++;
-			if((spawn->x & 0xFFE0) == RCT2_GLOBAL(0x9DE56A, uint16) &&
-			(spawn->y & 0xFFE0) == RCT2_GLOBAL(0x9DE56E, uint16))
-			{
-				unsigned int rotation = get_current_rotation();
-				unsigned int dx = RCT2_GLOBAL(0x13573FC, uint8) << 4;
-				unsigned int imageId = (((RCT2_GLOBAL(0x13573FD, uint8) ^ 2) + rotation) & 3) + 0x20380C27;
-				
-				//Add blue square
-				sub_98196C(0, 0x10, 0xA40, 0, dx, 0x20, 0x20, rotation);
-				//Add blue arrow
-				sub_98196C(0, 0x13, imageId, 0, dx, 0x20, 0x20, rotation);
-			}
+			unsigned int imageId = (((peepSpawn2->direction ^ 2) + rotation) & 3) + 0x20380C27;
+			
+			//Add blue highlight and blue arrow
+			sub_98196C(0, 0x10, 0xA40, 0,  peepSpawn2->z * 16, 0x20, 0x20, rotation);
+			sub_98196C(0, 0x13, imageId, 0,  peepSpawn2->z * 16, 0x20, 0x20, rotation);
 		}
 	}
 	
 //loc_660E9A:
 	//callcode_push1(0x660E9A, saved_esi, &regs); return;
-	assert(0x100 == VIEWPORT_FLAG_LAND_OWNERSHIP);
 	if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_OWNERSHIP)
 	{
 		assert(saved_esi == (int)mapElement);
-		if(mapElement->properties.surface.ownership & 0x20)
+		if(mapElement->properties.surface.ownership & OWNERSHIP_OWNED)
 		{
 			//0x660EAE
-			//Draw blue square if land is owned
+			//Add blue higlight
 			sub_68818E(0, RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0xA41, 0);
 		}
-		else
+		else if(mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE)
 		{
-			//loc_660ECB:
-			if(mapElement->properties.surface.ownership & 0x80)
-			{
-				//0x660ED4
-				//Put a sign if land is for sale
-				paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
-				
-				sub_98196C(0x10, 0, 0x59AB, 0x10, map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10) + 3, 1, 1, get_current_rotation());
-				RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
-			}
+			//0x660ED4
+			//Add for-sale sign
+			paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
+			unsigned int elementHeight = map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10) + 3;
+			
+			sub_98196C(0x10, 0, 0x59AB, 0x10, elementHeight, 1, 1, rotation);
+			RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
 		}
 	}
-loc_660F24:
+//loc_660F24:
 	//callcode_push1(0x660F24, saved_esi, &regs); return;
 	assert(saved_esi==(int)mapElement);
-	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & 0x200) && !(mapElement->properties.surface.ownership & 0x20))
+	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS) && !(mapElement->properties.surface.ownership & OWNERSHIP_OWNED))
 	{
-		if(mapElement->properties.surface.ownership & 0x10)
+		if(mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
 		{
 			//0x660F42
-			assert(regs.bl == regs.ebx); //Just being pedantic.
+			//Add hatched blue highlight
 			sub_68818E(0, RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0xA54, 0);
 		}
-		else
+		else if(mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE)
 		{
-			if(mapElement->properties.surface.ownership & 0x40)
-			{
-				//0x660F68
-				paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
-				unsigned int elementHeight = map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10) + 3; //edx
-				sub_98196C(0x10, 0, 0x59AC, 0x10, elementHeight, 1, 1, get_current_rotation());
-				RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
-				//restore edx, ecx, and ebx
-			}
+			//0x660F68
+			//Add hatched for-sale sign
+			paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
+			unsigned int elementHeight = map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10) + 3; //edx
+			
+			sub_98196C(0x10, 0, 0x59AC, 0x10, elementHeight, 1, 1, rotation);
+			RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
 		}
 	}
 loc_660FB8:
 	//callcode_push1(0x660FB8, saved_esi, &regs); return;
 	if((RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & 1) && 
-	(RCT2_GLOBAL(0x9DE56A, sint16) >= RCT2_GLOBAL(0x9DE58C, sint16)) &&
-	(RCT2_GLOBAL(0x9DE56A, sint16) <= RCT2_GLOBAL(0x9DE58E, sint16)) &&
-	(RCT2_GLOBAL(0x9DE56E, sint16) >= RCT2_GLOBAL(0x9DE590, sint16)) &&
-	(RCT2_GLOBAL(0x9DE56E, sint16) <= RCT2_GLOBAL(0x9DE592, sint16)))
+	(RCT2_GLOBAL(0x9DE56A, sint16) >= RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16)) &&
+	(RCT2_GLOBAL(0x9DE56A, sint16) <= RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16)) &&
+	(RCT2_GLOBAL(0x9DE56E, sint16) >= RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16)) &&
+	(RCT2_GLOBAL(0x9DE56E, sint16) <= RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16)))
 	{
+		//callcode_push1(0x661009, saved_esi, &regs); return;
 		//0x661009
 		//Highlight tiles on map (selected by land tools, path placement, scenery placement, etc.)
-		//callcode_push1(0x661009, saved_esi, &regs); return;
 		
-		//save ebx and ecx
-		saved_ebx = regs.ebx;
+		uint16 mapSelectionType = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16); //mapSelectionType = ax		
+		unsigned int imageId;
 		
-		uint16 mapSelectionType = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16); //mapSelectionType = ax
-		
-		if(mapSelectionType < 6)
+		switch(mapSelectionType)
 		{
-			//0x661017
-			if(mapSelectionType > 4)
-			{
-				//loc_6610B8
-				regs.esi = saved_esi;
-				assert(saved_esi = (int)mapElement);
-				
-				//save edx
-				
-				assert(height == regs.dx);
+			case 0: case 1: case 2: case 3: //0-3 Corners
+				mapSelectionType = (mapSelectionType + regs.cx) & 3;
+			case 4: //4 Whole tile
+				regs.eax = (mapSelectionType + 0x21) << 0x13;
+				imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000BE3) | regs.eax;
+				sub_68818E(0, imageId, 0);
+				break;
+			case 5: //5 Water tool
+				saved_ebx = regs.ebx;
 				uint16 myHeight = regs.dx; //myHeight = dx
-				
-				uint16 waterHeight = mapElement->properties.surface.terrain & 0x1F; //waterHeight = ax
+				uint16 waterHeight = (mapElement->properties.surface.terrain & 0x1F) * 16; //waterHeight = ax
 				if(waterHeight != 0)
 				{
-					//0x6610C3
-					waterHeight <<= 4;
 					if(waterHeight > myHeight)
 					{
-						//0x6610D3;
-						myHeight += 0x10;
-						
+						myHeight += 16;
 						if(waterHeight == myHeight && (regs.bl & 0x10))
 						{
 							regs.bl ^= 0xF;
@@ -2365,60 +2343,32 @@ loc_660FB8:
 						}
 						else
 						{
-							//loc_6610F7
 							myHeight = waterHeight;
 							regs.ebx = 0;
 						}
 					}
 				}
-				//loc_6610FC
-				assert(regs.bl == regs.ebx);
-				unsigned int imageId = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x21300BE3;
+				imageId = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x21300BE3;
 				paint_struct *saved_F1AD28 = RCT2_GLOBAL(0xF1AD28, paint_struct *);
-				sub_98196C(0, 1, imageId, 0, myHeight, 0x20, 0x20, get_current_rotation());
+				sub_98196C(0, 1, imageId, 0, myHeight, 0x20, 0x20, rotation);
 				RCT2_GLOBAL(0xF1AD28, paint_struct *) = saved_F1AD28;
-				
 				regs.ebx = saved_ebx;
-			}
-			else
-			{
-				//0x661021
-				if(mapSelectionType != 4)
-					mapSelectionType = (mapSelectionType + regs.cx) & 3;
-				//loc_66102A
-				assert(regs.ax == regs.eax);
-				regs.eax = (mapSelectionType + 0x21) << 0x13;
-				assert(regs.bl == regs.ebx);
-				unsigned int imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000BE3) | regs.eax;
+				break;
+			default:
+				if(mapSelectionType < 10) //6-9 Quarter tile
+				{
+					regs.eax = (unsigned int)(((mapSelectionType - 6 + regs.cx) & 3) + 0x27) << 0x13;
+					imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000C09) | regs.eax;
+				}
+				else //10-13 Edges
+				{
+					regs.eax = (unsigned int)(((mapSelectionType - 9 + regs.cx) & 3) + 0x21) << 0x13; 
+					imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000BF6) | regs.eax;
+				}
 				sub_68818E(0, imageId, 0);
-			}
-		}
-		else
-		{
-			//loc_661051
-			if(mapSelectionType < 10)
-			{
-				//0x661057
-				//Quarter-tile selection (placement of quarter-tile scenery)
-				assert(regs.ax == regs.eax);
-				regs.eax = (unsigned int)(((mapSelectionType - 6 + regs.cx) & 3) + 0x27) << 0x13;
-				assert(regs.bl == regs.ebx);
-				unsigned int imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000C09) | regs.eax;
-				sub_68818E(0, imageId, 0);
-			}
-			else
-			{
-				//loc_661089
-				//Tile-edge selection (placement of fences and walls)
-				assert(regs.ax == regs.eax);
-				regs.eax = (unsigned int)(((mapSelectionType - 9 + regs.cx) & 3) + 0x21) << 0x13; 
-				assert(regs.bl == regs.ebx);
-				unsigned int imageId = (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0x20000BF6) | regs.eax;
-				sub_68818E(0, imageId, 0);
-			}
 		}
 	}
-loc_661132:
+//loc_661132:
 	callcode_push1(0x661132, saved_esi, &regs); return;
 }
 

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1877,52 +1877,26 @@ void viewport_surface_paint_setup(int eax, int ebx, int height, rct_map_element 
 	//RESTORE
 	regs.esi = saved_esi;
 	
-	//ToDo: refactor this
+	//Handle height marks on land
 	//RCT2_CALLFUNC_Y(0x660A3D, &regs); return;
-	if(!(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_HEIGHTS))
-		goto loc_660AAB;
-	if(RCT2_GLOBAL(0x9E3296, uint16)!=0)
-		goto loc_660AAB;
-	//RCT2_CALLFUNC_Y(0x660A52, &regs); return;
-	
-	//SAVE
-	saved_ecx = regs.ecx;
-	saved_edx = regs.edx;
-	saved_esi = regs.esi;
-	
-	regs.ax = RCT2_GLOBAL(0x9DE56A, uint16) + 0x10;
-	regs.cx = RCT2_GLOBAL(0x9DE56E, uint16) + 0x10;
-	regs.dx = map_element_height(regs.ax, regs.cx) + 3;
-	regs.ebx = regs.dx;
-	regs.ebx = (unsigned)regs.ebx >> 4;
-	regs.ebx += 0x20781689;
-	regs.bx += RCT2_GLOBAL(0x9AACBD, uint16);
-	regs.bx -= RCT2_GLOBAL(0x1359208, uint16);
-	
-	regs.al = 0x10;
-	regs.cl = 0x10;
-	regs.di = 1;
-	regs.si = 1;
-	regs.ah = 0;
-	regs.ebp = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32);
-	
-	//I think the function being called returns void, but I can never be absolutely sure.
-	RCT2_CALLPROC_X(
-		(int)RCT2_ADDRESS(0x98196C, uint32*)[regs.ebp],
-		regs.eax,
-		regs.ebx,
-		regs.ecx,
-		regs.edx,
-		regs.esi,
-		regs.edi,
-		regs.ebp
-	);
-	
-	//RESTORE
-	regs.esi = saved_esi;
-	regs.edx = saved_edx;
-	regs.ecx = saved_ecx;
-	
+	if((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_LAND_HEIGHTS) && RCT2_GLOBAL(0x9E3296, uint16)==0)
+	{
+		//RCT2_CALLFUNC_Y(0x660A52, &regs); return;
+		uint16 elementHeight = 3 + map_element_height(RCT2_GLOBAL(0x9DE56A, uint16) + 0x10, RCT2_GLOBAL(0x9DE56E, uint16) + 0x10); //elementHeight = dx
+		unsigned int imageId = (elementHeight >> 4) + 0x20781689 + RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_HEIGHT_MARKERS, uint16) - RCT2_GLOBAL(0x1359208, uint16); //imageId = ebx
+		unsigned int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
+		
+		RCT2_CALLPROC_X(
+			(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
+			(0x10) | ((0) << 8), //These are actually two separate parameters, but I have to OR them together for now.
+			imageId,
+			0x10,
+			elementHeight,
+			1,
+			1,
+			rotation
+		);
+	}
 loc_660AAB:
 	RCT2_CALLFUNC_Y(0x660AAB, &regs); return;
 }

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -2124,7 +2124,7 @@ loc_660AAB:
 	else
 	{		
 		//callcode_push3(0x660ACB, saved_esi, saved_ebx, saved_ecx, &regs); return;
-		unsigned int imageId = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx]; //imageId = ebx;
+		unsigned int imageId = RCT2_ADDRESS(0x97B444, uint8)[RCT2_GLOBAL(0x9E3278, uint32)]; //imageId = ebx;
 		
 		if(RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) & VIEWPORT_FLAG_GRIDLINES)
 			regs.edi = 1;
@@ -2177,7 +2177,6 @@ loc_660AAB:
 			
 		}
 	//loc_660CDE:
-		//callcode_push3(0x660CDE, saved_esi, saved_ebx, saved_ecx, &regs); return;
 		int rotation = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint32); //rotation = ebp
 		RCT2_CALLPROC_X(
 				(int)RCT2_ADDRESS(0x98196C, uint32*)[rotation],
@@ -2195,66 +2194,29 @@ loc_660AAB:
 		regs.ecx = saved_ecx;
 		regs.ebx = saved_ebx;
 	}
-loc_660D02:
+//loc_660D02:
 	//callcode_push1(0x660D02, saved_esi, &regs); return;
 	if(RCT2_GLOBAL(0x9DEA50, uint16) != 0xFFFF)
 	{
-		//SAVE
-		saved_ebx = regs.ebx;
-		saved_ecx = regs.ecx;
-		
-		regs.di = RCT2_GLOBAL(0x9DEA50, uint16);
-		
 		x = RCT2_GLOBAL(0x9DE56A, uint16); //x = ax
 		y = RCT2_GLOBAL(0x9DE56E, uint16); //y = cx
+		int staffIndex = RCT2_GLOBAL(0x9DEA50, uint16) & 0x7FFF; //staffIndex = ebx
+		uint32 unk = 0x20380000; //unk = ebp
 		
-		regs.ax = RCT2_GLOBAL(0x9DE56A, uint16);
-		regs.cx = RCT2_GLOBAL(0x9DE56E, uint16);
-		regs.eax &= 0x1F80;
-		regs.ecx &= 0x1F80;
-		regs.eax >>= 7;
-		regs.ecx >>= 1;
-		regs.eax |= regs.ecx;
-		regs.bx = regs.di;
-		regs.ecx = regs.eax;
-		regs.ebx &= 0x7FFF;
-		regs.ecx &= 0x1F;
-		regs.eax >>= 5;
-		regs.ebp = 0x20380000;
-		//callcode_push3(0x660D4E, saved_esi, saved_ebx, saved_ecx, &regs); return;
-		if(regs.di >= 0)
+		if(RCT2_GLOBAL(0x9DEA50, uint16) >= 0)
 		{
-			//callcode_push3(0x660D53, saved_esi, saved_ebx, saved_ecx, &regs); return;
 			rct_peep *peep = &g_sprite_list[RCT2_GLOBAL(0x9DEA50, uint16)].peep; //peep = edi;
-			regs.edi = (int)peep;
-			regs.ebx = peep->staff_id;
-			regs.ebx <<= 9;
-			//callcode_push3(0x660D6D, saved_esi, saved_ebx, saved_ecx, &regs); return;
-			//if(gStaffPatrolAreas[regs.ebx/4 + regs.eax] & (1 << regs.ecx))
+			
 			if(staff_is_patrol_area_set(peep->staff_id, x, y))
 				goto loc_660D93;
-			regs.ebx = peep->staff_type;
-			regs.ebp = 0x20080000;
+			staffIndex = peep->staff_type;
+			unk = 0x20080000;
 		}
-//loc_660D80:
-		//callcode_push3(0x660D80, saved_esi, saved_ebx, saved_ecx, &regs); return;
-		regs.ebx += 0xC8;
-		//regs.ebx <<= 9;
-		//if((gStaffPatrolAreas[regs.ebx/4 + regs.eax] & (1 << regs.ecx)))
-		if(staff_is_patrol_area_set(regs.ebx, x, y))
+		if(staff_is_patrol_area_set(staffIndex + 0xC8, x, y))
 		{
 loc_660D93:
-			//callcode_push3(0x660D93, saved_esi, saved_ebx, saved_ecx, &regs); return;
-			regs.ebx = saved_ebx;
-			regs.bl = RCT2_ADDRESS(0x97B444, uint8)[regs.ebx];
-			regs.ebx += 0xA27;
-			sub_68818E(0, regs.ebx | regs.ebp, 0);
+			sub_68818E(0, (RCT2_ADDRESS(0x97B444, uint8)[regs.ebx] + 0xA27) | unk, 0);
 		}
-//loc_660DB0:
-
-		//RESTORE
-		regs.ecx = saved_ecx;
-		regs.ebx = saved_ebx;
 	}
 //loc_660DB2:
 	callcode_push1(0x660DB2, saved_esi, &regs); return;


### PR DESCRIPTION
Work in progress decompilation of viewport_surface_paint_setup().

Known original bugs:
* Some landscape edges appear smooth even with "Landscape Smoothing" turned off #2333 
* Peep spawn markers do not conform to the slope of the land
* Land highlight of water tool appears in front of some scenery
