### PR TITLE
fix #3234 native open window crash problem at OSX

### DIFF
--- a/src/platform/osx.m
+++ b/src/platform/osx.m
@@ -143,18 +143,19 @@ bool platform_open_common_file_dialog(utf8 *outFilename, file_dialog_desc *desc)
 			}
 		}
 		
-		NSString *filePath = [NSString stringWithUTF8String:desc->default_filename];
-		NSString *directory = filePath.stringByDeletingLastPathComponent;
-		NSString *basename = filePath.lastPathComponent;
-		
+		NSString *directory;
 		NSSavePanel *panel;
 		if (desc->type == FD_SAVE)
 		{
+			NSString *filePath = [NSString stringWithUTF8String:desc->default_filename];
+			directory = filePath.stringByDeletingLastPathComponent;
+			NSString *basename = filePath.lastPathComponent;
 			panel = [NSSavePanel savePanel];
 			panel.nameFieldStringValue = [NSString stringWithFormat:@"%@.%@", basename, extensions.firstObject];
 		}
 		else if (desc->type == FD_OPEN)
 		{
+			directory = [NSString stringWithUTF8String:desc->initial_directory];
 			NSOpenPanel *open = [NSOpenPanel openPanel];
 			open.canChooseDirectories = false;
 			open.canChooseFiles = true;


### PR DESCRIPTION
Fix #3234 

since default_filename will be null at opening(function `window_loadsave_mouseup` at `loadsave.c` set default_filename only at save), setting filePath with default_filename will raise exception.
Fixed by setting filePath, basename only at save(since two vars only used at creating nameFieldStringValue) and setting directory with initial_directory at opening.