### PR TITLE
validate windows – not for merging

### DIFF
--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -32,6 +32,7 @@
 #include "../localisation/string_ids.h"
 #include "../localisation/localisation.h"
 #include "../cursors.h"
+#include "widget.h"
 
 #define RCT2_FIRST_WINDOW		(RCT2_ADDRESS(RCT2_ADDRESS_WINDOW_LIST, rct_window))
 #define RCT2_LAST_WINDOW		(RCT2_GLOBAL(RCT2_ADDRESS_NEW_WINDOW_PTR, rct_window*) - 1)
@@ -976,6 +977,10 @@ void widget_invalidate(rct_window *w, int widgetIndex)
 	rct_widget* widget;
 
 	assert(w != NULL);
+	for (int i = 0; i <= widgetIndex; i++)
+	{
+		assert(w->widgets[i].type != WWT_LAST);
+	}
 	widget = &w->widgets[widgetIndex];
 	if (widget->left == -2)
 		return;


### PR DESCRIPTION
This it not for merging, debug purpose only.

I was looking at https://github.com/OpenRCT2/OpenRCT2/issues/1911 and noticed the peep window gets improperly invalidated.

To trigger this assert: load the save from #1911, select a sick guest, view thoughts tab.