### PR TITLE
Improve wall conversion

### DIFF
--- a/src/rct1.c
+++ b/src/rct1.c
@@ -1377,6 +1377,7 @@ static const rct_object_entry RCT1DefaultObjectsWall[] = {
 	{ 0x00000083, { "WSW     " }, 0 },
 	{ 0x00000083, { "WSWG    " }, 0 },
 	{ 0x00000083, { "WMW     " }, 0 },
+	{ 0x00000083, { "WALLGL16" }, 0 },
 	{ 0x00000083, { "WFW1    " }, 0 },
 	{ 0x00000083, { "WFWG    " }, 0 },
 	{ 0x00000083, { "WPW1    " }, 0 },
@@ -1391,6 +1392,8 @@ static const rct_object_entry RCT1DefaultObjectsWall[] = {
 	{ 0x00000083, { "WBW     " }, 0 },
 	{ 0x00000083, { "WBR1    " }, 0 },
 	{ 0x00000083, { "WBRG    " }, 0 },
+	{ 0x00000083, { "WALLCFAR" }, 0 },	// Should be white wooden fence
+	{ 0x00000083, { "WALLPOST" }, 0 },	// Should be red wooden fence
 	{ 0x00000083, { "WBR2    " }, 0 },
 	{ 0x00000083, { "WBR3    " }, 0 },
 	{ 0x00000083, { "WPW3    " }, 0 },
@@ -1432,7 +1435,6 @@ static const rct_object_entry RCT1DefaultObjectsWall[] = {
 	{ 0x00000083, { "WALLCB16" }, 0 },
 	{ 0x00000083, { "WALLCB32" }, 0 },
 	{ 0x00000083, { "WALLGL8 " }, 0 },
-	{ 0x00000083, { "WALLGL16" }, 0 },
 	{ 0x00000083, { "WALLGL32" }, 0 },
 	{ 0x00000083, { "WALLWD8 " }, 0 },
 	{ 0x00000083, { "WALLWD16" }, 0 },

--- a/src/rct1.c
+++ b/src/rct1.c
@@ -814,13 +814,14 @@ static void rct1_convert_wall(int *type, int *colourA, int *colourB, int *colour
 	case 12:	// creepy gate
 		*colourA = 24;
 		break;
-	case 26:	// medium brown castle wall
+	case 26:	// white wooden fence
+		*type = 12;
+		*colourA = 2;
+		break;
+	case 27:	// red wooden fence
 		*type = 12;
 		*colourA = 25;
 		break;
-	case 27:	// tall castle wall with grey window
-		*type = 12;
-		*colourA = 2;
 	case 50:	// plate glass
 		*colourA = 24;
 		break;
@@ -1392,8 +1393,8 @@ static const rct_object_entry RCT1DefaultObjectsWall[] = {
 	{ 0x00000083, { "WBW     " }, 0 },
 	{ 0x00000083, { "WBR1    " }, 0 },
 	{ 0x00000083, { "WBRG    " }, 0 },
-	{ 0x00000083, { "WALLCFAR" }, 0 },	// Should be white wooden fence
-	{ 0x00000083, { "WALLPOST" }, 0 },	// Should be red wooden fence
+	{ 0x00000083, { "WALLCFAR" }, 0 },	// Slot taken by white wooden fence in RCT1
+	{ 0x00000083, { "WALLPOST" }, 0 },	// Slot taken by red wooden fence in RCT1
 	{ 0x00000083, { "WBR2    " }, 0 },
 	{ 0x00000083, { "WBR3    " }, 0 },
 	{ 0x00000083, { "WPW3    " }, 0 },


### PR DESCRIPTION
OpenRCT2 messes up walls when importing SV4/SC4. This applies both to develop and rct1-import.
This PR fixes the order.

Importing a landscape with develop, before:
![scr162](https://cloud.githubusercontent.com/assets/1478678/13351134/e40640dc-dc84-11e5-83ec-178739ff6628.png)

After:
![scr163](https://cloud.githubusercontent.com/assets/1478678/13351146/f18a0f22-dc84-11e5-87b0-a15367ba3886.png)

