### PR TITLE
Remove Intamin and Phoenix Easter eggs

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -1653,8 +1653,8 @@ STR_1647    :
 STR_1648    :{SMALLFONT}{OPENQUOTES}Help! Put me down!{ENDQUOTES}
 STR_1649    :{SMALLFONT}{OPENQUOTES}I'm running out of cash!{ENDQUOTES}
 STR_1650    :{SMALLFONT}{OPENQUOTES}Wow! A new ride being built!{ENDQUOTES}
-STR_1651    :{SMALLFONT}{OPENQUOTES}Nice ride! But not as good as the Phoenix...{ENDQUOTES}
-STR_1652    :{SMALLFONT}{OPENQUOTES}I'm so excited - It's an Intamin ride!{ENDQUOTES}
+STR_1651    :<removed string - do not use>
+STR_1652    :<removed string - do not use>
 STR_1653    :{SMALLFONT}{OPENQUOTES}...and here we are on {STRINGID}!{ENDQUOTES}
 STR_1654    :{WINDOW_COLOUR_2}Recent thoughts:
 STR_1655    :{SMALLFONT}{BLACK}Construct footpath on land

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -135,8 +135,6 @@ const char *gPeepEasterEggNames[] = {
 	"KATIE SMITH",
 	"EILIDH BELL",
 	"NANCY STILLWAGON",
-	"ANDY HINE",
-	"ELISSA WHITE",
 	"DAVID ELLIS"
 };
 
@@ -8800,10 +8798,6 @@ static void peep_on_exit_ride(rct_peep *peep, int rideIndex)
 		}
 	}
 
-	if (peep->peep_flags & PEEP_FLAGS_NICE_RIDE) {
-		peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_NICE_RIDE, 255);
-	}
-
 	if (peep_really_liked_ride(peep, ride)) {
 		peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_WAS_GREAT, rideIndex);
 
@@ -9817,9 +9811,6 @@ static bool peep_should_go_on_ride(rct_peep *peep, int rideIndex, int entranceNu
 		// At this point, the peep has decided to go on the ride.
 		if (peepAtRide) {
 			ride_update_popularity(ride, 1);
-			if ((peep->peep_flags & PEEP_FLAGS_INTAMIN) && ride_type_is_intamin(ride->type)) {
-				peep_insert_new_thought(peep, PEEP_THOUGHT_TYPE_EXCITED, 255);
-			}
 		}
 
 		if (rideIndex == peep->guest_heading_to_ride_id) {
@@ -10638,16 +10629,6 @@ money32 set_peep_name(int flags, int state, uint16 sprite_index, uint8* text_1, 
 	peep->peep_flags &= ~PEEP_FLAGS_ICE_CREAM;
 	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_NANCY_STILLWAGON, peep)) {
 		peep->peep_flags |= PEEP_FLAGS_ICE_CREAM;
-	}
-
-	peep->peep_flags &= ~PEEP_FLAGS_NICE_RIDE;
-	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_ANDY_HINE, peep)) {
-		peep->peep_flags |= PEEP_FLAGS_NICE_RIDE;
-	}
-
-	peep->peep_flags &= ~PEEP_FLAGS_INTAMIN;
-	if (peep_check_easteregg_name(EASTEREGG_PEEP_NAME_ELISSA_WHITE, peep)) {
-		peep->peep_flags |= PEEP_FLAGS_INTAMIN;
 	}
 
 	peep->peep_flags &= ~PEEP_FLAGS_HERE_WE_ARE;

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -172,8 +172,8 @@ enum PEEP_THOUGHT_TYPE {
 	PEEP_THOUGHT_TYPE_HELP = 168, // "Help! Put me down!"
 	PEEP_THOUGHT_TYPE_RUNNING_OUT = 169, // "I'm running out of cash!"
 	PEEP_THOUGHT_TYPE_NEW_RIDE = 170, // "Wow! A new ride being built!"
-	PEEP_THOUGHT_TYPE_NICE_RIDE = 171, // "Nice ride! But not as good as the Phoenix..."
-	PEEP_THOUGHT_TYPE_EXCITED = 172, // "I'm so excited - It's an Intamin ride!"
+	PEEP_THOUGHT_TYPE_NICE_RIDE_DEPRECATED = 171, // "Nice ride! But not as good as the Phoenix..."
+	PEEP_THOUGHT_TYPE_EXCITED_DEPRECATED = 172, // "I'm so excited - It's an Intamin ride!"
 	PEEP_THOUGHT_TYPE_HERE_WE_ARE = 173, // "...and here we are on X!"
 
 	PEEP_THOUGHT_TYPE_NONE = 255
@@ -272,8 +272,8 @@ enum PEEP_FLAGS {
 	PEEP_FLAGS_JOY = (1 << 23), // Makes the peep jump in joy
 	PEEP_FLAGS_ANGRY = (1 << 24),
 	PEEP_FLAGS_ICE_CREAM = (1 << 25), // Gives passing peeps ice cream and they wave back
-	PEEP_FLAGS_NICE_RIDE = (1 << 26), // Makes the peep think "Nice ride! But not as good as the Phoenix..." on exiting a ride
-	PEEP_FLAGS_INTAMIN = (1 << 27), // Makes the peep think "I'm so excited - It's an Intamin ride!" while riding on a Intamin
+	PEEP_FLAGS_NICE_RIDE_DEPRECATED = (1 << 26), // Used to make the peep think "Nice ride! But not as good as the Phoenix..." on exiting a ride
+	PEEP_FLAGS_INTAMIN_DEPRECATED = (1 << 27), // Used to make the peep think "I'm so excited - It's an Intamin ride!" while riding on a Intamin ride.
 	PEEP_FLAGS_HERE_WE_ARE = (1 << 28), // Makes the peep think  "...and here we are on X!" while riding a ride
 	PEEP_FLAGS_TWITCH = (1 << 31)		// Added for twitch integration
 };
@@ -571,8 +571,6 @@ enum {
 	EASTEREGG_PEEP_NAME_KATIE_SMITH,
 	EASTEREGG_PEEP_NAME_EILIDH_BELL,
 	EASTEREGG_PEEP_NAME_NANCY_STILLWAGON,
-	EASTEREGG_PEEP_NAME_ANDY_HINE,
-	EASTEREGG_PEEP_NAME_ELISSA_WHITE,
 	EASTEREGG_PEEP_NAME_DAVID_ELLIS
 };
 

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -8406,16 +8406,8 @@ void ride_crash(uint8 rideIndex, uint8 vehicleIndex)
 	set_format_arg(0, rct_string_id, ride->name);
 	set_format_arg(2, uint32, ride->name_arguments);
 	if (gConfigNotifications.ride_crashed) {
-	news_item_add_to_queue(NEWS_ITEM_RIDE, STR_RIDE_HAS_CRASHED, rideIndex);
-}
-}
-
-bool ride_type_is_intamin(int rideType)
-{
-	return
-		rideType == RIDE_TYPE_HEARTLINE_TWISTER_COASTER ||
-		rideType == RIDE_TYPE_GIGA_COASTER ||
-		rideType == RIDE_TYPE_INVERTED_IMPULSE_COASTER;
+		news_item_add_to_queue(NEWS_ITEM_RIDE, STR_RIDE_HAS_CRASHED, rideIndex);
+	}
 }
 
 bool shop_item_is_food_or_drink(int shopItem)

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -1065,7 +1065,6 @@ void ride_set_to_default_inspection_interval(int rideIndex);
 void sub_6CB945(int rideIndex);
 void ride_crash(uint8 rideIndex, uint8 vehicleIndex);
 
-bool ride_type_is_intamin(int rideType);
 void sub_6C94D8();
 
 bool shop_item_is_food_or_drink(int shopItem);


### PR DESCRIPTION
RCT2 contains quite a lot of Easter eggs. Many of them are nice, but some seem more like in-jokes that aren't funny to people outside the dev team. This one removes two of the latter kind.