### PR TITLE
Fix a bug that cannot delete characters after typing korean on osx

### DIFF
--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -873,6 +873,7 @@ void platform_stop_text_input()
 {
 	SDL_StopTextInput();
 	gTextInput = NULL;
+	gTextInputCompositionActive = false;
 }
 
 static void platform_unload_cursors()

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -709,6 +709,10 @@ void platform_process_messages()
 			gTextInputCompositionActive = ((e.edit.length != 0 || strlen(e.edit.text) != 0) && gTextInputComposition[0] != 0);
 			break;
 		case SDL_TEXTINPUT:
+			// will receive an `SDL_TEXTINPUT` event when a composition is committed.
+			// so, set gTextInputCompositionActive to false.
+			gTextInputCompositionActive = false;
+
 			if (gTextInputLength < gTextInputMaxLength && gTextInput){
 				// HACK ` will close console, so don't input any text
 				if (e.text.text[0] == '`' && gConsoleOpen)


### PR DESCRIPTION
This video that describes bug. ( uploaded by @YJSoft )
https://www.youtube.com/watch?v=McXxVfEkcLY