### PR TITLE
Added Xcode Project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 *.fsproj merge=union
 *.dbproj merge=union
 
+# Custom for Xcode
+*.pbxproj merge=union
+
 # Standard to msysgit
 *.doc    diff=astextplain
 *.DOC    diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ sdl
 # Compiled dll
 openrct2.dll
 
+# Compiled linux executable
+openrct2
+
 # Distribution
 distribution/windows/*.exe
 
@@ -199,9 +202,38 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 
+#############
+## Xcode
+#############
+
+# Build generated
+build/
+DerivedData
+
+# Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+# Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+
 # Mac crap
 .DS_Store
 
+# We link logo files to .xcassets in Xcode project, so don't sync them
+distribution/osx/Assets.xcassets/AppIcon.appiconset/*.png
+
+# Extra Xcode-specific lib files
+libxc
 
 #############
 ## Python

--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -1,0 +1,1676 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D41B73EF1C2101890080A7B9 /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B73EE1C2101890080A7B9 /* libcurl.tbd */; };
+		D41B73F11C21018C0080A7B9 /* libssl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B73F01C21018C0080A7B9 /* libssl.tbd */; };
+		D41B741D1C210A7A0080A7B9 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B741C1C210A7A0080A7B9 /* libiconv.tbd */; };
+		D41B74731C2125E50080A7B9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D41B74721C2125E50080A7B9 /* Assets.xcassets */; };
+		D4EC47DF1C26342F0024B507 /* addresses.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46D61C26342F0024B507 /* addresses.c */; };
+		D4EC47E01C26342F0024B507 /* audio.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46D91C26342F0024B507 /* audio.c */; };
+		D4EC47E11C26342F0024B507 /* mixer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46DB1C26342F0024B507 /* mixer.cpp */; };
+		D4EC47E21C26342F0024B507 /* cheats.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46DD1C26342F0024B507 /* cheats.c */; };
+		D4EC47E31C26342F0024B507 /* cmdline_sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46DF1C26342F0024B507 /* cmdline_sprite.c */; };
+		D4EC47E41C26342F0024B507 /* cmdline.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46E01C26342F0024B507 /* cmdline.c */; };
+		D4EC47E51C26342F0024B507 /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46E31C26342F0024B507 /* config.c */; };
+		D4EC47E61C26342F0024B507 /* cursors.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46EF1C26342F0024B507 /* cursors.c */; };
+		D4EC47E71C26342F0024B507 /* diagnostic.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46F11C26342F0024B507 /* diagnostic.c */; };
+		D4EC47E81C26342F0024B507 /* drawing.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46F41C26342F0024B507 /* drawing.c */; };
+		D4EC47E91C26342F0024B507 /* font.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46F61C26342F0024B507 /* font.c */; };
+		D4EC47EA1C26342F0024B507 /* line.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46F81C26342F0024B507 /* line.c */; };
+		D4EC47EB1C26342F0024B507 /* rain.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46F91C26342F0024B507 /* rain.c */; };
+		D4EC47EC1C26342F0024B507 /* rect.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46FA1C26342F0024B507 /* rect.c */; };
+		D4EC47ED1C26342F0024B507 /* scrolling_text.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46FB1C26342F0024B507 /* scrolling_text.c */; };
+		D4EC47EE1C26342F0024B507 /* sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46FC1C26342F0024B507 /* sprite.c */; };
+		D4EC47EF1C26342F0024B507 /* string.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46FD1C26342F0024B507 /* string.c */; };
+		D4EC47F01C26342F0024B507 /* supports.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC46FE1C26342F0024B507 /* supports.c */; };
+		D4EC47F11C26342F0024B507 /* editor.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47001C26342F0024B507 /* editor.c */; };
+		D4EC47F21C26342F0024B507 /* game.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47021C26342F0024B507 /* game.c */; };
+		D4EC47F31C26342F0024B507 /* hook.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47041C26342F0024B507 /* hook.c */; };
+		D4EC47F41C26342F0024B507 /* input.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47061C26342F0024B507 /* input.c */; };
+		D4EC47F51C26342F0024B507 /* chat.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47091C26342F0024B507 /* chat.c */; };
+		D4EC47F61C26342F0024B507 /* colour.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC470B1C26342F0024B507 /* colour.c */; };
+		D4EC47F71C26342F0024B507 /* console.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC470D1C26342F0024B507 /* console.c */; };
+		D4EC47F81C26342F0024B507 /* graph.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC470F1C26342F0024B507 /* graph.c */; };
+		D4EC47F91C26342F0024B507 /* keyboard_shortcut.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47111C26342F0024B507 /* keyboard_shortcut.c */; };
+		D4EC47FA1C26342F0024B507 /* screenshot.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47131C26342F0024B507 /* screenshot.c */; };
+		D4EC47FB1C26342F0024B507 /* themes.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47151C26342F0024B507 /* themes.c */; };
+		D4EC47FC1C26342F0024B507 /* title_sequences.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47171C26342F0024B507 /* title_sequences.c */; };
+		D4EC47FD1C26342F0024B507 /* viewport.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47191C26342F0024B507 /* viewport.c */; };
+		D4EC47FE1C26342F0024B507 /* viewport_interaction.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC471B1C26342F0024B507 /* viewport_interaction.c */; };
+		D4EC47FF1C26342F0024B507 /* widget.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC471C1C26342F0024B507 /* widget.c */; };
+		D4EC48001C26342F0024B507 /* window.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC471E1C26342F0024B507 /* window.c */; };
+		D4EC48011C26342F0024B507 /* intro.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47201C26342F0024B507 /* intro.c */; };
+		D4EC48021C26342F0024B507 /* convert.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47231C26342F0024B507 /* convert.c */; };
+		D4EC48031C26342F0024B507 /* currency.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47241C26342F0024B507 /* currency.c */; };
+		D4EC48041C26342F0024B507 /* date.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47261C26342F0024B507 /* date.c */; };
+		D4EC48051C26342F0024B507 /* language.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47291C26342F0024B507 /* language.cpp */; };
+		D4EC48061C26342F0024B507 /* LanguagePack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC472B1C26342F0024B507 /* LanguagePack.cpp */; };
+		D4EC48071C26342F0024B507 /* localisation.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC472D1C26342F0024B507 /* localisation.c */; };
+		D4EC48081C26342F0024B507 /* real_names.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC472F1C26342F0024B507 /* real_names.c */; };
+		D4EC48091C26342F0024B507 /* user.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47311C26342F0024B507 /* user.c */; };
+		D4EC480A1C26342F0024B507 /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47331C26342F0024B507 /* utf8.c */; };
+		D4EC480B1C26342F0024B507 /* award.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47351C26342F0024B507 /* award.c */; };
+		D4EC480C1C26342F0024B507 /* finance.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47371C26342F0024B507 /* finance.c */; };
+		D4EC480D1C26342F0024B507 /* marketing.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47391C26342F0024B507 /* marketing.c */; };
+		D4EC480E1C26342F0024B507 /* news_item.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC473B1C26342F0024B507 /* news_item.c */; };
+		D4EC480F1C26342F0024B507 /* research.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC473D1C26342F0024B507 /* research.c */; };
+		D4EC48101C26342F0024B507 /* http.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47401C26342F0024B507 /* http.cpp */; };
+		D4EC48111C26342F0024B507 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47421C26342F0024B507 /* network.cpp */; };
+		D4EC48121C26342F0024B507 /* twitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47441C26342F0024B507 /* twitch.cpp */; };
+		D4EC48131C26342F0024B507 /* object_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47461C26342F0024B507 /* object_list.c */; };
+		D4EC48141C26342F0024B507 /* object.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47471C26342F0024B507 /* object.c */; };
+		D4EC48151C26342F0024B507 /* openrct2.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47491C26342F0024B507 /* openrct2.c */; };
+		D4EC48161C26342F0024B507 /* peep.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC474C1C26342F0024B507 /* peep.c */; };
+		D4EC48171C26342F0024B507 /* staff.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC474E1C26342F0024B507 /* staff.c */; };
+		D4EC48181C26342F0024B507 /* linux.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47511C26342F0024B507 /* linux.c */; };
+		D4EC48191C26342F0024B507 /* osx.m in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47521C26342F0024B507 /* osx.m */; };
+		D4EC481A1C26342F0024B507 /* posix.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47541C26342F0024B507 /* posix.c */; };
+		D4EC481B1C26342F0024B507 /* shared.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47551C26342F0024B507 /* shared.c */; };
+		D4EC481C1C26342F0024B507 /* windows.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47561C26342F0024B507 /* windows.c */; };
+		D4EC481D1C26342F0024B507 /* rct1.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47571C26342F0024B507 /* rct1.c */; };
+		D4EC481E1C26342F0024B507 /* rct2.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47591C26342F0024B507 /* rct2.c */; };
+		D4EC48201C26342F0024B507 /* ride.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC475D1C26342F0024B507 /* ride.c */; };
+		D4EC48211C26342F0024B507 /* ride_data.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC475F1C26342F0024B507 /* ride_data.c */; };
+		D4EC48221C26342F0024B507 /* ride_ratings.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47611C26342F0024B507 /* ride_ratings.c */; };
+		D4EC48231C26342F0024B507 /* station.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47631C26342F0024B507 /* station.c */; };
+		D4EC48241C26342F0024B507 /* track.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47651C26342F0024B507 /* track.c */; };
+		D4EC48251C26342F0024B507 /* track_data.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47671C26342F0024B507 /* track_data.c */; };
+		D4EC48261C26342F0024B507 /* track_paint.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47691C26342F0024B507 /* track_paint.c */; };
+		D4EC48271C26342F0024B507 /* vehicle.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC476B1C26342F0024B507 /* vehicle.c */; };
+		D4EC48281C26342F0024B507 /* scenario_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC476D1C26342F0024B507 /* scenario_list.c */; };
+		D4EC48291C26342F0024B507 /* scenario.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC476E1C26342F0024B507 /* scenario.c */; };
+		D4EC482A1C26342F0024B507 /* title.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47711C26342F0024B507 /* title.c */; };
+		D4EC482B1C26342F0024B507 /* tutorial.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47731C26342F0024B507 /* tutorial.c */; };
+		D4EC482C1C26342F0024B507 /* sawyercoding.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47761C26342F0024B507 /* sawyercoding.c */; };
+		D4EC482D1C26342F0024B507 /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47781C26342F0024B507 /* util.c */; };
+		D4EC482E1C26342F0024B507 /* about.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC477B1C26342F0024B507 /* about.c */; };
+		D4EC482F1C26342F0024B507 /* banner.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC477C1C26342F0024B507 /* banner.c */; };
+		D4EC48301C26342F0024B507 /* changelog.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC477D1C26342F0024B507 /* changelog.c */; };
+		D4EC48311C26342F0024B507 /* cheats.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC477E1C26342F0024B507 /* cheats.c */; };
+		D4EC48321C26342F0024B507 /* clear_scenery.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC477F1C26342F0024B507 /* clear_scenery.c */; };
+		D4EC48331C26342F0024B507 /* demolish_ride_prompt.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47801C26342F0024B507 /* demolish_ride_prompt.c */; };
+		D4EC48341C26342F0024B507 /* dropdown.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47811C26342F0024B507 /* dropdown.c */; };
+		D4EC48351C26342F0024B507 /* editor_bottom_toolbar.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47831C26342F0024B507 /* editor_bottom_toolbar.c */; };
+		D4EC48361C26342F0024B507 /* editor_inventions_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47841C26342F0024B507 /* editor_inventions_list.c */; };
+		D4EC48371C26342F0024B507 /* editor_main.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47851C26342F0024B507 /* editor_main.c */; };
+		D4EC48381C26342F0024B507 /* editor_object_selection.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47861C26342F0024B507 /* editor_object_selection.c */; };
+		D4EC48391C26342F0024B507 /* editor_objective_options.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47871C26342F0024B507 /* editor_objective_options.c */; };
+		D4EC483A1C26342F0024B507 /* editor_scenario_options.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47881C26342F0024B507 /* editor_scenario_options.c */; };
+		D4EC483B1C26342F0024B507 /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47891C26342F0024B507 /* error.c */; };
+		D4EC483C1C26342F0024B507 /* finances.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC478B1C26342F0024B507 /* finances.c */; };
+		D4EC483D1C26342F0024B507 /* footpath.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC478C1C26342F0024B507 /* footpath.c */; };
+		D4EC483E1C26342F0024B507 /* game_bottom_toolbar.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC478D1C26342F0024B507 /* game_bottom_toolbar.c */; };
+		D4EC483F1C26342F0024B507 /* guest.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC478E1C26342F0024B507 /* guest.c */; };
+		D4EC48401C26342F0024B507 /* guest_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC478F1C26342F0024B507 /* guest_list.c */; };
+		D4EC48411C26342F0024B507 /* install_track.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47901C26342F0024B507 /* install_track.c */; };
+		D4EC48421C26342F0024B507 /* land.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47911C26342F0024B507 /* land.c */; };
+		D4EC48431C26342F0024B507 /* land_rights.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47921C26342F0024B507 /* land_rights.c */; };
+		D4EC48441C26342F0024B507 /* loadsave.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47931C26342F0024B507 /* loadsave.c */; };
+		D4EC48451C26342F0024B507 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47941C26342F0024B507 /* main.c */; };
+		D4EC48461C26342F0024B507 /* map.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47951C26342F0024B507 /* map.c */; };
+		D4EC48471C26342F0024B507 /* map_tooltip.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47961C26342F0024B507 /* map_tooltip.c */; };
+		D4EC48481C26342F0024B507 /* mapgen.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47971C26342F0024B507 /* mapgen.c */; };
+		D4EC48491C26342F0024B507 /* maze_construction.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47981C26342F0024B507 /* maze_construction.c */; };
+		D4EC484A1C26342F0024B507 /* music_credits.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47991C26342F0024B507 /* music_credits.c */; };
+		D4EC484B1C26342F0024B507 /* network_status.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479A1C26342F0024B507 /* network_status.c */; };
+		D4EC484C1C26342F0024B507 /* new_campaign.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479B1C26342F0024B507 /* new_campaign.c */; };
+		D4EC484D1C26342F0024B507 /* new_ride.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479C1C26342F0024B507 /* new_ride.c */; };
+		D4EC484E1C26342F0024B507 /* news.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479D1C26342F0024B507 /* news.c */; };
+		D4EC484F1C26342F0024B507 /* options.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479E1C26342F0024B507 /* options.c */; };
+		D4EC48501C26342F0024B507 /* park.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC479F1C26342F0024B507 /* park.c */; };
+		D4EC48511C26342F0024B507 /* player_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A01C26342F0024B507 /* player_list.c */; };
+		D4EC48521C26342F0024B507 /* publisher_credits.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A11C26342F0024B507 /* publisher_credits.c */; };
+		D4EC48531C26342F0024B507 /* research.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A21C26342F0024B507 /* research.c */; };
+		D4EC48541C26342F0024B507 /* ride.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A31C26342F0024B507 /* ride.c */; };
+		D4EC48551C26342F0024B507 /* ride_construction.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A41C26342F0024B507 /* ride_construction.c */; };
+		D4EC48561C26342F0024B507 /* ride_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A51C26342F0024B507 /* ride_list.c */; };
+		D4EC48571C26342F0024B507 /* save_prompt.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A61C26342F0024B507 /* save_prompt.c */; };
+		D4EC48581C26342F0024B507 /* scenery.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A71C26342F0024B507 /* scenery.c */; };
+		D4EC48591C26342F0024B507 /* server_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A81C26342F0024B507 /* server_list.c */; };
+		D4EC485A1C26342F0024B507 /* server_start.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47A91C26342F0024B507 /* server_start.c */; };
+		D4EC485B1C26342F0024B507 /* shortcut_key_change.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AA1C26342F0024B507 /* shortcut_key_change.c */; };
+		D4EC485C1C26342F0024B507 /* shortcut_keys.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AB1C26342F0024B507 /* shortcut_keys.c */; };
+		D4EC485D1C26342F0024B507 /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AC1C26342F0024B507 /* sign.c */; };
+		D4EC485E1C26342F0024B507 /* staff.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AD1C26342F0024B507 /* staff.c */; };
+		D4EC485F1C26342F0024B507 /* staff_fire_prompt.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AE1C26342F0024B507 /* staff_fire_prompt.c */; };
+		D4EC48601C26342F0024B507 /* staff_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47AF1C26342F0024B507 /* staff_list.c */; };
+		D4EC48611C26342F0024B507 /* text_input.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B01C26342F0024B507 /* text_input.c */; };
+		D4EC48621C26342F0024B507 /* themes.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B11C26342F0024B507 /* themes.c */; };
+		D4EC48631C26342F0024B507 /* tile_inspector.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B21C26342F0024B507 /* tile_inspector.c */; };
+		D4EC48641C26342F0024B507 /* title_command_editor.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B31C26342F0024B507 /* title_command_editor.c */; };
+		D4EC48651C26342F0024B507 /* title_editor.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B41C26342F0024B507 /* title_editor.c */; };
+		D4EC48661C26342F0024B507 /* title_exit.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B51C26342F0024B507 /* title_exit.c */; };
+		D4EC48671C26342F0024B507 /* title_logo.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B61C26342F0024B507 /* title_logo.c */; };
+		D4EC48681C26342F0024B507 /* title_menu.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B71C26342F0024B507 /* title_menu.c */; };
+		D4EC48691C26342F0024B507 /* title_options.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B81C26342F0024B507 /* title_options.c */; };
+		D4EC486A1C26342F0024B507 /* title_scenarioselect.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47B91C26342F0024B507 /* title_scenarioselect.c */; };
+		D4EC486B1C26342F0024B507 /* tooltip.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47BA1C26342F0024B507 /* tooltip.c */; };
+		D4EC486C1C26342F0024B507 /* top_toolbar.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47BC1C26342F0024B507 /* top_toolbar.c */; };
+		D4EC486D1C26342F0024B507 /* track_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47BD1C26342F0024B507 /* track_list.c */; };
+		D4EC486E1C26342F0024B507 /* track_manage.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47BE1C26342F0024B507 /* track_manage.c */; };
+		D4EC486F1C26342F0024B507 /* track_place.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47BF1C26342F0024B507 /* track_place.c */; };
+		D4EC48701C26342F0024B507 /* viewport.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C01C26342F0024B507 /* viewport.c */; };
+		D4EC48711C26342F0024B507 /* water.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C11C26342F0024B507 /* water.c */; };
+		D4EC48721C26342F0024B507 /* balloon.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C31C26342F0024B507 /* balloon.c */; };
+		D4EC48731C26342F0024B507 /* banner.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C41C26342F0024B507 /* banner.c */; };
+		D4EC48741C26342F0024B507 /* climate.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C61C26342F0024B507 /* climate.c */; };
+		D4EC48751C26342F0024B507 /* duck.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47C81C26342F0024B507 /* duck.c */; };
+		D4EC48761C26342F0024B507 /* footpath.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47CA1C26342F0024B507 /* footpath.c */; };
+		D4EC48771C26342F0024B507 /* fountain.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47CC1C26342F0024B507 /* fountain.c */; };
+		D4EC48781C26342F0024B507 /* map.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47CE1C26342F0024B507 /* map.c */; };
+		D4EC48791C26342F0024B507 /* map_animation.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D01C26342F0024B507 /* map_animation.c */; };
+		D4EC487A1C26342F0024B507 /* map_helpers.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D21C26342F0024B507 /* map_helpers.c */; };
+		D4EC487B1C26342F0024B507 /* mapgen.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D41C26342F0024B507 /* mapgen.c */; };
+		D4EC487C1C26342F0024B507 /* money_effect.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D61C26342F0024B507 /* money_effect.c */; };
+		D4EC487D1C26342F0024B507 /* park.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D71C26342F0024B507 /* park.c */; };
+		D4EC487E1C26342F0024B507 /* particle.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47D91C26342F0024B507 /* particle.c */; };
+		D4EC487F1C26342F0024B507 /* scenery.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47DA1C26342F0024B507 /* scenery.c */; };
+		D4EC48801C26342F0024B507 /* sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC47DC1C26342F0024B507 /* sprite.c */; };
+		D4EC48CA1C2634870024B507 /* libjansson.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C51C2634870024B507 /* libjansson.dylib */; };
+		D4EC48CB1C2634870024B507 /* libSDL2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C61C2634870024B507 /* libSDL2.dylib */; };
+		D4EC48CC1C2634870024B507 /* libSDL2_ttf.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C71C2634870024B507 /* libSDL2_ttf.dylib */; };
+		D4EC48CD1C2634870024B507 /* libspeexdsp.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C81C2634870024B507 /* libspeexdsp.dylib */; };
+		D4EC48D01C2634C70024B507 /* libfreetype.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C41C2634870024B507 /* libfreetype.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4EC48D11C2634C70024B507 /* libjansson.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C51C2634870024B507 /* libjansson.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4EC48D21C2634C70024B507 /* libSDL2.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C61C2634870024B507 /* libSDL2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4EC48D31C2634C70024B507 /* libSDL2_ttf.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C71C2634870024B507 /* libSDL2_ttf.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4EC48D41C2634C70024B507 /* libspeexdsp.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC48C81C2634870024B507 /* libspeexdsp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D4EC48DF1C2634E90024B507 /* argparse.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC48D61C2634E90024B507 /* argparse.c */; };
+		D4EC48E01C2634E90024B507 /* CuTest.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC48D91C2634E90024B507 /* CuTest.c */; };
+		D4EC48E21C2634E90024B507 /* lodepng.c in Sources */ = {isa = PBXBuildFile; fileRef = D4EC48DD1C2634E90024B507 /* lodepng.c */; };
+		D4EC48E61C2637710024B507 /* g2.dat in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E31C2637710024B507 /* g2.dat */; };
+		D4EC48E71C2637710024B507 /* language in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E41C2637710024B507 /* language */; };
+		D4EC48E81C2637710024B507 /* title in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* title */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D41B74201C210B190080A7B9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D4EC48D01C2634C70024B507 /* libfreetype.dylib in Embed Frameworks */,
+				D4EC48D11C2634C70024B507 /* libjansson.dylib in Embed Frameworks */,
+				D4EC48D21C2634C70024B507 /* libSDL2.dylib in Embed Frameworks */,
+				D4EC48D31C2634C70024B507 /* libSDL2_ttf.dylib in Embed Frameworks */,
+				D4EC48D41C2634C70024B507 /* libspeexdsp.dylib in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		D41B73EE1C2101890080A7B9 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
+		D41B73F01C21018C0080A7B9 /* libssl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libssl.tbd; path = usr/lib/libssl.tbd; sourceTree = SDKROOT; };
+		D41B741C1C210A7A0080A7B9 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
+		D41B74721C2125E50080A7B9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = distribution/osx/Assets.xcassets; sourceTree = SOURCE_ROOT; };
+		D4895D321C23EFDD000CD788 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = distribution/osx/Info.plist; sourceTree = SOURCE_ROOT; };
+		D497D0781C20FD52002BF46A /* OpenRCT2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenRCT2.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4EC46D61C26342F0024B507 /* addresses.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = addresses.c; path = src/addresses.c; sourceTree = "<group>"; };
+		D4EC46D71C26342F0024B507 /* addresses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = addresses.h; path = src/addresses.h; sourceTree = "<group>"; };
+		D4EC46D91C26342F0024B507 /* audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = audio.c; sourceTree = "<group>"; };
+		D4EC46DA1C26342F0024B507 /* audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio.h; sourceTree = "<group>"; };
+		D4EC46DB1C26342F0024B507 /* mixer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mixer.cpp; sourceTree = "<group>"; };
+		D4EC46DC1C26342F0024B507 /* mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mixer.h; sourceTree = "<group>"; };
+		D4EC46DD1C26342F0024B507 /* cheats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cheats.c; path = src/cheats.c; sourceTree = "<group>"; };
+		D4EC46DE1C26342F0024B507 /* cheats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cheats.h; path = src/cheats.h; sourceTree = "<group>"; };
+		D4EC46DF1C26342F0024B507 /* cmdline_sprite.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cmdline_sprite.c; path = src/cmdline_sprite.c; sourceTree = "<group>"; };
+		D4EC46E01C26342F0024B507 /* cmdline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cmdline.c; path = src/cmdline.c; sourceTree = "<group>"; };
+		D4EC46E11C26342F0024B507 /* cmdline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cmdline.h; path = src/cmdline.h; sourceTree = "<group>"; };
+		D4EC46E21C26342F0024B507 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = src/common.h; sourceTree = "<group>"; };
+		D4EC46E31C26342F0024B507 /* config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = config.c; path = src/config.c; sourceTree = "<group>"; };
+		D4EC46E41C26342F0024B507 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = config.h; path = src/config.h; sourceTree = "<group>"; };
+		D4EC46E61C26342F0024B507 /* Exception.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Exception.hpp; sourceTree = "<group>"; };
+		D4EC46E71C26342F0024B507 /* FileStream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = FileStream.hpp; sourceTree = "<group>"; };
+		D4EC46E81C26342F0024B507 /* IDisposable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = IDisposable.hpp; sourceTree = "<group>"; };
+		D4EC46E91C26342F0024B507 /* IStream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = IStream.hpp; sourceTree = "<group>"; };
+		D4EC46EA1C26342F0024B507 /* Math.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Math.hpp; sourceTree = "<group>"; };
+		D4EC46EB1C26342F0024B507 /* Memory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Memory.hpp; sourceTree = "<group>"; };
+		D4EC46EC1C26342F0024B507 /* StringBuilder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = StringBuilder.hpp; sourceTree = "<group>"; };
+		D4EC46ED1C26342F0024B507 /* StringReader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = StringReader.hpp; sourceTree = "<group>"; };
+		D4EC46EE1C26342F0024B507 /* Util.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Util.hpp; sourceTree = "<group>"; };
+		D4EC46EF1C26342F0024B507 /* cursors.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cursors.c; path = src/cursors.c; sourceTree = "<group>"; };
+		D4EC46F01C26342F0024B507 /* cursors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cursors.h; path = src/cursors.h; sourceTree = "<group>"; };
+		D4EC46F11C26342F0024B507 /* diagnostic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = diagnostic.c; path = src/diagnostic.c; sourceTree = "<group>"; };
+		D4EC46F21C26342F0024B507 /* diagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = diagnostic.h; path = src/diagnostic.h; sourceTree = "<group>"; };
+		D4EC46F41C26342F0024B507 /* drawing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = drawing.c; sourceTree = "<group>"; };
+		D4EC46F51C26342F0024B507 /* drawing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = drawing.h; sourceTree = "<group>"; };
+		D4EC46F61C26342F0024B507 /* font.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = font.c; sourceTree = "<group>"; };
+		D4EC46F71C26342F0024B507 /* font.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = font.h; sourceTree = "<group>"; };
+		D4EC46F81C26342F0024B507 /* line.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = line.c; sourceTree = "<group>"; };
+		D4EC46F91C26342F0024B507 /* rain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rain.c; sourceTree = "<group>"; };
+		D4EC46FA1C26342F0024B507 /* rect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rect.c; sourceTree = "<group>"; };
+		D4EC46FB1C26342F0024B507 /* scrolling_text.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scrolling_text.c; sourceTree = "<group>"; };
+		D4EC46FC1C26342F0024B507 /* sprite.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sprite.c; sourceTree = "<group>"; };
+		D4EC46FD1C26342F0024B507 /* string.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = string.c; sourceTree = "<group>"; };
+		D4EC46FE1C26342F0024B507 /* supports.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = supports.c; sourceTree = "<group>"; };
+		D4EC46FF1C26342F0024B507 /* supports.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = supports.h; sourceTree = "<group>"; };
+		D4EC47001C26342F0024B507 /* editor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = editor.c; path = src/editor.c; sourceTree = "<group>"; };
+		D4EC47011C26342F0024B507 /* editor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = editor.h; path = src/editor.h; sourceTree = "<group>"; };
+		D4EC47021C26342F0024B507 /* game.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = game.c; path = src/game.c; sourceTree = "<group>"; };
+		D4EC47031C26342F0024B507 /* game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = game.h; path = src/game.h; sourceTree = "<group>"; };
+		D4EC47041C26342F0024B507 /* hook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hook.c; path = src/hook.c; sourceTree = "<group>"; };
+		D4EC47051C26342F0024B507 /* hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hook.h; path = src/hook.h; sourceTree = "<group>"; };
+		D4EC47061C26342F0024B507 /* input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = input.c; path = src/input.c; sourceTree = "<group>"; };
+		D4EC47071C26342F0024B507 /* input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = input.h; path = src/input.h; sourceTree = "<group>"; };
+		D4EC47091C26342F0024B507 /* chat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chat.c; sourceTree = "<group>"; };
+		D4EC470A1C26342F0024B507 /* chat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chat.h; sourceTree = "<group>"; };
+		D4EC470B1C26342F0024B507 /* colour.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = colour.c; sourceTree = "<group>"; };
+		D4EC470C1C26342F0024B507 /* colour.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = colour.h; sourceTree = "<group>"; };
+		D4EC470D1C26342F0024B507 /* console.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = console.c; sourceTree = "<group>"; };
+		D4EC470E1C26342F0024B507 /* console.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = console.h; sourceTree = "<group>"; };
+		D4EC470F1C26342F0024B507 /* graph.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = graph.c; sourceTree = "<group>"; };
+		D4EC47101C26342F0024B507 /* graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph.h; sourceTree = "<group>"; };
+		D4EC47111C26342F0024B507 /* keyboard_shortcut.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = keyboard_shortcut.c; sourceTree = "<group>"; };
+		D4EC47121C26342F0024B507 /* keyboard_shortcut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keyboard_shortcut.h; sourceTree = "<group>"; };
+		D4EC47131C26342F0024B507 /* screenshot.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = screenshot.c; sourceTree = "<group>"; };
+		D4EC47141C26342F0024B507 /* screenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = screenshot.h; sourceTree = "<group>"; };
+		D4EC47151C26342F0024B507 /* themes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = themes.c; sourceTree = "<group>"; };
+		D4EC47161C26342F0024B507 /* themes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = themes.h; sourceTree = "<group>"; };
+		D4EC47171C26342F0024B507 /* title_sequences.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_sequences.c; sourceTree = "<group>"; };
+		D4EC47181C26342F0024B507 /* title_sequences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = title_sequences.h; sourceTree = "<group>"; };
+		D4EC47191C26342F0024B507 /* viewport.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = viewport.c; sourceTree = "<group>"; };
+		D4EC471A1C26342F0024B507 /* viewport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewport.h; sourceTree = "<group>"; };
+		D4EC471B1C26342F0024B507 /* viewport_interaction.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = viewport_interaction.c; sourceTree = "<group>"; };
+		D4EC471C1C26342F0024B507 /* widget.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = widget.c; sourceTree = "<group>"; };
+		D4EC471D1C26342F0024B507 /* widget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = widget.h; sourceTree = "<group>"; };
+		D4EC471E1C26342F0024B507 /* window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = window.c; sourceTree = "<group>"; };
+		D4EC471F1C26342F0024B507 /* window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = window.h; sourceTree = "<group>"; };
+		D4EC47201C26342F0024B507 /* intro.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = intro.c; path = src/intro.c; sourceTree = "<group>"; };
+		D4EC47211C26342F0024B507 /* intro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = intro.h; path = src/intro.h; sourceTree = "<group>"; };
+		D4EC47231C26342F0024B507 /* convert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = convert.c; sourceTree = "<group>"; };
+		D4EC47241C26342F0024B507 /* currency.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = currency.c; sourceTree = "<group>"; };
+		D4EC47251C26342F0024B507 /* currency.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = currency.h; sourceTree = "<group>"; };
+		D4EC47261C26342F0024B507 /* date.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = date.c; sourceTree = "<group>"; };
+		D4EC47271C26342F0024B507 /* date.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = date.h; sourceTree = "<group>"; };
+		D4EC47281C26342F0024B507 /* format_codes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = format_codes.h; sourceTree = "<group>"; };
+		D4EC47291C26342F0024B507 /* language.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = language.cpp; sourceTree = "<group>"; };
+		D4EC472A1C26342F0024B507 /* language.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = language.h; sourceTree = "<group>"; };
+		D4EC472B1C26342F0024B507 /* LanguagePack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LanguagePack.cpp; sourceTree = "<group>"; };
+		D4EC472C1C26342F0024B507 /* LanguagePack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LanguagePack.h; sourceTree = "<group>"; };
+		D4EC472D1C26342F0024B507 /* localisation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = localisation.c; sourceTree = "<group>"; };
+		D4EC472E1C26342F0024B507 /* localisation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = localisation.h; sourceTree = "<group>"; };
+		D4EC472F1C26342F0024B507 /* real_names.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = real_names.c; sourceTree = "<group>"; };
+		D4EC47301C26342F0024B507 /* string_ids.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_ids.h; sourceTree = "<group>"; };
+		D4EC47311C26342F0024B507 /* user.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = user.c; sourceTree = "<group>"; };
+		D4EC47321C26342F0024B507 /* user.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = user.h; sourceTree = "<group>"; };
+		D4EC47331C26342F0024B507 /* utf8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf8.c; sourceTree = "<group>"; };
+		D4EC47351C26342F0024B507 /* award.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = award.c; sourceTree = "<group>"; };
+		D4EC47361C26342F0024B507 /* award.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = award.h; sourceTree = "<group>"; };
+		D4EC47371C26342F0024B507 /* finance.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = finance.c; sourceTree = "<group>"; };
+		D4EC47381C26342F0024B507 /* finance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = finance.h; sourceTree = "<group>"; };
+		D4EC47391C26342F0024B507 /* marketing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = marketing.c; sourceTree = "<group>"; };
+		D4EC473A1C26342F0024B507 /* marketing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = marketing.h; sourceTree = "<group>"; };
+		D4EC473B1C26342F0024B507 /* news_item.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = news_item.c; sourceTree = "<group>"; };
+		D4EC473C1C26342F0024B507 /* news_item.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = news_item.h; sourceTree = "<group>"; };
+		D4EC473D1C26342F0024B507 /* research.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = research.c; sourceTree = "<group>"; };
+		D4EC473E1C26342F0024B507 /* research.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = research.h; sourceTree = "<group>"; };
+		D4EC47401C26342F0024B507 /* http.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = http.cpp; sourceTree = "<group>"; };
+		D4EC47411C26342F0024B507 /* http.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http.h; sourceTree = "<group>"; };
+		D4EC47421C26342F0024B507 /* network.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network.cpp; sourceTree = "<group>"; };
+		D4EC47431C26342F0024B507 /* network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network.h; sourceTree = "<group>"; };
+		D4EC47441C26342F0024B507 /* twitch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = twitch.cpp; sourceTree = "<group>"; };
+		D4EC47451C26342F0024B507 /* twitch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = twitch.h; sourceTree = "<group>"; };
+		D4EC47461C26342F0024B507 /* object_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = object_list.c; path = src/object_list.c; sourceTree = "<group>"; };
+		D4EC47471C26342F0024B507 /* object.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = object.c; path = src/object.c; sourceTree = "<group>"; };
+		D4EC47481C26342F0024B507 /* object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = object.h; path = src/object.h; sourceTree = "<group>"; };
+		D4EC47491C26342F0024B507 /* openrct2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = openrct2.c; path = src/openrct2.c; sourceTree = "<group>"; };
+		D4EC474A1C26342F0024B507 /* openrct2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openrct2.h; path = src/openrct2.h; sourceTree = "<group>"; };
+		D4EC474C1C26342F0024B507 /* peep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = peep.c; sourceTree = "<group>"; };
+		D4EC474D1C26342F0024B507 /* peep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = peep.h; sourceTree = "<group>"; };
+		D4EC474E1C26342F0024B507 /* staff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = staff.c; sourceTree = "<group>"; };
+		D4EC474F1C26342F0024B507 /* staff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = staff.h; sourceTree = "<group>"; };
+		D4EC47511C26342F0024B507 /* linux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linux.c; sourceTree = "<group>"; };
+		D4EC47521C26342F0024B507 /* osx.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = osx.m; sourceTree = "<group>"; };
+		D4EC47531C26342F0024B507 /* platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform.h; sourceTree = "<group>"; };
+		D4EC47541C26342F0024B507 /* posix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = posix.c; sourceTree = "<group>"; };
+		D4EC47551C26342F0024B507 /* shared.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shared.c; sourceTree = "<group>"; };
+		D4EC47561C26342F0024B507 /* windows.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = windows.c; sourceTree = "<group>"; };
+		D4EC47571C26342F0024B507 /* rct1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rct1.c; path = src/rct1.c; sourceTree = "<group>"; };
+		D4EC47581C26342F0024B507 /* rct1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rct1.h; path = src/rct1.h; sourceTree = "<group>"; };
+		D4EC47591C26342F0024B507 /* rct2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rct2.c; path = src/rct2.c; sourceTree = "<group>"; };
+		D4EC475A1C26342F0024B507 /* rct2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rct2.h; path = src/rct2.h; sourceTree = "<group>"; };
+		D4EC475D1C26342F0024B507 /* ride.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride.c; sourceTree = "<group>"; };
+		D4EC475E1C26342F0024B507 /* ride.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ride.h; sourceTree = "<group>"; };
+		D4EC475F1C26342F0024B507 /* ride_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride_data.c; sourceTree = "<group>"; };
+		D4EC47601C26342F0024B507 /* ride_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ride_data.h; sourceTree = "<group>"; };
+		D4EC47611C26342F0024B507 /* ride_ratings.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride_ratings.c; sourceTree = "<group>"; };
+		D4EC47621C26342F0024B507 /* ride_ratings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ride_ratings.h; sourceTree = "<group>"; };
+		D4EC47631C26342F0024B507 /* station.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = station.c; sourceTree = "<group>"; };
+		D4EC47641C26342F0024B507 /* station.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = station.h; sourceTree = "<group>"; };
+		D4EC47651C26342F0024B507 /* track.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track.c; sourceTree = "<group>"; };
+		D4EC47661C26342F0024B507 /* track.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = track.h; sourceTree = "<group>"; };
+		D4EC47671C26342F0024B507 /* track_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track_data.c; sourceTree = "<group>"; };
+		D4EC47681C26342F0024B507 /* track_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = track_data.h; sourceTree = "<group>"; };
+		D4EC47691C26342F0024B507 /* track_paint.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track_paint.c; sourceTree = "<group>"; };
+		D4EC476A1C26342F0024B507 /* track_paint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = track_paint.h; sourceTree = "<group>"; };
+		D4EC476B1C26342F0024B507 /* vehicle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vehicle.c; sourceTree = "<group>"; };
+		D4EC476C1C26342F0024B507 /* vehicle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vehicle.h; sourceTree = "<group>"; };
+		D4EC476D1C26342F0024B507 /* scenario_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scenario_list.c; path = src/scenario_list.c; sourceTree = "<group>"; };
+		D4EC476E1C26342F0024B507 /* scenario.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scenario.c; path = src/scenario.c; sourceTree = "<group>"; };
+		D4EC476F1C26342F0024B507 /* scenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scenario.h; path = src/scenario.h; sourceTree = "<group>"; };
+		D4EC47701C26342F0024B507 /* sprites.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sprites.h; path = src/sprites.h; sourceTree = "<group>"; };
+		D4EC47711C26342F0024B507 /* title.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = title.c; path = src/title.c; sourceTree = "<group>"; };
+		D4EC47721C26342F0024B507 /* title.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = title.h; path = src/title.h; sourceTree = "<group>"; };
+		D4EC47731C26342F0024B507 /* tutorial.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tutorial.c; path = src/tutorial.c; sourceTree = "<group>"; };
+		D4EC47741C26342F0024B507 /* tutorial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tutorial.h; path = src/tutorial.h; sourceTree = "<group>"; };
+		D4EC47761C26342F0024B507 /* sawyercoding.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sawyercoding.c; sourceTree = "<group>"; };
+		D4EC47771C26342F0024B507 /* sawyercoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sawyercoding.h; sourceTree = "<group>"; };
+		D4EC47781C26342F0024B507 /* util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
+		D4EC47791C26342F0024B507 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
+		D4EC477B1C26342F0024B507 /* about.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = about.c; sourceTree = "<group>"; };
+		D4EC477C1C26342F0024B507 /* banner.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = banner.c; sourceTree = "<group>"; };
+		D4EC477D1C26342F0024B507 /* changelog.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = changelog.c; sourceTree = "<group>"; };
+		D4EC477E1C26342F0024B507 /* cheats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cheats.c; sourceTree = "<group>"; };
+		D4EC477F1C26342F0024B507 /* clear_scenery.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = clear_scenery.c; sourceTree = "<group>"; };
+		D4EC47801C26342F0024B507 /* demolish_ride_prompt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demolish_ride_prompt.c; sourceTree = "<group>"; };
+		D4EC47811C26342F0024B507 /* dropdown.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dropdown.c; sourceTree = "<group>"; };
+		D4EC47821C26342F0024B507 /* dropdown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropdown.h; sourceTree = "<group>"; };
+		D4EC47831C26342F0024B507 /* editor_bottom_toolbar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_bottom_toolbar.c; sourceTree = "<group>"; };
+		D4EC47841C26342F0024B507 /* editor_inventions_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_inventions_list.c; sourceTree = "<group>"; };
+		D4EC47851C26342F0024B507 /* editor_main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_main.c; sourceTree = "<group>"; };
+		D4EC47861C26342F0024B507 /* editor_object_selection.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_object_selection.c; sourceTree = "<group>"; };
+		D4EC47871C26342F0024B507 /* editor_objective_options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_objective_options.c; sourceTree = "<group>"; };
+		D4EC47881C26342F0024B507 /* editor_scenario_options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = editor_scenario_options.c; sourceTree = "<group>"; };
+		D4EC47891C26342F0024B507 /* error.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = error.c; sourceTree = "<group>"; };
+		D4EC478A1C26342F0024B507 /* error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
+		D4EC478B1C26342F0024B507 /* finances.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = finances.c; sourceTree = "<group>"; };
+		D4EC478C1C26342F0024B507 /* footpath.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = footpath.c; sourceTree = "<group>"; };
+		D4EC478D1C26342F0024B507 /* game_bottom_toolbar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = game_bottom_toolbar.c; sourceTree = "<group>"; };
+		D4EC478E1C26342F0024B507 /* guest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = guest.c; sourceTree = "<group>"; };
+		D4EC478F1C26342F0024B507 /* guest_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = guest_list.c; sourceTree = "<group>"; };
+		D4EC47901C26342F0024B507 /* install_track.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = install_track.c; sourceTree = "<group>"; };
+		D4EC47911C26342F0024B507 /* land.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = land.c; sourceTree = "<group>"; };
+		D4EC47921C26342F0024B507 /* land_rights.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = land_rights.c; sourceTree = "<group>"; };
+		D4EC47931C26342F0024B507 /* loadsave.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadsave.c; sourceTree = "<group>"; };
+		D4EC47941C26342F0024B507 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		D4EC47951C26342F0024B507 /* map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = map.c; sourceTree = "<group>"; };
+		D4EC47961C26342F0024B507 /* map_tooltip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = map_tooltip.c; sourceTree = "<group>"; };
+		D4EC47971C26342F0024B507 /* mapgen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mapgen.c; sourceTree = "<group>"; };
+		D4EC47981C26342F0024B507 /* maze_construction.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = maze_construction.c; sourceTree = "<group>"; };
+		D4EC47991C26342F0024B507 /* music_credits.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = music_credits.c; sourceTree = "<group>"; };
+		D4EC479A1C26342F0024B507 /* network_status.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = network_status.c; sourceTree = "<group>"; };
+		D4EC479B1C26342F0024B507 /* new_campaign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = new_campaign.c; sourceTree = "<group>"; };
+		D4EC479C1C26342F0024B507 /* new_ride.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = new_ride.c; sourceTree = "<group>"; };
+		D4EC479D1C26342F0024B507 /* news.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = news.c; sourceTree = "<group>"; };
+		D4EC479E1C26342F0024B507 /* options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = options.c; sourceTree = "<group>"; };
+		D4EC479F1C26342F0024B507 /* park.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = park.c; sourceTree = "<group>"; };
+		D4EC47A01C26342F0024B507 /* player_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = player_list.c; sourceTree = "<group>"; };
+		D4EC47A11C26342F0024B507 /* publisher_credits.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = publisher_credits.c; sourceTree = "<group>"; };
+		D4EC47A21C26342F0024B507 /* research.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = research.c; sourceTree = "<group>"; };
+		D4EC47A31C26342F0024B507 /* ride.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride.c; sourceTree = "<group>"; };
+		D4EC47A41C26342F0024B507 /* ride_construction.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride_construction.c; sourceTree = "<group>"; };
+		D4EC47A51C26342F0024B507 /* ride_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ride_list.c; sourceTree = "<group>"; };
+		D4EC47A61C26342F0024B507 /* save_prompt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = save_prompt.c; sourceTree = "<group>"; };
+		D4EC47A71C26342F0024B507 /* scenery.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scenery.c; sourceTree = "<group>"; };
+		D4EC47A81C26342F0024B507 /* server_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_list.c; sourceTree = "<group>"; };
+		D4EC47A91C26342F0024B507 /* server_start.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_start.c; sourceTree = "<group>"; };
+		D4EC47AA1C26342F0024B507 /* shortcut_key_change.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shortcut_key_change.c; sourceTree = "<group>"; };
+		D4EC47AB1C26342F0024B507 /* shortcut_keys.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shortcut_keys.c; sourceTree = "<group>"; };
+		D4EC47AC1C26342F0024B507 /* sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sign.c; sourceTree = "<group>"; };
+		D4EC47AD1C26342F0024B507 /* staff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = staff.c; sourceTree = "<group>"; };
+		D4EC47AE1C26342F0024B507 /* staff_fire_prompt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = staff_fire_prompt.c; sourceTree = "<group>"; };
+		D4EC47AF1C26342F0024B507 /* staff_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = staff_list.c; sourceTree = "<group>"; };
+		D4EC47B01C26342F0024B507 /* text_input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = text_input.c; sourceTree = "<group>"; };
+		D4EC47B11C26342F0024B507 /* themes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = themes.c; sourceTree = "<group>"; };
+		D4EC47B21C26342F0024B507 /* tile_inspector.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tile_inspector.c; sourceTree = "<group>"; };
+		D4EC47B31C26342F0024B507 /* title_command_editor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_command_editor.c; sourceTree = "<group>"; };
+		D4EC47B41C26342F0024B507 /* title_editor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_editor.c; sourceTree = "<group>"; };
+		D4EC47B51C26342F0024B507 /* title_exit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_exit.c; sourceTree = "<group>"; };
+		D4EC47B61C26342F0024B507 /* title_logo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_logo.c; sourceTree = "<group>"; };
+		D4EC47B71C26342F0024B507 /* title_menu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_menu.c; sourceTree = "<group>"; };
+		D4EC47B81C26342F0024B507 /* title_options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_options.c; sourceTree = "<group>"; };
+		D4EC47B91C26342F0024B507 /* title_scenarioselect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = title_scenarioselect.c; sourceTree = "<group>"; };
+		D4EC47BA1C26342F0024B507 /* tooltip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tooltip.c; sourceTree = "<group>"; };
+		D4EC47BB1C26342F0024B507 /* tooltip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tooltip.h; sourceTree = "<group>"; };
+		D4EC47BC1C26342F0024B507 /* top_toolbar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = top_toolbar.c; sourceTree = "<group>"; };
+		D4EC47BD1C26342F0024B507 /* track_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track_list.c; sourceTree = "<group>"; };
+		D4EC47BE1C26342F0024B507 /* track_manage.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track_manage.c; sourceTree = "<group>"; };
+		D4EC47BF1C26342F0024B507 /* track_place.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = track_place.c; sourceTree = "<group>"; };
+		D4EC47C01C26342F0024B507 /* viewport.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = viewport.c; sourceTree = "<group>"; };
+		D4EC47C11C26342F0024B507 /* water.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = water.c; sourceTree = "<group>"; };
+		D4EC47C31C26342F0024B507 /* balloon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = balloon.c; sourceTree = "<group>"; };
+		D4EC47C41C26342F0024B507 /* banner.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = banner.c; sourceTree = "<group>"; };
+		D4EC47C51C26342F0024B507 /* banner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = banner.h; sourceTree = "<group>"; };
+		D4EC47C61C26342F0024B507 /* climate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = climate.c; sourceTree = "<group>"; };
+		D4EC47C71C26342F0024B507 /* climate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = climate.h; sourceTree = "<group>"; };
+		D4EC47C81C26342F0024B507 /* duck.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = duck.c; sourceTree = "<group>"; };
+		D4EC47C91C26342F0024B507 /* entrance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = entrance.h; sourceTree = "<group>"; };
+		D4EC47CA1C26342F0024B507 /* footpath.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = footpath.c; sourceTree = "<group>"; };
+		D4EC47CB1C26342F0024B507 /* footpath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = footpath.h; sourceTree = "<group>"; };
+		D4EC47CC1C26342F0024B507 /* fountain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fountain.c; sourceTree = "<group>"; };
+		D4EC47CD1C26342F0024B507 /* fountain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fountain.h; sourceTree = "<group>"; };
+		D4EC47CE1C26342F0024B507 /* map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = map.c; sourceTree = "<group>"; };
+		D4EC47CF1C26342F0024B507 /* map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map.h; sourceTree = "<group>"; };
+		D4EC47D01C26342F0024B507 /* map_animation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = map_animation.c; sourceTree = "<group>"; };
+		D4EC47D11C26342F0024B507 /* map_animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map_animation.h; sourceTree = "<group>"; };
+		D4EC47D21C26342F0024B507 /* map_helpers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = map_helpers.c; sourceTree = "<group>"; };
+		D4EC47D31C26342F0024B507 /* map_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map_helpers.h; sourceTree = "<group>"; };
+		D4EC47D41C26342F0024B507 /* mapgen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mapgen.c; sourceTree = "<group>"; };
+		D4EC47D51C26342F0024B507 /* mapgen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mapgen.h; sourceTree = "<group>"; };
+		D4EC47D61C26342F0024B507 /* money_effect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = money_effect.c; sourceTree = "<group>"; };
+		D4EC47D71C26342F0024B507 /* park.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = park.c; sourceTree = "<group>"; };
+		D4EC47D81C26342F0024B507 /* park.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = park.h; sourceTree = "<group>"; };
+		D4EC47D91C26342F0024B507 /* particle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = particle.c; sourceTree = "<group>"; };
+		D4EC47DA1C26342F0024B507 /* scenery.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scenery.c; sourceTree = "<group>"; };
+		D4EC47DB1C26342F0024B507 /* scenery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scenery.h; sourceTree = "<group>"; };
+		D4EC47DC1C26342F0024B507 /* sprite.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sprite.c; sourceTree = "<group>"; };
+		D4EC47DD1C26342F0024B507 /* sprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sprite.h; sourceTree = "<group>"; };
+		D4EC47DE1C26342F0024B507 /* water.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = water.h; sourceTree = "<group>"; };
+		D4EC48821C2634870024B507 /* jansson.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jansson.h; sourceTree = "<group>"; };
+		D4EC48831C2634870024B507 /* jansson_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jansson_config.h; sourceTree = "<group>"; };
+		D4EC48851C2634870024B507 /* begin_code.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = begin_code.h; sourceTree = "<group>"; };
+		D4EC48861C2634870024B507 /* close_code.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = close_code.h; sourceTree = "<group>"; };
+		D4EC48871C2634870024B507 /* SDL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL.h; sourceTree = "<group>"; };
+		D4EC48881C2634870024B507 /* SDL_assert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_assert.h; sourceTree = "<group>"; };
+		D4EC48891C2634870024B507 /* SDL_atomic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_atomic.h; sourceTree = "<group>"; };
+		D4EC488A1C2634870024B507 /* SDL_audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_audio.h; sourceTree = "<group>"; };
+		D4EC488B1C2634870024B507 /* SDL_bits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_bits.h; sourceTree = "<group>"; };
+		D4EC488C1C2634870024B507 /* SDL_blendmode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_blendmode.h; sourceTree = "<group>"; };
+		D4EC488D1C2634870024B507 /* SDL_clipboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_clipboard.h; sourceTree = "<group>"; };
+		D4EC488E1C2634870024B507 /* SDL_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_config.h; sourceTree = "<group>"; };
+		D4EC488F1C2634870024B507 /* SDL_config_macosx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_config_macosx.h; sourceTree = "<group>"; };
+		D4EC48901C2634870024B507 /* SDL_copying.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_copying.h; sourceTree = "<group>"; };
+		D4EC48911C2634870024B507 /* SDL_cpuinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_cpuinfo.h; sourceTree = "<group>"; };
+		D4EC48921C2634870024B507 /* SDL_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_endian.h; sourceTree = "<group>"; };
+		D4EC48931C2634870024B507 /* SDL_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_error.h; sourceTree = "<group>"; };
+		D4EC48941C2634870024B507 /* SDL_events.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_events.h; sourceTree = "<group>"; };
+		D4EC48951C2634870024B507 /* SDL_filesystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_filesystem.h; sourceTree = "<group>"; };
+		D4EC48961C2634870024B507 /* SDL_gamecontroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_gamecontroller.h; sourceTree = "<group>"; };
+		D4EC48971C2634870024B507 /* SDL_gesture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_gesture.h; sourceTree = "<group>"; };
+		D4EC48981C2634870024B507 /* SDL_haptic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_haptic.h; sourceTree = "<group>"; };
+		D4EC48991C2634870024B507 /* SDL_hints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_hints.h; sourceTree = "<group>"; };
+		D4EC489A1C2634870024B507 /* SDL_joystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_joystick.h; sourceTree = "<group>"; };
+		D4EC489B1C2634870024B507 /* SDL_keyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_keyboard.h; sourceTree = "<group>"; };
+		D4EC489C1C2634870024B507 /* SDL_keycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_keycode.h; sourceTree = "<group>"; };
+		D4EC489D1C2634870024B507 /* SDL_loadso.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_loadso.h; sourceTree = "<group>"; };
+		D4EC489E1C2634870024B507 /* SDL_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_log.h; sourceTree = "<group>"; };
+		D4EC489F1C2634870024B507 /* SDL_main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_main.h; sourceTree = "<group>"; };
+		D4EC48A01C2634870024B507 /* SDL_messagebox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_messagebox.h; sourceTree = "<group>"; };
+		D4EC48A11C2634870024B507 /* SDL_mouse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_mouse.h; sourceTree = "<group>"; };
+		D4EC48A21C2634870024B507 /* SDL_mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_mutex.h; sourceTree = "<group>"; };
+		D4EC48A31C2634870024B507 /* SDL_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_name.h; sourceTree = "<group>"; };
+		D4EC48A41C2634870024B507 /* SDL_opengl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_opengl.h; sourceTree = "<group>"; };
+		D4EC48A51C2634870024B507 /* SDL_opengles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_opengles.h; sourceTree = "<group>"; };
+		D4EC48A61C2634870024B507 /* SDL_opengles2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_opengles2.h; sourceTree = "<group>"; };
+		D4EC48A71C2634870024B507 /* SDL_pixels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_pixels.h; sourceTree = "<group>"; };
+		D4EC48A81C2634870024B507 /* SDL_platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_platform.h; sourceTree = "<group>"; };
+		D4EC48A91C2634870024B507 /* SDL_power.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_power.h; sourceTree = "<group>"; };
+		D4EC48AA1C2634870024B507 /* SDL_quit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_quit.h; sourceTree = "<group>"; };
+		D4EC48AB1C2634870024B507 /* SDL_rect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_rect.h; sourceTree = "<group>"; };
+		D4EC48AC1C2634870024B507 /* SDL_render.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_render.h; sourceTree = "<group>"; };
+		D4EC48AD1C2634870024B507 /* SDL_revision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_revision.h; sourceTree = "<group>"; };
+		D4EC48AE1C2634870024B507 /* SDL_rwops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_rwops.h; sourceTree = "<group>"; };
+		D4EC48AF1C2634870024B507 /* SDL_scancode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_scancode.h; sourceTree = "<group>"; };
+		D4EC48B01C2634870024B507 /* SDL_shape.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_shape.h; sourceTree = "<group>"; };
+		D4EC48B11C2634870024B507 /* SDL_stdinc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_stdinc.h; sourceTree = "<group>"; };
+		D4EC48B21C2634870024B507 /* SDL_surface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_surface.h; sourceTree = "<group>"; };
+		D4EC48B31C2634870024B507 /* SDL_system.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_system.h; sourceTree = "<group>"; };
+		D4EC48B41C2634870024B507 /* SDL_syswm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_syswm.h; sourceTree = "<group>"; };
+		D4EC48B51C2634870024B507 /* SDL_thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_thread.h; sourceTree = "<group>"; };
+		D4EC48B61C2634870024B507 /* SDL_timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_timer.h; sourceTree = "<group>"; };
+		D4EC48B71C2634870024B507 /* SDL_touch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_touch.h; sourceTree = "<group>"; };
+		D4EC48B81C2634870024B507 /* SDL_ttf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_ttf.h; sourceTree = "<group>"; };
+		D4EC48B91C2634870024B507 /* SDL_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_types.h; sourceTree = "<group>"; };
+		D4EC48BA1C2634870024B507 /* SDL_version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_version.h; sourceTree = "<group>"; };
+		D4EC48BB1C2634870024B507 /* SDL_video.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_video.h; sourceTree = "<group>"; };
+		D4EC48BD1C2634870024B507 /* speex_echo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_echo.h; sourceTree = "<group>"; };
+		D4EC48BE1C2634870024B507 /* speex_jitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_jitter.h; sourceTree = "<group>"; };
+		D4EC48BF1C2634870024B507 /* speex_preprocess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_preprocess.h; sourceTree = "<group>"; };
+		D4EC48C01C2634870024B507 /* speex_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_resampler.h; sourceTree = "<group>"; };
+		D4EC48C11C2634870024B507 /* speexdsp_config_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speexdsp_config_types.h; sourceTree = "<group>"; };
+		D4EC48C21C2634870024B507 /* speexdsp_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speexdsp_types.h; sourceTree = "<group>"; };
+		D4EC48C41C2634870024B507 /* libfreetype.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreetype.dylib; sourceTree = "<group>"; };
+		D4EC48C51C2634870024B507 /* libjansson.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libjansson.dylib; sourceTree = "<group>"; };
+		D4EC48C61C2634870024B507 /* libSDL2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libSDL2.dylib; sourceTree = "<group>"; };
+		D4EC48C71C2634870024B507 /* libSDL2_ttf.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libSDL2_ttf.dylib; sourceTree = "<group>"; };
+		D4EC48C81C2634870024B507 /* libspeexdsp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libspeexdsp.dylib; sourceTree = "<group>"; };
+		D4EC48D61C2634E90024B507 /* argparse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argparse.c; sourceTree = "<group>"; };
+		D4EC48D71C2634E90024B507 /* argparse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = argparse.h; sourceTree = "<group>"; };
+		D4EC48D91C2634E90024B507 /* CuTest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CuTest.c; sourceTree = "<group>"; };
+		D4EC48DA1C2634E90024B507 /* CuTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CuTest.h; sourceTree = "<group>"; };
+		D4EC48DB1C2634E90024B507 /* license.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = license.txt; sourceTree = "<group>"; };
+		D4EC48DD1C2634E90024B507 /* lodepng.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lodepng.c; sourceTree = "<group>"; };
+		D4EC48DE1C2634E90024B507 /* lodepng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lodepng.h; sourceTree = "<group>"; };
+		D4EC48E31C2637710024B507 /* g2.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = g2.dat; path = data/g2.dat; sourceTree = SOURCE_ROOT; };
+		D4EC48E41C2637710024B507 /* language */ = {isa = PBXFileReference; lastKnownFileType = folder; name = language; path = data/language; sourceTree = SOURCE_ROOT; };
+		D4EC48E51C2637710024B507 /* title */ = {isa = PBXFileReference; lastKnownFileType = folder; name = title; path = data/title; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D497D0751C20FD52002BF46A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D41B73EF1C2101890080A7B9 /* libcurl.tbd in Frameworks */,
+				D41B741D1C210A7A0080A7B9 /* libiconv.tbd in Frameworks */,
+				D4EC48CA1C2634870024B507 /* libjansson.dylib in Frameworks */,
+				D4EC48CB1C2634870024B507 /* libSDL2.dylib in Frameworks */,
+				D4EC48CC1C2634870024B507 /* libSDL2_ttf.dylib in Frameworks */,
+				D4EC48CD1C2634870024B507 /* libspeexdsp.dylib in Frameworks */,
+				D41B73F11C21018C0080A7B9 /* libssl.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D41B72431C21015A0080A7B9 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC46D81C26342F0024B507 /* audio */,
+				D4EC46E51C26342F0024B507 /* core */,
+				D4EC46F31C26342F0024B507 /* drawing */,
+				D4EC47081C26342F0024B507 /* interface */,
+				D4EC47221C26342F0024B507 /* localisation */,
+				D4EC47341C26342F0024B507 /* management */,
+				D4EC473F1C26342F0024B507 /* network */,
+				D4EC474B1C26342F0024B507 /* peep */,
+				D4EC47501C26342F0024B507 /* platform */,
+				D4EC475C1C26342F0024B507 /* ride */,
+				D4EC47751C26342F0024B507 /* util */,
+				D4EC477A1C26342F0024B507 /* windows */,
+				D4EC47C21C26342F0024B507 /* world */,
+				D4EC46D61C26342F0024B507 /* addresses.c */,
+				D4EC46D71C26342F0024B507 /* addresses.h */,
+				D4EC46DD1C26342F0024B507 /* cheats.c */,
+				D4EC46DE1C26342F0024B507 /* cheats.h */,
+				D4EC46DF1C26342F0024B507 /* cmdline_sprite.c */,
+				D4EC46E01C26342F0024B507 /* cmdline.c */,
+				D4EC46E11C26342F0024B507 /* cmdline.h */,
+				D4EC46E21C26342F0024B507 /* common.h */,
+				D4EC46E31C26342F0024B507 /* config.c */,
+				D4EC46E41C26342F0024B507 /* config.h */,
+				D4EC46EF1C26342F0024B507 /* cursors.c */,
+				D4EC46F01C26342F0024B507 /* cursors.h */,
+				D4EC46F11C26342F0024B507 /* diagnostic.c */,
+				D4EC46F21C26342F0024B507 /* diagnostic.h */,
+				D4EC47001C26342F0024B507 /* editor.c */,
+				D4EC47011C26342F0024B507 /* editor.h */,
+				D4EC47021C26342F0024B507 /* game.c */,
+				D4EC47031C26342F0024B507 /* game.h */,
+				D4EC47041C26342F0024B507 /* hook.c */,
+				D4EC47051C26342F0024B507 /* hook.h */,
+				D4EC47061C26342F0024B507 /* input.c */,
+				D4EC47071C26342F0024B507 /* input.h */,
+				D4EC47201C26342F0024B507 /* intro.c */,
+				D4EC47211C26342F0024B507 /* intro.h */,
+				D4EC47461C26342F0024B507 /* object_list.c */,
+				D4EC47471C26342F0024B507 /* object.c */,
+				D4EC47481C26342F0024B507 /* object.h */,
+				D4EC47491C26342F0024B507 /* openrct2.c */,
+				D4EC474A1C26342F0024B507 /* openrct2.h */,
+				D4EC47571C26342F0024B507 /* rct1.c */,
+				D4EC47581C26342F0024B507 /* rct1.h */,
+				D4EC47591C26342F0024B507 /* rct2.c */,
+				D4EC475A1C26342F0024B507 /* rct2.h */,
+				D4EC476D1C26342F0024B507 /* scenario_list.c */,
+				D4EC476E1C26342F0024B507 /* scenario.c */,
+				D4EC476F1C26342F0024B507 /* scenario.h */,
+				D4EC47701C26342F0024B507 /* sprites.h */,
+				D4EC47711C26342F0024B507 /* title.c */,
+				D4EC47721C26342F0024B507 /* title.h */,
+				D4EC47731C26342F0024B507 /* tutorial.c */,
+				D4EC47741C26342F0024B507 /* tutorial.h */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		D41B73ED1C21017D0080A7B9 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48811C2634870024B507 /* include */,
+				D4EC48C31C2634870024B507 /* lib */,
+				D4EC48CE1C26348E0024B507 /* system */,
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		D41B740F1C2105B00080A7B9 /* Source Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48D51C2634E90024B507 /* argparse */,
+				D4EC48D81C2634E90024B507 /* cutest */,
+				D4EC48DC1C2634E90024B507 /* lodepng */,
+			);
+			name = "Source Libraries";
+			sourceTree = "<group>";
+		};
+		D497D06F1C20FD52002BF46A = {
+			isa = PBXGroup;
+			children = (
+				D41B72431C21015A0080A7B9 /* Sources */,
+				D497D07A1C20FD52002BF46A /* Resources */,
+				D41B73ED1C21017D0080A7B9 /* Libraries */,
+				D41B740F1C2105B00080A7B9 /* Source Libraries */,
+				D497D0791C20FD52002BF46A /* Products */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		D497D0791C20FD52002BF46A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D497D0781C20FD52002BF46A /* OpenRCT2.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D497D07A1C20FD52002BF46A /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				D41B74721C2125E50080A7B9 /* Assets.xcassets */,
+				D4895D321C23EFDD000CD788 /* Info.plist */,
+				D4C1EDD01C266A0B00F71B63 /* data */,
+			);
+			name = Resources;
+			path = OpenRCT2;
+			sourceTree = "<group>";
+		};
+		D4C1EDD01C266A0B00F71B63 /* data */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48E31C2637710024B507 /* g2.dat */,
+				D4EC48E41C2637710024B507 /* language */,
+				D4EC48E51C2637710024B507 /* title */,
+			);
+			name = data;
+			sourceTree = "<group>";
+		};
+		D4EC46D81C26342F0024B507 /* audio */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC46D91C26342F0024B507 /* audio.c */,
+				D4EC46DA1C26342F0024B507 /* audio.h */,
+				D4EC46DB1C26342F0024B507 /* mixer.cpp */,
+				D4EC46DC1C26342F0024B507 /* mixer.h */,
+			);
+			name = audio;
+			path = src/audio;
+			sourceTree = "<group>";
+		};
+		D4EC46E51C26342F0024B507 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC46E61C26342F0024B507 /* Exception.hpp */,
+				D4EC46E71C26342F0024B507 /* FileStream.hpp */,
+				D4EC46E81C26342F0024B507 /* IDisposable.hpp */,
+				D4EC46E91C26342F0024B507 /* IStream.hpp */,
+				D4EC46EA1C26342F0024B507 /* Math.hpp */,
+				D4EC46EB1C26342F0024B507 /* Memory.hpp */,
+				D4EC46EC1C26342F0024B507 /* StringBuilder.hpp */,
+				D4EC46ED1C26342F0024B507 /* StringReader.hpp */,
+				D4EC46EE1C26342F0024B507 /* Util.hpp */,
+			);
+			name = core;
+			path = src/core;
+			sourceTree = "<group>";
+		};
+		D4EC46F31C26342F0024B507 /* drawing */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC46F41C26342F0024B507 /* drawing.c */,
+				D4EC46F51C26342F0024B507 /* drawing.h */,
+				D4EC46F61C26342F0024B507 /* font.c */,
+				D4EC46F71C26342F0024B507 /* font.h */,
+				D4EC46F81C26342F0024B507 /* line.c */,
+				D4EC46F91C26342F0024B507 /* rain.c */,
+				D4EC46FA1C26342F0024B507 /* rect.c */,
+				D4EC46FB1C26342F0024B507 /* scrolling_text.c */,
+				D4EC46FC1C26342F0024B507 /* sprite.c */,
+				D4EC46FD1C26342F0024B507 /* string.c */,
+				D4EC46FE1C26342F0024B507 /* supports.c */,
+				D4EC46FF1C26342F0024B507 /* supports.h */,
+			);
+			name = drawing;
+			path = src/drawing;
+			sourceTree = "<group>";
+		};
+		D4EC47081C26342F0024B507 /* interface */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47091C26342F0024B507 /* chat.c */,
+				D4EC470A1C26342F0024B507 /* chat.h */,
+				D4EC470B1C26342F0024B507 /* colour.c */,
+				D4EC470C1C26342F0024B507 /* colour.h */,
+				D4EC470D1C26342F0024B507 /* console.c */,
+				D4EC470E1C26342F0024B507 /* console.h */,
+				D4EC470F1C26342F0024B507 /* graph.c */,
+				D4EC47101C26342F0024B507 /* graph.h */,
+				D4EC47111C26342F0024B507 /* keyboard_shortcut.c */,
+				D4EC47121C26342F0024B507 /* keyboard_shortcut.h */,
+				D4EC47131C26342F0024B507 /* screenshot.c */,
+				D4EC47141C26342F0024B507 /* screenshot.h */,
+				D4EC47151C26342F0024B507 /* themes.c */,
+				D4EC47161C26342F0024B507 /* themes.h */,
+				D4EC47171C26342F0024B507 /* title_sequences.c */,
+				D4EC47181C26342F0024B507 /* title_sequences.h */,
+				D4EC47191C26342F0024B507 /* viewport.c */,
+				D4EC471A1C26342F0024B507 /* viewport.h */,
+				D4EC471B1C26342F0024B507 /* viewport_interaction.c */,
+				D4EC471C1C26342F0024B507 /* widget.c */,
+				D4EC471D1C26342F0024B507 /* widget.h */,
+				D4EC471E1C26342F0024B507 /* window.c */,
+				D4EC471F1C26342F0024B507 /* window.h */,
+			);
+			name = interface;
+			path = src/interface;
+			sourceTree = "<group>";
+		};
+		D4EC47221C26342F0024B507 /* localisation */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47231C26342F0024B507 /* convert.c */,
+				D4EC47241C26342F0024B507 /* currency.c */,
+				D4EC47251C26342F0024B507 /* currency.h */,
+				D4EC47261C26342F0024B507 /* date.c */,
+				D4EC47271C26342F0024B507 /* date.h */,
+				D4EC47281C26342F0024B507 /* format_codes.h */,
+				D4EC47291C26342F0024B507 /* language.cpp */,
+				D4EC472A1C26342F0024B507 /* language.h */,
+				D4EC472B1C26342F0024B507 /* LanguagePack.cpp */,
+				D4EC472C1C26342F0024B507 /* LanguagePack.h */,
+				D4EC472D1C26342F0024B507 /* localisation.c */,
+				D4EC472E1C26342F0024B507 /* localisation.h */,
+				D4EC472F1C26342F0024B507 /* real_names.c */,
+				D4EC47301C26342F0024B507 /* string_ids.h */,
+				D4EC47311C26342F0024B507 /* user.c */,
+				D4EC47321C26342F0024B507 /* user.h */,
+				D4EC47331C26342F0024B507 /* utf8.c */,
+			);
+			name = localisation;
+			path = src/localisation;
+			sourceTree = "<group>";
+		};
+		D4EC47341C26342F0024B507 /* management */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47351C26342F0024B507 /* award.c */,
+				D4EC47361C26342F0024B507 /* award.h */,
+				D4EC47371C26342F0024B507 /* finance.c */,
+				D4EC47381C26342F0024B507 /* finance.h */,
+				D4EC47391C26342F0024B507 /* marketing.c */,
+				D4EC473A1C26342F0024B507 /* marketing.h */,
+				D4EC473B1C26342F0024B507 /* news_item.c */,
+				D4EC473C1C26342F0024B507 /* news_item.h */,
+				D4EC473D1C26342F0024B507 /* research.c */,
+				D4EC473E1C26342F0024B507 /* research.h */,
+			);
+			name = management;
+			path = src/management;
+			sourceTree = "<group>";
+		};
+		D4EC473F1C26342F0024B507 /* network */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47401C26342F0024B507 /* http.cpp */,
+				D4EC47411C26342F0024B507 /* http.h */,
+				D4EC47421C26342F0024B507 /* network.cpp */,
+				D4EC47431C26342F0024B507 /* network.h */,
+				D4EC47441C26342F0024B507 /* twitch.cpp */,
+				D4EC47451C26342F0024B507 /* twitch.h */,
+			);
+			name = network;
+			path = src/network;
+			sourceTree = "<group>";
+		};
+		D4EC474B1C26342F0024B507 /* peep */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC474C1C26342F0024B507 /* peep.c */,
+				D4EC474D1C26342F0024B507 /* peep.h */,
+				D4EC474E1C26342F0024B507 /* staff.c */,
+				D4EC474F1C26342F0024B507 /* staff.h */,
+			);
+			name = peep;
+			path = src/peep;
+			sourceTree = "<group>";
+		};
+		D4EC47501C26342F0024B507 /* platform */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47511C26342F0024B507 /* linux.c */,
+				D4EC47521C26342F0024B507 /* osx.m */,
+				D4EC47531C26342F0024B507 /* platform.h */,
+				D4EC47541C26342F0024B507 /* posix.c */,
+				D4EC47551C26342F0024B507 /* shared.c */,
+				D4EC47561C26342F0024B507 /* windows.c */,
+			);
+			name = platform;
+			path = src/platform;
+			sourceTree = "<group>";
+		};
+		D4EC475C1C26342F0024B507 /* ride */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC475D1C26342F0024B507 /* ride.c */,
+				D4EC475E1C26342F0024B507 /* ride.h */,
+				D4EC475F1C26342F0024B507 /* ride_data.c */,
+				D4EC47601C26342F0024B507 /* ride_data.h */,
+				D4EC47611C26342F0024B507 /* ride_ratings.c */,
+				D4EC47621C26342F0024B507 /* ride_ratings.h */,
+				D4EC47631C26342F0024B507 /* station.c */,
+				D4EC47641C26342F0024B507 /* station.h */,
+				D4EC47651C26342F0024B507 /* track.c */,
+				D4EC47661C26342F0024B507 /* track.h */,
+				D4EC47671C26342F0024B507 /* track_data.c */,
+				D4EC47681C26342F0024B507 /* track_data.h */,
+				D4EC47691C26342F0024B507 /* track_paint.c */,
+				D4EC476A1C26342F0024B507 /* track_paint.h */,
+				D4EC476B1C26342F0024B507 /* vehicle.c */,
+				D4EC476C1C26342F0024B507 /* vehicle.h */,
+			);
+			name = ride;
+			path = src/ride;
+			sourceTree = "<group>";
+		};
+		D4EC47751C26342F0024B507 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47761C26342F0024B507 /* sawyercoding.c */,
+				D4EC47771C26342F0024B507 /* sawyercoding.h */,
+				D4EC47781C26342F0024B507 /* util.c */,
+				D4EC47791C26342F0024B507 /* util.h */,
+			);
+			name = util;
+			path = src/util;
+			sourceTree = "<group>";
+		};
+		D4EC477A1C26342F0024B507 /* windows */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC477B1C26342F0024B507 /* about.c */,
+				D4EC477C1C26342F0024B507 /* banner.c */,
+				D4EC477D1C26342F0024B507 /* changelog.c */,
+				D4EC477E1C26342F0024B507 /* cheats.c */,
+				D4EC477F1C26342F0024B507 /* clear_scenery.c */,
+				D4EC47801C26342F0024B507 /* demolish_ride_prompt.c */,
+				D4EC47811C26342F0024B507 /* dropdown.c */,
+				D4EC47821C26342F0024B507 /* dropdown.h */,
+				D4EC47831C26342F0024B507 /* editor_bottom_toolbar.c */,
+				D4EC47841C26342F0024B507 /* editor_inventions_list.c */,
+				D4EC47851C26342F0024B507 /* editor_main.c */,
+				D4EC47861C26342F0024B507 /* editor_object_selection.c */,
+				D4EC47871C26342F0024B507 /* editor_objective_options.c */,
+				D4EC47881C26342F0024B507 /* editor_scenario_options.c */,
+				D4EC47891C26342F0024B507 /* error.c */,
+				D4EC478A1C26342F0024B507 /* error.h */,
+				D4EC478B1C26342F0024B507 /* finances.c */,
+				D4EC478C1C26342F0024B507 /* footpath.c */,
+				D4EC478D1C26342F0024B507 /* game_bottom_toolbar.c */,
+				D4EC478E1C26342F0024B507 /* guest.c */,
+				D4EC478F1C26342F0024B507 /* guest_list.c */,
+				D4EC47901C26342F0024B507 /* install_track.c */,
+				D4EC47911C26342F0024B507 /* land.c */,
+				D4EC47921C26342F0024B507 /* land_rights.c */,
+				D4EC47931C26342F0024B507 /* loadsave.c */,
+				D4EC47941C26342F0024B507 /* main.c */,
+				D4EC47951C26342F0024B507 /* map.c */,
+				D4EC47961C26342F0024B507 /* map_tooltip.c */,
+				D4EC47971C26342F0024B507 /* mapgen.c */,
+				D4EC47981C26342F0024B507 /* maze_construction.c */,
+				D4EC47991C26342F0024B507 /* music_credits.c */,
+				D4EC479A1C26342F0024B507 /* network_status.c */,
+				D4EC479B1C26342F0024B507 /* new_campaign.c */,
+				D4EC479C1C26342F0024B507 /* new_ride.c */,
+				D4EC479D1C26342F0024B507 /* news.c */,
+				D4EC479E1C26342F0024B507 /* options.c */,
+				D4EC479F1C26342F0024B507 /* park.c */,
+				D4EC47A01C26342F0024B507 /* player_list.c */,
+				D4EC47A11C26342F0024B507 /* publisher_credits.c */,
+				D4EC47A21C26342F0024B507 /* research.c */,
+				D4EC47A31C26342F0024B507 /* ride.c */,
+				D4EC47A41C26342F0024B507 /* ride_construction.c */,
+				D4EC47A51C26342F0024B507 /* ride_list.c */,
+				D4EC47A61C26342F0024B507 /* save_prompt.c */,
+				D4EC47A71C26342F0024B507 /* scenery.c */,
+				D4EC47A81C26342F0024B507 /* server_list.c */,
+				D4EC47A91C26342F0024B507 /* server_start.c */,
+				D4EC47AA1C26342F0024B507 /* shortcut_key_change.c */,
+				D4EC47AB1C26342F0024B507 /* shortcut_keys.c */,
+				D4EC47AC1C26342F0024B507 /* sign.c */,
+				D4EC47AD1C26342F0024B507 /* staff.c */,
+				D4EC47AE1C26342F0024B507 /* staff_fire_prompt.c */,
+				D4EC47AF1C26342F0024B507 /* staff_list.c */,
+				D4EC47B01C26342F0024B507 /* text_input.c */,
+				D4EC47B11C26342F0024B507 /* themes.c */,
+				D4EC47B21C26342F0024B507 /* tile_inspector.c */,
+				D4EC47B31C26342F0024B507 /* title_command_editor.c */,
+				D4EC47B41C26342F0024B507 /* title_editor.c */,
+				D4EC47B51C26342F0024B507 /* title_exit.c */,
+				D4EC47B61C26342F0024B507 /* title_logo.c */,
+				D4EC47B71C26342F0024B507 /* title_menu.c */,
+				D4EC47B81C26342F0024B507 /* title_options.c */,
+				D4EC47B91C26342F0024B507 /* title_scenarioselect.c */,
+				D4EC47BA1C26342F0024B507 /* tooltip.c */,
+				D4EC47BB1C26342F0024B507 /* tooltip.h */,
+				D4EC47BC1C26342F0024B507 /* top_toolbar.c */,
+				D4EC47BD1C26342F0024B507 /* track_list.c */,
+				D4EC47BE1C26342F0024B507 /* track_manage.c */,
+				D4EC47BF1C26342F0024B507 /* track_place.c */,
+				D4EC47C01C26342F0024B507 /* viewport.c */,
+				D4EC47C11C26342F0024B507 /* water.c */,
+			);
+			name = windows;
+			path = src/windows;
+			sourceTree = "<group>";
+		};
+		D4EC47C21C26342F0024B507 /* world */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC47C31C26342F0024B507 /* balloon.c */,
+				D4EC47C41C26342F0024B507 /* banner.c */,
+				D4EC47C51C26342F0024B507 /* banner.h */,
+				D4EC47C61C26342F0024B507 /* climate.c */,
+				D4EC47C71C26342F0024B507 /* climate.h */,
+				D4EC47C81C26342F0024B507 /* duck.c */,
+				D4EC47C91C26342F0024B507 /* entrance.h */,
+				D4EC47CA1C26342F0024B507 /* footpath.c */,
+				D4EC47CB1C26342F0024B507 /* footpath.h */,
+				D4EC47CC1C26342F0024B507 /* fountain.c */,
+				D4EC47CD1C26342F0024B507 /* fountain.h */,
+				D4EC47CE1C26342F0024B507 /* map.c */,
+				D4EC47CF1C26342F0024B507 /* map.h */,
+				D4EC47D01C26342F0024B507 /* map_animation.c */,
+				D4EC47D11C26342F0024B507 /* map_animation.h */,
+				D4EC47D21C26342F0024B507 /* map_helpers.c */,
+				D4EC47D31C26342F0024B507 /* map_helpers.h */,
+				D4EC47D41C26342F0024B507 /* mapgen.c */,
+				D4EC47D51C26342F0024B507 /* mapgen.h */,
+				D4EC47D61C26342F0024B507 /* money_effect.c */,
+				D4EC47D71C26342F0024B507 /* park.c */,
+				D4EC47D81C26342F0024B507 /* park.h */,
+				D4EC47D91C26342F0024B507 /* particle.c */,
+				D4EC47DA1C26342F0024B507 /* scenery.c */,
+				D4EC47DB1C26342F0024B507 /* scenery.h */,
+				D4EC47DC1C26342F0024B507 /* sprite.c */,
+				D4EC47DD1C26342F0024B507 /* sprite.h */,
+				D4EC47DE1C26342F0024B507 /* water.h */,
+			);
+			name = world;
+			path = src/world;
+			sourceTree = "<group>";
+		};
+		D4EC48811C2634870024B507 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48CF1C2634A30024B507 /* jansson */,
+				D4EC48841C2634870024B507 /* SDL2 */,
+				D4EC48BC1C2634870024B507 /* speex */,
+			);
+			name = include;
+			path = libxc/include;
+			sourceTree = "<group>";
+		};
+		D4EC48841C2634870024B507 /* SDL2 */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48851C2634870024B507 /* begin_code.h */,
+				D4EC48861C2634870024B507 /* close_code.h */,
+				D4EC48871C2634870024B507 /* SDL.h */,
+				D4EC48881C2634870024B507 /* SDL_assert.h */,
+				D4EC48891C2634870024B507 /* SDL_atomic.h */,
+				D4EC488A1C2634870024B507 /* SDL_audio.h */,
+				D4EC488B1C2634870024B507 /* SDL_bits.h */,
+				D4EC488C1C2634870024B507 /* SDL_blendmode.h */,
+				D4EC488D1C2634870024B507 /* SDL_clipboard.h */,
+				D4EC488E1C2634870024B507 /* SDL_config.h */,
+				D4EC488F1C2634870024B507 /* SDL_config_macosx.h */,
+				D4EC48901C2634870024B507 /* SDL_copying.h */,
+				D4EC48911C2634870024B507 /* SDL_cpuinfo.h */,
+				D4EC48921C2634870024B507 /* SDL_endian.h */,
+				D4EC48931C2634870024B507 /* SDL_error.h */,
+				D4EC48941C2634870024B507 /* SDL_events.h */,
+				D4EC48951C2634870024B507 /* SDL_filesystem.h */,
+				D4EC48961C2634870024B507 /* SDL_gamecontroller.h */,
+				D4EC48971C2634870024B507 /* SDL_gesture.h */,
+				D4EC48981C2634870024B507 /* SDL_haptic.h */,
+				D4EC48991C2634870024B507 /* SDL_hints.h */,
+				D4EC489A1C2634870024B507 /* SDL_joystick.h */,
+				D4EC489B1C2634870024B507 /* SDL_keyboard.h */,
+				D4EC489C1C2634870024B507 /* SDL_keycode.h */,
+				D4EC489D1C2634870024B507 /* SDL_loadso.h */,
+				D4EC489E1C2634870024B507 /* SDL_log.h */,
+				D4EC489F1C2634870024B507 /* SDL_main.h */,
+				D4EC48A01C2634870024B507 /* SDL_messagebox.h */,
+				D4EC48A11C2634870024B507 /* SDL_mouse.h */,
+				D4EC48A21C2634870024B507 /* SDL_mutex.h */,
+				D4EC48A31C2634870024B507 /* SDL_name.h */,
+				D4EC48A41C2634870024B507 /* SDL_opengl.h */,
+				D4EC48A51C2634870024B507 /* SDL_opengles.h */,
+				D4EC48A61C2634870024B507 /* SDL_opengles2.h */,
+				D4EC48A71C2634870024B507 /* SDL_pixels.h */,
+				D4EC48A81C2634870024B507 /* SDL_platform.h */,
+				D4EC48A91C2634870024B507 /* SDL_power.h */,
+				D4EC48AA1C2634870024B507 /* SDL_quit.h */,
+				D4EC48AB1C2634870024B507 /* SDL_rect.h */,
+				D4EC48AC1C2634870024B507 /* SDL_render.h */,
+				D4EC48AD1C2634870024B507 /* SDL_revision.h */,
+				D4EC48AE1C2634870024B507 /* SDL_rwops.h */,
+				D4EC48AF1C2634870024B507 /* SDL_scancode.h */,
+				D4EC48B01C2634870024B507 /* SDL_shape.h */,
+				D4EC48B11C2634870024B507 /* SDL_stdinc.h */,
+				D4EC48B21C2634870024B507 /* SDL_surface.h */,
+				D4EC48B31C2634870024B507 /* SDL_system.h */,
+				D4EC48B41C2634870024B507 /* SDL_syswm.h */,
+				D4EC48B51C2634870024B507 /* SDL_thread.h */,
+				D4EC48B61C2634870024B507 /* SDL_timer.h */,
+				D4EC48B71C2634870024B507 /* SDL_touch.h */,
+				D4EC48B81C2634870024B507 /* SDL_ttf.h */,
+				D4EC48B91C2634870024B507 /* SDL_types.h */,
+				D4EC48BA1C2634870024B507 /* SDL_version.h */,
+				D4EC48BB1C2634870024B507 /* SDL_video.h */,
+			);
+			path = SDL2;
+			sourceTree = "<group>";
+		};
+		D4EC48BC1C2634870024B507 /* speex */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48BD1C2634870024B507 /* speex_echo.h */,
+				D4EC48BE1C2634870024B507 /* speex_jitter.h */,
+				D4EC48BF1C2634870024B507 /* speex_preprocess.h */,
+				D4EC48C01C2634870024B507 /* speex_resampler.h */,
+				D4EC48C11C2634870024B507 /* speexdsp_config_types.h */,
+				D4EC48C21C2634870024B507 /* speexdsp_types.h */,
+			);
+			path = speex;
+			sourceTree = "<group>";
+		};
+		D4EC48C31C2634870024B507 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48C41C2634870024B507 /* libfreetype.dylib */,
+				D4EC48C51C2634870024B507 /* libjansson.dylib */,
+				D4EC48C61C2634870024B507 /* libSDL2.dylib */,
+				D4EC48C71C2634870024B507 /* libSDL2_ttf.dylib */,
+				D4EC48C81C2634870024B507 /* libspeexdsp.dylib */,
+			);
+			name = lib;
+			path = libxc/lib;
+			sourceTree = "<group>";
+		};
+		D4EC48CE1C26348E0024B507 /* system */ = {
+			isa = PBXGroup;
+			children = (
+				D41B73EE1C2101890080A7B9 /* libcurl.tbd */,
+				D41B741C1C210A7A0080A7B9 /* libiconv.tbd */,
+				D41B73F01C21018C0080A7B9 /* libssl.tbd */,
+			);
+			name = system;
+			sourceTree = "<group>";
+		};
+		D4EC48CF1C2634A30024B507 /* jansson */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48821C2634870024B507 /* jansson.h */,
+				D4EC48831C2634870024B507 /* jansson_config.h */,
+			);
+			name = jansson;
+			sourceTree = "<group>";
+		};
+		D4EC48D51C2634E90024B507 /* argparse */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48D61C2634E90024B507 /* argparse.c */,
+				D4EC48D71C2634E90024B507 /* argparse.h */,
+			);
+			name = argparse;
+			path = lib/argparse;
+			sourceTree = "<group>";
+		};
+		D4EC48D81C2634E90024B507 /* cutest */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48D91C2634E90024B507 /* CuTest.c */,
+				D4EC48DA1C2634E90024B507 /* CuTest.h */,
+				D4EC48DB1C2634E90024B507 /* license.txt */,
+			);
+			name = cutest;
+			path = lib/cutest;
+			sourceTree = "<group>";
+		};
+		D4EC48DC1C2634E90024B507 /* lodepng */ = {
+			isa = PBXGroup;
+			children = (
+				D4EC48DD1C2634E90024B507 /* lodepng.c */,
+				D4EC48DE1C2634E90024B507 /* lodepng.h */,
+			);
+			name = lodepng;
+			path = lib/lodepng;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D497D0771C20FD52002BF46A /* OpenRCT2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D497D0891C20FD53002BF46A /* Build configuration list for PBXNativeTarget "OpenRCT2" */;
+			buildPhases = (
+				D4EC48E91C264FC20024B507 /* Download Libraries */,
+				D4EC012A1C25532B00DAFE69 /* Setup AppIcon */,
+				D40F4E1D1C2528D5009582C9 /* Create Segment Files */,
+				D497D0741C20FD52002BF46A /* Sources */,
+				D497D0751C20FD52002BF46A /* Frameworks */,
+				D42C09D21C254F4E00309751 /* Build g2.dat */,
+				D497D0761C20FD52002BF46A /* Resources */,
+				D41B74201C210B190080A7B9 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenRCT2;
+			productName = OpenRCT2;
+			productReference = D497D0781C20FD52002BF46A /* OpenRCT2.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D497D0701C20FD52002BF46A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = OpenRCT2;
+				TargetAttributes = {
+					D497D0771C20FD52002BF46A = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = D497D0731C20FD52002BF46A /* Build configuration list for PBXProject "OpenRCT2" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D497D06F1C20FD52002BF46A;
+			productRefGroup = D497D0791C20FD52002BF46A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D497D0771C20FD52002BF46A /* OpenRCT2 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D497D0761C20FD52002BF46A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D41B74731C2125E50080A7B9 /* Assets.xcassets in Resources */,
+				D4EC48E61C2637710024B507 /* g2.dat in Resources */,
+				D4EC48E71C2637710024B507 /* language in Resources */,
+				D4EC48E81C2637710024B507 /* title in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		D40F4E1D1C2528D5009582C9 /* Create Segment Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/openrct2.exe",
+			);
+			name = "Create Segment Files";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/openrct2_text",
+				"$(DERIVED_FILE_DIR)/openrct2_data",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "dd if=\"${SRCROOT}/openrct2.exe\" of=\"${DERIVED_FILE_DIR}/openrct2_text\" bs=4096 skip=1 count=1187\ndd if=\"${SRCROOT}/openrct2.exe\" of=\"${DERIVED_FILE_DIR}/openrct2_data\" bs=4096 skip=1188 count=318\ndd if=/dev/zero of=\"${DERIVED_FILE_DIR}/openrct2_data\" bs=4096 seek=318 count=2630 conv=notrunc\ndd if=\"${SRCROOT}/openrct2.exe\" of=\"${DERIVED_FILE_DIR}/openrct2_data\" bs=4096 skip=1506 seek=2948 count=1 conv=notrunc";
+		};
+		D42C09D21C254F4E00309751 /* Build g2.dat */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/resources/g2/*",
+			);
+			name = "Build g2.dat";
+			outputPaths = (
+				"$(SRCROOT)/data/g2.dat",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}\" sprite build \"${SRCROOT}/data/g2.dat\" \"${SRCROOT}/resources/g2/\"";
+		};
+		D4EC012A1C25532B00DAFE69 /* Setup AppIcon */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/resources/logo/icon_x16.png",
+				"$(SRCROOT)/resources/logo/icon_x32.png",
+				"$(SRCROOT)/resources/logo/icon_x64.png",
+				"$(SRCROOT)/resources/logo/icon_x128.png",
+				"$(SRCROOT)/resources/logo/icon_x256.png",
+				"$(SRCROOT)/resources/logo/icon_x512.png",
+				"$(SRCROOT)/resources/logo/icon_x1024.png",
+			);
+			name = "Setup AppIcon";
+			outputPaths = (
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16@2x.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32@2x.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128@2x.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256@2x.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+				"$(SRCROOT)/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512@2x.png",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x16.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16@2x.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x32.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_16x16@2x.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x32.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32@2x.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x64.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_32x32@2x.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x128.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128@2x.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x256.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_128x128@2x.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x256.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256@2x.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x512.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_256x256@2x.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x512.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512.png\"; fi\nif [[ ! -e \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512@2x.png\" ]]; then ln \"${SRCROOT}/resources/logo/icon_x1024.png\" \"${SRCROOT}/distribution/osx/Assets.xcassets/AppIcon.appiconset/icon_512x512@2x.png\"; fi";
+		};
+		D4EC48E91C264FC20024B507 /* Download Libraries */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Download Libraries";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cachedir=\".cache\"\nliburl=\"https://openrct2.website/files/orctlibs-osx.zip\"\n# keep in sync with version in build.sh\nsha256sum=\"2cec3958352477fbb876a5b6398722077084b5ff7e95a7d3cd67492abf5012fc\"\n\n[[ ! -e \"${SRCROOT}/libversion\" || $(head -n 1 \"${SRCROOT}/libversion\") != $sha256sum ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]] || [[ ! -f \"${SRCROOT}/$cachedir/orctlibs.zip\" ]]; then\n    if [[ ! -d \"${SRCROOT}/$cachedir\" ]]; then mkdir \"${SRCROOT}/$cachedir\"; fi\n    if [[ -f \"${SRCROOT}/$cachedir/orctlibs.zip\" ]]; then rm \"${SRCROOT}/$cachedir/orctlibs.zip\"; fi\n    curl -L -o \"${SRCROOT}/$cachedir/orctlibs.zip\" \"$liburl\"\n    if [[ -d \"${SRCROOT}/$cachedir/orctlibs\" ]]; then rm -rf \"${SRCROOT}/$cachedir/orctlibs\"; fi\n    mkdir \"${SRCROOT}/$cachedir/orctlibs\"\n    unzip -uaq -d \"${SRCROOT}/$cachedir/orctlibs\" \"${SRCROOT}/$cachedir/orctlibs.zip\"\nfi\n\nif [[ $outdated -eq 0 ]] || [[ ! -d \"${SRCROOT}/lib\" ]]; then\n    if [[ -d \"${SRCROOT}/lib\" ]]; then rm -r \"${SRCROOT}/lib\"; fi\n    cp -Rf \"${SRCROOT}/$cachedir/orctlibs/local\" \"${SRCROOT}/lib\"\nfi\nif [[ $outdated -eq 0 ]] || [[ ! -d \"${SRCROOT}/libxc\" ]]; then\n    if [[ -d \"${SRCROOT}/libxc\" ]]; then rm -r \"${SRCROOT}/libxc\"; fi\n    cp -Rf \"${SRCROOT}/$cachedir/orctlibs/glob\" \"${SRCROOT}/libxc\"\nfi\n\nif [[ $outdated -eq 0 ]]; then\n    newsha=$(shasum -a 256 \"${SRCROOT}/$cachedir/orctlibs.zip\" | cut -f1 -d\" \")\n    [[ \"$newsha\" == \"$sha256sum\" ]]\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D497D0741C20FD52002BF46A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D4EC485D1C26342F0024B507 /* sign.c in Sources */,
+				D4EC47E61C26342F0024B507 /* cursors.c in Sources */,
+				D4EC48251C26342F0024B507 /* track_data.c in Sources */,
+				D4EC48661C26342F0024B507 /* title_exit.c in Sources */,
+				D4EC480C1C26342F0024B507 /* finance.c in Sources */,
+				D4EC47EB1C26342F0024B507 /* rain.c in Sources */,
+				D4EC48221C26342F0024B507 /* ride_ratings.c in Sources */,
+				D4EC48371C26342F0024B507 /* editor_main.c in Sources */,
+				D4EC48321C26342F0024B507 /* clear_scenery.c in Sources */,
+				D4EC48211C26342F0024B507 /* ride_data.c in Sources */,
+				D4EC47F11C26342F0024B507 /* editor.c in Sources */,
+				D4EC483A1C26342F0024B507 /* editor_scenario_options.c in Sources */,
+				D4EC48551C26342F0024B507 /* ride_construction.c in Sources */,
+				D4EC48461C26342F0024B507 /* map.c in Sources */,
+				D4EC47E41C26342F0024B507 /* cmdline.c in Sources */,
+				D4EC481D1C26342F0024B507 /* rct1.c in Sources */,
+				D4EC48291C26342F0024B507 /* scenario.c in Sources */,
+				D4EC485B1C26342F0024B507 /* shortcut_key_change.c in Sources */,
+				D4EC48741C26342F0024B507 /* climate.c in Sources */,
+				D4EC48201C26342F0024B507 /* ride.c in Sources */,
+				D4EC485F1C26342F0024B507 /* staff_fire_prompt.c in Sources */,
+				D4EC48381C26342F0024B507 /* editor_object_selection.c in Sources */,
+				D4EC482C1C26342F0024B507 /* sawyercoding.c in Sources */,
+				D4EC48631C26342F0024B507 /* tile_inspector.c in Sources */,
+				D4EC48181C26342F0024B507 /* linux.c in Sources */,
+				D4EC48651C26342F0024B507 /* title_editor.c in Sources */,
+				D4EC47EC1C26342F0024B507 /* rect.c in Sources */,
+				D4EC48101C26342F0024B507 /* http.cpp in Sources */,
+				D4EC47F21C26342F0024B507 /* game.c in Sources */,
+				D4EC48761C26342F0024B507 /* footpath.c in Sources */,
+				D4EC48031C26342F0024B507 /* currency.c in Sources */,
+				D4EC48011C26342F0024B507 /* intro.c in Sources */,
+				D4EC47EF1C26342F0024B507 /* string.c in Sources */,
+				D4EC48531C26342F0024B507 /* research.c in Sources */,
+				D4EC48401C26342F0024B507 /* guest_list.c in Sources */,
+				D4EC482F1C26342F0024B507 /* banner.c in Sources */,
+				D4EC47E91C26342F0024B507 /* font.c in Sources */,
+				D4EC48021C26342F0024B507 /* convert.c in Sources */,
+				D4EC48481C26342F0024B507 /* mapgen.c in Sources */,
+				D4EC48441C26342F0024B507 /* loadsave.c in Sources */,
+				D4EC47E21C26342F0024B507 /* cheats.c in Sources */,
+				D4EC481B1C26342F0024B507 /* shared.c in Sources */,
+				D4EC47FD1C26342F0024B507 /* viewport.c in Sources */,
+				D4EC480E1C26342F0024B507 /* news_item.c in Sources */,
+				D4EC48141C26342F0024B507 /* object.c in Sources */,
+				D4EC487F1C26342F0024B507 /* scenery.c in Sources */,
+				D4EC480A1C26342F0024B507 /* utf8.c in Sources */,
+				D4EC48681C26342F0024B507 /* title_menu.c in Sources */,
+				D4EC48751C26342F0024B507 /* duck.c in Sources */,
+				D4EC484F1C26342F0024B507 /* options.c in Sources */,
+				D4EC485C1C26342F0024B507 /* shortcut_keys.c in Sources */,
+				D4EC481A1C26342F0024B507 /* posix.c in Sources */,
+				D4EC47E31C26342F0024B507 /* cmdline_sprite.c in Sources */,
+				D4EC48611C26342F0024B507 /* text_input.c in Sources */,
+				D4EC48431C26342F0024B507 /* land_rights.c in Sources */,
+				D4EC486B1C26342F0024B507 /* tooltip.c in Sources */,
+				D4EC48511C26342F0024B507 /* player_list.c in Sources */,
+				D4EC48231C26342F0024B507 /* station.c in Sources */,
+				D4EC484D1C26342F0024B507 /* new_ride.c in Sources */,
+				D4EC484A1C26342F0024B507 /* music_credits.c in Sources */,
+				D4EC482B1C26342F0024B507 /* tutorial.c in Sources */,
+				D4EC48241C26342F0024B507 /* track.c in Sources */,
+				D4EC47DF1C26342F0024B507 /* addresses.c in Sources */,
+				D4EC484B1C26342F0024B507 /* network_status.c in Sources */,
+				D4EC483E1C26342F0024B507 /* game_bottom_toolbar.c in Sources */,
+				D4EC48731C26342F0024B507 /* banner.c in Sources */,
+				D4EC47F51C26342F0024B507 /* chat.c in Sources */,
+				D4EC48E01C2634E90024B507 /* CuTest.c in Sources */,
+				D4EC48591C26342F0024B507 /* server_list.c in Sources */,
+				D4EC48001C26342F0024B507 /* window.c in Sources */,
+				D4EC47F61C26342F0024B507 /* colour.c in Sources */,
+				D4EC486E1C26342F0024B507 /* track_manage.c in Sources */,
+				D4EC48331C26342F0024B507 /* demolish_ride_prompt.c in Sources */,
+				D4EC48131C26342F0024B507 /* object_list.c in Sources */,
+				D4EC47ED1C26342F0024B507 /* scrolling_text.c in Sources */,
+				D4EC483D1C26342F0024B507 /* footpath.c in Sources */,
+				D4EC47E81C26342F0024B507 /* drawing.c in Sources */,
+				D4EC47F71C26342F0024B507 /* console.c in Sources */,
+				D4EC47FA1C26342F0024B507 /* screenshot.c in Sources */,
+				D4EC485A1C26342F0024B507 /* server_start.c in Sources */,
+				D4EC486D1C26342F0024B507 /* track_list.c in Sources */,
+				D4EC487B1C26342F0024B507 /* mapgen.c in Sources */,
+				D4EC48151C26342F0024B507 /* openrct2.c in Sources */,
+				D4EC48781C26342F0024B507 /* map.c in Sources */,
+				D4EC48411C26342F0024B507 /* install_track.c in Sources */,
+				D4EC48341C26342F0024B507 /* dropdown.c in Sources */,
+				D4EC48301C26342F0024B507 /* changelog.c in Sources */,
+				D4EC48521C26342F0024B507 /* publisher_credits.c in Sources */,
+				D4EC485E1C26342F0024B507 /* staff.c in Sources */,
+				D4EC48DF1C2634E90024B507 /* argparse.c in Sources */,
+				D4EC486F1C26342F0024B507 /* track_place.c in Sources */,
+				D4EC48261C26342F0024B507 /* track_paint.c in Sources */,
+				D4EC48601C26342F0024B507 /* staff_list.c in Sources */,
+				D4EC48501C26342F0024B507 /* park.c in Sources */,
+				D4EC48041C26342F0024B507 /* date.c in Sources */,
+				D4EC486A1C26342F0024B507 /* title_scenarioselect.c in Sources */,
+				D4EC482A1C26342F0024B507 /* title.c in Sources */,
+				D4EC48491C26342F0024B507 /* maze_construction.c in Sources */,
+				D4EC48361C26342F0024B507 /* editor_inventions_list.c in Sources */,
+				D4EC482E1C26342F0024B507 /* about.c in Sources */,
+				D4EC487E1C26342F0024B507 /* particle.c in Sources */,
+				D4EC48071C26342F0024B507 /* localisation.c in Sources */,
+				D4EC47E01C26342F0024B507 /* audio.c in Sources */,
+				D4EC487D1C26342F0024B507 /* park.c in Sources */,
+				D4EC48161C26342F0024B507 /* peep.c in Sources */,
+				D4EC47FE1C26342F0024B507 /* viewport_interaction.c in Sources */,
+				D4EC48171C26342F0024B507 /* staff.c in Sources */,
+				D4EC48191C26342F0024B507 /* osx.m in Sources */,
+				D4EC48771C26342F0024B507 /* fountain.c in Sources */,
+				D4EC48711C26342F0024B507 /* water.c in Sources */,
+				D4EC48541C26342F0024B507 /* ride.c in Sources */,
+				D4EC484E1C26342F0024B507 /* news.c in Sources */,
+				D4EC47F31C26342F0024B507 /* hook.c in Sources */,
+				D4EC47F91C26342F0024B507 /* keyboard_shortcut.c in Sources */,
+				D4EC48351C26342F0024B507 /* editor_bottom_toolbar.c in Sources */,
+				D4EC487C1C26342F0024B507 /* money_effect.c in Sources */,
+				D4EC48641C26342F0024B507 /* title_command_editor.c in Sources */,
+				D4EC48671C26342F0024B507 /* title_logo.c in Sources */,
+				D4EC484C1C26342F0024B507 /* new_campaign.c in Sources */,
+				D4EC483B1C26342F0024B507 /* error.c in Sources */,
+				D4EC48121C26342F0024B507 /* twitch.cpp in Sources */,
+				D4EC48311C26342F0024B507 /* cheats.c in Sources */,
+				D4EC48051C26342F0024B507 /* language.cpp in Sources */,
+				D4EC48451C26342F0024B507 /* main.c in Sources */,
+				D4EC482D1C26342F0024B507 /* util.c in Sources */,
+				D4EC47EA1C26342F0024B507 /* line.c in Sources */,
+				D4EC48271C26342F0024B507 /* vehicle.c in Sources */,
+				D4EC48281C26342F0024B507 /* scenario_list.c in Sources */,
+				D4EC48581C26342F0024B507 /* scenery.c in Sources */,
+				D4EC48061C26342F0024B507 /* LanguagePack.cpp in Sources */,
+				D4EC48091C26342F0024B507 /* user.c in Sources */,
+				D4EC47E11C26342F0024B507 /* mixer.cpp in Sources */,
+				D4EC481E1C26342F0024B507 /* rct2.c in Sources */,
+				D4EC48801C26342F0024B507 /* sprite.c in Sources */,
+				D4EC486C1C26342F0024B507 /* top_toolbar.c in Sources */,
+				D4EC48621C26342F0024B507 /* themes.c in Sources */,
+				D4EC48081C26342F0024B507 /* real_names.c in Sources */,
+				D4EC481C1C26342F0024B507 /* windows.c in Sources */,
+				D4EC47EE1C26342F0024B507 /* sprite.c in Sources */,
+				D4EC480B1C26342F0024B507 /* award.c in Sources */,
+				D4EC47F81C26342F0024B507 /* graph.c in Sources */,
+				D4EC48111C26342F0024B507 /* network.cpp in Sources */,
+				D4EC47FF1C26342F0024B507 /* widget.c in Sources */,
+				D4EC48E21C2634E90024B507 /* lodepng.c in Sources */,
+				D4EC48691C26342F0024B507 /* title_options.c in Sources */,
+				D4EC48471C26342F0024B507 /* map_tooltip.c in Sources */,
+				D4EC483F1C26342F0024B507 /* guest.c in Sources */,
+				D4EC487A1C26342F0024B507 /* map_helpers.c in Sources */,
+				D4EC480F1C26342F0024B507 /* research.c in Sources */,
+				D4EC48561C26342F0024B507 /* ride_list.c in Sources */,
+				D4EC47E71C26342F0024B507 /* diagnostic.c in Sources */,
+				D4EC47F41C26342F0024B507 /* input.c in Sources */,
+				D4EC48391C26342F0024B507 /* editor_objective_options.c in Sources */,
+				D4EC47E51C26342F0024B507 /* config.c in Sources */,
+				D4EC483C1C26342F0024B507 /* finances.c in Sources */,
+				D4EC47F01C26342F0024B507 /* supports.c in Sources */,
+				D4EC47FC1C26342F0024B507 /* title_sequences.c in Sources */,
+				D4EC48421C26342F0024B507 /* land.c in Sources */,
+				D4EC48791C26342F0024B507 /* map_animation.c in Sources */,
+				D4EC480D1C26342F0024B507 /* marketing.c in Sources */,
+				D4EC48721C26342F0024B507 /* balloon.c in Sources */,
+				D4EC48571C26342F0024B507 /* save_prompt.c in Sources */,
+				D4EC47FB1C26342F0024B507 /* themes.c in Sources */,
+				D4EC48701C26342F0024B507 /* viewport.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		D497D0871C20FD53002BF46A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				LD_NO_PIE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				VALID_ARCHS = i386;
+			};
+			name = Debug;
+		};
+		D497D0881C20FD53002BF46A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = SDL_INCLUDE_FRAMEWORK;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				LD_NO_PIE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				VALID_ARCHS = i386;
+			};
+			name = Release;
+		};
+		D497D08A1C20FD53002BF46A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/libxc/include",
+					"$(SRCROOT)/libxc/include/SDL2",
+					"$(SRCROOT)/lib/",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/distribution/osx/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libxc/lib",
+				);
+				OTHER_LDFLAGS = (
+					"-sectcreate",
+					rct2_text,
+					__text,
+					"$(DERIVED_FILE_DIR)/openrct2_text",
+					"-segaddr",
+					rct2_text,
+					0x401000,
+					"-segprot",
+					rct2_text,
+					rwx,
+					rwx,
+					"-sectcreate",
+					rct2_data,
+					__data,
+					"$(DERIVED_FILE_DIR)/openrct2_data",
+					"-segaddr",
+					rct2_data,
+					0x8a4000,
+					"-segprot",
+					rct2_data,
+					rwx,
+					rwx,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = website.openrct2.OpenRCT2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		D497D08B1C20FD53002BF46A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/libxc/include",
+					"$(SRCROOT)/libxc/include/SDL2",
+					"$(SRCROOT)/lib/",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/distribution/osx/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/libxc/lib",
+				);
+				OTHER_LDFLAGS = (
+					"-sectcreate",
+					rct2_text,
+					__text,
+					"$(DERIVED_FILE_DIR)/openrct2_text",
+					"-segaddr",
+					rct2_text,
+					0x401000,
+					"-segprot",
+					rct2_text,
+					rwx,
+					rwx,
+					"-sectcreate",
+					rct2_data,
+					__data,
+					"$(DERIVED_FILE_DIR)/openrct2_data",
+					"-segaddr",
+					rct2_data,
+					0x8a4000,
+					"-segprot",
+					rct2_data,
+					rwx,
+					rwx,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = website.openrct2.OpenRCT2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D497D0731C20FD52002BF46A /* Build configuration list for PBXProject "OpenRCT2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D497D0871C20FD53002BF46A /* Debug */,
+				D497D0881C20FD53002BF46A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D497D0891C20FD53002BF46A /* Build configuration list for PBXNativeTarget "OpenRCT2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D497D08A1C20FD53002BF46A /* Debug */,
+				D497D08B1C20FD53002BF46A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D497D0701C20FD52002BF46A /* Project object */;
+}

--- a/OpenRCT2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OpenRCT2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:OpenRCT2.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OpenRCT2.xcodeproj/project.xcworkspace/xcshareddata/OpenRCT2.xcscmblueprint
+++ b/OpenRCT2.xcodeproj/project.xcworkspace/xcshareddata/OpenRCT2.xcscmblueprint
@@ -1,0 +1,16 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "E48FB7C08C6966C4BACE7D0390CDFA7C64DD04D8",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "E48FB7C08C6966C4BACE7D0390CDFA7C64DD04D8" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "6B7243E0-B9B8-4E6D-ACE9-4DF346FA52C7",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "E48FB7C08C6966C4BACE7D0390CDFA7C64DD04D8" : "OpenRCT2\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "OpenRCT2",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "OpenRCT2.xcodeproj"
+}

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,12 @@ if [[ ! -d build ]]; then
 fi
 
 # keep in sync with version in install.sh
-sha256sum=69ff98c9544838fb16384bc78af9dc1c452b9d01d919e43f5fec686d02c9bdd8
+if [[ $(uname -s) == "Darwin" ]]; then
+	# keep in sync with version in Xcode project
+	sha256sum=2cec3958352477fbb876a5b6398722077084b5ff7e95a7d3cd67492abf5012fc
+else
+	sha256sum=69ff98c9544838fb16384bc78af9dc1c452b9d01d919e43f5fec686d02c9bdd8
+fi
 libVFile="./libversion"
 libdir="./lib"
 currentversion=0

--- a/distribution/osx/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/distribution/osx/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "size" : "16x16",
+      "idiom" : "mac",
+      "filename" : "icon_16x16.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "16x16",
+      "idiom" : "mac",
+      "filename" : "icon_16x16@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "32x32",
+      "idiom" : "mac",
+      "filename" : "icon_32x32.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "32x32",
+      "idiom" : "mac",
+      "filename" : "icon_32x32@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "128x128",
+      "idiom" : "mac",
+      "filename" : "icon_128x128.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "128x128",
+      "idiom" : "mac",
+      "filename" : "icon_128x128@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "256x256",
+      "idiom" : "mac",
+      "filename" : "icon_256x256.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "256x256",
+      "idiom" : "mac",
+      "filename" : "icon_256x256@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "512x512",
+      "idiom" : "mac",
+      "filename" : "icon_512x512.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "512x512",
+      "idiom" : "mac",
+      "filename" : "icon_512x512@2x.png",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/distribution/osx/Info.plist
+++ b/distribution/osx/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>ORCT</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>OpenRCT2 is licensed under the GNU General Public License version 3</string>
+</dict>
+</plist>

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,11 @@ SDL2_PV=2.0.3
 SDL2_TTF_PV=2.0.12
 
 cachedir=.cache
-liburl=https://openrct2.website/files/orctlibs.zip
+if [[ $(uname -s) == "Darwin" ]]; then
+	liburl=https://openrct2.website/files/orctlibs-osx.zip
+else
+	liburl=https://openrct2.website/files/orctlibs.zip
+fi
 mkdir -p "$cachedir"
 
 # Sets default target to "linux", if none specified

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -99,9 +99,23 @@ int cmdline_run(const char **argv, int argc)
 	 * a null pointer in the array. Because of this, AppKit in OS X 10.10 will
 	 * dereference it, causing a segmentation fault.
 	 */
-	char** mutableArgv = malloc(argvsize);
+	const char** mutableArgv = malloc(argvsize);
+
+#ifdef __APPLE__
+	/**
+	 * Fixes problems with the default settings in the Xcode debugger
+	 * with it adding the option "-NSDocumentRevisionsDebugMode"
+	 */
+	int k=0;
+	for (int i=0; i < argc; ++i)
+		if (strcmp(argv[k], "-NSDocumentRevisionsDebugMode") != 0)
+			mutableArgv[k++] = argv[i];
+	argc = k;
+#else
 	memcpy(mutableArgv,argv,argvsize);
-	argc = argparse_parse(&argparse, argc, (const char**)mutableArgv);
+#endif
+
+	argc = argparse_parse(&argparse, argc, mutableArgv);
 
 	if (version) {
 		print_version();


### PR DESCRIPTION
This helps improve development on OS X, allows for building self-contained app bundles, and resolves #2463. 

This requires OpenRCT2/openrct2.github.io#2 to be merged for the lib downloading script to work. In the mean time, this can be tested by downloading the zip from the PR, putting the contents of `local` in `lib` and `glob` in `libxc`, and putting the sha256 hash in `libversion` (you can just grab the hash from `build.sh` or the Xcode project if you don't want to hash it yourself).

If you're wondering why I put the Xcode project is in the root folder, I did it to match #2426. If everybody would rather have it in the `projects` folder (as the Visual Studio projects are right now), then I can make that change, but it will not be a simple change to make.

@IntelOrca If you can take a look at this, please do. I'm not sure if my implementation of the project is similar enough to how the Visual Studio project and build scripts work, so I'd like someone to look at this who understands how everything is setup.