### PR TITLE
Revert uint assignment from 7eb3a90, Fixes #3367

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -3370,16 +3370,16 @@ int ride_music_params_update(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint
 			view_y2 < rotatedCoords.y) {
 				goto label58;
 		}
-		uint32 x2 = RCT2_GLOBAL(0x00F438A4, rct_viewport*)->x + ((rotatedCoords.x - RCT2_GLOBAL(0x00F438A4, rct_viewport*)->view_x) >> RCT2_GLOBAL(0x00F438A4, rct_viewport*)->zoom);
-		x2 <<= 16;
+		int x2 = RCT2_GLOBAL(0x00F438A4, rct_viewport*)->x + ((rotatedCoords.x - RCT2_GLOBAL(0x00F438A4, rct_viewport*)->view_x) >> RCT2_GLOBAL(0x00F438A4, rct_viewport*)->zoom);
+		x2 *= 0x10000;
 		uint16 screenwidth = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, uint16);
 		if (screenwidth < 64) {
 			screenwidth = 64;
 		}
 		int pan_x = ((x2 / screenwidth) - 0x8000) >> 4;
 
-		uint32 y2 = RCT2_GLOBAL(0x00F438A4, rct_viewport*)->y + ((rotatedCoords.y - RCT2_GLOBAL(0x00F438A4, rct_viewport*)->view_y) >> RCT2_GLOBAL(0x00F438A4, rct_viewport*)->zoom);
-		y2 <<= 16;
+		int y2 = RCT2_GLOBAL(0x00F438A4, rct_viewport*)->y + ((rotatedCoords.y - RCT2_GLOBAL(0x00F438A4, rct_viewport*)->view_y) >> RCT2_GLOBAL(0x00F438A4, rct_viewport*)->zoom);
+		y2 *= 0x10000;
 		uint16 screenheight = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_HEIGHT, uint16);
 		if (screenheight < 64) {
 			screenheight = 64;


### PR DESCRIPTION
I'm not sure if the change to uint32 (at https://github.com/OpenRCT2/OpenRCT2/commit/7eb3a90cea91025e10862a1e0f54ba0d7c114b16#diff-7279e4f6bdcbe512568b663cd2ed82c1R3373 and https://github.com/OpenRCT2/OpenRCT2/commit/7eb3a90cea91025e10862a1e0f54ba0d7c114b16#diff-7279e4f6bdcbe512568b663cd2ed82c1R3381) is correct because these values (`x2` and `y2`) can have a positive/negative value. 

As I have understood, unsigned values only can have positive values. I'm probably wrong.