### PR TITLE
Moved the configuration on OS X to ~/Library/Application Support/OpenRCT2

### DIFF
--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -22,6 +22,7 @@
 
 #include "platform.h"
 #include <dlfcn.h>
+#include <stdlib.h>
 
 // See http://syprog.blogspot.ru/2011/12/listing-loaded-shared-objects-in-linux.html
 struct lmap {
@@ -76,6 +77,38 @@ bool platform_check_steam_overlay_attached() {
 	dlclose(processHandle);
 
 	return false;
+}
+
+/**
+ * Default directory fallback is:
+ *   - (command line argument)
+ *   - $XDG_CONFIG_HOME/OpenRCT2
+ *   - /home/[uid]/.config/OpenRCT2
+ */
+void platform_posix_sub_user_data_path(char *buffer, const char *homedir, const char *separator) {
+	const char *configdir = getenv("XDG_CONFIG_HOME");
+	log_verbose("configdir = '%s'", configdir);
+	if (configdir == NULL)
+	{
+		log_verbose("configdir was null, used getuid, now is = '%s'", homedir);
+		if (homedir == NULL)
+		{
+			log_fatal("Couldn't find user data directory");
+			exit(-1);
+			return;
+		}
+		
+		strncat(buffer, homedir, MAX_PATH - 1);
+		strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+		strncat(buffer, ".config", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	}
+	else
+	{
+		strncat(buffer, configdir, MAX_PATH - 1);
+	}
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, "OpenRCT2", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
 }
 
 #endif

--- a/src/platform/osx.c
+++ b/src/platform/osx.c
@@ -52,4 +52,27 @@ void platform_get_exe_path(utf8 *outPath)
 	outPath[exeDelimiterIndex] = '\0';
 }
 
+/**
+ * Default directory fallback is:
+ *   - (command line argument)
+ *   - ~/Library/Application Support/OpenRCT2
+ */
+void platform_posix_sub_user_data_path(char *buffer, const char *homedir, const char *separator) {
+	if (homedir == NULL)
+	{
+		log_fatal("Couldn't find user data directory");
+		exit(-1);
+		return;
+	}
+	
+	strncat(buffer, homedir, MAX_PATH - 1);
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, "Library", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, "Application Support", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, "OpenRCT2", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+}
+
 #endif

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -528,11 +528,12 @@ wchar_t *regular_to_wchar(const char* src)
 	return w_buffer;
 }
 
+void platform_posix_sub_user_data_path(char *buffer, const char *homedir, const char *separator);
+
 /**
  * Default directory fallback is:
  *   - (command line argument)
- *   - $XDG_CONFIG_HOME/OpenRCT2
- *   - /home/[uid]/.config/OpenRCT2
+ *   - <platform dependent>
  */
 void platform_resolve_user_data_path()
 {
@@ -552,30 +553,10 @@ void platform_resolve_user_data_path()
 	char buffer[MAX_PATH];
 	buffer[0] = '\0';
 	log_verbose("buffer = '%s'", buffer);
-	const char *homedir = getenv("XDG_CONFIG_HOME");
-	log_verbose("homedir = '%s'", homedir);
-	if (homedir == NULL)
-	{
-		homedir = getpwuid(getuid())->pw_dir;
-		log_verbose("homedir was null, used getuid, now is = '%s'", homedir);
-		if (homedir == NULL)
-		{
-			log_fatal("Couldn't find user data directory");
-			exit(-1);
-			return;
-		}
-
-		strncat(buffer, homedir, MAX_PATH - 1);
-		strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
-		strncat(buffer, ".config", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
-	}
-	else
-	{
-		strncat(buffer, homedir, MAX_PATH - 1);
-	}
-	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
-	strncat(buffer, "OpenRCT2", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
-	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	
+	const char *homedir = getpwuid(getuid())->pw_dir;
+	platform_posix_sub_user_data_path(buffer, homedir, separator);
+	
 	log_verbose("OpenRCT2 user data directory = '%s'", buffer);
 	int len = strnlen(buffer, MAX_PATH);
 	wchar_t *w_buffer = regular_to_wchar(buffer);


### PR DESCRIPTION
This is to make it match the general standard for Mac OS X. .config is not unused on Macs, but it is very uncommon and is usually only used by bad ports from Linux. The Application Support folder on Macs is intended for this kind of usage, and should be moved over there.

I have not added any sort of fallback/moving for existing configurations in .config. This may want to be added or mentioned somewhere for the people who have run it before this patch is merged.