### PR TITLE
Fixed #2226: resetting screen age when quick saving

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -54,6 +54,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * (Myrtle)
 * (nean)
 * Michael Pham (nightroan)
+* Hielke Morsink (Broxzier)
 
 ## Toolchain
 * (Balletie) - OSX

--- a/src/game.c
+++ b/src/game.c
@@ -1042,11 +1042,14 @@ void save_game()
 			scenario_save(rw, 0x80000000);
 			log_verbose("Saved to %s", gScenarioSavePath);
 			SDL_RWclose(rw);
+
+			// Setting screen age to zero, so no prompt will pop up when closing the
+			// game shortly after saving.
+			RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_AGE, uint16) = 0;
 		}
 	} else {
 		save_game_as();
 	}
-
 }
 void save_game_as()
 {


### PR DESCRIPTION
Now the user will not be prompted after quick saving (Save icon > Save game, and Ctrl + F10).