### PR TITLE
Fix #3382: Explain what 'Advertise' means (Done)

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4110,6 +4110,7 @@ STR_5801    :Disable littering
 STR_5802    :{SMALLFONT}{BLACK}Stops guests from littering and vomiting
 STR_5803    :{SMALLFONT}{BLACK}Rotate selected map element
 STR_5804    :Mute sound
+STR_5805    :Show this server in the 'Server list' so anyone can find it
 
 
 #############

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -4110,7 +4110,7 @@ STR_5801    :Disable littering
 STR_5802    :{SMALLFONT}{BLACK}Stops guests from littering and vomiting
 STR_5803    :{SMALLFONT}{BLACK}Rotate selected map element
 STR_5804    :Mute sound
-STR_5805    :Show this server in the 'Server list' so anyone can find it
+STR_5805    :{SMALLFONT}{BLACK}If checked, your server will be added to the{NEWLINE}public server list so everyone can find it
 
 
 #############

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2441,6 +2441,8 @@ enum {
 	STR_CHEAT_DISABLE_LITTERING_TIP = 5802,
 
 	STR_SHORTCUT_MUTE_SOUND = 5804,
+	
+	STR_SERVER_TIP_ADVERTISE = 5805,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2442,7 +2442,7 @@ enum {
 
 	STR_SHORTCUT_MUTE_SOUND = 5804,
 	
-	STR_SERVER_TIP_ADVERTISE = 5805,
+	STR_ADVERTISE_SERVER_TIP = 5805,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/windows/server_start.c
+++ b/src/windows/server_start.c
@@ -61,7 +61,7 @@ static rct_widget window_server_start_widgets[] = {
 	{ WWT_SPINNER,			1,	120,	WW-8,	68,			77,		1871,					STR_NONE },					// max players
 	{ WWT_DROPDOWN_BUTTON,	1,	WW-18,	WW-8,	68,			72,		STR_NUMERIC_UP,			STR_NONE },
 	{ WWT_DROPDOWN_BUTTON,	1,	WW-18,	WW-8,	72,			76,		STR_NUMERIC_DOWN,		STR_NONE },
-	{ WWT_CHECKBOX,			1,	6,		WW-8,	85,			91,		STR_ADVERTISE,			STR_NONE },					// advertise checkbox
+	{ WWT_CHECKBOX,			1,	6,		WW-8,	85,			91,		STR_ADVERTISE,			STR_SERVER_TIP_ADVERTISE },			// advertise checkbox
 	{ WWT_DROPDOWN_BUTTON,	1,	6,		106,	WH-6-11,	WH-6,	STR_NEW_GAME,			STR_NONE },					// start server button
 	{ WWT_DROPDOWN_BUTTON,	1,	112,	212,	WH-6-11,	WH-6,	STR_LOAD_GAME,			STR_NONE },
 	{ WIDGETS_END },

--- a/src/windows/server_start.c
+++ b/src/windows/server_start.c
@@ -61,7 +61,7 @@ static rct_widget window_server_start_widgets[] = {
 	{ WWT_SPINNER,			1,	120,	WW-8,	68,			77,		1871,					STR_NONE },					// max players
 	{ WWT_DROPDOWN_BUTTON,	1,	WW-18,	WW-8,	68,			72,		STR_NUMERIC_UP,			STR_NONE },
 	{ WWT_DROPDOWN_BUTTON,	1,	WW-18,	WW-8,	72,			76,		STR_NUMERIC_DOWN,		STR_NONE },
-	{ WWT_CHECKBOX,			1,	6,		WW-8,	85,			91,		STR_ADVERTISE,			STR_SERVER_TIP_ADVERTISE },			// advertise checkbox
+	{ WWT_CHECKBOX,			1,	6,		WW-8,	85,			91,		STR_ADVERTISE,			STR_ADVERTISE_SERVER_TIP },			// advertise checkbox
 	{ WWT_DROPDOWN_BUTTON,	1,	6,		106,	WH-6-11,	WH-6,	STR_NEW_GAME,			STR_NONE },					// start server button
 	{ WWT_DROPDOWN_BUTTON,	1,	112,	212,	WH-6-11,	WH-6,	STR_LOAD_GAME,			STR_NONE },
 	{ WIDGETS_END },


### PR DESCRIPTION
I've made a fix for issue #3382 but, at the same time, I'm not sure about some things

~~Instead of getting a tooltip for it, isn't it better to change the name '**Advertise**' > '**List server**' 
Why? As Advertise isn't the mostly common used word when making a server public, then this tooltip probably isn't needed (If not add it too of course)~~

~~Or can the explanation be better?~~

Everything set