### PR TITLE
Fixes #3635 - Crash when inspecting paths

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,8 @@
 - Fix: [#3361] Missing Twister coaster piece.
 - Fix: [#3418] Launched freefall restraints are drawn incorrectly when up (original bug).
 - Fix: [#3451] Renaming staff is a guest command.
-- Fix: [#3210] Scenery window scrolls too far
+- Fix: [#3210] Scenery window scrolls too far.
+- Fix: [#3635] Inspecting sidewalk path crashes game.
 
 0.0.4-beta (2016-04-15)
 ------------------------------------------------------------------------

--- a/src/windows/tile_inspector.c
+++ b/src/windows/tile_inspector.c
@@ -610,7 +610,7 @@ static void window_tile_inspector_scrollpaint(rct_window *w, rct_drawpixelinfo *
 				} else {
 					sprintf(
 						buffer, "Path (%s)%s%s",
-						language_get_string(get_footpath_item_entry(pathType)->name), // Path name
+						language_get_string(get_footpath_entry(pathType)->string_idx), // Path name
 						pathHasScenery ? " with " : "", // Adds " with " when there is something on the path
 						pathHasScenery ? language_get_string(get_footpath_item_entry(pathAdditionType)->name) : "" // Path addition name
 					);


### PR DESCRIPTION
Bug was caused by 3d47f9869ff5d95757df9bf544809269cbf5b412
Fixes #3635