### PR TITLE
use RCT2_ADDRESS in track_manage.c

### DIFF
--- a/src/windows/new_ride.c
+++ b/src/windows/new_ride.c
@@ -847,9 +847,9 @@ static int get_num_track_designs(ride_list_item item)
 {
 	track_load_list(item);
 
-	uint8 *trackDesignList = (uint8*)0x00F441EC;
+	char *trackDesignList = RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char);
 	int count = 0;
-	while (*trackDesignList != 0 && trackDesignList < (uint8*)0x00F635EC) {
+	while (*trackDesignList != 0 && trackDesignList < (char*)0x00F635EC) {
 		trackDesignList += 128;
 		count++;
 	}
@@ -936,7 +936,7 @@ static void window_new_ride_select(rct_window *w)
 	if (ride_type_has_flag(item.type, RIDE_TYPE_FLAG_HAS_TRACK)) {
 		track_load_list(item);
 
-		uint8 *trackDesignList = (uint8*)0x00F441EC;
+		char *trackDesignList = RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char);
 		if (*trackDesignList != 0) {
 			window_track_list_open(item);
 			return;

--- a/src/windows/track_manage.c
+++ b/src/windows/track_manage.c
@@ -185,7 +185,7 @@ static void window_track_manage_close(rct_window *w)
  */
 static void window_track_manage_mouseup(rct_window *w, int widgetIndex)
 {
-	uint8 *trackDesignList = (uint8*)0x00F441EC;
+	char *trackDesignList = RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char);
 	rct_window *trackDesignListWindow;
 	char *dst, *src;
 


### PR DESCRIPTION
Fixes the following warning and also uses an already defined constant instead of hardcoding the address.

```text
[ 71%] Building C object CMakeFiles/openrct2.dir/src/windows/track_manage.c.o
/Users/linus/coding/OpenRCT2/src/windows/track_manage.c:199:8: warning: assigning to 'char *' from 'uint8 *' (aka 'unsigned char *') converts
      between pointers to integer types with different sign [-Wpointer-sign]
                        src = &trackDesignList[trackDesignListWindow->track_list.var_482 * 128];
                            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```