### PR TITLE
Expanded the search directories for the linker script.

### DIFF
--- a/distribution/linux/ld_script.xc
+++ b/distribution/linux/ld_script.xc
@@ -8,7 +8,7 @@ OUTPUT_FORMAT("elf32-i386", "elf32-i386",
 	      "elf32-i386")
 OUTPUT_ARCH(i386)
 ENTRY(_start)
-SEARCH_DIR("/usr/i386-unknown-linux-gnu/lib32"); SEARCH_DIR("/usr/x86_64-unknown-linux-gnu/lib32"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/i386-unknown-linux-gnu/lib");
+SEARCH_DIR("/usr/i386-unknown-linux-gnu/lib32"); SEARCH_DIR("/usr/x86_64-unknown-linux-gnu/lib32"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/lib32"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/local/lib32"); SEARCH_DIR("/usr/i386-unknown-linux-gnu/lib"); SEARCH_DIR("/lib"); SEARCH_DIR("/lib32");
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */


### PR DESCRIPTION
Fixes https://github.com/OpenRCT2/OpenRCT2/issues/3503. I kept the SUSE branded paths out. Just adding more standard paths was enough.