### PR TITLE
Don't prematurely fail network resolver

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -814,6 +814,8 @@ void Network::UpdateClient()
 				connectfailed = true;
 				break;
 			}
+		} else if (server_address.GetResolveStatus() == NetworkAddress::RESOLVE_INPROGRESS) {
+			break;
 		} else {
 			log_error("Could not resolve address.");
 			connectfailed = true;


### PR DESCRIPTION
Sometimes the resolver is still in progress while an update checks its
status, which is `INPROGRESS` and makes the game think there was a
connection failure.

This lets resolver continue doing its job if the status is `INPROGRESS`.