### PR TITLE
Disabling Debug Button When Playing Over A Network

### DIFF
--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -682,15 +682,16 @@ static void window_top_toolbar_invalidate(rct_window *w)
 			window_top_toolbar_widgets[WIDX_NEWS].type = WWT_EMPTY;
 
 		switch (network_get_mode()) {
-		case NETWORK_MODE_SERVER:
-			window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WWT_EMPTY;
+		case NETWORK_MODE_NONE:
+			window_top_toolbar_widgets[WIDX_NETWORK].type = WWT_EMPTY;
 			break;
 		case NETWORK_MODE_CLIENT:
 			window_top_toolbar_widgets[WIDX_PAUSE].type = WWT_EMPTY;
+		// Fall-through
+		case NETWORK_MODE_SERVER:
 			window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WWT_EMPTY;
+			window_top_toolbar_widgets[WIDX_DEBUG].type = WWT_EMPTY;
 			break;
-		default:
-			window_top_toolbar_widgets[WIDX_NETWORK].type = WWT_EMPTY;
 		}
 	}
 


### PR DESCRIPTION
This PR will hide the debug button for both the server and the client, not just the object selection, to prevent crashes and corrupted files caused by players using these tools.

This was mentioned here: #2727