### PR TITLE
Prevent SIGPIPE-ing on Linux when clients drop

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -428,7 +428,7 @@ bool NetworkConnection::SendPacket(NetworkPacket& packet)
 	tosend.insert(tosend.end(), (uint8*)&sizen, (uint8*)&sizen + sizeof(sizen));
 	tosend.insert(tosend.end(), packet.data->begin(), packet.data->end());
 	while (1) {
-		int sentBytes = send(socket, (const char*)&tosend[packet.transferred], tosend.size() - packet.transferred, 0);
+		int sentBytes = send(socket, (const char*)&tosend[packet.transferred], tosend.size() - packet.transferred, FLAG_NO_PIPE);
 		if (sentBytes == SOCKET_ERROR) {
 			return false;
 		}

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -81,6 +81,7 @@ extern "C" {
 	#ifndef SHUT_RDWR
 		#define SHUT_RDWR SD_BOTH
 	#endif
+	#define FLAG_NO_PIPE 0
 #else
 	#include <errno.h>
 	#include <arpa/inet.h>
@@ -94,6 +95,11 @@ extern "C" {
 	#define LAST_SOCKET_ERROR() errno
 	#define closesocket close
 	#define ioctlsocket ioctl
+	#if defined(__LINUX__)
+		#define FLAG_NO_PIPE MSG_NOSIGNAL
+	#else
+		#define FLAG_NO_PIPE 0
+	#endif // defined(__LINUX__)
 #endif // __WINDOWS__
 
 // Fixes issues on OS X


### PR DESCRIPTION
`send()` can only write to connected sockets [1]. In case where client
drops out, a socket may become closed by OS but we can still enqueue
packets for its connection and eventually call `send()`, which will
generate a SIGPIPE and shut the server down, because there was no
`MSG_NOSIGNAL` set.

This commit makes sure `MSG_NOSIGNAL` is used on Linux.

[1] http://linux.die.net/man/2/send