### PR TITLE
Handle touch events

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -35,6 +35,8 @@
 
 #define INVALID_HANDLE -1
 
+#define TOUCH_DOUBLE_TIMEOUT 300
+
 typedef struct {
 	int width, height;
 } resolution;
@@ -63,6 +65,8 @@ typedef struct {
 	unsigned char left, middle, right, any;
 	int wheel;
 	int old;
+        bool touch, touchIsDouble;
+        unsigned int touchDownTimestamp;
 } openrct2_cursor;
 
 enum {


### PR DESCRIPTION
Natively on Linux, using OpenRCT2 with touch is impossible because
touch events are not handled by the game.  They just don't do anything.

This commit handles touch events.  A single touch represents a
press of the left mouse button.  If it followed by another touch
within 300ms, a right mouse button event is emitted.

(This does not fix #2091, as I don't know where the viewport input is handled)