### PR TITLE
Peep pathfinding asserts - not for merging

### DIFF
--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -2803,6 +2803,7 @@ static void peep_go_to_ride_exit(rct_peep* peep, rct_ride* ride, sint16 x, sint1
 	sprite_move(x, y, z, (rct_sprite*)peep);
 	invalidate_sprite_2((rct_sprite*)peep);
 
+	assert(peep->current_ride_station < 4);
 	x = ride->exits[peep->current_ride_station] & 0xFF;
 	y = ride->exits[peep->current_ride_station] >> 8;
 	x *= 32;
@@ -3126,6 +3127,7 @@ static void peep_update_ride_sub_state_7(rct_peep* peep){
 
 	if (!(vehicle_entry->flags_b & VEHICLE_ENTRY_FLAG_B_10)){
 		sint16 x, y, z;
+		assert(peep->current_ride_station < 4);
 		x = ride->exits[peep->current_ride_station] & 0xFF;
 		y = ride->exits[peep->current_ride_station] >> 8;
 		z = ride->station_heights[peep->current_ride_station];


### PR DESCRIPTION
I've found a park which exhibits some odd peep AI and have added an assert which gets hit.

[Canyoneer by Xophe.sv6.txt](https://github.com/OpenRCT2/OpenRCT2/files/224504/Canyoneer.by.Xophe.sv6.txt) — this park is taken from http://www.nedesigns.com/park/2132/canyoneer/ and sped up a few in-game days.

Patch these `assert`s, load the attached park and wait a moment. Could be related to #2499.

Tested on: Linux, 0860cf4.

I have not noticed this in any other park so far, though if I do, I will update this issue.

Somewhat related: this park causes a crash sometimes when saving on my system. I haven't yet found where or why.
