### PR TITLE
OS X job for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,62 @@
 language: c
 
 before_install:
-    - bash scripts/linux/install.sh
+    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/install.sh; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then gem install xcpretty-travis-formatter; fi
+
+sudo: required
+dist: trusty
+
+matrix:
+    include:
+        - os: linux
+          env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
+        - os: linux
+          env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+        - os: linux
+          env: OPENRCT2_CMAKE_OPTS="-DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
+        - os: linux
+          env: TARGET=docker32
+          services:
+            - docker
+        - os: linux
+          env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON" TARGET=docker32
+          services:
+            - docker
+        - os: osx
+          sudo: false
+          osx_image: xcode7.2
+          after_success:
+            - cd build/Release
+            - hdiutil create -size 64m -fs HFS+ -volname "OpenRCT2 OS X" myimg.dmg
+            - hdiutil attach myimg.dmg
+            - export DEVS=$(hdiutil attach myimg.dmg | cut -f 1)
+            - export DEV=$(echo $DEVS | cut -f 1 -d ' ')
+            - cp -rv OpenRCT2.app "/Volumes/OpenRCT2 OS X"
+            - sync
+            - hdiutil detach $DEV
+            - hdiutil convert myimg.dmg -format UDZO -o OpenRCT2.dmg
+            - curl --upload-file OpenRCT2.dmg http://transfer.sh/OpenRCT2.dmg
+        # Following entries used to be included in testing, but they only proved useful while changing things in CMake setup.
+        # They are meant to be used when there are changes to CMakeLists.txt
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=OFF -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=OFF -DDISABLE_HTTP_TWITCH=OFF -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
+        # - os: linux
+        #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_HTTP_TWITCH=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
 
 script:
-    - bash scripts/linux/build.sh
+    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/build.sh ; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild | xcpretty -f `xcpretty-travis-formatter`; fi
 
 notifications:
     on_failure: change
@@ -14,25 +66,3 @@ cache:
     directories:
         - .cache
     apt: true
-
-env:
-    - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
-    - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-    - OPENRCT2_CMAKE_OPTS="-DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
-    - TARGET=docker32
-    - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON" TARGET=docker32
-    # Following entries used to be included in testing, but they only proved useful while changing things in CMake setup.
-    # They are meant to be used when there are changes to CMakeLists.txt
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=OFF -DDISABLE_HTTP_TWITCH=ON -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=OFF -DDISABLE_HTTP_TWITCH=OFF -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8"
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
-    # - OPENRCT2_CMAKE_OPTS="-DDISABLE_HTTP_TWITCH=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
-
-sudo: required
-dist: trusty
-
-services:
-    - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: c
 before_install:
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/install.sh; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then gem install xcpretty-travis-formatter; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then curl -L https://openrct2.website/files/MacOSX10.10.sdk.tar.xz -o MacOSX10.10.sdk.tar.xz; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo tar xf MacOSX10.10.sdk.tar.xz -C /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/; fi
 
 sudo: required
 dist: trusty
@@ -24,7 +26,6 @@ matrix:
           services:
             - docker
         - os: osx
-          sudo: false
           osx_image: xcode7.2
           after_success:
             - cd build/Release
@@ -56,7 +57,7 @@ matrix:
 
 script:
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/build.sh ; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild | xcpretty -f `xcpretty-travis-formatter`; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild -sdk macosx10.10 | xcpretty -f `xcpretty-travis-formatter`; fi
 
 notifications:
     on_failure: change


### PR DESCRIPTION
This adds automated builds for OS X to our CI infrastructure.

XCode's `xcodebuild` tool is quite spammy by default, so I used a
prettifier for its output. Since this could potentially cover errors
from XCode due to piping of commands, I enabled `pipefail` option which
would cause all of pipe construct fail, should any of its commands exit
with non-zero code.

The created app bundle is packaged into dmg and uploaded to transfer.sh,
if the build was successful. To the best of my knowledge, this is *the*
way of packaging and distributing OS X applications.