### PR TITLE
CMake updates for packaging on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,3 +170,15 @@ endif (UNIX)
 set_target_properties(${PROJECT} PROPERTIES PREFIX "")
 
 TARGET_LINK_LIBRARIES(${PROJECT} ${SDL2_LIBRARIES} ${ORCTLIBS_LIB} ${HTTPLIBS} ${NETWORKLIBS} ${SPEEX_LIBRARIES} ${DLLIB} ${RCT2_SECTIONS})
+
+# CMake does not allow specifying a dependency chain which includes built-in
+# targets, like `install`, so we have to trick it and execute dependency ourselves.
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
+install(TARGETS ${PROJECT} RUNTIME DESTINATION bin)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION share/${PROJECT})
+install(DIRECTORY data/ DESTINATION share/${PROJECT})
+
+set(CPACK_PACKAGE_VERSION_MAJOR 0)
+set(CPACK_PACKAGE_VERSION_MINOR 0)
+set(CPACK_PACKAGE_VERSION_PATCH "3.1")
+INCLUDE(CPack)

--- a/build.sh
+++ b/build.sh
@@ -86,8 +86,10 @@ if [[ $TARGET == "linux" ]] || [[ $TARGET == "docker32" ]]; then
 fi
 
 if [[ -z "$DISABLE_G2_BUILD" ]]; then
-    echo Building: data/g2.dat
-    ./build_g2.sh > /dev/null 2>&1
+    echo Building: g2.dat
+	pushd build
+	    make g2
+	popd
 fi
 
 if [[ $TARGET == "windows" ]]; then

--- a/build_g2.sh
+++ b/build_g2.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [[ $TARGET == "windows" ]]; then
-	wine openrct2.exe sprite build data/g2.dat resources/g2/
-else
-	./openrct2 sprite build data/g2.dat resources/g2/
-fi

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -98,7 +98,7 @@ void platform_posix_sub_user_data_path(char *buffer, const char *homedir, const 
 			exit(-1);
 			return;
 		}
-		
+
 		strncat(buffer, homedir, MAX_PATH - 1);
 		strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
 		strncat(buffer, ".config", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
@@ -121,11 +121,17 @@ void platform_posix_sub_user_data_path(char *buffer, const char *homedir, const 
  */
 void platform_posix_sub_resolve_openrct_data_path(utf8 *out) {
 	static const utf8 *searchLocations[] = {
+		"../share/openrct2",
+#ifdef ORCT2_RESOURCE_DIR
+		// defined in CMakeLists.txt
+		ORCT2_RESOURCE_DIR,
+#endif // ORCT2_RESOURCE_DIR
 		"/var/lib/openrct2",
 		"/usr/share/openrct2",
 	};
 	for (size_t i = 0; i < countof(searchLocations); i++)
 	{
+		log_verbose("Looking for OpenRCT2 data in %s", searchLocations[i]);
 		if (platform_directory_exists(searchLocations[i]))
 		{
 			out[0] = '\0';

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -602,14 +602,17 @@ void platform_resolve_openrct_data_path()
 
 	strncat(buffer, separator, MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
 	strncat(buffer, "data", MAX_PATH - strnlen(buffer, MAX_PATH) - 1);
+	log_verbose("Looking for OpenRCT2 data in %s", buffer);
 	if (platform_directory_exists(buffer))
 	{
 		_openrctDataDirectoryPath[0] = '\0';
 		safe_strncpy(_openrctDataDirectoryPath, buffer, MAX_PATH);
+		log_verbose("Found OpenRCT2 data in %s", _openrctDataDirectoryPath);
 		return;
 	}
-	
+
 	platform_posix_sub_resolve_openrct_data_path(_openrctDataDirectoryPath);
+	log_verbose("Trying to use OpenRCT2 data in %s", _openrctDataDirectoryPath);
 }
 
 void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory)


### PR DESCRIPTION
This enables `install` and `package` targets for `make`.

You can specify installation prefix with `-DCMAKE_INSTALL_PREFIX=path`,
when doing `make install`, OpenRCT shall be found there.

You can also use `make package` for creating packaged release files.