### PR TITLE
Strict aliasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ if (APPLE)
 endif (APPLE)
 
 # force 32bit build for now and set necessary flags to compile code as is
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -std=gnu99 -fno-omit-frame-pointer -fno-pie")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=gnu++11 -fno-omit-frame-pointer -fno-pie")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -std=gnu99 -fno-omit-frame-pointer -fno-pie -fstrict-aliasing -Werror=strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=gnu++11 -fno-omit-frame-pointer -fno-pie -fstrict-aliasing -Werror=strict-aliasing")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS}")
 

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -41,7 +41,7 @@
 
 rct_window* g_window_list = RCT2_ADDRESS(RCT2_ADDRESS_WINDOW_LIST, rct_window);
 
-uint8 TextInputDescriptionArgs[8];
+uint16 TextInputDescriptionArgs[4];
 widget_identifier gCurrentTextBox = { { 255, 0 }, 0 };
 char gTextBoxInput[512] = { 0 };
 int gMaxTextBoxInputLength = 0;

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -27,11 +27,13 @@
 #include "../ride/ride.h"
 #include "../ride/vehicle.h"
 #include "../world/park.h"
+#include "../management/research.h"
+#include "../scenario.h"
 #include "colour.h"
 
 struct rct_window;
 union rct_window_event;
-extern uint8 TextInputDescriptionArgs[8];
+extern uint16 TextInputDescriptionArgs[4];
 extern char gTextBoxInput[512];
 extern int gMaxTextBoxInputLength;
 extern int gTextBoxFrameNo;
@@ -264,7 +266,13 @@ typedef struct rct_window {
 	uint16 frame_no;				// 0x48E updated every tic for motion in windows sprites
 	uint16 list_information_type;	// 0x490 0 for none, Used as current position of marquee in window_peep
 	sint16 var_492;
-	uint32 highlighted_item;		// 0x494
+	union {							// 0x494
+		uint32 highlighted_item;
+		uint16 ride_colour;
+		rct_research_item* research_item;
+		rct_object_entry* object_entry;
+		rct_scenario_basic* scenario;
+	};
 	uint8 var_498[0x14];
 	sint16 selected_tab;			// 0x4AC
 	sint16 var_4AE;

--- a/src/object.c
+++ b/src/object.c
@@ -358,17 +358,15 @@ int object_entry_compare(const rct_object_entry *a, const rct_object_entry *b)
 	if (a->flags & 0xF0) {
 		if ((a->flags & 0x0F) != (b->flags & 0x0F))
 			return 0;
-		if (*((uint32*)a->name) != *((uint32*)b->name))
-			return 0;
-		if (*((uint32*)(&a->name[4])) != *((uint32*)(&b->name[4])))
+		int match = memcmp(a->name, b->name, 8);
+		if (match)
 			return 0;
 	}
 	else {
 		if (a->flags != b->flags)
 			return 0;
-		if (*((uint32*)a->name) != *((uint32*)b->name))
-			return 0;
-		if (*((uint32*)(&a->name[4])) != *((uint32*)(&b->name[4])))
+		int match = memcmp(a->name, b->name, 8);
+		if (match)
 			return 0;
 		if (a->checksum != b->checksum)
 			return 0;

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -242,7 +242,11 @@ void platform_draw()
 					if (pitch == (width * 2) + padding) {
 						uint16 *dst = pixels;
 						for (int y = height; y > 0; y--) {
-							for (int x = width; x > 0; x--) { *dst++ = *(uint16 *)(&gPaletteHWMapped[*src++]); }
+							for (int x = width; x > 0; x--) {
+								const uint8 lower = *(uint8 *)(&gPaletteHWMapped[*src++]);
+								const uint8 upper = *(uint8 *)(&gPaletteHWMapped[*src++]);
+								*dst++ = (lower << 8) | upper;
+							}
 							dst = (uint16*)(((uint8 *)dst) + padding);
 						}
 					}

--- a/src/windows/clear_scenery.c
+++ b/src/windows/clear_scenery.c
@@ -194,8 +194,8 @@ static void window_clear_scenery_textinput(rct_window *w, int widgetIndex, char 
 
 static void window_clear_scenery_inputsize(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_TOOL_SIZE;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
 	window_text_input_open(w, WIDX_PREVIEW, 5128, 5129, STR_NONE, STR_NONE, 3);
 }
 

--- a/src/windows/dropdown.c
+++ b/src/windows/dropdown.c
@@ -324,7 +324,7 @@ static void window_dropdown_paint(rct_window *w, rct_drawpixelinfo *dpi)
 			item = gDropdownItemsFormat[i];
 			if (item == (uint16)-1 || item == (uint16)-2) {
 				// Image item
-				image = *((uint32*)&gDropdownItemsArgs[i]);
+				image = (uint32)gDropdownItemsArgs[i];
 				if (item == (uint16)-2 && gDropdownHighlightedIndex == i)
 					image++;
 

--- a/src/windows/editor_inventions_list.c
+++ b/src/windows/editor_inventions_list.c
@@ -155,8 +155,6 @@ static rct_window_event_list window_editor_inventions_list_drag_events = {
 
 rct_research_item *_editorInventionsListDraggedItem;
 
-#define WindowHighlightedItem(w) *((rct_research_item**)&(w->highlighted_item))
-
 static void window_editor_inventions_list_drag_open(rct_research_item *researchItem);
 static void move_research_item(rct_research_item *beforeItem);
 
@@ -437,7 +435,7 @@ static void move_research_item(rct_research_item *beforeItem)
 
 	w = window_find_by_class(WC_EDITOR_INVENTION_LIST);
 	if (w != NULL) {
-		WindowHighlightedItem(w) = NULL;
+		w->research_item = NULL;
 		window_invalidate(w);
 	}
 }
@@ -549,7 +547,7 @@ void window_editor_inventions_list_open()
 	window_init_scroll_widgets(w);
 	w->var_4AE = 0;
 	w->selected_tab = 0;
-	WindowHighlightedItem(w) = NULL;
+	w->research_item = NULL;
 	_editorInventionsListDraggedItem = NULL;
 }
 
@@ -668,8 +666,8 @@ static void window_editor_inventions_list_scrollmouseover(rct_window *w, int scr
 	rct_research_item *researchItem;
 
 	researchItem = window_editor_inventions_list_get_item_from_scroll_y(scrollIndex, y);
-	if (researchItem != WindowHighlightedItem(w)) {
-		WindowHighlightedItem(w) = researchItem;
+	if (researchItem != w->research_item) {
+		w->research_item = researchItem;
 		window_invalidate(w);
 	}
 }
@@ -770,7 +768,7 @@ static void window_editor_inventions_list_paint(rct_window *w, rct_drawpixelinfo
 
 	researchItem = _editorInventionsListDraggedItem;
 	if (researchItem == NULL)
-		researchItem = WindowHighlightedItem(w);
+		researchItem = w->research_item;
 	// If the research item is null or a list separator.
 	if (researchItem == NULL || researchItem->entryIndex < 0)
 		return;
@@ -842,7 +840,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
 			continue;
 
 		colour = 142;
-		if (WindowHighlightedItem(w) == researchItem) {
+		if (w->research_item == researchItem) {
 			if (_editorInventionsListDraggedItem == NULL) {
 				// Highlight
 				top = itemY;
@@ -939,8 +937,8 @@ static void window_editor_inventions_list_drag_cursor(rct_window *w, int widgetI
 	inventionListWindow = window_find_by_class(WC_EDITOR_INVENTION_LIST);
 	if (inventionListWindow != NULL) {
 		researchItem = get_research_item_at(x, y);
-		if (researchItem != WindowHighlightedItem(inventionListWindow)) {
-			WindowHighlightedItem(inventionListWindow) = researchItem;
+		if (researchItem != inventionListWindow->research_item) {
+			inventionListWindow = (rct_window *)researchItem;
 			window_invalidate(inventionListWindow);
 		}
 	}

--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -419,7 +419,7 @@ void window_editor_object_selection_open()
 	window->var_4AE = 0;
 	window->selected_tab = 0;
 	window->selected_list_item = -1;
-	window->highlighted_item = 0xFFFFFFFF;
+	window->object_entry = (rct_object_entry *) 0xFFFFFFFF;
 	window->min_width = 600;
 	window->min_height = 400;
 	window->max_width = 1200;
@@ -836,7 +836,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, int widgetInde
 		visible_list_refresh(w);
 
 		w->selected_list_item = -1;
-		w->highlighted_item = 0xFFFFFFFF;
+		w->object_entry = (rct_object_entry *) 0xFFFFFFFF;
 		w->scrolls[0].v_top = 0;
 		object_free_scenario_text();
 		window_invalidate(w);
@@ -856,7 +856,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, int widgetInde
 		visible_list_refresh(w);
 
 		w->selected_list_item = -1;
-		w->highlighted_item = 0xFFFFFFFF;
+		w->object_entry = (rct_object_entry *) 0xFFFFFFFF;
 		w->scrolls[0].v_top = 0;
 		object_free_scenario_text();
 		window_invalidate(w);
@@ -1051,7 +1051,7 @@ static void window_editor_object_selection_scroll_mouseover(rct_window *w, int s
 		return;
 
 	w->selected_list_item = selectedObject;
-	w->highlighted_item = (uint32)installedEntry;
+	w->object_entry = installedEntry;
 	object_free_scenario_text();
 	if (selectedObject != -1)
 		object_get_scenario_text(installedEntry);
@@ -1342,7 +1342,7 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
 	if (w->selected_list_item == -1 || stex_entry == NULL)
 		return;
 
-	highlightedEntry = (rct_object_entry*)w->highlighted_item;
+	highlightedEntry = w->object_entry;
 	type = highlightedEntry->flags & 0x0F;
 
 	// Draw preview
@@ -1458,7 +1458,7 @@ static void window_editor_object_selection_scrollpaint(rct_window *w, rct_drawpi
 
 			// Highlight background
 			colour = 142;
-			if (listItem->entry == (rct_object_entry*)w->highlighted_item && !(*listItem->flags & OBJECT_SELECTION_FLAG_6)) {
+			if (listItem->entry == w->object_entry && !(*listItem->flags & OBJECT_SELECTION_FLAG_6)) {
 				gfx_fill_rect(dpi, 0, y, w->width, y + 11, 0x2000031);
 				colour = 14;
 			}
@@ -1515,7 +1515,7 @@ static void window_editor_object_set_page(rct_window *w, int page)
 
 	w->selected_tab = page;
 	w->selected_list_item = -1;
-	w->highlighted_item = 0xFFFFFFFF;
+	w->object_entry = (rct_object_entry *)0xFFFFFFFF;
 	w->scrolls[0].v_top = 0;
 	object_free_scenario_text();
 

--- a/src/windows/land.c
+++ b/src/windows/land.c
@@ -272,7 +272,7 @@ static void window_land_dropdown(rct_window *w, int widgetIndex, int dropdownInd
 
 		type = (dropdownIndex == -1) ?
 			_selectedFloorTexture :
-			*((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_FLOOR_TEXTURE_GRASS;
+			(uint32)gDropdownItemsArgs[dropdownIndex] - SPR_FLOOR_TEXTURE_GRASS;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) = 255;
@@ -288,7 +288,7 @@ static void window_land_dropdown(rct_window *w, int widgetIndex, int dropdownInd
 
 		type = (dropdownIndex == -1) ?
 			_selectedWallTexture :
-			*((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_WALL_TEXTURE_ROCK;
+			(uint32)gDropdownItemsArgs[dropdownIndex] - SPR_WALL_TEXTURE_ROCK;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) = 255;
@@ -321,8 +321,8 @@ static void window_land_textinput(rct_window *w, int widgetIndex, char *text)
 
 static void window_land_inputsize(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_TOOL_SIZE;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
 	window_text_input_open(w, WIDX_PREVIEW, 5128, 5129, STR_NONE, STR_NONE, 3);
 }
 

--- a/src/windows/land_rights.c
+++ b/src/windows/land_rights.c
@@ -188,8 +188,8 @@ static void window_land_rights_textinput(rct_window *w, int widgetIndex, char *t
 
 static void window_land_rights_inputsize(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_TOOL_SIZE;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
 	window_text_input_open(w, WIDX_PREVIEW, 5128, 5129, STR_NONE, STR_NONE, 3);
 }
 

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -311,7 +311,7 @@ static void window_loadsave_mouseup(rct_window *w, int widgetIndex)
 
 		memset(filter, '\0', MAX_PATH);
 		safe_strncpy(filter, "*", MAX_PATH);
-		strncat(filter, _extension, MAX_PATH);
+		strncat(filter, _extension, MAX_PATH - strnlen(filter, MAX_PATH) - 1);
 
 		switch (_type) {
 		case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME) :
@@ -336,7 +336,7 @@ static void window_loadsave_mouseup(rct_window *w, int widgetIndex)
 
 		if (result) {
 			if (!has_extension(path, _extension)) {
-				strncat(path, _extension, MAX_PATH);
+				strncat(path, _extension, sizeof(path) - strnlen(path, sizeof(path)) - 1);
 			}
 			window_loadsave_select(w, path);
 		}
@@ -684,7 +684,7 @@ static void window_loadsave_populate_list(rct_window *w, int includeNewItem, con
 			listItem = &_listItems[_listItemsCount];
 			memset(listItem->path, '\0', MAX_PATH);
 			safe_strncpy(listItem->path, directory, MAX_PATH);
-			strncat(listItem->path, subDir, MAX_PATH);
+			strncat(listItem->path, subDir, MAX_PATH - strnlen(listItem->path, MAX_PATH) - 1);
 			safe_strncpy(listItem->name, subDir, sizeof(listItem->name));
 			listItem->type = TYPE_DIRECTORY;
 			_listItemsCount++;
@@ -700,7 +700,7 @@ static void window_loadsave_populate_list(rct_window *w, int includeNewItem, con
 
 			listItem = &_listItems[_listItemsCount];
 			safe_strncpy(listItem->path, directory, sizeof(listItem->path));
-			strncat(listItem->path, fileInfo.path, sizeof(listItem->path));
+			strncat(listItem->path, fileInfo.path, sizeof(listItem->path) - strnlen(listItem->path, MAX_PATH) - 1);
 			listItem->type = TYPE_FILE;
 			listItem->date_modified = platform_file_get_modified_time(listItem->path);
 

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -935,15 +935,15 @@ static void window_map_show_default_scenario_editor_buttons(rct_window *w) {
 
 static void window_map_inputsize_land(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_TOOL_SIZE;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
 	window_text_input_open(w, WIDX_LAND_TOOL, 5128, 5129, STR_NONE, STR_NONE, 3);
 }
 
 static void window_map_inputsize_map(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
+	TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
+	TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
 	window_text_input_open(w, WIDX_MAP_SIZE_SPINNER, 5130, 5131, STR_NONE, STR_NONE, 4);
 }
 

--- a/src/windows/mapgen.c
+++ b/src/windows/mapgen.c
@@ -488,19 +488,19 @@ static void window_mapgen_base_mouseup(rct_window *w, int widgetIndex)
 		gfx_invalidate_screen();
 		break;
 	case WIDX_MAP_SIZE:
-		((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-		((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
+		TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
+		TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
 		// Practical map size is 2 lower than the technical map size
 		window_text_input_open(w, WIDX_MAP_SIZE, 5130, 5131, 5182, _mapSize - 2, 4);
 		break;
 	case WIDX_BASE_HEIGHT:
-		((uint16*)TextInputDescriptionArgs)[0] = (BASESIZE_MIN - 12) / 2;
-		((uint16*)TextInputDescriptionArgs)[1] = (BASESIZE_MAX - 12) / 2;
+		TextInputDescriptionArgs[0] = (BASESIZE_MIN - 12) / 2;
+		TextInputDescriptionArgs[1] = (BASESIZE_MAX - 12) / 2;
 		window_text_input_open(w, WIDX_BASE_HEIGHT, 5183, 5184, 5182, (_baseHeight - 12) / 2, 3);
 		break;
 	case WIDX_WATER_LEVEL:
-		((uint16*)TextInputDescriptionArgs)[0] = (WATERLEVEL_MIN - 12) / 2;
-		((uint16*)TextInputDescriptionArgs)[1] = (WATERLEVEL_MAX - 12) / 2;
+		TextInputDescriptionArgs[0] = (WATERLEVEL_MIN - 12) / 2;
+		TextInputDescriptionArgs[1] = (WATERLEVEL_MAX - 12) / 2;
 		window_text_input_open(w, WIDX_WATER_LEVEL, 5185, 5186, 5182, (_waterLevel - 12) / 2, 3);
 		break;
 	}
@@ -583,7 +583,7 @@ static void window_mapgen_base_dropdown(rct_window *w, int widgetIndex, int drop
 
 		type = (dropdownIndex == -1) ?
 			_floorTexture :
-			*((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_FLOOR_TEXTURE_GRASS;
+			(uint32)gDropdownItemsArgs[dropdownIndex] - SPR_FLOOR_TEXTURE_GRASS;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) = 255;
@@ -599,7 +599,7 @@ static void window_mapgen_base_dropdown(rct_window *w, int widgetIndex, int drop
 
 		type = (dropdownIndex == -1) ?
 			_wallTexture :
-			*((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_WALL_TEXTURE_ROCK;
+			(uint32)gDropdownItemsArgs[dropdownIndex] - SPR_WALL_TEXTURE_ROCK;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) = 255;
@@ -790,8 +790,8 @@ static void window_mapgen_simplex_mouseup(rct_window *w, int widgetIndex)
 		window_mapgen_set_page(w, widgetIndex - WIDX_TAB_1);
 		break;
 	case WIDX_SIMPLEX_MAP_SIZE:
-		((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-		((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
+		TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
+		TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
 		// Practical map size is 2 lower than the technical map size
 		window_text_input_open(w, WIDX_SIMPLEX_MAP_SIZE, 5130, 5131, 5182, _mapSize - 2, 4);
 		break;
@@ -916,7 +916,7 @@ static void window_mapgen_simplex_dropdown(rct_window *w, int widgetIndex, int d
 
 		type = (dropdownIndex == -1) ?
 		_floorTexture :
-					  *((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_FLOOR_TEXTURE_GRASS;
+					  (uint32)gDropdownItemsArgs[dropdownIndex] - SPR_FLOOR_TEXTURE_GRASS;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) = 255;
@@ -933,7 +933,7 @@ static void window_mapgen_simplex_dropdown(rct_window *w, int widgetIndex, int d
 
 		type = (dropdownIndex == -1) ?
 		_wallTexture :
-					 *((uint32*)&gDropdownItemsArgs[dropdownIndex]) - SPR_WALL_TEXTURE_ROCK;
+					 (uint32)gDropdownItemsArgs[dropdownIndex] - SPR_WALL_TEXTURE_ROCK;
 
 		if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) == type) {
 			RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) = 255;

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1183,7 +1183,7 @@ rct_window *window_ride_open(int rideIndex)
 	w->frame_no = 0;
 	w->list_information_type = 0;
 	w->var_492 = 0;
-	w->highlighted_item = 0;
+	w->ride_colour = 0;
 	window_ride_disable_tabs(w);
 	w->min_width = 316;
 	w->min_height = 180;
@@ -3722,7 +3722,7 @@ static void window_ride_set_track_colour_scheme(rct_window *w, int x, int y)
 	uint8 newColourScheme;
 	int interactionType, z, direction;
 
-	newColourScheme = (uint8)(*((uint16*)&w->highlighted_item));
+	newColourScheme = (uint8)w->ride_colour;
 
 	rct_xy16 mapCoord = { 0 };
 	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_RIDE, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, NULL);
@@ -3812,7 +3812,7 @@ static void window_ride_colour_mousedown(int widgetIndex, rct_window *w, rct_wid
 
 	ride = GET_RIDE(w->number);
 	rideEntry = ride_get_entry(ride);
-	colourSchemeIndex = *((uint16*)&w->highlighted_item);
+	colourSchemeIndex = w->ride_colour;
 	dropdownWidget = widget - 1;
 
 	switch (widgetIndex) {
@@ -3952,20 +3952,20 @@ static void window_ride_colour_dropdown(rct_window *w, int widgetIndex, int drop
 
 	switch (widgetIndex) {
 	case WIDX_TRACK_COLOUR_SCHEME_DROPDOWN:
-		*((uint16*)&w->highlighted_item) = dropdownIndex;
+		w->ride_colour = (uint16)dropdownIndex;
 		window_invalidate(w);
 		break;
 	case WIDX_TRACK_MAIN_COLOUR:
-		game_do_command(0, (0 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
+		game_do_command(0, (0 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, w->ride_colour, 0);
 		break;
 	case WIDX_TRACK_ADDITIONAL_COLOUR:
-		game_do_command(0, (1 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
+		game_do_command(0, (1 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, w->ride_colour, 0);
 		break;
 	case WIDX_TRACK_SUPPORT_COLOUR:
-		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
+		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, w->ride_colour, 0);
 		break;
 	case WIDX_MAZE_STYLE_DROPDOWN:
-		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, *((uint16*)&w->highlighted_item), 0);
+		game_do_command(0, (4 << 8) | 1, 0, (dropdownIndex << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, w->ride_colour, 0);
 		break;
 	case WIDX_ENTRANCE_STYLE_DROPDOWN:
 		game_do_command(0, (6 << 8) | 1, 0, (window_ride_entrance_style_list[dropdownIndex] << 8) | w->number, GAME_COMMAND_SET_RIDE_APPEARANCE, 0, 0);
@@ -4052,7 +4052,7 @@ static void window_ride_colour_invalidate(rct_window *w)
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = ride->name_arguments;
 
 	// Track colours
-	int colourScheme = *((uint16*)&w->highlighted_item);
+	int colourScheme = w->ride_colour;
 	trackColour = ride_get_track_colour(ride, colourScheme);
 
 	// Maze style
@@ -4221,7 +4221,7 @@ static void window_ride_colour_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	if (widget->type != WWT_EMPTY)
 		gfx_fill_rect(dpi, w->x + widget->left + 1, w->y + widget->top + 1, w->x + widget->right - 1, w->y + widget->bottom - 1, 12);
 
-	trackColour = ride_get_track_colour(ride, *((uint16*)&w->highlighted_item));
+	trackColour = ride_get_track_colour(ride, w->ride_colour);
 
 	//
 	if (rideEntry->shop_item == 0xFF) {

--- a/src/windows/ride_list.c
+++ b/src/windows/ride_list.c
@@ -286,7 +286,7 @@ static void window_ride_list_dropdown(rct_window *w, int widgetIndex, int dropdo
 		if (dropdownIndex == -1)
 			return;
 
-		_window_ride_list_information_type = *((uint32*)&gDropdownItemsArgs[dropdownIndex]) - STR_STATUS;
+		_window_ride_list_information_type = (uint32)gDropdownItemsArgs[dropdownIndex] - STR_STATUS;
 		window_invalidate(w);
 	}
 }

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -127,7 +127,7 @@ void window_scenarioselect_open()
 
 	window_init_scroll_widgets(window);
 	window->viewport_focus_coordinates.var_480 = -1;
-	window->highlighted_item = 0;
+	window->scenario = NULL;
 
 	window_scenarioselect_init_tabs();
 
@@ -176,7 +176,7 @@ static void window_scenarioselect_mousedown(int widgetIndex, rct_window*w, rct_w
 {
 	if (widgetIndex >= WIDX_TAB1 && widgetIndex <= WIDX_TAB5) {
 		w->selected_tab = widgetIndex - 4;
-		w->highlighted_item = 0;
+		w->scenario = NULL;
 		window_invalidate(w);
 		window_event_resize_call(w);
 		window_event_invalidate_call(w);
@@ -250,8 +250,8 @@ static void window_scenarioselect_scrollmouseover(rct_window *w, int scrollIndex
 		selected = scenario;
 		break;
 	}
-	if (w->highlighted_item != (uint32)selected) {
-		w->highlighted_item = (uint32)selected;
+	if (w->scenario != selected) {
+		w->scenario = selected;
 		window_invalidate(w);
 	}
 }
@@ -289,7 +289,7 @@ static void window_scenarioselect_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	}
 
 	// Return if no scenario highlighted
-	scenario = (rct_scenario_basic*)w->highlighted_item;
+	scenario = w->scenario;
 	if (scenario == NULL)
 		return;
 
@@ -345,7 +345,7 @@ static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *
 		if (y > dpi->y + dpi->height)
 			continue;
 
-		highlighted = w->highlighted_item == (int)scenario;
+		highlighted = w->scenario == scenario;
 
 		// Draw hover highlight
 		if (highlighted)

--- a/src/windows/water.c
+++ b/src/windows/water.c
@@ -181,8 +181,8 @@ static void window_water_textinput(rct_window *w, int widgetIndex, char *text)
 
 static void window_water_inputsize(rct_window *w)
 {
-	((uint16*)TextInputDescriptionArgs)[0] = MINIMUM_TOOL_SIZE;
-	((uint16*)TextInputDescriptionArgs)[1] = MAXIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
+	TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
 	window_text_input_open(w, WIDX_PREVIEW, 5128, 5129, STR_NONE, STR_NONE, 3);
 }
 


### PR DESCRIPTION
Compiler only guarantees proper accesses to variables when using
variable's native type or `char` (i.e. single byte type) [1].

This commit fixes violations of this rule. In most cases changing code
to a simple cast was enough, some required a bit deeper modifications.

I've split the commit in two to highlight how Travis will handle these:
Enable check: https://travis-ci.org/janisozaur/OpenRCT2/builds/99565388
Fixes: https://travis-ci.org/janisozaur/OpenRCT2/builds/99567147

I tested these changes and they all appear to be matching previous intentions.

This fixes #2596.

[1] http://blog.qt.io/blog/2011/06/10/type-punning-and-strict-aliasing/