### PR TITLE
Shift segments in Mach-O to outside of required AS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,10 @@ if (UNIX)
 	# force 32bit build for now and set necessary flags to compile code as is
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -std=gnu99 -fno-omit-frame-pointer")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=gnu++11 -fno-omit-frame-pointer")
-	set(CMAKE_SHARED_LINKER_FLAGS "-m32")
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32")
+	if (APPLE)
+		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-image_base,0x3401000")
+	endif (APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
 endif (UNIX)
 

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -566,7 +566,7 @@ static bool openrct2_setup_rct2_segment()
 		exit(1);
 	}
 
-	void *fbase = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, gExeFd, 0);
+	void *fbase = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE | MAP_FILE, gExeFd, 0);
 	err = errno;
 	log_warning("mmapped file to %p", fbase);
 	if (fbase == MAP_FAILED)


### PR DESCRIPTION
Mach-O defaults to having .text segment starting at 0x1000 RVA, which
clashes with the address space required for mmap to work properly.

This change tells linker to move the segment outside of required AS, and
then some, so that mmap can properly allocate required addresses without
evicting anything else.