### PR TITLE
Assert for evergreen gardens

### DIFF
--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -21,6 +21,7 @@
 #include "../addresses.h"
 #include "../platform/platform.h"
 #include "sawyercoding.h"
+#include "../scenario.h"
 
 static size_t decode_chunk_rle(const uint8* src_buffer, uint8* dst_buffer, size_t length);
 static size_t decode_chunk_repeat(uint8 *buffer, size_t length);
@@ -418,6 +419,8 @@ static size_t encode_chunk_repeat(const uint8 *src_buffer, uint8 *dst_buffer, si
 			repeatCount = 0;
 			maxRepeatCount = min(7, searchEnd - repeatIndex);
 			for (j = 0; j <= maxRepeatCount; j++) {
+				assert(repeatIndex + j < sizeof(rct_s6_data) - offsetof(rct_s6_data, dword_010E63B8));
+				assert(i + j < sizeof(rct_s6_data) - offsetof(rct_s6_data, dword_010E63B8));
 				if (src_buffer[repeatIndex + j] == src_buffer[i + j]) {
 					repeatCount++;
 				} else {

--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -419,8 +419,8 @@ static size_t encode_chunk_repeat(const uint8 *src_buffer, uint8 *dst_buffer, si
 			repeatCount = 0;
 			maxRepeatCount = min(7, searchEnd - repeatIndex);
 			for (j = 0; j <= maxRepeatCount; j++) {
-				assert(repeatIndex + j < sizeof(rct_s6_data) - offsetof(rct_s6_data, dword_010E63B8));
-				assert(i + j < sizeof(rct_s6_data) - offsetof(rct_s6_data, dword_010E63B8));
+				assert(repeatIndex + j < length);
+				assert(i + j < length);
 				if (src_buffer[repeatIndex + j] == src_buffer[i + j]) {
 					repeatCount++;
 				} else {


### PR DESCRIPTION
This is really an issue report, but with code attached.

It is possible to break the enclosed assertion by using "Evergreen gardens" scenario.

To trigger it: use crappage's rct1 recreations, load "Evergreen gardens" scenario, save game (without doing anything, but happens also when i tried doing something), assertion gets triggered.