### PR TITLE
Change screenshot logic to use palette that is actually used for rendering (fixes #2925)

### DIFF
--- a/src/interface/screenshot.c
+++ b/src/interface/screenshot.c
@@ -70,6 +70,18 @@ void screenshot_check()
 	}
 }
 
+static void screenshot_get_rendered_palette(rct_palette* palette) {
+	for (int i = 0; i < 256; i++) {
+		const SDL_Color *renderedEntry = &gPalette[i];
+		rct_palette_entry *entry = &palette->entries[i];
+
+		entry->red = renderedEntry->r;
+		entry->green = renderedEntry->g;
+		entry->blue = renderedEntry->b;
+		entry->alpha = renderedEntry->a;
+	}
+}
+
 static int screenshot_get_next_path(char *path, int format)
 {
 	char screenshotPath[MAX_PATH];
@@ -122,8 +134,11 @@ int screenshot_dump_bmp()
 	}
 
 	rct_drawpixelinfo *dpi = RCT2_ADDRESS(RCT2_ADDRESS_SCREEN_DPI, rct_drawpixelinfo);
-	rct_palette *palette = RCT2_ADDRESS(RCT2_ADDRESS_PALETTE, rct_palette);
-	if (image_io_bmp_write(dpi, palette, path)) {
+
+	rct_palette renderedPalette;
+	screenshot_get_rendered_palette(&renderedPalette);
+
+	if (image_io_bmp_write(dpi, &renderedPalette, path)) {
 		return index;
 	} else {
 		return -1;
@@ -140,8 +155,11 @@ int screenshot_dump_png()
 	}
 
 	rct_drawpixelinfo *dpi = RCT2_ADDRESS(RCT2_ADDRESS_SCREEN_DPI, rct_drawpixelinfo);
-	rct_palette *palette = RCT2_ADDRESS(RCT2_ADDRESS_PALETTE, rct_palette);
-	if (image_io_png_write(dpi, palette, path)) {
+
+	rct_palette renderedPalette;
+	screenshot_get_rendered_palette(&renderedPalette);
+
+	if (image_io_png_write(dpi, &renderedPalette, path)) {
 		return index;
 	} else {
 		return -1;
@@ -229,8 +247,10 @@ void screenshot_giant()
 		return;
 	}
 
-	rct_palette *palette = RCT2_ADDRESS(RCT2_ADDRESS_PALETTE, rct_palette);
-	image_io_png_write(&dpi, palette, path);
+	rct_palette renderedPalette;
+	screenshot_get_rendered_palette(&renderedPalette);
+
+	image_io_png_write(&dpi, &renderedPalette, path);
 
 	free(dpi.bits);
 
@@ -364,8 +384,10 @@ int cmdline_for_screenshot(const char **argv, int argc)
 
 		viewport_render(&dpi, &viewport, 0, 0, viewport.width, viewport.height);
 
-		rct_palette *palette = RCT2_ADDRESS(RCT2_ADDRESS_PALETTE, rct_palette);
-		image_io_png_write(&dpi, palette, outputPath);
+		rct_palette renderedPalette;
+		screenshot_get_rendered_palette(&renderedPalette);
+
+		image_io_png_write(&dpi, &renderedPalette, outputPath);
 
 		free(dpi.bits);
 	}

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -105,6 +105,8 @@ extern int gNumResolutions;
 extern resolution *gResolutions;
 extern SDL_Window *gWindow;
 
+extern SDL_Color gPalette[256];
+
 extern bool gHardwareDisplay;
 
 extern bool gSteamOverlayActive;


### PR DESCRIPTION
Since the altered palette is only available as `SDL_Color` array there were two options:

* Change the image io functions to take `SDL_Color*` palettes
* Change the screenshot functions to create an `rct_palette` from the `SDL_Color` palette

I think the second option makes the most sense for now, because there's also functions like `sprite_file_export`. Nevertheless, I expect that we'll standardize on `SDL_Color*` at some point later on.