### PR TITLE
Allow Starting Server With New Scenario

### DIFF
--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -498,6 +498,7 @@ enum {
 };
 
 typedef void (*modal_callback)(int result);
+typedef void (*scenarioselect_callback)(const utf8 *path);
 
 extern bool gLoadSaveTitleSequenceSave;
 extern modal_callback gLoadSaveCallback;
@@ -585,7 +586,7 @@ void window_title_exit_open();
 void window_title_options_open();
 void window_title_logo_open();
 void window_news_open();
-void window_scenarioselect_open();
+void window_scenarioselect_open(scenarioselect_callback callback);
 void window_track_list_open(ride_list_item item);
 void window_clear_scenery_open();
 void window_land_open();

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -217,6 +217,7 @@ int scenario_load_and_play_from_path(const char *path)
 
 	log_verbose("starting scenario, %s", path);
 	scenario_begin();
+	network_free_string_ids();
 	if (network_get_mode() == NETWORK_MODE_SERVER) {
 		network_send_map();
 	}

--- a/src/windows/server_start.c
+++ b/src/windows/server_start.c
@@ -25,6 +25,7 @@
 #include "../localisation/localisation.h"
 #include "../network/network.h"
 #include "../sprites.h"
+#include "../title.h"
 #include "../util/util.h"
 #include "error.h"
 
@@ -43,7 +44,8 @@ enum {
 	WIDX_MAXPLAYERS_INCREASE,
 	WIDX_MAXPLAYERS_DECREASE,
 	WIDX_ADVERTISE_CHECKBOX,
-	WIDX_START_SERVER
+	WIDX_START_SERVER,
+	WIDX_LOAD_SERVER
 };
 
 #define WW 300
@@ -61,6 +63,7 @@ static rct_widget window_server_start_widgets[] = {
 	{ WWT_DROPDOWN_BUTTON,	1,	WW-18,	WW-8,	72,			76,		STR_NUMERIC_DOWN,		STR_NONE },
 	{ WWT_CHECKBOX,			1,	6,		WW-8,	85,			91,		STR_ADVERTISE,			STR_NONE },					// advertise checkbox
 	{ WWT_DROPDOWN_BUTTON,	1,	6,		106,	WH-6-11,	WH-6,	STR_START_SERVER,		STR_NONE },					// start server button
+	{ WWT_DROPDOWN_BUTTON,	1,	112,	212,	WH-6-11,	WH-6,	STR_LOAD_GAME,			STR_NONE },					// load game button
 	{ WIDGETS_END },
 };
 
@@ -123,7 +126,8 @@ void window_server_start_open()
 		(1 << WIDX_MAXPLAYERS_INCREASE) |
 		(1 << WIDX_MAXPLAYERS_DECREASE) |
 		(1 << WIDX_ADVERTISE_CHECKBOX) |
-		(1 << WIDX_START_SERVER)
+		(1 << WIDX_START_SERVER) |
+		(1 << WIDX_LOAD_SERVER)
 	);
 	window_init_scroll_widgets(window);
 	window->no_list_items = 0;
@@ -144,6 +148,16 @@ void window_server_start_open()
 static void window_server_start_close(rct_window *w)
 {
 
+}
+
+static void window_server_start_scenarioselect_callback(const utf8 *path)
+{
+	network_set_password(_password);
+	if (scenario_load_and_play_from_path(path)) {
+		network_begin_server(gConfigNetwork.default_port);
+	} else {
+		title_load();
+	}
 }
 
 static void window_server_start_mouseup(rct_window *w, int widgetIndex)
@@ -181,6 +195,9 @@ static void window_server_start_mouseup(rct_window *w, int widgetIndex)
 		window_invalidate(w);
 		break;
 	case WIDX_START_SERVER:
+		window_scenarioselect_open(window_server_start_scenarioselect_callback);
+		break;
+	case WIDX_LOAD_SERVER:
 		network_set_password(_password);
 		window_loadsave_open(LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME | LOADSAVETYPE_NETWORK, NULL);
 		break;

--- a/src/windows/title_menu.c
+++ b/src/windows/title_menu.c
@@ -28,6 +28,7 @@
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
 #include "../sprites.h"
+#include "../title.h"
 #include "dropdown.h"
 
 enum {
@@ -131,11 +132,18 @@ void window_title_menu_open()
 	window_init_scroll_widgets(window);
 }
 
+static void window_title_menu_scenarioselect_callback(const utf8 *path)
+{
+	if (!scenario_load_and_play_from_path(path)) {
+		title_load();
+	}
+}
+
 static void window_title_menu_mouseup(rct_window *w, int widgetIndex)
 {
 	switch (widgetIndex) {
 	case WIDX_START_NEW_GAME:
-		window_scenarioselect_open();
+		window_scenarioselect_open(window_title_menu_scenarioselect_callback);
 		break;
 	case WIDX_CONTINUE_SAVED_GAME:
 		game_do_command(0, 1, 0, 0, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -23,6 +23,7 @@
 #include "../audio/audio.h"
 #include "../localisation/date.h"
 #include "../localisation/localisation.h"
+#include "../network/network.h"
 #include "../scenario.h"
 #include "../sprites.h"
 #include "../interface/widget.h"
@@ -130,20 +131,26 @@ static rct_window_event_list window_scenarioselect_events = {
 	window_scenarioselect_scrollpaint
 };
 
+bool _network;
+
 static void draw_category_heading(rct_window *w, rct_drawpixelinfo *dpi, int left, int right, int y, rct_string_id stringId);
 static void initialise_list_items(rct_window *w);
 static bool is_scenario_visible(rct_window *w, scenario_index_entry *scenario);
 static bool is_locking_enabled(rct_window *w);
 
+static scenarioselect_callback _callback;
+
 /**
  *
  *  rct2: 0x006781B5
  */
-void window_scenarioselect_open()
+void window_scenarioselect_open(scenarioselect_callback callback)
 {
 	rct_window* window;
 	int windowWidth;
 	int windowHeight = 334;
+
+	_callback = callback;
 
 	if (window_bring_to_front_by_class(WC_SCENARIO_SELECT) != NULL)
 		return;
@@ -275,9 +282,7 @@ static void window_scenarioselect_scrollmousedown(rct_window *w, int scrollIndex
 			y -= 24;
 			if (y < 0 && !listItem->scenario.is_locked) {
 				audio_play_sound_panned(SOUND_CLICK_1, w->width / 2 + w->x, 0, 0, 0);
-				if (!scenario_load_and_play_from_path(listItem->scenario.scenario->path)) {
-					title_load();
-				}
+				_callback(listItem->scenario.scenario->path);
 			}
 			break;
 		}

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -19,27 +19,28 @@
  *****************************************************************************/
 
 #include "../addresses.h"
+#include "../audio/audio.h"
 #include "../cheats.h"
 #include "../config.h"
 #include "../editor.h"
 #include "../game.h"
 #include "../input.h"
-#include "../sprites.h"
-#include "../audio/audio.h"
+#include "../interface/console.h"
 #include "../interface/screenshot.h"
+#include "../interface/themes.h"
+#include "../interface/viewport.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
-#include "../interface/viewport.h"
 #include "../localisation/localisation.h"
 #include "../network/network.h"
 #include "../network/twitch.h"
 #include "../scenario.h"
+#include "../title.h"
+#include "../sprites.h"
 #include "../util/util.h"
-#include "../world/scenery.h"
 #include "../world/banner.h"
+#include "../world/scenery.h"
 #include "dropdown.h"
-#include "../interface/themes.h"
-#include "../interface/console.h"
 
 enum {
 	WIDX_PAUSE,
@@ -498,6 +499,13 @@ static void window_top_toolbar_mousedown(int widgetIndex, rct_window*w, rct_widg
 	}
 }
 
+static void window_top_toolbar_scenarioselect_callback(const utf8 *path)
+{
+	if (!scenario_load_and_play_from_path(path)) {
+		title_load();
+	}
+}
+
 /**
  *
  *  rct2: 0x0066C9EA
@@ -521,7 +529,7 @@ static void window_top_toolbar_dropdown(rct_window *w, int widgetIndex, int drop
 
 		switch (dropdownIndex) {
 		case DDIDX_NEW_GAME:
-			window_scenarioselect_open();
+			window_scenarioselect_open(window_top_toolbar_scenarioselect_callback);
 			break;
 		case DDIDX_LOAD_GAME:
 			game_do_command(0, 1, 0, 0, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);


### PR DESCRIPTION
I've made a few changes to the code that allow opening the scenario selector and starting a server using a fresh scenario instead of a saved game, but I'm not sure how the interface should be handled, since I assume we would still like to be able to load a saved game as well.  I have just added a load game button for the time being, and I thought I'd push this up to see what needs fixing.