### PR TITLE
Peep stat bar disappearing on highest speed

### DIFF
--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -1400,6 +1400,7 @@ void window_guest_stats_bars_paint(int value, int x, int y, rct_window *w, rct_d
 	colour &= ~(1 << 0x1F);
 	if (!blink_flag ||
 		game_is_paused() ||
+		(gGameSpeed & 8) ||
 		(gCurrentTicks & 8) == 0)
 	{
 		if (value <= 2)


### PR DESCRIPTION
Fix for window peep stats hunger, thirst, nausea and bathroom bar from disappearing whilst playing on the highest game speed.