### PR TITLE
Symlink data folder to bin folder with VS install scirpt

### DIFF
--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -379,11 +379,6 @@
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
-    <PreBuildEvent>
-      <Command>XCOPY data bin\data /E /Y</Command>
-      <Message>
-      </Message>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -410,11 +405,6 @@
       <AdditionalDependencies>openrct2-libs-vs2015.lib;imm32.lib;version.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
-    <PreBuildEvent>
-      <Command>XCOPY data bin\data /E /Y</Command>
-      <Message>
-      </Message>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -379,6 +379,11 @@
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PreBuildEvent>
+      <Command>XCOPY data bin\data /E /Y</Command>
+      <Message>
+      </Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -405,6 +410,11 @@
       <AdditionalDependencies>openrct2-libs-vs2015.lib;imm32.lib;version.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PreBuildEvent>
+      <Command>XCOPY data bin\data /E /Y</Command>
+      <Message>
+      </Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/scripts/ps/build.ps1
+++ b/scripts/ps/build.ps1
@@ -28,9 +28,24 @@ $openrct2Path = Join-Path $binPath "openrct2.exe"
 
 function Build-Data()
 {
-    Write-Host "Copying data to bin..." -ForegroundColor Cyan
-    New-Item -Force -ItemType Directory $binPath > $null
-    Copy-Item -Force -Recurse "$rootPath\data" $binPath
+	if(Test-Path "$binPath\data")
+	{
+		$object = Get-Item "$binPath\data"
+		
+		if(-not ([bool]($object.Attributes -band [IO.FileAttributes]::ReparsePoint)))
+		{
+			Write-Host "Copying data to bin..." -ForegroundColor Cyan
+			New-Item -Force -ItemType Directory $binPath > $null
+			Copy-Item -Force -Recurse "$rootPath\data" $binPath
+		}
+		else{
+			Write-Host "Symlink already in place" -ForegroundColor Cyan
+		}
+	}
+	else {
+		Write-Host "Symlink data to bin..." -ForegroundColor Cyan
+		New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
+	}
     return 0
 }
 

--- a/scripts/ps/build.ps1
+++ b/scripts/ps/build.ps1
@@ -28,24 +28,26 @@ $openrct2Path = Join-Path $binPath "openrct2.exe"
 
 function Build-Data()
 {
-	if(Test-Path "$binPath\data")
-	{
-		$object = Get-Item "$binPath\data"
-		
-		if(-not ([bool]($object.Attributes -band [IO.FileAttributes]::ReparsePoint)))
-		{
-			Write-Host "Copying data to bin..." -ForegroundColor Cyan
-			New-Item -Force -ItemType Directory $binPath > $null
-			Copy-Item -Force -Recurse "$rootPath\data" $binPath
-		}
-		else{
-			Write-Host "Symlink already in place" -ForegroundColor Cyan
-		}
-	}
-	else {
-		Write-Host "Symlink data to bin..." -ForegroundColor Cyan
-		New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
-	}
+    if(Test-Path "$binPath\data")
+    {
+        $object = Get-Item "$binPath\data"
+
+        if(-not ([bool]($object.Attributes -band [IO.FileAttributes]::ReparsePoint)))
+        {
+            Write-Host "Copying data to bin..." -ForegroundColor Cyan
+            New-Item -Force -ItemType Directory $binPath > $null
+            Copy-Item -Force -Recurse "$rootPath\data" $binPath
+        }
+        else
+        {
+            Write-Host "Symlink already in place" -ForegroundColor Cyan
+        }
+    }
+    else
+    {
+        Write-Host "Symlink data to bin..." -ForegroundColor Cyan
+        New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
+    }
     return 0
 }
 

--- a/scripts/ps/install.ps1
+++ b/scripts/ps/install.ps1
@@ -19,6 +19,7 @@ $libsVersion = 7
 # Get paths
 $rootPath        = Get-RootPath
 $libsPath        = Join-Path $rootPath "lib"
+$binPath        = Join-Path $rootPath "bin"
 $zipPath         = Join-Path $libsPath "openrct2-libs-vs2015.zip"
 $libsVersionPath = Join-Path $libsPath "libversion"
 
@@ -35,8 +36,30 @@ if ($currentLibsVersion -ge $libsVersion)
 }
 
 #symlink data to bin\data
-Write-Host "Symlink data to bin..." -ForegroundColor Cyan
-New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
+try {
+    Write-Host "Symlink data to bin..." -ForegroundColor Cyan
+    New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
+} 
+catch [System.Management.Automation.ParameterBindingException] {
+	Write-Host "Your powershell can not create symlinks" -ForegroundColor Red
+	Write-Host "Copying data to bin..." -ForegroundColor Cyan
+	New-Item -Force -ItemType Directory $binPath > $null
+	Copy-Item -Force -Recurse "$rootPath\data" $binPath
+} 
+catch {
+    Write-Host "Symlink not possible" -ForegroundColor Red
+    if($force) {
+        Write-Host "Copying data to bin..." -ForegroundColor Cyan
+        New-Item -Force -ItemType Directory $binPath > $null
+        Copy-Item -Force -Recurse "$rootPath\data" $binPath
+    }
+    else
+    {
+        Write-Host "You need to run powershell in administration mode to symlink the data folder" -ForegroundColor Red
+        Write-Host "Or run the script in force mode to copy the data folder" -ForegroundColor Red
+        throw
+    }
+}
 
 # Check if user needs to download dependencies
 $libsPathExists = Test-Path $libsPath

--- a/scripts/ps/install.ps1
+++ b/scripts/ps/install.ps1
@@ -19,7 +19,7 @@ $libsVersion = 7
 # Get paths
 $rootPath        = Get-RootPath
 $libsPath        = Join-Path $rootPath "lib"
-$binPath        = Join-Path $rootPath "bin"
+$binPath         = Join-Path $rootPath "bin"
 $zipPath         = Join-Path $libsPath "openrct2-libs-vs2015.zip"
 $libsVersionPath = Join-Path $libsPath "libversion"
 
@@ -36,19 +36,23 @@ if ($currentLibsVersion -ge $libsVersion)
 }
 
 #symlink data to bin\data
-try {
+try
+{
     Write-Host "Symlink data to bin..." -ForegroundColor Cyan
     New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
 } 
-catch [System.Management.Automation.ParameterBindingException] {
-	Write-Host "Your powershell can not create symlinks" -ForegroundColor Red
-	Write-Host "Copying data to bin..." -ForegroundColor Cyan
-	New-Item -Force -ItemType Directory $binPath > $null
-	Copy-Item -Force -Recurse "$rootPath\data" $binPath
-} 
-catch {
+catch [System.Management.Automation.ParameterBindingException] 
+{
+    Write-Host "Your powershell can not create symlinks" -ForegroundColor Red
+    Write-Host "Copying data to bin..." -ForegroundColor Cyan
+    New-Item -Force -ItemType Directory $binPath > $null
+    Copy-Item -Force -Recurse "$rootPath\data" $binPath
+}
+catch
+{
     Write-Host "Symlink not possible" -ForegroundColor Red
-    if($force) {
+    if($force)
+    {
         Write-Host "Copying data to bin..." -ForegroundColor Cyan
         New-Item -Force -ItemType Directory $binPath > $null
         Copy-Item -Force -Recurse "$rootPath\data" $binPath

--- a/scripts/ps/install.ps1
+++ b/scripts/ps/install.ps1
@@ -34,6 +34,10 @@ if ($currentLibsVersion -ge $libsVersion)
     $updateLibs = $false
 }
 
+#symlink data to bin\data
+Write-Host "Symlink data to bin..." -ForegroundColor Cyan
+New-Item -force -ItemType SymbolicLink -Name bin\data -Target data
+
 # Check if user needs to download dependencies
 $libsPathExists = Test-Path $libsPath
 if ($libsPathExists -and -not $updateLibs -and -not $Force)


### PR DESCRIPTION
Today I couldn't run the develop branch because of the langue file chances. This add a build event to Visual Studio that always copy data map to the bin/data map. Then you have always the newest data files when running the game. I seemed to me very handy.
What is your opinion on this subject?