### PR TITLE
use stdint types

### DIFF
--- a/src/rct2.h
+++ b/src/rct2.h
@@ -41,14 +41,14 @@
 	#include <time.h>
 #endif
 
-typedef signed char sint8;
-typedef signed short sint16;
-typedef signed long sint32;
-typedef signed long long sint64;
-typedef unsigned char uint8;
-typedef unsigned short uint16;
-typedef unsigned long uint32;
-typedef unsigned long long uint64;
+typedef int8_t sint8;
+typedef int16_t sint16;
+typedef int32_t sint32;
+typedef int64_t sint64;
+typedef uint8_t uint8;
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef uint64_t uint64;
 
 typedef char utf8;
 typedef utf8* utf8string;


### PR DESCRIPTION
This uses the types defined in `stdint.h` since they actually guarantees a fixed number of bytes. The other ones are defined as "at least" that large.

ping @kkirby with this you no longer need `NO_INT_TYPE_DECLARE ` in #2473, it will just work since they have the exact same type