### PR TITLE
Fix crash issue #3448

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -1575,7 +1575,8 @@ void remove_peep_from_queue(rct_peep* peep)
 		return;
 	}
 
-	for (rct_peep* other_peep = GET_PEEP(ride->last_peep_in_queue[cur_station]);;
+	for (rct_peep* other_peep = GET_PEEP(ride->last_peep_in_queue[cur_station]); 
+		other_peep->next_in_queue != 0xFFFF;
 		other_peep = GET_PEEP(other_peep->next_in_queue)){
 		if (peep->sprite_index == other_peep->next_in_queue){
 			other_peep->next_in_queue = peep->next_in_queue;


### PR DESCRIPTION
Next in queue peep seems to sometimes have the sprite index 0xFFFF, it crashes when it loops over this peep. It happened with a First Aid ride, I tested it and it shouldn't cause any further implications.