### PR TITLE
Add "*.directory" to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,10 @@ openrct2.id*
 openrct2.nam
 openrct2.til
 data/g2.dat
+
+#################
+## Linux
+#################
+
+# KDE folder settings
+*.directory


### PR DESCRIPTION
On KDE/Linux systems, you can have `.directory` files. These files contain the settings for a specific folder view and should not commitet to git.