### PR TITLE
Allow mixed language configuration in Xcode project

### DIFF
--- a/distribution/osx/Info.plist
+++ b/distribution/osx/Info.plist
@@ -22,5 +22,7 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>OpenRCT2 is licensed under the GNU General Public License version 3</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This should resolve #2758. I temporarily set my system language to Spanish, and it seemed to work. 