### PR TITLE
Update docker files

### DIFF
--- a/dockerfiles/32bit/Dockerfile
+++ b/dockerfiles/32bit/Dockerfile
@@ -1,29 +1,16 @@
 FROM nfnty/arch-mini
 
+RUN echo -e "[archlinuxfr]\nSigLevel = Never\nServer = http://repo.archlinux.fr/\$arch" >> /etc/pacman.conf
+RUN sed -i '/#\[multilib\]/,/#Include = \/etc\/pacman.d\/mirrorlist/ s/#//' /etc/pacman.conf
 RUN pacman -Syyu --noconfirm
-RUN pacman -S --noconfirm git curl jshon expac yajl wget unzip cmake
-RUN pacman -S --noconfirm --needed base-devel
+RUN pacman -S --noconfirm git curl jshon expac yajl wget unzip cmake && pacman -Sc
+RUN yes | pacman -S gcc-multilib gcc-libs-multilib && pacman -Sc
+RUN pacman -S --noconfirm --needed make pkg-config patch yaourt grep file sudo gawk fakeroot gzip m4 which util-linux && pacman -Sc
 
 RUN useradd -mg root travis
 RUN usermod -aG wheel travis
 RUN sed -i 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
 
-WORKDIR /tmp
+RUN pacman -S --noconfirm lib32-curl lib32-sdl2 lib32-speex lib32-fontconfig lib32-openssl lib32-libpng && pacman -Sc
 USER travis
-RUN curl -sLO https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=package-query
-RUN mv PKGBUILD?h=package-query PKGBUILD
-RUN makepkg
-USER root
-RUN pacman --noconfirm -U *.pkg.tar.xz
-USER travis
-RUN curl -sLO https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=yaourt
-RUN mv PKGBUILD?h=yaourt PKGBUILD
-RUN makepkg
-USER root
-RUN pacman --noconfirm -U *.pkg.tar.xz
-
-RUN pacman -R --noconfirm gcc
-RUN yes | pacman -S gcc-libs-multilib
-RUN pacman -S --noconfirm gcc-multilib
-USER travis
-RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf lib32-speex lib32-fontconfig
+RUN yaourt -S --noconfirm lib32-jansson lib32-sdl2_ttf && rm -rf /tmp/yaourt-tmp-travis && sudo pacman -Sc


### PR DESCRIPTION
Updates to recent ArchLinux changes, simplifaction

It hopefully creates smaller images and thus improves build throughput
on travis.

Tested with https://travis-ci.org/janisozaur/OpenRCT2/builds/133374630, there are few seconds shaved off from travis' docker builds.