### PR TITLE
Fix XP compatibility after #2546

### DIFF
--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -900,7 +900,7 @@ void platform_get_exe_path(utf8 *outPath)
 
 bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer)
 {
-#ifndef __MINGW32__
+#if !defined(__MINGW32__) && ((NTDDI_VERSION >= NTDDI_VISTA) && !defined(_USING_V110_SDK71_) && !defined(_ATL_XP_TARGETING))
 	wchar_t *fontFolder;
 	if (SUCCEEDED(SHGetKnownFolderPath(&FOLDERID_Fonts, 0, NULL, &fontFolder)))
 	{
@@ -922,7 +922,7 @@ bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer)
 		return false;
 	}
 #else
-	log_warning("MINGW-compatibility hack: falling back to C:\\Windows\\Fonts");
+	log_warning("Compatibility hack: falling back to C:\\Windows\\Fonts");
 	strcat(buffer, "C:\\Windows\\Fonts\\");
 	strcat(buffer, font->filename);
 	return true;


### PR DESCRIPTION
8bdec9f68 (#2546) introduced call to SHGetKnownFolderPath which is only
available on Vista and later operating systems, but eda733165 restored
previous hard-coded functionality for MinGW. Use the same for XP
support.

According to
https://tedwvc.wordpress.com/2014/01/01/how-to-target-xp-with-vc2012-or-vc2013-and-continue-to-use-the-windows-8-x-sdk/
it should work.