### PR TITLE
Fix #3318. Mine/Mouse train now can swing on turns.

### DIFF
--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5690,7 +5690,7 @@ static void vehicle_update_swinging_car(rct_vehicle *vehicle)
 									if (ax >= -2730) {
 										bl = 4;
 										if (ax <= 2730) {
-											ax = 1;
+											bl = 1;
 											if (ax >= -910) {
 												bl = 2;
 												if (ax <= 910) {


### PR DESCRIPTION
I fixed a mistake in the implementation, I tested this change (comparing OpenRCT2 and RCT2) and this solves my problem, but I'm not sure if the `ax = 1` code is necessary, I assumed that this is a mistake.