### PR TITLE
Make chat history's line height to 15px

### DIFF
--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -68,7 +68,7 @@ void chat_draw()
 	_chatLeft = 10;
 	_chatTop = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_HEIGHT, uint16) - 40 - ((CHAT_HISTORY_SIZE + 1) * 10);
 	_chatRight = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, uint16) - 10;
-	_chatBottom = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_HEIGHT, uint16) - 40;
+	_chatBottom = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_HEIGHT, uint16) - 45;
 	char lineBuffer[CHAT_INPUT_SIZE + 10];
 	char* lineCh = lineBuffer;
 	int x = _chatLeft;

--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -72,10 +72,10 @@ void chat_draw()
 	char lineBuffer[CHAT_INPUT_SIZE + 10];
 	char* lineCh = lineBuffer;
 	int x = _chatLeft;
-	int y = _chatBottom - (10 * 2);
+	int y = _chatBottom - (15 * 2);
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_SPRITE_BASE, uint16) = 224;
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_FONT_FLAGS, uint16) = 0;
-	for (int i = 0; i < CHAT_HISTORY_SIZE; i++, y -= 10) {
+	for (int i = 0; i < CHAT_HISTORY_SIZE; i++, y -= 15) {
 		if (!gChatOpen && SDL_TICKS_PASSED(SDL_GetTicks(), chat_history_get_time(i) + 10000)) {
 			break;
 		}
@@ -87,14 +87,14 @@ void chat_draw()
 		lineCh = utf8_write_codepoint(lineCh, FORMAT_OUTLINE);
 		lineCh = utf8_write_codepoint(lineCh, FORMAT_CELADON);
 		safe_strcpy(lineCh, _chatCurrentLine, CHAT_INPUT_SIZE);
-		y = _chatBottom - 10;
+		y = _chatBottom - 15;
 		gfx_set_dirty_blocks(x, y, x + gfx_get_string_width(lineBuffer) + 7, y + 12);
 		gfx_draw_string(dpi, lineBuffer, 255, x, y);
 		if (_chatCaretTicks < 15) {
 			memcpy(lineBuffer, _chatCurrentLine, gTextInputCursorPosition);
 			lineBuffer[gTextInputCursorPosition] = 0;
 			int caretX = x + gfx_get_string_width(lineBuffer);
-			int caretY = y + 10;
+			int caretY = y + 15;
 
 			gfx_fill_rect(dpi, caretX, caretY, caretX + 6, caretY + 1, 0x38);
 		}


### PR DESCRIPTION
In Korean, 10px is too narrow for line height in chat histories.
I changed them to 15px.

Before:
![image](https://cloud.githubusercontent.com/assets/10726524/13547171/0c8bce10-e30a-11e5-8fc7-42a480472449.png)


After, in Korean:
![image](https://cloud.githubusercontent.com/assets/10726524/13547172/172a67fa-e30a-11e5-98b3-9aef24becdc4.png)


In English(UK):
![image](https://cloud.githubusercontent.com/assets/10726524/13547167/ea755cba-e309-11e5-9c0a-ffefa1236579.png)

Please comment if you have any opinion or that I missed/did wrong.