### PR TITLE
Make sure config.ini gets created

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -306,8 +306,8 @@ notification_configuration gConfigNotifications;
 themes_configuration gConfigThemes;
 title_sequences_configuration gConfigTitleSequences;
 
-bool config_open(const utf8string path);
-bool config_save(const utf8string path);
+static bool config_open(const utf8string path);
+static bool config_save(const utf8string path);
 static void config_read_properties(config_section_definition **currentSection, const_utf8string line);
 static void config_save_property_value(SDL_RWops *file, uint8 type, value_union *value);
 static bool config_read_enum(void *dest, int destSize, const utf8 *key, int keySize, config_enum_definition *enumDefinitions);
@@ -396,12 +396,17 @@ void config_set_defaults()
 	}
 }
 
+void config_get_default_path(utf8 *outPath)
+{
+	platform_get_user_directory(outPath, NULL);
+	strcat(outPath, "config.ini");
+}
+
 bool config_open_default()
 {
 	utf8 path[MAX_PATH];
 
-	platform_get_user_directory(path, NULL);
-	strcat(path, "config.ini");
+	config_get_default_path(path);
 	if (config_open(path)) {
 		config_apply_to_old_addresses();
 		return true;
@@ -414,8 +419,7 @@ bool config_save_default()
 {
 	utf8 path[MAX_PATH];
 
-	platform_get_user_directory(path, NULL);
-	strcat(path, "config.ini");
+	config_get_default_path(path);
 	if (config_save(path)) {
 		config_apply_to_old_addresses();
 		return true;

--- a/src/config.h
+++ b/src/config.h
@@ -337,6 +337,7 @@ extern title_sequences_configuration gConfigTitleSequences;
 
 extern uint16 gShortcutKeys[SHORTCUT_COUNT];
 
+void config_get_default_path(utf8 *outPath);
 void config_set_defaults();
 bool config_open_default();
 bool config_save_default();

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -196,7 +196,11 @@ bool openrct2_initialise()
 	config_set_defaults();
 	if (!config_open_default()) {
 		if (!config_find_or_browse_install_directory()) {
-			log_fatal("An RCT2 install directory must be specified!");
+			gConfigGeneral.last_run_version = strndup(OPENRCT2_VERSION, strlen(OPENRCT2_VERSION));
+			config_save_default();
+			utf8 path[MAX_PATH];
+			config_get_default_path(path);
+			log_fatal("An RCT2 install directory must be specified! Please edit \"game_path\" in %s.", path);
 			return false;
 		}
 	}

--- a/src/rct2.c
+++ b/src/rct2.c
@@ -202,7 +202,9 @@ int rct2_init_directories()
 	if (!platform_original_game_data_exists(gConfigGeneral.game_path)) {
 		log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGeneral.game_path);
 		if (!config_find_or_browse_install_directory()) {
-			log_fatal("Invalid RCT2 installation path. Please correct in config.ini.");
+			utf8 path[MAX_PATH];
+			config_get_default_path(path);
+			log_fatal("Invalid RCT2 installation path. Please correct \"game_path\" in %s.", path);
 			return 0;
 	}
 	}


### PR DESCRIPTION
This commit makes sure config.ini gets created even when RCT2 path is
not selected.

This makes for a better out-of-box experience on Linux, where no
directory selector is provided yet, as we provide default config file
and state in the error message how to fix it.