### PR TITLE
POSIX: MAP_ANONYMOUS should have fd = -1

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -514,7 +514,7 @@ static bool openrct2_setup_rct2_segment()
 
 	int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
 	// section: rw data
-	gDataSegment = mmap((void *)0x8a4000, len, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+	gDataSegment = mmap((void *)0x8a4000, len, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_ANONYMOUS | MAP_SHARED, -1, 0);
 	if (gDataSegment != (void *)0x8a4000) {
 		log_fatal("mmap failed to get required offset for data segment! got %p, expected %p, errno = %d", gDataSegment, (void *)(0x8a4000), errno);
 		exit(1);


### PR DESCRIPTION
http://man7.org/linux/man-pages/man2/mmap.2.html
```
       MAP_ANONYMOUS
              The mapping is not backed by any file; its contents are
              initialized to zero.  The fd and offset arguments are ignored;
              however, some implementations require fd to be -1 if
              MAP_ANONYMOUS (or MAP_ANON) is specified, and portable
              applications should ensure this.  The use of MAP_ANONYMOUS in
              conjunction with MAP_SHARED is supported on Linux only since
              kernel 2.4.
```