### PR TITLE
Prevent Uncapped FPS in Headless Mode

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -365,7 +365,7 @@ static void openrct2_loop()
 
 	_finished = 0;
 	do {
-		if (gConfigGeneral.uncap_fps && gGameSpeed <= 4) {
+		if (!gOpenRCT2Headless && gConfigGeneral.uncap_fps && gGameSpeed <= 4) {
 			currentTick = SDL_GetTicks();
 			if (uncapTick == 0) {
 				// Reset sprite locations


### PR DESCRIPTION
This fixes an issues with excessive CPU usage when the option is enabled and the system doesn't properly pause for V-Sync.