### PR TITLE
Add console command to set ride type

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -424,6 +424,45 @@ static int cc_echo(const utf8 **argv, int argc)
 	return 0;
 }
 
+static int cc_rides(const utf8 **argv, int argc)
+{
+	if (argc > 0) {
+		if (strcmp(argv[0], "list") == 0) {
+			rct_ride *ride;
+			int i;
+			FOR_ALL_RIDES(i, ride) {
+				char name[128];
+				format_string(name, ride->name, &ride->name_arguments);
+				console_printf("ride %03d type: %02u subtype %03u name %s", i, ride->type, ride->subtype, name);
+			}
+		} else if (strcmp(argv[0], "set") == 0) {
+			if (argc < 4) {
+				console_printf("ride set type <ride id> <ride type> [ride subtype]");
+				return 0;
+			}
+			if (strcmp(argv[1], "type") == 0) {
+				int int_val[3];
+				bool int_valid[3] = { 0 };
+				int_val[0] = console_parse_int(argv[2], &int_valid[0]);
+				int_val[1] = console_parse_int(argv[3], &int_valid[1]);
+				if (argc > 4) {
+					int_val[2] = console_parse_int(argv[4], &int_valid[2]);
+				}
+				if (int_valid[0] && int_valid[1] && (get_ride(int_val[0])->type != RIDE_TYPE_NULL)) {
+					rct_ride *ride = get_ride(int_val[0]);
+					ride->type = int_val[1];
+					if (int_valid[2]) {
+						ride->subtype = int_val[2];
+					}
+				}
+			}
+		}
+	} else {
+		console_printf("subcommands: list, set");
+	}
+	return 0;
+}
+
 static int cc_get(const utf8 **argv, int argc)
 {
 	if (argc > 0) {
@@ -952,7 +991,8 @@ console_command console_command_table[] = {
 	{ "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
 	{ "twitch", cc_twitch, "Twitch API" },
 	{ "reset_user_strings", cc_reset_user_strings, "Resets all user-defined strings, to fix incorrectly occurring 'Chosen name in use already' errors.", "reset_user_strings" },
-	{ "fix_banner_count", cc_fix_banner_count, "Fixes incorrectly appearing 'Too many banners' error by marking every banner entry without a map element as null.", "fix_banner_count" }
+	{ "fix_banner_count", cc_fix_banner_count, "Fixes incorrectly appearing 'Too many banners' error by marking every banner entry without a map element as null.", "fix_banner_count" },
+	{ "rides", cc_rides, "Ride management.", "rides <subcommand>" },
 };
 
 static int cc_windows(const utf8 **argv, int argc) {


### PR DESCRIPTION
https://vid.me/Yh2U

Based on discussion on nedesigns: http://www.nedesigns.com/topic/32012/openrct-advantages-and-disadvantages/page-11

disneylandian192:
> In vanilla, changing a ride track type to crooked house makes the ride track invisible. Certain track types cause the game to crash in this instance (Any diagonal pieces or largest turns). 


inthemanual:
> Corrupt elements take up map data, Crooked house makes things invisible without using any additional map data. It's also the quickest way to make an entire ride invisible. It may be unstable due to certain track types not being able to work with it, but you may be able to find a way to make it work stably. 


This is in no way robust right now and for this reason I fear this might get vetoed. Can cause crashes in native (drawing) code.