### PR TITLE
Fix ride rating penalties

### DIFF
--- a/src/ride/ride_ratings.c
+++ b/src/ride/ride_ratings.c
@@ -1122,6 +1122,7 @@ static rating_tuple ride_ratings_get_gforce_ratings(rct_ride *ride)
 	result.nausea += (ride->max_lateral_g * 21845) >> 16;
 
 	// Very high lateral G force penalty
+	#ifdef ORIGINAL_RATINGS
 	if (ride->max_lateral_g > FIXED_2DP(2,80)) {
 		result.intensity += FIXED_2DP(3,75);
 		result.nausea += FIXED_2DP(2,00);
@@ -1131,6 +1132,7 @@ static rating_tuple ride_ratings_get_gforce_ratings(rct_ride *ride)
 		result.intensity += FIXED_2DP(8,50);
 		result.nausea += FIXED_2DP(4,00);
 	}
+	#endif
 
 	return result;
 }
@@ -1347,6 +1349,21 @@ static void ride_ratings_apply_max_lateral_g_penalty(rating_tuple *ratings, rct_
 	}
 }
 
+static void ride_ratings_apply_excessive_lateral_g_penalty(rating_tuple *ratings, rct_ride *ride)
+{
+	#ifndef ORIGINAL_RATINGS
+	if (ride->max_lateral_g > FIXED_2DP(2,80)) {
+		ratings->intensity += FIXED_2DP(3,75);
+		ratings->nausea += FIXED_2DP(2,00);
+	}
+	if (ride->max_lateral_g > FIXED_2DP(3,10)) {
+		ratings->excitement /= 2;
+		ratings->intensity += FIXED_2DP(8,50);
+		ratings->nausea += FIXED_2DP(4,00);
+	}
+	#endif
+}
+
 static void ride_ratings_apply_first_length_penalty(rating_tuple *ratings, rct_ride *ride, int minFirstLength, int excitementPenalty, int intensityPenalty, int nauseaPenalty)
 {
 	if (ride->length[0] < minFirstLength) {
@@ -1393,6 +1410,7 @@ static void ride_ratings_calculate_spiral_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1431,6 +1449,7 @@ static void ride_ratings_calculate_stand_up_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
 	ride_ratings_apply_max_negative_g_penalty(&ratings, ride, FIXED_2DP(0,50), 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1471,6 +1490,7 @@ static void ride_ratings_calculate_suspended_swinging_coaster(rct_ride *ride)
 	ride_ratings_apply_max_lateral_g_penalty(&ratings, ride, FIXED_2DP(1, 50), 2, 2, 2);
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x1720000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1514,6 +1534,7 @@ static void ride_ratings_calculate_inverted_roller_coaster(rct_ride *ride)
 	if ((ride->inversions & 0x1F) == 0)
 		ride_ratings_apply_max_negative_g_penalty(&ratings, ride, FIXED_2DP(0,30), 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1552,6 +1573,7 @@ static void ride_ratings_calculate_junior_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 1, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1663,6 +1685,7 @@ static void ride_ratings_calculate_mini_suspended_coaster(rct_ride *ride)
 	ride_ratings_apply_max_lateral_g_penalty(&ratings, ride, FIXED_2DP(1,30), 2, 2, 2);
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xC80000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1735,6 +1758,7 @@ static void ride_ratings_calculate_wooden_wild_mouse(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xAA0000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 3, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1775,6 +1799,7 @@ static void ride_ratings_calculate_steeplechase(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xF00000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1899,6 +1924,7 @@ static void ride_ratings_calculate_bobsleigh_coaster(rct_ride *ride)
 	ride_ratings_apply_max_lateral_g_penalty(&ratings, ride, FIXED_2DP(1,20), 2, 2, 2);
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x1720000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -1975,6 +2001,7 @@ static void ride_ratings_calculate_looping_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2013,6 +2040,7 @@ static void ride_ratings_calculate_dinghy_slide(rct_ride *ride)
 	ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x8C0000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2053,6 +2081,7 @@ static void ride_ratings_calculate_mine_train_coaster(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x1720000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2140,6 +2169,7 @@ static void ride_ratings_calculate_corkscrew_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2727,6 +2757,7 @@ static void ride_ratings_calculate_vertical_drop_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_max_negative_g_penalty(&ratings, ride, FIXED_2DP(0,10), 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 1, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2831,6 +2862,7 @@ static void ride_ratings_calculate_flying_roller_coaster(rct_ride *ride)
 
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 1, 1);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2868,6 +2900,7 @@ static void ride_ratings_calculate_virginia_reel(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xD20000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -2984,6 +3017,7 @@ static void ride_ratings_calculate_lay_down_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3067,6 +3101,7 @@ static void ride_ratings_calculate_reverser_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xC80000, 2, 1, 1);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 1, 1);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3107,6 +3142,7 @@ static void ride_ratings_calculate_heartline_twister_coaster(rct_ride *ride)
 
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 1, 4, 1, 1);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3255,6 +3291,7 @@ static void ride_ratings_calculate_twister_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3295,6 +3332,7 @@ static void ride_ratings_calculate_wooden_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x1720000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3334,6 +3372,7 @@ static void ride_ratings_calculate_side_friction_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xFA0000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3374,6 +3413,7 @@ static void ride_ratings_calculate_wild_mouse(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xAA0000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3419,6 +3459,7 @@ static void ride_ratings_calculate_multi_dimension_roller_coaster(rct_ride *ride
 	if ((ride->inversions & 0x1F) == 0)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 1, 1);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3464,6 +3505,7 @@ static void ride_ratings_calculate_giga_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3634,6 +3676,7 @@ static void ride_ratings_calculate_compact_inverted_coaster(rct_ride *ride)
 	if ((ride->inversions & 0x1F) == 0)
 		ride_ratings_apply_max_negative_g_penalty(&ratings, ride, FIXED_2DP(0,30), 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3672,6 +3715,7 @@ static void ride_ratings_calculate_water_coaster(rct_ride *ride)
 	ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 1, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3706,6 +3750,7 @@ static void ride_ratings_calculate_air_powered_vertical_coaster(rct_ride *ride)
 	ride_ratings_apply_scenery(&ratings, ride, 11155);
 	ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 34, 2, 1, 1);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3747,6 +3792,7 @@ static void ride_ratings_calculate_inverted_hairpin_coaster(rct_ride *ride)
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0xAA0000, 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 3, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3900,6 +3946,7 @@ static void ride_ratings_calculate_inverted_impulse_coaster(rct_ride *ride)
 	ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 20, 2, 2, 2);
 	ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3939,6 +3986,7 @@ static void ride_ratings_calculate_mini_roller_coaster(rct_ride *ride)
 	ride_ratings_apply_max_negative_g_penalty(&ratings, ride, FIXED_2DP(0,50), 2, 2, 2);
 	ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -3975,6 +4023,7 @@ static void ride_ratings_calculate_mine_ride(rct_ride *ride)
 	ride_ratings_apply_scenery(&ratings, ride, 16732);
 	ride_ratings_apply_first_length_penalty(&ratings, ride, 0x10E0000, 2, 2, 2);
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 
@@ -4020,6 +4069,7 @@ static void ride_ratings_calculate_lim_launched_roller_coaster(rct_ride *ride)
 		ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
 	}
 
+	ride_ratings_apply_excessive_lateral_g_penalty(&ratings, ride);
 	ride_ratings_apply_intensity_penalty(&ratings);
 	ride_ratings_apply_adjustments(ride, &ratings);
 


### PR DESCRIPTION
Changes the penalty for high lateral G-forces to be applied after the other penalties instead of before.
