### PR TITLE
Separated game path configurations and swapped RCT2_ACCESS with global configuration.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -837,10 +837,10 @@ static void config_init_directories()
 	for(i =2; i < countof(_gamePathDefinitions)-1; i++)
 	{
 		size_t offset = _gamePathDefinitions[i].offset;
-		void *root = (&gConfigGamePath);
-		utf8string *path = root + (size_t)offset;
+		size_t root = (size_t)(&gConfigGamePath);
+		utf8string *path = (utf8string *)(root + offset);
 		size_t malloc_size = strlen(gConfigGamePath.game_path_slash) +strlen(subDirectories[i]) + strlen(separator);
-		malloc_size += fileExtensions[i] == NULL ?:strlen(fileExtensions[i]);
+		malloc_size += fileExtensions[i] == NULL?0:strlen(fileExtensions[i]);
 
 		SafeFree(*path);
 		*path = malloc(malloc_size);

--- a/src/config.c
+++ b/src/config.c
@@ -161,13 +161,13 @@ config_enum_definition _dateFormatEnum[] = {
 
 #pragma region Section / property definitions
 config_property_definition _gamePathDefinitions[] = {
-	{ offsetof(game_path_configuration, game_path),						"game_path",					CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, saved_game_path),				"saved_game_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, scenario_path),					"scenario_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, landscapes_path),				"landscapes_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, object_data_path),				"object_data_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, tracks_path),					"tracks_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, saved_game_path_2),				"saved_game_path_2",			CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, installed_game),						"installed_game",					CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, saved_game),				"saved_game",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, scenario),					"scenario",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, landscapes),				"landscapes",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, object_data),				"object_data",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, tracks),					"tracks_",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
+	{ offsetof(game_path_configuration, buffer),					"buffer",			CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
 
 };
 
@@ -827,10 +827,9 @@ static void config_init_directories()
 	char *subDirectories[] = {NULL, "Saved games\0", "Scenarios\0", "Landscapes", "ObjData", "Tracks"};
 	char *fileExtensions[] = {NULL, "\0", "*.SC6", "*.SC6", "*.DAT", "*.TD?" };
 	int i;
-	utf8string root_directory_slash =NULL;
 
-	root_directory_slash = malloc(strlen(gConfigGamePath.game_path + strlen(separator)));
-	safe_strcat(root_directory_slash, gConfigGamePath.game_path, MAX_PATH);
+	utf8string root_directory_slash = malloc(MAX_PATH);
+	safe_strcat(root_directory_slash, gConfigGamePath.installed_game, MAX_PATH);
 	safe_strcat(root_directory_slash, separator, MAX_PATH);
 
 	for(i =2; i < countof(_gamePathDefinitions)-1; i++)
@@ -838,22 +837,20 @@ static void config_init_directories()
 		size_t offset = _gamePathDefinitions[i].offset;
 		size_t root = (size_t)(&gConfigGamePath);
 		utf8string *path = (utf8string *)(root + offset);
-		size_t malloc_size = strlen(root_directory_slash) + strlen(subDirectories[i]) + strlen(separator);
-		malloc_size += fileExtensions[i] == NULL?0:strlen(fileExtensions[i]);
 
 		SafeFree(*path);
-		*path = malloc(malloc_size);
+		*path = malloc(MAX_PATH);
 		safe_strncpy(*path, root_directory_slash, MAX_PATH);
 		safe_strcat(*path, subDirectories[i], MAX_PATH);
 		safe_strcat(*path, separator, MAX_PATH);
 		safe_strcat(*path, fileExtensions[i], MAX_PATH);
 	}
 
-	SafeFree(gConfigGamePath.saved_game_path_2);
-	gConfigGamePath.saved_game_path_2 = malloc(strlen(gConfigGamePath.saved_game_path));
-	safe_strncpy(gConfigGamePath.saved_game_path_2, gConfigGamePath.saved_game_path, MAX_PATH);
+	SafeFree(gConfigGamePath.buffer);
+	gConfigGamePath.buffer = malloc(MAX_PATH);
+	safe_strncpy(gConfigGamePath.buffer, gConfigGamePath.saved_game, MAX_PATH);
 
-	free(root_directory_slash);
+	SafeFree(root_directory_slash);
 }
 
 bool config_find_or_browse_install_directory()
@@ -862,17 +859,17 @@ bool config_find_or_browse_install_directory()
 	utf8 *installPath;
 
 	if (config_find_rct2_path(path)) {
-		SafeFree(gConfigGamePath.game_path);
-		gConfigGamePath.game_path = malloc(strlen(path) + 1);
-		safe_strncpy(gConfigGamePath.game_path, path, MAX_PATH);
+		SafeFree(gConfigGamePath.installed_game);
+		gConfigGamePath.installed_game = malloc(strlen(path) + 1);
+		safe_strncpy(gConfigGamePath.installed_game, path, MAX_PATH);
 	} else {
 		platform_show_messagebox("Unable to find RCT2 installation directory. Please select the directory where you installed RCT2!");
 		installPath = platform_open_directory_browser("Please select your RCT2 directory");
 		if (installPath == NULL)
 			return false;
 
-		SafeFree(gConfigGamePath.game_path);
-		gConfigGamePath.game_path = installPath;
+		SafeFree(gConfigGamePath.installed_game);
+		gConfigGamePath.installed_game = installPath;
 	}
 	config_init_directories();
 

--- a/src/config.c
+++ b/src/config.c
@@ -162,7 +162,6 @@ config_enum_definition _dateFormatEnum[] = {
 #pragma region Section / property definitions
 config_property_definition _gamePathDefinitions[] = {
 	{ offsetof(game_path_configuration, game_path),						"game_path",					CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
-	{ offsetof(game_path_configuration, game_path_slash),				"game_path_slash",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
 	{ offsetof(game_path_configuration, saved_game_path),				"saved_game_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
 	{ offsetof(game_path_configuration, scenario_path),					"scenario_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
 	{ offsetof(game_path_configuration, landscapes_path),				"landscapes_path",				CONFIG_VALUE_TYPE_STRING,		{ .value_string = NULL },		NULL					},
@@ -825,26 +824,26 @@ static bool config_find_rct2_path(utf8 *resultPath)
 static void config_init_directories()
 {
 	char separator[] = {platform_get_path_separator(), 0};
-	char *subDirectories[] = {NULL, NULL, "Saved games\0", "Scenarios\0", "Landscapes", "ObjData", "Tracks"};
-	char *fileExtensions[] = {NULL, NULL, "\0", "*.SC6", "*.SC6", "*.DAT", "*.TD?" };
+	char *subDirectories[] = {NULL, "Saved games\0", "Scenarios\0", "Landscapes", "ObjData", "Tracks"};
+	char *fileExtensions[] = {NULL, "\0", "*.SC6", "*.SC6", "*.DAT", "*.TD?" };
 	int i;
+	utf8string root_directory_slash =NULL;
 
-	SafeFree(gConfigGamePath.game_path_slash);
-	gConfigGamePath.game_path_slash = malloc(strlen(gConfigGamePath.game_path + strlen(separator)));
-	safe_strcat(gConfigGamePath.game_path_slash, gConfigGamePath.game_path, MAX_PATH);
-	safe_strcat(gConfigGamePath.game_path_slash, separator, MAX_PATH);
+	root_directory_slash = malloc(strlen(gConfigGamePath.game_path + strlen(separator)));
+	safe_strcat(root_directory_slash, gConfigGamePath.game_path, MAX_PATH);
+	safe_strcat(root_directory_slash, separator, MAX_PATH);
 
 	for(i =2; i < countof(_gamePathDefinitions)-1; i++)
 	{
 		size_t offset = _gamePathDefinitions[i].offset;
 		size_t root = (size_t)(&gConfigGamePath);
 		utf8string *path = (utf8string *)(root + offset);
-		size_t malloc_size = strlen(gConfigGamePath.game_path_slash) +strlen(subDirectories[i]) + strlen(separator);
+		size_t malloc_size = strlen(root_directory_slash) + strlen(subDirectories[i]) + strlen(separator);
 		malloc_size += fileExtensions[i] == NULL?0:strlen(fileExtensions[i]);
 
 		SafeFree(*path);
 		*path = malloc(malloc_size);
-		safe_strcat(*path, gConfigGamePath.game_path_slash, MAX_PATH);
+		safe_strncpy(*path, root_directory_slash, MAX_PATH);
 		safe_strcat(*path, subDirectories[i], MAX_PATH);
 		safe_strcat(*path, separator, MAX_PATH);
 		safe_strcat(*path, fileExtensions[i], MAX_PATH);
@@ -853,6 +852,8 @@ static void config_init_directories()
 	SafeFree(gConfigGamePath.saved_game_path_2);
 	gConfigGamePath.saved_game_path_2 = malloc(strlen(gConfigGamePath.saved_game_path));
 	safe_strncpy(gConfigGamePath.saved_game_path_2, gConfigGamePath.saved_game_path, MAX_PATH);
+
+	free(root_directory_slash);
 }
 
 bool config_find_or_browse_install_directory()

--- a/src/config.h
+++ b/src/config.h
@@ -132,12 +132,21 @@ enum {
 	SCENARIO_SELECT_MODE_DIFFICULTY,
 	SCENARIO_SELECT_MODE_ORIGIN,
 };
+typedef struct {
+	utf8string game_path;
+	utf8string game_path_slash;
+	utf8string saved_game_path;
+	utf8string scenario_path;
+	utf8string landscapes_path;
+	utf8string object_data_path;
+	utf8string tracks_path;
+	utf8string saved_game_path_2;
+} game_path_configuration;
 
 typedef struct {
 	uint8 play_intro;
 	uint8 confirmation_prompt;
 	uint8 screenshot_format;
-	utf8string game_path;
 	sint8 measurement_format;
 	sint8 temperature_format;
 	sint8 currency_format;
@@ -325,6 +334,7 @@ typedef struct {
 	uint8 modifier;
 } shortcut_entry;
 
+extern game_path_configuration gConfigGamePath;
 extern general_configuration gConfigGeneral;
 extern interface_configuration gConfigInterface;
 extern sound_configuration gConfigSound;

--- a/src/config.h
+++ b/src/config.h
@@ -134,7 +134,6 @@ enum {
 };
 typedef struct {
 	utf8string game_path;
-	utf8string game_path_slash;
 	utf8string saved_game_path;
 	utf8string scenario_path;
 	utf8string landscapes_path;

--- a/src/config.h
+++ b/src/config.h
@@ -133,13 +133,13 @@ enum {
 	SCENARIO_SELECT_MODE_ORIGIN,
 };
 typedef struct {
-	utf8string game_path;
-	utf8string saved_game_path;
-	utf8string scenario_path;
-	utf8string landscapes_path;
-	utf8string object_data_path;
-	utf8string tracks_path;
-	utf8string saved_game_path_2;
+	utf8string installed_game;
+	utf8string saved_game;
+	utf8string scenario;
+	utf8string landscapes;
+	utf8string object_data;
+	utf8string tracks;
+	utf8string buffer;
 } game_path_configuration;
 
 typedef struct {

--- a/src/game.c
+++ b/src/game.c
@@ -604,7 +604,7 @@ static int open_landscape_file_dialog()
 {
 	int result;
 	format_string((char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, STR_LOAD_LANDSCAPE_DIALOG_TITLE, 0);
-	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.landscapes_path, MAX_PATH);
+	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.landscapes, MAX_PATH);
 	format_string((char*)0x0141EE68, STR_RCT2_LANDSCAPE_FILE, 0);
 	audio_pause_sounds();
 	result = platform_open_common_file_dialog(1, (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, (char*)0x0141EF68, "*.SV6;*.SV4;*.SC6", (char*)0x0141EE68);
@@ -621,7 +621,7 @@ static int open_load_game_dialog()
 {
 	int result;
 	format_string((char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, STR_LOAD_GAME_DIALOG_TITLE, 0);
-	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.saved_game_path, MAX_PATH);
+	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.saved_game, MAX_PATH);
 	format_string((char*)0x0141EE68, STR_RCT2_SAVED_GAME, 0);
 	audio_pause_sounds();
 	result = platform_open_common_file_dialog(1, (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, (char*)0x0141EF68, "*.SV6", (char*)0x0141EE68);
@@ -653,7 +653,7 @@ static void load_landscape()
 			strcpy(esi, ".SC6");
 			break;
 		}
-		safe_strncpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, (char*)0x0141EF68, MAX_PATH);
+		safe_strncpy((char*)gConfigGamePath.buffer, (char*)0x0141EF68, MAX_PATH);
 
 		editor_load_landscape((char*)0x0141EF68);
 		if (1) {
@@ -892,7 +892,7 @@ int game_load_save(const char *path)
 	log_verbose("loading saved game, %s", path);
 
 	safe_strncpy((char*)0x0141EF68, path, MAX_PATH);
-	safe_strncpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, path, MAX_PATH);
+	safe_strncpy((char*)gConfigGamePath.buffer, path, MAX_PATH);
 
 	safe_strncpy(gScenarioSavePath, path, MAX_PATH);
 
@@ -999,7 +999,7 @@ static void load_game()
 			strcpy(esi, ".SV6");
 			break;
 		}
-		safe_strncpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, (char*)0x0141EF68, MAX_PATH);
+		safe_strncpy((char*)gConfigGamePath.buffer, (char*)0x0141EF68, MAX_PATH);
 
 		if (game_load_save((char *)0x0141EF68)) {
 			gfx_invalidate_screen();
@@ -1025,7 +1025,7 @@ static int show_save_game_dialog(char *resultPath)
 	char filterName[256];
 
 	format_string(title, STR_SAVE_GAME_1040, NULL);
-	safe_strncpy(filename, RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH_2, char), MAX_PATH);
+	safe_strncpy(filename, gConfigGamePath.buffer, MAX_PATH);
 	format_string(filterName, STR_RCT2_SAVED_GAME, NULL);
 
 	audio_pause_sounds();

--- a/src/game.c
+++ b/src/game.c
@@ -604,7 +604,7 @@ static int open_landscape_file_dialog()
 {
 	int result;
 	format_string((char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, STR_LOAD_LANDSCAPE_DIALOG_TITLE, 0);
-	safe_strncpy((char*)0x0141EF68, (char*)RCT2_ADDRESS_LANDSCAPES_PATH, MAX_PATH);
+	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.landscapes_path, MAX_PATH);
 	format_string((char*)0x0141EE68, STR_RCT2_LANDSCAPE_FILE, 0);
 	audio_pause_sounds();
 	result = platform_open_common_file_dialog(1, (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, (char*)0x0141EF68, "*.SV6;*.SV4;*.SC6", (char*)0x0141EE68);
@@ -621,7 +621,7 @@ static int open_load_game_dialog()
 {
 	int result;
 	format_string((char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, STR_LOAD_GAME_DIALOG_TITLE, 0);
-	safe_strncpy((char*)0x0141EF68, (char*)RCT2_ADDRESS_SAVED_GAMES_PATH, MAX_PATH);
+	safe_strncpy((char*)0x0141EF68, (char*)gConfigGamePath.saved_game_path, MAX_PATH);
 	format_string((char*)0x0141EE68, STR_RCT2_SAVED_GAME, 0);
 	audio_pause_sounds();
 	result = platform_open_common_file_dialog(1, (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, (char*)0x0141EF68, "*.SV6", (char*)0x0141EE68);

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -748,7 +748,7 @@ static int cc_load_object(const utf8 **argv, int argc) {
 	if (argc > 0) {
 		utf8 path[MAX_PATH];
 
-		substitute_path(path, gConfigGamePath.object_data_path, argv[0]);
+		substitute_path(path, gConfigGamePath.object_data, argv[0]);
 		// Require pointer to start of filename
 		utf8* last_char = path + strlen(path);
 		strcat(path, ".DAT\0");

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -748,7 +748,7 @@ static int cc_load_object(const utf8 **argv, int argc) {
 	if (argc > 0) {
 		utf8 path[MAX_PATH];
 
-		substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), argv[0]);
+		substitute_path(path, gConfigGamePath.object_data_path, argv[0]);
 		// Require pointer to start of filename
 		utf8* last_char = path + strlen(path);
 		strcat(path, ".DAT\0");

--- a/src/object.c
+++ b/src/object.c
@@ -59,7 +59,7 @@ int object_load_file(int groupIndex, const rct_object_entry *entry, int* chunkSi
 	char path[MAX_PATH];
 	SDL_RWops* rw;
 
-	substitute_path(path, gConfigGamePath.object_data_path, (char*)installedObject + 16);
+	substitute_path(path, gConfigGamePath.object_data, (char*)installedObject + 16);
 
 	log_verbose("loading object, %s", path);
 
@@ -299,7 +299,7 @@ int object_load_packed(SDL_RWops* rw)
 			objectPath[i] = '\0';
 	}
 
-	substitute_path(path, gConfigGamePath.object_data_path, objectPath);
+	substitute_path(path, gConfigGamePath.object_data, objectPath);
 	// Require pointer to start of filename
 	char* last_char = path + strlen(path);
 	strcat(path, ".DAT");
@@ -309,7 +309,7 @@ int object_load_packed(SDL_RWops* rw)
 	for (; platform_file_exists(path);){
 		for (char* curr_char = last_char - 1;; --curr_char){
 			if (*curr_char == '\\'){
-				substitute_path(path, gConfigGamePath.object_data_path, "00000000.DAT");
+				substitute_path(path, gConfigGamePath.object_data, "00000000.DAT");
 				char* last_char = path + strlen(path);
 				break;
 			}
@@ -1534,7 +1534,7 @@ int object_get_scenario_text(rct_object_entry *entry)
 
 	char path[MAX_PATH];
 	char *objectPath = (char*)installedObject + 16;
-	substitute_path(path, gConfigGamePath.object_data_path, objectPath);
+	substitute_path(path, gConfigGamePath.object_data, objectPath);
 
 	rct_object_entry openedEntry;
 	SDL_RWops* rw = SDL_RWFromFile(path, "rb");

--- a/src/object.c
+++ b/src/object.c
@@ -59,7 +59,7 @@ int object_load_file(int groupIndex, const rct_object_entry *entry, int* chunkSi
 	char path[MAX_PATH];
 	SDL_RWops* rw;
 
-	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), (char*)installedObject + 16);
+	substitute_path(path, gConfigGamePath.object_data_path, (char*)installedObject + 16);
 
 	log_verbose("loading object, %s", path);
 
@@ -299,7 +299,7 @@ int object_load_packed(SDL_RWops* rw)
 			objectPath[i] = '\0';
 	}
 
-	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
+	substitute_path(path, gConfigGamePath.object_data_path, objectPath);
 	// Require pointer to start of filename
 	char* last_char = path + strlen(path);
 	strcat(path, ".DAT");
@@ -309,7 +309,7 @@ int object_load_packed(SDL_RWops* rw)
 	for (; platform_file_exists(path);){
 		for (char* curr_char = last_char - 1;; --curr_char){
 			if (*curr_char == '\\'){
-				substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), "00000000.DAT");
+				substitute_path(path, gConfigGamePath.object_data_path, "00000000.DAT");
 				char* last_char = path + strlen(path);
 				break;
 			}
@@ -1534,7 +1534,7 @@ int object_get_scenario_text(rct_object_entry *entry)
 
 	char path[MAX_PATH];
 	char *objectPath = (char*)installedObject + 16;
-	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), objectPath);
+	substitute_path(path, gConfigGamePath.object_data_path, objectPath);
 
 	rct_object_entry openedEntry;
 	SDL_RWops* rw = SDL_RWFromFile(path, "rb");

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -228,7 +228,7 @@ static int object_list_query_directory(int *outTotalFiles, uint64 *outTotalFileS
 	fileDateModifiedChecksum = 0;
 
 	// Enumerate through each object in the directory
-	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data_path);
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data);
 	if (enumFileHandle == INVALID_HANDLE)
 		return 0;
 
@@ -293,7 +293,7 @@ void object_list_load()
 		_installedObjectFilters = NULL;
 	}
 
-	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data_path);
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data);
 	if (enumFileHandle != INVALID_HANDLE) {
 		size_t installedObjectsCapacity = 4096;
 		while (platform_enumerate_files_next(enumFileHandle, &enumFileInfo)) {
@@ -310,7 +310,7 @@ void object_list_load()
 			}
 
 			char path[MAX_PATH];
-			substitute_path(path, gConfigGamePath.object_data_path, enumFileInfo.path);
+			substitute_path(path, gConfigGamePath.object_data, enumFileInfo.path);
 
 			rct_object_entry entry;
 			if (object_load_entry(path, &entry)) {

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -228,7 +228,7 @@ static int object_list_query_directory(int *outTotalFiles, uint64 *outTotalFileS
 	fileDateModifiedChecksum = 0;
 
 	// Enumerate through each object in the directory
-	enumFileHandle = platform_enumerate_files_begin(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char));
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data_path);
 	if (enumFileHandle == INVALID_HANDLE)
 		return 0;
 
@@ -293,7 +293,7 @@ void object_list_load()
 		_installedObjectFilters = NULL;
 	}
 
-	enumFileHandle = platform_enumerate_files_begin(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char));
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.object_data_path);
 	if (enumFileHandle != INVALID_HANDLE) {
 		size_t installedObjectsCapacity = 4096;
 		while (platform_enumerate_files_next(enumFileHandle, &enumFileInfo)) {
@@ -310,7 +310,7 @@ void object_list_load()
 			}
 
 			char path[MAX_PATH];
-			substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), enumFileInfo.path);
+			substitute_path(path, gConfigGamePath.object_data_path, enumFileInfo.path);
 
 			rct_object_entry entry;
 			if (object_load_entry(path, &entry)) {

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -167,10 +167,10 @@ static void openrct2_copy_original_user_files_over()
 	utf8 path[MAX_PATH];
 
 	platform_get_user_directory(path, "save");
-	openrct2_copy_files_over((utf8*)gConfigGamePath.saved_game_path, path, ".sv6");
+	openrct2_copy_files_over((utf8*)gConfigGamePath.saved_game, path, ".sv6");
 
 	platform_get_user_directory(path, "landscape");
-	openrct2_copy_files_over((utf8*)gConfigGamePath.landscapes_path, path, ".sc6");
+	openrct2_copy_files_over((utf8*)gConfigGamePath.landscapes, path, ".sc6");
 }
 
 bool openrct2_initialise()

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -167,10 +167,10 @@ static void openrct2_copy_original_user_files_over()
 	utf8 path[MAX_PATH];
 
 	platform_get_user_directory(path, "save");
-	openrct2_copy_files_over((utf8*)RCT2_ADDRESS_SAVED_GAMES_PATH, path, ".sv6");
+	openrct2_copy_files_over((utf8*)gConfigGamePath.saved_game_path, path, ".sv6");
 
 	platform_get_user_directory(path, "landscape");
-	openrct2_copy_files_over((utf8*)RCT2_ADDRESS_LANDSCAPES_PATH, path, ".sc6");
+	openrct2_copy_files_over((utf8*)gConfigGamePath.landscapes_path, path, ".sc6");
 }
 
 bool openrct2_initialise()

--- a/src/rct2.c
+++ b/src/rct2.c
@@ -148,15 +148,14 @@ int rct2_init_directories()
 	// windows_get_registry_install_info((rct2_install_info*)0x009AA10C, "RollerCoaster Tycoon 2 Setup", "MS Sans Serif", 0);
 
 	// check install directory
-	if (!platform_original_game_data_exists(gConfigGamePath.game_path)) {
-		log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGamePath.game_path);
+	if (!platform_original_game_data_exists(gConfigGamePath.installed_game)) {
+		log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGamePath.installed_game);
 		if (!config_find_or_browse_install_directory()) {
 			log_fatal("Invalid RCT2 installation path. Please correct in config.ini.");
 			return 0;
 		}
 	}
 
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH_2, char), gConfigGamePath.saved_game_path);
 	return 1;
 }
 
@@ -285,7 +284,7 @@ int rct2_open_file(const char *path)
 	extension++;
 
 	if (_stricmp(extension, "sv6") == 0) {
-		strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, path);
+		strcpy((char*)gConfigGamePath.buffer, path);
 		game_load_save(path);
 		return 1;
 	} else if (_stricmp(extension, "sc6") == 0) {
@@ -439,7 +438,7 @@ const utf8 *get_file_path(int pathId)
 	// The original implementation checks if the file is on CD-ROM here (file_on_cdrom[pathId] @ 0x009AA0B1).
 	// If so, the CD-ROM path (cdrom_path @ 0x9AA318) is used instead. This has been removed for now for
 	// the sake of simplicity.
-	strcpy(path, gConfigGamePath.game_path);
+	strcpy(path, gConfigGamePath.installed_game);
 
 	// Make sure base path is terminated with a slash
 	if (strlen(path) == 0 || path[strlen(path) - 1] != platform_get_path_separator())

--- a/src/rct2.c
+++ b/src/rct2.c
@@ -148,51 +148,15 @@ int rct2_init_directories()
 	// windows_get_registry_install_info((rct2_install_info*)0x009AA10C, "RollerCoaster Tycoon 2 Setup", "MS Sans Serif", 0);
 
 	// check install directory
-	if (!platform_original_game_data_exists(gConfigGeneral.game_path)) {
-		log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGeneral.game_path);
+	if (!platform_original_game_data_exists(gConfigGamePath.game_path)) {
+		log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGamePath.game_path);
 		if (!config_find_or_browse_install_directory()) {
 			log_fatal("Invalid RCT2 installation path. Please correct in config.ini.");
 			return 0;
+		}
 	}
-	}
 
-	char separator[] = {platform_get_path_separator(), 0};
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char), gConfigGeneral.game_path);
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH_SLASH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH_SLASH, char), separator);
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH, char), "Saved Games");
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH, char), separator);
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), "Scenarios");
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), "*.SC6");
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_LANDSCAPES_PATH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_LANDSCAPES_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_LANDSCAPES_PATH, char), "Landscapes");
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_LANDSCAPES_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_LANDSCAPES_PATH, char), "*.SC6");
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), "ObjData");
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_OBJECT_DATA_PATH, char), "*.DAT");
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), RCT2_ADDRESS(RCT2_ADDRESS_APP_PATH, char));
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), "Tracks");
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), separator);
-	strcat(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), "*.TD?");
-
-	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH_2, char), RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH, char));
+	strcpy(RCT2_ADDRESS(RCT2_ADDRESS_SAVED_GAMES_PATH_2, char), gConfigGamePath.saved_game_path);
 	return 1;
 }
 
@@ -475,7 +439,7 @@ const utf8 *get_file_path(int pathId)
 	// The original implementation checks if the file is on CD-ROM here (file_on_cdrom[pathId] @ 0x009AA0B1).
 	// If so, the CD-ROM path (cdrom_path @ 0x9AA318) is used instead. This has been removed for now for
 	// the sake of simplicity.
-	strcpy(path, gConfigGeneral.game_path);
+	strcpy(path, gConfigGamePath.game_path);
 
 	// Make sure base path is terminated with a slash
 	if (strlen(path) == 0 || path[strlen(path) - 1] != platform_get_path_separator())

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -270,7 +270,7 @@ static void track_list_query_directory(int *outTotalFiles){
 	*outTotalFiles = 0;
 
 	// Enumerate through each track in the directory
-	enumFileHandle = platform_enumerate_files_begin(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char));
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks_path);
 	if (enumFileHandle == INVALID_HANDLE)
 		return;
 
@@ -428,7 +428,7 @@ void track_load_list(ride_list_item item)
 		uint8* new_file_pointer = new_track_file;
 		file_info enumFileInfo;
 
-		int enumFileHandle = platform_enumerate_files_begin(RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char));
+		int enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks_path);
 		if (enumFileHandle == INVALID_HANDLE)
 		{
 			free(new_file_pointer);
@@ -439,7 +439,7 @@ void track_load_list(ride_list_item item)
 			if (new_file_pointer > new_track_file + 0x3FF00)break;
 
 			char path[MAX_PATH];
-			substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), enumFileInfo.path);
+			substitute_path(path, gConfigGamePath.tracks_path, enumFileInfo.path);
 
 			rct_track_td6* loaded_track = load_track_design(path);
 			if (loaded_track){
@@ -2269,7 +2269,7 @@ rct_track_design *track_get_info(int index, uint8** preview)
 		RCT2_ADDRESS(RCT2_ADDRESS_TRACK_DESIGN_INDEX_CACHE, uint32)[i] = index;
 
 		char track_path[MAX_PATH] = { 0 };
-		substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, (char *)trackDesignList + (index * 128));
+		substitute_path(track_path, (char*)gConfigGamePath.tracks_path, (char *)trackDesignList + (index * 128));
 
 		rct_track_td6* loaded_track = NULL;
 
@@ -2324,13 +2324,13 @@ int track_rename(const char *text)
 	}
 
 	char new_path[MAX_PATH];
-	substitute_path(new_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), text);
+	substitute_path(new_path, gConfigGamePath.tracks_path, text);
 	strcat(new_path, ".TD6");
 
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char old_path[MAX_PATH];
-	substitute_path(old_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(old_path, gConfigGamePath.tracks_path, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_move(old_path, new_path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_ANOTHER_FILE_EXISTS_WITH_NAME_OR_FILE_IS_WRITE_PROTECTED;
@@ -2359,7 +2359,7 @@ int track_delete()
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char path[MAX_PATH];
-	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(path, gConfigGamePath.tracks_path, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_delete(path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_FILE_IS_WRITE_PROTECTED_OR_LOCKED;
@@ -3091,7 +3091,7 @@ int save_track_design(uint8 rideIndex){
 	format_string(track_name, ride->name, &ride->name_arguments);
 
 	char path[MAX_PATH];
-	substitute_path(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(path, gConfigGamePath.tracks_path, track_name);
 
 	// Save track design
 	format_string(RCT2_ADDRESS(0x141ED68, char), 2306, NULL);
@@ -3237,7 +3237,7 @@ int install_track(char* source_path, char* dest_name){
 	strcat(track_name, ".TD4");
 
 	char dest_path[MAX_PATH];
-	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(dest_path, gConfigGamePath.tracks_path, track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
@@ -3248,13 +3248,13 @@ int install_track(char* source_path, char* dest_name){
 	// Check if .TD6 file exists under that name
 	strcat(track_name, ".TD6");
 
-	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), track_name);
+	substitute_path(dest_path, gConfigGamePath.tracks_path, track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
 
 	// Set path for actual copy
-	substitute_path(dest_path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), dest_name);
+	substitute_path(dest_path, gConfigGamePath.tracks_path, dest_name);
 
 	return platform_file_copy(source_path, dest_path, false);
 }

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -270,7 +270,7 @@ static void track_list_query_directory(int *outTotalFiles){
 	*outTotalFiles = 0;
 
 	// Enumerate through each track in the directory
-	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks_path);
+	enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks);
 	if (enumFileHandle == INVALID_HANDLE)
 		return;
 
@@ -428,7 +428,7 @@ void track_load_list(ride_list_item item)
 		uint8* new_file_pointer = new_track_file;
 		file_info enumFileInfo;
 
-		int enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks_path);
+		int enumFileHandle = platform_enumerate_files_begin(gConfigGamePath.tracks);
 		if (enumFileHandle == INVALID_HANDLE)
 		{
 			free(new_file_pointer);
@@ -439,7 +439,7 @@ void track_load_list(ride_list_item item)
 			if (new_file_pointer > new_track_file + 0x3FF00)break;
 
 			char path[MAX_PATH];
-			substitute_path(path, gConfigGamePath.tracks_path, enumFileInfo.path);
+			substitute_path(path, gConfigGamePath.tracks, enumFileInfo.path);
 
 			rct_track_td6* loaded_track = load_track_design(path);
 			if (loaded_track){
@@ -2269,7 +2269,7 @@ rct_track_design *track_get_info(int index, uint8** preview)
 		RCT2_ADDRESS(RCT2_ADDRESS_TRACK_DESIGN_INDEX_CACHE, uint32)[i] = index;
 
 		char track_path[MAX_PATH] = { 0 };
-		substitute_path(track_path, (char*)gConfigGamePath.tracks_path, (char *)trackDesignList + (index * 128));
+		substitute_path(track_path, (char*)gConfigGamePath.tracks, (char *)trackDesignList + (index * 128));
 
 		rct_track_td6* loaded_track = NULL;
 
@@ -2324,13 +2324,13 @@ int track_rename(const char *text)
 	}
 
 	char new_path[MAX_PATH];
-	substitute_path(new_path, gConfigGamePath.tracks_path, text);
+	substitute_path(new_path, gConfigGamePath.tracks, text);
 	strcat(new_path, ".TD6");
 
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char old_path[MAX_PATH];
-	substitute_path(old_path, gConfigGamePath.tracks_path, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(old_path, gConfigGamePath.tracks, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_move(old_path, new_path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_ANOTHER_FILE_EXISTS_WITH_NAME_OR_FILE_IS_WRITE_PROTECTED;
@@ -2359,7 +2359,7 @@ int track_delete()
 	rct_window* w = window_find_by_class(WC_TRACK_DESIGN_LIST);
 
 	char path[MAX_PATH];
-	substitute_path(path, gConfigGamePath.tracks_path, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
+	substitute_path(path, gConfigGamePath.tracks, &RCT2_ADDRESS(RCT2_ADDRESS_TRACK_LIST, char)[128 * w->track_list.var_482]);
 
 	if (!platform_file_delete(path)) {
 		RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_TEXT, uint16) = STR_FILE_IS_WRITE_PROTECTED_OR_LOCKED;
@@ -3091,7 +3091,7 @@ int save_track_design(uint8 rideIndex){
 	format_string(track_name, ride->name, &ride->name_arguments);
 
 	char path[MAX_PATH];
-	substitute_path(path, gConfigGamePath.tracks_path, track_name);
+	substitute_path(path, gConfigGamePath.tracks, track_name);
 
 	// Save track design
 	format_string(RCT2_ADDRESS(0x141ED68, char), 2306, NULL);
@@ -3237,7 +3237,7 @@ int install_track(char* source_path, char* dest_name){
 	strcat(track_name, ".TD4");
 
 	char dest_path[MAX_PATH];
-	substitute_path(dest_path, gConfigGamePath.tracks_path, track_name);
+	substitute_path(dest_path, gConfigGamePath.tracks, track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
@@ -3248,13 +3248,13 @@ int install_track(char* source_path, char* dest_name){
 	// Check if .TD6 file exists under that name
 	strcat(track_name, ".TD6");
 
-	substitute_path(dest_path, gConfigGamePath.tracks_path, track_name);
+	substitute_path(dest_path, gConfigGamePath.tracks, track_name);
 
 	if (platform_file_exists(dest_path))
 		return 2;
 
 	// Set path for actual copy
-	substitute_path(dest_path, gConfigGamePath.tracks_path, dest_name);
+	substitute_path(dest_path, gConfigGamePath.tracks, dest_name);
 
 	return platform_file_copy(source_path, dest_path, false);
 }

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -324,7 +324,7 @@ void scenario_begin()
 	strncat(gScenarioSavePath, parkName, sizeof(gScenarioSavePath) - strlen(gScenarioSavePath) - 1);
 	strncat(gScenarioSavePath, ".sv6", sizeof(gScenarioSavePath) - strlen(gScenarioSavePath) - 1);
 
-	strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, (char*)RCT2_ADDRESS_SAVED_GAMES_PATH);
+	strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, (char*)gConfigGamePath.saved_game_path);
 	strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2 + strlen((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2), gScenarioSavePath);
 	strcat((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, ".SV6");
 
@@ -379,7 +379,7 @@ void scenario_end()
 
 void scenario_set_filename(const char *value)
 {
-	substitute_path(_scenarioPath, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), value);
+	substitute_path(_scenarioPath, gConfigGamePath.scenario_path, value);
 	_scenarioFileName = path_get_filename(_scenarioPath);
 }
 

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -324,9 +324,9 @@ void scenario_begin()
 	strncat(gScenarioSavePath, parkName, sizeof(gScenarioSavePath) - strlen(gScenarioSavePath) - 1);
 	strncat(gScenarioSavePath, ".sv6", sizeof(gScenarioSavePath) - strlen(gScenarioSavePath) - 1);
 
-	strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, (char*)gConfigGamePath.saved_game_path);
-	strcpy((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2 + strlen((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2), gScenarioSavePath);
-	strcat((char*)RCT2_ADDRESS_SAVED_GAMES_PATH_2, ".SV6");
+	strcpy((char*)gConfigGamePath.buffer, (char*)gConfigGamePath.saved_game);
+	strcpy((char*)gConfigGamePath.buffer + strlen((char*)gConfigGamePath.buffer), gScenarioSavePath);
+	strcat((char*)gConfigGamePath.buffer, ".SV6");
 
 	memset((void*)0x001357848, 0, 56);
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_EXPENDITURE, uint32) = 0;
@@ -379,7 +379,7 @@ void scenario_end()
 
 void scenario_set_filename(const char *value)
 {
-	substitute_path(_scenarioPath, gConfigGamePath.scenario_path, value);
+	substitute_path(_scenarioPath, gConfigGamePath.scenario, value);
 	_scenarioFileName = path_get_filename(_scenarioPath);
 }
 

--- a/src/scenario_list.c
+++ b/src/scenario_list.c
@@ -60,7 +60,7 @@ void scenario_load_list()
 	gScenarioListCount = 0;
 
 	// Get scenario directory from RCT2
-	safe_strncpy(directory, gConfigGamePath.game_path, sizeof(directory));
+	safe_strncpy(directory, gConfigGamePath.installed_game, sizeof(directory));
 	safe_strcat_path(directory, "Scenarios", sizeof(directory));
 	scenario_list_include(directory);
 

--- a/src/scenario_list.c
+++ b/src/scenario_list.c
@@ -60,7 +60,7 @@ void scenario_load_list()
 	gScenarioListCount = 0;
 
 	// Get scenario directory from RCT2
-	safe_strncpy(directory, gConfigGeneral.game_path, sizeof(directory));
+	safe_strncpy(directory, gConfigGamePath.game_path, sizeof(directory));
 	safe_strcat_path(directory, "Scenarios", sizeof(directory));
 	scenario_list_include(directory);
 

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -333,7 +333,7 @@ static int show_save_scenario_dialog(char *resultPath)
 
 
 	format_string(title, STR_SAVE_SCENARIO, NULL);
-	substitute_path(filename, gConfigGamePath.scenario_path, s6Info->name);
+	substitute_path(filename, gConfigGamePath.scenario, s6Info->name);
 	strcat(filename, ".SC6");
 	format_string(filterName, STR_RCT2_SCENARIO_FILE, NULL);
 

--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -333,7 +333,7 @@ static int show_save_scenario_dialog(char *resultPath)
 
 
 	format_string(title, STR_SAVE_SCENARIO, NULL);
-	substitute_path(filename, RCT2_ADDRESS(RCT2_ADDRESS_SCENARIOS_PATH, char), s6Info->name);
+	substitute_path(filename, gConfigGamePath.scenario_path, s6Info->name);
 	strcat(filename, ".SC6");
 	format_string(filterName, STR_RCT2_SCENARIO_FILE, NULL);
 

--- a/src/windows/install_track.c
+++ b/src/windows/install_track.c
@@ -182,7 +182,7 @@ static void window_install_track_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	substitute_path(track_path, (char*)gConfigGamePath.tracks_path, trackDesignItem);
+	substitute_path(track_path, (char*)gConfigGamePath.tracks, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();

--- a/src/windows/install_track.c
+++ b/src/windows/install_track.c
@@ -182,7 +182,7 @@ static void window_install_track_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
+	substitute_path(track_path, (char*)gConfigGamePath.tracks_path, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -239,7 +239,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 		}
 		*/
 
-		safe_strncpy(path, RCT2_ADDRESS(RCT2_ADDRESS_TRACKS_PATH, char), MAX_PATH);
+		safe_strncpy(path, gConfigGamePath.tracks_path, MAX_PATH);
 		ch = strchr(path, '*');
 		if (ch != NULL)
 			*ch = 0;

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -239,7 +239,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 		}
 		*/
 
-		safe_strncpy(path, gConfigGamePath.tracks_path, MAX_PATH);
+		safe_strncpy(path, gConfigGamePath.tracks, MAX_PATH);
 		ch = strchr(path, '*');
 		if (ch != NULL)
 			*ch = 0;

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -183,7 +183,7 @@ static void window_track_list_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	substitute_path(track_path, (char*)gConfigGamePath.tracks_path, trackDesignItem);
+	substitute_path(track_path, (char*)gConfigGamePath.tracks, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -183,7 +183,7 @@ static void window_track_list_select(rct_window *w, int index)
 		1);
 
 	char track_path[MAX_PATH] = { 0 };
-	substitute_path(track_path, (char*)RCT2_ADDRESS_TRACKS_PATH, trackDesignItem);
+	substitute_path(track_path, (char*)gConfigGamePath.tracks_path, trackDesignItem);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_MANAGER) {
 		window_track_manage_open();


### PR DESCRIPTION
- Separated game path configuration (game_path, game_path_slash ..etc) from gConfigGeneral structure.

- Created to initialise directories information what separated.

- Swapped RCT2_ACCESS with global configurations.

- And questions : what is RCT2_ADDRESS_SAVED_GAMES_PATH_2? it not be used saving saved game path, just used like.. buffer? it just be coped one time! what is major use of it? please let me know it.

- Please somebody test it in other environment. it just be tested in OS X.