### PR TITLE
Add a password to headless server mode

### DIFF
--- a/openrct2.vcxproj.user
+++ b/openrct2.vcxproj.user
@@ -7,8 +7,7 @@
     <LocalDebuggerCommand>$(TargetDir)\openrct2.exe</LocalDebuggerCommand>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>host "http://www.stuffie.org/R%26J2.sv6" --port=7777 --headless</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>

--- a/src/cmdline/RootCommands.cpp
+++ b/src/cmdline/RootCommands.cpp
@@ -137,10 +137,11 @@ exitcode_t CommandLine::HandleCommandDefault()
         Memory::Free(_openrctDataPath);
     }
 
- if (_password != NULL) {
-  String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
-  Memory::Free(_password);
- }
+    if (_password != NULL) {
+        String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
+        Memory::Free(_password);
+    }
+
     return result;
 }
 
@@ -214,7 +215,7 @@ exitcode_t HandleCommandHost(CommandLineArgEnumerator * enumerator)
     gOpenRCT2StartupAction = STARTUP_ACTION_OPEN;
     String::Set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
 
- gNetworkStart = NETWORK_MODE_SERVER;
+    gNetworkStart = NETWORK_MODE_SERVER;
     gNetworkStartPort = _port;
     return EXITCODE_CONTINUE;
 }
@@ -234,9 +235,9 @@ exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator)
         return EXITCODE_FAIL;
     }
 
- gNetworkStart = NETWORK_MODE_CLIENT;
+    gNetworkStart = NETWORK_MODE_CLIENT;
     gNetworkStartPort = _port;
- String::Set(gNetworkStartHost, sizeof(gNetworkStartHost), hostname);
+    String::Set(gNetworkStartHost, sizeof(gNetworkStartHost), hostname);
     return EXITCODE_CONTINUE;
 }
 

--- a/src/cmdline/RootCommands.cpp
+++ b/src/cmdline/RootCommands.cpp
@@ -29,6 +29,7 @@ static bool   _headless        = false;
 #ifndef DISABLE_NETWORK
 static uint32 _port            = 0;
 #endif
+static utf8 * _password        = nullptr;
 static utf8 * _userDataPath    = nullptr;
 static utf8 * _openrctDataPath = nullptr;
 
@@ -44,6 +45,7 @@ static const CommandLineOptionDefinition StandardOptions[]
 #ifndef DISABLE_NETWORK
     { CMDLINE_TYPE_INTEGER, &_port,            NAC, "port",              "port to use for hosting or joining a server"                },
 #endif
+	{ CMDLINE_TYPE_STRING,  &_password,		   NAC, "password",			 "Server password"                                            },
     { CMDLINE_TYPE_STRING,  &_userDataPath,    NAC, "user-data-path",    "path to the user data directory (containing config.ini)"    },
     { CMDLINE_TYPE_STRING,  &_openrctDataPath, NAC, "openrct-data-path", "path to the OpenRCT2 data directory (containing languages)" },
     OptionTableEnd
@@ -135,6 +137,10 @@ exitcode_t CommandLine::HandleCommandDefault()
         Memory::Free(_openrctDataPath);
     }
 
+	if (_password != NULL) {
+		String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
+		Memory::Free(_password);
+	}
     return result;
 }
 

--- a/src/cmdline/RootCommands.cpp
+++ b/src/cmdline/RootCommands.cpp
@@ -45,7 +45,7 @@ static const CommandLineOptionDefinition StandardOptions[]
 #ifndef DISABLE_NETWORK
     { CMDLINE_TYPE_INTEGER, &_port,            NAC, "port",              "port to use for hosting or joining a server"                },
 #endif
-	{ CMDLINE_TYPE_STRING,  &_password,		   NAC, "password",			 "Server password"                                            },
+    { CMDLINE_TYPE_STRING,  &_password,        NAC, "password",          "Server password"                                            },
     { CMDLINE_TYPE_STRING,  &_userDataPath,    NAC, "user-data-path",    "path to the user data directory (containing config.ini)"    },
     { CMDLINE_TYPE_STRING,  &_openrctDataPath, NAC, "openrct-data-path", "path to the OpenRCT2 data directory (containing languages)" },
     OptionTableEnd
@@ -137,10 +137,10 @@ exitcode_t CommandLine::HandleCommandDefault()
         Memory::Free(_openrctDataPath);
     }
 
-	if (_password != NULL) {
-		String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
-		Memory::Free(_password);
-	}
+ if (_password != NULL) {
+  String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
+  Memory::Free(_password);
+ }
     return result;
 }
 
@@ -214,7 +214,7 @@ exitcode_t HandleCommandHost(CommandLineArgEnumerator * enumerator)
     gOpenRCT2StartupAction = STARTUP_ACTION_OPEN;
     String::Set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
 
-	gNetworkStart = NETWORK_MODE_SERVER;
+ gNetworkStart = NETWORK_MODE_SERVER;
     gNetworkStartPort = _port;
     return EXITCODE_CONTINUE;
 }
@@ -234,9 +234,9 @@ exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator)
         return EXITCODE_FAIL;
     }
 
-	gNetworkStart = NETWORK_MODE_CLIENT;
+ gNetworkStart = NETWORK_MODE_CLIENT;
     gNetworkStartPort = _port;
-	String::Set(gNetworkStartHost, sizeof(gNetworkStartHost), hostname);
+ String::Set(gNetworkStartHost, sizeof(gNetworkStartHost), hostname);
     return EXITCODE_CONTINUE;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -253,6 +253,7 @@ config_property_definition _twitchDefinitions[] = {
 config_property_definition _networkDefinitions[] = {
 	{ offsetof(network_configuration, player_name),						"player_name",					CONFIG_VALUE_TYPE_STRING,		{.value_string = "Player" },	NULL					},
 	{ offsetof(network_configuration, default_port),					"default_port",					CONFIG_VALUE_TYPE_UINT32,		NETWORK_DEFAULT_PORT,			NULL					},
+	{ offsetof(network_configuration, default_password),				"default_password",			    CONFIG_VALUE_TYPE_STRING,       {.value_string = NULL     },   NULL                    },
 	{ offsetof(network_configuration, stay_connected),					"stay_connected",				CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(network_configuration, advertise),						"advertise",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(network_configuration, maxplayers),						"maxplayers",					CONFIG_VALUE_TYPE_UINT8,		16,								NULL					},

--- a/src/config.c
+++ b/src/config.c
@@ -253,7 +253,7 @@ config_property_definition _twitchDefinitions[] = {
 config_property_definition _networkDefinitions[] = {
 	{ offsetof(network_configuration, player_name),						"player_name",					CONFIG_VALUE_TYPE_STRING,		{.value_string = "Player" },	NULL					},
 	{ offsetof(network_configuration, default_port),					"default_port",					CONFIG_VALUE_TYPE_UINT32,		NETWORK_DEFAULT_PORT,			NULL					},
-	{ offsetof(network_configuration, default_password),				"default_password",			    CONFIG_VALUE_TYPE_STRING,       {.value_string = NULL     },   NULL                    },
+	{ offsetof(network_configuration, default_password),				"default_password",				CONFIG_VALUE_TYPE_STRING,		{.value_string = NULL		},	NULL					},
 	{ offsetof(network_configuration, stay_connected),					"stay_connected",				CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(network_configuration, advertise),						"advertise",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(network_configuration, maxplayers),						"maxplayers",					CONFIG_VALUE_TYPE_UINT8,		16,								NULL					},

--- a/src/config.h
+++ b/src/config.h
@@ -226,6 +226,7 @@ typedef struct {
 typedef struct {
 	utf8string player_name;
 	uint32 default_port;
+	utf8string default_password;
 	uint8 stay_connected;
 	uint8 advertise;
 	uint8 maxplayers;

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -55,6 +55,7 @@ utf8 gOpenRCT2StartupActionPath[512] = { 0 };
 utf8 gExePath[MAX_PATH];
 utf8 gCustomUserDataPath[MAX_PATH] = { 0 };
 utf8 gCustomOpenrctDataPath[MAX_PATH] = { 0 };
+utf8 gCustomPassword[MAX_PATH] = { 0 };
 
 // This should probably be changed later and allow a custom selection of things to initialise like SDL_INIT
 bool gOpenRCT2Headless = false;
@@ -287,6 +288,13 @@ void openrct2_launch()
 				if (gNetworkStartPort == 0) {
 					gNetworkStartPort = gConfigNetwork.default_port;
 				}
+
+				if (strlen(gCustomPassword) == 0) {	
+					network_set_password(gConfigNetwork.default_password);
+				}
+				else {
+					network_set_password(gCustomPassword);
+				}
 				network_begin_server(gNetworkStartPort);
 			}
 #endif // DISABLE_NETWORK
@@ -305,6 +313,7 @@ void openrct2_launch()
 			if (gNetworkStartPort == 0) {
 				gNetworkStartPort = gConfigNetwork.default_port;
 			}
+			
 			network_begin_client(gNetworkStartHost, gNetworkStartPort);
 		}
 #endif // DISABLE_NETWORK

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -289,7 +289,7 @@ void openrct2_launch()
 					gNetworkStartPort = gConfigNetwork.default_port;
 				}
 
-				if (strlen(gCustomPassword) == 0) {	
+				if (str_is_null_or_empty(gCustomPassword)) {
 					network_set_password(gConfigNetwork.default_password);
 				}
 				else {

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -39,6 +39,7 @@ extern utf8 gOpenRCT2StartupActionPath[512];
 extern utf8 gExePath[MAX_PATH];
 extern utf8 gCustomUserDataPath[MAX_PATH];
 extern utf8 gCustomOpenrctDataPath[MAX_PATH];
+extern utf8 gCustomPassword[MAX_PATH];
 extern bool gOpenRCT2Headless;
 extern bool gOpenRCT2ShowChangelog;
 


### PR DESCRIPTION
1. Added --password=<str> to headless server mode to configure a password
2. added default_password under [network] to configure a default password for headless server mode