### PR TITLE
Add message box on Linux platforms

### DIFF
--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -154,8 +154,8 @@ utf8 *platform_open_directory_browser(utf8 *title)
 
 void platform_show_messagebox(char *message)
 {
-	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenRCT2", message, gWindow);
-	log_verbose(message);
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "OpenRCT2", message, gWindow);
+	log_warning(message);
 }
 
 /**

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -154,7 +154,7 @@ utf8 *platform_open_directory_browser(utf8 *title)
 
 void platform_show_messagebox(char *message)
 {
-	STUB();
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenRCT2", message, gWindow);
 	log_verbose(message);
 }
 


### PR DESCRIPTION
Replacing the stub with the relevant SDL call.
Is SDL_MESSAGEBOX_ERROR the most suitable flag for this?