### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/paint/map_element/scenery_multiple.c
+++ b/src/paint/map_element/scenery_multiple.c
@@ -94,7 +94,7 @@ const utf8 *scenery_multiple_sign_fit_text(const utf8 *str, rct_large_scenery_te
 	strncpy(fitStr, str, sizeof(fitStr) - 1);
 	int w = 0;
 	uint32 codepoint;
-	while (w <= text->max_width && (codepoint = utf8_get_next(fitStrEnd, &fitStrEnd)) != 0) {
+	while (w <= text->max_width && (codepoint = utf8_get_next(fitStrEnd, (const utf8**)&fitStrEnd)) != 0) {
 		if (height) {
 			w += scenery_multiple_sign_get_glyph(text, codepoint)->height;
 		} else {
@@ -273,14 +273,14 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
 						utf8 *spacesrc = 0;
 						utf8 *spacedst = 0;
 						int w = 0;
-						uint32 codepoint = utf8_get_next(src, &src);
+						uint32 codepoint = utf8_get_next(src, (const utf8**)&src);
 						do {
 							w += scenery_multiple_sign_get_glyph(text, codepoint)->width;
 							if (codepoint == ' ') {
 								spacesrc = src;
 								spacedst = dst;
 							}
-						} while(w <= text->max_width && (dst = utf8_write_codepoint(dst, codepoint)) && (srcold = src) && (codepoint = utf8_get_next(src, &src)));
+						} while(w <= text->max_width && (dst = utf8_write_codepoint(dst, codepoint)) && (srcold = src) && (codepoint = utf8_get_next(src, (const utf8**)&src)));
 						src = srcold;
 						if (spacesrc && codepoint) {
 							*spacedst = 0;


### PR DESCRIPTION
```
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/scenery_multiple.c:97:71: warning: passing 'utf8 **' (aka 'char **') to parameter of type 'const utf8 **' (aka 'const char **') discards qualifiers in nested pointer types
      [-Wincompatible-pointer-types-discards-qualifiers]
        while (w <= text->max_width && (codepoint = utf8_get_next(fitStrEnd, &fitStrEnd)) != 0) {
                                                                             ^~~~~~~~~~
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/../../localisation/language.h:73:57: note: passing argument to parameter 'nextchar_ptr' here
uint32 utf8_get_next(const utf8 *char_ptr, const utf8 **nextchar_ptr);
                                                        ^
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/scenery_multiple.c:276:45: warning: passing 'utf8 **' (aka 'char **') to parameter of type 'const utf8 **' (aka 'const char **') discards qualifiers in nested pointer types
      [-Wincompatible-pointer-types-discards-qualifiers]
                                                uint32 codepoint = utf8_get_next(src, &src);
                                                                                      ^~~~
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/../../localisation/language.h:73:57: note: passing argument to parameter 'nextchar_ptr' here
uint32 utf8_get_next(const utf8 *char_ptr, const utf8 **nextchar_ptr);
                                                        ^
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/scenery_multiple.c:283:137: warning: passing 'utf8 **' (aka 'char **') to parameter of type 'const utf8 **' (aka 'const char **') discards qualifiers in nested pointer types
      [-Wincompatible-pointer-types-discards-qualifiers]
                                                } while(w <= text->max_width && (dst = utf8_write_codepoint(dst, codepoint)) && (srcold = src) && (codepoint = utf8_get_next(src, &src)));
                                                                                                                                                                                  ^~~~
/home/janisozaur/workspace/OpenRCT2/src/paint/map_element/../../localisation/language.h:73:57: note: passing argument to parameter 'nextchar_ptr' here
uint32 utf8_get_next(const utf8 *char_ptr, const utf8 **nextchar_ptr);
                                                        ^
3 warnings generated.
```