### PR TITLE
Decouple network version from OpenRCT2 version

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4018,6 +4018,9 @@ STR_5713    :Kick Player
 STR_5714    :Show options window
 STR_5715    :New Game
 STR_5716    :Not allowed in multiplayer mode
+# For identifying client network version in server list window
+STR_5717    :Network version: {STRING}
+STR_5718    :{SMALLFONT}{BLACK}Network version: {STRING}
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2310,6 +2310,9 @@ enum {
 
 	STR_NOT_ALLOWED_IN_MULTIPLAYER = 5716,
 
+	STR_NETWORK_VERSION = 5717,
+	STR_NETWORK_VERSION_TIP = 5718,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1253,7 +1253,7 @@ void Network::Client_Send_AUTH(const char* name, const char* password)
 {
 	std::unique_ptr<NetworkPacket> packet = std::move(NetworkPacket::Allocate());
 	*packet << (uint32)NETWORK_COMMAND_AUTH;
-	packet->WriteString(OPENRCT2_VERSION);
+	packet->WriteString(NETWORK_STREAM_ID);
 	packet->WriteString(name);
 	packet->WriteString(password);
 	server_connection.authstatus = NETWORK_AUTH_REQUESTED;
@@ -1411,7 +1411,7 @@ void Network::Server_Send_GAMEINFO(NetworkConnection& connection)
 	json_t* obj = json_object();
 	json_object_set_new(obj, "name", json_string(gConfigNetwork.server_name));
 	json_object_set_new(obj, "requiresPassword", json_boolean(password.size() > 0));
-	json_object_set_new(obj, "version", json_string(OPENRCT2_VERSION));
+	json_object_set_new(obj, "version", json_string(NETWORK_STREAM_ID));
 	json_object_set_new(obj, "players", json_integer(player_list.size()));
 	json_object_set_new(obj, "maxPlayers", json_integer(gConfigNetwork.maxplayers));
 	json_object_set_new(obj, "description", json_string(gConfigNetwork.server_description));
@@ -1629,7 +1629,7 @@ void Network::Server_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
 		const char* gameversion = packet.ReadString();
 		const char* name = packet.ReadString();
 		const char* password = packet.ReadString();
-		if (!gameversion || strcmp(gameversion, OPENRCT2_VERSION) != 0) {
+		if (!gameversion || strcmp(gameversion, NETWORK_STREAM_ID) != 0) {
 			connection.authstatus = NETWORK_AUTH_BADVERSION;
 		} else
 		if (!name) {

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -65,6 +65,12 @@ extern "C" {
 
 #ifndef DISABLE_NETWORK
 
+// This define specifies which version of network stream current build uses.
+// It is used for making sure only compatible builds get connected, even within
+// single OpenRCT2 version.
+#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
+
 #ifdef __WINDOWS__
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
@@ -402,6 +408,8 @@ private:
 };
 
 #endif // __cplusplus
+#else /* DISABLE_NETWORK */
+#define NETWORK_STREAM_ID "Multiplayer disabled"
 #endif /* DISABLE_NETWORK */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This allows to present a different version of network stream than just
OpenRCT2 version, as we can possibly have breaking changes to network in
one release cycle.

This commit also adds easy way of identification which hosts are running
which versions, by showing a tooltip when hovering mouse cursor over the
network compatibility icon. Client's own version is displayed as well.

![zaznaczenie_099](https://cloud.githubusercontent.com/assets/550290/12698613/ae7add08-c7a1-11e5-8674-9784f7bd7672.png)
