### PR TITLE
Merge currency detection and add missing currencies

### DIFF
--- a/src/localisation/currency.c
+++ b/src/localisation/currency.c
@@ -22,17 +22,17 @@
 #include "string_ids.h"
 
 const currency_descriptor CurrencyDescriptors[CURRENCY_END] = {
-	{ 10	, CURRENCY_PREFIX, "\xC2\xA3"		,	CURRENCY_SUFFIX,	"GBP"	, STR_POUNDS		},		// British Pound
-	{ 10	, CURRENCY_PREFIX, "$"				,	CURRENCY_PREFIX,	"$"		, STR_DOLLARS		},		// US Dollar
-	{ 10	, CURRENCY_SUFFIX, "F"				,	CURRENCY_SUFFIX,	"F"		, STR_FRANC			},		// French Franc
-	{ 10	, CURRENCY_PREFIX, "DM"				,	CURRENCY_PREFIX,	"DM"	, STR_DEUTSCHMARK	},		// Deutschmark
-	{ 1000	, CURRENCY_PREFIX, "\xC2\xA5"		,	CURRENCY_SUFFIX,	"YEN"	, STR_YEN			},		// Japanese Yen
-	{ 10	, CURRENCY_SUFFIX, "Pts"			,	CURRENCY_SUFFIX,	"Pts"	, STR_PESETA		},		// Spanish Peseta
-	{ 1000	, CURRENCY_PREFIX, "L"				,	CURRENCY_PREFIX,	"L"		, STR_LIRA			},		// Italian Lira
-	{ 10	, CURRENCY_PREFIX, "\xC6\x92"		,	CURRENCY_PREFIX,	"fl."	, STR_GUILDERS		},		// Dutch Guilder
-	{ 10	, CURRENCY_SUFFIX, "kr."			,	CURRENCY_SUFFIX,	"kr."	, STR_KRONA			},		// Swedish Krona
-	{ 10	, CURRENCY_PREFIX, "\xE2\x82\xAC"	,	CURRENCY_SUFFIX,	"EUR"	, STR_EUROS			},		// Euro
-	{ 10000 , CURRENCY_PREFIX, "\xE2\x82\xA9"	,	CURRENCY_PREFIX,	"W"		, STR_WON			},		// South Korean Won
-	{ 1000  , CURRENCY_PREFIX, "R "				,	CURRENCY_PREFIX,	"R "	, STR_ROUBLE		},		// Russian Rouble
-	{ 100	, CURRENCY_SUFFIX, " K\xC4\x8D"		,	CURRENCY_SUFFIX,	" Kc"	, STR_CZECH_KORUNA	},		// Czech koruna
+	{	"GBP",	10,		CURRENCY_PREFIX,	"\xC2\xA3",		CURRENCY_SUFFIX,	"GBP",	STR_POUNDS			},	// British Pound
+	{	"USD",	10,		CURRENCY_PREFIX,	"$",			CURRENCY_PREFIX,	"$",	STR_DOLLARS			},	// US Dollar
+	{	"FRF",	10,		CURRENCY_SUFFIX,	"F",			CURRENCY_SUFFIX,	"F",	STR_FRANC			},	// French Franc
+	{	"DEM",	10,		CURRENCY_PREFIX,	"DM",			CURRENCY_PREFIX,	"DM",	STR_DEUTSCHMARK		},	// Deutschmark
+	{	"JPY",	1000,	CURRENCY_PREFIX,	"\xC2\xA5",		CURRENCY_SUFFIX,	"YEN",	STR_YEN				},	// Japanese Yen
+	{	"ESP",	10,		CURRENCY_SUFFIX,	"Pts",			CURRENCY_SUFFIX,	"Pts",	STR_PESETA			},	// Spanish Peseta
+	{	"ITL",	1000,	CURRENCY_PREFIX,	"L",			CURRENCY_PREFIX,	"L",	STR_LIRA			},	// Italian Lira
+	{	"NLG",	10,		CURRENCY_PREFIX,	"\xC6\x92",		CURRENCY_PREFIX,	"fl.",	STR_GUILDERS		},	// Dutch Guilder
+	{	"SEK",	10,		CURRENCY_SUFFIX,	"kr.",			CURRENCY_SUFFIX,	"kr.",	STR_KRONA			},	// Swedish Krona
+	{	"EUR",	10,		CURRENCY_PREFIX,	"\xE2\x82\xAC",	CURRENCY_SUFFIX,	"EUR",	STR_EUROS			},	// Euro
+	{	"KRW",	10000,	CURRENCY_PREFIX,	"\xE2\x82\xA9",	CURRENCY_PREFIX,	"W",	STR_WON				},	// South Korean Won
+	{	"RUB",	1000,	CURRENCY_PREFIX,	"R ",			CURRENCY_PREFIX,	"R ",	STR_ROUBLE			},	// Russian Rouble
+	{	"CZK",	100,	CURRENCY_SUFFIX,	" K\xC4\x8D",	CURRENCY_SUFFIX,	" Kc",	STR_CZECH_KORUNA	},	// Czech koruna
 };

--- a/src/localisation/currency.h
+++ b/src/localisation/currency.h
@@ -51,6 +51,7 @@ typedef enum {
 
 // Currency format specification - inspired by OpenTTD
 typedef struct {
+	char isoCode[4];
 	// Rate is relative to 0.10 GBP
 	int rate;
 	uint8 affix_unicode;

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -160,6 +160,7 @@ void platform_show_messagebox(utf8 *message);
 int platform_open_common_file_dialog(int type, utf8 *title, utf8 *filename, utf8 *filterPattern, utf8 *filterName);
 utf8 *platform_open_directory_browser(utf8 *title);
 uint8 platform_get_locale_currency();
+uint8 platform_get_currency_value(const char *currencyCode);
 uint16 platform_get_locale_language();
 uint8 platform_get_locale_measurement_format();
 uint8 platform_get_locale_temperature_format();

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -32,7 +32,6 @@
 #include <SDL_syswm.h>
 #include "../addresses.h"
 #include "../config.h"
-#include "../localisation/currency.h"
 #include "../localisation/language.h"
 #include "../openrct2.h"
 #include "../util/util.h"
@@ -818,26 +817,13 @@ time_t platform_file_get_modified_time(const utf8* path){
 uint8 platform_get_locale_currency(){
 	char *langstring = setlocale(LC_MONETARY, "");
 
-	if(langstring != NULL){
-		struct lconv *lc = localeconv();
-
-		//Only works if g_currency_specs contains the actual (local) symbol
-		for(int i = 0; i < CURRENCY_END; ++i){
-			if(!strcmp(lc->currency_symbol, CurrencyDescriptors[i].symbol_unicode)){
-				return i;
-			}
-		}
-		//TODO: can be removed when CurrencyDescriptors contains the actual symbols for won and rubel
-		//Won should remain a special case, beacause some (or all?) systems use the full width won sign (e.g. Gentoo)
-		if(!strncmp(lc->int_curr_symbol, "KRW", 3)){
-			return CURRENCY_WON;
-		}
-		else if(!strncmp(lc->int_curr_symbol, "RUB", 3)){
-			return CURRENCY_ROUBLE;
-		}
+	if (langstring == NULL) {
+		return platform_get_currency_value(NULL);
 	}
-	//All other currencies are historic
-	return CURRENCY_POUNDS;
+	
+	struct lconv *lc = localeconv();
+	
+	return platform_get_currency_value(lc->int_curr_symbol);
 }
 
 uint8 platform_get_locale_measurement_format(){

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -29,6 +29,7 @@
 #include "../interface/keyboard_shortcut.h"
 #include "../interface/window.h"
 #include "../input.h"
+#include "../localisation/currency.h"
 #include "../localisation/localisation.h"
 #include "../openrct2.h"
 #include "../title.h"
@@ -1114,4 +1115,18 @@ void platform_set_cursor_position(int x, int y)
 unsigned int platform_get_ticks()
 {
 	return SDL_GetTicks();
+}
+
+uint8 platform_get_currency_value(const char *currCode) {
+	if (currCode == NULL || strlen(currCode) < 3) {
+			return CURRENCY_POUNDS;
+	}
+	
+	for (int currency = 0; currency < CURRENCY_END; ++currency) {
+		if (strncmp(currCode, CurrencyDescriptors[currency].isoCode, 3) == 0) {
+			return currency;
+		}
+	}
+	
+	return CURRENCY_POUNDS;
 }

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -28,7 +28,6 @@
 #include "../addresses.h"
 #include "../openrct2.h"
 #include "../localisation/language.h"
-#include "../localisation/currency.h"
 #include "../util/util.h"
 #include "../config.h"
 #include "platform.h"
@@ -842,45 +841,15 @@ time_t platform_file_get_modified_time(const utf8* path)
 uint8 platform_get_locale_currency()
 {
 	CHAR currCode[4];
-
 	if (GetLocaleInfo(LOCALE_USER_DEFAULT,
 		LOCALE_SINTLSYMBOL,
 		(LPSTR)&currCode,
 		sizeof(currCode)) == 0
 	) {
-		return CURRENCY_POUNDS;
+		return platform_get_currency_value(NULL);
 	}
-	if (strcmp(currCode, "GBP") == 0){
-		return CURRENCY_POUNDS;
-	}
-	else if (strcmp(currCode, "USD") == 0){
-		return CURRENCY_DOLLARS;
-	}
-	else if (strcmp(currCode, "EUR") == 0){
-		return CURRENCY_EUROS;
-	}
-	else if (strcmp(currCode, "SEK") == 0){
-		return CURRENCY_KRONA;
-	}
-	else if (strcmp(currCode, "DEM") == 0){
-		return CURRENCY_DEUTSCHMARK;
-	}
-	else if (strcmp(currCode, "ITL") == 0){
-		return CURRENCY_LIRA;
-	}
-	else if (strcmp(currCode, "JPY") == 0){
-		return CURRENCY_YEN;
-	}
-	else if (strcmp(currCode, "ESP") == 0){
-		return CURRENCY_PESETA;
-	}
-	else if (strcmp(currCode, "FRF") == 0){
-		return CURRENCY_FRANC;
-	}
-	else if (strcmp(currCode, "NLG") == 0){
-		return CURRENCY_GUILDERS;
-	}
-	return CURRENCY_POUNDS;
+	
+	return platform_get_currency_value(currCode);
 }
 
 uint8 platform_get_locale_measurement_format()


### PR DESCRIPTION
Use ISO 4217-based locale currency detection on all platforms. Platform-specific code only reports the currency string.

Fixes #2705 