### PR TITLE
Fix #3685. Also refactor related enum value.

### DIFF
--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -3306,7 +3306,8 @@ static void window_ride_operating_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	// Number of block sections
 	if (ride->mode == RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED || ride->mode == RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED) {
 		blockSections = ride->num_block_brakes + ride->num_stations;
-		gfx_draw_string_left(dpi, STR_BLOCK_SECTIONS, &blockSections, 0, w->x + 21, ride->mode == 36 ? w->y + 76 : w->y + 61);
+		gfx_draw_string_left(dpi, STR_BLOCK_SECTIONS, &blockSections, 0, w->x + 21,
+							 ride->mode == RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED ? w->y + 89 : w->y + 61);
 	}
 }
 


### PR DESCRIPTION
Labels don't overlap anymore.
![screenshot_2016-05-20_22-28-23](https://cloud.githubusercontent.com/assets/16853773/15441272/48c971d2-1eda-11e6-9c37-61fb3dc6d88d.png)
(as opposed to:)
![](https://cloud.githubusercontent.com/assets/10995998/15439826/678e4708-1ed2-11e6-9f11-bd4c542e2307.png)