### PR TITLE
Fix a miscalculation on the track cost (Fixes #3074)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -59,6 +59,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Lucas Riutzel (jackinloadup)
 * Youngjae Yu (YJSoft)
 * Chanwoong Kim (kexplo)
+* Josué Acevedo (Wirlie)
 
 ## Toolchain
 * (Balletie) - OSX

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -4575,9 +4575,6 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		if (!gCheatsDisableClearanceChecks || flags & GAME_COMMAND_FLAG_GHOST){
 			if (!map_can_construct_with_clear_at(x, y, baseZ, clearanceZ, &map_place_non_scenery_clear_func, bl, flags, &cost))
 				return MONEY32_UNDEFINED;
-			else
-				//"map_place_non_scenery_clear_func" multiply the value of "cost" with 10. The value "cost" is needed  without the multiplication.
-				cost = cost / 10;
 		}
 
 		//6c53dc
@@ -4722,7 +4719,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 			support_height = 10;
 		}
 
-		cost += ((support_height / 2) * RCT2_ADDRESS(0x0097DD7A, uint16)[ride->type * 2]) / 2;
+		cost += (((support_height / 2) * RCT2_ADDRESS(0x0097DD7A, uint16)[ride->type * 2]) / 2) * 10;
 
 		//6c56d3
 
@@ -4868,7 +4865,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		RCT2_ADDRESS(0x0099DA34, money32)[type];
 
 	price >>= 16;
-	price = (cost + (price / 2)) * 10;
+	price = cost + ((price / 2) * 10);
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY) {
 		return 0;

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -4575,6 +4575,9 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		if (!gCheatsDisableClearanceChecks || flags & GAME_COMMAND_FLAG_GHOST){
 			if (!map_can_construct_with_clear_at(x, y, baseZ, clearanceZ, &map_place_non_scenery_clear_func, bl, flags, &cost))
 				return MONEY32_UNDEFINED;
+			else
+				//"map_place_non_scenery_clear_func" multiply the value of "cost" with 10. The value "cost" is needed  without the multiplication.
+				cost = cost / 10;
 		}
 
 		//6c53dc
@@ -4719,7 +4722,8 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 			support_height = 10;
 		}
 
-		cost += (support_height / 2) * RCT2_ADDRESS(0x0097DD7A, uint16)[ride->type * 2];
+		cost += ((support_height / 2) * RCT2_ADDRESS(0x0097DD7A, uint16)[ride->type * 2]) / 2;
+
 		//6c56d3
 
 		if (!(flags & GAME_COMMAND_FLAG_APPLY))
@@ -4864,7 +4868,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		RCT2_ADDRESS(0x0099DA34, money32)[type];
 
 	price >>= 16;
-	price = ((cost + price) / 2) * 10;
+	price = (cost + (price / 2)) * 10;
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY) {
 		return 0;


### PR DESCRIPTION
Track cost isn't calculated correctly if a track/ride is placed on a small scenery because to a miscalculation on RCT2. 
This change fixes this issue.
(See: #3074)

---
_Demonstration: Remove a fountain, cost: -$50 dollars._

**Before this fix**
![Image](https://k60.kn3.net/99C31B9EF.png)

Miscalculation: track piece ($22) + scenery(-$249) = -$227 dollars.

**With this fix**
![Image](https://k60.kn3.net/1E5A23830.png)

Calculation: track piece ($22) + scenery(-$50) = -$28 dollars.