### PR TITLE
Refactor sprite_flags

### DIFF
--- a/src/cheats.c
+++ b/src/cheats.c
@@ -330,7 +330,7 @@ static void cheat_explode_guests()
 
 	FOR_ALL_GUESTS(sprite_index, peep) {
 		if (scenario_rand_max(6) == 0) {
-			peep->flags |= PEEP_FLAGS_EXPLODE;
+			peep->peep_flags |= PEEP_FLAGS_EXPLODE;
 		}
 	}
 }

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1087,7 +1087,7 @@ void viewport_vehicle_paint_setup(rct_vehicle *vehicle, int imageDirection)
 	int y = vehicle->y;
 	int z = vehicle->z;
 
-	if (vehicle->var_0C & 0x80) {
+	if (vehicle->sprite_flags & SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE) {
 		uint32 ebx = 22965 + vehicle->var_C5;
 		RCT2_GLOBAL(0x9DEA52, uint16) = 0;
 		RCT2_GLOBAL(0x9DEA54, uint16) = 0;

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1087,7 +1087,7 @@ void viewport_vehicle_paint_setup(rct_vehicle *vehicle, int imageDirection)
 	int y = vehicle->y;
 	int z = vehicle->z;
 
-	if (vehicle->sprite_flags & SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE) {
+	if (vehicle->flags & SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE) {
 		uint32 ebx = 22965 + vehicle->var_C5;
 		RCT2_GLOBAL(0x9DEA52, uint16) = 0;
 		RCT2_GLOBAL(0x9DEA54, uint16) = 0;

--- a/src/network/twitch.cpp
+++ b/src/network/twitch.cpp
@@ -304,23 +304,23 @@ static void twitch_parse_followers()
 					}
 				}
 
-				if (peep->flags & PEEP_FLAGS_TWITCH) {
+				if (peep->peep_flags & PEEP_FLAGS_TWITCH) {
 					if (member == NULL) {
 						// Member no longer peep name worthy
-						peep->flags &= ~(PEEP_FLAGS_TRACKING | PEEP_FLAGS_TWITCH);
+						peep->peep_flags &= ~(PEEP_FLAGS_TRACKING | PEEP_FLAGS_TWITCH);
 
 						// TODO set peep name back to number / real name
 					} else {
 						if (member->shouldTrack)
-							peep->flags |= (PEEP_FLAGS_TRACKING);
+							peep->peep_flags |= (PEEP_FLAGS_TRACKING);
 						else if (!member->shouldTrack)
-							peep->flags &= ~(PEEP_FLAGS_TRACKING);
+							peep->peep_flags &= ~(PEEP_FLAGS_TRACKING);
 					}
-				} else if (member != NULL && !(peep->flags & PEEP_FLAGS_LEAVING_PARK)) {
+				} else if (member != NULL && !(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)) {
 					// Peep with same name already exists but not twitch
-					peep->flags |= PEEP_FLAGS_TWITCH;
+					peep->peep_flags |= PEEP_FLAGS_TWITCH;
 					if (member->shouldTrack)
-						peep->flags |= PEEP_FLAGS_TRACKING;
+						peep->peep_flags |= PEEP_FLAGS_TRACKING;
 				}
 			}
 		}
@@ -340,14 +340,14 @@ static void twitch_parse_followers()
 					break;
 
 				AudienceMember *member = &members[memberIndex];
-				if (!is_user_string_id(peep->name_string_idx) && !(peep->flags & PEEP_FLAGS_LEAVING_PARK)) {
+				if (!is_user_string_id(peep->name_string_idx) && !(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)) {
 					// Rename peep and add flags
 					rct_string_id newStringId = user_string_allocate(4, member->name);
 					if (newStringId != 0) {
 						peep->name_string_idx = newStringId;
-						peep->flags |= PEEP_FLAGS_TWITCH;
+						peep->peep_flags |= PEEP_FLAGS_TWITCH;
 						if (member->shouldTrack)
-							peep->flags |= PEEP_FLAGS_TRACKING;
+							peep->peep_flags |= PEEP_FLAGS_TRACKING;
 					}
 				} else {
 					// Peep still yet to be found for member

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -316,15 +316,15 @@ static void peep_update_hunger(rct_peep *peep){
  */
 static void peep_leave_park(rct_peep* peep){
 	peep->guest_heading_to_ride_id = 0xFF;
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK){
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK){
 		if (peep->peep_is_lost_countdown < 60){
 			return;
 		}
 	}
 	else{
 		peep->peep_is_lost_countdown = 254;
-		peep->flags |= PEEP_FLAGS_LEAVING_PARK;
-		peep->flags &= ~PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
+		peep->peep_flags |= PEEP_FLAGS_LEAVING_PARK;
+		peep->peep_flags &= ~PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
 	}
 
 	peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_GO_HOME, 0xFF);
@@ -352,7 +352,7 @@ static void sub_68F8CD(rct_peep *peep)
 		return;
 	}
 
-	if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK)){
+	if (!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)){
 		if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY) {
 			if (peep->energy >= 70 && peep->happiness >= 60) {
 				return;
@@ -398,9 +398,9 @@ static void sub_68F41A(rct_peep *peep, int index)
 		if (peep->action < PEEP_ACTION_NONE_1)
 			peep->action = PEEP_ACTION_NONE_2;
 
-		peep->flags &= ~PEEP_FLAGS_SLOW_WALK;
+		peep->peep_flags &= ~PEEP_FLAGS_SLOW_WALK;
 		if (RCT2_ADDRESS(0x00982134, uint8)[sprite_type] & 1){
-			peep->flags |= PEEP_FLAGS_SLOW_WALK;
+			peep->peep_flags |= PEEP_FLAGS_SLOW_WALK;
 		}
 
 		peep->action_sprite_type = 0xFF;
@@ -411,14 +411,14 @@ static void sub_68F41A(rct_peep *peep, int index)
 	if ((index & 0x1FF) == (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TICKS, uint32) & 0x1FF)){
 		//RCT2_GLOBAL(0x00F1EDFE, uint32) = index; not needed all cases accounted for
 
-		if (peep->flags & PEEP_FLAGS_CROWDED){
+		if (peep->peep_flags & PEEP_FLAGS_CROWDED){
 			uint8 thought_type = RCT2_ADDRESS(0x009823AC, uint8)[scenario_rand() & 0xF];
 			if (thought_type != PEEP_THOUGHT_TYPE_NONE){
 				peep_insert_new_thought(peep, thought_type, 0xFF);
 			}
 		}
 
-		if (peep->flags & PEEP_FLAGS_EXPLODE && peep->x != (sint16)0x8000){
+		if (peep->peep_flags & PEEP_FLAGS_EXPLODE && peep->x != (sint16)0x8000){
 			audio_play_sound_at_location(SOUND_CRASH, peep->x, peep->y, peep->z);
 
 			sprite_misc_3_create(peep->x, peep->y, peep->z + 16);
@@ -428,19 +428,19 @@ static void sub_68F41A(rct_peep *peep, int index)
 			return;
 		}
 
-		if (peep->flags & PEEP_FLAGS_HUNGER){
+		if (peep->peep_flags & PEEP_FLAGS_HUNGER){
 			if (peep->hunger >= 15)peep->hunger -= 15;
 		}
 
-		if (peep->flags & PEEP_FLAGS_BATHROOM){
+		if (peep->peep_flags & PEEP_FLAGS_BATHROOM){
 			if (peep->bathroom <= 180)peep->bathroom += 50;
 		}
 
-		if (peep->flags & PEEP_FLAGS_HAPPINESS){
+		if (peep->peep_flags & PEEP_FLAGS_HAPPINESS){
 			peep->happiness_growth_rate = 5;
 		}
 
-		if (peep->flags & PEEP_FLAGS_NAUSEA){
+		if (peep->peep_flags & PEEP_FLAGS_NAUSEA){
 			peep->nausea_growth_rate = 200;
 			if (peep->nausea <= 130)peep->nausea = 130;
 		}
@@ -483,7 +483,7 @@ static void sub_68F41A(rct_peep *peep, int index)
 		if (peep->state == PEEP_STATE_ON_RIDE || peep->state == PEEP_STATE_ENTERING_RIDE){
 			peep->time_on_ride = min(255, peep->time_on_ride + 1);
 
-			if (peep->flags & PEEP_FLAGS_WOW){
+			if (peep->peep_flags & PEEP_FLAGS_WOW){
 				peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_WOW2, 0xFF);
 			}
 
@@ -504,7 +504,7 @@ static void sub_68F41A(rct_peep *peep, int index)
 
 		if (peep->state == PEEP_STATE_WALKING &&
 			peep->outside_of_park == 0 &&
-			!(peep->flags & PEEP_FLAGS_LEAVING_PARK) &&
+			!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) &&
 			peep->no_of_rides == 0 &&
 			peep->guest_heading_to_ride_id == 0xFF){
 
@@ -535,7 +535,7 @@ static void sub_68F41A(rct_peep *peep, int index)
 				uint8 num_thoughts = 0;
 				uint8 possible_thoughts[5] = { 0 };
 
-				if (peep->flags & PEEP_FLAGS_LEAVING_PARK){
+				if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK){
 					possible_thoughts[num_thoughts++] = PEEP_THOUGHT_TYPE_GO_HOME;
 				}
 				else{
@@ -921,11 +921,11 @@ static void peep_state_reset(rct_peep* peep){
  * Check if lost.
  */
 void peep_check_if_lost(rct_peep* peep){
-	if (!(peep->flags & PEEP_FLAGS_LOST)){
+	if (!(peep->peep_flags & PEEP_FLAGS_LOST)){
 		if (RCT2_GLOBAL(RCT2_ADDRESS_RIDE_COUNT, uint16) < 2)return;
-		peep->flags ^= PEEP_FLAGS_21;
+		peep->peep_flags ^= PEEP_FLAGS_21;
 
-		if (!(peep->flags & PEEP_FLAGS_21)) return;
+		if (!(peep->peep_flags & PEEP_FLAGS_21)) return;
 
 		peep->var_F4++;
 		if (peep->var_F4 != 254)return;
@@ -971,7 +971,7 @@ void peep_check_cant_find_ride(rct_peep* peep){
 * Check if cant find exit.
 */
 void peep_check_cant_find_exit(rct_peep* peep){
-	if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK))
+	if (!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK))
 		return;
 
 	// Peeps who can't find the park exit will continue to get less happy until they find it.
@@ -1114,9 +1114,9 @@ void set_sprite_type(rct_peep* peep, uint8 type){
 	if (peep->action >= PEEP_ACTION_NONE_1)
 		peep->action = PEEP_ACTION_NONE_2;
 
-	peep->flags &= ~PEEP_FLAGS_SLOW_WALK;
+	peep->peep_flags &= ~PEEP_FLAGS_SLOW_WALK;
 	if (RCT2_ADDRESS(0x00982134, uint8)[type] & 1){
-		peep->flags |= PEEP_FLAGS_SLOW_WALK;
+		peep->peep_flags |= PEEP_FLAGS_SLOW_WALK;
 	}
 
 	peep->action_sprite_type = 0xFF;
@@ -1528,7 +1528,7 @@ void peep_update_sitting(rct_peep* peep){
 			return;
 		}
 
-		if ((peep->flags & PEEP_FLAGS_LEAVING_PARK)){
+		if ((peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)){
 			peep_decrement_num_riders(peep);
 			peep->state = PEEP_STATE_WALKING;
 			peep_window_state_update(peep);
@@ -2148,7 +2148,7 @@ static void peep_update_ride_sub_state_2_enter_ride(rct_peep* peep, rct_ride* ri
 		window_invalidate_by_number(WC_RIDE, peep->current_ride);
 	}
 
-	if (peep->flags & PEEP_FLAGS_TRACKING){
+	if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = peep->name_string_idx;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
@@ -3201,7 +3201,7 @@ static void peep_update_ride_sub_state_18(rct_peep* peep){
 
 	peep_on_enter_or_exit_ride(peep, peep->current_ride, 1);
 
-	if (peep->flags & PEEP_FLAGS_TRACKING){
+	if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, uint16) = peep->name_string_idx;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, uint16) = ride->name;
@@ -4671,7 +4671,7 @@ static void peep_update_walking_break_scenery(rct_peep* peep){
 	if(gCheatsDisableVandalism)
 		return;
 
-	if (!(peep->flags & PEEP_FLAGS_ANGRY)){
+	if (!(peep->peep_flags & PEEP_FLAGS_ANGRY)){
 		if (peep->happiness >= 48) return;
 		if (peep->energy < 85) return;
 		if (peep->state != PEEP_STATE_WALKING) return;
@@ -5414,7 +5414,7 @@ static void peep_update_patrolling(rct_peep* peep){
 static void peep_update_walking(rct_peep* peep){
 	if (!checkForPath(peep))return;
 
-	if (peep->flags & PEEP_FLAGS_WAVING){
+	if (peep->peep_flags & PEEP_FLAGS_WAVING){
 		if (peep->action >= PEEP_ACTION_NONE_1){
 			if ((0xFFFF & scenario_rand()) < 936){
 				invalidate_sprite_2((rct_sprite*)peep);
@@ -5429,7 +5429,7 @@ static void peep_update_walking(rct_peep* peep){
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_PHOTO){
+	if (peep->peep_flags & PEEP_FLAGS_PHOTO){
 		if (peep->action >= PEEP_ACTION_NONE_1){
 			if ((0xFFFF & scenario_rand()) < 936){
 				invalidate_sprite_2((rct_sprite*)peep);
@@ -5444,7 +5444,7 @@ static void peep_update_walking(rct_peep* peep){
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_PAINTING){
+	if (peep->peep_flags & PEEP_FLAGS_PAINTING){
 		if (peep->action >= PEEP_ACTION_NONE_1){
 			if ((0xFFFF & scenario_rand()) < 936){
 				invalidate_sprite_2((rct_sprite*)peep);
@@ -5459,7 +5459,7 @@ static void peep_update_walking(rct_peep* peep){
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_LITTER){
+	if (peep->peep_flags & PEEP_FLAGS_LITTER){
 		if (!(peep->next_var_29 & 0x18)){
 			if ((0xFFFF & scenario_rand()) <= 4096){
 				int ebp = (scenario_rand() & 0x3) + 2;
@@ -5537,7 +5537,7 @@ static void peep_update_walking(rct_peep* peep){
 
 	if (peep->state != PEEP_STATE_WALKING)return;
 
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)return;
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)return;
 
 	if (peep->nausea > 140)return;
 
@@ -5699,7 +5699,7 @@ static void peep_update(rct_peep *peep)
 	unsigned int stepsToTake = peep->energy;
 	if (stepsToTake < 95 && peep->state == PEEP_STATE_QUEUING)
 		stepsToTake = 95;
-	if ((peep->flags & PEEP_FLAGS_SLOW_WALK) && peep->state != PEEP_STATE_QUEUING)
+	if ((peep->peep_flags & PEEP_FLAGS_SLOW_WALK) && peep->state != PEEP_STATE_QUEUING)
 		stepsToTake /= 2;
 	if (peep->action == 255 && (peep->next_var_29 & 4)) {
 		stepsToTake /= 2;
@@ -6089,7 +6089,7 @@ rct_peep *peep_generate(int x, int y, int z)
 	peep->action_sprite_image_offset = 0;
 	peep->no_action_frame_no = 0;
 	peep->action_sprite_type = 0;
-	peep->flags = 0;
+	peep->peep_flags = 0;
 	peep->favourite_ride = 0xFF;
 	peep->favourite_ride_rating = 0;
 
@@ -6264,7 +6264,7 @@ void get_arguments_from_action(rct_peep* peep, uint32 *argument_1, uint32* argum
 			*argument_2 = ride->name_arguments;
 		}
 		else{
-			*argument_1 = peep->flags & PEEP_FLAGS_LEAVING_PARK ? STR_LEAVING_PARK : STR_WALKING;
+			*argument_1 = peep->peep_flags & PEEP_FLAGS_LEAVING_PARK ? STR_LEAVING_PARK : STR_WALKING;
 			*argument_2 = 0;
 		}
 		break;
@@ -6628,7 +6628,7 @@ static int peep_has_empty_container(rct_peep* peep){
 
 /* Simplifies 0x690582. Returns 1 if should find bench*/
 static int peep_should_find_bench(rct_peep* peep){
-	if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK)){
+	if (!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)){
 		if (peep_has_food(peep)){
 			if (peep->hunger < 128 || peep->happiness < 128){
 				if (!(peep->next_var_29 & 0x1C)){
@@ -6738,7 +6738,7 @@ static void peep_stop_purchase_thought(rct_peep* peep, uint8 ride_type){
 void peep_set_map_tooltip(rct_peep *peep)
 {
 	if (peep->type == PEEP_TYPE_GUEST) {
-		RCT2_GLOBAL(RCT2_ADDRESS_MAP_TOOLTIP_ARGS + 0, uint16) = peep->flags & PEEP_FLAGS_TRACKING ? 1450 : 1449;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_TOOLTIP_ARGS + 0, uint16) = peep->peep_flags & PEEP_FLAGS_TRACKING ? 1450 : 1449;
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_TOOLTIP_ARGS + 2, uint32) = get_peep_face_sprite_small(peep);
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_TOOLTIP_ARGS + 6, uint16) = peep->name_string_idx;
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_TOOLTIP_ARGS + 8, uint32) = peep->id;
@@ -6916,7 +6916,7 @@ static int peep_interact_with_entrance(rct_peep* peep, sint16 x, sint16 y, rct_m
 		peep_window_state_update(peep);
 		peep->sub_state = 11;
 		peep->time_in_queue = 0;
-		if (peep->flags & PEEP_FLAGS_TRACKING){
+		if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, rct_string_id) = peep->name_string_idx;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, rct_string_id) = ride->name;
@@ -6944,7 +6944,7 @@ static int peep_interact_with_entrance(rct_peep* peep, sint16 x, sint16 y, rct_m
 			if (peep->state != PEEP_STATE_WALKING)
 				return peep_return_to_center_of_tile(peep);
 
-			if (!(peep->flags & PEEP_FLAGS_LEAVING_PARK)){
+			if (!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)){
 				// If the park is open and leaving flag isnt set return to center
 				if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_PARK_OPEN)
 					return peep_return_to_center_of_tile(peep);
@@ -6962,7 +6962,7 @@ static int peep_interact_with_entrance(rct_peep* peep, sint16 x, sint16 y, rct_m
 			peep_window_state_update(peep);
 
 			peep->var_37 = 0;
-			if (peep->flags & PEEP_FLAGS_TRACKING){
+			if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, rct_string_id) = peep->name_string_idx;
 				RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 				if (gConfigNotifications.guest_left_park) {
@@ -7068,7 +7068,7 @@ static int peep_interact_with_entrance(rct_peep* peep, sint16 x, sint16 y, rct_m
 			RCT2_GLOBAL(RCT2_ADDRESS_INCOME_FROM_ADMISSIONS, money32) += entranceFee;
 			RCT2_GLOBAL(RCT2_ADDRESS_NEXT_EXPENDITURE_TYPE, uint8) = RCT_EXPENDITURE_TYPE_PARK_ENTRANCE_TICKETS * 4;
 			peep_spend_money(peep, &peep->paid_to_enter, entranceFee);
-			peep->flags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
+			peep->peep_flags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
 		}
 
 		RCT2_GLOBAL(RCT2_ADDRESS_TOTAL_ADMISSIONS, uint32)++;
@@ -7297,7 +7297,7 @@ static int peep_interact_with_path(rct_peep* peep, sint16 x, sint16 y, rct_map_e
 		peep->sub_state = 10;
 		peep->destination_tolerence = 2;
 		peep->time_in_queue = 0;
-		if (peep->flags & PEEP_FLAGS_TRACKING){
+		if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, rct_string_id) = peep->name_string_idx;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, rct_string_id) = ride->name;
@@ -7343,7 +7343,7 @@ static int peep_interact_with_shop(rct_peep* peep, sint16 x, sint16 y, rct_map_e
 	if (peep->var_79 == rideIndex)
 		return peep_return_to_center_of_tile(peep);
 
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
 		return peep_return_to_center_of_tile(peep);
 
 	if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_PEEP_SHOULD_GO_INSIDE_FACILITY)){
@@ -7370,7 +7370,7 @@ static int peep_interact_with_shop(rct_peep* peep, sint16 x, sint16 y, rct_map_e
 
 		peep->time_on_ride = 0;
 		ride->cur_num_customers++;
-		if (peep->flags & PEEP_FLAGS_TRACKING){
+		if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS, rct_string_id) = peep->name_string_idx;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2, uint32) = peep->id;
 			RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6, rct_string_id) = ride->name;
@@ -7710,14 +7710,14 @@ uint8 sub_69A60A(rct_peep* peep){
 
 	RCT2_GLOBAL(0x00F1AED8, uint32) = 0x3A98;
 	RCT2_GLOBAL(0x00F1AEDD, uint8) = 0;
-	if ((peep->flags & PEEP_FLAGS_2)){
+	if ((peep->peep_flags & PEEP_FLAGS_2)){
 		if ((scenario_rand() & 0xFFFF) <= 7281)
-			peep->flags &= ~PEEP_FLAGS_2;
+			peep->peep_flags &= ~PEEP_FLAGS_2;
 
 		return 16;
 	}
 
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK &&
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK &&
 		peep->peep_is_lost_countdown < 90){
 		return 16;
 	}
@@ -7725,7 +7725,7 @@ uint8 sub_69A60A(rct_peep* peep){
 	if (peep->item_standard_flags & PEEP_ITEM_MAP)
 		return 14;
 
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
 		return 14;
 
 	return 10;
@@ -7998,12 +7998,12 @@ static int guest_path_find_park_entrance(rct_peep* peep, rct_map_element *map_el
 	uint8 entranceNum;
 	
 	// Resolves already-corrupt guests (e.g. loaded from save)
-	if (peep->flags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN &&
+	if (peep->peep_flags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN &&
 		(peep->current_ride >= 4 ||
 		 RCT2_ADDRESS(RCT2_ADDRESS_PARK_ENTRANCE_X, sint16)[peep->current_ride] == (sint16)0x8000)
-		) peep->flags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
+		) peep->peep_flags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
 
-	if (!(peep->flags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN)){
+	if (!(peep->peep_flags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN)){
 		uint8 chosenEntrance = 0xFF;
 		uint16 nearestDist = 0xFFFF;
 		for (entranceNum = 0; entranceNum < 4; ++entranceNum){
@@ -8024,7 +8024,7 @@ static int guest_path_find_park_entrance(rct_peep* peep, rct_map_element *map_el
 			return guest_path_find_aimless(peep, edges);
 
 		peep->current_ride = chosenEntrance;
-		peep->flags |= PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
+		peep->peep_flags |= PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
 	}
 
 	entranceNum = peep->current_ride;
@@ -8270,7 +8270,7 @@ static int guest_path_finding(rct_peep* peep)
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
 		return guest_path_find_park_entrance(peep, mapElement, edges);
 
 	if (peep->guest_heading_to_ride_id == 0xFF)
@@ -8559,12 +8559,12 @@ static void peep_on_enter_ride(rct_peep *peep, int rideIndex)
  */
 static void peep_update_favourite_ride(rct_peep *peep, rct_ride *ride)
 {
-	peep->flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
+	peep->peep_flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
 	uint8 peepRideRating = clamp(0, (ride->excitement / 4) + peep->happiness, 255);
 	if (peepRideRating >= peep->favourite_ride_rating) {
 		if (peep->happiness >= 160 && peep->happiness_growth_rate >= 160) {
 			peep->favourite_ride_rating = peepRideRating;
-			peep->flags |= PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
+			peep->peep_flags |= PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
 		}
 	}
 }
@@ -8779,8 +8779,8 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 {
 	rct_ride *ride = get_ride(rideIndex);
 
-	if (peep->flags & PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE) {
-		peep->flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
+	if (peep->peep_flags & PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE) {
+		peep->peep_flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
 		peep->favourite_ride = rideIndex;
 		// TODO fix this flag name or add another one
 		peep->window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
@@ -8789,8 +8789,8 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 	peep->nausea = peep->nausea_growth_rate;
 	peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_STATS;
 	
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK)
-		peep->flags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
+		peep->peep_flags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
 
 	if (peep_should_go_on_ride_again(peep, ride)) {
 		peep->guest_heading_to_ride_id = rideIndex;
@@ -8810,7 +8810,7 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_NICE_RIDE) {
+	if (peep->peep_flags & PEEP_FLAGS_NICE_RIDE) {
 		peep_insert_new_thought(peep, PEEP_THOUGHT_NICE_RIDE, 255);
 	}
 
@@ -9040,7 +9040,7 @@ loc_69B221:
 
 	peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
 	peep_update_sprite_type(peep);
-	if (peep->flags & PEEP_FLAGS_TRACKING) {
+	if (peep->peep_flags & PEEP_FLAGS_TRACKING) {
 		RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS,uint16) = peep->name_string_idx;
 		RCT2_GLOBAL((RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2), uint32) = peep->id;
 		RCT2_GLOBAL((RCT2_ADDRESS_COMMON_FORMAT_ARGS + 6), uint16) = (shopItem >= 32 ? STR_SHOP_ITEM_INDEFINITE_PHOTO2 + (shopItem - 32) : STR_SHOP_ITEM_INDEFINITE_BALLOON + shopItem);
@@ -9099,7 +9099,7 @@ loc_69B221:
 static bool peep_should_use_cash_machine(rct_peep *peep, int rideIndex)
 {
 	if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY) return false;
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK) return false;
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) return false;
 	if (peep->cash_in_pocket > MONEY(20,00)) return false;
 	if (115 + (scenario_rand() % 128) > peep->happiness) return false;
 	if (peep->energy < 80) return false;
@@ -9240,19 +9240,19 @@ static void peep_give_passing_peeps_ice_cream(rct_peep *peep)
  */
 static void peep_easter_egg_peep_interactions(rct_peep *peep)
 {
-	if (peep->flags & PEEP_FLAGS_PURPLE) {
+	if (peep->peep_flags & PEEP_FLAGS_PURPLE) {
 		peep_give_passing_peeps_purple_clothes(peep);
 	}
 
-	if (peep->flags & PEEP_FLAGS_PIZZA) {
+	if (peep->peep_flags & PEEP_FLAGS_PIZZA) {
 		peep_give_passing_peeps_pizza(peep);
 	}
 
-	if (peep->flags & PEEP_FLAGS_CONTAGIOUS) {
+	if (peep->peep_flags & PEEP_FLAGS_CONTAGIOUS) {
 		peep_make_passing_peeps_sick(peep);
 	}
 
-	if (peep->flags & PEEP_FLAGS_JOY) {
+	if (peep->peep_flags & PEEP_FLAGS_JOY) {
 		if (scenario_rand() <= 1456) {
 			if (peep->action == PEEP_ACTION_NONE_1 || peep->action == PEEP_ACTION_NONE_2) {
 				peep->action = PEEP_ACTION_JOY;
@@ -9264,7 +9264,7 @@ static void peep_easter_egg_peep_interactions(rct_peep *peep)
 		}
 	}
 
-	if (peep->flags & PEEP_FLAGS_ICE_CREAM) {
+	if (peep->peep_flags & PEEP_FLAGS_ICE_CREAM) {
 		peep_give_passing_peeps_ice_cream(peep);
 	}
 }
@@ -9612,7 +9612,7 @@ static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNu
 
 			// Peeps that are leaving the park will refuse to go on any rides, with the exception of free transport rides.
 			if (!(RideData4[ride->type].flags & RIDE_TYPE_FLAG4_TRANSPORT_RIDE) || ride->value == 0xFFFF || ride->price != 0) {
-				if (peep->flags & PEEP_FLAGS_LEAVING_PARK) {
+				if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) {
 					peep_chose_not_to_go_on_ride(peep, rideIndex, peepAtRide, false);
 					return false;
 				}
@@ -9798,7 +9798,7 @@ static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNu
 				if (value != 0xFFFF && !peep_has_voucher_for_free_ride(peep, rideIndex)) {
 
 					// The amount peeps are willing to pay is decreased by 75% if they had to pay to enter the park.
-					if (peep->flags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)
+					if (peep->peep_flags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)
 						value /= 4;
 
 					// Peeps won't pay more than twice the value of the ride.
@@ -9817,7 +9817,7 @@ static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNu
 					// A ride is good value if the price is 50% or less of the ride value and the peep didn't pay to enter the park.
 					if (ride->price <= (money16)(value / 2) && peepAtRide) {
 						if (!(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)) {
-							if (!(peep->flags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)) {
+							if (!(peep->peep_flags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)) {
 								peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_GOOD_VALUE, rideIndex);
 							}
 						}
@@ -9828,7 +9828,7 @@ static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNu
 			// At this point, the peep has decided to go on the ride.
 			if (peepAtRide) {
 				ride_update_popularity(ride, 1);
-				if ((peep->flags & PEEP_FLAGS_INTAMIN) && ride_type_is_intamin(ride->type)) {
+				if ((peep->peep_flags & PEEP_FLAGS_INTAMIN) && ride_type_is_intamin(ride->type)) {
 					peep_insert_new_thought(peep, PEEP_THOUGHT_EXCITED, 255);
 				}
 			}
@@ -9961,7 +9961,7 @@ static void peep_pick_ride_to_go_on(rct_peep *peep)
 
 	if (peep->state != PEEP_STATE_WALKING) return;
 	if (peep->guest_heading_to_ride_id != 255) return;
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK) return;
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) return;
 	if (peep_has_food(peep)) return;
 	if (peep->x == (sint16)0x8000) return;
 
@@ -10074,7 +10074,7 @@ static void peep_head_for_nearest_ride_type(rct_peep *peep, int rideType)
 	if (peep->state != PEEP_STATE_SITTING && peep->state != PEEP_STATE_WATCHING && peep->state != PEEP_STATE_WALKING) {
 		return;
 	}
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK) return;
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) return;
 	if (peep->x == (sint16)0x8000) return;
 	if (peep->guest_heading_to_ride_id != 255) {
 		ride = get_ride(peep->guest_heading_to_ride_id);
@@ -10182,7 +10182,7 @@ static void peep_head_for_nearest_ride_with_flags(rct_peep *peep, int rideTypeFl
 	if (peep->state != PEEP_STATE_SITTING && peep->state != PEEP_STATE_WATCHING && peep->state != PEEP_STATE_WALKING) {
 		return;
 	}
-	if (peep->flags & PEEP_FLAGS_LEAVING_PARK) return;
+	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) return;
 	if (peep->x == (sint16)0x8000) return;
 	if (peep->guest_heading_to_ride_id != 255) {
 		ride = get_ride(peep->guest_heading_to_ride_id);
@@ -10456,7 +10456,7 @@ static void peep_read_map(rct_peep *peep)
 
 static bool peep_heading_for_ride_or_park_exit(rct_peep *peep)
 {
-	return (peep->flags & PEEP_FLAGS_LEAVING_PARK) || peep->guest_heading_to_ride_id != 0xFF;
+	return (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) || peep->guest_heading_to_ride_id != 0xFF;
 }
 
 money32 set_peep_name(int flags, int state, uint16 sprite_index, uint8* text_1, uint8* text_2, uint8* text_3) {
@@ -10505,24 +10505,24 @@ money32 set_peep_name(int flags, int state, uint16 sprite_index, uint8* text_1, 
 
 	peep_update_name_sort(peep);
 
-	peep->flags &= ~PEEP_FLAGS_WAVING;
+	peep->peep_flags &= ~PEEP_FLAGS_WAVING;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_KATIE_BRAYSHAW, peep)) {
-		peep->flags |= PEEP_FLAGS_WAVING;
+		peep->peep_flags |= PEEP_FLAGS_WAVING;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_PHOTO;
+	peep->peep_flags &= ~PEEP_FLAGS_PHOTO;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_CHRIS_SAWYER, peep)) {
-		peep->flags |= PEEP_FLAGS_PHOTO;
+		peep->peep_flags |= PEEP_FLAGS_PHOTO;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_PAINTING;
+	peep->peep_flags &= ~PEEP_FLAGS_PAINTING;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_SIMON_FOSTER, peep)) {
-		peep->flags |= PEEP_FLAGS_PAINTING;
+		peep->peep_flags |= PEEP_FLAGS_PAINTING;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_WOW;
+	peep->peep_flags &= ~PEEP_FLAGS_WOW;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_JOHN_WARDLEY, peep)) {
-		peep->flags |= PEEP_FLAGS_WOW;
+		peep->peep_flags |= PEEP_FLAGS_WOW;
 	}
 
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_MELANIE_WARN, peep)) {
@@ -10534,89 +10534,89 @@ money32 set_peep_name(int flags, int state, uint16 sprite_index, uint8* text_1, 
 		peep->nausea_growth_rate = 0;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_LITTER;
+	peep->peep_flags &= ~PEEP_FLAGS_LITTER;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_LISA_STIRLING, peep)) {
-		peep->flags |= PEEP_FLAGS_LITTER;
+		peep->peep_flags |= PEEP_FLAGS_LITTER;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_LOST;
+	peep->peep_flags &= ~PEEP_FLAGS_LOST;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_DONALD_MACRAE, peep)) {
-		peep->flags |= PEEP_FLAGS_LOST;
+		peep->peep_flags |= PEEP_FLAGS_LOST;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_HUNGER;
+	peep->peep_flags &= ~PEEP_FLAGS_HUNGER;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_KATHERINE_MCGOWAN, peep)) {
-		peep->flags |= PEEP_FLAGS_HUNGER;
+		peep->peep_flags |= PEEP_FLAGS_HUNGER;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_BATHROOM;
+	peep->peep_flags &= ~PEEP_FLAGS_BATHROOM;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_FRANCES_MCGOWAN, peep)) {
-		peep->flags |= PEEP_FLAGS_BATHROOM;
+		peep->peep_flags |= PEEP_FLAGS_BATHROOM;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_CROWDED;
+	peep->peep_flags &= ~PEEP_FLAGS_CROWDED;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_CORINA_MASSOURA, peep)) {
-		peep->flags |= PEEP_FLAGS_CROWDED;
+		peep->peep_flags |= PEEP_FLAGS_CROWDED;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_HAPPINESS;
+	peep->peep_flags &= ~PEEP_FLAGS_HAPPINESS;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_CAROL_YOUNG, peep)) {
-		peep->flags |= PEEP_FLAGS_HAPPINESS;
+		peep->peep_flags |= PEEP_FLAGS_HAPPINESS;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_NAUSEA;
+	peep->peep_flags &= ~PEEP_FLAGS_NAUSEA;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_MIA_SHERIDAN, peep)) {
-		peep->flags |= PEEP_FLAGS_NAUSEA;
+		peep->peep_flags |= PEEP_FLAGS_NAUSEA;
 	}
 
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_KATIE_RODGER, peep)) {
-		peep->flags |= PEEP_FLAGS_LEAVING_PARK;
-		peep->flags &= ~PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
+		peep->peep_flags |= PEEP_FLAGS_LEAVING_PARK;
+		peep->peep_flags &= ~PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_PURPLE;
+	peep->peep_flags &= ~PEEP_FLAGS_PURPLE;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_EMMA_GARRELL, peep)) {
-		peep->flags |= PEEP_FLAGS_PURPLE;
+		peep->peep_flags |= PEEP_FLAGS_PURPLE;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_PIZZA;
+	peep->peep_flags &= ~PEEP_FLAGS_PIZZA;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_JOANNE_BARTON, peep)) {
-		peep->flags |= PEEP_FLAGS_PIZZA;
+		peep->peep_flags |= PEEP_FLAGS_PIZZA;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_CONTAGIOUS;
+	peep->peep_flags &= ~PEEP_FLAGS_CONTAGIOUS;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_FELICITY_ANDERSON, peep)) {
-		peep->flags |= PEEP_FLAGS_CONTAGIOUS;
+		peep->peep_flags |= PEEP_FLAGS_CONTAGIOUS;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_JOY;
+	peep->peep_flags &= ~PEEP_FLAGS_JOY;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_KATIE_SMITH, peep)) {
-		peep->flags |= PEEP_FLAGS_JOY;
+		peep->peep_flags |= PEEP_FLAGS_JOY;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_ANGRY;
+	peep->peep_flags &= ~PEEP_FLAGS_ANGRY;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_EILIDH_BELL, peep)) {
-		peep->flags |= PEEP_FLAGS_ANGRY;
+		peep->peep_flags |= PEEP_FLAGS_ANGRY;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_ICE_CREAM;
+	peep->peep_flags &= ~PEEP_FLAGS_ICE_CREAM;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_NANCY_STILLWAGON, peep)) {
-		peep->flags |= PEEP_FLAGS_ICE_CREAM;
+		peep->peep_flags |= PEEP_FLAGS_ICE_CREAM;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_NICE_RIDE;
+	peep->peep_flags &= ~PEEP_FLAGS_NICE_RIDE;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_ANDY_HINE, peep)) {
-		peep->flags |= PEEP_FLAGS_NICE_RIDE;
+		peep->peep_flags |= PEEP_FLAGS_NICE_RIDE;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_INTAMIN;
+	peep->peep_flags &= ~PEEP_FLAGS_INTAMIN;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_ELISSA_WHITE, peep)) {
-		peep->flags |= PEEP_FLAGS_INTAMIN;
+		peep->peep_flags |= PEEP_FLAGS_INTAMIN;
 	}
 
-	peep->flags &= ~PEEP_FLAGS_HERE_WE_ARE;
+	peep->peep_flags &= ~PEEP_FLAGS_HERE_WE_ARE;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_DAVID_ELLIS, peep)) {
-		peep->flags |= PEEP_FLAGS_HERE_WE_ARE;
+		peep->peep_flags |= PEEP_FLAGS_HERE_WE_ARE;
 	}
 
 	gfx_invalidate_screen();

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -391,7 +391,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -502,7 +502,7 @@ typedef struct {
 		uint8 peep_is_lost_countdown;	// 0xC6
 	};
 	uint8 photo1_ride_ref;			// 0xC7
-	uint32 flags;					// 0xC8
+	uint32 peep_flags;				// 0xC8
 	rct_xyzd8 pathfind_goal;		// 0xCC
 	rct_xyzd8 pathfind_history[4];	// 0xD0
 	uint8 no_action_frame_no;		// 0xE0

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -374,12 +374,6 @@ enum {
 	PEEP_RIDE_DECISION_THINKING = 1 << 2
 };
 
-// Flags used by peep->list_flags
-enum {
-	PEEP_LIST_FLAGS_VISIBLE = 1 << 8, // Peep is eligible to show in summarized guest list window (is inside park?)
-	PEEP_LIST_FLAGS_FLASHING = 1 << 9, // Peep belongs to highlighted group (flashes red on map)
-};
-
 typedef struct {
 	uint8 type;		//0
 	uint8 item;		//1
@@ -397,7 +391,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 list_flags;              // 0x0C Used for highlighting peeps on map with staff list or guest list open
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -139,7 +139,7 @@ void game_command_hire_new_staff_member(int* eax, int* ebx, int* ecx, int* edx, 
 		newPeep->var_C4 = 0;
 		newPeep->type = PEEP_TYPE_STAFF;
 		newPeep->outside_of_park = 0;
-		newPeep->flags = 0;
+		newPeep->peep_flags = 0;
 		newPeep->paid_to_enter = 0;
 		newPeep->paid_on_rides = 0;
 		newPeep->paid_on_food = 0;
@@ -307,9 +307,9 @@ void game_command_set_staff_order(int *eax, int *ebx, int *ecx, int *edx, int *e
 			uint8 sprite_type = order_id & ~0x80;
 			sprite_type += 4;
 			peep->sprite_type = sprite_type;
-			peep->flags &= ~PEEP_FLAGS_SLOW_WALK;
+			peep->peep_flags &= ~PEEP_FLAGS_SLOW_WALK;
 			if(RCT2_ADDRESS(0x00982134, uint8)[sprite_type] & 1){
-				peep->flags |= PEEP_FLAGS_SLOW_WALK;
+				peep->peep_flags |= PEEP_FLAGS_SLOW_WALK;
 			}
 			peep->action_frame = 0;
 			sub_693B58(peep);

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -2503,7 +2503,7 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle) {
 				);
 		}
 
-		train->var_0C |= (1 << 7);
+		train->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 		train->var_C8 = scenario_rand();
 		train->var_CA = scenario_rand();
 
@@ -4095,7 +4095,7 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle) {
 	while (numParticles-- != 0)
 		crashed_vehicle_particle_create(vehicle->colours, vehicle->x, vehicle->y, vehicle->z);
 
-	vehicle->var_0C |= (1 << 7);
+	vehicle->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 	vehicle->var_C5 = 0;
 	vehicle->var_C8 = 0;
 	vehicle->sprite_width = 13;
@@ -4147,7 +4147,7 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle) {
 	for (int i = 0; i < 10; ++i)
 		crashed_vehicle_particle_create(vehicle->colours, vehicle->x - 4, vehicle->y + 8, vehicle->z);
 
-	vehicle->var_0C |= (1 << 7);
+	vehicle->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 	vehicle->var_C5 = 0;
 	vehicle->var_C8 = 0;
 	vehicle->sprite_width = 13;

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -1983,7 +1983,7 @@ void vehicle_peep_easteregg_here_we_are(rct_vehicle* vehicle) {
 		vehicle = GET_VEHICLE(spriteId);
 		for (int i = 0; i < vehicle->num_peeps; ++i) {
 			rct_peep* peep = GET_PEEP(vehicle->peep[i]);
-			if (peep->flags & PEEP_FLAGS_HERE_WE_ARE) {
+			if (peep->peep_flags & PEEP_FLAGS_HERE_WE_ARE) {
 				peep_insert_new_thought(peep, PEEP_THOUGHT_HERE_WE_ARE, peep->current_ride);
 			}
 		}
@@ -2503,7 +2503,7 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle) {
 				);
 		}
 
-		train->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
+		train->flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 		train->var_C8 = scenario_rand();
 		train->var_CA = scenario_rand();
 
@@ -4095,7 +4095,7 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle) {
 	while (numParticles-- != 0)
 		crashed_vehicle_particle_create(vehicle->colours, vehicle->x, vehicle->y, vehicle->z);
 
-	vehicle->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
+	vehicle->flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 	vehicle->var_C5 = 0;
 	vehicle->var_C8 = 0;
 	vehicle->sprite_width = 13;
@@ -4147,7 +4147,7 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle) {
 	for (int i = 0; i < 10; ++i)
 		crashed_vehicle_particle_create(vehicle->colours, vehicle->x - 4, vehicle->y + 8, vehicle->z);
 
-	vehicle->sprite_flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
+	vehicle->flags |= SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
 	vehicle->var_C5 = 0;
 	vehicle->var_C8 = 0;
 	vehicle->sprite_width = 13;

--- a/src/ride/vehicle.h
+++ b/src/ride/vehicle.h
@@ -90,7 +90,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 var_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12

--- a/src/ride/vehicle.h
+++ b/src/ride/vehicle.h
@@ -90,7 +90,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -652,7 +652,7 @@ void window_guest_overview_mouse_up(rct_window *w, int widgetIndex)
 		window_scroll_to_viewport(w);
 		break;
 	case WIDX_TRACK:
-		g_sprite_list[w->number].peep.flags ^= PEEP_FLAGS_TRACKING;
+		g_sprite_list[w->number].peep.peep_flags ^= PEEP_FLAGS_TRACKING;
 		break;
 	}
 }
@@ -1076,7 +1076,7 @@ void window_guest_overview_invalidate(rct_window *w)
 	RCT2_GLOBAL(RCT2_ADDRESS_COMMON_FORMAT_ARGS + 2,uint32) = peep->id;
 
 	w->pressed_widgets &= ~(1<<WIDX_TRACK);
-	if (peep->flags & 0x8){
+	if (peep->peep_flags & PEEP_FLAGS_TRACKING){
 		w->pressed_widgets |= (1<<WIDX_TRACK);
 	}
 

--- a/src/windows/guest_list.c
+++ b/src/windows/guest_list.c
@@ -433,7 +433,7 @@ static void window_guest_list_scrollgetsize(rct_window *w, int scrollIndex, int 
 			if (_window_guest_list_selected_filter != -1)
 				if (window_guest_list_is_peep_in_filter(peep))
 					continue;
-			if (_window_guest_list_tracking_only && !(peep->flags & PEEP_FLAGS_TRACKING))
+			if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
 				continue;
 			numGuests++;
 		}
@@ -495,7 +495,7 @@ static void window_guest_list_scrollmousedown(rct_window *w, int scrollIndex, in
 			if (_window_guest_list_selected_filter != -1)
 				if (window_guest_list_is_peep_in_filter(peep))
 					continue;
-			if (_window_guest_list_tracking_only && !(peep->flags & PEEP_FLAGS_TRACKING))
+			if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
 				continue;
 
 			if (i == 0) {
@@ -656,16 +656,16 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
 		// For each guest
 		FOR_ALL_GUESTS(spriteIndex, peep) {
-			peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
+			peep->flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
 			if (peep->outside_of_park != 0)
 				continue;
 			if (_window_guest_list_selected_filter != -1) {
 				if (window_guest_list_is_peep_in_filter(peep))
 					continue;
 				RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) |= (1 << 0);
-				peep->sprite_flags |= SPRITE_FLAGS_PEEP_FLASHING;
+				peep->flags |= SPRITE_FLAGS_PEEP_FLASHING;
 			}
-			if (_window_guest_list_tracking_only && !(peep->flags & PEEP_FLAGS_TRACKING))
+			if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
 				continue;
 
 			//
@@ -692,7 +692,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 					gfx_draw_sprite(dpi, get_peep_face_sprite_small(peep), 118, y, 0);
 
 					// Tracking icon
-					if (peep->flags & PEEP_FLAGS_TRACKING)
+					if (peep->peep_flags & PEEP_FLAGS_TRACKING)
 						gfx_draw_sprite(dpi, 5129, 112, y, 0);
 
 					// Action
@@ -842,11 +842,11 @@ static void window_guest_list_find_groups()
 	// Set all guests to unassigned
 	FOR_ALL_GUESTS(spriteIndex, peep)
 		if (peep->outside_of_park == 0)
-			peep->sprite_flags |= SPRITE_FLAGS_PEEP_VISIBLE;
+			peep->flags |= SPRITE_FLAGS_PEEP_VISIBLE;
 
 	// For each guest / group
 	FOR_ALL_GUESTS(spriteIndex, peep) {
-		if (peep->outside_of_park != 0 || !(peep->sprite_flags & SPRITE_FLAGS_PEEP_VISIBLE))
+		if (peep->outside_of_park != 0 || !(peep->flags & SPRITE_FLAGS_PEEP_VISIBLE))
 			continue;
 
 		// New group, cap at 240 though
@@ -857,7 +857,7 @@ static void window_guest_list_find_groups()
 		int ax = peep->sprite_index;
 		_window_guest_list_num_groups++;
 		_window_guest_list_groups_num_guests[groupIndex] = 1;
-		peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
+		peep->flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
 
 		get_arguments_from_peep( peep, &_window_guest_list_groups_argument_1[groupIndex], &_window_guest_list_groups_argument_2[groupIndex]);
 		RCT2_GLOBAL(0x00F1EDF6, uint32) = _window_guest_list_groups_argument_1[groupIndex];
@@ -869,7 +869,7 @@ static void window_guest_list_find_groups()
 
 		// Find more peeps that belong to same group
 		FOR_ALL_GUESTS(spriteIndex2, peep2) {
-			if (peep2->outside_of_park != 0 || !(peep2->sprite_flags & SPRITE_FLAGS_PEEP_VISIBLE))
+			if (peep2->outside_of_park != 0 || !(peep2->flags & SPRITE_FLAGS_PEEP_VISIBLE))
 				continue;
 
 			uint32 argument1, argument2;
@@ -880,7 +880,7 @@ static void window_guest_list_find_groups()
 
 			// Assign guest
 			_window_guest_list_groups_num_guests[groupIndex]++;
-			peep2->sprite_flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
+			peep2->flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
 
 			// Add face sprite, cap at 56 though
 			if (_window_guest_list_groups_num_guests[groupIndex] >= 56)

--- a/src/windows/guest_list.c
+++ b/src/windows/guest_list.c
@@ -656,14 +656,14 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
 		// For each guest
 		FOR_ALL_GUESTS(spriteIndex, peep) {
-			peep->list_flags &= ~(PEEP_LIST_FLAGS_FLASHING);
+			peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
 			if (peep->outside_of_park != 0)
 				continue;
 			if (_window_guest_list_selected_filter != -1) {
 				if (window_guest_list_is_peep_in_filter(peep))
 					continue;
 				RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) |= (1 << 0);
-				peep->list_flags |= PEEP_LIST_FLAGS_FLASHING;
+				peep->sprite_flags |= SPRITE_FLAGS_PEEP_FLASHING;
 			}
 			if (_window_guest_list_tracking_only && !(peep->flags & PEEP_FLAGS_TRACKING))
 				continue;
@@ -842,11 +842,11 @@ static void window_guest_list_find_groups()
 	// Set all guests to unassigned
 	FOR_ALL_GUESTS(spriteIndex, peep)
 		if (peep->outside_of_park == 0)
-			peep->list_flags |= PEEP_LIST_FLAGS_VISIBLE;
+			peep->sprite_flags |= SPRITE_FLAGS_PEEP_VISIBLE;
 
 	// For each guest / group
 	FOR_ALL_GUESTS(spriteIndex, peep) {
-		if (peep->outside_of_park != 0 || !(peep->list_flags & PEEP_LIST_FLAGS_VISIBLE))
+		if (peep->outside_of_park != 0 || !(peep->sprite_flags & SPRITE_FLAGS_PEEP_VISIBLE))
 			continue;
 
 		// New group, cap at 240 though
@@ -857,7 +857,7 @@ static void window_guest_list_find_groups()
 		int ax = peep->sprite_index;
 		_window_guest_list_num_groups++;
 		_window_guest_list_groups_num_guests[groupIndex] = 1;
-		peep->list_flags &= ~(PEEP_LIST_FLAGS_VISIBLE);
+		peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
 
 		get_arguments_from_peep( peep, &_window_guest_list_groups_argument_1[groupIndex], &_window_guest_list_groups_argument_2[groupIndex]);
 		RCT2_GLOBAL(0x00F1EDF6, uint32) = _window_guest_list_groups_argument_1[groupIndex];
@@ -869,7 +869,7 @@ static void window_guest_list_find_groups()
 
 		// Find more peeps that belong to same group
 		FOR_ALL_GUESTS(spriteIndex2, peep2) {
-			if (peep2->outside_of_park != 0 || !(peep2->list_flags & PEEP_LIST_FLAGS_VISIBLE))
+			if (peep2->outside_of_park != 0 || !(peep2->sprite_flags & SPRITE_FLAGS_PEEP_VISIBLE))
 				continue;
 
 			uint32 argument1, argument2;
@@ -880,7 +880,7 @@ static void window_guest_list_find_groups()
 
 			// Assign guest
 			_window_guest_list_groups_num_guests[groupIndex]++;
-			peep2->list_flags &= ~(PEEP_LIST_FLAGS_VISIBLE);
+			peep2->sprite_flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
 
 			// Add face sprite, cap at 56 though
 			if (_window_guest_list_groups_num_guests[groupIndex] >= 56)

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -1028,7 +1028,7 @@ static void window_map_paint_peep_overlay(rct_drawpixelinfo *dpi)
 
 		color = 0x14;
 
-		if ((peep->sprite_flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
+		if ((peep->flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
 			if (peep->type == PEEP_TYPE_STAFF) {
 				if ((RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) & (1 << 3)) != 0) {
 					color = 0x8A;

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -1028,7 +1028,7 @@ static void window_map_paint_peep_overlay(rct_drawpixelinfo *dpi)
 
 		color = 0x14;
 
-		if ((peep->list_flags & PEEP_LIST_FLAGS_FLASHING) != 0) {
+		if ((peep->sprite_flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
 			if (peep->type == PEEP_TYPE_STAFF) {
 				if ((RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) & (1 << 3)) != 0) {
 					color = 0x8A;

--- a/src/windows/staff_list.c
+++ b/src/windows/staff_list.c
@@ -314,10 +314,10 @@ void window_staff_list_update(rct_window *w)
 		widget_invalidate(w, WIDX_STAFF_LIST_HANDYMEN_TAB + RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_STAFF_LIST_SELECTED_TAB, uint8));
 		RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) |= (1 << 2);
 		FOR_ALL_STAFF(spriteIndex, peep) {
-			peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
+			peep->flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
 
 			if (peep->staff_type == RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_STAFF_LIST_SELECTED_TAB, uint8)) {
-				peep->sprite_flags |= SPRITE_FLAGS_PEEP_FLASHING;
+				peep->flags |= SPRITE_FLAGS_PEEP_FLASHING;
 			}
 		}
 	}

--- a/src/windows/staff_list.c
+++ b/src/windows/staff_list.c
@@ -314,10 +314,10 @@ void window_staff_list_update(rct_window *w)
 		widget_invalidate(w, WIDX_STAFF_LIST_HANDYMEN_TAB + RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_STAFF_LIST_SELECTED_TAB, uint8));
 		RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_MAP_FLASHING_FLAGS, uint16) |= (1 << 2);
 		FOR_ALL_STAFF(spriteIndex, peep) {
-			peep->list_flags &= ~(PEEP_LIST_FLAGS_FLASHING);
+			peep->sprite_flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
 
 			if (peep->staff_type == RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_STAFF_LIST_SELECTED_TAB, uint8)) {
-				peep->list_flags |= PEEP_LIST_FLAGS_FLASHING;
+				peep->sprite_flags |= SPRITE_FLAGS_PEEP_FLASHING;
 			}
 		}
 	}

--- a/src/world/balloon.c
+++ b/src/world/balloon.c
@@ -70,7 +70,7 @@ void balloon_press(rct_balloon *balloon)
 		return;
 
 	uint32 random = util_rand();
-	if ((balloon->var_0A & 7) || (random & 0xFFFF) < 0x2000) {
+	if ((balloon->sprite_index & 7) || (random & 0xFFFF) < 0x2000) {
 		balloon_pop(balloon);
 		return;
 	}

--- a/src/world/duck.c
+++ b/src/world/duck.c
@@ -167,7 +167,7 @@ static void duck_update_fly_to_water(rct_duck *duck)
  */
 static void duck_update_swim(rct_duck *duck)
 {
-	if ((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TICKS, uint32) + duck->var_0A) & 3)
+	if ((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TICKS, uint32) + duck->sprite_index) & 3)
 		return;
 
 	uint32 randomNumber = scenario_rand();

--- a/src/world/fountain.c
+++ b/src/world/fountain.c
@@ -192,7 +192,7 @@ void jumping_fountain_create(int type, int x, int y, int z, int direction, int f
 
 	jumpingFountain->iteration = iteration;
 	jumpingFountain->var_2E = direction;
-	jumpingFountain->flags = flags;
+	jumpingFountain->fountain_flags = flags;
 	jumpingFountain->sprite_direction = direction << 3;
 	jumpingFountain->var_14 = 33;
 	jumpingFountain->var_09 = 36;
@@ -222,10 +222,10 @@ void jumping_fountain_update(rct_jumping_fountain *jumpingFountain)
 
 	switch (jumpingFountain->misc_identifier) {
 	case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
-		if (jumpingFountain->var_26b == 11 && (jumpingFountain->flags & FOUNTAIN_FLAG_FAST))
+		if (jumpingFountain->var_26b == 11 && (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_FAST))
 			jumping_fountain_continue(jumpingFountain);
 
-		if (jumpingFountain->var_26b == 16 && !(jumpingFountain->flags & FOUNTAIN_FLAG_FAST))
+		if (jumpingFountain->var_26b == 16 && !(jumpingFountain->fountain_flags & FOUNTAIN_FLAG_FAST))
 			jumping_fountain_continue(jumpingFountain);
 		break;
 	case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
@@ -263,20 +263,20 @@ static void jumping_fountain_continue(rct_jumping_fountain *jumpingFountain)
 	if (availableDirections == 0)
 		return;
 
-	if (jumpingFountain->flags & FOUNTAIN_FLAG_TERMINATE)
+	if (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_TERMINATE)
 		return;
 
-	if (jumpingFountain->flags & FOUNTAIN_FLAG_GOTO_EDGE) {
+	if (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_GOTO_EDGE) {
 		jumping_fountain_goto_edge(jumpingFountain, x, y, z, availableDirections);
 		return;
 	}
 
-	if (jumpingFountain->flags & FOUNTAIN_FLAG_BOUNCE) {
+	if (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_BOUNCE) {
 		jumping_fountain_bounce(jumpingFountain, x, y, z, availableDirections);
 		return;
 	}
 
-	if (jumpingFountain->flags & FOUNTAIN_FLAG_SPLIT) {
+	if (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_SPLIT) {
 		jumping_fountain_split(jumpingFountain, x, y, z, availableDirections);
 		return;
 	}
@@ -337,7 +337,7 @@ static void jumping_fountain_goto_edge(rct_jumping_fountain *jumpingFountain, in
 	if ((randomIndex & 0xFFFF) < 0x3333)
 		return;
 
-	if (jumpingFountain->flags & FOUNTAIN_FLAG_SPLIT) {
+	if (jumpingFountain->fountain_flags & FOUNTAIN_FLAG_SPLIT) {
 		jumping_fountain_split(jumpingFountain, x, y, z, availableDirections);
 		return;
 	}
@@ -394,7 +394,7 @@ static void jumping_fountain_split(rct_jumping_fountain *jumpingFountain, int x,
 				type,
 				x, y, z,
 				direction >> 1,
-				jumpingFountain->flags & ~FOUNTAIN_FLAG_7,
+				jumpingFountain->fountain_flags & ~FOUNTAIN_FLAG_7,
 				jumpingFountain->iteration + 1
 			);
 		}
@@ -404,7 +404,7 @@ static void jumping_fountain_split(rct_jumping_fountain *jumpingFountain, int x,
 				type,
 				x, y, z,
 				direction >> 1,
-				jumpingFountain->flags | FOUNTAIN_FLAG_7,
+				jumpingFountain->fountain_flags | FOUNTAIN_FLAG_7,
 				jumpingFountain->iteration + 1
 			);
 		}
@@ -434,7 +434,7 @@ static void jumping_fountain_random(rct_jumping_fountain *jumpingFountain, int x
  */
 static void jumping_fountain_create_next(rct_jumping_fountain *jumpingFountain, int x, int y, int z, int direction)
 {
-	int flags = jumpingFountain->flags & ~FOUNTAIN_FLAG_7;
+	int flags = jumpingFountain->fountain_flags & ~FOUNTAIN_FLAG_7;
 	if (direction & 1)
 		flags |= FOUNTAIN_FLAG_7;
 

--- a/src/world/park.c
+++ b/src/world/park.c
@@ -194,7 +194,7 @@ int calculate_park_rating()
 				continue;
 			if (peep->happiness > 128)
 				num_happy_peeps++;
-			if ((peep->flags & PEEP_FLAGS_LEAVING_PARK) && (peep->peep_is_lost_countdown < 90))
+			if ((peep->peep_flags & PEEP_FLAGS_LEAVING_PARK) && (peep->peep_is_lost_countdown < 90))
 				num_lost_guests++;
 		}
 

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -212,7 +212,7 @@ rct_sprite *create_sprite(uint8 bl)
 	sprite->sprite_width = 0x10;
 	sprite->sprite_height_negative = 0x14;
 	sprite->sprite_height_positive = 0x8;
-	sprite->var_0C = 0;
+	sprite->sprite_flags = 0;
 	sprite->sprite_left = SPRITE_LOCATION_NULL;
 
 	sprite->next_in_quadrant = RCT2_ADDRESS(0xF1EF60, uint16)[0x10000];

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -212,7 +212,7 @@ rct_sprite *create_sprite(uint8 bl)
 	sprite->sprite_width = 0x10;
 	sprite->sprite_height_negative = 0x14;
 	sprite->sprite_height_positive = 0x8;
-	sprite->sprite_flags = 0;
+	sprite->flags = 0;
 	sprite->sprite_left = SPRITE_LOCATION_NULL;
 
 	sprite->next_in_quadrant = RCT2_ADDRESS(0xF1EF60, uint16)[0x10000];

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -56,7 +56,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -88,7 +88,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -109,7 +109,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;					// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -138,7 +138,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;					// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -164,7 +164,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -182,7 +182,7 @@ typedef struct {
 	};
 	uint8 pad_28[0x6];
 	uint8 var_2E;
-	uint8 flags;
+	uint8 fountain_flags;			// 0x2F
 	sint16 target_x;				// 0x30
 	sint16 target_y;				// 0x32
 	uint8 pad_34[0x12];
@@ -198,7 +198,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -223,7 +223,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -265,7 +265,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -294,7 +294,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 sprite_flags;			// 0x0C
+	uint16 flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -56,7 +56,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 var_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -88,7 +88,7 @@ typedef struct {
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 pad_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -108,8 +108,8 @@ typedef struct {
 	uint16 previous;				// 0x06
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;					// 0x09
-	uint16 var_0A;
-	uint8 pad_0C[0x2];
+	uint16 sprite_index;			// 0x0A
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -137,8 +137,8 @@ typedef struct {
 	uint16 previous;				// 0x06
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;					// 0x09
-	uint16 var_0A;
-	uint8 pad_0C[0x2];
+	uint16 sprite_index;			// 0x0A
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -163,7 +163,8 @@ typedef struct {
 	uint16 previous;				// 0x06
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;
-	uint8 pad_0A[0x4];
+	uint16 sprite_index;			// 0x0A
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -196,7 +197,8 @@ typedef struct {
 	uint16 previous;				// 0x06
 	uint8 linked_list_type_offset;	// 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
 	uint8 var_09;
-	uint8 pad_0A[0x4];
+	uint16 sprite_index;			// 0x0A
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -221,7 +223,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 var_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -263,7 +265,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 var_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -292,7 +294,7 @@ typedef struct {
 	// Height from center of sprite to bottom
 	uint8 sprite_height_negative;	// 0x09
 	uint16 sprite_index;			// 0x0A
-	uint16 var_0C;
+	uint16 sprite_flags;			// 0x0C
 	sint16 x;						// 0x0E
 	sint16 y;						// 0x10
 	sint16 z;						// 0x12
@@ -358,6 +360,12 @@ enum {
 	SPRITE_MISC_BALLOON,
 	SPRITE_MISC_DUCK,
 	SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
+};
+
+enum {
+	SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE = 1 << 7,
+	SPRITE_FLAGS_PEEP_VISIBLE = 1 << 8, // Peep is eligible to show in summarized guest list window (is inside park?)
+	SPRITE_FLAGS_PEEP_FLASHING = 1 << 9, // Peep belongs to highlighted group (flashes red on map)
 };
 
 // rct2: 0x010E63BC


### PR DESCRIPTION
I think var_0C of the sprite structure is sprite_flags. This refactors the peep list_flags into this new sprite_flags. The only minor issue is vehicle entries also have a sprite_flags. Any suggestions of a better name?