### PR TITLE
Fix formatting characters in user strings (fixes #2892)

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -691,6 +691,7 @@ void game_convert_strings_to_utf8()
 
 		if (!str_is_null_or_empty(userString)) {
 			rct2_to_utf8_self(userString, 32);
+			utf8_remove_formatting(userString);
 		}
 	}
 

--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -183,6 +183,23 @@ int utf8_get_format_code_arg_length(int codepoint)
 	}
 }
 
+void utf8_remove_formatting(utf8* string) {
+	utf8* readPtr = string;
+	utf8* writePtr = string;
+
+	while (true) {
+		uint32 code = utf8_get_next(readPtr, &readPtr);
+
+		if (code == 0) {
+			*writePtr = 0;
+			break;
+		}
+		else if (!utf8_is_format_code(code)) {
+			writePtr = utf8_write_codepoint(writePtr, code);
+		}
+	}
+}
+
 #pragma endregion
 
 void format_string_part_from_raw(char **dest, const char *src, char **args);

--- a/src/localisation/localisation.h
+++ b/src/localisation/localisation.h
@@ -27,6 +27,7 @@ bool utf8_is_colour_code(int codepoint);
 bool utf8_should_use_sprite_for_codepoint(int codepoint);
 int font_sprite_get_codepoint_offset(int codepoint);
 int utf8_get_format_code_arg_length(int codepoint);
+void utf8_remove_formatting(utf8* string);
 
 void format_string(char *dest, rct_string_id format, void *args);
 void format_string_raw(char *dest, char *src, void *args);

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -632,8 +632,13 @@ void platform_process_messages()
 			}
 			else if (e.key.keysym.sym == SDLK_v && (SDL_GetModState() & KEYBOARD_PRIMARY_MODIFIER)) {
 				if (SDL_HasClipboardText()) {
-					utf8 *text = SDL_GetClipboardText();
+					utf8* text = SDL_GetClipboardText();
+
+					utf8_remove_formatting(text);
 					textinputbuffer_insert(&gTextInput, text);
+
+					SDL_free(text);
+
 					window_update_textbox();
 				}
 			}
@@ -676,13 +681,11 @@ void platform_process_messages()
 				break;
 			}
 
-			// Entering formatting characters is not allowed
-			if (utf8_is_format_code(utf8_get_next(e.text.text, NULL))) {
-				break;
-			}
+			utf8* newText = e.text.text;
 
-			utf8 *newText = e.text.text;
+			utf8_remove_formatting(newText);
 			textinputbuffer_insert(&gTextInput, newText);
+
 			console_refresh_caret();
 			window_update_textbox();
 			break;


### PR DESCRIPTION
This changes input handling to not allow entering any formatting characters, either by keyboard or by pasting them. If text is pasted that includes formatting characters, then only the non-formatting characters will actually be pasted.

User strings from saves created before this patch are also sanitised.