### PR TITLE
[Linux] Implement platform_get_locale_language.

### DIFF
--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -699,11 +699,12 @@ uint8 platform_get_locale_currency(){
 
 	//Only works if g_currency_specs contains the actual (local) symbol
 	for(int i = 0; i < CURRENCY_END; ++i){
-		if(!strcmp(lc->currency_symbol, g_currency_specs[i].symbol)){
+		if(!strcmp(lc->currency_symbol, CurrencyDescriptors[i].symbol_unicode)){
 			return i;
 		}
 	}
-	//TODO: can be removed when g_currency_specs contains the actual symbols for won and rubel
+	//TODO: can be removed when CurrencyDescriptors contains the actual symbols for won and rubel
+	//Won should remain a special case, beacause some (or all?) systems use the full width won sign (e.g. Gentoo)
 	if(!strncmp(lc->int_curr_symbol, "KRW", 3)){
 		return CURRENCY_WON;
 	}

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -739,44 +739,24 @@ uint8 platform_get_locale_currency(){
 }
 
 uint8 platform_get_locale_measurement_format(){
-	/*
-	UINT measurement_system;
-	if (GetLocaleInfo(LOCALE_USER_DEFAULT,
-		LOCALE_IMEASURE | LOCALE_RETURN_NUMBER,
-		(LPSTR)&measurement_system,
-		sizeof(measurement_system)) == 0){
+	//FIXME: LC_MEASUREMENT is GNU specific.
+	const char *langstring = setlocale(LC_MEASUREMENT, "");
+
+	//using https://en.wikipedia.org/wiki/Metrication#Chronology_and_status_of_conversion_by_country as reference
+	if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_MM*", langstring, 0) || !fnmatch("*_LR*", langstring, 0)){
 		return MEASUREMENT_FORMAT_IMPERIAL;
 	}
-	switch (measurement_system){
-	case 0:
-		return MEASUREMENT_FORMAT_METRIC;
-	case 1:
-	default:
-		return MEASUREMENT_FORMAT_IMPERIAL;
-	}*/
-	STUB();
+
 	return MEASUREMENT_FORMAT_METRIC;
 }
 
 uint8 platform_get_locale_temperature_format(){
-	/*
-	// There does not seem to be a function to obtain this, just check the countries
-	UINT country;
-	if (GetLocaleInfo(LOCALE_USER_DEFAULT,
-		LOCALE_IMEASURE | LOCALE_RETURN_NUMBER,
-		(LPSTR)&country,
-		sizeof(country)) == 0){
-		return TEMPERATURE_FORMAT_C;
-	}
-	switch (country){
-	case CTRY_UNITED_STATES:
-	case CTRY_BELIZE:
+	const char *langstring = setlocale(LC_MEASUREMENT, "");
+
+	if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0) || !fnmatch("*_PW*", langstring, 0)){
 		return TEMPERATURE_FORMAT_F;
-	default:
-		return TEMPERATURE_FORMAT_C;
 	}
-	*/
-	STUB();
+
 	return TEMPERATURE_FORMAT_C;
 }
 

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -664,10 +664,10 @@ uint16 platform_get_locale_language(){
 		if(!fnmatch(pattern, "en_CA", 0)){
 			return LANGUAGE_ENGLISH_US;
 		}
-		else if (!fnmatch(pattern, "zn_CA", 0)){
+		else if (!fnmatch(pattern, "zh_CN", 0)){
 			return LANGUAGE_CHINESE_SIMPLIFIED;
 		}
-		else if (!fnmatch(pattern, "zn_TW", 0)){
+		else if (!fnmatch(pattern, "zh_TW", 0)){
 			return LANGUAGE_CHINESE_TRADITIONAL;
 		}
 
@@ -694,47 +694,24 @@ time_t platform_file_get_modified_time(const utf8* path){
 }
 
 uint8 platform_get_locale_currency(){
-	/*
-	CHAR currCode[4];
+	char *langstring = setlocale(LC_MONETARY, "");
+	struct lconv *lc = localeconv();
 
-	if (GetLocaleInfo(LOCALE_USER_DEFAULT,
-		LOCALE_SINTLSYMBOL,
-		(LPSTR)&currCode,
-		sizeof(currCode)) == 0){
-		return CURRENCY_POUNDS;
+	//Only works if g_currency_specs contains the actual (local) symbol
+	for(int i = 0; i < CURRENCY_END; ++i){
+		if(!strcmp(lc->currency_symbol, g_currency_specs[i].symbol)){
+			return i;
+		}
 	}
-	if (strcmp(currCode, "GBP") == 0){
-		return CURRENCY_POUNDS;
+	//TODO: can be removed when g_currency_specs contains the actual symbols for won and rubel
+	if(!strncmp(lc->int_curr_symbol, "KRW", 3)){
+		return CURRENCY_WON;
 	}
-	else if (strcmp(currCode, "USD") == 0){
-		return CURRENCY_DOLLARS;
+	else if(!strncmp(lc->int_curr_symbol, "RUB", 3)){
+		return CURRENCY_ROUBLE;
 	}
-	else if (strcmp(currCode, "EUR") == 0){
-		return CURRENCY_EUROS;
-	}
-	else if (strcmp(currCode, "SEK") == 0){
-		return CURRENCY_KRONA;
-	}
-	else if (strcmp(currCode, "DEM") == 0){
-		return CURRENCY_DEUTSCHMARK;
-	}
-	else if (strcmp(currCode, "ITL") == 0){
-		return CURRENCY_LIRA;
-	}
-	else if (strcmp(currCode, "JPY") == 0){
-		return CURRENCY_YEN;
-	}
-	else if (strcmp(currCode, "ESP") == 0){
-		return CURRENCY_PESETA;
-	}
-	else if (strcmp(currCode, "FRF") == 0){
-		return CURRENCY_FRANC;
-	}
-	else if (strcmp(currCode, "NLG") == 0){
-		return CURRENCY_GUILDERS;
-	}
-	*/
-	STUB();
+
+	//All other currencies are historic
 	return CURRENCY_POUNDS;
 }
 

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -695,23 +695,25 @@ time_t platform_file_get_modified_time(const utf8* path){
 
 uint8 platform_get_locale_currency(){
 	char *langstring = setlocale(LC_MONETARY, "");
-	struct lconv *lc = localeconv();
 
-	//Only works if g_currency_specs contains the actual (local) symbol
-	for(int i = 0; i < CURRENCY_END; ++i){
-		if(!strcmp(lc->currency_symbol, CurrencyDescriptors[i].symbol_unicode)){
-			return i;
+	if(langstring != NULL){
+		struct lconv *lc = localeconv();
+
+		//Only works if g_currency_specs contains the actual (local) symbol
+		for(int i = 0; i < CURRENCY_END; ++i){
+			if(!strcmp(lc->currency_symbol, CurrencyDescriptors[i].symbol_unicode)){
+				return i;
+			}
+		}
+		//TODO: can be removed when CurrencyDescriptors contains the actual symbols for won and rubel
+		//Won should remain a special case, beacause some (or all?) systems use the full width won sign (e.g. Gentoo)
+		if(!strncmp(lc->int_curr_symbol, "KRW", 3)){
+			return CURRENCY_WON;
+		}
+		else if(!strncmp(lc->int_curr_symbol, "RUB", 3)){
+			return CURRENCY_ROUBLE;
 		}
 	}
-	//TODO: can be removed when CurrencyDescriptors contains the actual symbols for won and rubel
-	//Won should remain a special case, beacause some (or all?) systems use the full width won sign (e.g. Gentoo)
-	if(!strncmp(lc->int_curr_symbol, "KRW", 3)){
-		return CURRENCY_WON;
-	}
-	else if(!strncmp(lc->int_curr_symbol, "RUB", 3)){
-		return CURRENCY_ROUBLE;
-	}
-
 	//All other currencies are historic
 	return CURRENCY_POUNDS;
 }
@@ -720,21 +722,23 @@ uint8 platform_get_locale_measurement_format(){
 	//FIXME: LC_MEASUREMENT is GNU specific.
 	const char *langstring = setlocale(LC_MEASUREMENT, "");
 
-	//using https://en.wikipedia.org/wiki/Metrication#Chronology_and_status_of_conversion_by_country as reference
-	if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_MM*", langstring, 0) || !fnmatch("*_LR*", langstring, 0)){
-		return MEASUREMENT_FORMAT_IMPERIAL;
+	if(langstring != NULL){
+		//using https://en.wikipedia.org/wiki/Metrication#Chronology_and_status_of_conversion_by_country as reference
+		if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_MM*", langstring, 0) || !fnmatch("*_LR*", langstring, 0)){
+			return MEASUREMENT_FORMAT_IMPERIAL;
+		}
 	}
-
 	return MEASUREMENT_FORMAT_METRIC;
 }
 
 uint8 platform_get_locale_temperature_format(){
 	const char *langstring = setlocale(LC_MEASUREMENT, "");
 
-	if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0) || !fnmatch("*_PW*", langstring, 0)){
-		return TEMPERATURE_FORMAT_F;
+	if(langstring != NULL){
+		if(!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0) || !fnmatch("*_PW*", langstring, 0)){
+			return TEMPERATURE_FORMAT_F;
+		}
 	}
-
 	return TEMPERATURE_FORMAT_C;
 }
 


### PR DESCRIPTION
A simple implementation of `platform_get_locale_language` using the environment variable `LANG`.

I don't know if this variable is present in all distributions (testet on Debian, Ubuntu and Gentoo), but if it's not the old behaviour is unchanged.