### PR TITLE
Fix #2550 Program crashes when executing "exit" command from the console

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -1045,8 +1045,10 @@ void console_execute_silent(const utf8 *src)
 		return;
 
 	// Aliases for hiding the console
-	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0)
-		argv[0]="hide";
+	if(strcmp(argv[0],"quit") == 0 || strcmp(argv[0],"exit") == 0) {
+		free(argv[0]);
+		argv[0] = _strdup("hide");
+	}
 
 	bool validCommand = false;
 	for (int i = 0; i < countof(console_command_table); i++) {


### PR DESCRIPTION
 - exit and quit commands are aliased to "hide"
 - value of the command was being set to a constant value and could not be freed
 - updated command value to use a freeable value