### PR TITLE
Fixed curl error in OS X bundles

### DIFF
--- a/src/network/http.cpp
+++ b/src/network/http.cpp
@@ -117,8 +117,8 @@ http_json_response *http_request_json(const http_json_request *request)
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, true);
-#ifndef __linux__
-        // On GNU/Linux, curl will use the system certs by default
+#ifdef _WIN32
+	// On GNU/Linux (and OS X), curl will use the system certs by default
 	curl_easy_setopt(curl, CURLOPT_CAINFO, "curl-ca-bundle.crt");
 #endif
 	curl_easy_setopt(curl, CURLOPT_URL, request->url);


### PR DESCRIPTION
In short, this expands #2389 to cover OS X as well, as it's pretty much only Windows that requires the cert to be included.