### PR TITLE
Change fallback measurement system to metric.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -173,7 +173,7 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, game_path),						"game_path",					CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
 	{ offsetof(general_configuration, landscape_smoothing),				"landscape_smoothing",			CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(general_configuration, language),						"language",						CONFIG_VALUE_TYPE_UINT16,		LANGUAGE_ENGLISH_UK,			_languageEnum			},
-	{ offsetof(general_configuration, measurement_format),				"measurement_format",			CONFIG_VALUE_TYPE_UINT8,		MEASUREMENT_FORMAT_IMPERIAL,	_measurementFormatEnum	},
+	{ offsetof(general_configuration, measurement_format),				"measurement_format",			CONFIG_VALUE_TYPE_UINT8,		MEASUREMENT_FORMAT_METRIC,	_measurementFormatEnum	},
 	{ offsetof(general_configuration, play_intro),						"play_intro",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, save_plugin_data),				"save_plugin_data",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, debugging_tools),					"debugging_tools",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -783,15 +783,15 @@ uint8 platform_get_locale_measurement_format()
 		(LPSTR)&measurement_system,
 		sizeof(measurement_system)) == 0
 	) {
-		return MEASUREMENT_FORMAT_IMPERIAL;
+		return MEASUREMENT_FORMAT_METRIC;
 	}
 
 	switch (measurement_system) {
-	case 0:
-		return MEASUREMENT_FORMAT_METRIC;
 	case 1:
-	default:
 		return MEASUREMENT_FORMAT_IMPERIAL;
+	case 0:
+	default:
+		return MEASUREMENT_FORMAT_METRIC;
 	}
 }
 


### PR DESCRIPTION
Most of the world uses metric. Exceptions are the US and in some respects the UK, which are already taken care of in the localisation code and will thus keep defaulting to imperial. In other cases, having metric as default makes more sense.

