### PR TITLE
Safely support up to 32 cars per train

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -7396,7 +7396,7 @@ void ride_update_max_vehicles(int rideIndex)
 	rct_ride *ride;
 	rct_ride_entry *rideEntry;
 	rct_ride_entry_vehicle *vehicleEntry;
-	uint8 trainLayout[16], numCarsPerTrain, numVehicles;
+	uint8 trainLayout[32], numCarsPerTrain, numVehicles;
 	int trainLength, maxNumTrains;
 
 	ride = get_ride(rideIndex);

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1047,7 +1047,7 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
 
 		ride = get_ride(w->number);
 
-		uint8 trainLayout[16];
+		uint8 trainLayout[32];
 		ride_entry_get_train_layout(ride->subtype, ride->num_cars_per_train, trainLayout);
 
 		rideEntry = get_ride_entry_by_ride(ride);
@@ -2688,7 +2688,7 @@ static void window_ride_vehicle_scrollpaint(rct_window *w, rct_drawpixelinfo *dp
 	// Background
 	gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width, dpi->y + dpi->height, 12);
 
-	uint8 trainLayout[16];
+	uint8 trainLayout[32];
 	ride_entry_get_train_layout(ride->subtype, ride->num_cars_per_train, trainLayout);
 
 	widget = &window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
@@ -4200,7 +4200,7 @@ static void window_ride_colour_invalidate(rct_window *w)
 		window_ride_colour_widgets[WIDX_VEHICLE_MAIN_COLOUR].type = WWT_COLOURBTN;
 		window_ride_colour_widgets[WIDX_VEHICLE_MAIN_COLOUR].image = window_ride_get_colour_button_image(vehicleColour.main);
 
-		uint8 trainLayout[16];
+		uint8 trainLayout[32];
 		ride_entry_get_train_layout(ride->subtype, ride->num_cars_per_train, trainLayout);
 
 		uint32 colourFlags = 0;
@@ -4389,7 +4389,7 @@ static void window_ride_colour_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
 	x = (vehiclePreviewWidget->right - vehiclePreviewWidget->left) / 2;
 	y = vehiclePreviewWidget->bottom - vehiclePreviewWidget->top - 15;
 
-	uint8 trainLayout[16];
+	uint8 trainLayout[32];
 	ride_entry_get_train_layout(ride->subtype, ride->num_cars_per_train, trainLayout);
 
 	// ?


### PR DESCRIPTION
When manually hacking ride files, the game can be made to accept rides with more than previously allowed cars.

This seems to be possible and we can tentatively support that in a safe manner, not one relying on undefined variables.

You can grab the modified files from here: http://www.nedesigns.com/screenshot/2334/30-car-mini-suspended-coaster/
See also discussion in https://openrct2.org/forums/topic/979-car-length-of-rides/

This PR needs some more thorough testing and verifying, perhaps there are other places affected as well that I have not yet noticed – this is very likely as I have only done basic testing.