### PR TITLE
Hide cheats button in multiplayer.

### DIFF
--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -690,7 +690,7 @@ static void window_top_toolbar_invalidate(rct_window *w)
 		if (!gConfigInterface.toolbar_show_research)
 			window_top_toolbar_widgets[WIDX_RESEARCH].type = WWT_EMPTY;
 
-		if (!gConfigInterface.toolbar_show_cheats)
+		if (!gConfigInterface.toolbar_show_cheats || network_get_mode() != NETWORK_MODE_NONE)
 			window_top_toolbar_widgets[WIDX_CHEATS].type = WWT_EMPTY;
 
 		if (!gConfigInterface.toolbar_show_news)


### PR DESCRIPTION
Related to #2812. This PR hides the button from the top toolbar completely in multiplayer, the hotkey does still work, but generates a warning for the user.