### PR TITLE
Fix .travis.yml script error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
             - mv OpenRCT2/bin/openrct2 OpenRCT2/ && mv OpenRCT2/share/openrct2 OpenRCT2/data && mv OpenRCT2/share/doc/openrct2 OpenRCT2/doc
             - rm -rf OpenRCT2/bin OpenRCT2/share # remove empty dirs
             - tar cvzf openrct2-linux.tar.gz OpenRCT2/
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-linux.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=4" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build"; else; curl --progress-bar --upload-file openrct2-linux.tar.gz.zip https://transfer.sh/openrct2-linux.tar.gz -o link && cat link; fi
+            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-linux.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=4" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build"; else curl --progress-bar --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux.tar.gz -o link && cat link; fi
         - os: linux
           env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
         - os: linux
@@ -42,7 +42,7 @@ matrix:
           after_success:
             - cd build/Release
             - zip -r openrct2-osx.zip OpenRCT2.app
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-osx.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=3" --form "file=@openrct2-osx.zip" "https://openrct2.org/altapi/?command=push-build"; else; curl --progress-bar --upload-file openrct2-osx.zip https://transfer.sh/openrct2-osx.zip -o link && cat link; fi
+            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then curl -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}-${TRAVIS_BRANCH}-${TRAVIS_COMMIT:0:7}-osx.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$TRAVIS_BRANCH" --form "flavourId=3" --form "file=@openrct2-osx.zip" "https://openrct2.org/altapi/?command=push-build"; else curl --progress-bar --upload-file openrct2-osx.zip https://transfer.sh/openrct2-osx.zip -o link && cat link; fi
         - os: linux
           env: OPENRCT2_CMAKE_OPTS="-DFORCE64=ON" TARGET=linux64
         # Following entries used to be included in testing, but they only proved useful while changing things in CMake setup.


### PR DESCRIPTION
This PR fixes script error introduced by #3750

- `else;` -> `else`
- `openrct2-linux.tar.gz.zip` -> `openrct2-linux.tar.gz`

transfer.sh build link of this PR : https://transfer.sh/Z1SKr/openrct2-linux.tar.gz