### PR TITLE
Try loading objects for x86-64

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -36,6 +36,8 @@
 
 #if defined(__i386__) || defined(_M_IX86)
 #define PLATFORM_X86
+#else
+#define NO_RCT2 1
 #endif
 
 #ifdef PLATFORM_X86

--- a/src/drawing/drawing.c
+++ b/src/drawing/drawing.c
@@ -183,7 +183,7 @@ void load_palette(){
 
 	uint32 palette = 0x5FC;
 
-	if ((sint32)water_type != -1){
+	if ((uintptr_t)water_type != (uint32)-1){
 		palette = water_type->image_id;
 	}
 

--- a/src/drawing/drawing.h
+++ b/src/drawing/drawing.h
@@ -35,7 +35,7 @@ typedef struct {
 	uint16 zoom_level;	// 0x0E
 } rct_drawpixelinfo;
 
-// Size: 0x10
+// Size: 0x10 or more
 typedef struct {
 	uint8* offset;			// 0x00
 	sint16 width;			// 0x04
@@ -45,6 +45,17 @@ typedef struct {
 	uint16 flags;			// 0x0C
 	uint16 zoomed_offset;	// 0x0E
 } rct_g1_element;
+
+// Size: 0x10
+typedef struct {
+		uint32 offset;                  // 0x00 note: uint32 always!
+		sint16 width;                   // 0x04
+		sint16 height;                  // 0x06
+		sint16 x_offset;                // 0x08
+		sint16 y_offset;                // 0x0A
+		uint16 flags;                   // 0x0C
+		uint16 zoomed_offset;   // 0x0E
+} rct_g1_element_32bit;
 
 enum{
 	G1_FLAG_BMP = (1 << 0), //No invisible sections

--- a/src/drawing/sprite.c
+++ b/src/drawing/sprite.c
@@ -56,17 +56,6 @@ int gfx_load_g1()
 			 * pointers to however long our machine wants them.
 			 */
 
-			// Size: 0x10
-			typedef struct {
-				uint32 offset;			// 0x00 note: uint32 always!
-				sint16 width;			// 0x04
-				sint16 height;			// 0x06
-				sint16 x_offset;		// 0x08
-				sint16 y_offset;		// 0x0A
-				uint16 flags;			// 0x0C
-				uint16 zoomed_offset;	// 0x0E
-			} rct_g1_element_32bit;
-
 			/* number of elements is stored in g1.dat, but because the entry
 			 * headers are static, this can't be variable until made into a
 			 * dynamic array.
@@ -96,8 +85,9 @@ int gfx_load_g1()
 			SDL_RWclose(file);
 
 			// Fix entry data offsets
-			for (i = 0; i < header.num_entries; i++)
+			for (i = 0; i < header.num_entries; i++) {
 				g1Elements[i].offset += (uintptr_t)_g1Buffer;
+			}
 
 			// Successful
 			return 1;

--- a/src/drawing/sprite.c
+++ b/src/drawing/sprite.c
@@ -35,6 +35,25 @@ rct_gx g2;
 	rct_g1_element *g1Elements = (rct_g1_element*)RCT2_ADDRESS_G1_ELEMENTS;
 #endif
 
+static void read_and_convert_gxdat(SDL_RWops *file, size_t count, rct_g1_element *elements)
+{
+	rct_g1_element_32bit *g1Elements32 = calloc(count, sizeof(rct_g1_element_32bit));
+	SDL_RWread(file, g1Elements32, count * sizeof(rct_g1_element_32bit), 1);
+	for (size_t i = 0; i < count; i++) {
+		/* Double cast to silence compiler warning about casting to
+		 * pointer from integer of mismatched length.
+		 */
+		elements[i].offset        = (uint8*)(uintptr_t)g1Elements32[i].offset;
+		elements[i].width         = g1Elements32[i].width;
+		elements[i].height        = g1Elements32[i].height;
+		elements[i].x_offset      = g1Elements32[i].x_offset;
+		elements[i].y_offset      = g1Elements32[i].y_offset;
+		elements[i].flags         = g1Elements32[i].flags;
+		elements[i].zoomed_offset = g1Elements32[i].zoomed_offset;
+	}
+	free(g1Elements32);
+}
+
 /**
  *
  *  rct2: 0x00678998
@@ -65,18 +84,7 @@ int gfx_load_g1()
 			// Read element headers
 			g1Elements = calloc(324206, sizeof(rct_g1_element));
 
-			rct_g1_element_32bit *g1Elements32 = calloc(324206, sizeof(rct_g1_element_32bit));
-			SDL_RWread(file, g1Elements32, header.num_entries * sizeof(rct_g1_element_32bit), 1);
-			for (int i = 0; i < header.num_entries; i++) {
-				g1Elements[i].offset        = (uint8*)g1Elements32[i].offset;
-				g1Elements[i].width         = g1Elements32[i].width;
-				g1Elements[i].height        = g1Elements32[i].height;
-				g1Elements[i].x_offset      = g1Elements32[i].x_offset;
-				g1Elements[i].y_offset      = g1Elements32[i].y_offset;
-				g1Elements[i].flags         = g1Elements32[i].flags;
-				g1Elements[i].zoomed_offset = g1Elements32[i].zoomed_offset;
-			}
-			free(g1Elements32);
+			read_and_convert_gxdat(file, header.num_entries, g1Elements);
 
 			// Read element data
 			_g1Buffer = malloc(header.total_size);
@@ -128,7 +136,8 @@ int gfx_load_g2()
 		if (SDL_RWread(file, &g2.header, 8, 1) == 1) {
 			// Read element headers
 			g2.elements = malloc(g2.header.num_entries * sizeof(rct_g1_element));
-			SDL_RWread(file, g2.elements, g2.header.num_entries * sizeof(rct_g1_element), 1);
+
+			read_and_convert_gxdat(file, g2.header.num_entries, g2.elements);
 
 			// Read element data
 			g2.data = malloc(g2.header.total_size);

--- a/src/hook.c
+++ b/src/hook.c
@@ -19,6 +19,9 @@
  *****************************************************************************/
 
 #include "common.h"
+#include "hook.h"
+
+#if !defined(NO_RCT2)
 
 #ifdef __WINDOWS__
 	#include <windows.h>
@@ -26,7 +29,6 @@
 	#include <sys/mman.h>
 #endif // __WINDOWS__
 
-#include "hook.h"
 #include "platform/platform.h"
 
 void* g_hooktableaddress = 0;
@@ -210,9 +212,11 @@ void hookfunc(int address, int newaddress, int stacksize, int registerargs[], in
 	memcpy((void *)address, data, i);
 #endif // __WINDOWS__
 }
+#endif // !defined(NO_RCT2)
 
 void addhook(int address, int newaddress, int stacksize, int registerargs[], int registersreturned, int eaxDestinationRegister)
 {
+#if !defined(NO_RCT2)
 	if (!g_hooktableaddress) {
 		size_t size = g_maxhooks * 100;
 #ifdef __WINDOWS__
@@ -258,4 +262,5 @@ void addhook(int address, int newaddress, int stacksize, int registerargs[], int
 #endif // __WINDOWS__
 	hookfunc(hookaddress, newaddress, stacksize, registerargs, registersreturned, eaxDestinationRegister);
 	g_hooktableoffset++;
+#endif // !defined(NO_RCT2)
 }

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -41,43 +41,6 @@
 
 rct_viewport g_viewport_list[MAX_VIEWPORT_COUNT];
 
-typedef struct paint_struct paint_struct;
-
-struct paint_struct{
-	uint32 image_id;		// 0x00
-	uint32 var_04;
-	uint16 attached_x;		// 0x08
-	uint16 attached_y;		// 0x0A
-	union {
-		struct {
-			uint8 var_0C;
-			uint8 pad_0D;
-			paint_struct* next_attached_ps;	//0x0E
-			uint16 pad_12;
-		};
-		struct {
-			uint16 attached_z; // 0x0C
-			uint16 attached_z_end; // 0x0E
-			uint16 attached_x_end; // 0x10
-			uint16 attached_y_end; // 0x12
-		};
-	};
-	uint16 x;				// 0x14
-	uint16 y;				// 0x16
-	uint16 var_18;
-	uint8 var_1A;
-	uint8 var_1B;
-	paint_struct* attached_ps;	//0x1C
-	paint_struct* var_20;
-	paint_struct* next_quadrant_ps; // 0x24
-	uint8 sprite_type;		//0x28
-	uint8 var_29;
-	uint16 pad_2A;
-	uint16 map_x;			// 0x2C
-	uint16 map_y;			// 0x2E
-	rct_map_element *mapElement; // 0x30 (or sprite pointer)
-};
-
 paint_struct *unk_EE7884;
 paint_struct *unk_EE7888;
 

--- a/src/object.c
+++ b/src/object.c
@@ -2603,7 +2603,7 @@ void object_reset(int type, void *objectEntry, uint32 entryIndex)
 {
 	assert(type >= OBJECT_TYPE_RIDE && type <= OBJECT_TYPE_SCENARIO_TEXT);
 	const object_type_vtable *vtable = object_type_vtables[type];
-	return vtable->reset(objectEntry, entryIndex);
+	vtable->reset(objectEntry, entryIndex);
 }
 
 /**

--- a/src/object.c
+++ b/src/object.c
@@ -830,15 +830,6 @@ static uint8* object_type_ride_load(void *objectEntry, uint32 entryIndex, int *c
 			cur_vehicle_images_offset = image_index + vehicleEntry->no_seating_rows * vehicleEntry->no_vehicle_images;
 			// 0x6DEB0D
 
-			if (!(vehicleEntry->flags_a & VEHICLE_ENTRY_FLAG_A_10)) {
-				int num_images = cur_vehicle_images_offset - vehicleEntry->base_image_id;
-				if (vehicleEntry->flags_a & VEHICLE_ENTRY_FLAG_A_13) {
-					num_images *= 2;
-				}
-
-				set_vehicle_type_image_max_sizes(vehicleEntry, num_images);
-			}
-
 			// Copy the vehicle entry over to new one
 			outVehicleEntry->rotation_frame_mask = vehicleEntry->rotation_frame_mask;
 			outVehicleEntry->var_02 = vehicleEntry->var_02;
@@ -883,6 +874,15 @@ static uint8* object_type_ride_load(void *objectEntry, uint32 entryIndex, int *c
 			outVehicleEntry->pad_5E = vehicleEntry->pad_5E;
 			outVehicleEntry->draw_order = vehicleEntry->draw_order;
 			outVehicleEntry->special_frames = vehicleEntry->special_frames;
+
+			if (!(vehicleEntry->flags_a & VEHICLE_ENTRY_FLAG_A_10)) {
+				int num_images = cur_vehicle_images_offset - vehicleEntry->base_image_id;
+				if (vehicleEntry->flags_a & VEHICLE_ENTRY_FLAG_A_13) {
+					num_images *= 2;
+				}
+
+				set_vehicle_type_image_max_sizes(outVehicleEntry, num_images);
+			}
 
 			sint8 no_positions = *peep_loading_positions++;
 			if (no_positions == -1) {
@@ -2345,7 +2345,7 @@ static rct_string_id object_type_park_entrance_desc(void *objectEntry)
 	return STR_NONE;
 }
 
-static bool object_type_park_entrance_reset(void *objectEntry, uint32 entryIndex)
+static void object_type_park_entrance_reset(void *objectEntry, uint32 entryIndex)
 {
 	rct_entrance_type *entranceType = (rct_entrance_type*)objectEntry;
 	uint8 *extendedEntryData = (uint8*)((size_t)objectEntry + sizeof(rct_entrance_type));
@@ -2708,7 +2708,7 @@ void object_free_scenario_text()
 
 int object_get_length(rct_object_entry *entry)
 {
-	return (int)object_get_next(entry) - (int)entry;
+	return (intptr_t)object_get_next(entry) - (intptr_t)entry;
 }
 
 rct_object_entry *object_get_next(rct_object_entry *entry)

--- a/src/object.h
+++ b/src/object.h
@@ -133,7 +133,7 @@ char *object_get_name(rct_object_entry *entry);
 
 rct_object_filters *get_object_filter(int index);
 
-bool object_load(int type, void *objectEntry, uint32 entryIndex);
+uint8* object_load(int type, void *objectEntry, uint32 entryIndex, int *chunkSize);
 void object_unload(int type, void *objectEntry);
 bool object_test(int type, void *objectEntry);
 void object_paint(int type, void *objectEntry, rct_drawpixelinfo *dpi, sint32 x, sint32 y);

--- a/src/object.h
+++ b/src/object.h
@@ -138,5 +138,6 @@ void object_unload(int type, void *objectEntry);
 bool object_test(int type, void *objectEntry);
 void object_paint(int type, void *objectEntry, rct_drawpixelinfo *dpi, sint32 x, sint32 y);
 rct_string_id object_desc(int type, void *objectEntry);
+void object_reset(int type, void *objectEntry, uint32 entryIndex);
 
 #endif

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -219,6 +219,7 @@ static void object_list_examine()
  */
 void reset_loaded_objects()
 {
+	return;
 	reset_type_to_ride_entry_index_map();
 
 	RCT2_GLOBAL(RCT2_ADDRESS_TOTAL_NO_IMAGES, uint32) = 0xF26E;
@@ -227,7 +228,7 @@ void reset_loaded_objects()
 		for (int j = 0; j < object_entry_group_counts[type]; j++){
 			uint8* chunk = object_entry_groups[type].chunks[j];
 			if (chunk != (uint8*)-1)
-				object_load(type, chunk, j);
+				object_load(type, chunk, j, NULL);
 		}
 	}
 }

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -142,7 +142,7 @@ static void object_list_sort()
 	entry = *objectBuffer;
 	for (i = 0; i < numObjects; i++)
 		entry = object_get_next(entry);
-	bufferSize = (int)entry - (int)*objectBuffer;
+	bufferSize = (uintptr_t)entry - (uintptr_t)*objectBuffer;
 
 	// Create new buffer
 	newBuffer = (rct_object_entry*)malloc(bufferSize);
@@ -170,7 +170,7 @@ static void object_list_sort()
 		}
 		entrySize = object_get_length(lowestEntry);
 		memcpy(destEntry, lowestEntry, entrySize);
-		destEntry = (rct_object_entry*)((int)destEntry + entrySize);
+		destEntry = (rct_object_entry*)((uintptr_t)destEntry + entrySize);
 		if (_installedObjectFilters)
 			destFilter[i] = _installedObjectFilters[lowestIndex];
 		copied[lowestIndex] = 1;

--- a/src/object_list.c
+++ b/src/object_list.c
@@ -219,7 +219,6 @@ static void object_list_examine()
  */
 void reset_loaded_objects()
 {
-	return;
 	reset_type_to_ride_entry_index_map();
 
 	RCT2_GLOBAL(RCT2_ADDRESS_TOTAL_NO_IMAGES, uint32) = 0xF26E;
@@ -228,7 +227,7 @@ void reset_loaded_objects()
 		for (int j = 0; j < object_entry_group_counts[type]; j++){
 			uint8* chunk = object_entry_groups[type].chunks[j];
 			if (chunk != (uint8*)-1)
-				object_load(type, chunk, j, NULL);
+				object_reset(type, chunk, j);
 		}
 	}
 }

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -52,8 +52,6 @@
 #endif // defined(__unix__)
 
 int gExitCode;
-int fdData;
-void *segments;
 
 int gOpenRCT2StartupAction = STARTUP_ACTION_TITLE;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
@@ -342,8 +340,6 @@ void openrct2_dispose()
 	language_close_all();
 	rct2_dispose();
 	config_release();
-	munmap(segments, 16941056);
-	close(fdData);
 	platform_free();
 }
 
@@ -534,19 +530,6 @@ bool openrct2_setup_rct2_segment()
 	int pageSize = getpagesize();
 	int numPages = (len + pageSize - 1) / pageSize;
 	unsigned char *dummy = malloc(numPages);
-
-	fdData = open("openrct2_load", O_RDONLY);
-	if (fdData < 0)
-	{
-		log_fatal("failed to load rct2 data. cat openrct2_text openrct2_data > openrct2_load");
-		exit(1);
-	}
-	segments = mmap((void*)0x401000, 16941056, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_FIXED | MAP_PRIVATE, fdData, 0);
-	if (segments != (void*)0x401000)
-	{
-		log_fatal("mmap failed");
-		exit(1);
-	}
 	int err = mincore((void *)0x8a4000, len, dummy);
 	bool pagesMissing = false;
 	if (err != 0)

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -598,6 +598,7 @@ bool openrct2_setup_rct2_segment()
  */
 static void openrct2_setup_rct2_hooks()
 {
+#if !defined(NO_RCT2)
 	addhook(0x006E732D, (int)gfx_set_dirty_blocks, 0, (int[]){ EAX, EBX, EDX, EBP, END }, 0, 0);			// remove when all callers are decompiled
 	addhook(0x006E7499, (int)gfx_redraw_screen_rect, 0, (int[]){ EAX, EBX, EDX, EBP, END }, 0, 0);			// remove when 0x6E7FF3 is decompiled
 	addhook(0x006B752C, (int)ride_crash, 0, (int[]){ EDX, EBX, END }, 0, 0);								// remove when all callers are decompiled
@@ -606,6 +607,7 @@ static void openrct2_setup_rct2_hooks()
 	addhook(0x006C42D9, (int)scrolling_text_setup, 0, (int[]){EAX, ECX, EBP, END}, 0, EBX);					// remove when all callers are decompiled
 	addhook(0x006C2321, (int)gfx_get_string_width, 0, (int[]){ESI, END}, 0, ECX);							// remove when all callers are decompiled
 	addhook(0x006C2555, (int)format_string, 0, (int[]){EDI, EAX, ECX, END}, 0, 0);							// remove when all callers are decompiled
+#endif // !defined(NO_RCT2)
 }
 
 #if _MSC_VER >= 1900

--- a/src/rct1.c
+++ b/src/rct1.c
@@ -82,7 +82,11 @@ bool rct1_read_sv4(const char *path, rct1_s4 *s4)
 	return success;
 }
 
-bool rideTypeShouldLoseSeparateFlag(rct_ride_entry *rideEntry)
+/**
+ * Only to be used when loading 32 bit items from files, otherwise use
+ * rideTypeShouldLoseSeparateFlag.
+ */
+bool rideTypeShouldLoseSeparateFlagByRideType(uint8 ride_type[3])
 {
 	if (!gConfigInterface.select_by_track_type) {
 		return false;
@@ -90,14 +94,19 @@ bool rideTypeShouldLoseSeparateFlag(rct_ride_entry *rideEntry)
 
 	bool remove_flag = true;
 	for (int j = 0; j < 3; j++) {
-		if (ride_type_has_flag(rideEntry->ride_type[j], RIDE_TYPE_FLAG_FLAT_RIDE)) {
+		if (ride_type_has_flag(ride_type[j], RIDE_TYPE_FLAG_FLAT_RIDE)) {
 			remove_flag = false;
 		}
-		if (rideEntry->ride_type[j] == RIDE_TYPE_MAZE || rideEntry->ride_type[j] == RIDE_TYPE_MINI_GOLF) {
+		if (ride_type[j] == RIDE_TYPE_MAZE || ride_type[j] == RIDE_TYPE_MINI_GOLF) {
 			remove_flag = false;
 		}
 	}
 	return remove_flag;
+}
+
+bool rideTypeShouldLoseSeparateFlag(rct_ride_entry *rideEntry)
+{
+	return rideTypeShouldLoseSeparateFlagByRideType(rideEntry->ride_type);
 }
 
 const uint8 gRideCategories[] = {

--- a/src/rct1.h
+++ b/src/rct1.h
@@ -725,6 +725,7 @@ void rct1_import_s4(rct1_s4 *s4);
 void rct1_fix_landscape();
 int vehicle_preference_compare(uint8 rideType, const char * a, const char * b);
 bool rideTypeShouldLoseSeparateFlag(rct_ride_entry *rideEntry);
+bool rideTypeShouldLoseSeparateFlagByRideType(uint8 ride_type[3]);
 
 bool rct1_load_saved_game(const char *path);
 bool rct1_load_scenario(const char *path);

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -35,6 +35,7 @@
 #include "../management/news_item.h"
 #include "../network/network.h"
 #include "../object_list.h"
+#include "../openrct2.h"
 #include "../peep/peep.h"
 #include "../peep/staff.h"
 #include "../rct1.h"
@@ -6886,8 +6887,10 @@ void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int 
 		.zoom_level = 0
 	};
 
-	for (int i = 0; i < num_images; ++i){
-		gfx_draw_sprite(&dpi, vehicle_type->base_image_id + i, 0, 0, 0);
+	if (!gOpenRCT2Headless) {
+		for (int i = 0; i < num_images; ++i){
+			gfx_draw_sprite(&dpi, vehicle_type->base_image_id + i, 0, 0, 0);
+		}
 	}
 	int al = -1;
 	for (int i = 99; i != 0; --i){

--- a/src/world/scenery.h
+++ b/src/world/scenery.h
@@ -30,7 +30,7 @@ typedef struct {
 	uint8 tool_id;			// 0x0B
 	sint16 price;			// 0x0C
 	sint16 removal_price;	// 0x0E
-	uint32 var_10;
+	uintptr_t var_10;
 	uint8 pad_14[0x06];
 	uint8 scenery_tab_id;	// 0x1A
 } rct_small_scenery_entry;
@@ -80,7 +80,7 @@ typedef struct {
 	rct_large_scenery_tile* tiles; // 0x0C
 	uint8 scenery_tab_id;	// 0x10
 	uint8 var_11;
-	uint32 var_12;
+	uintptr_t var_12;
 	uint32 var_16;
 } rct_large_scenery_entry;
 


### PR DESCRIPTION
This is not fully functional just yet, I'd like to request some more eyes on this.

The objects cannot be loaded directly, just like g1, as they sometimes contain pointers or pointers disguised as `uint32`s. Their size changes on x86-64, so we need to reflect that.

I modified `object_load_func` signature to allow it returning newly created object with native pointer types, while reading 32 bit pointers from files. This seems to work, even if not all memory is properly deallocated just yet.

The problem, however, arises with `reset_loaded_objects`, which breaks my assumption of `object_load` being only called with data exactly as it is stored in the file, as it tries to reload already convert objects in memory.

I'd like to get some feedback wrt to current approach and how to solve the issue I pointed out.