### PR TITLE
Fix travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_install:
 sudo: required
 dist: trusty
 env:
-    - OPENRCT2_VERSION="0.0.4"
+    global:
+        - OPENRCT2_VERSION="0.0.4"
 
 matrix:
     include:


### PR DESCRIPTION
I missed `global` keyword in #2753 and it caused another job to be create, while the others don't have their version variable set. This fixes it.