### PR TITLE
Fix user being able to enter formatting characters (fixes #2892)

### DIFF
--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -712,6 +712,10 @@ void platform_process_messages()
 				if (e.text.text[0] == '`' && gConsoleOpen)
 					break;
 
+				// Entering formatting characters is not allowed
+				if (utf8_is_format_code((int)e.text.text[0]))
+					break;
+
 				utf8 *newText = e.text.text;
 				int newTextLength = strlen(newText);
 

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -713,7 +713,7 @@ void platform_process_messages()
 					break;
 
 				// Entering formatting characters is not allowed
-				if (utf8_is_format_code((int)e.text.text[0]))
+				if (utf8_is_format_code(utf8_get_next(e.text.text, NULL)))
 					break;
 
 				utf8 *newText = e.text.text;


### PR DESCRIPTION
The original game silently removes these characters after entering them. It seems more appropriate for OpenRCT2 to simply not accept entering them.