### PR TITLE
Resolved leaving guests searching for invalid entrance

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8065,6 +8065,9 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 	peep->happiness = peep->happiness_growth_rate;
 	peep->nausea = peep->nausea_growth_rate;
 	peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_STATS;
+	
+	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)
+		peep->flags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
 
 	if (peep_should_go_on_ride_again(peep, ride)) {
 		peep->guest_heading_to_ride_id = rideIndex;


### PR DESCRIPTION
This will resolve at least some of #2499 

This may not be the proper solution, but this does seem to prevent guests from having an invalid entrance set (but doesn't help for guests that are already corrupt).