### PR TITLE
declaring local variables where needed instead of at the top

### DIFF
--- a/src/cmdline/CommandLine.cpp
+++ b/src/cmdline/CommandLine.cpp
@@ -130,8 +130,7 @@ namespace CommandLine
 
         if (allCommands)
         {
-            const CommandLineCommand * command;
-            for (command = RootCommands; command->Name != nullptr; command++)
+            for (const CommandLineCommand *command = RootCommands; command->Name != nullptr; command++)
             {
                 if (command->SubCommands != nullptr)
                 {
@@ -159,8 +158,6 @@ namespace CommandLine
 
     static void PrintHelpFor(const CommandLineCommand * commands)
     {
-        const CommandLineCommand * command;
-
         // Print usage
         const char * usageString = "usage: openrct2 ";
         const size_t usageStringLength = String::LengthOf(usageString);
@@ -169,6 +166,7 @@ namespace CommandLine
         // Get the largest command name length and parameter length
         size_t maxNameLength = 0;
         size_t maxParamsLength = 0;
+        const CommandLineCommand * command;
         for (command = commands; command->Name != nullptr; command++)
         {
             maxNameLength = Math::Max(maxNameLength, String::LengthOf(command->Name));

--- a/src/drawing/drawing.c
+++ b/src/drawing/drawing.c
@@ -124,14 +124,11 @@ static void gfx_draw_dirty_blocks(int x, int y, int columns, int rows);
  */
 void gfx_clear(rct_drawpixelinfo *dpi, int colour)
 {
-	int y, w, h;
-	uint8* ptr;
+	int w = dpi->width >> dpi->zoom_level;
+	int h = dpi->height >> dpi->zoom_level;
+	uint8* ptr = dpi->bits;
 
-	w = dpi->width >> dpi->zoom_level;
-	h = dpi->height >> dpi->zoom_level;
-
-	ptr = dpi->bits;
-	for (y = 0; y < h; y++) {
+	for (int y = 0; y < h; y++) {
 		memset(ptr, colour, w);
 		ptr += w + dpi->pitch;
 	}
@@ -338,7 +335,6 @@ static void gfx_draw_dirty_blocks(int x, int y, int columns, int rows)
  */
 void gfx_redraw_screen_rect(short left, short top, short right, short bottom)
 {
-	rct_window* w;
 	rct_drawpixelinfo *screenDPI = &gScreenDPI;
 	rct_drawpixelinfo *windowDPI = &gWindowDPI;
 
@@ -349,7 +345,7 @@ void gfx_redraw_screen_rect(short left, short top, short right, short bottom)
 	windowDPI->height = bottom - top;
 	windowDPI->pitch = screenDPI->width + screenDPI->pitch + left - right;
 
-	for (w = g_window_list; w < gWindowNextSlot; w++) {
+	for (rct_window *w = g_window_list; w < gWindowNextSlot; w++) {
 		if (w->flags & WF_TRANSPARENT)
 			continue;
 		if (right <= w->x || bottom <= w->y)

--- a/src/drawing/line.c
+++ b/src/drawing/line.c
@@ -49,9 +49,8 @@ void gfx_draw_line_on_buffer(rct_drawpixelinfo *dpi, char colour, int y, int x, 
 		if (no_pixels <= 0)return;
 	}
 
-	uint8* bits_pointer;
 	//Get the buffer we are drawing to and move to the first coordinate.
-	bits_pointer = dpi->bits + y*(dpi->pitch + dpi->width) + x;
+	uint8* bits_pointer = dpi->bits + y*(dpi->pitch + dpi->width) + x;
 
 	//Draw the line to the specified colour
 	for (; no_pixels > 0; --no_pixels, ++bits_pointer){

--- a/src/drawing/rect.c
+++ b/src/drawing/rect.c
@@ -32,13 +32,11 @@
  */
 void gfx_fill_rect(rct_drawpixelinfo *dpi, int left, int top, int right, int bottom, int colour)
 {
-	int left_, right_, top_, bottom_;
-	rct_drawpixelinfo* dpi_;
-	left_ = left;
-	right_ = right;
-	top_ = top;
-	bottom_ = bottom;
-	dpi_ = dpi;
+	int left_ = left;
+	int right_ = right;
+	int top_ = top;
+	int bottom_ = bottom;
+	rct_drawpixelinfo *dpi_ = dpi;
 
 	if ((left > right) || (top > bottom) || (dpi->x > right) || (left >= (dpi->x + dpi->width)) ||
 		(bottom < dpi->y) || (top >= (dpi->y + dpi->height)))
@@ -123,8 +121,7 @@ void gfx_fill_rect(rct_drawpixelinfo *dpi, int left, int top, int right, int bot
 	if (colour & 0x4000000){
 		//0x4000000
 		// 00678B8A   00678E38
-		uint8* dest_pointer;
-		dest_pointer = start_y * (dpi->width + dpi->pitch) + start_x + dpi->bits;
+		uint8* dest_pointer = start_y * (dpi->width + dpi->pitch) + start_x + dpi->bits;
 
 		//The pattern loops every 15 lines this is which
 		//part the pattern is on.
@@ -135,8 +132,7 @@ void gfx_fill_rect(rct_drawpixelinfo *dpi, int left, int top, int right, int bot
 		int start_pattern_x = (start_x + dpi_->x) % 16;
 		int pattern_x = start_pattern_x;
 
-		uint16* pattern_pointer;
-		pattern_pointer = RCT2_ADDRESS(0x0097FEFC,uint16*)[colour >> 28]; // or possibly uint8)[esi*4] ?
+		uint16* pattern_pointer = RCT2_ADDRESS(0x0097FEFC,uint16*)[colour >> 28]; // or possibly uint8)[esi*4] ?
 
 		for (int no_lines = height; no_lines > 0; no_lines--) {
 			uint8* next_dest_pointer = dest_pointer + dpi->width + dpi->pitch;

--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -245,9 +245,7 @@ int gfx_wrap_string(utf8 *text, int width, int *outNumLines, int *outFontHeight)
  */
 void gfx_draw_string_left_clipped(rct_drawpixelinfo* dpi, int format, void* args, int colour, int x, int y, int width)
 {
-	char* buffer;
-
-	buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
+	char* buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 	format_string(buffer, format, args);
 
 	gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
@@ -272,16 +270,13 @@ void gfx_draw_string_left_clipped(rct_drawpixelinfo* dpi, int format, void* args
  */
 void gfx_draw_string_centred_clipped(rct_drawpixelinfo *dpi, int format, void *args, int colour, int x, int y, int width)
 {
-	char* buffer;
-	int text_width;
-
-	buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
+	char* buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 	format_string(buffer, format, args);
 
 	gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
 	// Clip text
-	text_width = gfx_clip_string(buffer, width);
+	int text_width = gfx_clip_string(buffer, width);
 
 	// Draw the text centred
 	if (text_width <= 0xFFFF && text_width >= 0) {
@@ -304,14 +299,11 @@ void gfx_draw_string_centred_clipped(rct_drawpixelinfo *dpi, int format, void *a
  */
 void gfx_draw_string_right(rct_drawpixelinfo* dpi, int format, void* args, int colour, int x, int y)
 {
-	char* buffer;
-	short text_width;
-
-	buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
+	char* buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 	format_string(buffer, format, args);
 
 	// Measure text width
-	text_width = gfx_get_string_width(buffer);
+	short text_width = gfx_get_string_width(buffer);
 
 	// Draw the text right aligned
 	x -= text_width;
@@ -433,9 +425,7 @@ int gfx_draw_string_left_wrapped(rct_drawpixelinfo *dpi, void *args, int x, int 
  */
 void gfx_draw_string_left(rct_drawpixelinfo *dpi, int format, void *args, int colour, int x, int y)
 {
-	char* buffer;
-
-	buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
+	char* buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
 	format_string(buffer, format, args);
 	gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 	gfx_draw_string(dpi, buffer, colour, x, y);
@@ -446,10 +436,8 @@ void gfx_draw_string_left(rct_drawpixelinfo *dpi, int format, void *args, int co
  */
 void gfx_draw_string_left_centred(rct_drawpixelinfo *dpi, rct_string_id format, void *args, int colour, int x, int y)
 {
-	char* buffer;
-
 	gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-	buffer = (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER;
+	char *buffer = (char*)RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER;
 	format_string(buffer, format, args);
 	int height = string_get_height_raw(buffer);
 	gfx_draw_string(dpi, buffer, colour, x, y - (height / 2));

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -875,10 +875,9 @@ rct_xy16 viewport_coord_to_map_coord(int x, int y, int z)
  */
 void show_gridlines()
 {
-	rct_window *mainWindow;
-
 	if (RCT2_GLOBAL(0x009E32B0, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_GRIDLINES)) {
 				mainWindow->viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
 				window_invalidate(mainWindow);
@@ -894,11 +893,10 @@ void show_gridlines()
  */
 void hide_gridlines()
 {
-	rct_window *mainWindow;
-
 	RCT2_GLOBAL(0x009E32B0, uint8)--;
 	if (RCT2_GLOBAL(0x009E32B0, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (!gConfigGeneral.always_show_gridlines) {
 				mainWindow->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
 				window_invalidate(mainWindow);
@@ -913,10 +911,9 @@ void hide_gridlines()
  */
 void show_land_rights()
 {
-	rct_window *mainWindow;
-
 	if (RCT2_GLOBAL(0x009E32B2, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP)) {
 				mainWindow->viewport->flags |= VIEWPORT_FLAG_LAND_OWNERSHIP;
 				window_invalidate(mainWindow);
@@ -932,11 +929,10 @@ void show_land_rights()
  */
 void hide_land_rights()
 {
-	rct_window *mainWindow;
-
 	RCT2_GLOBAL(0x009E32B2, uint8)--;
 	if (RCT2_GLOBAL(0x009E32B2, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP) {
 				mainWindow->viewport->flags &= ~VIEWPORT_FLAG_LAND_OWNERSHIP;
 				window_invalidate(mainWindow);
@@ -951,10 +947,9 @@ void hide_land_rights()
  */
 void show_construction_rights()
 {
-	rct_window *mainWindow;
-
 	if (RCT2_GLOBAL(0x009E32B3, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS)) {
 				mainWindow->viewport->flags |= VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
 				window_invalidate(mainWindow);
@@ -970,11 +965,10 @@ void show_construction_rights()
  */
 void hide_construction_rights()
 {
-	rct_window *mainWindow;
-
 	RCT2_GLOBAL(0x009E32B3, uint8)--;
 	if (RCT2_GLOBAL(0x009E32B3, uint8) == 0) {
-		if ((mainWindow = window_get_main()) != NULL) {
+		rct_window *mainWindow = window_get_main();
+		if (mainWindow != NULL) {
 			if (mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS) {
 				mainWindow->viewport->flags &= ~VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
 				window_invalidate(mainWindow);
@@ -1371,7 +1365,6 @@ void sub_68862C()
 {
 	rct_drawpixelinfo *dpi = RCT2_GLOBAL(0x0140E9A8, rct_drawpixelinfo*);
 	paint_struct *ps = RCT2_GLOBAL(0x00EE7884, paint_struct*), *old_ps, *next_ps;
-	attached_paint_struct* attached_ps;
 
 	while ((ps = ps->next_quadrant_ps) != NULL) {
 		old_ps = ps;
@@ -1385,7 +1378,7 @@ void sub_68862C()
 			next_ps = ps->var_20;
 		}
 
-		for (attached_ps = ps->attached_ps; attached_ps != NULL; attached_ps = attached_ps->next) {
+		for (attached_paint_struct *attached_ps = ps->attached_ps; attached_ps != NULL; attached_ps = attached_ps->next) {
 			sub_679023(
 				dpi,
 				attached_ps->image_id,
@@ -1489,14 +1482,11 @@ void viewport_invalidate(rct_viewport *viewport, int left, int top, int right, i
 
 rct_viewport *viewport_find_from_point(int screenX, int screenY)
 {
-	rct_window *w;
-	rct_viewport *viewport;
-
-	w = window_find_from_point(screenX, screenY);
+	rct_window *w = window_find_from_point(screenX, screenY);
 	if (w == NULL)
 		return NULL;
 
-	viewport = w->viewport;
+	rct_viewport *viewport = w->viewport;
 	if (viewport == NULL)
 		return NULL;
 
@@ -1522,7 +1512,7 @@ rct_viewport *viewport_find_from_point(int screenX, int screenY)
  */
 void screen_get_map_xy(int screenX, int screenY, sint16 *x, sint16 *y, rct_viewport **viewport) {
 	sint16 my_x, my_y;
-	int z, interactionType;
+	int interactionType;
 	rct_viewport *myViewport;
 	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_TERRAIN, &my_x, &my_y, &interactionType, NULL, &myViewport);
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE) {
@@ -1539,7 +1529,7 @@ void screen_get_map_xy(int screenX, int screenY, sint16 *x, sint16 *y, rct_viewp
 	rct_xy16 map_pos = { my_x + 16, my_y + 16 };
 
 	for (int i = 0; i < 5; i++) {
-		z = map_element_height(map_pos.x, map_pos.y);
+		int z = map_element_height(map_pos.x, map_pos.y);
 		map_pos = viewport_coord_to_map_coord(start_vp_pos.x, start_vp_pos.y, z);
 		map_pos.x = clamp(RCT2_GLOBAL(0x00F1AD34, sint16), map_pos.x, RCT2_GLOBAL(0x00F1AD38, sint16));
 		map_pos.y = clamp(RCT2_GLOBAL(0x00F1AD36, sint16), map_pos.y, RCT2_GLOBAL(0x00F1AD3A, sint16));

--- a/src/interface/viewport_interaction.c
+++ b/src/interface/viewport_interaction.c
@@ -477,9 +477,7 @@ void viewport_interaction_remove_park_entrance(rct_map_element *mapElement, int 
  */
 static void viewport_interaction_remove_park_wall(rct_map_element *mapElement, int x, int y)
 {
-	rct_scenery_entry* sceneryEntry;
-
-	sceneryEntry = g_wallSceneryEntries[mapElement->properties.fence.type];
+	rct_scenery_entry* sceneryEntry = g_wallSceneryEntries[mapElement->properties.fence.type];
 	if (sceneryEntry->wall.var_0D != 0xFF){
 		window_sign_small_open(mapElement->properties.fence.item[0]);
 	} else {
@@ -502,9 +500,7 @@ static void viewport_interaction_remove_park_wall(rct_map_element *mapElement, i
  */
 static void viewport_interaction_remove_large_scenery(rct_map_element *mapElement, int x, int y)
 {
-	rct_scenery_entry* sceneryEntry;
-
-	sceneryEntry = g_largeSceneryEntries[mapElement->properties.scenerymultiple.type & MAP_ELEMENT_LARGE_TYPE_MASK];
+	rct_scenery_entry* sceneryEntry = g_largeSceneryEntries[mapElement->properties.scenerymultiple.type & MAP_ELEMENT_LARGE_TYPE_MASK];
 
 	if (sceneryEntry->large_scenery.var_11 != 0xFF){
 		int id = (mapElement->type & 0xC0) |

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -50,18 +50,14 @@ static void widget_draw_image(rct_drawpixelinfo *dpi, rct_window *w, int widgetI
  */
 void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 {
-	rct_widget* widget;
-	rct_scroll* scroll;
-	int x, y, view_size;
-
-	widget = &w->widgets[widget_index];
-	scroll = &w->scrolls[window_get_scroll_data_index(w, widget_index)];
+	rct_widget *widget = &w->widgets[widget_index];
+	rct_scroll* scroll = &w->scrolls[window_get_scroll_data_index(w, widget_index)];
 
 	if (scroll->flags & HSCROLLBAR_VISIBLE) {
-		view_size = widget->right - widget->left - 21;
+		int view_size = widget->right - widget->left - 21;
 		if (scroll->flags & VSCROLLBAR_VISIBLE)
 			view_size -= 11;
-		x = scroll->h_left * view_size;
+		int x = scroll->h_left * view_size;
 		if (scroll->h_right != 0)
 			x /= scroll->h_right;
 		scroll->h_thumb_left = x + 11;
@@ -78,10 +74,10 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 	}
 
 	if (scroll->flags & VSCROLLBAR_VISIBLE) {
-		view_size = widget->bottom - widget->top - 21;
+		int view_size = widget->bottom - widget->top - 21;
 		if (scroll->flags & HSCROLLBAR_VISIBLE)
 			view_size -= 11;
-		y = scroll->v_top * view_size;
+		int y = scroll->v_top * view_size;
 		if (scroll->v_bottom != 0)
 			y /= scroll->v_bottom;
 		scroll->v_thumb_top = y + 11;
@@ -172,24 +168,20 @@ void widget_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
  */
 static void widget_frame_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	//
-	press = (w->flags & WF_10 ? 0x80 : 0);
+	int press = (w->flags & WF_10 ? 0x80 : 0);
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Draw the frame
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, press);
@@ -212,21 +204,17 @@ static void widget_frame_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetI
  */
 static void widget_resize_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Draw the panel
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0);
@@ -249,24 +237,20 @@ static void widget_resize_draw(rct_drawpixelinfo *dpi, rct_window *w, int widget
  */
 static void widget_button_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Check if the button is pressed down
-	press = widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex) ? 0x20 : 0;
+	int press = widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex) ? 0x20 : 0;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	if (widget->image == -2) {
 		// Draw border with no fill
@@ -286,13 +270,8 @@ static void widget_button_draw(rct_drawpixelinfo *dpi, rct_window *w, int widget
  */
 static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint32 image;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	//
 	if (widget->image == -1)
@@ -313,14 +292,14 @@ static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetInd
 	}
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour and image
-	colour = w->colours[widget->colour] & 0x7F;
-	image = widget->image + 2;
+	uint8 colour = w->colours[widget->colour] & 0x7F;
+	uint32 image = widget->image + 2;
 
 	// Draw coloured image
 	gfx_draw_sprite(dpi, image | (colour << 19), l, t, 0);
@@ -332,26 +311,22 @@ static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetInd
  */
 static void widget_flat_button_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint8 colour;
-
 	if (!widget_is_disabled(w, widgetIndex) && widget_is_highlighted(w, widgetIndex)) {
 		widget_button_draw(dpi, w, widgetIndex);
 		return;
 	}
 
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Check if the button is pressed down
 	if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex)) {
@@ -375,24 +350,20 @@ static void widget_flat_button_draw(rct_drawpixelinfo *dpi, rct_window *w, int w
  */
 static void widget_text_button(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Border
-	press = widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex) ? 0x20 : 0;
+	int press = widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex) ? 0x20 : 0;
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, press);
 
 	// Text
@@ -405,25 +376,21 @@ static void widget_text_button(rct_drawpixelinfo *dpi, rct_window *w, int widget
  */
 static void widget_text_unknown(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, stringId;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 	// do not use widget colour as this is already used as background for the text_button
 	// colour = 2;
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
-	stringId = widget->image;
+	int stringId = widget->image;
 	if (stringId == -1)
 		return;
 
@@ -464,21 +431,17 @@ static void widget_text_unknown(rct_drawpixelinfo *dpi, rct_window *w, int widge
  */
 static void widget_text(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	if (widget->image == (uint32)-2 || widget->image == (uint32)-1)
 		return;
@@ -494,21 +457,17 @@ static void widget_text(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
  */
 static void widget_text_inset(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0x60);
 	widget_text(dpi, w, widgetIndex);
@@ -520,23 +479,19 @@ static void widget_text_inset(rct_drawpixelinfo *dpi, rct_window *w, int widgetI
  */
 static void widget_text_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left + 5;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left + 5;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
-	press = 0;
+	int press = 0;
 	if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex))
 		press |= 0x20;
 
@@ -553,23 +508,19 @@ static void widget_text_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIn
  */
 static void widget_groupbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, textRight;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left + 5;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
-	textRight = l;
+	int l = w->x + widget->left + 5;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
+	int textRight = l;
 
 	// Text
 	if (widget->image != (uint32)-1) {
-		colour = w->colours[widget->colour] & 0x7F;
+		uint8 colour = w->colours[widget->colour] & 0x7F;
 		if (widget_is_disabled(w, widgetIndex))
 			colour |= 0x40;
 		gfx_draw_string_left(dpi, widget->image, (void*)RCT2_ADDRESS_COMMON_FORMAT_ARGS, colour, l, t);
@@ -584,7 +535,7 @@ static void widget_groupbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
 	b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour] & 0x7F;
+	uint8 colour = w->colours[widget->colour] & 0x7F;
 
 	// Border left of text
 	gfx_fill_rect(dpi, l, t, l + 4, t, ColourMapA[colour].mid_dark);
@@ -613,21 +564,17 @@ static void widget_groupbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
  */
 static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, width, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	//
 	if (w->var_4B8 != -1) {
@@ -641,7 +588,7 @@ static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widge
 		}
 
 		//
-		press = 0x70;
+		int press = 0x70;
 		if (w->flags & WF_10)
 			press |= 0x80;
 
@@ -649,7 +596,7 @@ static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widge
 		gfx_fill_rect(dpi, r + 1, t, r + 1, b, ColourMapA[colour].mid_dark);
 	} else {
 		//
-		press = 0x60;
+		int press = 0x60;
 		if (w->flags & WF_10)
 			press |= 0x80;
 
@@ -668,7 +615,7 @@ static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widge
 
 	l = widget->left + w->x + 2;
 	t = widget->top + w->y + 1;
-	width = widget->right - widget->left - 4;
+	int width = widget->right - widget->left - 4;
 	if ((widget + 1)->type == WWT_CLOSEBOX) {
 		width -= 10;
 		if ((widget + 2)->type == WWT_CLOSEBOX)
@@ -684,28 +631,24 @@ static void widget_caption_draw(rct_drawpixelinfo *dpi, rct_window *w, int widge
  */
 static void widget_closebox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b, press;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Check if the button is pressed down
-	press = 0;
+	int press = 0;
 	if (w->flags & WF_10)
 		press |= 0x80;
 	if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex))
 		press |= 0x20;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Draw the button
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, press);
@@ -728,21 +671,17 @@ static void widget_closebox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
 */
 static void widget_checkbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, b, yMid;
-	uint8 colour;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	b = w->y + widget->bottom;
-	yMid = (b + t) / 2;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int b = w->y + widget->bottom;
+	int yMid = (b + t) / 2;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	if (widget->type != WWT_24) {
 		// checkbox
@@ -772,27 +711,19 @@ static void widget_checkbox_draw(rct_drawpixelinfo *dpi, rct_window *w, int widg
  */
 static void widget_scroll_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	rct_scroll* scroll;
-	int scrollIndex;
-	int l, t, r, b;
-	int cl, ct, cr, cb;
-	uint8 colour;
-	rct_drawpixelinfo scroll_dpi;
-
 	// Get the widget
-	scrollIndex = window_get_scroll_data_index(w, widgetIndex);
-	widget = &w->widgets[widgetIndex];
-	scroll = &w->scrolls[scrollIndex];
+	int scrollIndex = window_get_scroll_data_index(w, widgetIndex);
+	rct_widget *widget = &w->widgets[widgetIndex];
+	rct_scroll* scroll = &w->scrolls[scrollIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
+	uint8 colour = w->colours[widget->colour];
 
 	// Draw the border
 	gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0x60);
@@ -823,13 +754,13 @@ static void widget_scroll_draw(rct_drawpixelinfo *dpi, rct_window *w, int widget
 	r++;
 
 	// Create a new inner scroll dpi
-	scroll_dpi = *dpi;
+	rct_drawpixelinfo scroll_dpi = *dpi;
 
 	// Clip the scroll dpi against the outer dpi
-	cl = max(dpi->x, l);
-	ct = max(dpi->y, t);
-	cr = min(dpi->x + dpi->width, r);
-	cb = min(dpi->y + dpi->height, b);
+	int cl = max(dpi->x, l);
+	int ct = max(dpi->y, t);
+	int cr = min(dpi->x + dpi->width, r);
+	int cb = min(dpi->y + dpi->height, b);
 
 	// Set the respective dpi attributes
 	scroll_dpi.x = cl - l + scroll->h_left;
@@ -903,25 +834,22 @@ static void widget_vscrollbar_draw(rct_drawpixelinfo *dpi, rct_scroll *scroll, i
  */
 static void widget_draw_image(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	int l, t, r, b, colour, image;
-	rct_widget *widget;
-
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Get the image
-	image = widget->image;
+	int image = widget->image;
 	if (image == -1)
 		return;
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour] & 0x7F;
+	uint8 colour = w->colours[widget->colour] & 0x7F;
 
 	if (widget->type == WWT_4 || widget->type == WWT_COLOURBTN || widget->type == WWT_TRNBTN || widget->type == WWT_TAB)
 		if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex))
@@ -1019,7 +947,7 @@ int widget_is_active_tool(rct_window *w, int widgetIndex)
  *	esi: w
  *	edi: widget
  */
-void widget_scroll_get_part(rct_window *w, rct_widget* widget, int x, int y, int *output_x, int *output_y, int *output_scroll_area, int *scroll_id)
+void widget_scroll_get_part(rct_window *w, rct_widget *widget, int x, int y, int *output_x, int *output_y, int *output_scroll_area, int *scroll_id)
 {
 	rct_widget* iterator = w->widgets;
 	*scroll_id = 0;
@@ -1132,25 +1060,21 @@ void widget_set_checkbox_value(rct_window *w, int widgetIndex, int value)
 
 static void widget_text_box_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 {
-	rct_widget* widget;
-	int l, t, r, b;
-	uint8 colour;
 	int no_lines = 0;
 	int font_height = 0;
 	char wrapped_string[512];
 
 	// Get the widget
-	widget = &w->widgets[widgetIndex];
+	rct_widget *widget = &w->widgets[widgetIndex];
 
 	// Resolve the absolute ltrb
-	l = w->x + widget->left;
-	t = w->y + widget->top;
-	r = w->x + widget->right;
-	b = w->y + widget->bottom;
+	int l = w->x + widget->left;
+	int t = w->y + widget->top;
+	int r = w->x + widget->right;
+	int b = w->y + widget->bottom;
 
 	// Get the colour
-	colour = w->colours[widget->colour];
-
+	uint8 colour = w->colours[widget->colour];
 
 	bool active = w->classification == gCurrentTextBox.window.classification &&
 		w->number == gCurrentTextBox.window.number &&

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -76,10 +76,8 @@ static int window_draw_split(rct_window *w, int left, int top, int right, int bo
 
 int window_get_widget_index(rct_window *w, rct_widget *widget)
 {
-	rct_widget *widget2;
-
 	int i = 0;
-	for (widget2 = w->widgets; widget2->type != WWT_LAST; widget2++, i++)
+	for (rct_widget *widget2 = w->widgets; widget2->type != WWT_LAST; widget2++, i++)
 		if (widget == widget2)
 			return i;
 	return -1;
@@ -87,15 +85,12 @@ int window_get_widget_index(rct_window *w, rct_widget *widget)
 
 int window_get_scroll_index(rct_window *w, int targetWidgetIndex)
 {
-	int widgetIndex, scrollIndex;
-	rct_widget *widget;
-
 	if (w->widgets[targetWidgetIndex].type != WWT_SCROLL)
 		return -1;
 
-	scrollIndex = 0;
-	widgetIndex = 0;
-	for (widget = w->widgets; widget->type != WWT_LAST; widget++, widgetIndex++) {
+	int scrollIndex = 0;
+	int widgetIndex = 0;
+	for (rct_widget *widget = w->widgets; widget->type != WWT_LAST; widget++, widgetIndex++) {
 		if (widgetIndex == targetWidgetIndex)
 			break;
 		if (widget->type == WWT_SCROLL)
@@ -107,14 +102,11 @@ int window_get_scroll_index(rct_window *w, int targetWidgetIndex)
 
 int window_get_scroll_index_from_widget(rct_window *w, rct_widget *widget)
 {
-	int scrollIndex;
-	rct_widget *widget2;
-
 	if (widget->type != WWT_SCROLL)
 		return -1;
 
-	scrollIndex = 0;
-	for (widget2 = w->widgets; widget2->type != WWT_LAST; widget2++) {
+	int scrollIndex = 0;
+	for (rct_widget *widget2 = w->widgets; widget2->type != WWT_LAST; widget2++) {
 		if (widget2 == widget)
 			break;
 		if (widget2->type == WWT_SCROLL)
@@ -126,9 +118,7 @@ int window_get_scroll_index_from_widget(rct_window *w, rct_widget *widget)
 
 rct_widget *window_get_scroll_widget(rct_window *w, int scrollIndex)
 {
-	rct_widget *widget;
-
-	for (widget = w->widgets; widget->type != WWT_LAST; widget++) {
+	for (rct_widget *widget = w->widgets; widget->type != WWT_LAST; widget++) {
 		if (widget->type != WWT_SCROLL)
 			continue;
 
@@ -146,11 +136,9 @@ rct_widget *window_get_scroll_widget(rct_window *w, int scrollIndex)
  */
 void window_dispatch_update_all()
 {
-	rct_window *w;
-
 	RCT2_GLOBAL(0x01423604, sint32)++;
 	// gTooltipNotShownTicks++;
-	for (w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
+	for (rct_window *w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
 		window_event_update_call(w);
 }
 
@@ -167,8 +155,6 @@ void window_update_all_viewports()
  */
 void window_update_all()
 {
-	rct_window* w;
-
 	RCT2_GLOBAL(0x009E3CD8, sint32)++;
 
 	gfx_draw_all_dirty_blocks();
@@ -179,12 +165,12 @@ void window_update_all()
 	RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_UPDATE_TICKS, sint16) += RCT2_GLOBAL(RCT2_ADDRESS_TICKS_SINCE_LAST_UPDATE, sint16);
 	if (RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_UPDATE_TICKS, sint16) >= 1000) {
 		RCT2_GLOBAL(RCT2_ADDRESS_WINDOW_UPDATE_TICKS, sint16) = 0;
-		for (w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
+		for (rct_window* w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
 			window_event_unknown_07_call(w);
 	}
 
 	// Border flash invalidation
-	for (w = RCT2_LAST_WINDOW; w >= g_window_list; w--) {
+	for (rct_window* w = RCT2_LAST_WINDOW; w >= g_window_list; w--) {
 		if (w->flags & WF_WHITE_BORDER_MASK) {
 			w->flags -= WF_WHITE_BORDER_ONE;
 			if (!(w->flags & WF_WHITE_BORDER_MASK))
@@ -201,22 +187,18 @@ void window_update_all()
  */
 static void window_scroll_wheel_input(rct_window *w, int scrollIndex, int wheel)
 {
-	int widgetIndex, size;
-	rct_scroll *scroll;
-	rct_widget *widget;
-
-	scroll = &w->scrolls[scrollIndex];
-	widget = window_get_scroll_widget(w, scrollIndex);
-	widgetIndex = window_get_widget_index(w, widget);
+	rct_scroll *scroll = &w->scrolls[scrollIndex];
+	rct_widget *widget = window_get_scroll_widget(w, scrollIndex);
+	int widgetIndex = window_get_widget_index(w, widget);
 
 	if (scroll->flags & VSCROLLBAR_VISIBLE) {
-		size = widget->bottom - widget->top - 1;
+		int size = widget->bottom - widget->top - 1;
 		if (scroll->flags & HSCROLLBAR_VISIBLE)
 			size -= 11;
 		size = max(0, scroll->v_bottom - size);
 		scroll->v_top = min(max(0, scroll->v_top + wheel), size);
 	} else {
-		size = widget->right - widget->left - 1;
+		int size = widget->right - widget->left - 1;
 		if (scroll->flags & VSCROLLBAR_VISIBLE)
 			size -= 11;
 		size = max(0, scroll->h_right - size);
@@ -233,17 +215,13 @@ static void window_scroll_wheel_input(rct_window *w, int scrollIndex, int wheel)
  */
 static int window_wheel_input(rct_window *w, int wheel)
 {
-	int i;
-	rct_widget *widget;
-	rct_scroll *scroll;
-
-	i = 0;
-	for (widget = w->widgets; widget->type != WWT_LAST; widget++) {
+	int i = 0;
+	for (rct_widget *widget = w->widgets; widget->type != WWT_LAST; widget++) {
 		if (widget->type != WWT_SCROLL)
 			continue;
 
 		// Originally always checked first scroll view, bug maybe?
-		scroll = &w->scrolls[i];
+		rct_scroll *scroll = &w->scrolls[i];
 		if (scroll->flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE)) {
 			window_scroll_wheel_input(w, i, wheel);
 			return 1;
@@ -308,14 +286,9 @@ static bool window_other_wheel_input(rct_window *w, int widgetIndex, int wheel)
  */
 static void window_all_wheel_input()
 {
-	int raw, wheel, widgetIndex;
-	rct_window *w;
-	rct_widget *widget;
-	rct_scroll *scroll;
-
 	// Get wheel value
-	raw = gCursorState.wheel;
-	wheel = 0;
+	int raw = gCursorState.wheel;
+	int wheel = 0;
 	while (1) {
 		raw -= 120;
 		if (raw < 0)
@@ -337,7 +310,7 @@ static void window_all_wheel_input()
 
 	// Check window cursor is over
 	if (!(gInputFlags & INPUT_FLAG_5)) {
-		w = window_find_from_point(gCursorState.x, gCursorState.y);
+		rct_window *w = window_find_from_point(gCursorState.x, gCursorState.y);
 		if (w != NULL) {
 			// Check if main window
 			if (w->classification == WC_MAIN_WINDOW || w->classification == WC_VIEWPORT) {
@@ -346,11 +319,11 @@ static void window_all_wheel_input()
 			}
 
 			// Check scroll view, cursor is over
-			widgetIndex = window_find_widget_from_point(w, gCursorState.x, gCursorState.y);
+			int widgetIndex = window_find_widget_from_point(w, gCursorState.x, gCursorState.y);
 			if (widgetIndex != -1) {
-				widget = &w->widgets[widgetIndex];
+				rct_widget *widget = &w->widgets[widgetIndex];
 				if (widget->type == WWT_SCROLL) {
-					scroll = &w->scrolls[RCT2_GLOBAL(0x01420075, uint8)];
+					rct_scroll *scroll = &w->scrolls[RCT2_GLOBAL(0x01420075, uint8)];
 					if (scroll->flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE)) {
 						window_scroll_wheel_input(w, window_get_scroll_index(w, widgetIndex), wheel);
 						return;
@@ -369,7 +342,7 @@ static void window_all_wheel_input()
 	}
 
 	// Check windows, front to back
-	for (w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
+	for (rct_window *w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
 		if (window_wheel_input(w, wheel))
 			return;
 }
@@ -388,9 +361,9 @@ static void window_all_wheel_input()
  */
 rct_window *window_create(int x, int y, int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags)
 {
-	rct_window *w;
 	// Check if there are any window slots left
 	if (RCT2_NEW_WINDOW >= &(g_window_list[MAX_WINDOW_COUNT])) {
+		rct_window *w = NULL;
 		// Close least recently used window
 		for (w = g_window_list; w < RCT2_NEW_WINDOW; w++)
 			if (!(w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT | WF_NO_AUTO_CLOSE)))
@@ -399,7 +372,7 @@ rct_window *window_create(int x, int y, int width, int height, rct_window_event_
 		window_close(w);
 	}
 
-	w = RCT2_NEW_WINDOW;
+	rct_window *w = RCT2_NEW_WINDOW;
 
 	// Flags
 	if (flags & WF_STICK_TO_BACK) {
@@ -515,9 +488,7 @@ static bool sub_6EA934(int x, int y, int width, int height)
  */
 static bool sub_6EA95D(int x, int y, int width, int height)
 {
-	rct_window *w;
-
-	for (w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
+	for (rct_window *w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
 		if (w->flags & WF_STICK_TO_BACK)
 			continue;
 
@@ -543,22 +514,19 @@ static bool sub_6EA95D(int x, int y, int width, int height)
  */
 rct_window *window_create_auto_pos(int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags)
 {
-	rct_window *w;
-	int x, y;
-
 	uint16 screenWidth = gScreenWidth;
 	uint16 screenHeight = gScreenHeight;
 
 	if (cls & 0x80) {
 		cls &= ~0x80;
-		w = window_find_by_number(RCT2_GLOBAL(0x0013CE928, rct_windowclass), RCT2_GLOBAL(0x0013CE92A, rct_windownumber));
+		rct_window *w = window_find_by_number(RCT2_GLOBAL(0x0013CE928, rct_windowclass), RCT2_GLOBAL(0x0013CE92A, rct_windownumber));
 		if (w != NULL) {
 			if (w->x > -60 && w->x < gScreenWidth - 20) {
 				if (w->y < gScreenHeight - 20) {
-					x = w->x;
+					int x = w->x;
 					if (w->x + width > gScreenWidth)
 						x = gScreenWidth - 20 - width;
-					y = w->y;
+					int y = w->y;
 					return window_create(x + 10, y + 10, width, height, event_handlers, cls, flags);
 				}
 			}
@@ -566,8 +534,8 @@ rct_window *window_create_auto_pos(int width, int height, rct_window_event_list 
 	}
 
 	// Place window in an empty corner of the screen
-	x = 0;
-	y = 30;
+	int x = 0;
+	int y = 30;
 	if (sub_6EA934(x, y, width, height)) goto foundSpace;
 
 	x = screenWidth - width;
@@ -583,12 +551,12 @@ rct_window *window_create_auto_pos(int width, int height, rct_window_event_list 
 	if (sub_6EA934(x, y, width, height)) goto foundSpace;
 
 	// Place window next to another
-	for (w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
+	for (rct_window *w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
 		if (w->flags & WF_STICK_TO_BACK)
 			continue;
 
-		x = w->x + w->width + 2;
-		y = w->y;
+		int x = w->x + w->width + 2;
+		int y = w->y;
 		if (sub_6EA934(x, y, width, height)) goto foundSpace;
 
 		x = w->x - w->width - 2;
@@ -621,12 +589,12 @@ rct_window *window_create_auto_pos(int width, int height, rct_window_event_list 
 	}
 
 	// Overlap
-	for (w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
+	for (rct_window *w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
 		if (w->flags & WF_STICK_TO_BACK)
 			continue;
 
-		x = w->x + w->width + 2;
-		y = w->y;
+		int x = w->x + w->width + 2;
+		int y = w->y;
 		if (sub_6EA8EC(x, y, width, height)) goto foundSpace;
 
 		x = w->x - w->width - 2;
@@ -645,7 +613,7 @@ rct_window *window_create_auto_pos(int width, int height, rct_window_event_list 
 	// Cascade
 	x = 0;
 	y = 30;
-	for (w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
+	for (rct_window *w = g_window_list; w < RCT2_LAST_WINDOW; w++) {
 		if (x != w->x || y != w->y)
 			continue;
 
@@ -721,9 +689,7 @@ void window_close(rct_window* window)
  */
 void window_close_by_class(rct_windowclass cls)
 {
-	rct_window *w;
-
-	for (w = g_window_list; w < RCT2_NEW_WINDOW; w++) {
+	for (rct_window *w = g_window_list; w < RCT2_NEW_WINDOW; w++) {
 		if (w->classification == cls) {
 			window_close(w);
 			w = g_window_list - 1;
@@ -739,9 +705,7 @@ void window_close_by_class(rct_windowclass cls)
  */
 void window_close_by_number(rct_windowclass cls, rct_windownumber number)
 {
-	rct_window* w;
-
-	for (w = g_window_list; w < RCT2_NEW_WINDOW; w++) {
+	for (rct_window* w = g_window_list; w < RCT2_NEW_WINDOW; w++) {
 		if (w->classification == cls && w->number == number) {
 			window_close(w);
 			w = g_window_list - 1;
@@ -757,9 +721,7 @@ void window_close_by_number(rct_windowclass cls, rct_windownumber number)
  */
 rct_window *window_find_by_class(rct_windowclass cls)
 {
-	rct_window *w;
-
-	for (w = g_window_list; w < RCT2_NEW_WINDOW; w++)
+	for (rct_window *w = g_window_list; w < RCT2_NEW_WINDOW; w++)
 		if (w->classification == cls)
 			return w;
 

--- a/src/ride/ride_ratings.c
+++ b/src/ride/ride_ratings.c
@@ -116,13 +116,11 @@ void ride_ratings_update_all()
  */
 static void ride_ratings_update_state_0()
 {
-	rct_ride *ride;
-
 	_rideRatingsCurrentRide += 1;
 	if (_rideRatingsCurrentRide == 255)
 		_rideRatingsCurrentRide = 0;
 
-	ride = get_ride(_rideRatingsCurrentRide);
+	rct_ride *ride = get_ride(_rideRatingsCurrentRide);
 	if (ride->type != RIDE_TYPE_NULL && ride->status != RIDE_STATUS_CLOSED)
 		_rideRatingsState = RIDE_RATINGS_STATE_INITIALISE;
 }
@@ -150,23 +148,18 @@ static void ride_ratings_update_state_1()
  */
 static void ride_ratings_update_state_2()
 {
-	rct_ride *ride;
-	rct_map_element *mapElement;
-	rct_xy_element trackElement, nextTrackElement;
-	int x, y, z, trackType, entranceIndex;
-
-	ride = get_ride(_rideRatingsCurrentRide);
+	rct_ride *ride = get_ride(_rideRatingsCurrentRide);
 	if (ride->type == RIDE_TYPE_NULL || ride->status == RIDE_STATUS_CLOSED) {
 		_rideRatingsState = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 		return;
 	}
 
-	x = _rideRatingsProximityX / 32;
-	y = _rideRatingsProximityY / 32;
-	z = _rideRatingsProximityZ / 8;
-	trackType = _rideRatingsProximityTrackType;
+	int x = _rideRatingsProximityX / 32;
+	int y = _rideRatingsProximityY / 32;
+	int z = _rideRatingsProximityZ / 8;
+	int trackType = _rideRatingsProximityTrackType;
 
-	mapElement = map_get_first_element_at(x, y);
+	rct_map_element *mapElement = map_get_first_element_at(x, y);
 	do {
 		if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_TRACK)
 			continue;
@@ -175,7 +168,7 @@ static void ride_ratings_update_state_2()
 
 		if (trackType == 255 || ((mapElement->properties.track.sequence & 0x0F) == 0 && trackType == mapElement->properties.track.type)) {
 			if (trackType == TRACK_ELEM_END_STATION) {
-				entranceIndex = map_get_station(mapElement);
+				int entranceIndex = map_get_station(mapElement);
 				_rideRatingsStationFlags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
 				if (ride->entrances[entranceIndex] == 0xFFFF) {
 					_rideRatingsStationFlags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
@@ -184,9 +177,12 @@ static void ride_ratings_update_state_2()
 
 			ride_ratings_score_close_proximity(mapElement);
 
-			trackElement.x = _rideRatingsProximityX;
-			trackElement.y = _rideRatingsProximityY;
-			trackElement.element = mapElement;
+			rct_xy_element trackElement = {
+				.x = _rideRatingsProximityX,
+				.y = _rideRatingsProximityY,
+				.element = mapElement
+			};
+			rct_xy_element nextTrackElement;
 			if (!track_block_get_next(&trackElement, &nextTrackElement, NULL, NULL)) {
 				_rideRatingsState = RIDE_RATINGS_STATE_4;
 				return;
@@ -217,9 +213,7 @@ static void ride_ratings_update_state_2()
  */
 static void ride_ratings_update_state_3()
 {
-	rct_ride *ride;
-
-	ride = get_ride(_rideRatingsCurrentRide);
+	rct_ride *ride = get_ride(_rideRatingsCurrentRide);
 	if (ride->type == RIDE_TYPE_NULL || ride->status == RIDE_STATUS_CLOSED) {
 		_rideRatingsState = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 		return;
@@ -248,23 +242,18 @@ static void ride_ratings_update_state_4()
  */
 static void ride_ratings_update_state_5()
 {
-	rct_ride *ride;
-	rct_map_element *mapElement;
-	track_begin_end trackBeginEnd;
-	int x, y, z, trackType;
-
-	ride = get_ride(_rideRatingsCurrentRide);
+	rct_ride *ride = get_ride(_rideRatingsCurrentRide);
 	if (ride->type == RIDE_TYPE_NULL || ride->status == RIDE_STATUS_CLOSED) {
 		_rideRatingsState = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 		return;
 	}
 
-	x = _rideRatingsProximityX / 32;
-	y = _rideRatingsProximityY / 32;
-	z = _rideRatingsProximityZ / 8;
-	trackType = _rideRatingsProximityTrackType;
+	int x = _rideRatingsProximityX / 32;
+	int y = _rideRatingsProximityY / 32;
+	int z = _rideRatingsProximityZ / 8;
+	int trackType = _rideRatingsProximityTrackType;
 
-	mapElement = map_get_first_element_at(x, y);
+	rct_map_element *mapElement = map_get_first_element_at(x, y);
 	do {
 		if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_TRACK)
 			continue;
@@ -276,6 +265,7 @@ static void ride_ratings_update_state_5()
 
 			x = _rideRatingsProximityX;
 			y = _rideRatingsProximityY;
+			track_begin_end trackBeginEnd;
 			if (!track_block_get_previous(x, y, mapElement, &trackBeginEnd)) {
 				_rideRatingsState = RIDE_RATINGS_STATE_CALCULATE;
 				return;
@@ -305,10 +295,7 @@ static void ride_ratings_update_state_5()
  */
 static void ride_ratings_begin_proximity_loop()
 {
-	rct_ride *ride;
-	int i, x, y, z;
-
-	ride = get_ride(_rideRatingsCurrentRide);
+	rct_ride *ride = get_ride(_rideRatingsCurrentRide);
 	if (ride->type == RIDE_TYPE_NULL || ride->status == RIDE_STATUS_CLOSED) {
 		_rideRatingsState = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 		return;
@@ -319,16 +306,16 @@ static void ride_ratings_begin_proximity_loop()
 		return;
 	}
 
-	for (i = 0; i < 4; i++) {
+	for (int i = 0; i < 4; i++) {
 		if (ride->station_starts[i] != 0xFFFF) {
 			_rideRatingsStationFlags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
 			if (ride->entrances[i] == 0xFFFF) {
 				_rideRatingsStationFlags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
 			}
 
-			x = (ride->station_starts[i] & 0xFF) * 32;
-			y = (ride->station_starts[i] >> 8) * 32;
-			z = ride->station_heights[i] * 8;
+			int x = (ride->station_starts[i] & 0xFF) * 32;
+			int y = (ride->station_starts[i] >> 8) * 32;
+			int z = ride->station_heights[i] * 8;
 
 			_rideRatingsProximityX = x;
 			_rideRatingsProximityY = y;
@@ -355,15 +342,12 @@ static void proximity_score_increment(int type)
  */
 static void ride_ratings_score_close_proximity_in_direction(rct_map_element *inputMapElement, int direction)
 {
-	rct_map_element *mapElement;
-	int x, y;
-
-	x = _rideRatingsProximityX + TileDirectionDelta[direction].x;
-	y = _rideRatingsProximityY + TileDirectionDelta[direction].y;
+	int x = _rideRatingsProximityX + TileDirectionDelta[direction].x;
+	int y = _rideRatingsProximityY + TileDirectionDelta[direction].y;
 	if (x < 0 || y < 0 || x >= (32 * 256) || y >= (32 * 256))
 		return;
 
-	mapElement = map_get_first_element_at(x >> 5, y >> 5);
+	rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);
 	do {
 		switch (map_element_get_type(mapElement)) {
 		case MAP_ELEMENT_TYPE_SURFACE:
@@ -402,33 +386,37 @@ static void ride_ratings_score_close_proximity_in_direction(rct_map_element *inp
 
 static void ride_ratings_score_close_proximity_loops_helper(rct_map_element *inputMapElement, int x, int y)
 {
-	rct_map_element *mapElement;
-	int zDiff, unk;
-
-	mapElement = map_get_first_element_at(x >> 5, y >> 5);
+	rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);
 	do {
 		switch (map_element_get_type(mapElement)) {
 		case MAP_ELEMENT_TYPE_PATH:
-			zDiff = (int)mapElement->base_height - (int)inputMapElement->base_height;
-			if (zDiff >= 0 && zDiff <= 16) {
+		{
+			int zDiff = (int)mapElement->base_height - (int)inputMapElement->base_height;
+			if (zDiff >= 0 && zDiff <= 16)
+			{
 				proximity_score_increment(PROXIMITY_PATH_TROUGH_VERTICAL_LOOP);
 			}
-			break;
+		} break;
+
 		case MAP_ELEMENT_TYPE_TRACK:
-			unk = (mapElement->type ^ inputMapElement->type) & 1;
-			if (unk != 0) {
-				zDiff = (int)mapElement->base_height - (int)inputMapElement->base_height;
-				if (zDiff >= 0 && zDiff <= 16) {
+		{
+			int unk = (mapElement->type ^ inputMapElement->type) & 1;
+			if (unk != 0)
+			{
+				int zDiff = (int)mapElement->base_height - (int)inputMapElement->base_height;
+				if (zDiff >= 0 && zDiff <= 16)
+				{
 					proximity_score_increment(PROXIMITY_TRACK_THROUGH_VERTICAL_LOOP);
 					if (
 						mapElement->properties.track.type == TRACK_ELEM_LEFT_VERTICAL_LOOP ||
 						mapElement->properties.track.type == TRACK_ELEM_RIGHT_VERTICAL_LOOP
-					) {
+						)
+					{
 						proximity_score_increment(PROXIMITY_INTERSECTING_VERTICAL_LOOP);
 					}
 				}
 			}
-			break;
+		} break;
 		}
 	} while (!map_element_is_last_for_tile(mapElement++));
 }
@@ -439,15 +427,13 @@ static void ride_ratings_score_close_proximity_loops_helper(rct_map_element *inp
  */
 static void ride_ratings_score_close_proximity_loops(rct_map_element *inputMapElement)
 {
-	int x, y, direction, trackType;
-
-	trackType = inputMapElement->properties.track.type;
+	int trackType = inputMapElement->properties.track.type;
 	if (trackType == TRACK_ELEM_LEFT_VERTICAL_LOOP || trackType == TRACK_ELEM_RIGHT_VERTICAL_LOOP) {
-		x = _rideRatingsProximityX;
-		y = _rideRatingsProximityY;
+		int x = _rideRatingsProximityX;
+		int y = _rideRatingsProximityY;
 		ride_ratings_score_close_proximity_loops_helper(inputMapElement, _rideRatingsProximityX, _rideRatingsProximityY);
 
-		direction = inputMapElement->type & MAP_ELEMENT_DIRECTION_MASK;
+		int direction = inputMapElement->type & MAP_ELEMENT_DIRECTION_MASK;
 		x = _rideRatingsProximityX + TileDirectionDelta[direction].x;
 		y = _rideRatingsProximityY + TileDirectionDelta[direction].y;
 		ride_ratings_score_close_proximity_loops_helper(inputMapElement, x, y);
@@ -460,18 +446,14 @@ static void ride_ratings_score_close_proximity_loops(rct_map_element *inputMapEl
  */
 static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 {
-	rct_map_element *mapElement;
-	int x, y, z, direction, waterHeight, trackType, sequence;
-	bool isStation;
-
 	if (_rideRatingsStationFlags & RIDE_RATING_STATION_FLAG_NO_ENTRANCE) {
 		return;
 	}
 
 	_rideRatingsProximityTotal++;
-	x = _rideRatingsProximityX;
-	y = _rideRatingsProximityY;
-	mapElement = map_get_first_element_at(x >> 5, y >> 5);
+	int x = _rideRatingsProximityX;
+	int y = _rideRatingsProximityY;
+	rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);
 	do {
 		switch (map_element_get_type(mapElement)) {
 		case MAP_ELEMENT_TYPE_SURFACE:
@@ -479,9 +461,9 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 			if (mapElement->base_height * 8 == _rideRatingsProximityZ) {
 				proximity_score_increment(PROXIMITY_SURFACE_TOUCH);
 			}
-			waterHeight = (mapElement->properties.surface.terrain & 0x1F);
+			int waterHeight = (mapElement->properties.surface.terrain & 0x1F);
 			if (waterHeight != 0) {
-				z = waterHeight * 16;
+				int z = waterHeight * 16;
 				if (z <= _rideRatingsProximityZ) {
 					proximity_score_increment(PROXIMITY_WATER_OVER);
 					if (z == _rideRatingsProximityZ) {
@@ -519,9 +501,10 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 			}
 			break;
 		case MAP_ELEMENT_TYPE_TRACK:
-			trackType = mapElement->properties.track.type;
+		{
+			int trackType = mapElement->properties.track.type;
 			if (trackType == TRACK_ELEM_LEFT_VERTICAL_LOOP || trackType == TRACK_ELEM_RIGHT_VERTICAL_LOOP) {
-				sequence = mapElement->properties.track.sequence & 0x0F;
+				int sequence = mapElement->properties.track.sequence & 0x0F;
 				if (sequence == 3 || sequence == 6) {
 					if (mapElement->base_height - inputMapElement->clearance_height <= 10) {
 						proximity_score_increment(PROXIMITY_THROUGH_VERTICAL_LOOP);
@@ -548,7 +531,7 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 				}
 			} else {
 				trackType = mapElement->properties.track.type;
-				isStation = (
+				bool isStation = (
 					trackType == TRACK_ELEM_END_STATION ||
 					trackType == TRACK_ELEM_MIDDLE_STATION ||
 					trackType == TRACK_ELEM_BEGIN_STATION
@@ -567,7 +550,7 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 						}
 					}
 				}
-
+			
 				if (inputMapElement->clearance_height == mapElement->base_height) {
 					proximity_score_increment(PROXIMITY_OWN_TRACK_TOUCH_ABOVE);
 					if (isStation) {
@@ -583,11 +566,11 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 					}
 				}
 			}
-			break;
-		}
+		} break;
+		} // switch map_element_get_type
 	} while (!map_element_is_last_for_tile(mapElement++));
 
-	direction = inputMapElement->type & MAP_ELEMENT_DIRECTION_MASK;
+	uint8 direction = inputMapElement->type & MAP_ELEMENT_DIRECTION_MASK;
 	ride_ratings_score_close_proximity_in_direction(inputMapElement, (direction + 1) & 3);
 	ride_ratings_score_close_proximity_in_direction(inputMapElement, (direction - 1) & 3);
 	ride_ratings_score_close_proximity_loops(inputMapElement);
@@ -605,9 +588,7 @@ static void ride_ratings_score_close_proximity(rct_map_element *inputMapElement)
 
 static void ride_ratings_calculate(rct_ride *ride)
 {
-	ride_ratings_calculation calcFunc;
-
-	calcFunc = ride_ratings_calculate_func_table[ride->type];
+	ride_ratings_calculation calcFunc = ride_ratings_calculate_func_table[ride->type];
 	if (calcFunc != NULL) {
 		calcFunc(ride);
 	}
@@ -624,9 +605,6 @@ static void ride_ratings_calculate(rct_ride *ride)
 
 static void ride_ratings_calculate_value(rct_ride *ride)
 {
-	rct_ride *ride2;
-	int i, otherRidesOfSameType;
-
 	if (ride->excitement == (ride_rating)0xFFFF)
 		return;
 
@@ -655,7 +633,9 @@ static void ride_ratings_calculate_value(rct_ride *ride)
 	}
 
 	// Other ride of same type penalty
-	otherRidesOfSameType = 0;
+	int otherRidesOfSameType = 0;
+	rct_ride *ride2;
+	int i;
 	FOR_ALL_RIDES(i, ride2) {
 		if (ride2->type == ride->type)
 			otherRidesOfSameType++;
@@ -768,9 +748,7 @@ static uint16 ride_compute_upkeep(rct_ride *ride)
  */
 static void ride_ratings_apply_adjustments(rct_ride *ride, rating_tuple *ratings)
 {
-	rct_ride_entry *rideEntry;
-
-	rideEntry = get_ride_entry(ride->subtype);
+	rct_ride_entry *rideEntry = get_ride_entry(ride->subtype);
 
 	// Apply ride entry multipliers
 	ratings->excitement += ((ratings->excitement * rideEntry->excitement_multipler) >> 7);
@@ -911,13 +889,13 @@ static int sub_65E72D(rct_ride *ride)
 	return (dh << 8) | numShelteredEighths;
 }
 
-static rating_tuple get_flat_turns_rating(rct_ride* ride) {
-	rating_tuple rating;
-
+static rating_tuple get_flat_turns_rating(rct_ride* ride)
+{
 	int no_3_plus_turns = get_turn_count_3_elements(ride, 0);
 	int no_2_turns = get_turn_count_2_elements(ride, 0);
 	int no_1_turns = get_turn_count_1_element(ride, 0);
 
+	rating_tuple rating;
 	rating.excitement = (no_3_plus_turns * 0x28000) >> 16;
 	rating.excitement += (no_2_turns * 0x30000) >> 16;
 	rating.excitement += (no_1_turns * 63421) >> 16;
@@ -937,13 +915,13 @@ static rating_tuple get_flat_turns_rating(rct_ride* ride) {
  *
  *  rct2: 0x0065DF72
  */
-static rating_tuple get_banked_turns_rating(rct_ride* ride) {
-	rating_tuple rating;
-
+static rating_tuple get_banked_turns_rating(rct_ride* ride)
+{
 	int no_3_plus_turns = get_turn_count_3_elements(ride, 1);
 	int no_2_turns = get_turn_count_2_elements(ride, 1);
 	int no_1_turns = get_turn_count_1_element(ride, 1);
 
+	rating_tuple rating;
 	rating.excitement = (no_3_plus_turns * 0x3C000) >> 16;
 	rating.excitement += (no_2_turns * 0x3C000) >> 16;
 	rating.excitement += (no_1_turns * 73992) >> 16;
@@ -1121,12 +1099,11 @@ static rating_tuple sub_65E1C2(rct_ride *ride)
  */
 static rating_tuple ride_ratings_get_gforce_ratings(rct_ride *ride)
 {
-	rating_tuple result;
-	fixed16_2dp gforce;
-
-	result.excitement = 0;
-	result.intensity = 0;
-	result.nausea = 0;
+	rating_tuple result = {
+		.excitement = 0,
+		.intensity = 0,
+		.nausea = 0
+	};
 
 	// Apply maximum positive G force factor
 	result.excitement += (ride->max_positive_vertical_g * 5242) >> 16;
@@ -1134,7 +1111,7 @@ static rating_tuple ride_ratings_get_gforce_ratings(rct_ride *ride)
 	result.nausea += (ride->max_positive_vertical_g * 17039) >> 16;
 
 	// Apply maximum negative G force factor
-	gforce = ride->max_negative_vertical_g;
+	fixed16_2dp gforce = ride->max_negative_vertical_g;
 	result.excitement += (clamp(-FIXED_2DP(2,50), gforce, FIXED_2DP(0,00)) * -15728) >> 16;
 	result.intensity += ((gforce - FIXED_2DP(1,00)) * -52428) >> 16;
 	result.nausea += ((gforce - FIXED_2DP(1,00)) * -14563) >> 16;
@@ -1164,15 +1141,14 @@ static rating_tuple ride_ratings_get_gforce_ratings(rct_ride *ride)
  */
 static rating_tuple ride_ratings_get_drop_ratings(rct_ride *ride)
 {
-	rating_tuple result;
-	int drops;
-
-	result.excitement = 0;
-	result.intensity = 0;
-	result.nausea = 0;
+	rating_tuple result = {
+		.excitement = 0,
+		.intensity = 0,
+		.nausea = 0
+	};
 
 	// Apply number of drops factor
-	drops = ride->drops & 0x3F;
+	int drops = ride->drops & 0x3F;
 	result.excitement += (min(9, drops) * 728177) >> 16;
 	result.intensity += (drops * 928426) >> 16;
 	result.nausea += (drops * 655360) >> 16;
@@ -1191,10 +1167,8 @@ static rating_tuple ride_ratings_get_drop_ratings(rct_ride *ride)
  */
 static int ride_ratings_get_scenery_score(rct_ride *ride)
 {
-	int i, x, y, z, xx, yy, type, numSceneryItems;
+	int i;
 	uint16 stationXY;
-	rct_map_element *mapElement;
-
 	for (i = 0; i < 4; i++) {
 		stationXY = ride->station_starts[i];
 		if (stationXY != 0xFFFF)
@@ -1206,25 +1180,25 @@ static int ride_ratings_get_scenery_score(rct_ride *ride)
 	if (ride->type == RIDE_TYPE_MAZE)
 		stationXY = ride->entrances[0];
 
-	x = stationXY & 0xFF;
-	y = stationXY >> 8;
-	z = map_element_height(x * 32, y * 32) & 0xFFFF;
+	int x = stationXY & 0xFF;
+	int y = stationXY >> 8;
+	int z = map_element_height(x * 32, y * 32) & 0xFFFF;
 
 	// Check if station is underground, returns a fixed mediocre score since you can't have scenery underground
 	if (z > ride->station_heights[i] * 8)
 		return 40;
 
 	// Count surrounding scenery items
-	numSceneryItems = 0;
-	for (yy = max(y - 5, 0); yy <= min(y + 5, 255); yy++) {
-		for (xx = max(x - 5, 0); xx <= min(x + 5, 255); xx++) {
+	int numSceneryItems = 0;
+	for (int yy = max(y - 5, 0); yy <= min(y + 5, 255); yy++) {
+		for (int xx = max(x - 5, 0); xx <= min(x + 5, 255); xx++) {
 			// Count scenery items on this tile
-			mapElement = map_get_first_element_at(xx, yy);
+			rct_map_element *mapElement = map_get_first_element_at(xx, yy);
 			do {
 				if (mapElement->flags & (1 << 4))
 					continue;
 
-				type = map_element_get_type(mapElement);
+				int type = map_element_get_type(mapElement);
 				if (type == MAP_ELEMENT_TYPE_SCENERY || type == MAP_ELEMENT_TYPE_SCENERY_MULTIPLE)
 					numSceneryItems++;
 			} while (!map_element_is_last_for_tile(mapElement++));
@@ -1388,14 +1362,13 @@ static void ride_ratings_apply_first_length_penalty(rating_tuple *ratings, rct_r
 
 static void ride_ratings_calculate_spiral_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,30), RIDE_RATING(0,30), RIDE_RATING(0,30));
 	ride_ratings_apply_length(&ratings, ride, 6000, 819);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -1434,14 +1407,13 @@ static void ride_ratings_calculate_spiral_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_stand_up_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 17;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,50), RIDE_RATING(3,00), RIDE_RATING(3,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,10));
@@ -1473,14 +1445,13 @@ static void ride_ratings_calculate_stand_up_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_suspended_swinging_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 18;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,30), RIDE_RATING(2,90), RIDE_RATING(3,50));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,10));
@@ -1514,14 +1485,13 @@ static void ride_ratings_calculate_suspended_swinging_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_inverted_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 17;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,60), RIDE_RATING(2,80), RIDE_RATING(3,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,42), RIDE_RATING(0,05));
@@ -1558,14 +1528,13 @@ static void ride_ratings_calculate_inverted_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_junior_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 13;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,40), RIDE_RATING(2,50), RIDE_RATING(1,80));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -1597,14 +1566,13 @@ static void ride_ratings_calculate_junior_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_miniature_railway(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 11;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,50), RIDE_RATING(0,00), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_train_length(&ratings, ride, 140434);
@@ -1634,14 +1602,13 @@ static void ride_ratings_calculate_miniature_railway(rct_ride *ride)
 
 static void ride_ratings_calculate_monorail(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,00), RIDE_RATING(0,00), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_train_length(&ratings, ride, 93622);
@@ -1671,14 +1638,13 @@ static void ride_ratings_calculate_monorail(rct_ride *ride)
 
 static void ride_ratings_calculate_mini_suspended_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,80), RIDE_RATING(2,50), RIDE_RATING(2,70));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,45), RIDE_RATING(0,15));
@@ -1711,8 +1677,6 @@ static void ride_ratings_calculate_mini_suspended_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_boat_ride(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->unreliability_factor = 7;
 	set_unreliability_factor(ride);
 
@@ -1720,6 +1684,7 @@ static void ride_ratings_calculate_boat_ride(rct_ride *ride)
 	// the calculation functions do this before hand. This is because set_unreliability_factor alters the value of
 	// ebx (excitement). This is assumed to be a bug and therefore fixed.
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,90), RIDE_RATING(0,80), RIDE_RATING(0,90));
 
 	// Most likely checking if the ride has does not have a circuit
@@ -1743,14 +1708,13 @@ static void ride_ratings_calculate_boat_ride(rct_ride *ride)
 
 static void ride_ratings_calculate_wooden_wild_mouse(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,90), RIDE_RATING(2,90), RIDE_RATING(2,10));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0, 8));
@@ -1785,14 +1749,13 @@ static void ride_ratings_calculate_wooden_wild_mouse(rct_ride *ride)
 
 static void ride_ratings_calculate_steeplechase(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,70), RIDE_RATING(2,40), RIDE_RATING(1,80));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,75), RIDE_RATING(0, 9));
@@ -1826,14 +1789,13 @@ static void ride_ratings_calculate_steeplechase(rct_ride *ride)
 
 static void ride_ratings_calculate_car_ride(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 12;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,00), RIDE_RATING(0,50), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,15), RIDE_RATING(0,00));
@@ -1862,14 +1824,13 @@ static void ride_ratings_calculate_car_ride(rct_ride *ride)
 
 static void ride_ratings_calculate_launched_freefall(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,70), RIDE_RATING(3,00), RIDE_RATING(3,50));
 
 	if (ride->mode == RIDE_MODE_DOWNWARD_LAUNCH) {
@@ -1914,14 +1875,13 @@ static void ride_ratings_calculate_launched_freefall(rct_ride *ride)
 
 static void ride_ratings_calculate_bobsleigh_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,80), RIDE_RATING(3,20), RIDE_RATING(2,50));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,20), RIDE_RATING(0,00));
@@ -1953,14 +1913,13 @@ static void ride_ratings_calculate_bobsleigh_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_observation_tower(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(0,00), RIDE_RATING(0,10));
 	ratings.excitement += ((ride_get_total_length(ride) >> 16) * 45875) >> 16;
 	ratings.nausea += ((ride_get_total_length(ride) >> 16) * 26214) >> 16;
@@ -1985,14 +1944,13 @@ static void ride_ratings_calculate_observation_tower(rct_ride *ride)
 
 static void ride_ratings_calculate_looping_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = ride_is_powered_launched(ride) ? 20 : 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,00), RIDE_RATING(0,50), RIDE_RATING(0,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2031,14 +1989,13 @@ static void ride_ratings_calculate_looping_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_dinghy_slide(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 13;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,70), RIDE_RATING(2,00), RIDE_RATING(1,50));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,50), RIDE_RATING(0,05));
@@ -2070,14 +2027,13 @@ static void ride_ratings_calculate_dinghy_slide(rct_ride *ride)
 
 static void ride_ratings_calculate_mine_train_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,90), RIDE_RATING(2,30), RIDE_RATING(2,10));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2111,14 +2067,13 @@ static void ride_ratings_calculate_mine_train_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_chairlift(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14 + (ride->speed * 2);
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,60), RIDE_RATING(0,40), RIDE_RATING(0,50));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_train_length(&ratings, ride, 187245);
@@ -2154,14 +2109,13 @@ static void ride_ratings_calculate_chairlift(rct_ride *ride)
 
 static void ride_ratings_calculate_corkscrew_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,00), RIDE_RATING(0,50), RIDE_RATING(0,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2200,13 +2154,12 @@ static void ride_ratings_calculate_corkscrew_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_maze(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 8;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,30), RIDE_RATING(0,50), RIDE_RATING(0,00));
 
 	int size = min(ride->maze_tiles, 100);
@@ -2229,13 +2182,12 @@ static void ride_ratings_calculate_maze(rct_ride *ride)
 
 static void ride_ratings_calculate_spiral_slide(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 8;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(1,40), RIDE_RATING(0,90));
 
 	// Unlimited slides boost
@@ -2261,14 +2213,13 @@ static void ride_ratings_calculate_spiral_slide(rct_ride *ride)
 
 static void ride_ratings_calculate_go_karts(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,42), RIDE_RATING(1,73), RIDE_RATING(0,40));
 	ride_ratings_apply_length(&ratings, ride, 700, 32768);
 
@@ -2306,14 +2257,13 @@ static void ride_ratings_calculate_go_karts(rct_ride *ride)
 
 static void ride_ratings_calculate_log_flume(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(0,55), RIDE_RATING(0,30));
 	ride_ratings_apply_length(&ratings, ride, 2000, 7208);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2340,14 +2290,13 @@ static void ride_ratings_calculate_log_flume(rct_ride *ride)
 
 static void ride_ratings_calculate_river_rapids(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,20), RIDE_RATING(0,70), RIDE_RATING(0,50));
 	ride_ratings_apply_length(&ratings, ride, 2000, 6225);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,30), RIDE_RATING(0,05));
@@ -2375,13 +2324,12 @@ static void ride_ratings_calculate_river_rapids(rct_ride *ride)
 
 static void ride_ratings_calculate_dodgems(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,30), RIDE_RATING(0,50), RIDE_RATING(0,35));
 
 	if (ride->num_vehicles >= 4)
@@ -2409,13 +2357,12 @@ static void ride_ratings_calculate_dodgems(rct_ride *ride)
 
 static void ride_ratings_calculate_pirate_ship(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 10;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(1,90), RIDE_RATING(1,41));
 
 	ratings.excitement += ride->operation_option * 5;
@@ -2438,13 +2385,12 @@ static void ride_ratings_calculate_pirate_ship(rct_ride *ride)
 
 static void ride_ratings_calculate_inverter_ship(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,50), RIDE_RATING(2,70), RIDE_RATING(2,74));
 
 	ratings.excitement += ride->operation_option * 11;
@@ -2485,13 +2431,12 @@ static void ride_ratings_calculate_shop(rct_ride *ride)
 
 static void ride_ratings_calculate_merry_go_round(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(0,60), RIDE_RATING(0,15), RIDE_RATING(0,30));
 
 	int rotationsFactor = ride->rotations * 5;
@@ -2527,13 +2472,12 @@ static void ride_ratings_calculate_toilets(rct_ride *ride)
 
 static void ride_ratings_calculate_ferris_wheel(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(0,60), RIDE_RATING(0,25), RIDE_RATING(0,30));
 
 	int rotationsFactor = ride->rotations * 25;
@@ -2557,14 +2501,13 @@ static void ride_ratings_calculate_ferris_wheel(rct_ride *ride)
 
 static void ride_ratings_calculate_motion_simulator(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 21;
 	set_unreliability_factor(ride);
 
 	// Base ratings
+	rating_tuple ratings;
 	if (ride->mode == RIDE_MODE_FILM_THRILL_RIDERS) {
 		ratings.excitement	= RIDE_RATING(3,25);
 		ratings.intensity	= RIDE_RATING(4,10);
@@ -2589,14 +2532,13 @@ static void ride_ratings_calculate_motion_simulator(rct_ride *ride)
 
 static void ride_ratings_calculate_3d_cinema(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 21;
 	set_unreliability_factor(ride);
 
 	// Base ratings
+	rating_tuple ratings;
 	switch (ride->mode) {
 	default:
 	case RIDE_MODE_3D_FILM_MOUSE_TAILS:
@@ -2630,14 +2572,13 @@ static void ride_ratings_calculate_3d_cinema(rct_ride *ride)
 
 static void ride_ratings_calculate_top_spin(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 19;
 	set_unreliability_factor(ride);
 
 	// Base ratings
+	rating_tuple ratings;
 	switch (ride->mode) {
 	default:
 	case RIDE_MODE_BEGINNERS:
@@ -2673,13 +2614,12 @@ static void ride_ratings_calculate_top_spin(rct_ride *ride)
 
 static void ride_ratings_calculate_space_rings(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 7;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(2,10), RIDE_RATING(6,50));
 	ride_ratings_apply_scenery(&ratings, ride, 25098);
 
@@ -2697,14 +2637,13 @@ static void ride_ratings_calculate_space_rings(rct_ride *ride)
 
 static void ride_ratings_calculate_reverse_freefall_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 25;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,00), RIDE_RATING(3,20), RIDE_RATING(2,80));
 	ride_ratings_apply_length(&ratings, ride, 6000, 327);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,60), RIDE_RATING(0,15));
@@ -2729,7 +2668,6 @@ static void ride_ratings_calculate_reverse_freefall_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_lift(rct_ride *ride)
 {
-	rating_tuple ratings;
 	int totalLength;
 
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
@@ -2738,6 +2676,7 @@ static void ride_ratings_calculate_lift(rct_ride *ride)
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,11), RIDE_RATING(0,35), RIDE_RATING(0,30));
 
 	totalLength = ride_get_total_length(ride) >> 16;
@@ -2764,14 +2703,13 @@ static void ride_ratings_calculate_lift(rct_ride *ride)
 
 static void ride_ratings_calculate_vertical_drop_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,20), RIDE_RATING(0,80), RIDE_RATING(0,30));
 	ride_ratings_apply_length(&ratings, ride, 4000, 1146);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2809,13 +2747,12 @@ static void ride_ratings_calculate_cash_machine(rct_ride *ride)
 
 static void ride_ratings_calculate_twist(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,13), RIDE_RATING(0,97), RIDE_RATING(1,90));
 
 	ratings.excitement += ride->rotations * 20;
@@ -2838,16 +2775,16 @@ static void ride_ratings_calculate_twist(rct_ride *ride)
 
 static void ride_ratings_calculate_haunted_house(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 8;
 	set_unreliability_factor(ride);
 
-	ratings.excitement	= RIDE_RATING(3,41);
-	ratings.intensity	= RIDE_RATING(1,53);
-	ratings.nausea		= RIDE_RATING(0,10);
+	rating_tuple ratings = {
+		.excitement = RIDE_RATING(3,41),
+		.intensity = RIDE_RATING(1,53),
+		.nausea = RIDE_RATING(0,10)
+	};
 
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
@@ -2863,14 +2800,13 @@ static void ride_ratings_calculate_haunted_house(rct_ride *ride)
 
 static void ride_ratings_calculate_flying_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 17;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(4,35), RIDE_RATING(1,85), RIDE_RATING(4,33));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2909,14 +2845,13 @@ static void ride_ratings_calculate_flying_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_virginia_reel(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 19;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,10), RIDE_RATING(1,90), RIDE_RATING(3,70));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2947,14 +2882,13 @@ static void ride_ratings_calculate_virginia_reel(rct_ride *ride)
 
 static void ride_ratings_calculate_splash_boats(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,46), RIDE_RATING(0,35), RIDE_RATING(0,30));
 	ride_ratings_apply_length(&ratings, ride, 2000, 7208);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -2981,14 +2915,13 @@ static void ride_ratings_calculate_splash_boats(rct_ride *ride)
 
 static void ride_ratings_calculate_mini_helicopters(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 12;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,60), RIDE_RATING(0,40), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,15), RIDE_RATING(0,00));
@@ -3017,14 +2950,13 @@ static void ride_ratings_calculate_mini_helicopters(rct_ride *ride)
 
 static void ride_ratings_calculate_lay_down_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 18;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,85), RIDE_RATING(1,15), RIDE_RATING(2,75));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3066,14 +2998,13 @@ static void ride_ratings_calculate_lay_down_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_suspended_monorail(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,15), RIDE_RATING(0,23), RIDE_RATING(0, 8));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_train_length(&ratings, ride, 93622);
@@ -3103,14 +3034,13 @@ static void ride_ratings_calculate_suspended_monorail(rct_ride *ride)
 
 static void ride_ratings_calculate_reverser_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 19;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,40), RIDE_RATING(1,80), RIDE_RATING(1,70));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3151,14 +3081,13 @@ static void ride_ratings_calculate_reverser_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_heartline_twister_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 18;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,40), RIDE_RATING(1,70), RIDE_RATING(1,65));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,20), RIDE_RATING(0,04));
@@ -3192,14 +3121,13 @@ static void ride_ratings_calculate_heartline_twister_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_mini_golf(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 0;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,50), RIDE_RATING(0,90), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_65DDD1(&ratings, ride, 14860, 0, 0);
@@ -3237,16 +3165,16 @@ static void ride_ratings_calculate_first_aid(rct_ride *ride)
 
 static void ride_ratings_calculate_circus_show(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 9;
 	set_unreliability_factor(ride);
 
-	ratings.excitement	= RIDE_RATING(2,10);
-	ratings.intensity	= RIDE_RATING(0,30);
-	ratings.nausea		= RIDE_RATING(0,0);
+	rating_tuple ratings = {
+		.excitement	= RIDE_RATING(2,10),
+		.intensity	= RIDE_RATING(0,30),
+		.nausea		= RIDE_RATING(0,0)
+	};
 
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
@@ -3262,14 +3190,13 @@ static void ride_ratings_calculate_circus_show(rct_ride *ride)
 
 static void ride_ratings_calculate_ghost_train(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 12;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,00), RIDE_RATING(0,20), RIDE_RATING(0,03));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,15), RIDE_RATING(0,00));
@@ -3297,14 +3224,13 @@ static void ride_ratings_calculate_ghost_train(rct_ride *ride)
 
 static void ride_ratings_calculate_twister_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 15;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,50), RIDE_RATING(0,40), RIDE_RATING(0,30));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3343,14 +3269,13 @@ static void ride_ratings_calculate_twister_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_wooden_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 19;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,20), RIDE_RATING(2,60), RIDE_RATING(2,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3384,14 +3309,13 @@ static void ride_ratings_calculate_wooden_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_side_friction_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 19;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,50), RIDE_RATING(2,00), RIDE_RATING(1,50));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3424,14 +3348,13 @@ static void ride_ratings_calculate_side_friction_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_wild_mouse(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,80), RIDE_RATING(2,50), RIDE_RATING(2,10));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0, 8));
@@ -3465,14 +3388,13 @@ static void ride_ratings_calculate_wild_mouse(rct_ride *ride)
 
 static void ride_ratings_calculate_multi_dimension_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 18;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,75), RIDE_RATING(1,95), RIDE_RATING(4,79));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3511,14 +3433,13 @@ static void ride_ratings_calculate_multi_dimension_roller_coaster(rct_ride *ride
 
 static void ride_ratings_calculate_giga_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,85), RIDE_RATING(0,40), RIDE_RATING(0,35));
 	ride_ratings_apply_length(&ratings, ride, 6000, 819);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3557,14 +3478,13 @@ static void ride_ratings_calculate_giga_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_roto_drop(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 24;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,80), RIDE_RATING(3,50), RIDE_RATING(3,50));
 
 	int lengthFactor = ((ride_get_total_length(ride) >> 16) * 209715) >> 16;
@@ -3589,16 +3509,16 @@ static void ride_ratings_calculate_roto_drop(rct_ride *ride)
 
 static void ride_ratings_calculate_flying_saucers(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 32;
 	set_unreliability_factor(ride);
 
-	ratings.excitement	= RIDE_RATING(2,40);
-	ratings.intensity	= RIDE_RATING(0,55);
-	ratings.nausea		= RIDE_RATING(0,39);
+	rating_tuple ratings = {
+		.excitement = RIDE_RATING(2,40),
+		.intensity =  RIDE_RATING(0,55),
+		.nausea =     RIDE_RATING(0,39)
+	};
 
 	if (ride->num_vehicles >= 4)
 		ratings.excitement += RIDE_RATING(0,40);
@@ -3625,16 +3545,16 @@ static void ride_ratings_calculate_flying_saucers(rct_ride *ride)
 
 static void ride_ratings_calculate_crooked_house(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 5;
 	set_unreliability_factor(ride);
 
-	ratings.excitement	= RIDE_RATING(2,15);
-	ratings.intensity	= RIDE_RATING(0,62);
-	ratings.nausea		= RIDE_RATING(0,34);
+	rating_tuple ratings = {
+		.excitement	= RIDE_RATING(2,15),
+		.intensity	= RIDE_RATING(0,62),
+		.nausea		= RIDE_RATING(0,34)
+	};
 
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
@@ -3650,14 +3570,13 @@ static void ride_ratings_calculate_crooked_house(rct_ride *ride)
 
 static void ride_ratings_calculate_monorail_cycles(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 4;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,40), RIDE_RATING(0,20), RIDE_RATING(0,00));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,15), RIDE_RATING(0,00));
@@ -3686,14 +3605,13 @@ static void ride_ratings_calculate_monorail_cycles(rct_ride *ride)
 
 static void ride_ratings_calculate_compact_inverted_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = ride->mode == RIDE_MODE_REVERSE_INCLINE_LAUNCHED_SHUTTLE ? 31 : 21;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,15), RIDE_RATING(2,80), RIDE_RATING(3,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,42), RIDE_RATING(0,05));
@@ -3730,14 +3648,13 @@ static void ride_ratings_calculate_compact_inverted_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_water_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,70), RIDE_RATING(2,80), RIDE_RATING(2,10));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3772,14 +3689,13 @@ static void ride_ratings_calculate_water_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_air_powered_vertical_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 28;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(4,13), RIDE_RATING(2,50), RIDE_RATING(2,80));
 	ride_ratings_apply_length(&ratings, ride, 6000, 327);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,60), RIDE_RATING(0,05));
@@ -3804,14 +3720,13 @@ static void ride_ratings_calculate_air_powered_vertical_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_inverted_hairpin_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 14;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(3,00), RIDE_RATING(2,65), RIDE_RATING(2,25));
 	ride_ratings_apply_length(&ratings, ride, 6000, 873);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0, 8));
@@ -3846,13 +3761,12 @@ static void ride_ratings_calculate_inverted_hairpin_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_magic_carpet(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,45), RIDE_RATING(1,60), RIDE_RATING(2,60));
 
 	ratings.excitement += ride->operation_option * 10;
@@ -3875,13 +3789,12 @@ static void ride_ratings_calculate_magic_carpet(rct_ride *ride)
 
 static void ride_ratings_calculate_submarine_ride(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->unreliability_factor = 7;
 	set_unreliability_factor(ride);
 
 	// NOTE Fixed bug from original game, see boat ride.
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,20), RIDE_RATING(1,80), RIDE_RATING(1,40));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_proximity(&ratings, ride, 11183);
@@ -3901,14 +3814,13 @@ static void ride_ratings_calculate_submarine_ride(rct_ride *ride)
 
 static void ride_ratings_calculate_river_rafts(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 12;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(1,45), RIDE_RATING(0,25), RIDE_RATING(0,34));
 	ride_ratings_apply_length(&ratings, ride, 2000, 7208);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -3933,17 +3845,17 @@ static void ride_ratings_calculate_river_rafts(rct_ride *ride)
 
 static void ride_ratings_calculate_enterprise(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
 	ride->unreliability_factor = 22;
 	set_unreliability_factor(ride);
 
 	// Base ratings
-	ratings.excitement	= RIDE_RATING(3,60);
-	ratings.intensity	= RIDE_RATING(4,55);
-	ratings.nausea		= RIDE_RATING(5,72);
+	rating_tuple ratings = {
+		.excitement	= RIDE_RATING(3,60),
+		.intensity	= RIDE_RATING(4,55),
+		.nausea		= RIDE_RATING(5,72)
+	};
 
 	ratings.excitement += ride->operation_option;
 	ratings.intensity += ride->operation_option * 16;
@@ -3965,14 +3877,13 @@ static void ride_ratings_calculate_enterprise(rct_ride *ride)
 
 static void ride_ratings_calculate_inverted_impulse_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 20;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(4,00), RIDE_RATING(3,00), RIDE_RATING(3,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,42), RIDE_RATING(0,05));
@@ -4003,14 +3914,13 @@ static void ride_ratings_calculate_inverted_impulse_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_mini_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 13;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,55), RIDE_RATING(2,40), RIDE_RATING(1,85));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -4043,14 +3953,13 @@ static void ride_ratings_calculate_mini_roller_coaster(rct_ride *ride)
 
 static void ride_ratings_calculate_mine_ride(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 16;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,75), RIDE_RATING(1,00), RIDE_RATING(1,80));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));
@@ -4080,14 +3989,13 @@ static void ride_ratings_calculate_mine_ride(rct_ride *ride)
 
 static void ride_ratings_calculate_lim_launched_roller_coaster(rct_ride *ride)
 {
-	rating_tuple ratings;
-
 	if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
 		return;
 
 	ride->unreliability_factor = 25;
 	set_unreliability_factor(ride);
 
+	rating_tuple ratings;
 	ride_ratings_set(&ratings, RIDE_RATING(2,90), RIDE_RATING(1,50), RIDE_RATING(2,20));
 	ride_ratings_apply_length(&ratings, ride, 6000, 764);
 	ride_ratings_apply_synchronisation(&ratings, ride, RIDE_RATING(0,40), RIDE_RATING(0,05));

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -36,9 +36,7 @@
 /* move to ride.c */
 void sub_6B2FA9(rct_windownumber number)
 {
-	rct_window* w;
-
-	w = window_find_by_number(WC_RIDE, number);
+	rct_window* w  = window_find_by_number(WC_RIDE, number);
 	if (w != NULL && w->page == 1)
 		window_close(w);
 }


### PR DESCRIPTION
This PR cleans up the code a bit by declaring variables when they are first assigned, sometimes in a different scope when not needed anywhere else. By hand this is going to take a while, so I'm dropping it now. Perhaps clang-tidy has a module for this. Perhaps @janisozaur knows more.