### PR TITLE
Fixed warnings in Xcode

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -109,7 +109,7 @@ int cmdline_run(const char **argv, int argc)
 	int k=0;
 	for (int i=0; i < argc; ++i)
 		if (strcmp(argv[k], "-NSDocumentRevisionsDebugMode") != 0)
-			mutableArgv[k++] = argv[i];
+			mutableArgv[k++] = (char *) argv[i];
 	argc = k;
 #else
 	memcpy(mutableArgv,argv,argvsize);

--- a/src/input.c
+++ b/src/input.c
@@ -1088,7 +1088,7 @@ void process_mouse_over(int x, int y)
 				if (subWindow == NULL)
 					break;
 
-				ebx = ebx & 0xFFFFFF00;
+				ebx = 0;
 				edi = cursorId;
 				esi = (int)subWindow;
 				// Not sure what this is for, no windows actually implement a handler

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -573,7 +573,7 @@ static int cc_set(const utf8 **argv, int argc)
 			console_execute_silent("get max_loan");
 		}
 		else if (strcmp(argv[0], "guest_initial_cash") == 0 && invalidArguments(&invalidArgs, double_valid[0])) {
-			RCT2_GLOBAL(RCT2_ADDRESS_GUEST_INITIAL_CASH, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(15000, 0));
+			RCT2_GLOBAL(RCT2_ADDRESS_GUEST_INITIAL_CASH, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(1000, 0));
 			console_execute_silent("get guest_initial_cash");
 		}
 		else if (strcmp(argv[0], "guest_initial_happiness") == 0 && invalidArguments(&invalidArgs, int_valid[0])) {
@@ -633,11 +633,11 @@ static int cc_set(const utf8 **argv, int argc)
 			console_execute_silent("get park_open");
 		}
 		else if (strcmp(argv[0], "land_rights_cost") == 0 && invalidArguments(&invalidArgs, double_valid[0])) {
-			RCT2_GLOBAL(RCT2_ADDRESS_LAND_COST, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(15000, 0));
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_COST, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(200, 0));
 			console_execute_silent("get land_rights_cost");
 		}
 		else if (strcmp(argv[0], "construction_rights_cost") == 0 && invalidArguments(&invalidArgs, double_valid[0])) {
-			RCT2_GLOBAL(RCT2_ADDRESS_CONSTRUCTION_RIGHTS_COST, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(15000, 0));
+			RCT2_GLOBAL(RCT2_ADDRESS_CONSTRUCTION_RIGHTS_COST, money16) = clamp(MONEY((int)double_val[0], ((int)(double_val[0] * 100)) % 100), MONEY(0, 0), MONEY(200, 0));
 			console_execute_silent("get construction_rights_cost");
 		}
 		else if (strcmp(argv[0], "climate") == 0) {


### PR DESCRIPTION
This fixes a few warnings that Xcode warns about. This is *mostly* identical functionality to what's in the repository now.

As for the functional change (in `interface/console.c`), I figured that the idea is to clamp the values to what is achievable via the UI. With trial-and-error, I was able to determine the limits of the values in the scenario editor, which I then set in the code. If this is not the intended use of the code, let me know and I'll change it.