### PR TITLE
Corrected misspellings of "substitute"

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -748,7 +748,7 @@ static int cc_load_object(const utf8 **argv, int argc) {
 	if (argc > 0) {
 		utf8 path[260];
 
-		subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), argv[0]);
+		substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), argv[0]);
 		// Require pointer to start of filename
 		utf8* last_char = path + strlen(path);
 		strcat(path, ".DAT\0");

--- a/src/object.c
+++ b/src/object.c
@@ -59,7 +59,7 @@ int object_load_file(int groupIndex, const rct_object_entry *entry, int* chunkSi
 	char path[MAX_PATH];
 	SDL_RWops* rw;
 
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), (char*)installedObject + 16);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), (char*)installedObject + 16);
 
 	log_verbose("loading object, %s", path);
 
@@ -296,7 +296,7 @@ int object_load_packed(SDL_RWops* rw)
 			objectPath[i] = '\0';
 	}
 
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
 	// Require pointer to start of filename
 	char* last_char = path + strlen(path);
 	strcat(path, ".DAT");
@@ -306,7 +306,7 @@ int object_load_packed(SDL_RWops* rw)
 	for (; platform_file_exists(path);){
 		for (char* curr_char = last_char - 1;; --curr_char){
 			if (*curr_char == '\\'){
-				subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), "00000000.DAT");
+				substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), "00000000.DAT");
 				char* last_char = path + strlen(path);
 				break;
 			}
@@ -1536,7 +1536,7 @@ int object_get_scenario_text(rct_object_entry *entry)
 
 	char path[MAX_PATH];
 	char *objectPath = (char*)installedObject + 16;
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
 
 	rct_object_entry openedEntry;
 	SDL_RWops* rw = SDL_RWFromFile(path, "rb");

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -313,7 +313,7 @@ void object_list_load()
 			}
 
 			char path[MAX_PATH];
-			subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), enumFileInfo.path);
+			substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), enumFileInfo.path);
 
 			rct_object_entry entry;
 			if (!object_load_entry(path, &entry))

--- a/src/rct2.c
+++ b/src/rct2.c
@@ -195,7 +195,7 @@ int rct2_init_directories()
 	return 1;
 }
 
-void subsitute_path(char *dest, const char *path, const char *filename)
+void substitute_path(char *dest, const char *path, const char *filename)
 {
 	while (*path != '*') {
 		*dest++ = *path++;

--- a/src/rct2.h
+++ b/src/rct2.h
@@ -315,7 +315,7 @@ int rct2_init();
 void rct2_update();
 void rct2_draw();
 void rct2_endupdate();
-void subsitute_path(char *dest, const char *path, const char *filename);
+void substitute_path(char *dest, const char *path, const char *filename);
 int check_mutex();
 int check_file_paths();
 int check_file_path(int pathId);

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -439,7 +439,7 @@ void track_load_list(ride_list_item item)
 			if (new_file_pointer > new_track_file + 0x3FF00)break;
 
 			char path[MAX_PATH];
-			subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), enumFileInfo.path);
+			substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), enumFileInfo.path);
 
 			rct_track_td6* loaded_track = load_track_design(path);
 			if (loaded_track){
@@ -2269,7 +2269,7 @@ rct_track_design *track_get_info(int index, uint8** preview)
 		RCT2_ADDRESS(RCT2_ADDRESS_TRACK_DESIGN_INDEX_CACHE, uint32)[i] = index;
 
 		char track_path[MAX_PATH] = { 0 };
-		subsitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, (char *)trackDesignList + (index * 128));
+		substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, (char *)trackDesignList + (index * 128));
 
 		rct_track_td6* loaded_track = NULL;
 
@@ -2324,13 +2324,13 @@ int track_rename(const char *text)
 	}
 
 	char new_path[MAX_PATH];
-	subsitute_path(new_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), text);
+	substitute_path(new_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), text);
 	strcat(new_path, ".TD6");
 
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char old_path[MAX_PATH];
-	subsitute_path(old_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(old_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_move(old_path, new_path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_ANOTHER_FILE_EXISTS_WITH_NAME_OR_FILE_IS_WRITE_PROTECTED;
@@ -2359,7 +2359,7 @@ int track_delete()
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char path[MAX_PATH];
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_delete(path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_FILE_IS_WRITE_PROTECTED_OR_LOCKED;
@@ -3091,7 +3091,7 @@ int save_track_design(uint8 rideIndex){
 	format_string(track_name, ride->name, &ride->name_arguments);
 
 	char path[MAX_PATH];
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
 
 	strcat(path, ".TD6");
 
@@ -3238,7 +3238,7 @@ int install_track(char* source_path, char* dest_name){
 	strcat(track_name, ".TD4");
 
 	char dest_path[MAX_PATH];
-	subsitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
@@ -3249,13 +3249,13 @@ int install_track(char* source_path, char* dest_name){
 	// Check if .TD6 file exists under that name
 	strcat(track_name, ".TD6");
 
-	subsitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
 
 	// Set path for actual copy
-	subsitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), dest_name);
+	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), dest_name);
 
 	return platform_file_copy(source_path, dest_path, false);
 }

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -228,7 +228,7 @@ int scenario_load_and_play(const rct_scenario_basic *scenario)
 {
 	char path[MAX_PATH];
 
-	subsitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), scenario->path);
+	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), scenario->path);
 	return scenario_load_and_play_from_path(path);
 }
 
@@ -417,7 +417,7 @@ void scenario_end()
 
 void scenario_set_filename(const char *value)
 {
-	subsitute_path(_scenarioPath, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), value);
+	substitute_path(_scenarioPath, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), value);
 	_scenarioFileName = path_get_filename(_scenarioPath);
 }
 

--- a/src/scenario_list.c
+++ b/src/scenario_list.c
@@ -83,7 +83,7 @@ static void scenario_list_add(const char *path)
 	rct_s6_info s6Info;
 
 	// Get absolute path
-	subsitute_path(scenarioPath, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), path);
+	substitute_path(scenarioPath, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), path);
 
 	// Load the basic scenario information
 	if (!scenario_load_basic(scenarioPath, &s6Header, &s6Info))

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -332,7 +332,7 @@ static int show_save_scenario_dialog(char *resultPath)
 
 
 	format_string(title, STR_SAVE_SCENARIO, NULL);
-	subsitute_path(filename, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), s6Info->name);
+	substitute_path(filename, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), s6Info->name);
 	strcat(filename, ".SC6");
 	format_string(filterName, STR_RCT2_SCENARIO_FILE, NULL);
 

--- a/src/windows/install_track.c
+++ b/src/windows/install_track.c
@@ -184,7 +184,7 @@ static void window_install_track_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	subsitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
+	substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();
@@ -291,7 +291,7 @@ static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	uint16 holes, speed, drops, dropHeight, inversions;
 	fixed32_2dp rating;
 	int x, y, colour, gForces, airTime;
-	rct_g1_element tmpElement, *subsituteElement;
+	rct_g1_element tmpElement, *substituteElement;
 
 	window_draw_widgets(w, dpi);
 
@@ -312,16 +312,16 @@ static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	rct_track_td6* track_td6 = &trackDesign->track_td6;
 
-	subsituteElement = &g1Elements[0];
-	tmpElement = *subsituteElement;
-	subsituteElement->offset = image;
-	subsituteElement->width = 370;
-	subsituteElement->height = 217;
-	subsituteElement->x_offset = 0;
-	subsituteElement->y_offset = 0;
-	subsituteElement->flags = G1_FLAG_BMP;
+	substituteElement = &g1Elements[0];
+	tmpElement = *substituteElement;
+	substituteElement->offset = image;
+	substituteElement->width = 370;
+	substituteElement->height = 217;
+	substituteElement->x_offset = 0;
+	substituteElement->y_offset = 0;
+	substituteElement->flags = G1_FLAG_BMP;
 	gfx_draw_sprite(dpi, 0, x, y, 0);
-	*subsituteElement = tmpElement;
+	*substituteElement = tmpElement;
 
 	x = w->x + (widget->left + widget->right) / 2;
 	y = w->y + widget->bottom - 12;

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -191,7 +191,7 @@ static void window_track_list_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	subsitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
+	substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();
@@ -395,7 +395,7 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	uint16 holes, speed, drops, dropHeight, inversions;
 	fixed32_2dp rating;
 	int trackIndex, x, y, colour, gForces, airTime;
-	rct_g1_element tmpElement, *subsituteElement;
+	rct_g1_element tmpElement, *substituteElement;
 
 	window_draw_widgets(w, dpi);
 
@@ -420,16 +420,16 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	rct_track_td6* track_td6 = &trackDesign->track_td6;
 
-	subsituteElement = &g1Elements[0];
-	tmpElement = *subsituteElement;
-	subsituteElement->offset = image;
-	subsituteElement->width = 370;
-	subsituteElement->height = 217;
-	subsituteElement->x_offset = 0;
-	subsituteElement->y_offset = 0;
-	subsituteElement->flags = G1_FLAG_BMP;
+	substituteElement = &g1Elements[0];
+	tmpElement = *substituteElement;
+	substituteElement->offset = image;
+	substituteElement->width = 370;
+	substituteElement->height = 217;
+	substituteElement->x_offset = 0;
+	substituteElement->y_offset = 0;
+	substituteElement->flags = G1_FLAG_BMP;
 	gfx_draw_sprite(dpi, 0, x, y, 0);
-	*subsituteElement = tmpElement;
+	*substituteElement = tmpElement;
 
 	x = w->x + (widget->left + widget->right) / 2;
 	y = w->y + widget->bottom - 12;

--- a/src/windows/track_place.c
+++ b/src/windows/track_place.c
@@ -596,23 +596,23 @@ static void window_track_place_invalidate(rct_window *w)
 static void window_track_place_paint(rct_window *w, rct_drawpixelinfo *dpi)
 {
 	rct_drawpixelinfo *clippedDpi;
-	rct_g1_element tmpElement, *subsituteElement;
+	rct_g1_element tmpElement, *substituteElement;
 
 	window_draw_widgets(w, dpi);
 
 	// Draw mini tile preview
 	clippedDpi = clip_drawpixelinfo(dpi, w->x + 4, 168, w->y + 18, 78);
 	if (clippedDpi != NULL) {
-		subsituteElement = &g1Elements[0];
-		tmpElement = *subsituteElement;
-		subsituteElement->offset = _window_track_place_mini_preview;
-		subsituteElement->width = TRACK_MINI_PREVIEW_WIDTH;
-		subsituteElement->height = TRACK_MINI_PREVIEW_HEIGHT;
-		subsituteElement->x_offset = 0;
-		subsituteElement->y_offset = 0;
-		subsituteElement->flags = 0;
+		substituteElement = &g1Elements[0];
+		tmpElement = *substituteElement;
+		substituteElement->offset = _window_track_place_mini_preview;
+		substituteElement->width = TRACK_MINI_PREVIEW_WIDTH;
+		substituteElement->height = TRACK_MINI_PREVIEW_HEIGHT;
+		substituteElement->x_offset = 0;
+		substituteElement->y_offset = 0;
+		substituteElement->flags = 0;
 		gfx_draw_sprite(clippedDpi, 0, 0, 0, 0);
-		*subsituteElement = tmpElement;
+		*substituteElement = tmpElement;
 
 		rct2_free(clippedDpi);
 	}


### PR DESCRIPTION
Not sure if this sort of code quality patch is welcome at this stage of the project, but I came across misspelt instances of "subsitute" when reading into the code.

The patch itself is rather trivial: it just changes all instances of `subsitute_path` into `substitute_path`, and `subsituteElement` into `substituteElement`.
