### PR TITLE
Fixed a theoretical security issue for OS X and Linux

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -1600,7 +1600,7 @@
 					"-segprot",
 					rct2_text,
 					rwx,
-					rwx,
+					rx,
 					"-sectcreate",
 					rct2_data,
 					__data,
@@ -1610,8 +1610,8 @@
 					0x8a4000,
 					"-segprot",
 					rct2_data,
-					rwx,
-					rwx,
+					rw,
+					rw,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = website.openrct2.OpenRCT2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1646,7 +1646,7 @@
 					"-segprot",
 					rct2_text,
 					rwx,
-					rwx,
+					rx,
 					"-sectcreate",
 					rct2_data,
 					__data,
@@ -1656,8 +1656,8 @@
 					0x8a4000,
 					"-segprot",
 					rct2_data,
-					rwx,
-					rwx,
+					rw,
+					rw,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = website.openrct2.OpenRCT2;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/hook.c
+++ b/src/hook.c
@@ -242,7 +242,19 @@ void addhook(int address, int newaddress, int stacksize, int registerargs[], int
 	WriteProcessMemory(GetCurrentProcess(), (LPVOID)address, data, i, 0);
 #else
 	// We own the pages with PROT_WRITE | PROT_EXEC, we can simply just memcpy the data
+	int err = mprotect((void *)0x401000, 0x8a4000 - 0x401000, PROT_READ | PROT_WRITE);
+	if (err != 0)
+	{
+		perror("mprotect");
+	}
+	
 	memcpy((void *)address, data, i);
+	
+	err = mprotect((void *)0x401000, 0x8a4000 - 0x401000, PROT_READ | PROT_EXEC);
+	if (err != 0)
+	{
+		perror("mprotect");
+	}
 #endif // __WINDOWS__
 	hookfunc(hookaddress, newaddress, stacksize, registerargs, registersreturned, eaxDestinationRegister);
 	g_hooktableoffset++;

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -548,7 +548,7 @@ bool openrct2_setup_rct2_segment()
 		log_error("At least one of required pages was not found in memory. This can cause segfaults later on.");
 	}
 	// section: text
-	err = mprotect((void *)0x401000, 0x8a4000 - 0x401000, PROT_READ | PROT_WRITE | PROT_EXEC);
+	err = mprotect((void *)0x401000, 0x8a4000 - 0x401000, PROT_READ | PROT_EXEC);
 	if (err != 0)
 	{
 		perror("mprotect");


### PR DESCRIPTION
As far as I'm aware, there are no known exploits that makes this patch necessary, but it is still a good idea to make this change.

In short, this makes the RCT2 code section read-only outside of the hook setting code. This prevents something like index underflow from being able to write to the text section and changing the assembly.