### PR TITLE
Don't make empty boats leave the platform on closed boat rides with passengers still on it, fixes #2728

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,6 +54,7 @@
 - Fix: [#2681] When lowering/raising land/water with clearance checks off, walls still get removed.
 - Fix: [#2693] Multiplayer chat caret does not show true position.
 - Fix: [#2704] OSX Command Key not read for keyboard shortcuts.
+- Fix: [#2728] Closing a boat ride with passengers causes empty boats to leave the platform (original bug).
 - Fix: [#2925] Screenshots don't show night filters.
 - Fix: [#2941] Enter does not work on input box when on the title screen.
 - Fix: [#2948] New Ride window incorrectly said there were track designs available when in multiplayer mode.

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -1304,8 +1304,9 @@ static void train_ready_to_depart(rct_vehicle* vehicle, uint8 num_peeps_on_train
 	}
 
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)){
+		// Original code did not check if the ride was a boat hire, causing empty boats to leave the platform when closing a Boat Ride with passengers on it.
 		if (ride->status != RIDE_STATUS_CLOSED ||
-			ride->num_riders != 0){
+			(ride->num_riders != 0 && ride->type != RIDE_TYPE_BOAT_RIDE)){
 			ride->train_at_station[vehicle->current_station] = 0xFF;
 			vehicle->sub_state = 2;
 			return;


### PR DESCRIPTION
RCT2 contains code that makes vehicles leave the platform when a ride is closed, in order to clear it, as it frequently happens not all vehicles fit into one platform. However, it did not make an exception for the boat ride, causing empty boats to leave the platform.
(An original bug I came across in 2004!)