### PR TITLE
Drop quotes preventing regex match from travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
     include:
         - os: linux
           env:
-            - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=OpenRCT2"
-            - OPENRCT2_MAKE_OPTS="-j2"
+            - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=OpenRCT2" OPENRCT2_MAKE_OPTS="-j2"
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             - cd build
@@ -23,7 +22,7 @@ matrix:
             - mv OpenRCT2/bin/openrct2 OpenRCT2/ && mv OpenRCT2/share/openrct2 OpenRCT2/data && mv OpenRCT2/share/doc/openrct2 OpenRCT2/doc
             - rm -rf OpenRCT2/bin OpenRCT2/share # remove empty dirs
             - tar cvzf openrct2-linux.tar.gz OpenRCT2/
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ "^(develop|push/)" || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-linux.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=4" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build"; fi
+            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-linux.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=4" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build"; fi
         - os: linux
           env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
         - os: linux
@@ -43,7 +42,7 @@ matrix:
           after_success:
             - cd build/Release
             - zip -r openrct2-osx.zip OpenRCT2.app
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ "^(develop|push/)" || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-osx.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=3" --form "file=@openrct2-osx.zip" "https://openrct2.org/altapi/?command=push-build"; fi
+            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-osx.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=3" --form "file=@openrct2-osx.zip" "https://openrct2.org/altapi/?command=push-build"; fi
         # Following entries used to be included in testing, but they only proved useful while changing things in CMake setup.
         # They are meant to be used when there are changes to CMakeLists.txt
         # - os: linux


### PR DESCRIPTION
Original implementation was only tested in zsh, bash requires the regex
to be without quotes.

Caused Linux & OS X builds not to get pushed to openrct2.org