### PR TITLE
osx: correct modifier key

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -33,6 +33,12 @@
 #define MAX_PATH 260
 #endif
 
+#if defined(__APPLE__) && defined(__MACH__)
+#define KEYBOARD_PRIMARY_MODIFIER KMOD_GUI
+#else
+#define KEYBOARD_PRIMARY_MODIFIER KMOD_CTRL
+#endif
+
 #define INVALID_HANDLE -1
 
 typedef struct {

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -531,16 +531,14 @@ void platform_process_messages()
 
 			// Text input
 
-                        // Clear the input on <CTRL>Backspace
-                        if (gTextInput != NULL
-                                && e.key.keysym.sym == SDLK_BACKSPACE
-                                && e.key.keysym.mod & KMOD_CTRL) {
-                            memset(gTextInput, '\0', gTextInputMaxLength);
-                            gTextInputCursorPosition = 0;
-                            gTextInputLength = 0;
-                            console_refresh_caret();
-                            window_update_textbox();
-                        }
+			// Clear the input on <CTRL>Backspace (Windows/Linux) or <MOD>Backspace (OS X)
+			if (gTextInput != NULL && e.key.keysym.sym == SDLK_BACKSPACE && (e.key.keysym.mod & KEYBOARD_PRIMARY_MODIFIER)) {
+				memset(gTextInput, '\0', gTextInputMaxLength);
+				gTextInputCursorPosition = 0;
+				gTextInputLength = 0;
+				console_refresh_caret();
+				window_update_textbox();
+			}
 
 			// If backspace and we have input text with a cursor position none zero
 			if (e.key.keysym.sym == SDLK_BACKSPACE && gTextInputLength > 0 && gTextInput != NULL && gTextInputCursorPosition) {
@@ -601,12 +599,7 @@ void platform_process_messages()
 				} while (!utf8_is_codepoint_start(&gTextInput[gTextInputCursorPosition]));
 				console_refresh_caret();
 			}
-			// Checks GUI modifier key for MACs otherwise CTRL key
-#ifdef MAC
-			else if (e.key.keysym.sym == SDLK_v && SDL_GetModState() & KMOD_GUI && gTextInput != NULL) {
-#else
-			else if (e.key.keysym.sym == SDLK_v && SDL_GetModState() & KMOD_CTRL && gTextInput != NULL) {
-#endif
+			else if (e.key.keysym.sym == SDLK_v && (SDL_GetModState() & KEYBOARD_PRIMARY_MODIFIER) && gTextInput != NULL) {
 				if (SDL_HasClipboardText()) {
 					utf8 *text = SDL_GetClipboardText();
 					for (int i = 0; text[i] != '\0' && gTextInputLength < gTextInputMaxLength; i++) {


### PR DESCRIPTION
Defines a new constant `KEYBOARD_PRIMARY_MODIFIER` which is used to control which modifier key should be used. On Windows and Linux it's the control key, while on OS X it's the command key.

Also changes the space indentation to tabs to match the rest of the file.