### PR TITLE
Fix ferris wheel rotating one extra time (fixes #2918)

### DIFF
--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -3631,7 +3631,7 @@ static void vehicle_update_ferris_wheel_rotating(rct_vehicle* vehicle) {
 	if (subState == vehicle->var_1F) {
 		bool shouldStop = true;
 		if (ride->status != RIDE_STATUS_CLOSED) {
-			if (vehicle->var_CE <= ride->rotations)
+			if (vehicle->var_CE < ride->rotations)
 				shouldStop = false;
 		}
 

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -3638,6 +3638,7 @@ static void vehicle_update_ferris_wheel_rotating(rct_vehicle* vehicle) {
 		if (shouldStop) {
 			ferris_wheel_var_0 = vehicle->ferris_wheel_var_0;
 			vehicle->ferris_wheel_var_0 = -abs(ferris_wheel_var_0);
+			vehicle->ferris_wheel_var_1 = abs(ferris_wheel_var_0);
 		}
 	}
 


### PR DESCRIPTION
Comparison is now a `<` like the other rides.