### PR TITLE
fix #2620 and preventing names with dots from breaking.

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -109,7 +109,7 @@ void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
 	char *lastDot = strrchr(path, '.');
-	if (*lastDot) *lastDot = '\0';
+	if (lastDot != NULL) *lastDot = '\0';
 }
 
 bool readentirefile(const utf8 *path, void **outBuffer, int *outLength)

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -160,7 +160,6 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 
 	if (!str_is_null_or_empty(defaultName)) {
 		safe_strncpy(_defaultName, defaultName, sizeof(_defaultName));
-		path_remove_extension(_defaultName);
 	}
 
 	w = window_bring_to_front_by_class(WC_LOADSAVE);


### PR DESCRIPTION
A park named `before the dot.after the dot` would also save as just `before the dot`.