### PR TITLE
Change Japanese Font from msgothic_02.ttf to msgothic.ttc, Fix #3118

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -48,10 +48,10 @@ enum {
 };
 
 static TTFFontSetDescriptor TTFFontMSGothic = {{
-	{ "msgothic_02.ttf",	"MS PGothic",	9,		1,		0,		15,		nullptr },
-	{ "msgothic_02.ttf",	"MS PGothic",	12,		1,		0,		17,		nullptr },
-	{ "msgothic_02.ttf",	"MS PGothic",	12,		1,		0,		17,		nullptr },
-	{ "msgothic_02.ttf",	"MS PGothic",	13,		1,		0,		20,		nullptr },
+	{ "msgothic.ttc",	"MS PGothic",	9,		1,		0,		15,		nullptr },
+	{ "msgothic.ttc",	"MS PGothic",	12,		1,		0,		17,		nullptr },
+	{ "msgothic.ttc",	"MS PGothic",	12,		1,		0,		17,		nullptr },
+	{ "msgothic.ttc",	"MS PGothic",	13,		1,		0,		20,		nullptr },
 }};
 
 static TTFFontSetDescriptor TTFFontMingLiu = {{


### PR DESCRIPTION
In Chinese, there is also a newer MingLiu called "PMingLiu", but it was embedded as a large text pack as ttc. (ttc is a collection file for TrueType Font)  I have tested to use MingLiu_02.ttf in the early stage of utf8 implementation but it won't work, because Windows has **bad** support on TTC, so changing into "msgothic.ttc" should fix the issue.