### PR TITLE
fix some issues with multiplayer

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -547,11 +547,6 @@ int game_do_command_p(int command, int *eax, int *ebx, int *ecx, int *edx, int *
 
 			if (network_get_mode() == NETWORK_MODE_SERVER && !(flags & GAME_COMMAND_FLAG_NETWORKED) && !(flags & GAME_COMMAND_FLAG_GHOST)) {
 				network_set_player_last_action(network_get_player_index(network_get_current_player_id()), command);
-				rct_xyz16 coord;
-				coord.x = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint16);
-				coord.y = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint16);
-				coord.z = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint16);
-				network_set_player_last_action_coord(network_get_player_index(network_get_current_player_id()), coord);
 				network_add_player_money_spent(network_get_current_player_id(), cost);
 			}
 

--- a/src/game.c
+++ b/src/game.c
@@ -904,6 +904,7 @@ bool game_load_save(const utf8 *path)
 
 	if (result) {
 		game_load_init();
+		network_free_string_ids();
 		if (network_get_mode() == NETWORK_MODE_SERVER) {
 			network_send_map();
 		}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1518,11 +1518,6 @@ void Network::ProcessGameCommandQueue()
 			if (player) {
 				player->last_action = gNetworkActions.FindCommand(command);
 				player->last_action_time = SDL_GetTicks();
-				rct_xyz16 coord;
-				coord.x = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint16);
-				coord.y = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint16);
-				coord.z = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint16);
-				player->last_action_coord = coord;
 				player->AddMoneySpent(cost);
 			}
 		}
@@ -1802,11 +1797,6 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 
 	connection.player->last_action = gNetworkActions.FindCommand(commandCommand);
 	connection.player->last_action_time = SDL_GetTicks();
-	rct_xyz16 coord;
-	coord.x = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_X, uint16);
-	coord.y = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Y, uint16);
-	coord.z = RCT2_GLOBAL(RCT2_ADDRESS_COMMAND_MAP_Z, uint16);
-	connection.player->last_action_coord = coord;
 	connection.player->AddMoneySpent(cost);
 	Server_Send_GAMECMD(args[0], args[1], args[2], args[3], args[4], args[5], args[6], playerid, callback);
 }
@@ -2030,7 +2020,9 @@ rct_xyz16 network_get_player_last_action_coord(unsigned int index)
 
 void network_set_player_last_action_coord(unsigned int index, rct_xyz16 coord)
 {
-	gNetwork.player_list[index]->last_action_coord = coord;
+	if (index >= 0 && index < gNetwork.player_list.size()) {
+		gNetwork.player_list[index]->last_action_coord = coord;
+	}
 }
 
 unsigned int network_get_player_commands_ran(unsigned int index)

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1239,6 +1239,13 @@ void Network::LoadGroups()
 	SDL_RWclose(file);
 }
 
+void Network::FreeStringIds()
+{
+	for (auto it = group_list.begin(); it != group_list.end(); it++) {
+		(*it)->FreeNameStringId();
+	}
+}
+
 void Network::Client_Send_AUTH(const char* name, const char* password)
 {
 	std::unique_ptr<NetworkPacket> packet = std::move(NetworkPacket::Allocate());
@@ -2270,6 +2277,11 @@ int network_can_perform_action(unsigned int groupindex, unsigned int index)
 	return gNetwork.group_list[groupindex]->CanPerformAction(index);
 }
 
+void network_free_string_ids()
+{
+	gNetwork.FreeStringIds();
+}
+
 void network_send_map()
 {
 	gNetwork.Server_Send_MAP();
@@ -2347,6 +2359,7 @@ uint8 network_get_default_group() { return 0; }
 int network_get_num_actions() { return 0; }
 rct_string_id network_get_action_name_string_id(unsigned int index) { return -1; }
 int network_can_perform_action(unsigned int groupindex, unsigned int index) { return 0; }
+void network_free_string_ids() {}
 void network_send_chat(const char* text) {}
 void network_send_password(const char* password) {}
 void network_close() {}

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -306,6 +306,7 @@ public:
 	void SetDefaultGroup(uint8 id);
 	void SaveGroups();
 	void LoadGroups();
+	void FreeStringIds();
 
 	void Client_Send_AUTH(const char* name, const char* password);
 	void Server_Send_AUTH(NetworkConnection& connection);
@@ -445,6 +446,7 @@ uint8 network_get_default_group();
 int network_get_num_actions();
 rct_string_id network_get_action_name_string_id(unsigned int index);
 int network_can_perform_action(unsigned int groupindex, unsigned int index);
+void network_free_string_ids();
 
 void network_send_map();
 void network_send_chat(const char* text);

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -3668,6 +3668,14 @@ void game_command_set_ride_setting(int *eax, int *ebx, int *ecx, int *edx, int *
 		return;
 	}
 
+	if (ride->overall_view != (uint16)-1) {
+		rct_xyz16 coord;
+		coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+		coord.y = (ride->overall_view >> 8) * 32 + 16;
+		coord.z = map_element_height(coord.x, coord.y);
+		network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+	}
+
 	switch (setting){
 	case 0:
 		// Alteration: only check if the ride mode exists, and fall back to the default if it doesn't.
@@ -5261,6 +5269,16 @@ void game_command_set_ride_status(int *eax, int *ebx, int *ecx, int *edx, int *e
 	}
 	RCT2_GLOBAL(0x00F43484, uint32) = RCT2_GLOBAL(RCT2_ADDRESS_RIDE_FLAGS + (ride->type * 8), uint32);
 
+	if (*ebx & GAME_COMMAND_FLAG_APPLY) {
+		if (ride->overall_view != (uint16)-1) {
+			rct_xyz16 coord;
+			coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+			coord.y = (ride->overall_view >> 8) * 32 + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
+	}
+
 	switch (targetStatus) {
 	case RIDE_STATUS_CLOSED:
 		if (*ebx & GAME_COMMAND_FLAG_APPLY) {
@@ -5382,6 +5400,14 @@ void game_command_set_ride_name(int *eax, int *ebx, int *ecx, int *edx, int *esi
 	}
 
 	if (*ebx & GAME_COMMAND_FLAG_APPLY) {
+		if (ride->overall_view != (uint16)-1) {
+			rct_xyz16 coord;
+			coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+			coord.y = (ride->overall_view >> 8) * 32 + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
+
 		// Free the old ride name
 		user_string_free(ride->name);
 
@@ -6052,6 +6078,14 @@ void game_command_demolish_ride(int *eax, int *ebx, int *ecx, int *edx, int *esi
 		return;
 	}else{
 		if(*ebx & GAME_COMMAND_FLAG_APPLY){
+			if (ride->overall_view != (uint16)-1) {
+				rct_xyz16 coord;
+				coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+				coord.y = (ride->overall_view >> 8) * 32 + 16;
+				coord.z = map_element_height(coord.x, coord.y);
+				network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+			}
+
 			if(!(*ebx & 8)){
 				window_close_by_number(WC_RIDE_CONSTRUCTION, ride_id);
 			}
@@ -6183,6 +6217,16 @@ void game_command_set_ride_appearance(int *eax, int *ebx, int *ecx, int *edx, in
 		log_warning("Invalid game command, ride_id = %u", ride_id);
 		*ebx = MONEY32_UNDEFINED;
 		return;
+	}
+
+	if (apply && RCT2_GLOBAL(0x009A8C28, uint8) == 1) {
+		if (ride->overall_view != (uint16)-1) {
+			rct_xyz16 coord;
+			coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+			coord.y = (ride->overall_view >> 8) * 32 + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
 	}
 
 	*ebx = 0;
@@ -6325,6 +6369,15 @@ void game_command_set_ride_price(int *eax, int *ebx, int *ecx, int *edx, int *es
 
 	RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_PARK_RIDE_TICKETS * 4;
 	if (flags & 0x1) {
+
+		if (ride->overall_view != (uint16)-1) {
+			rct_xyz16 coord;
+			coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+			coord.y = (ride->overall_view >> 8) * 32 + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
+
 		if (!secondary_price) {
 			shop_item = 0x1F;
 			if (ride->type != RIDE_TYPE_TOILETS) {
@@ -7440,6 +7493,14 @@ void game_command_set_ride_vehicles(int *eax, int *ebx, int *ecx, int *edx, int 
 		return;
 	}
 
+	if (ride->overall_view != (uint16)-1) {
+		rct_xyz16 coord;
+		coord.x = (ride->overall_view & 0xFF) * 32 + 16;
+		coord.y = (ride->overall_view >> 8) * 32 + 16;
+		coord.z = map_element_height(coord.x, coord.y);
+		network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+	}
+
 	ride_clear_for_construction(rideIndex);
 	ride_remove_peeps(rideIndex);
 	ride->var_1CA = 100;
@@ -7711,6 +7772,12 @@ money32 place_ride_entrance_or_exit(sint16 x, sint16 y, sint16 z, uint8 directio
 		}
 
 		if (flags & GAME_COMMAND_FLAG_APPLY) {
+			rct_xyz16 coord;
+			coord.x = x + 16;
+			coord.y = y + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+
 			rct_map_element* mapElement = map_element_insert(x / 32, y / 32, z / 8, 0xF);
 			mapElement->clearance_height = clear_z;
 			mapElement->properties.entrance.type = is_exit;
@@ -7818,6 +7885,12 @@ money32 remove_ride_entrance_or_exit(sint16 x, sint16 y, uint8 rideIndex, uint8 
 		if (!found){
 			return MONEY32_UNDEFINED;
 		}
+
+		rct_xyz16 coord;
+		coord.x = x + 16;
+		coord.y = y + 16;
+		coord.z = map_element_height(coord.x, coord.y);
+		network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
 
 		sub_6A7594();
 		maze_entrance_hedge_replacement(x, y, mapElement);

--- a/src/windows/player.c
+++ b/src/windows/player.c
@@ -221,7 +221,7 @@ void window_player_overview_mouse_up(rct_window *w, int widgetIndex)
 		rct_window* mainWindow = window_get_main();
 		if (mainWindow != NULL) {
 			rct_xyz16 coord = network_get_player_last_action_coord(w->number);
-			if (coord.x && coord.y && coord.z) {
+			if (coord.x || coord.y || coord.z) {
 				window_scroll_to_location(mainWindow, coord.x, coord.y, coord.z);
 			}
 		}

--- a/src/windows/player.c
+++ b/src/windows/player.c
@@ -220,7 +220,11 @@ void window_player_overview_mouse_up(rct_window *w, int widgetIndex)
 	case WIDX_LOCATE:{
 		rct_window* mainWindow = window_get_main();
 		if (mainWindow != NULL) {
-			rct_xyz16 coord = network_get_player_last_action_coord(w->number);
+			int player = network_get_player_index((uint8)w->number);
+			if (player == -1) {
+				return;
+			}
+			rct_xyz16 coord = network_get_player_last_action_coord(player);
 			if (coord.x || coord.y || coord.z) {
 				window_scroll_to_location(mainWindow, coord.x, coord.y, coord.z);
 			}

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -24,6 +24,7 @@
 #include "../game.h"
 #include "../localisation/localisation.h"
 #include "../management/finance.h"
+#include "../network/network.h"
 #include "../util/util.h"
 #include "footpath.h"
 #include "map.h"
@@ -350,6 +351,14 @@ static money32 footpath_place_real(int type, int x, int y, int z, int slope, int
 	// Force ride construction to recheck area
 	RCT2_GLOBAL(0x00F440B0, uint8) |= 8;
 
+	if (RCT2_GLOBAL(0x009A8C28, uint8) == 1 && !(flags & GAME_COMMAND_FLAG_GHOST)) {
+		rct_xyz16 coord;
+		coord.x = x + 16;
+		coord.y = y + 16;
+		coord.z = map_element_height(coord.x, coord.y);
+		network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+	}
+
 	footpath_provisional_remove();
 	mapElement = map_get_footpath_element_slope((x / 32), (y / 32), z, slope);
 	if (mapElement == NULL) {
@@ -397,6 +406,14 @@ money32 footpath_remove_real(int x, int y, int z, int flags)
 
 	mapElement = map_get_footpath_element(x / 32, y / 32, z);
 	if (mapElement != NULL && (flags & GAME_COMMAND_FLAG_APPLY)) {
+		if (RCT2_GLOBAL(0x009A8C28, uint8) == 1 && !(flags & GAME_COMMAND_FLAG_GHOST)) {
+			rct_xyz16 coord;
+			coord.x = x + 16;
+			coord.y = y + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
+
 		RCT2_GLOBAL(0x00F3EFF4, uint32) = 0x00F3EFF8;
 		remove_banners_at_element(x, y, mapElement);
 		footpath_remove_edges_at(x, y, mapElement);
@@ -498,6 +515,14 @@ static money32 footpath_place_from_track(int type, int x, int y, int z, int slop
 	RCT2_GLOBAL(0x00F3EFD9, money32) += supportHeight < 0 ? MONEY(20, 00) : (supportHeight / 2) * MONEY(5, 00);
 
 	if (flags & GAME_COMMAND_FLAG_APPLY) {
+		if (RCT2_GLOBAL(0x009A8C28, uint8) == 1 && !(flags & GAME_COMMAND_FLAG_GHOST)) {
+			rct_xyz16 coord;
+			coord.x = x + 16;
+			coord.y = y + 16;
+			coord.z = map_element_height(coord.x, coord.y);
+			network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+		}
+
 		mapElement = map_element_insert(x / 32, y / 32, z, 0x0F);
 		mapElement->type = MAP_ELEMENT_TYPE_PATH;
 		mapElement->clearance_height = z + 4 + (slope & 4 ? 2 : 0);


### PR DESCRIPTION
I noticed a bug where if you load a new map, the group names would sometimes show up as something else, had to reset string id.

Also, the last player action locations were not really working very well, so I fixed that.

Finally, there was a bug with using player id as an index, which would sometimes cause a crash.

None of these change data sent or anything so it is still compatible.