### PR TITLE
Fall-back to default language in case none is set

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -346,6 +346,11 @@ rct_string_id object_get_localised_text(uint8_t** pStringTable/*ebp*/, int type/
 		// Skip over the actual string entry to get to the next entry
 		while (*(*pStringTable)++ != 0);
 	}
+	// Fall back in case language does not get set.
+	if (pString == NULL)
+	{
+		pString = (char*)(*pStringTable);
+	}
 
 	char name[9];
 	if (RCT2_GLOBAL(0x009ADAFC, uint8) == 0) {


### PR DESCRIPTION
From thread https://openrct2.org/forums/topic/720-openrct2-doesnt-work/,
the object http://www.nedesigns.com/rct2-object/5130/scgletrs/ does not
set `pString` properly, so use a default fallback in such case.

This is a simple & hackish, though effective, way of dealing with this problem. Feel free to veto if you don't find this solution appropriate.