### PR TITLE
Use platform-specific font directories (fixes #2537)

### DIFF
--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -888,7 +888,8 @@ bool ttf_initialise()
 		for (int i = 0; i < 4; i++) {
 			TTFFontDescriptor *fontDesc = &(gCurrentTTFFontSet->size[i]);
 
-			utf8 fontPath[MAX_PATH] = "C:\\Windows\\Fonts\\";
+			utf8 fontPath[MAX_PATH];
+			platform_get_font_directory(fontPath);
 			strcat(fontPath, fontDesc->filename);
 
 			fontDesc->font = TTF_OpenFont(fontPath, fontDesc->ptSize);

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -147,6 +147,11 @@ void platform_show_messagebox(char *message)
 	log_verbose(message);
 }
 
+void platform_get_font_directory(utf8 *buffer)
+{
+	strcpy(buffer, "/usr/share/fonts/");
+}
+
 /**
  *
  *  rct2: 0x004080EA

--- a/src/platform/osx.m
+++ b/src/platform/osx.m
@@ -172,4 +172,9 @@ int platform_open_common_file_dialog(int type, utf8 *title, utf8 *filename, utf8
 	}
 }
 
+void platform_get_font_directory(utf8 *buffer)
+{
+	strcpy(buffer, "/Library/Fonts/");
+}
+
 #endif

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -161,6 +161,7 @@ uint8 platform_get_locale_currency();
 uint16 platform_get_locale_language();
 uint8 platform_get_locale_measurement_format();
 uint8 platform_get_locale_temperature_format();
+void platform_get_font_directory();
 
 bool platform_check_steam_overlay_attached();
 

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -897,4 +897,10 @@ void platform_get_exe_path(utf8 *outPath)
 	_wfullpath(exePath, tempPath, MAX_PATH);
 	WideCharToMultiByte(CP_UTF8, 0, exePath, countof(exePath), outPath, MAX_PATH, NULL, NULL);
 }
+
+void platform_get_font_directory(utf8 *buffer)
+{
+	strcpy(buffer, "C:\\Windows\\Fonts\\");
+}
+
 #endif


### PR DESCRIPTION
This PR introduces a crude way to make fonts working on platforms other than Windows.

Drawbacks:
* Retains use of hardcoded font filenames. While Linux and Windows likely share these, OS X does not. For example, `arial.ttf` works, but `simsun.ttc` does not.
* This approach only takes system default folders into account.