### PR TITLE
Create temporary workaround for assert problem and cluster vandalism

### DIFF
--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -2672,8 +2672,9 @@ static bool sub_6CA2DF(int *trackType, int *trackDirection, int *rideIndex, int 
 	uint16 original_edxRS16, original_x, original_y, original_z, original_properties;
 	bool original_return = original_sub_6CA2DF(&original_trackType, &original_trackDirection, &original_rideIndex, &original_edxRS16, &original_x, &original_y, &original_z, &original_properties);
 	uint8 original_currentTrackLiftHill = _currentTrackLiftHill;
-
+#if DEBUG_LEVEL_2
 	assert(new_return == original_return);
+#endif
 	if (new_return) {
 		return true;
 	}

--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -33,12 +33,14 @@
 #include "../world/sprite.h"
 #include "dropdown.h"
 #include "../interface/themes.h"
+#include "../network/network.h"
+#include "../windows/error.h"
 
 #define WINDOW_SCENERY_WIDTH	634
 #define WINDOW_SCENERY_HEIGHT	142
 #define SCENERY_BUTTON_WIDTH	66
 #define SCENERY_BUTTON_HEIGHT	80
-
+#define SCENERY_DISABLE_CLUSTER_IN_MULTI_CLIENT true
 enum {
 	WINDOW_SCENERY_TAB_1,
 	WINDOW_SCENERY_TAB_2,
@@ -547,7 +549,13 @@ static void window_scenery_mouseup(rct_window *w, int widgetIndex)
 		window_invalidate(w);
 		break;
 	case WIDX_SCENERY_BUILD_CLUSTER_BUTTON:
-		window_scenery_is_build_cluster_tool_on ^= 1;
+		if (SCENERY_DISABLE_CLUSTER_IN_MULTI_CLIENT && network_get_mode() == NETWORK_MODE_CLIENT) {
+			window_scenery_is_build_cluster_tool_on = 0;
+			window_error_open(STR_CANT_DO_THIS, STR_NOT_ALLOWED_IN_MULTIPLAYER);
+		}
+		else {
+			window_scenery_is_build_cluster_tool_on ^= 1;
+		}
 		window_invalidate(w);
 		break;
 	}


### PR DESCRIPTION
Only assert new_return check in debug mode:
I have noticed people (both me and many other people) having crashes when dealing with diagonal pieces. I've even noticed this line fails if someone is merely deleting track. when this line is disabled, the line right that existed right afterward exits the function and leaves a blank space on the build button. I am sure this is more preferable than the entire game crashing.


Disable Cluster build in MP client:
Due to the frequent abuse of the cluster build button, it feels only right to come up with some sort of temporary damage control until someone can modify the permissions system to allow the cluster build not to pass through. This solution may be bypassable, but it is meant only to provide a temporary workaround. People that are out to vandalise will likely not take the extra effort to vandalise if they do not know how to bypass it, and manually clicking in objects would not be as convenient and likely will prevent them from trying, or at least get a chance to find out who is vandalising the park before they really damage it. I feel disabling the button in multiplayer clients would be worth it, the only downside is things such as forests and schrubbery will require manual placement, but the compromise feels worth it.
