### PR TITLE
Validate loading of chunks

### DIFF
--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -320,8 +320,10 @@ static size_t decode_chunk_repeat(uint8 *buffer, size_t length)
 		} else {
 			count = (src[i] & 7) + 1;
 			copyOffset = dst + (int)(src[i] >> 3) - 32;
-			for (j = 0; j < count; j++)
+			assert(dst + count < buffer + length);
+			for (j = 0; j < count; j++) {
 				*dst++ = *copyOffset++;
+			}
 		}
 	}
 


### PR DESCRIPTION
This makes sure we only use memory we have. It fails on many (all?) parks, so it needs to be solved before it can get merged.

Uncovered while investigating #3558.