### PR TITLE
Fix objects and their localized string ids not being reloaded after changing language (fixes #2751)

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -199,6 +199,9 @@ int language_open(int id)
 			}
 		}
 
+		// Objects and their localized strings need to be refreshed
+		reset_loaded_objects();
+
 		return 1;
 	}
 


### PR DESCRIPTION
After changing the language, names and descriptions of certain rides couldn't be found because the string ids were still based on the previous language.