### PR TITLE
Fix overflow in ride_mode_tweak

### DIFF
--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -2798,9 +2798,9 @@ static void window_ride_mode_tweak_increase(rct_window *w)
 	}
 
 	uint8 increment = ride->mode == RIDE_MODE_BUMPERCAR ? 10 : 1;
-	uint8 newValue = ride->operation_option + increment;
-	if (newValue <= maxValue) {
-		window_ride_mode_tweak_set(w, newValue);
+
+	if (maxValue - increment >= ride->operation_option) {
+		window_ride_mode_tweak_set(w, ride->operation_option + increment);
 	}
 }
 


### PR DESCRIPTION
Fixes issues #3424 and #2529. Would be nice if we eventually could increase it beyond the uint8 max but this will fix the overflow at least.