### PR TITLE
Use GCC's __builtin_ffs for bitscanforward impl

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -162,6 +162,10 @@ int bitscanforward(int source)
 		int success = __builtin_ffs(source);
 		return success - 1;
 	#else
+	#pragma message "Falling back to iterative bitscan forward, consider using intrinsics"
+	// This is a low-hanging optimisation boost, check if your compiler offers
+	// any intrinsic.
+	// cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
 	for (i = 0; i < 32; i++)
 		if (source & (1u << i))
 			return i;

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -158,6 +158,9 @@ int bitscanforward(int source)
 	#if _MSC_VER >= 1400 // Visual Studio 2005
 		uint8 success = _BitScanForward(&i, source);
 		return success != 0 ? i : -1;
+	#elif __GNUC__
+		int success = __builtin_ffs(source);
+		return success - 1;
 	#else
 	for (i = 0; i < 32; i++)
 		if (source & (1u << i))


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html

>
>— Built-in Function: int __builtin_ffs (int x)
>
>    Returns one plus the index of the least significant 1-bit of x, or if x is zero, returns zero. 