### PR TITLE
fix #2415: day / night cycle not working

### DIFF
--- a/src/scenario.c
+++ b/src/scenario.c
@@ -627,6 +627,8 @@ static void scenario_update_daynight_cycle()
 	} else {
 		gDayNightCycle = 0.0f;
 	}
+
+	platform_update_palette(RCT2_ADDRESS(RCT2_ADDRESS_PALETTE, uint8), 10, 236);
 }
 
 /*


### PR DESCRIPTION
This needs to be a hot fix for 0.0.3, it was supposed to be a significant feature and there is no work around.