### PR TITLE
osx: install.sh improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,11 +103,17 @@ All libs listed here (bar cmake) required in 32 bit variants.
 Alternatively, to simply build the project you can just execute ``build.bat`` within VS2015 Native Tools Command prompt or Github Windows prompt.
 
 ### Mac OS X:
-Providing Homebrew or MacPorts are installed (but not both!), OpenRCT2's dependencies and Wine can be installed automatically through `install.sh`.
+We support native builds OS X (limited to i386 only for now).
+Make sure that you have [Homebrew](http://brew.sh/) installed and than run the following commands to install all the needed libraries and build openrct2.
 ```
-bash install.sh
-bash build.sh
-wine openrct2.exe
+# Install libraries
+./install.sh
+
+# Build OpenRCT2
+./build.sh
+
+# Run the game
+./openrct2
 ```
 
 ### Linux:


### PR DESCRIPTION
This improves the installation script on OS X in the following ways:

- Install all necessary libs with the correct flags (using brew)
- Only installs mingw and wine if `TARGET=windows` (we now have native OS X support so I think this is desirable)
- Remove support for macports (it has already been removed from the readme in #2459 and I don't think that anyone uses it anymore)

This is extracted from #2401 which is waiting for me to fix the bottles. I think it's a good idea to merge this in the mean time so that people can get up and running more easily on OS X.