### PR TITLE
Fix windows xp font loading problem

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -57,6 +57,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Michael Pham (nightroan)
 * Hielke Morsink (Broxzier)
 * Lucas Riutzel (jackinloadup)
+* Youngjae Yu (YJSoft)
 
 ## Toolchain
 * (Balletie) - OSX

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -957,7 +957,7 @@ bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer)
 	}
 #else
 	log_warning("Compatibility hack: falling back to C:\\Windows\\Fonts");
-	strcat(buffer, "C:\\Windows\\Fonts\\");
+	strcpy(buffer, "C:\\Windows\\Fonts\\");
 	strcat(buffer, font->filename);
 	return true;
 #endif


### PR DESCRIPTION
strcat would corrupt buffer(some weird charactors added before `C:\`), so I changed strcat to strcpy.