### PR TITLE
Fix #2550 Program crashes when executing "exit" command from the console

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -1047,7 +1047,7 @@ void console_execute_silent(const utf8 *src)
 	// Aliases for hiding the console
 	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0) {
 		free(argv[0]);
-		strcpy(argv[0], "hide");
+		argv[0] = _strdup("hide");
 	}
 
 	bool validCommand = false;

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -1046,7 +1046,7 @@ void console_execute_silent(const utf8 *src)
 
 	// Aliases for hiding the console
 	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0)
-		argv[0]="hide";
+		strcpy(argv[0], "hide");
 
 	bool validCommand = false;
 	for (int i = 0; i < countof(console_command_table); i++) {

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -1045,8 +1045,10 @@ void console_execute_silent(const utf8 *src)
 		return;
 
 	// Aliases for hiding the console
-	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0)
+	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0) {
+		free(argv[0]);
 		strcpy(argv[0], "hide");
+	}
 
 	bool validCommand = false;
 	for (int i = 0; i < countof(console_command_table); i++) {


### PR DESCRIPTION
Replace string constant with free-able value