### PR TITLE
Set minimal window size to 720×480

### DIFF
--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -795,6 +795,7 @@ static void platform_create_window()
 	}
 
 	SDL_SetWindowGrab(gWindow, gConfigGeneral.trap_cursor ? SDL_TRUE : SDL_FALSE);
+	SDL_SetWindowMinimumSize(gWindow, 720, 480);
 
 	// Set the update palette function pointer
 	RCT2_GLOBAL(0x009E2BE4, update_palette_func) = platform_update_palette;


### PR DESCRIPTION
Smaller width causes toolbars to be cut off.