### PR TITLE
Raise the lower limit for scale to 0.5f

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -691,7 +691,7 @@ static int cc_set(const utf8 **argv, int argc)
 		}
 		else if (strcmp(argv[0], "window_scale") == 0 && invalidArguments(&invalidArgs, double_valid[0])) {
 			float newScale = (float)(0.001*trunc(1000*double_val[0]));
-			gConfigGeneral.window_scale = clamp(newScale, 0.1f, 5.0f);
+			gConfigGeneral.window_scale = clamp(newScale, 0.5f, 5.0f);
 			config_save_default();
 			gfx_invalidate_screen();
 			platform_trigger_resize();


### PR DESCRIPTION
Setting the scale to anything lower than 0.3f crashes the game on my
machine, although I don't know the exact reason of that.

The game at window_scale=0.1 is unusable anyway, as the interface is far
too small.