### PR TITLE
Fix the file dialog on Linux being case sensitive

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4067,6 +4067,7 @@ STR_5759    :Downloading map ... ({INT32} / {INT32})
 STR_5760    :Hong Kong Dollars (HK$)
 STR_5761    :New Taiwan Dollar (NT$)
 STR_5762    :Chinese Yuan (CN{YEN})
+STR_5763    :All files
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2370,6 +2370,8 @@ enum {
 	STR_NEW_TAIWAN_DOLLAR = 5761,
 	STR_CHINESE_YUAN = 5762,
 
+	STR_ALL_FILES = 5763,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -26,6 +26,8 @@
 #include <errno.h>
 #include <fontconfig/fontconfig.h>
 
+#include "../localisation/language.h"
+#include "../localisation/string_ids.h"
 #include "../util/util.h"
 #include "platform.h"
 
@@ -220,6 +222,7 @@ int platform_open_common_file_dialog(filedialog_type type, utf8 *title, utf8 *fi
 	char *flags;
 	char *filter = NULL;
 	char *filterPatternRegex;
+	char *allFilesPatternDescription;
 
 	size = MAX_PATH;
 	dtype = get_dialog_app(executable, &size);
@@ -272,8 +275,9 @@ int platform_open_common_file_dialog(filedialog_type type, utf8 *title, utf8 *fi
 				else
 					filterPatternRegex = (char *)filterPattern;
 
-				filter = (char*) malloc(strlen("--file-filter=\"") + strlen(filterPatternRegex) + 3 + strlen(filterName) + 2 + strlen(" --file-filter=\"All files | *\""));
-				sprintf(filter, "--file-filter=\"%s | %s\" --file-filter=\"All files | *\"", filterName, filterPatternRegex);
+				allFilesPatternDescription = (char *)language_get_string(STR_ALL_FILES);
+				filter = (char*) malloc(strlen("--file-filter=\"") + strlen(filterPatternRegex) + 3 + strlen(filterName) + 2 + strlen(" --file-filter=\"") + strlen(allFilesPatternDescription) + strlen(" | *\""));
+				sprintf(filter, "--file-filter=\"%s | %s\" --file-filter=\"%s | *\"", filterName, filterPatternRegex, allFilesPatternDescription);
 			}
 
 			snprintf(cmd, MAX_PATH, "%s %s %s --title=\"%s\" / %s", executable, action, flags, title, filter?filter:"");


### PR DESCRIPTION
This PR makes Zenity's file filter case insensitive, and also adds an entry for 'All files' to allow easier loading of SC4/SV4 files for landscapes.

KDialog already seemed to be case insensitive. By default it opened the root directory, I changed that to the user directory. Also, the malloc for the filter seemed to lack one byte, so I added that. (Please check that.)