### PR TITLE
Fix for libpng

### DIFF
--- a/src/image_io.c
+++ b/src/image_io.c
@@ -142,7 +142,7 @@ bool image_io_png_write(const rct_drawpixelinfo *dpi, const rct_palette *palette
 	// Write pixels
 	uint8 *bits = dpi->bits;
 	for (int y = 0; y < dpi->height; y++) {
-		png_write_row(png_ptr, (png_const_bytep)bits);
+		png_write_row(png_ptr, (png_byte *)bits);
 		bits += stride;
 	}
 


### PR DESCRIPTION
Some libpng versions apparently don't know `png_const_bytep`.