### PR TITLE
Prevent extension from showing when "saving as"

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -1059,7 +1059,10 @@ void save_game()
 }
 void save_game_as()
 {
-	window_loadsave_open(LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME, (char*)path_get_filename(gScenarioSavePath));
+	char name[MAX_PATH];
+	safe_strncpy(name, path_get_filename(gScenarioSavePath), MAX_PATH);
+	path_remove_extension(name);
+	window_loadsave_open(LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME, name);
 }
 
 int compare_autosave_file_paths (const void * a, const void * b ) {

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -154,7 +154,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 	int includeNewItem;
 	rct_window* w;
 	_type = type;
-	_defaultName[0] = 0;
+	_defaultName[0] = '\0';
 
 	if (!str_is_null_or_empty(defaultName)) {
 		safe_strncpy(_defaultName, defaultName, sizeof(_defaultName));


### PR DESCRIPTION
Sending park name as argument, instead of the filename, when opening the loadsave window.