### PR TITLE
Blue transparent console, to make it more obvious the game still accepts input behind it - resolves #3289

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -151,7 +151,7 @@ void console_draw(rct_drawpixelinfo *dpi)
 	}
 
 	// Background
-	gfx_fill_rect(dpi, _consoleLeft, _consoleTop, _consoleRight, _consoleBottom, 10);
+	gfx_fill_rect(dpi, _consoleLeft, _consoleTop, _consoleRight, _consoleBottom, 0x2000000 | 57);
 
 	int x = _consoleLeft + 4;
 	int y = _consoleTop + 4;


### PR DESCRIPTION
Because the game still accepts mouse input behind the console, like clicking on rides and windows, making the console transparent makes it more obvious this is allowed. Scrolling through interfaces and zooming in and out is still disabled.
This resolves #3289