### PR TITLE
Refactoring: replace several magic numbers with named equivalents

### DIFF
--- a/src/interface/graph.c
+++ b/src/interface/graph.c
@@ -36,7 +36,7 @@ static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, uint8 *history, int 
 		if (history[i] != 0 && history[i] != 255 && yearOver32 % 4 == 0) {
 			// Draw month text
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = ((yearOver32 / 4) + 8) % 8 + STR_MONTH_SHORT_MAR;
-			gfx_draw_string_centred(dpi, 2222, x, y - 10, 0, (void*)0x013CE952);
+			gfx_draw_string_centred(dpi, 2222, x, y - 10, 0, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS);
 
 			// Draw month mark
 			gfx_fill_rect(dpi, x, y, x, y + 3, 10);

--- a/src/interface/screenshot.c
+++ b/src/interface/screenshot.c
@@ -57,7 +57,7 @@ void screenshot_check()
 
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = stringId;
 				// RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = STR_SCR_BMP;
-				// RCT2_GLOBAL(0x013CE952 + 2, uint16) = screenshotIndex;
+				// RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = screenshotIndex;
 				RCT2_GLOBAL(0x009A8C29, uint8) |= 1;
 
 				window_error_open(STR_SCREENSHOT_SAVED_AS, -1);

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -440,7 +440,7 @@ static void widget_text_unknown(rct_drawpixelinfo *dpi, rct_window *w, int widge
 		gfx_draw_string_left_clipped(
 			dpi,
 			stringId,
-			(void*)0x013CE952,
+			(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS,
 			colour,
 			l + 1,
 			t,
@@ -453,7 +453,7 @@ static void widget_text_unknown(rct_drawpixelinfo *dpi, rct_window *w, int widge
 		gfx_draw_string_centred_clipped(
 			dpi,
 			stringId,
-			(void*)0x013CE952,
+			(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS,
 			colour,
 			(w->x + w->x + widget->left + widget->right + 1) / 2 - 1,
 			t,
@@ -489,7 +489,7 @@ static void widget_text(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 
 	if (widget_is_disabled(w, widgetIndex))
 		colour |= 0x40;
-	gfx_draw_string_left(dpi, widget->image, (void*)0x013CE952, colour, l + 1, t);
+	gfx_draw_string_left(dpi, widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, colour, l + 1, t);
 }
 
 /**
@@ -576,7 +576,7 @@ static void widget_groupbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
 		colour = w->colours[widget->colour] & 0x7F;
 		if (widget_is_disabled(w, widgetIndex))
 			colour |= 0x40;
-		gfx_draw_string_left(dpi, widget->image, (void*)0x013CE952, colour, l, t);
+		gfx_draw_string_left(dpi, widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, colour, l, t);
 		textRight = l + gfx_get_string_width((char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER) + 1;
 	}
 
@@ -679,7 +679,7 @@ static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widge
 			width -= 10;
 	}
 	l += width / 2;
-	gfx_draw_string_centred_clipped(dpi, widget->image, (void*)0x013CE952, 34, l, t, width);
+	gfx_draw_string_centred_clipped(dpi, widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 34, l, t, width);
 }
 
 /**
@@ -723,7 +723,7 @@ static void widget_closebox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
 	if (widget_is_disabled(w, widgetIndex))
 		colour |= 0x40;
 
-	gfx_draw_string_centred_clipped(dpi, widget->image, (void*)0x013CE952, colour, l, t, widget->right - widget->left - 2);
+	gfx_draw_string_centred_clipped(dpi, widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, colour, l, t, widget->right - widget->left - 2);
 }
 
 /**
@@ -767,7 +767,7 @@ static void widget_checkbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
 		colour |= 0x40;
 	}
 
-	gfx_draw_string_left_centred(dpi, (rct_string_id)widget->image, (void*)0x013CE952, colour, l + 14, yMid);
+	gfx_draw_string_left_centred(dpi, (rct_string_id)widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, colour, l + 14, yMid);
 }
 
 /**

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -264,7 +264,7 @@ typedef struct rct_window {
 	uint16 frame_no;				// 0x48E updated every tic for motion in windows sprites
 	uint16 list_information_type;	// 0x490 0 for none, Used as current position of marquee in window_peep
 	sint16 var_492;
-	uint32 var_494;					// 0x494 highlighted item?
+	uint32 highlighted_item;		// 0x494
 	uint8 var_498[0x14];
 	sint16 selected_tab;			// 0x4AC
 	sint16 var_4AE;

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -264,7 +264,7 @@ typedef struct rct_window {
 	uint16 frame_no;				// 0x48E updated every tic for motion in windows sprites
 	uint16 list_information_type;	// 0x490 0 for none, Used as current position of marquee in window_peep
 	sint16 var_492;
-	uint32 var_494;
+	uint32 var_494;					// 0x494 highlighted item?
 	uint8 var_498[0x14];
 	sint16 selected_tab;			// 0x4AC
 	sint16 var_4AE;

--- a/src/management/news_item.c
+++ b/src/management/news_item.c
@@ -301,7 +301,7 @@ void news_item_get_subject_location(int type, int subject, int *x, int *y, int *
 void news_item_add_to_queue(uint8 type, rct_string_id string_id, uint32 assoc)
 {
 	utf8 *buffer = (char*)0x0141EF68;
-	void *args = (void*)0x013CE952;
+	void *args = (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS;
 
 	format_string(buffer, string_id, args); // overflows possible?
 	news_item_add_to_queue_raw(type, buffer, assoc);

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -811,15 +811,15 @@ void reset_all_ride_build_dates()
 static int ride_check_if_construction_allowed(rct_ride *ride)
 {
 	if (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN) {
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = ride->name;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = ride->name_arguments;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = ride->name_arguments;
 		window_error_open(STR_CANT_START_CONSTRUCTION_ON, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING);
 		return 0;
 	}
 
 	if (ride->status != RIDE_STATUS_CLOSED) {
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = ride->name;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = ride->name_arguments;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = ride->name_arguments;
 		window_error_open(STR_CANT_START_CONSTRUCTION_ON, STR_MUST_BE_CLOSED_FIRST);
 		return 0;
 	}
@@ -1666,8 +1666,8 @@ int ride_modify(rct_xy_element *input)
 		return 0;
 
 	if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE) {
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = ride->name;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = ride->name_arguments;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = ride->name_arguments;
 		window_error_open(STR_CANT_START_CONSTRUCTION_ON, STR_LOCAL_AUTHORITY_FORBIDS_DEMOLITION_OR_MODIFICATIONS_TO_THIS_RIDE);
 		return 0;
 	}
@@ -2884,7 +2884,7 @@ rct_ride_measurement *ride_get_measurement(int rideIndex, rct_string_id *message
 		return measurement;
 	} else {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = RideNameConvention[ride->type].vehicle_name;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = RideNameConvention[ride->type].station_name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = RideNameConvention[ride->type].station_name;
 		if (message != NULL) *message = STR_DATA_LOGGING_WILL_START_WHEN_NEXT_LEAVES;
 		return NULL;
 	}

--- a/src/windows/editor_inventions_list.c
+++ b/src/windows/editor_inventions_list.c
@@ -155,7 +155,7 @@ static rct_window_event_list window_editor_inventions_list_drag_events = {
 
 rct_research_item *_editorInventionsListDraggedItem;
 
-#define WindowHighlightedItem(w) *((rct_research_item**)&(w->var_494))
+#define WindowHighlightedItem(w) *((rct_research_item**)&(w->highlighted_item))
 
 static void window_editor_inventions_list_drag_open(rct_research_item *researchItem);
 static void move_research_item(rct_research_item *beforeItem);

--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -419,7 +419,7 @@ void window_editor_object_selection_open()
 	window->var_4AE = 0;
 	window->selected_tab = 0;
 	window->selected_list_item = -1;
-	window->var_494 = 0xFFFFFFFF;
+	window->highlighted_item = 0xFFFFFFFF;
 	window->min_width = 600;
 	window->min_height = 400;
 	window->max_width = 1200;
@@ -836,7 +836,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, int widgetInde
 		visible_list_refresh(w);
 
 		w->selected_list_item = -1;
-		w->var_494 = 0xFFFFFFFF;
+		w->highlighted_item = 0xFFFFFFFF;
 		w->scrolls[0].v_top = 0;
 		object_free_scenario_text();
 		window_invalidate(w);
@@ -856,7 +856,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, int widgetInde
 		visible_list_refresh(w);
 
 		w->selected_list_item = -1;
-		w->var_494 = 0xFFFFFFFF;
+		w->highlighted_item = 0xFFFFFFFF;
 		w->scrolls[0].v_top = 0;
 		object_free_scenario_text();
 		window_invalidate(w);
@@ -1051,7 +1051,7 @@ static void window_editor_object_selection_scroll_mouseover(rct_window *w, int s
 		return;
 
 	w->selected_list_item = selectedObject;
-	w->var_494 = (uint32)installedEntry;
+	w->highlighted_item = (uint32)installedEntry;
 	object_free_scenario_text();
 	if (selectedObject != -1)
 		object_get_scenario_text(installedEntry);
@@ -1342,7 +1342,7 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
 	if (w->selected_list_item == -1 || stex_entry == NULL)
 		return;
 
-	highlightedEntry = (rct_object_entry*)w->var_494;
+	highlightedEntry = (rct_object_entry*)w->highlighted_item;
 	type = highlightedEntry->flags & 0x0F;
 
 	// Draw preview
@@ -1458,7 +1458,7 @@ static void window_editor_object_selection_scrollpaint(rct_window *w, rct_drawpi
 
 			// Highlight background
 			colour = 142;
-			if (listItem->entry == (rct_object_entry*)w->var_494 && !(*listItem->flags & OBJECT_SELECTION_FLAG_6)) {
+			if (listItem->entry == (rct_object_entry*)w->highlighted_item && !(*listItem->flags & OBJECT_SELECTION_FLAG_6)) {
 				gfx_fill_rect(dpi, 0, y, w->width, y + 11, 0x2000031);
 				colour = 14;
 			}
@@ -1515,7 +1515,7 @@ static void window_editor_object_set_page(rct_window *w, int page)
 
 	w->selected_tab = page;
 	w->selected_list_item = -1;
-	w->var_494 = 0xFFFFFFFF;
+	w->highlighted_item = 0xFFFFFFFF;
 	w->scrolls[0].v_top = 0;
 	object_free_scenario_text();
 

--- a/src/windows/editor_objective_options.c
+++ b/src/windows/editor_objective_options.c
@@ -988,12 +988,12 @@ static void window_editor_objective_options_main_paint(rct_window *w, rct_drawpi
 	width = w->widgets[WIDX_PARK_NAME].left - 16;
 
 	if (stex != NULL) {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = stex->park_name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = stex->park_name;
 	} else {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME, rct_string_id);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME, rct_string_id);
 	}
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
-	gfx_draw_string_left_clipped(dpi, 3298, (void*)0x013CE952, 0, x, y, width);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
+	gfx_draw_string_left_clipped(dpi, 3298, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, width);
 
 	// Scenario name
 	x = w->x + 8;
@@ -1001,13 +1001,13 @@ static void window_editor_objective_options_main_paint(rct_window *w, rct_drawpi
 	width = w->widgets[WIDX_SCENARIO_NAME].left - 16;
 
 	if (stex != NULL) {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = stex->scenario_name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = stex->scenario_name;
 	} else {
 		safe_strncpy((char*)0x009BC677, s6Info->name, 64);
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = 3165;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 3165;
 	}
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
-	gfx_draw_string_left_clipped(dpi, 3300, (void*)0x013CE952, 0, x, y, width);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
+	gfx_draw_string_left_clipped(dpi, 3300, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, width);
 
 	// Scenario details label
 	x = w->x + 8;
@@ -1020,13 +1020,13 @@ static void window_editor_objective_options_main_paint(rct_window *w, rct_drawpi
 	width = w->widgets[WIDX_DETAILS].left - 4;
 
 	if (stex != NULL) {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = stex->details;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = stex->details;
 	} else {
 		safe_strncpy((char*)0x009BC677, s6Info->details, 256);
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = 3165;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 3165;
 	}
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
-	gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x, y, width, 1191, 0);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(0x0013573D8, uint32);
+	gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, width, 1191, 0);
 
 	// Scenario category label
 	x = w->x + 8;

--- a/src/windows/finances.c
+++ b/src/windows/finances.c
@@ -640,7 +640,7 @@ static void window_finances_summary_invalidate(rct_window *w)
 	}
 
 	window_finances_set_pressed_tab(w);
-	RCT2_GLOBAL(0x013CE952 + 6, money32) = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_LOAN, money32);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, money32) = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_LOAN, money32);
 }
 
 /**
@@ -1183,7 +1183,7 @@ static void window_finances_marketing_paint(rct_window *w, rct_drawpixelinfo *dp
 
 		noCampaignsActive = 0;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME, rct_string_id);
-		RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
 
 		// Set special parameters
 		switch (i) {
@@ -1191,7 +1191,7 @@ static void window_finances_marketing_paint(rct_window *w, rct_drawpixelinfo *dp
 		case ADVERTISING_CAMPAIGN_RIDE:
 			ride = GET_RIDE(gMarketingCampaignRideIndex[i]);
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = ride->name;
-			RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 			break;
 		case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = ShopItemStringIds[gMarketingCampaignRideIndex[i]].plural;
@@ -1199,7 +1199,7 @@ static void window_finances_marketing_paint(rct_window *w, rct_drawpixelinfo *dp
 		}
 
 		// Advertisement
-		gfx_draw_string_left_clipped(dpi, STR_VOUCHERS_FOR_FREE_ENTRY_TO + i, (void*)0x013CE952, 0, x + 4, y, 296);
+		gfx_draw_string_left_clipped(dpi, STR_VOUCHERS_FOR_FREE_ENTRY_TO + i, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x + 4, y, 296);
 
 		// Duration
 		weeksRemaining = (gMarketingCampaignDaysLeft[i] % 128);

--- a/src/windows/game_bottom_toolbar.c
+++ b/src/windows/game_bottom_toolbar.c
@@ -388,7 +388,7 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
 			(RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, int) < 0 ? 1391 : 1390),
 			x, y - 3,
 			(RCT2_GLOBAL(RCT2_ADDRESS_CURSOR_OVER_WINDOWCLASS, rct_windowclass) == 2 && RCT2_GLOBAL(RCT2_ADDRESS_CURSOR_OVER_WIDGETINDEX, sint32) == WIDX_MONEY ? 2 : w->colours[0] & 0x7F),
-			(void*)0x013CE952
+			(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS
 			);
 		y += 7;
 	}
@@ -466,7 +466,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, 
 		x,
 		y,
 		(RCT2_GLOBAL(RCT2_ADDRESS_CURSOR_OVER_WINDOWCLASS, rct_windowclass) == 2 && RCT2_GLOBAL(RCT2_ADDRESS_CURSOR_OVER_WIDGETINDEX, sint32) == WIDX_DATE ? 2 : w->colours[0] & 0x7F),
-		(void*)0x013CE952
+		(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS
 	);
 
 	// Temperature
@@ -480,7 +480,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, 
 		format = STR_FAHRENHEIT_VALUE;
 	}
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, short) = temperature;
-	gfx_draw_string_left(dpi, format, (void*)0x013CE952, 0, x, y + 6);
+	gfx_draw_string_left(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y + 6);
 	x += 30;
 
 	// Current weather

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -504,7 +504,7 @@ void window_guest_open(rct_peep* peep){
 		window->frame_no = 0;
 		window->list_information_type = 0;
 		window->var_492 = 0;
-		window->var_494 = 0;
+		window->highlighted_item = 0;
 		window_guest_disable_widgets(window);
 		window->min_width = 192;
 		window->min_height = 157;
@@ -835,7 +835,7 @@ void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi){
 	int eax = 0;
 
 	if (w->page == WINDOW_GUEST_OVERVIEW){
-		eax = w->var_494>>16;
+		eax = w->highlighted_item>>16;
 		eax &= 0xFFFC;
 	}
 	ebx += eax;
@@ -1111,27 +1111,27 @@ void window_guest_overview_invalidate(rct_window *w)
  *  rct2: 0x696F45
  */
 void window_guest_overview_update(rct_window* w){
-	int var_496 = w->var_494 >> 16;
+	int var_496 = w->highlighted_item >> 16;
 	var_496++;
 	var_496 %= 24;
-	w->var_494 &= 0x0000FFFF;
-	w->var_494 |= var_496 << 16;
+	w->highlighted_item &= 0x0000FFFF;
+	w->highlighted_item |= var_496 << 16;
 
 	widget_invalidate(w, WIDX_TAB_1);
 	widget_invalidate(w, WIDX_TAB_2);
 
 	w->list_information_type += 2;
 
-	if ((w->var_494 & 0xFFFF) == 0xFFFF)
-		w->var_494 &= 0xFFFF0000;
+	if ((w->highlighted_item & 0xFFFF) == 0xFFFF)
+		w->highlighted_item &= 0xFFFF0000;
 	else
-		w->var_494++;
+		w->highlighted_item++;
 
 	// Disable peep watching thought for multiplayer as its client specific
 	if (network_get_mode() == NETWORK_MODE_NONE) {
 		// Create the "I have the strangest feeling I am being watched thought"
-		if ((w->var_494 & 0xFFFF) >= 3840) {
-			if (!(w->var_494 & 0x3FF)) {
+		if ((w->highlighted_item & 0xFFFF) >= 3840) {
+			if (!(w->highlighted_item & 0x3FF)) {
 				int random = util_rand() & 0xFFFF;
 				if (random <= 0x2AAA) {
 					rct_peep* peep = GET_PEEP(w->number);

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -2186,7 +2186,7 @@ void window_guest_inventory_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		if (y >= maxY) break;
 		if (!peep_has_item(peep, item)) continue;
 
-		void *args = (void*)0x013CE952;
+		void *args = (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS;
 		rct_string_id stringId = window_guest_inventory_format_item(peep, item, (uint8*)args);
 		y += gfx_draw_string_left_wrapped(dpi, args, x, y, itemNameWidth, stringId, 0);
 		numItems++;

--- a/src/windows/guest_list.c
+++ b/src/windows/guest_list.c
@@ -630,7 +630,7 @@ static void window_guest_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		x = w->x + 4;
 		y = w->y + window_guest_list_widgets[WIDX_GUEST_LIST].bottom + 2;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, sint16) = w->var_492;
-		gfx_draw_string_left(dpi, (w->var_492 == 1 ? 1755 : 1754), (void*)0x013CE952, 0, x, y);
+		gfx_draw_string_left(dpi, (w->var_492 == 1 ? 1755 : 1754), (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	}
 }
 
@@ -683,7 +683,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 				// Guest name
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = peep->name_string_idx;
 				RCT2_GLOBAL(0x013CE954, uint32) = peep->id;
-				gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 0, y - 1, 113);
+				gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 0, y - 1, 113);
 
 				switch (_window_guest_list_selected_view) {
 				case VIEW_ACTIONS:
@@ -699,8 +699,8 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 					get_arguments_from_action(peep, &argument_1, &argument_2);
 
 					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = argument_1;
-					RCT2_GLOBAL(0x013CE952 + 4, uint32) = argument_2;
-					gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 133, y - 1, 314);
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint32) = argument_2;
+					gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 133, y - 1, 314);
 					break;
 				case VIEW_THOUGHTS:
 					// For each thought
@@ -716,8 +716,8 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 						get_arguments_from_thought(peep->thoughts[j], &argument_1, &argument_2);
 
 						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = argument_1;
-						RCT2_GLOBAL(0x013CE952 + 4, uint32) = argument_2;
-						gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 118, y - 1, 329);
+						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint32) = argument_2;
+						gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 118, y - 1, 329);
 						break;
 					}
 					break;
@@ -754,9 +754,9 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
 				// Draw action
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = _window_guest_list_groups_argument_1[i];
-				RCT2_GLOBAL(0x013CE952 + 4, uint32) = _window_guest_list_groups_argument_2[i];
-				RCT2_GLOBAL(0x013CE952 + 10, uint32) = numGuests;
-				gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 0, y - 1, 414);
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint32) = _window_guest_list_groups_argument_2[i];
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 10, uint32) = numGuests;
+				gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 0, y - 1, 414);
 
 				// Draw guest count
 				RCT2_GLOBAL(0x013CE95A, uint16) = STR_GUESTS_COUNT_COMMA_SEP;

--- a/src/windows/install_track.c
+++ b/src/windows/install_track.c
@@ -380,9 +380,9 @@ static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		}
 
 		// Ride length
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = 1345;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = track_td6->ride_length;
-		gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, (void*)0x013CE952, 0, x, y, 214);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 1345;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = track_td6->ride_length;
+		gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, 214);
 		y += 10;
 	}
 
@@ -437,9 +437,9 @@ static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	if (track_td6->space_required_x != 0xFF) {
 		// Space required
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = track_td6->space_required_x;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = track_td6->space_required_y;
-		gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, (void*)0x013CE952, 0, x, y);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = track_td6->space_required_x;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = track_td6->space_required_y;
+		gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 		y += 10;
 	}
 

--- a/src/windows/land.c
+++ b/src/windows/land.c
@@ -408,6 +408,6 @@ static void window_land_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	if (price != 0 && !(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, sint32) = price;
-		gfx_draw_string_centred(dpi, 986, x, y, 0, (void*)0x013CE952);
+		gfx_draw_string_centred(dpi, 986, x, y, 0, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS);
 	}
 }

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -930,7 +930,7 @@ static void window_map_show_default_scenario_editor_buttons(rct_window *w) {
 	w->widgets[WIDX_MAP_SIZE_SPINNER].type = WWT_SPINNER;
 	w->widgets[WIDX_MAP_SIZE_SPINNER_UP].type = WWT_DROPDOWN_BUTTON;
 	w->widgets[WIDX_MAP_SIZE_SPINNER_DOWN].type = WWT_DROPDOWN_BUTTON;
-	RCT2_GLOBAL(0x013CE952 + 2, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE, uint16) - 2;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE, uint16) - 2;
 }
 
 static void window_map_inputsize_land(rct_window *w)

--- a/src/windows/new_ride.c
+++ b/src/windows/new_ride.c
@@ -874,9 +874,9 @@ static void window_new_ride_paint_ride_information(rct_window *w, rct_drawpixeli
 		rideDescription = item.type + 512;
 	}
 
-	RCT2_GLOBAL(0x013CE952 + 0, rct_string_id) = rideName;
-	RCT2_GLOBAL(0x013CE952 + 2, rct_string_id) = rideDescription;
-	gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x, y, width, 1690, 0);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, rct_string_id) = rideName;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, rct_string_id) = rideDescription;
+	gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, width, 1690, 0);
 
 	// Number of designs available
 	if (ride_type_has_flag(item.type, RIDE_TYPE_FLAG_HAS_TRACK)) {

--- a/src/windows/news.c
+++ b/src/windows/news.c
@@ -291,8 +291,8 @@ static void window_news_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int s
 
 		// Date text
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = STR_DATE_DAY_1 + newsItem->day - 1;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = STR_MONTH_MARCH + (newsItem->month_year % 8);
-		gfx_draw_string_left(dpi, 2235, (void*)0x013CE952, 2, 4, y);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = STR_MONTH_MARCH + (newsItem->month_year % 8);
+		gfx_draw_string_left(dpi, 2235, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 2, 4, y);
 
 		// Item text
 		utf8 buffer[400];

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -1187,9 +1187,9 @@ static void window_options_invalidate(rct_window *w)
 
 	switch (w->page) {
 	case WINDOW_OPTIONS_PAGE_DISPLAY:
-		RCT2_GLOBAL(0x013CE952 + 16, uint16) = (uint16)gConfigGeneral.fullscreen_width;
-		RCT2_GLOBAL(0x013CE952 + 18, uint16) = (uint16)gConfigGeneral.fullscreen_height;
-		RCT2_GLOBAL(0x013CE952 + 12, uint16) = 2773 + gConfigGeneral.fullscreen_mode;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 16, uint16) = (uint16)gConfigGeneral.fullscreen_width;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 18, uint16) = (uint16)gConfigGeneral.fullscreen_height;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 12, uint16) = 2773 + gConfigGeneral.fullscreen_mode;
 
 		// disable resolution dropdown on "Fullscreen (desktop)"
 		if (gConfigGeneral.fullscreen_mode == 2){
@@ -1233,7 +1233,7 @@ static void window_options_invalidate(rct_window *w)
 
 	case WINDOW_OPTIONS_PAGE_CULTURE:
 		// currency: pounds, dollars, etc. (10 total)
-		RCT2_GLOBAL(0x013CE952 + 12, uint16) = CurrencyDescriptors[gConfigGeneral.currency_format].stringId;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 12, uint16) = CurrencyDescriptors[gConfigGeneral.currency_format].stringId;
 
 		// distance: metric / imperial / si
 		{
@@ -1244,14 +1244,14 @@ static void window_options_invalidate(rct_window *w)
 			case MEASUREMENT_FORMAT_METRIC: stringId = STR_METRIC; break;
 			case MEASUREMENT_FORMAT_SI: stringId = STR_SI; break;
 			}
-			RCT2_GLOBAL(0x013CE952 + 14, uint16) = stringId;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 14, uint16) = stringId;
 		}
 
 		// temperature: celsius/fahrenheit
-		RCT2_GLOBAL(0x013CE952 + 20, uint16) = STR_CELSIUS + gConfigGeneral.temperature_format;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 20, uint16) = STR_CELSIUS + gConfigGeneral.temperature_format;
 
 		// height: units/real values
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = gConfigGeneral.show_height_as_units ? STR_UNITS : STR_REAL_VALUES;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = gConfigGeneral.show_height_as_units ? STR_UNITS : STR_REAL_VALUES;
 
 		window_options_culture_widgets[WIDX_LANGUAGE].type = WWT_DROPDOWN;
 		window_options_culture_widgets[WIDX_LANGUAGE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
@@ -1280,11 +1280,11 @@ static void window_options_invalidate(rct_window *w)
 			else
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = 1170;
 
-			RCT2_GLOBAL(0x013CE952 + 2, uint32) = (uint32)gAudioDevices[currentSoundDevice].name;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = (uint32)gAudioDevices[currentSoundDevice].name;
 		}
 
 		// music: on/off
-		RCT2_GLOBAL(0x013CE952 + 8, uint16) = STR_OFF + gConfigSound.ride_music;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint16) = STR_OFF + gConfigSound.ride_music;
 
 		widget_set_checkbox_value(w, WIDX_SOUND_CHECKBOX, gConfigSound.sound);
 		widget_set_checkbox_value(w, WIDX_MUSIC_CHECKBOX, gConfigSound.ride_music);

--- a/src/windows/park.c
+++ b/src/windows/park.c
@@ -576,7 +576,7 @@ static void window_park_set_disabled_tabs(rct_window *w)
 static void window_park_prepare_window_title_text()
 {
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME, rct_string_id);
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
 }
 
 #pragma region Entrance page
@@ -949,7 +949,7 @@ static void window_park_entrance_invalidate(rct_window *w)
 
 	// Set open / close park button state
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME, rct_string_id);
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_NAME_ARGS, uint32);
 	window_park_entrance_widgets[WIDX_OPEN_OR_CLOSE].image = park_is_open() ? SPR_OPEN : SPR_CLOSED;
 	window_park_entrance_widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + !park_is_open() * 2 + widget_is_pressed(w, WIDX_CLOSE_LIGHT);
 	window_park_entrance_widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + park_is_open() * 2 + widget_is_pressed(w, WIDX_OPEN_LIGHT);
@@ -1038,7 +1038,7 @@ static void window_park_entrance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	gfx_draw_string_centred_clipped(
 		dpi,
 		1191,
-		(void*)0x013CE952,
+		(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS,
 		0,
 		w->x + (labelWidget->left + labelWidget->right) / 2,
 		w->y + labelWidget->top,
@@ -1468,7 +1468,7 @@ static void window_park_price_invalidate(rct_window *w)
 		window_park_price_widgets[WIDX_DECREASE_PRICE].type = WWT_DROPDOWN_BUTTON;
 	}
 
-	RCT2_GLOBAL(0x013CE952 + 6, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_ENTRANCE_FEE, uint16);
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_PARK_ENTRANCE_FEE, uint16);
 	window_park_price_widgets[WIDX_PRICE].image = RCT2_GLOBAL(RCT2_ADDRESS_PARK_ENTRANCE_FEE, uint16) == 0 ? STR_FREE : 1429;
 
 	window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_7);
@@ -1590,20 +1590,20 @@ static void window_park_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		parkSize = squaredmetres_to_squaredfeet(parkSize);
 	}
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = parkSize;
-	gfx_draw_string_left(dpi, stringIndex, (void*)0x013CE952, 0, x, y);
+	gfx_draw_string_left(dpi, stringIndex, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	y += 10;
 
 	// Draw number of rides / attractions
 	if (w->list_information_type != (uint16)-1) {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = w->list_information_type;
-		gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, (void*)0x013CE952, 0, x, y);
+		gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	}
 	y += 10;
 
 	// Draw number of staff
 	if (w->var_48C != -1) {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = w->var_48C;
-		gfx_draw_string_left(dpi, STR_STAFF_LABEL, (void*)0x013CE952, 0, x, y);
+		gfx_draw_string_left(dpi, STR_STAFF_LABEL, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	}
 	y += 10;
 
@@ -1748,7 +1748,7 @@ static void window_park_objective_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	y = w->y + window_park_objective_widgets[WIDX_PAGE_BACKGROUND].top + 7;
 	safe_strncpy((char*)0x009BC677, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIO_DETAILS, char), 256);
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, short) = 3165;
-	y += gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x, y, 222, 1191, 0);
+	y += gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, 222, 1191, 0);
 	y += 5;
 
 	// Your objective:
@@ -1760,7 +1760,7 @@ static void window_park_objective_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	RCT2_GLOBAL(0x013CE954, short) = date_get_total_months(MONTH_OCTOBER, RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_YEAR, uint8));
 	RCT2_GLOBAL(0x013CE956, int) = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_CURRENCY, sint32);
 
-	y += gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x, y, 221, 2385 + RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_TYPE, uint8), 0);
+	y += gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, 221, 2385 + RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_TYPE, uint8), 0);
 	y += 5;
 
 	// Objective outcome
@@ -1771,7 +1771,7 @@ static void window_park_objective_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		} else {
 			// Objective completed
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, int) = RCT2_GLOBAL(RCT2_ADDRESS_COMPLETED_COMPANY_VALUE, money32);
-			gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x, y, 222, 2788, 0);
+			gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, 222, 2788, 0);
 		}
 	}
 }

--- a/src/windows/research.c
+++ b/src/windows/research.c
@@ -341,7 +341,7 @@ void window_research_development_page_paint(rct_window *w, rct_drawpixelinfo *dp
 		y += 15;
 
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = STR_UNKNOWN;
-		gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, (void*)0x013CE952, 0, x, y);
+		gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	} else {
 		// Research type
 		stringId = STR_RESEARCH_UNKNOWN;
@@ -373,11 +373,11 @@ void window_research_development_page_paint(rct_window *w, rct_drawpixelinfo *dp
 			uint16 expectedDay = RCT2_GLOBAL(RCT2_ADDRESS_NEXT_RESEARCH_EXPECTED_DAY, uint8);
 			if (expectedDay != 255) {
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = 2289;
-				RCT2_GLOBAL(0x013CE952 + 2, uint16) = STR_DATE_DAY_1 + expectedDay;
-				RCT2_GLOBAL(0x013CE952 + 4, uint16) = STR_MONTH_MARCH + RCT2_GLOBAL(RCT2_ADDRESS_NEXT_RESEARCH_EXPECTED_MONTH, uint8);
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = STR_DATE_DAY_1 + expectedDay;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = STR_MONTH_MARCH + RCT2_GLOBAL(RCT2_ADDRESS_NEXT_RESEARCH_EXPECTED_MONTH, uint8);
 			}
 		}
-		gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, (void*)0x013CE952, 0, x, y);
+		gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 	}
 
 	// Last development

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1183,7 +1183,7 @@ rct_window *window_ride_open(int rideIndex)
 	w->frame_no = 0;
 	w->list_information_type = 0;
 	w->var_492 = 0;
-	w->var_494 = 0;
+	w->highlighted_item = 0;
 	window_ride_disable_tabs(w);
 	w->min_width = 316;
 	w->min_height = 180;
@@ -3722,7 +3722,7 @@ static void window_ride_set_track_colour_scheme(rct_window *w, int x, int y)
 	uint8 newColourScheme;
 	int interactionType, z, direction;
 
-	newColourScheme = (uint8)(*((uint16*)&w->var_494));
+	newColourScheme = (uint8)(*((uint16*)&w->highlighted_item));
 
 	rct_xy16 mapCoord = { 0 };
 	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_RIDE, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, NULL);
@@ -3812,7 +3812,7 @@ static void window_ride_colour_mousedown(int widgetIndex, rct_window *w, rct_wid
 
 	ride = GET_RIDE(w->number);
 	rideEntry = ride_get_entry(ride);
-	colourSchemeIndex = *((uint16*)&w->var_494);
+	colourSchemeIndex = *((uint16*)&w->highlighted_item);
 	dropdownWidget = widget - 1;
 
 	switch (widgetIndex) {
@@ -3952,20 +3952,20 @@ static void window_ride_colour_dropdown(rct_window *w, int widgetIndex, int drop
 
 	switch (widgetIndex) {
 	case WIDX_TRACK_COLOUR_SCHEME_DROPDOWN:
-		*((uint16*)&w->var_494) = dropdownIndex;
+		*((uint16*)&w->highlighted_item) = dropdownIndex;
 		window_invalidate(w);
 		break;
 	case WIDX_TRACK_MAIN_COLOUR:
-		game_do_command(0, (0 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->var_494), 0);
+		game_do_command(0, (0 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
 		break;
 	case WIDX_TRACK_ADDITIONAL_COLOUR:
-		game_do_command(0, (1 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->var_494), 0);
+		game_do_command(0, (1 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
 		break;
 	case WIDX_TRACK_SUPPORT_COLOUR:
-		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->var_494), 0);
+		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
 		break;
 	case WIDX_MAZE_STYLE_DROPDOWN:
-		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->var_494), 0);
+		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
 		break;
 	case WIDX_ENTRANCE_STYLE_DROPDOWN:
 		game_do_command(0, (6 << 8) | 1, 0, (window_ride_entrance_style_list[dropdownIndex] << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, 0, 0);
@@ -4052,7 +4052,7 @@ static void window_ride_colour_invalidate(rct_window *w)
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Track colours
-	int colourScheme = *((uint16*)&w->var_494);
+	int colourScheme = *((uint16*)&w->highlighted_item);
 	trackColour = ride_get_track_colour(ride, colourScheme);
 
 	// Maze style
@@ -4221,7 +4221,7 @@ static void window_ride_colour_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	if (widget->type != WWT_EMPTY)
 		gfx_fill_rect(dpi, w->x + widget->left + 1, w->y + widget->top + 1, w->x + widget->right - 1, w->y + widget->bottom - 1, 12);
 
-	trackColour = ride_get_track_colour(ride, *((uint16*)&w->var_494));
+	trackColour = ride_get_track_colour(ride, *((uint16*)&w->highlighted_item));
 
 	//
 	if (rideEntry->shop_item == 0xFF) {

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1675,8 +1675,8 @@ static void window_ride_main_mouseup(rct_window *w, int widgetIndex)
 			break;
 		}
 
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = ride->name;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = ride->name_arguments;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = ride->name_arguments;
 		ride_set_status(w->number, status);
 		break;
 	}
@@ -1916,8 +1916,8 @@ static void window_ride_main_dropdown(rct_window *w, int widgetIndex, int dropdo
 			break;
 		}
 
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = ride->name;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = ride->name_arguments;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = ride->name_arguments;
 		ride_set_status(w->number, status);
 		break;
 	}
@@ -2012,8 +2012,8 @@ static void window_ride_main_invalidate(rct_window *w)
 	if (ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK))
 		w->disabled_widgets |= (1 << 22);
 
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 	window_ride_main_widgets[WIDX_OPEN].image = SPR_CLOSED + ride->status;
 
 	window_ride_main_widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + (ride->status == RIDE_STATUS_CLOSED) * 2 + widget_is_pressed(w, WIDX_CLOSE_LIGHT);
@@ -2233,10 +2233,10 @@ static void window_ride_main_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	if (w->ride.view != 0) {
 		stringId = RideNameConvention[ride->type].vehicle_name + 6;
 		if (w->ride.view > ride->num_vehicles) {
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = w->ride.view - ride->num_vehicles;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = w->ride.view - ride->num_vehicles;
 			stringId = RideNameConvention[ride->type].station_name + 6;
 		} else {
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = w->ride.view;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = w->ride.view;
 		}
 	}
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = stringId;
@@ -2248,15 +2248,15 @@ static void window_ride_main_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		w->x + (widget->left + widget->right - 11) / 2,
 		w->y + widget->top,
 		0,
-		(void*)0x013CE952
+		(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS
 	);
 
 	// Status
 	widget = &window_ride_main_widgets[WIDX_STATUS];
 	gfx_draw_string_centred_clipped(
 		dpi,
-		window_ride_get_status(w, (void*)0x013CE952),
-		(void*)0x013CE952,
+		window_ride_get_status(w, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS),
+		(void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS,
 		0,
 		w->x + (widget->left + widget->right) / 2,
 		w->y + widget->top,
@@ -2497,8 +2497,8 @@ static void window_ride_vehicle_invalidate(rct_window *w)
 	ride = GET_RIDE(w->number);
 	rideEntry = ride_get_entry(ride);
 
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Widget setup
 	carsPerTrain = ride->num_cars_per_train - rideEntry->zero_cars;
@@ -2535,12 +2535,12 @@ static void window_ride_vehicle_invalidate(rct_window *w)
 		window_ride_vehicle_widgets[WIDX_VEHICLE_CARS_PER_TRAIN_DROPDOWN].type = WWT_EMPTY;
 	}
 
-	RCT2_GLOBAL(0x013CE952 + 6, uint16) = carsPerTrain;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = carsPerTrain;
 	stringId = RideNameConvention[ride->type].vehicle_name + 4;
 	if (ride->num_vehicles > 1)
 		stringId++;
-	RCT2_GLOBAL(0x013CE952 + 8, uint16) = stringId;
-	RCT2_GLOBAL(0x013CE952 + 10, uint16) = ride->num_vehicles;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint16) = stringId;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 10, uint16) = ride->num_vehicles;
 
 	window_ride_anchor_border_widgets(w);
 	window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_10);
@@ -3036,8 +3036,8 @@ static void window_ride_operating_invalidate(rct_window *w)
 	ride = GET_RIDE(w->number);
 	rideEntry = ride_get_entry(ride);
 
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Widget setup
 	w->pressed_widgets &= ~0x44700000;
@@ -3115,7 +3115,7 @@ static void window_ride_operating_invalidate(rct_window *w)
 		window_ride_operating_widgets[WIDX_MAXIMUM_LENGTH_INCREASE].type = WWT_DROPDOWN_BUTTON;
 		window_ride_operating_widgets[WIDX_MAXIMUM_LENGTH_DECREASE].type = WWT_DROPDOWN_BUTTON;
 
-		RCT2_GLOBAL(0x013CE952 + 10, uint16) = 1217;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 10, uint16) = 1217;
 		RCT2_GLOBAL(0x013CE95E, uint16) = ride->min_waiting_time;
 		RCT2_GLOBAL(0x013CE960, uint16) = 1217;
 		RCT2_GLOBAL(0x013CE962, uint16) = ride->max_waiting_time;
@@ -3559,8 +3559,8 @@ static void window_ride_maintenance_invalidate(rct_window *w)
 	window_ride_set_pressed_tab(w);
 
 	rct_ride *ride = GET_RIDE(w->number);
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL].image = STR_EVERY_10_MINUTES + ride->inspection_interval;
 
@@ -3670,9 +3670,9 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 			} else {
 				mechanicSprite = &(g_sprite_list[ride->mechanic].peep);
 				if (peep_is_mechanic(mechanicSprite)) {
-					RCT2_GLOBAL(0x013CE952 + 0, uint16) = mechanicSprite->name_string_idx;
-					RCT2_GLOBAL(0x013CE952 + 2, uint32) = mechanicSprite->id;
-					gfx_draw_string_left_wrapped(dpi, (void*)0x013CE952, x + 4, y, 280, stringId, 0);
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = mechanicSprite->name_string_idx;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = mechanicSprite->id;
+					gfx_draw_string_left_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x + 4, y, 280, stringId, 0);
 				}
 			}
 		}
@@ -4048,8 +4048,8 @@ static void window_ride_colour_invalidate(rct_window *w)
 	ride = GET_RIDE(w->number);
 	rideEntry = ride_get_entry(ride);
 
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Track colours
 	int colourScheme = *((uint16*)&w->var_494);
@@ -4167,10 +4167,10 @@ static void window_ride_colour_invalidate(rct_window *w)
 			window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WWT_EMPTY;
 			window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WWT_EMPTY;
 		}
-		RCT2_GLOBAL(0x013CE952 +  6, uint16) = STR_ALL_VEHICLES_IN_SAME_COLOURS + vehicleColourSchemeType;
-		RCT2_GLOBAL(0x013CE952 +  8, uint16) = RideNameConvention[ride->type].vehicle_name;
-		RCT2_GLOBAL(0x013CE952 + 10, uint16) = RideNameConvention[ride->type].vehicle_name + 2;
-		RCT2_GLOBAL(0x013CE952 + 12, uint16) = w->var_48C + 1;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS +  6, uint16) = STR_ALL_VEHICLES_IN_SAME_COLOURS + vehicleColourSchemeType;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS +  8, uint16) = RideNameConvention[ride->type].vehicle_name;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 10, uint16) = RideNameConvention[ride->type].vehicle_name + 2;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 12, uint16) = w->var_48C + 1;
 		// Vehicle index
 		if (vehicleColourSchemeType != 0) {
 			window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_INDEX].type = WWT_DROPDOWN;
@@ -4528,8 +4528,8 @@ static void window_ride_music_invalidate(rct_window *w)
 	window_ride_set_pressed_tab(w);
 
 	rct_ride *ride = GET_RIDE(w->number);
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Set selected music
 	window_ride_music_widgets[WIDX_MUSIC].image = STR_MUSIC_STYLE_START + ride->music;
@@ -4813,8 +4813,8 @@ static void window_ride_measurements_invalidate(rct_window *w)
 	window_ride_set_pressed_tab(w);
 
 	rct_ride *ride = GET_RIDE(w->number);
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	window_ride_measurements_widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN_NOT_POSSIBLE;
 	window_ride_measurements_widgets[WIDX_SAVE_TRACK_DESIGN].type = WWT_EMPTY;
@@ -4879,15 +4879,15 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
 
 		if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED) {
 			// Excitement
-			RCT2_GLOBAL(0x013CE952 + 0, uint32) = ride->excitement;
-			RCT2_GLOBAL(0x013CE952 + 4, uint16) = STR_RATING_LOW + min(ride->excitement >> 8, 5);
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint32) = ride->excitement;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = STR_RATING_LOW + min(ride->excitement >> 8, 5);
 			stringId = ride->excitement == -1 ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE : STR_EXCITEMENT_RATING;
-			gfx_draw_string_left(dpi, stringId, (void*)0x013CE952, 0, x, y);
+			gfx_draw_string_left(dpi, stringId, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 			y += 10;
 
 			// Intensity
-			RCT2_GLOBAL(0x013CE952 + 0, uint32) = ride->intensity;
-			RCT2_GLOBAL(0x013CE952 + 4, uint16) = STR_RATING_LOW + min(ride->intensity >> 8, 5);
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint32) = ride->intensity;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = STR_RATING_LOW + min(ride->intensity >> 8, 5);
 
 			stringId = STR_INTENSITY_RATING;
 			if (ride->excitement == -1)
@@ -4895,14 +4895,14 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
 			else if (ride->intensity >= RIDE_RATING(10,00))
 				stringId = STR_INTENSITY_RATING_RED;
 
-			gfx_draw_string_left(dpi, stringId, (void*)0x013CE952, 0, x, y);
+			gfx_draw_string_left(dpi, stringId, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 			y += 10;
 
 			// Nausea
-			RCT2_GLOBAL(0x013CE952 + 0, uint32) = ride->nausea;
-			RCT2_GLOBAL(0x013CE952 + 4, uint16) = STR_RATING_LOW + min(ride->nausea >> 8, 5);
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint32) = ride->nausea;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = STR_RATING_LOW + min(ride->nausea >> 8, 5);
 			stringId = ride->excitement == -1 ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
-			gfx_draw_string_left(dpi, stringId, (void*)0x013CE952, 0, x, y);
+			gfx_draw_string_left(dpi, stringId, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 			y += 20;
 
 			// Horizontal rule
@@ -4930,22 +4930,22 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
 					for (i = 0; i < ride->num_stations; i++) {
 						time = ride->time[numTimes];
 						if (time != 0) {
-							RCT2_GLOBAL(0x013CE952 + 0 + (numTimes * 4), uint16) = 1343;
-							RCT2_GLOBAL(0x013CE952 + 2 + (numTimes * 4), uint16) = time;
+							RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0 + (numTimes * 4), uint16) = 1343;
+							RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2 + (numTimes * 4), uint16) = time;
 							numTimes++;
 						}
 					}
 					if (numTimes == 0) {
-						RCT2_GLOBAL(0x013CE952 + 0, uint16) = 1343;
-						RCT2_GLOBAL(0x013CE952 + 2, uint16) = 0;
+						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 1343;
+						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = 0;
 						numTimes++;
 					}
 					RCT2_GLOBAL(0x013CE94E + (numTimes * 4), uint16) = 1342;
-					RCT2_GLOBAL(0x013CE952 + 0 + (numTimes * 4), uint16) = 0;
-					RCT2_GLOBAL(0x013CE952 + 2 + (numTimes * 4), uint16) = 0;
-					RCT2_GLOBAL(0x013CE952 + 4 + (numTimes * 4), uint16) = 0;
-					RCT2_GLOBAL(0x013CE952 + 6 + (numTimes * 4), uint16) = 0;
-					gfx_draw_string_left_clipped(dpi, STR_RIDE_TIME, (void*)0x013CE952, 0, x, y, 308);
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0 + (numTimes * 4), uint16) = 0;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2 + (numTimes * 4), uint16) = 0;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4 + (numTimes * 4), uint16) = 0;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6 + (numTimes * 4), uint16) = 0;
+					gfx_draw_string_left_clipped(dpi, STR_RIDE_TIME, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, 308);
 					y += 10;
 				}
 
@@ -4955,22 +4955,22 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
 					length = ride->length[numLengths];
 					if (length != 0) {
 						length >>= 16;
-						RCT2_GLOBAL(0x013CE952 + 0 + (numLengths * 4), uint16) = 1346;
-						RCT2_GLOBAL(0x013CE952 + 2 + (numLengths * 4), uint16) = (length & 0xFFFF);
+						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0 + (numLengths * 4), uint16) = 1346;
+						RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2 + (numLengths * 4), uint16) = (length & 0xFFFF);
 						numLengths++;
 					}
 				}
 				if (numLengths == 0) {
-					RCT2_GLOBAL(0x013CE952 + 0, uint16) = 1346;
-					RCT2_GLOBAL(0x013CE952 + 2, uint16) = 0;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 1346;
+					RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = 0;
 					numLengths++;
 				}
 				RCT2_GLOBAL(0x013CE94E + (numLengths * 4), uint16) = 1345;
-				RCT2_GLOBAL(0x013CE952 + 0 + (numLengths * 4), uint16) = 0;
-				RCT2_GLOBAL(0x013CE952 + 2 + (numLengths * 4), uint16) = 0;
-				RCT2_GLOBAL(0x013CE952 + 4 + (numLengths * 4), uint16) = 0;
-				RCT2_GLOBAL(0x013CE952 + 6 + (numLengths * 4), uint16) = 0;
-				gfx_draw_string_left_clipped(dpi, STR_RIDE_LENGTH, (void*)0x013CE952, 0, x, y, 308);
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0 + (numLengths * 4), uint16) = 0;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2 + (numLengths * 4), uint16) = 0;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4 + (numLengths * 4), uint16) = 0;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6 + (numLengths * 4), uint16) = 0;
+				gfx_draw_string_left_clipped(dpi, STR_RIDE_LENGTH, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, 308);
 				y += 10;
 
 				if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_G_FORCES)) {
@@ -5181,9 +5181,9 @@ static void window_ride_graphs_tooltip(rct_window* w, int widgetIndex, rct_strin
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = 3158;
 		measurement = ride_get_measurement(w->number, &message);
 		if (measurement != NULL && (measurement->flags & RIDE_MEASUREMENT_FLAG_RUNNING)) {
-			RCT2_GLOBAL(0x013CE952 + 4, uint16) = measurement->vehicle_index + 1;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = measurement->vehicle_index + 1;
 			ride = GET_RIDE(w->number);
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = RideNameConvention[ride->type].vehicle_name + 6;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = RideNameConvention[ride->type].vehicle_name + 6;
 		} else {
 			*stringId = message;
 		}
@@ -5214,8 +5214,8 @@ static void window_ride_graphs_invalidate(rct_window *w)
 
 	ride = GET_RIDE(w->number);
 
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Set pressed graph button type
 	w->pressed_widgets &= ~(1 << WIDX_GRAPH_VELOCITY);
@@ -5285,7 +5285,7 @@ static void window_ride_graphs_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
 		x = (widget->right - widget->left) / 2;
 		y = (widget->bottom - widget->top) / 2 - 5;
 		width = widget->right - widget->left - 2;
-		gfx_draw_string_centred_wrapped(dpi, (void*)0x013CE952, x, y, width, stringId, 0);
+		gfx_draw_string_centred_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, width, stringId, 0);
 		return;
 	}
 
@@ -5666,8 +5666,8 @@ static void window_ride_income_invalidate(rct_window *w)
 	window_ride_set_pressed_tab(w);
 
 	rct_ride *ride = GET_RIDE(w->number);
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	rideEntry = ride_get_entry(ride);
 
@@ -5687,7 +5687,7 @@ static void window_ride_income_invalidate(rct_window *w)
 	window_ride_income_widgets[WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK].type = WWT_EMPTY;
 
 	window_ride_income_widgets[WIDX_PRIMARY_PRICE].image = 1429;
-	RCT2_GLOBAL(0x013CE952 + 6, money32) = ride->price;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, money32) = ride->price;
 	if (ride->price == 0)
 		window_ride_income_widgets[WIDX_PRIMARY_PRICE].image = STR_FREE;
 
@@ -5752,7 +5752,7 @@ static void window_ride_income_invalidate(rct_window *w)
 
 		// Set secondary item price
 		window_ride_income_widgets[WIDX_SECONDARY_PRICE].image = 1799;
-		RCT2_GLOBAL(0x013CE952 + 10, money32) = ride->price_secondary;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 10, money32) = ride->price_secondary;
 		if (ride->price_secondary == 0)
 			window_ride_income_widgets[WIDX_SECONDARY_PRICE].image = STR_FREE;
 	}
@@ -5933,8 +5933,8 @@ static void window_ride_customer_invalidate(rct_window *w)
 	window_ride_set_pressed_tab(w);
 
 	rct_ride *ride = GET_RIDE(w->number);
-	RCT2_GLOBAL(0x013CE952 + 0, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	window_ride_customer_widgets[WIDX_SHOW_GUESTS_THOUGHTS].type = WWT_FLATBTN;
 	if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP)) {
@@ -6007,9 +6007,9 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	// Primary shop items sold
 	shopItem = ride_get_entry(ride)->shop_item;
 	if (shopItem != 0xFF) {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = ShopItemStringIds[shopItem].plural;
-		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->no_primary_items_sold;
-		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)0x013CE952, 0, x, y);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ShopItemStringIds[shopItem].plural;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->no_primary_items_sold;
+		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 		y += 10;
 	}
 
@@ -6018,9 +6018,9 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		RCT2_GLOBAL(0x0097D7CB + (ride->type * 4), uint8) :
 		ride_get_entry(ride)->shop_item_secondary;
 	if (shopItem != 0xFF) {
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = ShopItemStringIds[shopItem].plural;
-		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->no_secondary_items_sold;
-		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)0x013CE952, 0, x, y);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = ShopItemStringIds[shopItem].plural;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->no_secondary_items_sold;
+		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 		y += 10;
 	}
 

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -2073,17 +2073,17 @@ static void window_ride_construction_invalidate(rct_window *w)
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = stringId;
 
 	if (RCT2_GLOBAL(0x00F440D3, uint8) == 1)
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = ((RCT2_GLOBAL(0x00F440CD, uint8) * 9) >> 2) & 0xFFFF;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ((RCT2_GLOBAL(0x00F440CD, uint8) * 9) >> 2) & 0xFFFF;
 
 	window_ride_construction_widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].image =
 		STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_NEG_180 + RCT2_GLOBAL(0x00F440CF, uint8);
 
 	if (RCT2_GLOBAL(0x00F440D3, uint8) == 2)
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = ((RCT2_GLOBAL(0x00F440CE, uint8) * 9) >> 2) & 0xFFFF;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ((RCT2_GLOBAL(0x00F440CE, uint8) * 9) >> 2) & 0xFFFF;
 
 	// Set window title arguments
-	RCT2_GLOBAL(0x013CE952 + 4, uint16) = ride->name;
-	RCT2_GLOBAL(0x013CE952 + 6, uint32) = ride->name_arguments;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint16) = ride->name;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint32) = ride->name_arguments;
 }
 
 /**

--- a/src/windows/ride_list.c
+++ b/src/windows/ride_list.c
@@ -474,59 +474,59 @@ static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, 
 		switch (_window_ride_list_information_type) {
 		case INFORMATION_TYPE_STATUS:
 			ride_get_status(w->list_item_positions[i], &formatSecondary, &argument);
-			RCT2_GLOBAL(0x013CE952 + 2, sint32) = argument;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, sint32) = argument;
 			break;
 		case INFORMATION_TYPE_POPULARITY:
 			formatSecondary = STR_POPULARITY_UNKNOWN_LABEL;
 			if (ride->popularity != 255) {
 				formatSecondary = STR_POPULARITY_LABEL;
-				RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->popularity * 4;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride->popularity * 4;
 			}
 			break;
 		case INFORMATION_TYPE_SATISFACTION:
 			formatSecondary = STR_SATISFACTION_UNKNOWN_LABEL;
 			if (ride->satisfaction != 255) {
 				formatSecondary = STR_SATISFACTION_LABEL;
-				RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->satisfaction * 5;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride->satisfaction * 5;
 			}
 			break;
 		case INFORMATION_TYPE_PROFIT:
 			formatSecondary = 0;
 			if (ride->profit != MONEY32_UNDEFINED) {
 				formatSecondary = STR_PROFIT_LABEL;
-				RCT2_GLOBAL(0x013CE952 + 2, sint32) = ride->profit;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, sint32) = ride->profit;
 			}
 			break;
 		case INFORMATION_TYPE_QUEUE_LENGTH:
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride_get_total_queue_length(ride);
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride_get_total_queue_length(ride);
 			formatSecondary = STR_QUEUE_EMPTY;
-			if (RCT2_GLOBAL(0x013CE952 + 2, uint16) == 1)
+			if (RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) == 1)
 				formatSecondary = STR_QUEUE_ONE_PERSON;
-			else if (RCT2_GLOBAL(0x013CE952 + 2, uint16) > 1)
+			else if (RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) > 1)
 				formatSecondary = STR_QUEUE_PEOPLE;
 			break;
 		case INFORMATION_TYPE_QUEUE_TIME:
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride_get_max_queue_time(ride);
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride_get_max_queue_time(ride);
 			formatSecondary = STR_QUEUE_TIME_LABEL;
-			if (RCT2_GLOBAL(0x013CE952 + 2, uint16) > 1)
+			if (RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) > 1)
 				formatSecondary = STR_QUEUE_TIME_PLURAL_LABEL;
 			break;
 		case INFORMATION_TYPE_RELIABILITY:
 			// edx = RCT2_GLOBAL(0x009ACFA4 + (ride->var_001 * 4), uint32);
 
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->reliability >> 8;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride->reliability >> 8;
 			formatSecondary = STR_RELIABILITY_LABEL;
 			break;
 		case INFORMATION_TYPE_DOWN_TIME:
 			// edx = RCT2_GLOBAL(0x009ACFA4 + (ride->var_001 * 4), uint32);
 
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->downtime;
+			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride->downtime;
 			formatSecondary = STR_DOWN_TIME_LABEL;
 			break;
 		case INFORMATION_TYPE_GUESTS_FAVOURITE:
 			formatSecondary = 0;
 			if (RCT2_ADDRESS(0x0097C3AF, uint8)[ride->type] == PAGE_RIDES) {
-				RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->guests_favourite;
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = ride->guests_favourite;
 				formatSecondary = ride->guests_favourite == 1 ? STR_GUESTS_FAVOURITE_LABEL : STR_GUESTS_FAVOURITE_PLURAL_LABEL;
 			}
 			break;
@@ -537,7 +537,7 @@ static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, 
 			format = 1192;
 
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = formatSecondary;
-		gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 160, y - 1, 157);
+		gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 160, y - 1, 157);
 		y += 10;
 	}
 }
@@ -712,8 +712,8 @@ static void window_ride_list_close_all(rct_window *w)
 			continue;
 		if (ride->status == RIDE_STATUS_CLOSED)
 			continue;
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = w->scrolls[0].v_top;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = w->scrolls[0].v_bottom;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = w->scrolls[0].v_top;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = w->scrolls[0].v_bottom;
 
 		ride_set_status(i, RIDE_STATUS_CLOSED);
 	}
@@ -729,8 +729,8 @@ static void window_ride_list_open_all(rct_window *w)
 			continue;
 		if (ride->status == RIDE_STATUS_OPEN)
 			continue;
-		RCT2_GLOBAL(0x013CE952 + 6, uint16) = w->scrolls[0].v_top;
-		RCT2_GLOBAL(0x013CE952 + 8, uint32) = w->scrolls[0].v_bottom;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = w->scrolls[0].v_top;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 8, uint32) = w->scrolls[0].v_bottom;
 
 		ride_set_status(i, RIDE_STATUS_OPEN);
 	}

--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -1031,12 +1031,12 @@ void window_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	if (!(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)) {
 		// -14
-		gfx_draw_string_right(dpi, STR_COST_LABEL, (void*)0x013CE952, 0,
+		gfx_draw_string_right(dpi, STR_COST_LABEL, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0,
 			w->x + w->width - 0x1A, w->y + w->height - 13);
 	}
 
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = sceneryEntry->name;
-	gfx_draw_string_left_clipped(dpi, 0x4A7, (void*)0x013CE952, 0,
+	gfx_draw_string_left_clipped(dpi, 0x4A7, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0,
 		w->x + 3, w->y + w->height - 13, w->width - 19);
 }
 

--- a/src/windows/shortcut_key_change.c
+++ b/src/windows/shortcut_key_change.c
@@ -122,5 +122,5 @@ static void window_shortcut_change_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	int y = w->y + 30;
 
 	RCT2_GLOBAL(0x13CE952, uint16) = ShortcutStringIds[RCT2_GLOBAL(0x009DE511, uint8)];
-	gfx_draw_string_centred_wrapped(dpi, (void*)0x013CE952, x, y, 242, 2785, RCT2_GLOBAL(0x9DEB8D, uint8));
+	gfx_draw_string_centred_wrapped(dpi, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, x, y, 242, 2785, RCT2_GLOBAL(0x9DEB8D, uint8));
 }

--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -1056,7 +1056,7 @@ void window_staff_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	if (!(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)){
 
 		RCT2_GLOBAL(0x13CE952,uint32) = RCT2_ADDRESS(0x992A00,uint16)[peep->staff_type];
-		gfx_draw_string_left(dpi, 2349, (void*)0x013CE952, 0,x, y);
+		gfx_draw_string_left(dpi, 2349, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0,x, y);
 
 		y += 10;
 	}

--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -309,8 +309,7 @@ rct_window *window_staff_open(rct_peep* peep)
 		w->page = 0;
 		w->viewport_focus_coordinates.y = 0;
 		w->frame_no = 0;
-
-		RCT2_GLOBAL((int*)w + 0x496, uint16) = 0; // missing, var_494 should perhaps be uint16?
+		w->highlighted_item = 0;
 
 		window_staff_disable_widgets(w);
 
@@ -993,7 +992,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
 	int eax = 0;
 
 	if (w->page == WINDOW_STAFF_OVERVIEW){
-		eax = w->var_494 >> 16;
+		eax = w->highlighted_item >> 16;
 		eax &= 0xFFFC;
 	}
 	ebx += eax;

--- a/src/windows/staff_list.c
+++ b/src/windows/staff_list.c
@@ -591,7 +591,7 @@ void window_staff_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	if (!(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = RCT2_ADDRESS(0x00992A00, uint16)[selectedTab];
-		gfx_draw_string_left(dpi, 1858, (void*)0x013CE952, 0, w->x + 0xA5, w->y + 0x20);
+		gfx_draw_string_left(dpi, 1858, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, w->x + 0xA5, w->y + 0x20);
 	}
 
 	if (selectedTab < 3) {
@@ -605,9 +605,9 @@ void window_staff_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	}
 
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = _window_staff_list_selected_type_count;
-	RCT2_GLOBAL(0x013CE952 + 2, uint16) = staffTypeStringId;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = staffTypeStringId;
 
-	gfx_draw_string_left(dpi, STR_STAFF_LIST_COUNTER, (void*)0x013CE952, 0, w->x + 4, window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + w->y + 2);
+	gfx_draw_string_left(dpi, STR_STAFF_LIST_COUNTER, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, w->x + 4, window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + w->y + 2);
 }
 
 /**
@@ -641,13 +641,13 @@ void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int sc
 				}
 
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = peep->name_string_idx;
-				RCT2_GLOBAL(0x013CE952 + 2, uint32) = peep->id;
-				gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 0, y - 1, 107);
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
+				gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 0, y - 1, 107);
 
 				get_arguments_from_action(peep, &argument_1, &argument_2);
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint32) = argument_1;
-				RCT2_GLOBAL(0x013CE952 + 4, uint32) = argument_2;
-				gfx_draw_string_left_clipped(dpi, format, (void*)0x013CE952, 0, 175, y - 1, 305);
+				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 4, uint32) = argument_2;
+				gfx_draw_string_left_clipped(dpi, format, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, 175, y - 1, 305);
 
 				// True if a patrol path is set for the worker
 				if (RCT2_ADDRESS(RCT2_ADDRESS_STAFF_MODE_ARRAY, uint8)[peep->staff_id] & 2) {

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -125,7 +125,7 @@ void window_scenarioselect_open()
 	window->enabled_widgets = 0x04 | 0x10 | 0x20 | 0x40 | 0x80 | 0x100;
 	window_init_scroll_widgets(window);
 	window->viewport_focus_coordinates.var_480 = -1;
-	window->var_494 = 0;
+	window->highlighted_item = 0;
 
 	window_scenarioselect_init_tabs();
 
@@ -174,7 +174,7 @@ static void window_scenarioselect_mousedown(int widgetIndex, rct_window*w, rct_w
 {
 	if (widgetIndex >= WIDX_TAB1 && widgetIndex <= WIDX_TAB5) {
 		w->selected_tab = widgetIndex - 4;
-		w->var_494 = 0;
+		w->highlighted_item = 0;
 		window_invalidate(w);
 		window_event_resize_call(w);
 		window_event_invalidate_call(w);
@@ -248,8 +248,8 @@ static void window_scenarioselect_scrollmouseover(rct_window *w, int scrollIndex
 		selected = scenario;
 		break;
 	}
-	if (w->var_494 != (uint32)selected) {
-		w->var_494 = (uint32)selected;
+	if (w->highlighted_item != (uint32)selected) {
+		w->highlighted_item = (uint32)selected;
 		window_invalidate(w);
 	}
 }
@@ -285,7 +285,7 @@ static void window_scenarioselect_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	}
 
 	// Return if no scenario highlighted
-	scenario = (rct_scenario_basic*)w->var_494;
+	scenario = (rct_scenario_basic*)w->highlighted_item;
 	if (scenario == NULL)
 		return;
 
@@ -341,7 +341,7 @@ static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *
 		if (y > dpi->y + dpi->height)
 			continue;
 
-		highlighted = w->var_494 == (int)scenario;
+		highlighted = w->highlighted_item == (int)scenario;
 
 		// Draw hover highlight
 		if (highlighted)

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -122,7 +122,9 @@ void window_scenarioselect_open()
 	);
 	window->widgets = window_scenarioselect_widgets;
 
-	window->enabled_widgets = 0x04 | 0x10 | 0x20 | 0x40 | 0x80 | 0x100;
+	window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_TAB1) | (1 << WIDX_TAB2)
+							| (1 << WIDX_TAB3) | (1 << WIDX_TAB4) | (1 << WIDX_TAB5);
+
 	window_init_scroll_widgets(window);
 	window->viewport_focus_coordinates.var_480 = -1;
 	window->highlighted_item = 0;
@@ -258,7 +260,9 @@ static void window_scenarioselect_invalidate(rct_window *w)
 {
 	colour_scheme_update(w);
 
-	w->pressed_widgets &= ~(0x10 | 0x20 | 0x40 | 0x80 | 0x100);
+	w->pressed_widgets &= ~( (1 << WIDX_CLOSE) | (1 << WIDX_TAB1) | (1 << WIDX_TAB2)
+						   | (1 << WIDX_TAB3) | (1 << WIDX_TAB4) | (1 << WIDX_TAB5) );
+
 	w->pressed_widgets |= 1LL << (w->selected_tab + 4);
 }
 

--- a/src/windows/tooltip.c
+++ b/src/windows/tooltip.c
@@ -92,7 +92,7 @@ void window_tooltip_show(rct_string_id id, int x, int y)
 	RCT2_GLOBAL(0x0142006C, sint32) = -1;
 	char* buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 
-	format_string(buffer, id, (void*)0x013CE952);
+	format_string(buffer, id, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS);
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, uint16) = FONT_SPRITE_BASE_MEDIUM;
 
 	int tooltip_text_width;

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -483,9 +483,9 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		}
 
 		// Ride length
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = 1345;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = track_td6->ride_length;
-		gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, (void*)0x013CE952, 0, x, y, 214);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = 1345;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = track_td6->ride_length;
+		gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y, 214);
 		y += 10;
 	}
 
@@ -540,9 +540,9 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	if (track_td6->space_required_x != 0xFF) {
 		// Space required
-		RCT2_GLOBAL(0x013CE952 + 0, uint16) = track_td6->space_required_x;
-		RCT2_GLOBAL(0x013CE952 + 2, uint16) = track_td6->space_required_y;
-		gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, (void*)0x013CE952, 0, x, y);
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint16) = track_td6->space_required_x;
+		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint16) = track_td6->space_required_y;
+		gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, 0, x, y);
 		y += 10;
 	}
 

--- a/src/windows/viewport.c
+++ b/src/windows/viewport.c
@@ -221,7 +221,7 @@ static void window_viewport_invalidate(rct_window *w)
 	}
 
 	// Set title
-	RCT2_GLOBAL(0x013CE952 + 0, uint32) = w->number;
+	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 0, uint32) = w->number;
 
 	// Set disabled widgets
 	w->disabled_widgets = 0;


### PR DESCRIPTION
This PR addresses three things:
* Names the `RCT2_ADDRESS_COMMON_FORMAT_ARGS` address where used.
* Names `var_494` in the `rct_window` struct as `highlighted_item`.
* Names the `enabled_widgets` flags used on scenario select screen.