### PR TITLE
Fix clang optimized builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,11 @@ INCLUDE_DIRECTORIES(${SDL2_INCLUDE_DIRS} ${LIBCURL_INCLUDE_DIRS} ${JANSSON_INCLU
 
 LINK_DIRECTORIES(${SDL2_LIBRARY_DIRS} ${JANSSON_LIBRARY_DIRS} ${LIBCURL_LIBRARY_DIRS} ${PNG_LIBRARY_DIRS} ${ZLIB_LIBRARY_DIRS} ${BREAKPAD_LIBRARY_DIR})
 
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+	# Disable optimizations for clang, to allow optimized builds
+	set_source_files_properties(src/addresses.c PROPERTIES COMPILE_FLAGS -O0)
+endif()
+
 if (WIN32)
 	# build as library for now, replace with add_executable
 	add_library(${PROJECT} SHARED ${ORCT2_SOURCES} ${SPEEX_SOURCES})


### PR DESCRIPTION
This apparently applies to non-Apple clang only.

When passed any optimization level other than 0, clang took liberty and
re-organised arguments passed to `RCT2_CALL*`, even in presence of
attributes put in place to prevent that: optnone,noinline.

This change allows easier project setup. It was previously possible to
produce a clang optimized build by manually recompiling and relinking
addresses.c.o.