### PR TITLE
Add docker fonctonfig library for #2546

### DIFF
--- a/dockerfiles/32bit/Dockerfile
+++ b/dockerfiles/32bit/Dockerfile
@@ -26,4 +26,4 @@ RUN pacman -R --noconfirm gcc
 RUN yes | pacman -S gcc-libs-multilib
 RUN pacman -S --noconfirm gcc-multilib
 USER travis
-RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf lib32-speex
+RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf lib32-speex lib32-fontconfig


### PR DESCRIPTION
If we decide to go with fontconfig for #2546, docker builds will require new library installed. This prepares docker images (autobuilt) for incoming change, so it shall pass when needed. Tested on my personal travis setup: https://travis-ci.org/janisozaur/OpenRCT2/builds/98698814

**Only merge when #2546 is near-ready**