### PR TITLE
Fix Junior RC import, use constants

### DIFF
--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -632,9 +632,6 @@ rct_track_td6* load_track_design(const char *path)
 		if (td4_track_has_boosters(track_design, track_elements))
 			track_design->type = RIDE_TYPE_NULL;
 
-		if (track_design->type == RCT1_RIDE_TYPE_STEEL_MINI_ROLLER_COASTER)
-			track_design->type = RIDE_TYPE_NULL;
-
 		if (track_design->type == RCT1_RIDE_TYPE_WOODEN_ROLLER_COASTER)
 			track_design->type = RIDE_TYPE_WOODEN_ROLLER_COASTER;
 
@@ -654,8 +651,8 @@ rct_track_td6* load_track_design(const char *path)
 			vehicle_object = RCT2_ADDRESS(0x0097F66C, rct_object_entry);
 		} else {
 			int vehicle_type = track_design->vehicle_type;
-			if (vehicle_type == 3 && track_design->type == RIDE_TYPE_INVERTED_ROLLER_COASTER)
-				vehicle_type = 80;
+			if (vehicle_type == RCT1_VEHICLE_TYPE_INVERTED_COASTER_TRAIN && track_design->type == RIDE_TYPE_INVERTED_ROLLER_COASTER)
+				vehicle_type = RCT1_VEHICLE_TYPE_4_ACROSS_INVERTED_COASTER_TRAIN;
 			vehicle_object = &RCT2_ADDRESS(0x0097F0DC, rct_object_entry)[vehicle_type];
 		}
 


### PR DESCRIPTION
Due to missing elements, cars, etc. RCT2 did not allow to import Steel Mini RC. Removing this restriction allows import again, it even detects rocket cars correctly. (Which is remarkable, as the table it uses seems to be using the original implementation!).

Also uses some constants.

It needs to be remarked that the information at address 0x0097F0DC and RCT1AlternativeVehicleMappings[89] is very similar, and can thus be refactored to reduce duplicate code, and to make sure rides imported from S4 and TD4 get treated the same. (Also applies to several other checks like launch modes.)