### PR TITLE
Skip "Default sound device" on Linux

### DIFF
--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -78,18 +78,26 @@ void audio_populate_devices()
 	if (gAudioDeviceCount <= 0)
 		return;
 
-		gAudioDeviceCount++;
-		gAudioDevices = malloc(gAudioDeviceCount * sizeof(audio_device));
-		safe_strncpy(gAudioDevices[0].name, language_get_string(5510), AUDIO_DEVICE_NAME_SIZE);
-
-	for (int i = 1; i < gAudioDeviceCount; i++) {
-		const char *utf8Name = SDL_GetAudioDeviceName(i - 1, SDL_FALSE);
+	audio_device *systemAudioDevices = malloc(gAudioDeviceCount * sizeof(audio_device));
+	for (int i = 0; i < gAudioDeviceCount; i++) {
+		const char *utf8Name = SDL_GetAudioDeviceName(i, SDL_FALSE);
 		if (utf8Name == NULL)
 			utf8Name = language_get_string(5511);
 
-		safe_strncpy(gAudioDevices[i].name, utf8Name, AUDIO_DEVICE_NAME_SIZE);
-		}
+		safe_strncpy(systemAudioDevices[i].name, utf8Name, AUDIO_DEVICE_NAME_SIZE);
 	}
+#ifndef __linux__
+	gAudioDeviceCount++;
+	gAudioDevices = malloc(gAudioDeviceCount * sizeof(audio_device));
+	safe_strncpy(gAudioDevices[0].name, language_get_string(5510), AUDIO_DEVICE_NAME_SIZE);
+	memcpy(&gAudioDevices[1], systemAudioDevices, (gAudioDeviceCount - 1) * sizeof(audio_device));
+#else
+	gAudioDevices = malloc(gAudioDeviceCount * sizeof(audio_device));
+	memcpy(gAudioDevices, systemAudioDevices, gAudioDeviceCount * sizeof(audio_device));
+#endif // __linux__
+
+	free(systemAudioDevices);
+}
 
 int audio_play_sound_panned(int soundId, int pan, sint16 x, sint16 y, sint16 z)
 {

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -1316,9 +1316,11 @@ static void window_options_invalidate(rct_window *w)
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = STR_SOUND_NONE;
 		}
 		else {
+#ifndef __linux__
 			if (currentSoundDevice == 0)
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = 5510;
 			else
+#endif // __linux__
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = 1170;
 
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = (uint32)gAudioDevices[currentSoundDevice].name;


### PR DESCRIPTION
Sound on Linux is handled by PulseAudio, which creates a sink and offers
a central place to control which sources are distributed how and where.

Applications in general are expected to only offer volume controls.

Tested with 0 A.D., SuperTuxKart and a few media players, none of which
offers selecting sink directly.

As per https://en.wikipedia.org/wiki/PulseAudio#Adoption it should
covert vast majority of uses.