### PR TITLE
Improved Rendering of Disabled Scenario Names

### DIFF
--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -353,12 +353,12 @@ int gfx_draw_string_centred_wrapped(rct_drawpixelinfo *dpi, void *args, int x, i
 {
 	int font_height, line_height, line_width, line_y, num_lines;
 	// Location of font sprites
-	uint16* current_font_sprite_base;
+	sint16* current_font_sprite_base;
 
 	char* buffer = RCT2_ADDRESS(0x009C383D, char);
 
-	current_font_sprite_base = RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, uint16);
-	*current_font_sprite_base = 0xE0;
+	current_font_sprite_base = RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, sint16);
+	if (*current_font_sprite_base >= 0) *current_font_sprite_base = 0xE0;
 
 	gfx_draw_string(dpi, buffer, colour, dpi->x, dpi->y);
 

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -460,6 +460,7 @@ static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *
 			safe_strcpy((char*)language_get_string(placeholderStringId), scenario->name, 64);
 			int format = isDisabled ? 865 : (isHighlighted ? highlighted_format : unhighlighted_format);
 			colour = isDisabled ? w->colours[1] | 0x40 : COLOUR_BLACK;
+			if (isDisabled) RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, sint16) = -1;
 			gfx_draw_string_centred(dpi, format, wide ? 270 : 210, y + 1, colour, &placeholderStringId);
 
 			// Check if scenario is completed


### PR DESCRIPTION
This uses code used in places such as the inventions list to draw the disabled text darker than normal. Because the string drawing code wasn't originally intended to be called like this, I had to change a small amount of it to get it to work. I tried to make sure that this change would not affect any other instances of string drawing.