### PR TITLE
Limit what is considered a valid tile

### DIFF
--- a/src/world/map.c
+++ b/src/world/map.c
@@ -655,7 +655,7 @@ int map_height_from_slope(int x, int y, int slope)
 
 bool map_is_location_valid(int x, int y)
 {
-	if (x <= (256 * 32) && x >= 0 && y <= (256 * 32) && y >= 0) {
+	if (x < (256 * 32) && x >= 0 && y < (256 * 32) && y >= 0) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/blob/193ae36/src/world/map.c#L2250

`smooth_land_tile` already calls to `map_is_location_valid`, but the [latter](https://github.com/OpenRCT2/OpenRCT2/blob/193ae36/src/world/map.c#L658) allows for elements that are clearly [outside of range](https://github.com/OpenRCT2/OpenRCT2/blob/193ae36/src/world/map.c#L183)

Fixes #3549