### PR TITLE
Make sure g1.dat and g2.dat are loaded early

### DIFF
--- a/src/rct2.c
+++ b/src/rct2.c
@@ -157,14 +157,15 @@ int rct2_init()
 	gInputPlaceObjectModifier = PLACE_OBJECT_MODIFIER_NONE;
 	// config_load();
 
+	gfx_load_g1();
+	gfx_load_g2();
+
 	object_list_load();
 	scenario_load_list();
 
 	ride_list_item item = { 253, 0 };
 	track_load_list(item);
 
-	gfx_load_g1();
-	gfx_load_g2();
 	font_sprite_initialise_characters();
 	if (!gOpenRCT2Headless) {
 		platform_init();


### PR DESCRIPTION
This makes sure any later references to `g1Elements` will be valid, which will be a case for x86-64.

Making this a separate PR to `develop` to make sure it works for x86 as well.