### PR TITLE
Fix zlib inflate on broken builders

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -347,6 +347,10 @@ unsigned char *util_zlib_inflate(unsigned char *data, size_t data_in_size, size_
 			buffer_size *= 2;
 			out_size = buffer_size;
 			buffer = realloc(buffer, buffer_size);
+		} else if (ret == Z_STREAM_ERROR) {
+			log_error("Your build is shipped with broken zlib. Please use the official build.");
+			free(buffer);
+			return NULL;
 		}
 		ret = uncompress(buffer, &out_size, data, data_in_size);
 	} while (ret != Z_OK);
@@ -377,12 +381,8 @@ unsigned char *util_zlib_deflate(unsigned char *data, size_t data_in_size, size_
 			buffer = realloc(buffer, buffer_size);
 		} else if (ret == Z_STREAM_ERROR) {
 			log_error("Your build is shipped with broken zlib. Please use the official build.");
-			log_error("Falling back to non-compressed sv6.");
-			buffer = realloc(buffer, data_in_size);
-			memcpy(buffer, data, data_in_size);
-			out_size = data_in_size;
-			ret = Z_OK;
-			break;
+			free(buffer);
+			return NULL;
 		}
 		ret = compress(buffer, &out_size, data, data_in_size);
 	} while (ret != Z_OK);


### PR DESCRIPTION
More correct version of https://github.com/OpenRCT2/OpenRCT2/pull/2805

It will not send header for compressed data at all if broken zlib is detected, which means the client should have no problem with interpreting it.