### PR TITLE
OS X build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ else (WIN32)
 	add_executable(${PROJECT} ${ORCT2_SOURCES})
 endif (WIN32)
 
+if (APPLE)
+	FIND_LIBRARY(ICONV_LIBRARIES NAMES iconv libiconv libiconv-2 c)
+	TARGET_LINK_LIBRARIES(${PROJECT} ${ICONV_LIBRARIES})
+endif (APPLE)
+
 # install into ${CMAKE_INSTALL_PREFIX}/bin/
 #install (TARGETS ${PROJECT} DESTINATION bin)
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -152,6 +152,11 @@ uint8 platform_get_locale_temperature_format();
 
 bool platform_check_steam_overlay_attached();
 
+// BSD and OS X has MAP_ANON instead of MAP_ANONYMOUS
+#ifndef MAP_ANONYMOUS
+	#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 // Windows specific definitions
 #ifdef _WIN32
 	#ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
I've pulled these out of #2401 since I need to fix brew bottles for that one and that isn't really related to this. With this fixes I can actually build successfully on OS X.

- The fix to `CMakeList.txt` will fix linking issues where the linker can't find iconv.
- BSD and OS X has `MAP_ANON` instead of `MAP_ANONYMOUS`