### PR TITLE
small fixes for platform/osx.c

### DIFF
--- a/src/platform/osx.c
+++ b/src/platform/osx.c
@@ -21,6 +21,7 @@
 #if defined(__APPLE__) && defined(__MACH__)
 
 #include "platform.h"
+#include "../util/util.h"
 
 #include <mach-o/dyld.h>
 
@@ -32,7 +33,7 @@ bool platform_check_steam_overlay_attached() {
 void platform_get_exe_path(utf8 *outPath)
 {
 	char exePath[MAX_PATH];
-	int size = MAX_PATH;
+	uint32_t size = MAX_PATH;
 	int result = _NSGetExecutablePath(exePath, &size);
 	if (result != 0) {
 		log_fatal("failed to get path");


### PR DESCRIPTION
1) Includes `util.h` since that is where `safe_strncpy` is defined.

2) Changes the second parameter to `_NSGetExecutablePath` to actually be `uint32_t` which is what it expects. It was working now because we are only compiling for 32-bit and the sign part will only generate a warning. Nevertheless, now it should be correct and no warnings are emitted.

This was the warnings fixed by this commit:

```text
[ 31%] Building C object CMakeFiles/openrct2.dir/src/platform/osx.c.o
/Users/linus/coding/OpenRCT2/src/platform/osx.c:36:45: warning: passing 'int *' to parameter of type 'uint32_t *' (aka 'unsigned int *')
      converts between pointers to integer types with different sign [-Wpointer-sign]
        int result = _NSGetExecutablePath(exePath, &size);
                                                   ^~~~~
/usr/include/mach-o/dyld.h:92:54: note: passing argument to parameter 'bufsize' here
extern int _NSGetExecutablePath(char* buf, uint32_t* bufsize)                 __OSX_AVAILABLE_STARTING(__MAC_10_2, __IPHONE_2_0);
                                                     ^
/Users/linus/coding/OpenRCT2/src/platform/osx.c:50:2: warning: implicit declaration of function 'safe_strncpy' is invalid in C99
      [-Wimplicit-function-declaration]
        safe_strncpy(outPath, exePath, exeDelimiterIndex + 1);
        ^
2 warnings generated.
```