### PR TITLE
Quality hinting

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4029,13 +4029,13 @@ STR_5723    :Heavy Rain
 STR_5724    :Thunderstorm
 STR_5725    :{BLACK}Force weather:
 STR_5726    :{SMALLFONT}{BLACK}Sets the current weather in park
-
 STR_5727    :Scaling quality
 STR_5728    :Requires hardware display option
 STR_5729    :{SMALLFONT}{BLACK}Requires hardware display option
 STR_5730    :Nearest neighbour
 STR_5731    :Linear
 STR_5732    :Anisotropic
+STR_5733    :Use NN scaling at integer scales
 
 #############
 # Scenarios #

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -2364,7 +2364,7 @@ STR_2356    :{WINDOW_COLOUR_2}Rides inspected: {BLACK}{COMMA16}
 STR_2357    :House
 STR_2358    :Units
 STR_2359    :Real Values
-STR_2360    :{WINDOW_COLOUR_2}Display Resolution:
+STR_2360    :Display Resolution:
 STR_2361    :Landscape Smoothing
 STR_2362    :{SMALLFONT}{BLACK}Toggle landscape tile edge smoothing on/off
 STR_2363    :Gridlines on Landscape
@@ -4036,9 +4036,8 @@ STR_5730    :Nearest neighbour
 STR_5731    :Linear
 STR_5732    :Anisotropic
 STR_5733    :Use NN scaling at integer scales
-
 # tooltip for tab in options window
-STR_5727    :{SMALLFONT}{BLACK}Rendering
+STR_5734    :{SMALLFONT}{BLACK}Rendering
 
 #############
 # Scenarios #

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4030,6 +4030,13 @@ STR_5724    :Thunderstorm
 STR_5725    :{BLACK}Force weather:
 STR_5726    :{SMALLFONT}{BLACK}Sets the current weather in park
 
+STR_5727    :Scaling quality
+STR_5728    :Requires hardware display option
+STR_5729    :{SMALLFONT}{BLACK}Requires hardware display option
+STR_5730    :Nearest neighbour
+STR_5731    :Linear
+STR_5732    :Anisotropic
+
 #############
 # Scenarios #
 ################

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4037,6 +4037,9 @@ STR_5731    :Linear
 STR_5732    :Anisotropic
 STR_5733    :Use NN scaling at integer scales
 
+# tooltip for tab in options window
+STR_5727    :{SMALLFONT}{BLACK}Rendering
+
 #############
 # Scenarios #
 ################

--- a/src/config.c
+++ b/src/config.c
@@ -205,6 +205,7 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, allow_loading_with_incorrect_checksum),"allow_loading_with_incorrect_checksum",	CONFIG_VALUE_TYPE_BOOLEAN,		false,			NULL					},
 	{ offsetof(general_configuration, steam_overlay_pause),				"steam_overlay_pause",			CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(general_configuration, window_scale),					"window_scale",					CONFIG_VALUE_TYPE_FLOAT,		{ .value_float = 1.0f },		NULL					},
+	{ offsetof(general_configuration, scale_quality),					"scale_quality",				CONFIG_VALUE_TYPE_UINT8,		1,								NULL					},
 	{ offsetof(general_configuration, show_fps),						"show_fps",						CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, trap_cursor),						"trap_cursor",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, auto_open_shops),					"auto_open_shops",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},

--- a/src/config.c
+++ b/src/config.c
@@ -206,6 +206,7 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, steam_overlay_pause),				"steam_overlay_pause",			CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(general_configuration, window_scale),					"window_scale",					CONFIG_VALUE_TYPE_FLOAT,		{ .value_float = 1.0f },		NULL					},
 	{ offsetof(general_configuration, scale_quality),					"scale_quality",				CONFIG_VALUE_TYPE_UINT8,		1,								NULL					},
+	{ offsetof(general_configuration, use_nn_at_integer_scales),		"use_nn_at_integer_scales",		CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 	{ offsetof(general_configuration, show_fps),						"show_fps",						CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, trap_cursor),						"trap_cursor",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, auto_open_shops),					"auto_open_shops",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},

--- a/src/config.h
+++ b/src/config.h
@@ -177,6 +177,7 @@ typedef struct {
 	uint8 allow_loading_with_incorrect_checksum;
 	uint8 steam_overlay_pause;
 	float window_scale;
+	uint8 scale_quality;
 	uint8 show_fps;
 	uint8 trap_cursor;
 	uint8 auto_open_shops;

--- a/src/config.h
+++ b/src/config.h
@@ -178,6 +178,7 @@ typedef struct {
 	uint8 steam_overlay_pause;
 	float window_scale;
 	uint8 scale_quality;
+	uint8 use_nn_at_integer_scales;
 	uint8 show_fps;
 	uint8 trap_cursor;
 	uint8 auto_open_shops;

--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -447,7 +447,7 @@ void gfx_draw_string_left(rct_drawpixelinfo *dpi, int format, void *args, int co
 
 	buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 	format_string(buffer, format, args);
-	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, uint16) = 224;
+	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, sint16) = 224;
 	gfx_draw_string(dpi, buffer, colour, x, y);
 }
 

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2330,6 +2330,8 @@ enum {
 	STR_SCALING_QUALITY_ANISOTROPIC = 5732,
 	STR_USE_NN_AT_INTEGER_SCALE = 5733,
 
+	STR_OPTIONS_RENDERING_TIP = 5727,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2330,7 +2330,7 @@ enum {
 	STR_SCALING_QUALITY_ANISOTROPIC = 5732,
 	STR_USE_NN_AT_INTEGER_SCALE = 5733,
 
-	STR_OPTIONS_RENDERING_TIP = 5727,
+	STR_OPTIONS_RENDERING_TIP = 5734,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2322,6 +2322,13 @@ enum {
 	STR_FORCE_WEATHER = 5725,
 	STR_FORCE_WEATHER_TOOLTIP = 5726,
 
+	STR_SCALING_QUALITY = 5727,
+	STR_REQUIRES_HW_DISPLAY = 5728,
+	STR_REQUIRES_HW_DISPLAY_TIP = 5729,
+	STR_SCALING_QUALITY_NN = 5730,
+	STR_SCALING_QUALITY_LINEAR = 5731,
+	STR_SCALING_QUALITY_ANISOTROPIC = 5732,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2328,6 +2328,7 @@ enum {
 	STR_SCALING_QUALITY_NN = 5730,
 	STR_SCALING_QUALITY_LINEAR = 5731,
 	STR_SCALING_QUALITY_ANISOTROPIC = 5732,
+	STR_USE_NN_AT_INTEGER_SCALE = 5733,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -352,8 +352,18 @@ static void platform_resize(int width, int height)
 	}
 }
 
+/**
+ * @brief platform_trigger_resize
+ * Helper function to set various render target features.
+ *
+ * Does not get triggered on resize, but rather manually on config changes.
+ */
 void platform_trigger_resize()
 {
+	char scale_quality[4]; // just to make sure we can hold whole uint8
+	snprintf(scale_quality, sizeof(scale_quality), "%u", gConfigGeneral.scale_quality);
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scale_quality);
+
 	int w, h;
 	SDL_GetWindowSize(gWindow, &w, &h);
 	platform_resize(w, h);
@@ -766,7 +776,6 @@ static void platform_create_window()
 		exit(-1);
 	}
 
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, 0);
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss ? "1" : "0");
 
 	platform_load_cursors();
@@ -809,6 +818,7 @@ static void platform_create_window()
 
 	// Check if steam overlay renderer is loaded into the process
 	gSteamOverlayActive = platform_check_steam_overlay_attached();
+	platform_trigger_resize();
 }
 
 int platform_scancode_to_rct_keycode(int sdl_key)

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -360,9 +360,13 @@ static void platform_resize(int width, int height)
  */
 void platform_trigger_resize()
 {
-	char scale_quality[4]; // just to make sure we can hold whole uint8
-	snprintf(scale_quality, sizeof(scale_quality), "%u", gConfigGeneral.scale_quality);
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scale_quality);
+	char scale_quality_buffer[4]; // just to make sure we can hold whole uint8
+	uint8 scale_quality = gConfigGeneral.scale_quality;
+	if (gConfigGeneral.use_nn_at_integer_scales && gConfigGeneral.window_scale == floor(gConfigGeneral.window_scale)) {
+		scale_quality = 0;
+	}
+	snprintf(scale_quality_buffer, sizeof(scale_quality_buffer), "%u", scale_quality);
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scale_quality_buffer);
 
 	int w, h;
 	SDL_GetWindowSize(gWindow, &w, &h);

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -88,6 +88,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_SCALE_DOWN,
 	WIDX_SCALE_QUALITY,
 	WIDX_SCALE_QUALITY_DROPDOWN,
+	WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX,
 	WIDX_RENDERING_GROUP,
 	WIDX_TILE_SMOOTHING_CHECKBOX,
 	WIDX_GRIDLINES_CHECKBOX,
@@ -167,7 +168,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 };
 
 #define WW 			310
-#define WH 			317
+#define WH 			332
 
 #define MAIN_OPTIONS_WIDGETS \
 	{ WWT_FRAME,			0,	0,		WW-1,	0,		WH-1,	STR_NONE,			STR_NONE }, \
@@ -183,7 +184,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
 static rct_widget window_options_display_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
-	{ WWT_GROUPBOX,			1,	5,      304,	53,		190,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
+	{ WWT_GROUPBOX,			1,	5,      304,	53,		205,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
 	{ WWT_DROPDOWN,			1,	155,	299,	68,		79,		STR_RESOLUTION_X_BY_Y,	STR_NONE },					// resolution
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	69,		78,		STR_DROPDOWN_GLYPH,		STR_NONE },
 	{ WWT_DROPDOWN,			1,	155,	299,	83,		94,		871,					STR_NONE },					// fullscreen
@@ -198,8 +199,9 @@ static rct_widget window_options_display_widgets[] = {
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	165,	169,	STR_NUMERIC_DOWN,		STR_NONE },					// scale spinner down
 	{ WWT_DROPDOWN,			1,	155,	299,	174,	185,	STR_NONE,				STR_REQUIRES_HW_DISPLAY },	// scaling quality hint
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	175,	184,	STR_DROPDOWN_GLYPH,		STR_REQUIRES_HW_DISPLAY_TIP },
+	{ WWT_CHECKBOX,			1,	10,		290,	189,	200,	STR_USE_NN_AT_INTEGER_SCALE,	STR_NONE },			// use nn scaling at integer scales
 
-#define FRAME_RENDERING_START 194
+#define FRAME_RENDERING_START 209
 	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,	FRAME_RENDERING_START + 91,	STR_RENDERING_GROUP,	STR_NONE },					// Rendering group
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,	FRAME_RENDERING_START + 26,	STR_TILE_SMOOTHING, 	STR_TILE_SMOOTHING_TIP },	// landscape smoothing
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,	FRAME_RENDERING_START + 41,	STR_GRIDLINES,			STR_GRIDLINES_TIP },		// gridlines
@@ -392,9 +394,10 @@ static uint32 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_SCALE_DOWN) |
 	(1 << WIDX_SCALE_QUALITY) |
 	(1 << WIDX_SCALE_QUALITY_DROPDOWN) |
+	(1 << WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX) |
 	(1 << WIDX_CONSTRUCTION_MARKER) |
 	(1 << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
-	(1 << WIDX_DAY_NIGHT_CHECKBOX) |
+	(1u << WIDX_DAY_NIGHT_CHECKBOX) |
 	(1u << WIDX_UPPER_CASE_BANNERS_CHECKBOX),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
@@ -563,6 +566,12 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 			gConfigGeneral.steam_overlay_pause ^= 1;
 			config_save_default();
 			window_invalidate(w);
+			break;
+		case WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX:
+			gConfigGeneral.use_nn_at_integer_scales ^= 1;
+			config_save_default();
+			gfx_invalidate_screen();
+			platform_trigger_resize();
 			break;
 		case WIDX_DAY_NIGHT_CHECKBOX:
 			gConfigGeneral.day_night_cycle ^= 1;
@@ -1277,6 +1286,7 @@ static void window_options_invalidate(rct_window *w)
 		widget_set_checkbox_value(w, WIDX_SHOW_FPS_CHECKBOX, gConfigGeneral.show_fps);
 		widget_set_checkbox_value(w, WIDX_MINIMIZE_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss);
 		widget_set_checkbox_value(w, WIDX_STEAM_OVERLAY_PAUSE, gConfigGeneral.steam_overlay_pause);
+		widget_set_checkbox_value(w, WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX, gConfigGeneral.use_nn_at_integer_scales);
 		widget_set_checkbox_value(w, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
 		widget_set_checkbox_value(w, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
 

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -86,6 +86,8 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_SCALE,
 	WIDX_SCALE_UP,
 	WIDX_SCALE_DOWN,
+	WIDX_SCALE_QUALITY,
+	WIDX_SCALE_QUALITY_DROPDOWN,
 	WIDX_RENDERING_GROUP,
 	WIDX_TILE_SMOOTHING_CHECKBOX,
 	WIDX_GRIDLINES_CHECKBOX,
@@ -165,7 +167,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 };
 
 #define WW 			310
-#define WH 			302
+#define WH 			317
 
 #define MAIN_OPTIONS_WIDGETS \
 	{ WWT_FRAME,			0,	0,		WW-1,	0,		WH-1,	STR_NONE,			STR_NONE }, \
@@ -181,7 +183,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
 static rct_widget window_options_display_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
-	{ WWT_GROUPBOX,			1,	5,      304,	53,		175,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
+	{ WWT_GROUPBOX,			1,	5,      304,	53,		190,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
 	{ WWT_DROPDOWN,			1,	155,	299,	68,		79,		STR_RESOLUTION_X_BY_Y,	STR_NONE },					// resolution
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	69,		78,		STR_DROPDOWN_GLYPH,		STR_NONE },
 	{ WWT_DROPDOWN,			1,	155,	299,	83,		94,		871,					STR_NONE },					// fullscreen
@@ -190,18 +192,22 @@ static rct_widget window_options_display_widgets[] = {
 	{ WWT_CHECKBOX,			1,	10,		290,	114,	125,	STR_UNCAP_FPS,			STR_NONE },					// uncap fps
 	{ WWT_CHECKBOX,			1,	155,	299,	114,	125,	STR_SHOW_FPS,			STR_NONE },					// show fps
 	{ WWT_CHECKBOX,			1,	10,		290,	129,	140,	STR_MININISE_FULL_SCREEN_ON_FOCUS_LOSS,	STR_NONE },	// minimise fullscreen focus loss
-	{ WWT_CHECKBOX,			1,	10,		290,	144,	155,	STR_STEAM_OVERLAY_PAUSE,	STR_NONE },				// minimise fullscreen focus loss
+	{ WWT_CHECKBOX,			1,	10,		290,	144,	155,	STR_STEAM_OVERLAY_PAUSE,	STR_NONE },				// pause on steam overlay
 	{ WWT_SPINNER,			1,	155,	299,	159,	170,	STR_NONE,				STR_NONE },					// scale spinner
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	160,	164,	STR_NUMERIC_UP,			STR_NONE },					// scale spinner up
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	165,	169,	STR_NUMERIC_DOWN,		STR_NONE },					// scale spinner down
+	{ WWT_DROPDOWN,			1,	155,	299,	174,	185,	STR_NONE,				STR_REQUIRES_HW_DISPLAY },	// scaling quality hint
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	175,	184,	STR_DROPDOWN_GLYPH,		STR_REQUIRES_HW_DISPLAY_TIP },
 
-	{ WWT_GROUPBOX,			1,	5,      304,	179,	270,	STR_RENDERING_GROUP,	STR_NONE },					// Rendering group
-	{ WWT_CHECKBOX,			1,	10,		290,	194,	205,	STR_TILE_SMOOTHING, 	STR_TILE_SMOOTHING_TIP },	// landscape smoothing
-	{ WWT_CHECKBOX,			1,	10,		290,	209,	220,	STR_GRIDLINES,			STR_GRIDLINES_TIP },		// gridlines
-	{ WWT_DROPDOWN,			1,	155,	299,	224,	234,	STR_NONE,				STR_NONE },					// construction marker
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	225,	233,	STR_DROPDOWN_GLYPH,		STR_NONE },
-	{ WWT_CHECKBOX,			1,	10,		290,	239,	250,	STR_CYCLE_DAY_NIGHT,	STR_NONE },					// cycle day-night
-	{ WWT_CHECKBOX,			1,	10,		290,	254,	265,	STR_UPPER_CASE_BANNERS,	STR_NONE },					// upper case banners
+#define FRAME_RENDERING_START 194
+	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,	FRAME_RENDERING_START + 91,	STR_RENDERING_GROUP,	STR_NONE },					// Rendering group
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,	FRAME_RENDERING_START + 26,	STR_TILE_SMOOTHING, 	STR_TILE_SMOOTHING_TIP },	// landscape smoothing
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,	FRAME_RENDERING_START + 41,	STR_GRIDLINES,			STR_GRIDLINES_TIP },		// gridlines
+	{ WWT_DROPDOWN,			1,	155,	299,	FRAME_RENDERING_START + 45,	FRAME_RENDERING_START + 55,	STR_NONE,				STR_NONE },					// construction marker
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	FRAME_RENDERING_START + 46,	FRAME_RENDERING_START + 54,	STR_DROPDOWN_GLYPH,		STR_NONE },
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 60,	FRAME_RENDERING_START + 71,	STR_CYCLE_DAY_NIGHT,	STR_NONE },					// cycle day-night
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 75,	FRAME_RENDERING_START + 86,	STR_UPPER_CASE_BANNERS,	STR_NONE },					// upper case banners
+#undef FRAME_RENDERING_START
 	{ WIDGETS_END },
 };
 
@@ -384,10 +390,12 @@ static uint32 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_SCALE) |
 	(1 << WIDX_SCALE_UP) |
 	(1 << WIDX_SCALE_DOWN) |
+	(1 << WIDX_SCALE_QUALITY) |
+	(1 << WIDX_SCALE_QUALITY_DROPDOWN) |
 	(1 << WIDX_CONSTRUCTION_MARKER) |
 	(1 << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
 	(1 << WIDX_DAY_NIGHT_CHECKBOX) |
-	(1 << WIDX_UPPER_CASE_BANNERS_CHECKBOX),
+	(1u << WIDX_UPPER_CASE_BANNERS_CHECKBOX),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
 	(1 << WIDX_LANGUAGE) |
@@ -821,6 +829,18 @@ static void window_options_mousedown(int widgetIndex, rct_window*w, rct_widget* 
 			gfx_invalidate_screen();
 			platform_trigger_resize();
 			break;
+		case WIDX_SCALE_QUALITY_DROPDOWN:
+			gDropdownItemsFormat[0] = 1142;
+			gDropdownItemsFormat[1] = 1142;
+			gDropdownItemsFormat[2] = 1142;
+			gDropdownItemsArgs[0] = STR_SCALING_QUALITY_NN;
+			gDropdownItemsArgs[1] = STR_SCALING_QUALITY_LINEAR;
+			gDropdownItemsArgs[2] = STR_SCALING_QUALITY_ANISOTROPIC;
+
+			window_options_show_dropdown(w, widget, 3);
+
+			dropdown_set_checked(gConfigGeneral.scale_quality, true);
+			break;
 		}
 		break;
 
@@ -1058,6 +1078,14 @@ static void window_options_dropdown(rct_window *w, int widgetIndex, int dropdown
 				gfx_invalidate_screen();
 			}
 			break;
+		case WIDX_SCALE_QUALITY_DROPDOWN:
+			if (dropdownIndex != gConfigGeneral.scale_quality) {
+				gConfigGeneral.scale_quality = (uint8)dropdownIndex;
+				config_save_default();
+				gfx_invalidate_screen();
+				platform_trigger_resize();
+			}
+			break;
 		}
 		break;
 
@@ -1252,6 +1280,7 @@ static void window_options_invalidate(rct_window *w)
 		widget_set_checkbox_value(w, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
 		widget_set_checkbox_value(w, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
 
+		window_options_display_widgets[WIDX_SCALE_QUALITY].image = STR_SCALING_QUALITY_NN + gConfigGeneral.scale_quality;
 		// construction marker: white/translucent
 		window_options_display_widgets[WIDX_CONSTRUCTION_MARKER].image = STR_WHITE + gConfigGeneral.construction_marker_colour;
 
@@ -1489,6 +1518,7 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		gfx_draw_string_left(dpi, STR_FULLSCREEN_MODE, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_FULLSCREEN].top + 1);
 		gfx_draw_string_left(dpi, STR_CONSTRUCTION_MARKER, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_CONSTRUCTION_MARKER].top + 1);
 		gfx_draw_string_left(dpi, STR_UI_SCALING_DESC, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE].top + 1);
+		gfx_draw_string_left(dpi, STR_SCALING_QUALITY, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
 
 		int scale = (int)(gConfigGeneral.window_scale * 100);
 		gfx_draw_string_left(dpi, 3311, &scale, w->colours[1], w->x + w->widgets[WIDX_SCALE].left + 1, w->y + w->widgets[WIDX_SCALE].top + 1);

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -48,6 +48,7 @@
 
 enum WINDOW_OPTIONS_PAGE {
 	WINDOW_OPTIONS_PAGE_DISPLAY,
+	WINDOW_OPTIONS_PAGE_RENDERING,
 	WINDOW_OPTIONS_PAGE_CULTURE,
 	WINDOW_OPTIONS_PAGE_AUDIO,
 	WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
@@ -69,6 +70,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_TAB_4,
 	WIDX_TAB_5,
 	WIDX_TAB_6,
+	WIDX_TAB_7,
 
 	WIDX_PAGE_START,
 
@@ -89,7 +91,9 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_SCALE_QUALITY,
 	WIDX_SCALE_QUALITY_DROPDOWN,
 	WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX,
-	WIDX_RENDERING_GROUP,
+
+	// Rendering
+	WIDX_RENDERING_GROUP = WIDX_PAGE_START,
 	WIDX_TILE_SMOOTHING_CHECKBOX,
 	WIDX_GRIDLINES_CHECKBOX,
 	WIDX_CONSTRUCTION_MARKER,
@@ -176,11 +180,12 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	{ WWT_CLOSEBOX,			0,	WW-13,	WW-3,	2,		13,		STR_CLOSE_X,		STR_CLOSE_WINDOW_TIP }, \
 	{ WWT_RESIZE,			1,	0,		WW-1,	43,		WH-1,	0xFFFFFFFF,			STR_NONE }, \
 	{ WWT_TAB,				1,	3,		33,		17,		43,		0x2000144E,			STR_OPTIONS_DISPLAY_TIP }, \
-	{ WWT_TAB,				1,	34,		64,		17,		43,		0x2000144E,			STR_OPTIONS_CULTURE_TIP }, \
-	{ WWT_TAB,				1,	65,		95,		17,		43,		0x2000144E,			STR_OPTIONS_AUDIO_TIP }, \
-	{ WWT_TAB,				1,	96,		126,	17,		43,		0x2000144E,			STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP }, \
-	{ WWT_TAB,				1,	127,	157,	17,		43,		0x2000144E,			STR_OPTIONS_MISCELLANEOUS_TIP }, \
-	{ WWT_TAB,				1,	158,	188,	17,		43,		0x2000144E,			STR_OPTIONS_TWITCH_TIP }
+	{ WWT_TAB,				1,	34,		64,		17,		43,		0x2000144E,			STR_OPTIONS_RENDERING_TIP }, \
+	{ WWT_TAB,				1,	65,		95,		17,		43,		0x2000144E,			STR_OPTIONS_CULTURE_TIP }, \
+	{ WWT_TAB,				1,	96,		126,	17,		43,		0x2000144E,			STR_OPTIONS_AUDIO_TIP }, \
+	{ WWT_TAB,				1,	127,	157,	17,		43,		0x2000144E,			STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP }, \
+	{ WWT_TAB,				1,	158,	188,	17,		43,		0x2000144E,			STR_OPTIONS_MISCELLANEOUS_TIP }, \
+	{ WWT_TAB,				1,	189,	209,	17,		43,		0x2000144E,			STR_OPTIONS_TWITCH_TIP }
 
 static rct_widget window_options_display_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
@@ -200,8 +205,12 @@ static rct_widget window_options_display_widgets[] = {
 	{ WWT_DROPDOWN,			1,	155,	299,	174,	185,	STR_NONE,				STR_REQUIRES_HW_DISPLAY },	// scaling quality hint
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	175,	184,	STR_DROPDOWN_GLYPH,		STR_REQUIRES_HW_DISPLAY_TIP },
 	{ WWT_CHECKBOX,			1,	10,		290,	189,	200,	STR_USE_NN_AT_INTEGER_SCALE,	STR_NONE },			// use nn scaling at integer scales
+	{ WIDGETS_END },
+};
 
-#define FRAME_RENDERING_START 209
+static rct_widget window_options_rendering_widgets[] = {
+	MAIN_OPTIONS_WIDGETS,
+#define FRAME_RENDERING_START 53
 	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,	FRAME_RENDERING_START + 91,	STR_RENDERING_GROUP,	STR_NONE },					// Rendering group
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,	FRAME_RENDERING_START + 26,	STR_TILE_SMOOTHING, 	STR_TILE_SMOOTHING_TIP },	// landscape smoothing
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,	FRAME_RENDERING_START + 41,	STR_GRIDLINES,			STR_GRIDLINES_TIP },		// gridlines
@@ -302,6 +311,7 @@ static rct_widget window_options_twitch_widgets[] = {
 
 rct_widget *window_options_page_widgets[] = {
 	window_options_display_widgets,
+	window_options_rendering_widgets,
 	window_options_culture_widgets,
 	window_options_audio_widgets,
 	window_options_controls_and_interface_widgets,
@@ -311,8 +321,8 @@ rct_widget *window_options_page_widgets[] = {
 
 #pragma endregion
 
-const int window_options_tab_animation_divisor[] = { 4, 8, 2, 2, 2, 1 };
-const int window_options_tab_animation_frames[] = { 16, 8, 16, 4, 16, 1 };
+const int window_options_tab_animation_divisor[] = { 4, 4, 8, 2, 2, 2, 1 };
+const int window_options_tab_animation_frames[] = { 16, 8, 8, 16, 4, 16, 1 };
 
 static void window_options_set_page(rct_window *w, int page);
 static void window_options_set_pressed_tab(rct_window *w);
@@ -374,7 +384,8 @@ static rct_window_event_list window_options_events = {
 	(1 << WIDX_TAB_3) | \
 	(1 << WIDX_TAB_4) | \
 	(1 << WIDX_TAB_5) | \
-	(1 << WIDX_TAB_6)
+	(1 << WIDX_TAB_6) | \
+	(1 << WIDX_TAB_7)
 
 static uint32 window_options_page_enabled_widgets[] = {
 	MAIN_OPTIONS_ENABLED_WIDGETS |
@@ -394,11 +405,15 @@ static uint32 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_SCALE_DOWN) |
 	(1 << WIDX_SCALE_QUALITY) |
 	(1 << WIDX_SCALE_QUALITY_DROPDOWN) |
-	(1 << WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX) |
+	(1 << WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX),
+
+	MAIN_OPTIONS_ENABLED_WIDGETS |
+	(1 << WIDX_TILE_SMOOTHING_CHECKBOX) |
+	(1 << WIDX_GRIDLINES_CHECKBOX) |
 	(1 << WIDX_CONSTRUCTION_MARKER) |
 	(1 << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
-	(1u << WIDX_DAY_NIGHT_CHECKBOX) |
-	(1u << WIDX_UPPER_CASE_BANNERS_CHECKBOX),
+	(1 << WIDX_DAY_NIGHT_CHECKBOX) |
+	(1 << WIDX_UPPER_CASE_BANNERS_CHECKBOX),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
 	(1 << WIDX_LANGUAGE) |
@@ -508,6 +523,7 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 	case WIDX_TAB_4:
 	case WIDX_TAB_5:
 	case WIDX_TAB_6:
+	case WIDX_TAB_7:
 		window_options_set_page(w, widgetIndex - WIDX_TAB_1);
 		break;
 	}
@@ -515,22 +531,6 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 	switch (w->page) {
 	case WINDOW_OPTIONS_PAGE_DISPLAY:
 		switch (widgetIndex) {
-		case WIDX_TILE_SMOOTHING_CHECKBOX:
-			gConfigGeneral.landscape_smoothing ^= 1;
-			config_save_default();
-			gfx_invalidate_screen();
-			break;
-		case WIDX_GRIDLINES_CHECKBOX:
-			gConfigGeneral.always_show_gridlines ^= 1;
-			config_save_default();
-			gfx_invalidate_screen();
-			if ((w = window_get_main()) != NULL) {
-				if (gConfigGeneral.always_show_gridlines)
-					w->viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
-				else
-					w->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
-			}
-			break;
 		case WIDX_HARDWARE_DISPLAY_CHECKBOX:
 			gConfigGeneral.hardware_display ^= 1;
 #ifdef __WINDOWS__
@@ -572,6 +572,27 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 			config_save_default();
 			gfx_invalidate_screen();
 			platform_trigger_resize();
+			break;
+		}
+		break;
+
+	case WINDOW_OPTIONS_PAGE_RENDERING:
+		switch (widgetIndex) {
+		case WIDX_TILE_SMOOTHING_CHECKBOX:
+			gConfigGeneral.landscape_smoothing ^= 1;
+			config_save_default();
+			gfx_invalidate_screen();
+			break;
+		case WIDX_GRIDLINES_CHECKBOX:
+			gConfigGeneral.always_show_gridlines ^= 1;
+			config_save_default();
+			gfx_invalidate_screen();
+			if ((w = window_get_main()) != NULL) {
+				if (gConfigGeneral.always_show_gridlines)
+					w->viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
+				else
+					w->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
+			}
 			break;
 		case WIDX_DAY_NIGHT_CHECKBOX:
 			gConfigGeneral.day_night_cycle ^= 1;
@@ -815,16 +836,6 @@ static void window_options_mousedown(int widgetIndex, rct_window*w, rct_widget* 
 
 			dropdown_set_checked(gConfigGeneral.fullscreen_mode, true);
 			break;
-		case WIDX_CONSTRUCTION_MARKER_DROPDOWN:
-			gDropdownItemsFormat[0] = 1142;
-			gDropdownItemsFormat[1] = 1142;
-			gDropdownItemsArgs[0] = STR_WHITE;
-			gDropdownItemsArgs[1] = STR_TRANSLUCENT;
-
-			window_options_show_dropdown(w, widget, 2);
-
-			dropdown_set_checked(gConfigGeneral.construction_marker_colour, true);
-			break;
 		case WIDX_SCALE_UP:
 			gConfigGeneral.window_scale += 0.25f;
 			config_save_default();
@@ -849,6 +860,21 @@ static void window_options_mousedown(int widgetIndex, rct_window*w, rct_widget* 
 			window_options_show_dropdown(w, widget, 3);
 
 			dropdown_set_checked(gConfigGeneral.scale_quality, true);
+			break;
+		}
+		break;
+
+	case WINDOW_OPTIONS_PAGE_RENDERING:
+		switch (widgetIndex) {
+		case WIDX_CONSTRUCTION_MARKER_DROPDOWN:
+			gDropdownItemsFormat[0] = 1142;
+			gDropdownItemsFormat[1] = 1142;
+			gDropdownItemsArgs[0] = STR_WHITE;
+			gDropdownItemsArgs[1] = STR_TRANSLUCENT;
+
+			window_options_show_dropdown(w, widget, 2);
+
+			dropdown_set_checked(gConfigGeneral.construction_marker_colour, true);
 			break;
 		}
 		break;
@@ -1080,19 +1106,24 @@ static void window_options_dropdown(rct_window *w, int widgetIndex, int dropdown
 				gfx_invalidate_screen();
 			}
 			break;
-		case WIDX_CONSTRUCTION_MARKER_DROPDOWN:
-			if (dropdownIndex != gConfigGeneral.construction_marker_colour) {
-				gConfigGeneral.construction_marker_colour = (uint8)dropdownIndex;
-				config_save_default();
-				gfx_invalidate_screen();
-			}
-			break;
 		case WIDX_SCALE_QUALITY_DROPDOWN:
 			if (dropdownIndex != gConfigGeneral.scale_quality) {
 				gConfigGeneral.scale_quality = (uint8)dropdownIndex;
 				config_save_default();
 				gfx_invalidate_screen();
 				platform_trigger_resize();
+			}
+			break;
+		}
+		break;
+
+	case WINDOW_OPTIONS_PAGE_RENDERING:
+		switch (widgetIndex) {
+		case WIDX_CONSTRUCTION_MARKER_DROPDOWN:
+			if (dropdownIndex != gConfigGeneral.construction_marker_colour) {
+				gConfigGeneral.construction_marker_colour = (uint8)dropdownIndex;
+				config_save_default();
+				gfx_invalidate_screen();
 			}
 			break;
 		}
@@ -1279,36 +1310,41 @@ static void window_options_invalidate(rct_window *w)
 			w->disabled_widgets &= ~(1 << WIDX_RESOLUTION);
 		}
 
-		widget_set_checkbox_value(w, WIDX_TILE_SMOOTHING_CHECKBOX, (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_DISABLE_SMOOTH_LANDSCAPE) == 0);
-		widget_set_checkbox_value(w, WIDX_GRIDLINES_CHECKBOX, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_ALWAYS_SHOW_GRIDLINES);
 		widget_set_checkbox_value(w, WIDX_HARDWARE_DISPLAY_CHECKBOX, gConfigGeneral.hardware_display);
 		widget_set_checkbox_value(w, WIDX_UNCAP_FPS_CHECKBOX, gConfigGeneral.uncap_fps);
 		widget_set_checkbox_value(w, WIDX_SHOW_FPS_CHECKBOX, gConfigGeneral.show_fps);
 		widget_set_checkbox_value(w, WIDX_MINIMIZE_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss);
 		widget_set_checkbox_value(w, WIDX_STEAM_OVERLAY_PAUSE, gConfigGeneral.steam_overlay_pause);
 		widget_set_checkbox_value(w, WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX, gConfigGeneral.use_nn_at_integer_scales);
-		widget_set_checkbox_value(w, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
-		widget_set_checkbox_value(w, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
 
 		window_options_display_widgets[WIDX_SCALE_QUALITY].image = STR_SCALING_QUALITY_NN + gConfigGeneral.scale_quality;
-		// construction marker: white/translucent
-		window_options_display_widgets[WIDX_CONSTRUCTION_MARKER].image = STR_WHITE + gConfigGeneral.construction_marker_colour;
 
 		window_options_display_widgets[WIDX_RESOLUTION].type = WWT_DROPDOWN;
 		window_options_display_widgets[WIDX_RESOLUTION_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 		window_options_display_widgets[WIDX_FULLSCREEN].type = WWT_DROPDOWN;
 		window_options_display_widgets[WIDX_FULLSCREEN_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
-		window_options_display_widgets[WIDX_TILE_SMOOTHING_CHECKBOX].type = WWT_CHECKBOX;
-		window_options_display_widgets[WIDX_GRIDLINES_CHECKBOX].type = WWT_CHECKBOX;
-		window_options_display_widgets[WIDX_CONSTRUCTION_MARKER].type = WWT_DROPDOWN;
-		window_options_display_widgets[WIDX_CONSTRUCTION_MARKER_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 		window_options_display_widgets[WIDX_HARDWARE_DISPLAY_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_display_widgets[WIDX_UNCAP_FPS_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_display_widgets[WIDX_SHOW_FPS_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_display_widgets[WIDX_MINIMIZE_FOCUS_LOSS].type = WWT_CHECKBOX;
 		window_options_display_widgets[WIDX_STEAM_OVERLAY_PAUSE].type = WWT_CHECKBOX;
-		window_options_display_widgets[WIDX_DAY_NIGHT_CHECKBOX].type = WWT_CHECKBOX;
-		window_options_display_widgets[WIDX_UPPER_CASE_BANNERS_CHECKBOX].type = WWT_CHECKBOX;
+		break;
+
+	case WINDOW_OPTIONS_PAGE_RENDERING:
+		widget_set_checkbox_value(w, WIDX_TILE_SMOOTHING_CHECKBOX, (RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_DISABLE_SMOOTH_LANDSCAPE) == 0);
+		widget_set_checkbox_value(w, WIDX_GRIDLINES_CHECKBOX, RCT2_GLOBAL(RCT2_ADDRESS_CONFIG_FLAGS, uint8) & CONFIG_FLAG_ALWAYS_SHOW_GRIDLINES);
+		widget_set_checkbox_value(w, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
+		widget_set_checkbox_value(w, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
+
+		// construction marker: white/translucent
+		window_options_rendering_widgets[WIDX_CONSTRUCTION_MARKER].image = STR_WHITE + gConfigGeneral.construction_marker_colour;
+
+		window_options_rendering_widgets[WIDX_TILE_SMOOTHING_CHECKBOX].type = WWT_CHECKBOX;
+		window_options_rendering_widgets[WIDX_GRIDLINES_CHECKBOX].type = WWT_CHECKBOX;
+		window_options_rendering_widgets[WIDX_CONSTRUCTION_MARKER].type = WWT_DROPDOWN;
+		window_options_rendering_widgets[WIDX_CONSTRUCTION_MARKER_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
+		window_options_rendering_widgets[WIDX_DAY_NIGHT_CHECKBOX].type = WWT_CHECKBOX;
+		window_options_rendering_widgets[WIDX_UPPER_CASE_BANNERS_CHECKBOX].type = WWT_CHECKBOX;
 		break;
 
 	case WINDOW_OPTIONS_PAGE_CULTURE:
@@ -1526,12 +1562,14 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	case WINDOW_OPTIONS_PAGE_DISPLAY:
 		gfx_draw_string_left(dpi, STR_DISPLAY_RESOLUTION, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_RESOLUTION].top + 1);
 		gfx_draw_string_left(dpi, STR_FULLSCREEN_MODE, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_FULLSCREEN].top + 1);
-		gfx_draw_string_left(dpi, STR_CONSTRUCTION_MARKER, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_CONSTRUCTION_MARKER].top + 1);
 		gfx_draw_string_left(dpi, STR_UI_SCALING_DESC, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE].top + 1);
 		gfx_draw_string_left(dpi, STR_SCALING_QUALITY, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
 
 		int scale = (int)(gConfigGeneral.window_scale * 100);
 		gfx_draw_string_left(dpi, 3311, &scale, w->colours[1], w->x + w->widgets[WIDX_SCALE].left + 1, w->y + w->widgets[WIDX_SCALE].top + 1);
+		break;
+	case WINDOW_OPTIONS_PAGE_RENDERING:
+		gfx_draw_string_left(dpi, STR_CONSTRUCTION_MARKER, w, w->colours[1], w->x + 10, w->y + window_options_rendering_widgets[WIDX_CONSTRUCTION_MARKER].top + 1);
 		break;
 	case WINDOW_OPTIONS_PAGE_CULTURE:
 		gfx_draw_string_left(dpi, 2776, w, w->colours[1], w->x + 10, w->y + window_options_culture_widgets[WIDX_LANGUAGE].top + 1);
@@ -1706,6 +1744,7 @@ static void window_options_draw_tab_image(rct_drawpixelinfo *dpi, rct_window *w,
 static void window_options_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w)
 {
 	window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_DISPLAY, 5442);
+	window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_RENDERING, 5221);
 	window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CULTURE, 5229);
 	window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_AUDIO, 5335);
 	window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE, 5201);

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -76,21 +76,21 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
 	// Display
 	WIDX_HARDWARE_GROUP = WIDX_PAGE_START,
-	WIDX_RESOLUTION,
-	WIDX_RESOLUTION_DROPDOWN,
 	WIDX_FULLSCREEN,
 	WIDX_FULLSCREEN_DROPDOWN,
-	WIDX_HARDWARE_DISPLAY_CHECKBOX,
-	WIDX_UNCAP_FPS_CHECKBOX,
-	WIDX_SHOW_FPS_CHECKBOX,
-	WIDX_MINIMIZE_FOCUS_LOSS,
-	WIDX_STEAM_OVERLAY_PAUSE,
+	WIDX_RESOLUTION,
+	WIDX_RESOLUTION_DROPDOWN,
 	WIDX_SCALE,
 	WIDX_SCALE_UP,
 	WIDX_SCALE_DOWN,
+	WIDX_HARDWARE_DISPLAY_CHECKBOX,
 	WIDX_SCALE_QUALITY,
 	WIDX_SCALE_QUALITY_DROPDOWN,
 	WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX,
+	WIDX_STEAM_OVERLAY_PAUSE,
+	WIDX_UNCAP_FPS_CHECKBOX,
+	WIDX_SHOW_FPS_CHECKBOX,
+	WIDX_MINIMIZE_FOCUS_LOSS,
 
 	// Rendering
 	WIDX_RENDERING_GROUP = WIDX_PAGE_START,
@@ -189,22 +189,31 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
 static rct_widget window_options_display_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
-	{ WWT_GROUPBOX,			1,	5,      304,	53,		205,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
-	{ WWT_DROPDOWN,			1,	155,	299,	68,		79,		STR_RESOLUTION_X_BY_Y,	STR_NONE },					// resolution
+	{ WWT_GROUPBOX,			1,	5,		304,	53,		205,	STR_HARDWARE_GROUP,		STR_NONE },					// Hardware group
+
+	{ WWT_DROPDOWN,			1,	155,	299,	68,		79,		871,					STR_NONE },					// fullscreen
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	69,		78,		STR_DROPDOWN_GLYPH,		STR_NONE },
-	{ WWT_DROPDOWN,			1,	155,	299,	83,		94,		871,					STR_NONE },					// fullscreen
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	84,		93,		STR_DROPDOWN_GLYPH,		STR_NONE },
-	{ WWT_CHECKBOX,			1,	10,		290,	99,		110,	STR_HARDWARE_DISPLAY,	STR_NONE },					// hardware display
-	{ WWT_CHECKBOX,			1,	10,		290,	114,	125,	STR_UNCAP_FPS,			STR_NONE },					// uncap fps
-	{ WWT_CHECKBOX,			1,	155,	299,	114,	125,	STR_SHOW_FPS,			STR_NONE },					// show fps
-	{ WWT_CHECKBOX,			1,	10,		290,	129,	140,	STR_MININISE_FULL_SCREEN_ON_FOCUS_LOSS,	STR_NONE },	// minimise fullscreen focus loss
-	{ WWT_CHECKBOX,			1,	10,		290,	144,	155,	STR_STEAM_OVERLAY_PAUSE,	STR_NONE },				// pause on steam overlay
-	{ WWT_SPINNER,			1,	155,	299,	159,	170,	STR_NONE,				STR_NONE },					// scale spinner
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	160,	164,	STR_NUMERIC_UP,			STR_NONE },					// scale spinner up
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	165,	169,	STR_NUMERIC_DOWN,		STR_NONE },					// scale spinner down
-	{ WWT_DROPDOWN,			1,	155,	299,	174,	185,	STR_NONE,				STR_REQUIRES_HW_DISPLAY },	// scaling quality hint
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	175,	184,	STR_DROPDOWN_GLYPH,		STR_REQUIRES_HW_DISPLAY_TIP },
-	{ WWT_CHECKBOX,			1,	10,		290,	189,	200,	STR_USE_NN_AT_INTEGER_SCALE,	STR_NONE },			// use nn scaling at integer scales
+
+		{ WWT_DROPDOWN,			1,	155,	299,	83,		94,		STR_RESOLUTION_X_BY_Y,	STR_NONE },					// resolution
+		{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	84,		93,		STR_DROPDOWN_GLYPH,		STR_NONE },
+
+	{ WWT_SPINNER,			1,	155,	299,	98,		109,	STR_NONE,				STR_NONE },					// scale spinner
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	99,		103,	STR_NUMERIC_UP,			STR_NONE },					// scale spinner up
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	104,	108,	STR_NUMERIC_DOWN,		STR_NONE },					// scale spinner down
+
+	{ WWT_CHECKBOX,			1,	10,		290,	113,	124,	STR_HARDWARE_DISPLAY,	STR_NONE },					// hardware display
+
+		{ WWT_DROPDOWN,			1,	155,	299,	128,	139,	STR_NONE,				STR_REQUIRES_HW_DISPLAY },	// scaling quality hint
+		{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	129,	138,	STR_DROPDOWN_GLYPH,		STR_REQUIRES_HW_DISPLAY_TIP },
+		{ WWT_CHECKBOX,			1,	25,		290,	143,	154,	STR_USE_NN_AT_INTEGER_SCALE,	STR_REQUIRES_HW_DISPLAY_TIP },	// use nn scaling at integer scales
+
+		{ WWT_CHECKBOX,			1,	25,		290,	158,	169,	STR_STEAM_OVERLAY_PAUSE,	STR_NONE },				// pause on steam overlay
+
+	{ WWT_CHECKBOX,			1,	10,		290,	174,	185,	STR_UNCAP_FPS,			STR_NONE },					// uncap fps
+	{ WWT_CHECKBOX,			1,	155,	299,	174,	185,	STR_SHOW_FPS,			STR_NONE },					// show fps
+	{ WWT_CHECKBOX,			1,	10,		290,	189,	200,	STR_MININISE_FULL_SCREEN_ON_FOCUS_LOSS,	STR_NONE },	// minimise fullscreen focus loss
+
+
 	{ WIDGETS_END },
 };
 
@@ -1310,6 +1319,18 @@ static void window_options_invalidate(rct_window *w)
 			w->disabled_widgets &= ~(1 << WIDX_RESOLUTION);
 		}
 
+		if (gConfigGeneral.hardware_display == false) {
+			w->disabled_widgets |= (1 << WIDX_SCALE_QUALITY);
+			w->disabled_widgets |= (1 << WIDX_SCALE_QUALITY_DROPDOWN);
+			w->disabled_widgets |= (1 << WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX);
+			w->disabled_widgets |= (1 << WIDX_STEAM_OVERLAY_PAUSE);
+		} else {
+			w->disabled_widgets &= ~(1 << WIDX_SCALE_QUALITY);
+			w->disabled_widgets &= ~(1 << WIDX_SCALE_QUALITY_DROPDOWN);
+			w->disabled_widgets &= ~(1 << WIDX_SCALE_USE_NN_AT_INTEGER_SCALES_CHECKBOX);
+			w->disabled_widgets &= ~(1 << WIDX_STEAM_OVERLAY_PAUSE);
+		}
+
 		widget_set_checkbox_value(w, WIDX_HARDWARE_DISPLAY_CHECKBOX, gConfigGeneral.hardware_display);
 		widget_set_checkbox_value(w, WIDX_UNCAP_FPS_CHECKBOX, gConfigGeneral.uncap_fps);
 		widget_set_checkbox_value(w, WIDX_SHOW_FPS_CHECKBOX, gConfigGeneral.show_fps);
@@ -1560,13 +1581,24 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 	switch (w->page) {
 	case WINDOW_OPTIONS_PAGE_DISPLAY:
-		gfx_draw_string_left(dpi, STR_DISPLAY_RESOLUTION, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_RESOLUTION].top + 1);
 		gfx_draw_string_left(dpi, STR_FULLSCREEN_MODE, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_FULLSCREEN].top + 1);
+
+		int colour = w->colours[1];
+		// disable resolution dropdown on "Fullscreen (desktop)"
+		if (gConfigGeneral.fullscreen_mode == 2) {
+			colour |= 0x40;
+		}
+		gfx_draw_string_left(dpi, STR_DISPLAY_RESOLUTION, w, colour, w->x + 10 + 15, w->y + window_options_display_widgets[WIDX_RESOLUTION].top + 1);
 		gfx_draw_string_left(dpi, STR_UI_SCALING_DESC, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE].top + 1);
-		gfx_draw_string_left(dpi, STR_SCALING_QUALITY, w, w->colours[1], w->x + 10, w->y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
 
 		int scale = (int)(gConfigGeneral.window_scale * 100);
 		gfx_draw_string_left(dpi, 3311, &scale, w->colours[1], w->x + w->widgets[WIDX_SCALE].left + 1, w->y + w->widgets[WIDX_SCALE].top + 1);
+
+		colour = w->colours[1];
+		if (gConfigGeneral.hardware_display == false) {
+			colour |= 0x40;
+		}
+		gfx_draw_string_left(dpi, STR_SCALING_QUALITY, w, colour, w->x + 25, w->y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
 		break;
 	case WINDOW_OPTIONS_PAGE_RENDERING:
 		gfx_draw_string_left(dpi, STR_CONSTRUCTION_MARKER, w, w->colours[1], w->x + 10, w->y + window_options_rendering_widgets[WIDX_CONSTRUCTION_MARKER].top + 1);


### PR DESCRIPTION
See respective commits' messages.

Some screens:

New page:
![zaznaczenie_102](https://cloud.githubusercontent.com/assets/550290/12704007/6e013a64-c851-11e5-8f1b-302869329210.png)

New options, at 1.75x with NN (see especially the tooltip):
![zaznaczenie_105](https://cloud.githubusercontent.com/assets/550290/12704010/8b4b6f72-c851-11e5-96d0-b111b3ab64d7.png)

New options, at 1.75x with linear (see especially the tooltip):
![zaznaczenie_103](https://cloud.githubusercontent.com/assets/550290/12704015/98b47776-c851-11e5-9182-781c2a162c2e.png)
