### PR TITLE
Fix a bug where argv will be replaced by the argparse library.

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -90,10 +90,19 @@ int cmdline_run(const char **argv, int argc)
 
 	argparse_t argparse;
 	argparse_init(&argparse, options, usage, 0);
-	argc = argparse_parse(&argparse, argc, argv);
+	size_t argvsize = sizeof(char**) * argc;
+	/**
+	 * argparse_parse ends up inadvertently mutating the argv variable, setting
+	 * a null pointer in the array. Because of this, AppKit in OS X 10.10 will
+	 * dereference it, causing a segmentation fault.
+	 */
+	const char** mutableArgv = malloc(argvsize);
+	memcpy(mutableArgv,argv,argvsize);
+	argc = argparse_parse(&argparse, argc, mutableArgv);
 
 	if (version) {
 		print_version();
+		free(mutableArgv);
 		return 0;
 	}
 
@@ -121,7 +130,8 @@ int cmdline_run(const char **argv, int argc)
 
 	if (argc != 0) {
 		// see comment next to cmdline_call_action for expected return codes
-		gExitCode = cmdline_call_action(argv, argc);
+		gExitCode = cmdline_call_action(mutableArgv, argc);
+		free(mutableArgv);
 		if (gExitCode < 0) {
 			// action failed, don't change exit code
 			// and don't start the game
@@ -133,6 +143,8 @@ int cmdline_run(const char **argv, int argc)
 			return 0;
 		}
 		// start the game, so far exit code means success.
+	} else {
+		free(mutableArgv);
 	}
 
 	// Headless mode requires a park to open


### PR DESCRIPTION
The argparse library takes the `argv` variable, assigns it to `this->output`, and then writes a null pointer to it. This causes issues on OS X 10.10 because AppKit tries to read the arguments passed to the application, which the first argument is null.