### PR TITLE
Don't crash when dealing with a hacked ride subtype

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -307,6 +307,9 @@ money32 ride_calculate_income_per_hour(rct_ride *ride)
 	int currentShopItem;
 
 	entry = get_ride_entry(ride->subtype);
+	if (entry == NULL) {
+		return 0;
+	}
 	customersPerHour = ride_customers_per_hour(ride);
 	priceMinusCost = ride->price;
 

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -1294,7 +1294,8 @@ static void scenario_objective_check_10_rollercoasters()
 		uint8 subtype_id = ride->subtype;
 		rct_ride_type *rideType = get_ride_entry(subtype_id);
 
-		if ((rideType->category[0] == RIDE_GROUP_ROLLERCOASTER || rideType->category[1] == RIDE_GROUP_ROLLERCOASTER) &&
+		if (rideType != NULL &&
+			(rideType->category[0] == RIDE_GROUP_ROLLERCOASTER || rideType->category[1] == RIDE_GROUP_ROLLERCOASTER) &&
 			ride->status == RIDE_STATUS_OPEN &&
 			ride->excitement >= RIDE_RATING(6,00) && type_already_counted[subtype_id] == 0){
 			type_already_counted[subtype_id]++;


### PR DESCRIPTION
Fixes hacked parks like `mci.sv6` and the one mentioned in https://www.reddit.com/r/openrct2/comments/45hpvh/invalid_index_255_for_ride_type_error/