### PR TITLE
Include the .dll in appveyor-built debug artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,5 +28,5 @@ artifacts:
   name: OpenRCT2-portable
 - path: .\artifacts\*.exe
   name: OpenRCT2-installer
-- path: .\artifacts\openrct2-symbols.zip
+- path: .\artifacts\openrct2-symbols-*.zip
   name: OpenRCT2 debug symbols

--- a/scripts/ps/publish.ps1
+++ b/scripts/ps/publish.ps1
@@ -104,9 +104,10 @@ function Do-Symbols()
     Write-Host "Publishing OpenRCT2 debug symbols as zip..." -ForegroundColor Cyan
     $artifactsDir = "$rootPath\artifacts"
     $releaseDir = "$rootPath\bin"
-    $outZip     = "$rootPath\artifacts\openrct2-symbols.zip"
+    $outZip     = "$rootPath\artifacts\openrct2-symbols-$GitSha1Short.zip"
 
     Copy-Item -Force          "$releaseDir\openrct2.pdb"       $artifactsDir -ErrorAction Stop
+    Copy-Item -Force          "$releaseDir\openrct2.dll"       $artifactsDir -ErrorAction Stop
 
     # Create archive using 7z (renowned for speed and compression)
     $7zcmd = "7za"
@@ -120,7 +121,7 @@ function Do-Symbols()
             return 1
         }
     }
-    & $7zcmd a -tzip -mx9 $outZip "$artifactsDir\openrct2.pdb" > $null
+    & $7zcmd a -tzip -mx9 $outZip "$artifactsDir\openrct2.pdb" "$artifactsDir\openrct2.dll" > $null
     if ($LASTEXITCODE -ne 0)
     {
         Write-Host "Failed to create zip." -ForegroundColor Red


### PR DESCRIPTION
Including the build artifact alleviates the need to also copy the
portable ZIP over to github issues, in case the build artifacts ever
get lost.