### PR TITLE
Embed OpenRCT2 icon for Windows

### DIFF
--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -197,6 +197,7 @@
     <ClCompile Include="src\world\sprite.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="resources\resource.h" />
     <ClInclude Include="src\addresses.h" />
     <ClInclude Include="src\audio\audio.h" />
     <ClInclude Include="src\audio\mixer.h" />
@@ -300,6 +301,12 @@
     <ClInclude Include="src\world\scenery.h" />
     <ClInclude Include="src\world\sprite.h" />
     <ClInclude Include="src\world\water.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="resources\OpenRCT2.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="resources\logo\icon.ico" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D24D94F6-2A74-480C-B512-629C306CE92F}</ProjectGuid>

--- a/openrct2.vcxproj.filters
+++ b/openrct2.vcxproj.filters
@@ -902,5 +902,18 @@
     <ClInclude Include="src\core\List.hpp">
       <Filter>Source\Core</Filter>
     </ClInclude>
+    <ClInclude Include="resources\resource.h">
+      <Filter>Resource Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="resources\logo\icon.ico">
+      <Filter>Resource Files</Filter>
+    </Image>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="resources\OpenRCT2.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/resources/OpenRCT2.rc
+++ b/resources/OpenRCT2.rc
@@ -1,0 +1,70 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United Kingdom) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDI_ICON                ICON                    "logo\\icon.ico"
+
+#endif    // English (United Kingdom) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -1,0 +1,16 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by OpenRCT2.rc
+//
+#define IDI_ICON                        101
+
+// Next default values for new objects
+//
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        102
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -156,6 +156,7 @@ void platform_enumerate_files_end(int handle);
 int platform_enumerate_directories_begin(const utf8 *directory);
 bool platform_enumerate_directories_next(int handle, utf8 *path);
 void platform_enumerate_directories_end(int handle);
+void platform_init_window_icon();
 
 // Returns the bitmask of the GetLogicalDrives function for windows, 0 for other systems
 int platform_get_drives();

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -892,4 +892,10 @@ utf8* platform_get_username() {
 	}
 }
 
+void platform_init_window_icon()
+{
+	// TODO Create a surface with the window icon
+	// SDL_SetWindowIcon(gWindow, iconSurface)
+}
+
 #endif

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -775,6 +775,7 @@ static void platform_create_window()
 
 	SDL_SetWindowGrab(gWindow, gConfigGeneral.trap_cursor ? SDL_TRUE : SDL_FALSE);
 	SDL_SetWindowMinimumSize(gWindow, 720, 480);
+	platform_init_window_icon();
 
 	// Set the update palette function pointer
 	RCT2_GLOBAL(0x009E2BE4, update_palette_func) = platform_update_palette;


### PR DESCRIPTION
Embeds the OpenRCT2 icon file using Win32 native resources and sets the window icon to it.