### PR TITLE
Added Button to kick every Person out of an attraction

### DIFF
--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2444,6 +2444,8 @@ enum {
 	
 	STR_ADVERTISE_SERVER_TIP = 5805,
 
+	STR_KICK_GUESTS_FROM_ATTRACTION = 5807,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -1035,6 +1035,8 @@ money32 ride_remove_track_piece(int x, int y, int z, int direction, int type);
 bool ride_are_all_possible_entrances_and_exits_built(rct_ride *ride);
 void ride_fix_breakdown(int rideIndex, int reliabilityIncreaseFactor);
 
+void ride_remove_peeps(int rideIndex);
+
 void ride_entry_get_train_layout(int rideEntryIndex, int numCarsPerTrain, uint8 *trainLayout);
 void ride_update_max_vehicles(int rideIndex);
 

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -179,7 +179,8 @@ enum {
 
 	WIDX_SHOW_GUESTS_THOUGHTS = 14,
 	WIDX_SHOW_GUESTS_ON_RIDE,
-	WIDX_SHOW_GUESTS_QUEUING
+	WIDX_SHOW_GUESTS_QUEUING,
+	WIDX_KICK_GUESTS_OUT_OF_ATTRACTION
 };
 
 #define RCT1_LIGHT_OFFSET 4
@@ -477,6 +478,7 @@ static rct_widget window_ride_customer_widgets[] = {
 	{ WWT_FLATBTN,			1,	289,	312,	54,		77,		SPR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION,	STR_SHOW_GUESTS_THOUGHTS_ABOUT_THIS_RIDE_ATTRACTION_TIP	},
 	{ WWT_FLATBTN,			1,	289,	312,	78,		101,	SPR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION,				STR_SHOW_GUESTS_ON_THIS_RIDE_ATTRACTION_TIP				},
 	{ WWT_FLATBTN,			1,	289,	312,	102,	125,	SPR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION,		STR_SHOW_GUESTS_QUEUING_FOR_THIS_RIDE_ATTRACTION_TIP	},
+	{ WWT_FLATBTN,			1,	265,	288,	54,		77,		SPR_GUESTS,	STR_KICK_GUESTS_FROM_ATTRACTION },
 	{ WIDGETS_END },
 };
 
@@ -503,7 +505,7 @@ const uint64 window_ride_page_enabled_widgets[] = {
 	0x000000000007FFF4,
 	0x000000000007BFF4,
 	0x0000000000E73FF4,
-	0x000000000001FFF4
+	0x000000000003FFF4
 };
 
 const uint64 window_ride_page_hold_down_widgets[] = {
@@ -5952,6 +5954,9 @@ static void window_ride_customer_mouseup(rct_window *w, int widgetIndex)
 	case WIDX_SHOW_GUESTS_QUEUING:
 		window_guest_list_open_with_filter(1, w->number);
 		break;
+	case WIDX_KICK_GUESTS_OUT_OF_ATTRACTION:
+		ride_remove_peeps(w->number);
+		break;
 	}
 }
 
@@ -6013,10 +6018,13 @@ static void window_ride_customer_invalidate(rct_window *w)
 	if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP)) {
 		window_ride_customer_widgets[WIDX_SHOW_GUESTS_ON_RIDE].type = WWT_EMPTY;
 		window_ride_customer_widgets[WIDX_SHOW_GUESTS_QUEUING].type = WWT_EMPTY;
+		window_ride_customer_widgets[WIDX_KICK_GUESTS_OUT_OF_ATTRACTION].type = WWT_EMPTY;
 	} else {
 		window_ride_customer_widgets[WIDX_SHOW_GUESTS_ON_RIDE].type = WWT_FLATBTN;
 		window_ride_customer_widgets[WIDX_SHOW_GUESTS_QUEUING].type = WWT_FLATBTN;
+		window_ride_customer_widgets[WIDX_KICK_GUESTS_OUT_OF_ATTRACTION].type = WWT_FLATBTN;
 	}
+	
 
 	window_ride_anchor_border_widgets(w);
 	window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_10);


### PR DESCRIPTION
Added Button to kick every Person without the need to close the attraction. For issue #3453.

Please note: We still need to add the string to the language-files:
STR_5807    :Kick all Guests out
or sth. similar.

It adds a button to the guest-tab for every attraction except shops (and so toilets).

Please have a look on it, because the issue was not very detailed. I hope I understood it correctly :D

![twist1](https://cloud.githubusercontent.com/assets/3903469/14932258/e618b0c8-0e73-11e6-8816-f2672fe89e69.png)

