### PR TITLE
Add font config at config.ini

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -285,6 +285,14 @@ config_property_definition _notificationsDefinitions[] = {
 	{ offsetof(notification_configuration, guest_died),							"guest_died",							CONFIG_VALUE_TYPE_BOOLEAN,	true,	NULL	},
 };
 
+config_property_definition _fontsDefinitions[] = {
+	{ offsetof(font_configuration, file_name),				"file_name",			CONFIG_VALUE_TYPE_STRING,		{.value_string = NULL },		NULL					},
+	{ offsetof(font_configuration, font_name),					"font_name",				CONFIG_VALUE_TYPE_STRING,		{.value_string = NULL },		NULL					},
+	{ offsetof(font_configuration, x_offset),					"x_offset",				CONFIG_VALUE_TYPE_SINT8,		{.value_string = NULL },		NULL					},
+	{ offsetof(font_configuration, y_offset),				"y_offset",				CONFIG_VALUE_TYPE_SINT8,		{.value_string = NULL },		NULL					}
+};
+
+
 config_section_definition _sectionDefinitions[] = {
 	{ &gConfigGeneral, "general", _generalDefinitions, countof(_generalDefinitions) },
 	{ &gConfigInterface, "interface", _interfaceDefinitions, countof(_interfaceDefinitions) },
@@ -292,6 +300,7 @@ config_section_definition _sectionDefinitions[] = {
 	{ &gConfigTwitch, "twitch", _twitchDefinitions, countof(_twitchDefinitions) },
 	{ &gConfigNetwork, "network", _networkDefinitions, countof(_networkDefinitions) },
 	{ &gConfigNotifications, "notifications", _notificationsDefinitions, countof(_notificationsDefinitions) },
+	{ &gConfigFonts, "fonts", _fontsDefinitions, countof(_fontsDefinitions) }
 };
 
 #pragma endregion
@@ -302,6 +311,7 @@ sound_configuration gConfigSound;
 twitch_configuration gConfigTwitch;
 network_configuration gConfigNetwork;
 notification_configuration gConfigNotifications;
+font_configuration gConfigFonts;
 title_sequences_configuration gConfigTitleSequences;
 
 static bool config_open(const utf8string path);

--- a/src/config.c
+++ b/src/config.c
@@ -292,7 +292,6 @@ config_property_definition _fontsDefinitions[] = {
 	{ offsetof(font_configuration, y_offset),				"y_offset",				CONFIG_VALUE_TYPE_SINT8,		{.value_string = NULL },		NULL					}
 };
 
-
 config_section_definition _sectionDefinitions[] = {
 	{ &gConfigGeneral, "general", _generalDefinitions, countof(_generalDefinitions) },
 	{ &gConfigInterface, "interface", _interfaceDefinitions, countof(_interfaceDefinitions) },

--- a/src/config.h
+++ b/src/config.h
@@ -255,6 +255,13 @@ typedef struct {
 	bool guest_died;
 } notification_configuration;
 
+typedef struct {
+	utf8string file_name;
+	utf8string font_name;
+	sint8 x_offset;
+	sint8 y_offset;
+} font_configuration;
+
 // Define structures for any other settings here
 typedef struct {
 	uint8 rct1_ride_lights;
@@ -306,6 +313,7 @@ extern sound_configuration gConfigSound;
 extern twitch_configuration gConfigTwitch;
 extern network_configuration gConfigNetwork;
 extern notification_configuration gConfigNotifications;
+extern font_configuration gConfigFonts;
 extern title_sequences_configuration gConfigTitleSequences;
 
 extern uint16 gShortcutKeys[SHORTCUT_COUNT];

--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -19,6 +19,7 @@
 extern "C" {
 
 #include "../addresses.h"
+#include "../config.h"
 #include "../drawing/drawing.h"
 #include "../object.h"
 #include "../openrct2.h"
@@ -174,6 +175,27 @@ int language_open(int id)
 			gUseTrueTypeFont = false;
 			gCurrentTTFFontSet = nullptr;
 		} else {
+			if (gConfigFonts.file_name != nullptr) {
+				static TTFFontSetDescriptor TTFFontCustom = {{
+					{ gConfigFonts.file_name,		gConfigFonts.font_name,	11,		gConfigFonts.x_offset,		gConfigFonts.y_offset,		15,		nullptr },
+					{ gConfigFonts.file_name,		gConfigFonts.font_name,	11,		gConfigFonts.x_offset,		gConfigFonts.y_offset,		17,		nullptr },
+					{ gConfigFonts.file_name,		gConfigFonts.font_name,	11,		gConfigFonts.x_offset,		gConfigFonts.y_offset,		17,		nullptr },
+					{ gConfigFonts.file_name,		gConfigFonts.font_name,	11,		gConfigFonts.x_offset,		gConfigFonts.y_offset,		20,		nullptr },
+				}};
+				ttf_dispose();
+				gUseTrueTypeFont = true;
+				gCurrentTTFFontSet = &TTFFontCustom;
+				
+				bool font_initialised = ttf_initialise();
+				if(!font_initialised) {
+					log_warning("Unable to initialise configured TrueType font -- falling back to Language default.");
+				} else {
+					// Objects and their localized strings need to be refreshed
+					reset_loaded_objects();
+					
+					return 1;
+				}
+			}
 			ttf_dispose();
 			gUseTrueTypeFont = true;
 			gCurrentTTFFontSet = LanguagesDescriptors[id].font;


### PR DESCRIPTION
This PR can make users use their prefered ttf file rather than language default ttf file.
this PR solves OS X lack of MS Fonts like `gulim.ttc`.

[fonts]
- file_name : set font's file_name(like `gulim.ttc`) - setting for windows
- font_name : set font's name(like `Gulim`) - setting for osx
- x_offset / y_offset : set x/y offset of font

if invalid font or no font specified, language default font will be loaded.