### PR TITLE
Silence compiler warning

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -216,7 +216,7 @@ utf8 * safe_strtrunc(utf8 * text, size_t size)
 	char *ch = text;
 	char *last = text;
 	uint32 codepoint;
-	while ((codepoint = utf8_get_next(ch, &ch)) != 0) {
+	while ((codepoint = utf8_get_next(ch, (const utf8 **)&ch)) != 0) {
 		if (ch <= sourceLimit) {
 			last = ch;
 		} else {


### PR DESCRIPTION
Though this really should be taken care of properly, see
https://stackoverflow.com/questions/14562845/why-does-passing-char-as-const-char-generate-a-warning