### PR TITLE
More secure checks for removing and setting file extensions.

### DIFF
--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -3116,7 +3116,7 @@ int save_track_design(uint8 rideIndex){
 		return 1;
 	}
 
-	path_set_extension(path, "TD6");
+	path_set_extension(path, "TD6", false);
 
 	save_track_to_file(RCT2_ADDRESS(0x009D8178, rct_track_td6), path);
 

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -3116,7 +3116,7 @@ int save_track_design(uint8 rideIndex){
 		return 1;
 	}
 
-	path_set_extension(path, "TD6", false);
+	path_append_extension(path, "TD6");
 
 	save_track_to_file(RCT2_ADDRESS(0x009D8178, rct_track_td6), path);
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -67,7 +67,6 @@ const char *path_get_filename(const utf8 *path)
 	// Checks if the path is valid (e.g. not just a file name)
 	if (filename == NULL)
 	{
-		log_warning("Invalid path given: %s", path);
 		// Return the input string to keep things working
 		return path;
 	}
@@ -78,6 +77,8 @@ const char *path_get_filename(const utf8 *path)
 	return filename;
 }
 
+// Returns the extension (dot inclusive) from the given path, or the end of the
+// string when no extension was found.
 const char *path_get_extension(const utf8 *path)
 {
 	// Get the filename from the path
@@ -93,23 +94,28 @@ const char *path_get_extension(const utf8 *path)
 	return extension;
 }
 
-void path_set_extension(utf8 *path, const utf8 *newExtension)
+void path_set_extension(utf8 *path, const utf8 *newExtension, bool replaceExistingExtension)
 {
+	// First remove the current extension
+	if (replaceExistingExtension)
+		path_remove_extension(path);
+
 	// Append a dot to the filename if the new extension doesn't start with it
 	char *endOfString = strrchr(path, '\0');
 	if (newExtension[0] != '.')
 		*endOfString++ = '.';
 
 	// Append the extension to the path
-	// No existing extensions should be removed ("ride.TD6" -> "ride.TD6.TD6")
 	safe_strncpy(endOfString, newExtension, MAX_PATH - (endOfString - path) - 1);
 }
 
 void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
-	char *lastDot = strrchr(path, '.');
-	if (lastDot != NULL) *lastDot = '\0';
+	char *lastDot = strrchr(path_get_filename(path), '.');
+	if (lastDot != NULL) {
+		*lastDot = '\0';
+	}
 }
 
 bool readentirefile(const utf8 *path, void **outBuffer, int *outLength)

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -94,12 +94,17 @@ const char *path_get_extension(const utf8 *path)
 	return extension;
 }
 
-void path_set_extension(utf8 *path, const utf8 *newExtension, bool replaceExistingExtension)
+void path_set_extension(utf8 *path, const utf8 *newExtension)
 {
-	// First remove the current extension
-	if (replaceExistingExtension)
+	// Remove existing extension (check first if there is one)
+	if (path_get_extension(path) < strrchr(path, '\0'))
 		path_remove_extension(path);
+	// Append new extension
+	path_append_extension(path, newExtension);
+}
 
+void path_append_extension(utf8 *path, const utf8 *newExtension)
+{
 	// Append a dot to the filename if the new extension doesn't start with it
 	char *endOfString = strrchr(path, '\0');
 	if (newExtension[0] != '.')
@@ -113,9 +118,10 @@ void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
 	char *lastDot = strrchr(path_get_filename(path), '.');
-	if (lastDot != NULL) {
+	if (lastDot != NULL)
 		*lastDot = '\0';
-	}
+	else
+		log_warning("No extension found. (path = %s)", path);
 }
 
 bool readentirefile(const utf8 *path, void **outBuffer, int *outLength)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -32,7 +32,8 @@ bool filename_valid_characters(const utf8 *filename);
 
 const char *path_get_filename(const utf8 *path);
 const char *path_get_extension(const utf8 *path);
-void path_set_extension(utf8 *path, const utf8 *newExtension, bool replaceExistingExtension);
+void path_set_extension(utf8 *path, const utf8 *newExtension);
+void path_append_extension(utf8 *path, const utf8 *newExtension);
 void path_remove_extension(utf8 *path);
 bool readentirefile(const utf8 *path, void **outBuffer, int *outLength);
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -32,7 +32,7 @@ bool filename_valid_characters(const utf8 *filename);
 
 const char *path_get_filename(const utf8 *path);
 const char *path_get_extension(const utf8 *path);
-void path_set_extension(utf8 *path, const utf8 *newExtension);
+void path_set_extension(utf8 *path, const utf8 *newExtension, bool replaceExistingExtension);
 void path_remove_extension(utf8 *path);
 bool readentirefile(const utf8 *path, void **outBuffer, int *outLength);
 

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -375,7 +375,7 @@ void window_editor_bottom_toolbar_jump_forward_to_save_scenario()
 	s6Info->editor_step = 255;
 
 	// Ensure path has .SC6 extension
-	path_set_extension(path, ".SC6", false);
+	path_append_extension(path, ".SC6");
 
 	// Save the scenario
 	parkFlagsBackup = RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32);

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -375,7 +375,7 @@ void window_editor_bottom_toolbar_jump_forward_to_save_scenario()
 	s6Info->editor_step = 255;
 
 	// Ensure path has .SC6 extension
-	path_set_extension(path, ".SC6");
+	path_set_extension(path, ".SC6", false);
 
 	// Save the scenario
 	parkFlagsBackup = RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32);


### PR DESCRIPTION
While working on #2620 I noticed that a path with a dot in it could cause issues. Everything after the last dot would be treated as if it were the file's extension.