### PR TITLE
Fix font config loaded without proper configuration

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -175,7 +175,7 @@ bool language_open(int id)
 			gUseTrueTypeFont = false;
 			gCurrentTTFFontSet = nullptr;
 		} else {
-			if (gConfigFonts.file_name != nullptr) {
+			if (!String::IsNullOrEmpty(gConfigFonts.file_name)) {
 				static TTFFontSetDescriptor TTFFontCustom = {{
 					{ gConfigFonts.file_name,	gConfigFonts.font_name,	gConfigFonts.size_tiny,		gConfigFonts.x_offset,	gConfigFonts.y_offset,	gConfigFonts.height_tiny,	nullptr },
 					{ gConfigFonts.file_name,	gConfigFonts.font_name,	gConfigFonts.size_small,	gConfigFonts.x_offset,	gConfigFonts.y_offset,	gConfigFonts.height_small,	nullptr },


### PR DESCRIPTION
Font config was tested without proper configuration. this PR fixes it by checking whether `file_name`'s first charactor is `\0` or not(if empty, first charactor will be `\0`)

Tested on OSX, not Windows(will do after appvoyer build)