### PR TITLE
Implement CTRL-Backspace shortcut for clearing inputs, fixes #2355

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1448,8 +1448,12 @@ void game_handle_keyboard_input()
 
 	// Handle key input
 	while (!gOpenRCT2Headless && (key = get_next_key()) != 0) {
+                bool mod_ctrl, clear_input;
 		if (key == 255)
 			continue;
+
+                mod_ctrl = gKeysState[SDL_SCANCODE_LCTRL] || gKeysState[SDL_SCANCODE_RCTRL];
+                clear_input = (key == SDL_SCANCODE_BACKSPACE) && mod_ctrl;
 
 		// Reserve backtick for console
 		if (key == SDL_SCANCODE_GRAVE) {
@@ -1459,10 +1463,16 @@ void game_handle_keyboard_input()
 			}
 			continue;
 		} else if (gConsoleOpen) {
-			console_input(key);
+                        if (clear_input)
+                            console_clear_input();
+                        else
+                            console_input(key);
 			continue;
 		} else if (gChatOpen) {
-			chat_input(key);
+                        if (clear_input)
+                            chat_clear_input();
+                        else
+                            chat_input(key);
 			continue;
 		}
 
@@ -1478,7 +1488,10 @@ void game_handle_keyboard_input()
 		else {
 			w = window_find_by_class(WC_TEXTINPUT);
 			if (w != NULL) {
-				window_text_input_key(w, key);
+                            if (clear_input) {
+                                window_text_input_clear(w);
+                            } else
+                                window_text_input_key(w, key);
 			} else if (!gUsingWidgetTextBox) {
 				keyboard_shortcut_handle(key);
 			}

--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -23,7 +23,6 @@ int _chatBottom;
 
 static const char* chat_history_get(unsigned int index);
 static uint32 chat_history_get_time(unsigned int index);
-static void chat_clear_input();
 
 void chat_open()
 {
@@ -135,7 +134,7 @@ static uint32 chat_history_get_time(unsigned int index)
 	return _chatHistoryTime[(_chatHistoryIndex + CHAT_HISTORY_SIZE - index - 1) % CHAT_HISTORY_SIZE];
 }
 
-static void chat_clear_input()
+void chat_clear_input()
 {
 	_chatCurrentLine[0] = 0;
 }

--- a/src/interface/chat.h
+++ b/src/interface/chat.h
@@ -16,6 +16,7 @@ void chat_draw();
 
 void chat_history_add(const char *src);
 void chat_input(int c);
+void chat_clear_input();
 
 
 #endif

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -49,7 +49,6 @@ static int _consoleHistoryCount = 0;
 static void console_invalidate();
 static void console_write_prompt();
 static void console_update_scroll();
-static void console_clear_input();
 static void console_history_add(const utf8 *src);
 static void console_write_all_commands();
 static int console_parse_int(const utf8 *src, bool *valid);
@@ -386,7 +385,7 @@ void console_refresh_caret()
 	_consoleCaretTicks = 0;
 }
 
-static void console_clear_input()
+void console_clear_input()
 {
 	_consoleCurrentLine[0] = 0;
 	gTextInputCursorPosition = 0;

--- a/src/interface/console.h
+++ b/src/interface/console.h
@@ -23,6 +23,7 @@ void console_execute(const utf8 *src);
 void console_execute_silent(const utf8 *src);
 void console_clear();
 void console_clear_line();
+void console_clear_input();
 void console_refresh_caret();
 void console_scroll(int delta);
 

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -550,6 +550,7 @@ void window_zoom_out(rct_window *w);
 
 void window_show_textinput(rct_window *w, int widgetIndex, uint16 title, uint16 text, int value);
 void window_text_input_key(rct_window* w, int key);
+void window_text_input_clear(rct_window* w);
 
 void window_draw(rct_window *w, int left, int top, int right, int bottom);
 void window_draw_widgets(rct_window *w, rct_drawpixelinfo *dpi);

--- a/src/windows/text_input.c
+++ b/src/windows/text_input.c
@@ -363,6 +363,14 @@ void window_text_input_key(rct_window* w, int key)
 	window_invalidate(w);
 }
 
+void window_text_input_clear(rct_window *w)
+{
+	memset(text_input, 0, _maxInputLength);
+        gTextInputCursorPosition = 0;
+
+	window_invalidate(w);
+}
+
 void window_text_input_update7(rct_window *w)
 {
 	rct_window* calling_w = window_find_by_number(calling_class, calling_number);


### PR DESCRIPTION
FIXME:  This commit does not seem to effect the text box in the
multiplayer popup, however I am unsure what code that uses in the
input system

Tested against the "new file" text box, as well as the console and
chat.