### PR TITLE
Validate ride type to create

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -5305,6 +5305,12 @@ money32 ride_create(int type, int subType, int flags, int *outRideIndex, int *ou
 	rct_ride_type *rideEntry;
 	int rideIndex, rideEntryIndex;
 
+	if (type > 90)
+	{
+		log_warning("Invalid request for ride type %u", type);
+		return MONEY32_UNDEFINED;
+	}
+
 	if (subType == 255) {
 		uint8 *availableRideEntries = get_ride_entry_indices_for_ride_type(type);
 		for (uint8 *rei = availableRideEntries; *rei != 255; rei++) {


### PR DESCRIPTION
This could *possibly* help with current multiplayer woes.

I could find no define saying what's the maximum, so I used the highest available type, `RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER = 90`.

Keep in mind this will also reject `RIDE_TYPE_NULL`, but I don't think such a request would be valid anyway.