### PR TITLE
Fix overall view position using z coordinate of arbitrary element in same column (fixes #2636)

### DIFF
--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -951,6 +951,15 @@ static rct_window_event_list *window_ride_page_events[] = {
 
 #pragma endregion
 
+// Cached overall view for each ride
+// (Re)calculated when the ride window is opened
+typedef struct ride_overall_view_t {
+	sint16 x, y, z;
+	uint8 zoom;
+} ride_overall_view;
+
+ride_overall_view ride_overall_views[MAX_RIDES] = {0};
+
 const int window_ride_tab_animation_divisor[] = { 0, 0, 2, 2, 4, 2, 8, 8, 2, 0 };
 const int window_ride_tab_animation_frames[] = { 0, 0, 4, 16, 8, 16, 8, 8, 8, 0 };
 
@@ -1168,6 +1177,53 @@ void window_ride_disable_tabs(rct_window *w)
 	w->disabled_widgets = disabled_tabs;
 }
 
+static void window_ride_update_overall_view(uint8 ride_index) {
+	// Calculate x, y, z bounds of the entire ride using its track elements
+	map_element_iterator it;
+
+	map_element_iterator_begin(&it);
+
+	int minx = INT_MAX, miny = INT_MAX, minz = INT_MAX;
+	int maxx = INT_MIN, maxy = INT_MIN, maxz = INT_MIN;
+
+	while (map_element_iterator_next(&it)) {
+		if (map_element_get_type(it.element) != MAP_ELEMENT_TYPE_TRACK)
+			continue;
+
+		if (it.element->properties.track.ride_index != ride_index)
+			continue;
+
+		int x = it.x * 32;
+		int y = it.y * 32;
+		int z1 = it.element->base_height * 8;
+		int z2 = it.element->clearance_height * 8;
+
+		minx = min(minx, x);
+		miny = min(miny, y);
+		minz = min(minz, z1);
+
+		maxx = max(maxx, x);
+		maxy = max(maxy, y);
+		maxz = max(maxz, z2);
+	}
+
+	ride_overall_view *view = &ride_overall_views[ride_index];
+	view->x = (minx + maxx) / 2;
+	view->y = (miny + maxy) / 2;
+	view->z = (minz + maxz) / 2 + 8;
+
+	// Calculate size to determine from how far away to view the ride
+	int dx = maxx - minx;
+	int dy = maxy - miny;
+	int dz = maxz - minz;
+
+	int size = (int) sqrt(dx*dx + dy*dy + dz*dz);
+
+	// Each farther zoom level shows twice as many tiles (log)
+	// Appropriate zoom is lowered by one to fill the entire view with the ride
+	view->zoom = (uint8) max(0, ceil(log(size / 80)) - 1);
+}
+
 /**
  *
  *  rct2: 0x006AEAB4
@@ -1195,6 +1251,8 @@ rct_window *window_ride_open(int rideIndex)
 	w->min_height = 180;
 	w->max_width = 500;
 	w->max_height = 450;
+
+	window_ride_update_overall_view((uint8) rideIndex);
 
 	ride = get_ride(rideIndex);
 	numSubTypes = 0;
@@ -1476,48 +1534,6 @@ static void window_ride_anchor_border_widgets(rct_window *w)
 
 #pragma region Main
 
-static void window_ride_calculate_overall_view(uint8 ride_index, sint16 *cx, sint16 *cy, sint16 *cz, uint8 *zoom) {
-	map_element_iterator it;
-
-	map_element_iterator_begin(&it);
-
-	int minx = INT_MAX, miny = INT_MAX, minz = INT_MAX;
-	int maxx = INT_MIN, maxy = INT_MIN, maxz = INT_MIN;
-
-	while (map_element_iterator_next(&it)) {
-		if (map_element_get_type(it.element) != MAP_ELEMENT_TYPE_TRACK)
-			continue;
-
-		if (it.element->properties.track.ride_index != ride_index)
-			continue;
-
-		int x = it.x * 32;
-		int y = it.y * 32;
-		int z1 = it.element->base_height * 8;
-		int z2 = it.element->clearance_height * 8;
-
-		minx = min(minx, x);
-		miny = min(miny, y);
-		minz = min(minz, z1);
-
-		maxx = max(maxx, x);
-		maxy = max(maxy, y);
-		maxz = max(maxz, z2);
-	}
-
-	*cx = (minx + maxx) / 2;
-	*cy = (miny + maxy) / 2;
-	*cz = (minz + maxz) / 2 + 8;
-
-	int dx = maxx - minx;
-	int dy = maxy - miny;
-	int dz = maxz - minz;
-
-	int size = (int) sqrt(dx*dx + dy*dy + dz*dz);
-
-	*zoom = max(0, ceil(log(size / 64)) - 1);
-}
-
 /**
  *
  *  rct2: 0x006AF994
@@ -1570,7 +1586,12 @@ static void window_ride_init_viewport(rct_window *w)
 			w->viewport_focus_coordinates.var_480 = 0;
 		}
 
-		window_ride_calculate_overall_view((uint8) w->number, &focus.coordinate.x, &focus.coordinate.y, &focus.coordinate.z, &focus.coordinate.zoom);
+		ride_overall_view *view = &ride_overall_views[w->number];
+
+		focus.coordinate.x = view->x;
+		focus.coordinate.y = view->y;
+		focus.coordinate.z = view->z;
+		focus.coordinate.zoom = view->zoom;
 
 		focus.sprite.type |= 0x40;
 	}

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1531,7 +1531,7 @@ static void window_ride_init_viewport(rct_window *w)
 		focus.coordinate.y = (ride->overall_view & 0xFF00) >> 3;
 		focus.coordinate.x += 16;
 		focus.coordinate.y += 16;
-		focus.coordinate.z = map_element_height(focus.coordinate.x, focus.coordinate.y) & 0xFFFF;
+		focus.coordinate.z = ride->station_heights[0] * 8;
 		focus.sprite.type |= 0x40;
 		focus.coordinate.zoom = 1;
 		if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_NO_TRACK))


### PR DESCRIPTION
This is a proposal to fix #2636 by using the `z` coordinate of the first station.

The `overall_view` variable is updated in three locations in `track.c`:

* Twice specifically for mazes in `place_maze_design` and `set_maze_track` where the station height is already set to the same `z` as the map element used for the `overall_view`. 
* The other case is in `track_place`, where `overall_view` is set to the position of the latest track piece. The last track piece should be the one connecting to the original station, so it also seems to be the right choice for that case.
* Rides without tracks, like shops and the ferris wheel will have their base as the first station.

Screenshot of the fix:

![](http://i.imgur.com/2ul8Khf.png)

And for rollercoasters:

![](https://cloud.githubusercontent.com/assets/285063/13037835/aa2e5a1a-d389-11e5-8f1b-8152ec98b8c5.png)
