### PR TITLE
Idea: Ride type descriptor

### DIFF
--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -371,6 +371,7 @@
     <ClInclude Include="src\ride\ride.h" />
     <ClInclude Include="src\ride\ride_data.h" />
     <ClInclude Include="src\ride\ride_ratings.h" />
+    <ClInclude Include="src\ride\ride_type.h" />
     <ClInclude Include="src\ride\station.h" />
     <ClInclude Include="src\ride\track.h" />
     <ClInclude Include="src\ride\track_data.h" />

--- a/openrct2.vcxproj.filters
+++ b/openrct2.vcxproj.filters
@@ -262,7 +262,6 @@
     <ClCompile Include="src\ride\gentle\ghost_train.c" />
     <ClCompile Include="src\ride\gentle\haunted_house.c" />
     <ClCompile Include="src\ride\gentle\maze.c" />
-    <ClCompile Include="src\ride\gentle\merry_go_round.c" />
     <ClCompile Include="src\ride\gentle\mini_golf.c" />
     <ClCompile Include="src\ride\gentle\mini_helicopters.c" />
     <ClCompile Include="src\ride\gentle\monorail_cycles.c" />
@@ -270,6 +269,7 @@
     <ClCompile Include="src\ride\gentle\space_rings.c" />
     <ClCompile Include="src\ride\gentle\spiral_slide.c" />
     <ClCompile Include="src\ride\vehicle_paint.c" />
+    <ClCompile Include="src\ride\gentle\merry_go_round.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resources\resource.h" />
@@ -382,6 +382,7 @@
     <ClInclude Include="src\world\sprite.h" />
     <ClInclude Include="src\world\water.h" />
     <ClInclude Include="src\ride\vehicle_paint.h" />
+    <ClInclude Include="src\ride\ride_type.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resources\OpenRCT2.rc" />

--- a/src/ride/gentle/merry_go_round.c
+++ b/src/ride/gentle/merry_go_round.c
@@ -13,3 +13,45 @@
  * A full copy of the GNU General Public License can be found in licence.txt
  *****************************************************************************/
 #pragma endregion
+
+#include "../ride_type.h"
+
+ride_type_desc RideTypeDescMerryGoRound = {
+	.flags						= RIDE_TYPE_DESC_FLAG_MUSIC_ON_DEFAULT |
+								  RIDE_TYPE_DESC_FLAG_ALLOW_MUSIC |
+								  RIDE_TYPE_DESC_FLAG_HAS_ENTRANCE_EXIT |
+								  RIDE_TYPE_DESC_FLAG_SINGLE_SESSION |
+								  RIDE_TYPE_DESC_FLAG_FLAG4_13,
+
+	.operating_modes			= (1 << RIDE_MODE_ROTATION),
+	.breakdowns					= (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE),
+
+	.default_music_style		= MUSIC_STYLE_FAIRGROUND_ORGAN,
+
+	.max_height					= 12,
+	.clearance_height			= 64,
+	.z_offset					= 3,
+	.max_friction				= 255,
+	.z							= 2,
+	.typical_price_multiplier	= 1,
+	.bonus_value				= 45,
+
+	.lift_hill_sound			= 255,
+	.lift_hill_min_speed		= 5,
+	.lift_hill_max_speed		= 5,
+
+	// Prices
+	.initial_upkeep_cost		= 50,
+	.cost_per_track_piece		= 0,
+	.price_primary				= 10,
+	.price_secondary			= 0,
+	.price_track				= 115,
+	.price_supports				= 2,
+
+	.value_rating_multiplier	= { 50, 10, 0 },
+
+	// Strings
+	.vehicle_name				= 1264,
+	.structure_name				= 1278,
+	.station_name				= 1257
+};

--- a/src/ride/ride_type.h
+++ b/src/ride/ride_type.h
@@ -1,0 +1,84 @@
+#pragma region Copyright (c) 2014-2016 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#ifndef _RIDE_TYPE_H_
+#define _RIDE_TYPE_H_
+
+#include "../common.h"
+#include "ride.h"
+
+typedef struct {
+	uint64 flags;					// RIDE_TYPE_DESC_FLAG
+	uint64 operating_modes;			// RIDE_MODE as flags
+	uint16 breakdowns;				// BREAKDOWN as flags
+	uint8 default_music_style;		// MUSIC_STYLE
+
+	uint8 max_height;
+	uint8 clearance_height;
+	sint8 z_offset;
+	uint8 max_friction;
+	uint8 z;
+	uint8 typical_price_multiplier;
+	uint8 bonus_value;				// Deprecated. Use rideBonusValue instead
+
+	uint8 lift_hill_sound;
+	uint8 lift_hill_min_speed;
+	uint8 lift_hill_max_speed;
+
+	// Prices
+	uint8 initial_upkeep_cost;
+	uint8 cost_per_track_piece;
+	money8 price_primary;
+	money8 price_secondary;
+	money16 price_track;
+	money16 price_supports;
+
+	rating_tuple value_rating_multiplier;
+
+	// Strings
+	rct_string_id vehicle_name;
+	rct_string_id structure_name;
+	rct_string_id station_name;
+} ride_type_desc;
+
+enum {
+	// All rides that have more than one piece than can be built for them,
+	// with the exception of BOAT_HIRE and MAZE
+	RIDE_TYPE_DESC_FLAG_HAS_RUNNING_TRACK				= 1 << 0,
+
+	// The following flags are taken from RIDE_TYPE_FLAG4
+	RIDE_TYPE_DESC_FLAG_FLAG4_0							= 1 << 0,		// FLAG4:0
+	RIDE_TYPE_DESC_FLAG_MUSIC_ON_DEFAULT				= 1 << 1,		// FLAG4:1
+	RIDE_TYPE_DESC_FLAG_ALLOW_MUSIC						= 1 << 2,		// FLAG4:2
+	RIDE_TYPE_DESC_FLAG_FLAG4_3							= 1 << 3,		// FLAG4:3
+	RIDE_TYPE_DESC_FLAG_PEEP_CHECK_GFORCES				= 1 << 4,		// FLAG4:4
+	RIDE_TYPE_DESC_FLAG_HAS_ENTRANCE_EXIT				= 1 << 5,		// FLAG4:5
+	RIDE_TYPE_DESC_FLAG_FLAG4_6							= 1 << 6,		// FLAG4:6
+	RIDE_TYPE_DESC_FLAG_HAS_AIR_TIME					= 1 << 7,		// FLAG4:7
+	RIDE_TYPE_DESC_FLAG_SINGLE_SESSION					= 1 << 8,		// FLAG4:8
+	RIDE_TYPE_DESC_FLAG_ALLOW_MULTIPLE_CIRCUITS			= 1 << 9,		// FLAG4:9
+	RIDE_TYPE_DESC_FLAG_FLAG4_10						= 1 << 10,		// FLAG4:A
+	RIDE_TYPE_DESC_FLAG_FLAG4_11						= 1 << 11,		// FLAG4:B
+	RIDE_TYPE_DESC_FLAG_TRANSPORT_RIDE					= 1 << 12,		// FLAG4:C
+	RIDE_TYPE_DESC_FLAG_FLAG4_13						= 1 << 13,		// FLAG4:D
+	RIDE_TYPE_DESC_FLAG_FLAG4_14						= 1 << 14,		// FLAG4:E
+	RIDE_TYPE_DESC_FLAG_FLAG4_15						= 1 << 15,		// FLAG4:F
+
+};
+
+ride_type_desc *get_ride_type_desc(uint8 rideType);
+
+#endif


### PR DESCRIPTION
So now that we have individual source files for each type of ride, I thought it would be a good place to move all the constant data specific to a ride type in each source.

Currently a lot of the ride data is broken up into different structs and arrays, so this is essentially combining them all into one struct, `ride_type_desc`.

One problem though is the MSVC does not support `.field =` syntax in C++, which is a shame because its a nice way of, not only specifying required fields, but also annotating each value without using comments.

``` c
ride_type_desc RideTypeDescMerryGoRound = {
    .flags                      = RIDE_TYPE_DESC_FLAG_MUSIC_ON_DEFAULT |
                                  RIDE_TYPE_DESC_FLAG_ALLOW_MUSIC |
                                  RIDE_TYPE_DESC_FLAG_HAS_ENTRANCE_EXIT |
                                  RIDE_TYPE_DESC_FLAG_SINGLE_SESSION |
                                  RIDE_TYPE_DESC_FLAG_FLAG4_13,

    .operating_modes            = (1 << RIDE_MODE_ROTATION),
    .breakdowns                 = (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE),

    .default_music_style        = MUSIC_STYLE_FAIRGROUND_ORGAN,

    .max_height                 = 12,
    .clearance_height           = 64,
    .z_offset                   = 3,
    .max_friction               = 255,
    .z                          = 2,
    .typical_price_multiplier   = 1,
    .bonus_value                = 45,

    .lift_hill_sound            = 255,
    .lift_hill_min_speed        = 5,
    .lift_hill_max_speed        = 5,

    // Prices
    .initial_upkeep_cost        = 50,
    .cost_per_track_piece       = 0,
    .price_primary              = 10,
    .price_secondary            = 0,
    .price_track                = 115,
    .price_supports             = 2,

    .value_rating_multiplier    = { 50, 10, 0 },

    // Strings
    .vehicle_name               = 1264,
    .structure_name             = 1278,
    .station_name               = 1257
};
```
