### PR TITLE
(Temp) Fix Travis OS X Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
           services:
             - docker
         - os: osx
-          osx_image: xcode7.2
+          osx_image: xcode7.1
           env:
             - secure: "OXn/i72FxW/oh6RGlaN+gHSbkt1ToFe36etaiDOsJQznt6fe9CpFdnE8U1XBHlGokcEjbGNErRU7CFDKYHQuGrPZyHXwgqG2/0emIqFaFt5ti5ypyYKf5qH9x1LLLfdZxDyHkxXdlJ7Etxbp3G7qrV8CGRQiYRNHm1f98AmuufE="
           after_success:


### PR DESCRIPTION
It appears to only affect the 10.11 build servers, so by downgrading the Xcode version to 7.1.1, it avoids the issue. This should be moved back once the issue is resolved on Travis's end.