### PR TITLE
Including short commit hash in dump filename

### DIFF
--- a/src/platform/crash.cpp
+++ b/src/platform/crash.cpp
@@ -50,7 +50,7 @@ static bool OnCrash(const wchar_t * dumpPath,
 {
     if (!succeeded)
     {
-        constexpr const char * DumpFailedMessage = "Failed to create the dump. Nothing left to do. Please file an issue with OpenRCT2 on Github and provide latest save.";
+        constexpr const char * DumpFailedMessage = "Failed to create the dump. Please file an issue with OpenRCT2 on GitHub and provide latest save, and provide information about what you did before the crash occured.";
         printf("%s\n", DumpFailedMessage);
         if (!gOpenRCT2SilentBreakpad)
         {
@@ -59,11 +59,21 @@ static bool OnCrash(const wchar_t * dumpPath,
         return succeeded;
     }
 
+    // Get filenames
     wchar_t dumpFilePath[MAX_PATH];
     wchar_t saveFilePath[MAX_PATH];
     wsprintfW(dumpFilePath, L"%s%s.dmp", dumpPath, miniDumpId);
     wsprintfW(saveFilePath, L"%s%s.sv6", dumpPath, miniDumpId);
 
+    // Try to rename the files
+    wchar_t dumpFilePathNew[MAX_PATH];
+    wsprintfW(dumpFilePathNew, L"%s%s (%s).dmp", dumpPath, miniDumpId, WSZ(OPENRCT2_COMMIT_SHA1_SHORT));
+    if (_wrename(dumpFilePath, dumpFilePathNew) == 0)
+    {
+        std::wcscpy(dumpFilePath, dumpFilePathNew);
+    }
+
+    // Log information to output
     wprintf(L"Dump Path: %s\n", dumpFilePath);
     wprintf(L"Dump Id: %s\n", miniDumpId);
     wprintf(L"Version: %s\n", WSZ(OPENRCT2_VERSION));
@@ -84,7 +94,7 @@ static bool OnCrash(const wchar_t * dumpPath,
     {
         return succeeded;
     }
-    constexpr const wchar_t * MessageFormat = L"A crash has occurred and dump was created at\n%s.\n\nPlease create an issue with OpenRCT2 on Github and provide the dump and save.\n\nVersion: %s\nCommit: %s";
+    constexpr const wchar_t * MessageFormat = L"A crash has occurred and a dump was created at\n%s.\n\nPlease file an issue with OpenRCT2 on GitHub, and provide the dump and saved game there.\n\nVersion: %s\nCommit: %s";
     wchar_t message[MAX_PATH * 2];
     swprintf_s(message,
                MessageFormat,

--- a/src/platform/crash.cpp
+++ b/src/platform/crash.cpp
@@ -67,14 +67,15 @@ static bool OnCrash(const wchar_t * dumpPath,
 
     // Try to rename the files
     wchar_t dumpFilePathNew[MAX_PATH];
-    wsprintfW(dumpFilePathNew, L"%s%s (%s).dmp", dumpPath, miniDumpId, WSZ(OPENRCT2_COMMIT_SHA1_SHORT));
+    wsprintfW(dumpFilePathNew, L"%s%s(%s).dmp", dumpPath, miniDumpId, WSZ(OPENRCT2_COMMIT_SHA1_SHORT));
     if (_wrename(dumpFilePath, dumpFilePathNew) == 0)
     {
         std::wcscpy(dumpFilePath, dumpFilePathNew);
     }
 
     // Log information to output
-    wprintf(L"Dump Path: %s\n", dumpFilePath);
+    wprintf(L"Dump Path: %s\n", dumpPath);
+    wprintf(L"Dump File Path: %s\n", dumpFilePath);
     wprintf(L"Dump Id: %s\n", miniDumpId);
     wprintf(L"Version: %s\n", WSZ(OPENRCT2_VERSION));
     wprintf(L"Commit: %s\n", WSZ(OPENRCT2_COMMIT_SHA1_SHORT));

--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -298,7 +298,7 @@ static size_t decode_chunk_rle(const uint8* src_buffer, uint8* dst_buffer, size_
 
 	dst = dst_buffer;
 
-	for (int i = 0; i < length; i++) {
+	for (size_t i = 0; i < length; i++) {
 		rleCodeByte = src_buffer[i];
 		if (rleCodeByte & 128) {
 			i++;


### PR DESCRIPTION
When breakpad kicks in and creates a dump, the .dmp file will now be renamed to include the short commit hash.

`4fd0de6c-ec81-4d55-96cd-0ca7f3891c3c`**`(abcdef0)`**`.dmp` (without the spaces)

The saved game file stays the same.