### PR TITLE
UK: Missed occurrence of the Fahrenreit symbol

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -2371,7 +2371,7 @@ STR_2363    :Gridlines on Landscape
 STR_2364    :{SMALLFONT}{BLACK}Toggle gridlines on landscape on/off
 STR_2365    :The bank refuses to increase your loan!
 STR_2366    :Celsius ({DEGREE}C)
-STR_2367    :Fahrenheit (F)
+STR_2367    :Fahrenheit ({DEGREE}F)
 STR_2368    :None
 STR_2369    :Low
 STR_2370    :Average


### PR DESCRIPTION
Thanks to @e-foley for pointing it out.