### PR TITLE
Show amount of peeps still on ride in tooltip when ride is closed (resolves #2708)

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4043,6 +4043,7 @@ STR_5735    :Network Status
 STR_5736    :Player
 STR_5737    :Closed, {COMMA16} person still on ride
 STR_5738    :Closed, {COMMA16} people still on ride
+STR_5739    :{WINDOW_COLOUR_2}Customers on ride: {BLACK}{COMMA16}
 
 #############
 # Scenarios #

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4041,6 +4041,8 @@ STR_5733    :Use NN scaling at integer scales
 STR_5734    :{SMALLFONT}{BLACK}Rendering
 STR_5735    :Network Status
 STR_5736    :Player
+STR_5737    :Closed, {COMMA16} person still on ride
+STR_5738    :Closed, {COMMA16} people still on ride
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2333,6 +2333,9 @@ enum {
 
 	STR_OPTIONS_RENDERING_TIP = 5734,
 
+	STR_CLOSED_WITH_PERSON = 5737,
+	STR_CLOSED_WITH_PEOPLE = 5738,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2336,6 +2336,8 @@ enum {
 	STR_CLOSED_WITH_PERSON = 5737,
 	STR_CLOSED_WITH_PEOPLE = 5738,
 
+	STR_CUSTOMERS_ON_RIDE = 5739,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -710,6 +710,17 @@ void ride_get_status(int rideIndex, int *formatSecondary, int *argument)
 	}
 	if (ride->status == RIDE_STATUS_CLOSED) {
 		*formatSecondary = STR_CLOSED;
+
+		if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP)) {
+			*argument = ride->num_riders;
+
+			if (*argument == 1) {
+				*formatSecondary = STR_CLOSED_WITH_PERSON;
+			} else if (*argument > 1) {
+				*formatSecondary = STR_CLOSED_WITH_PEOPLE;
+			}
+		}
+
 		return;
 	}
 	if (ride->status == RIDE_STATUS_TESTING) {

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5899,7 +5899,7 @@ static void window_ride_customer_mouseup(rct_window *w, int widgetIndex)
 static void window_ride_customer_resize(rct_window *w)
 {
 	w->flags |= WF_RESIZABLE;
-	window_set_resize(w, 316, 139, 316, 139);
+	window_set_resize(w, 316, 149, 316, 149);
 }
 
 /**
@@ -5978,6 +5978,13 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	ride = get_ride(w->number);
 	x = w->x + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].left + 4;
 	y = w->y + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+
+	// Customers currently on ride
+	if (gRideClassifications[ride->type] == RIDE_CLASS_RIDE) {
+		sint16 customersOnRide = ride->num_riders;
+		gfx_draw_string_left(dpi, STR_CUSTOMERS_ON_RIDE, &customersOnRide, 0, x, y);
+		y += 10;
+	}
 
 	// Customers per hour
 	customersPerHour = ride_customers_per_hour(ride);


### PR DESCRIPTION
Showing this in the tooltip seems more convenient than adding it to the window.