### PR TITLE
Add symbolic link support

### DIFF
--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -351,7 +351,7 @@ static int dirfilter(const struct dirent *d)
 		return 0;
 	}
 #if defined(_DIRENT_HAVE_D_TYPE) || defined(DT_UNKNOWN)
-	if (d->d_type == DT_DIR)
+	if (d->d_type == DT_DIR || d->d_type == DT_LNK)
 	{
 		return 1;
 	} else {


### PR DESCRIPTION
This may fix #2277. Symbolic folders and files are treated correctly with this patch as far as I can tell. I loaded and saved symlink'd saves and entered symlink'd folders successfully.