### PR TITLE
Make sure to hold string alive when using c_str()

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -739,7 +739,8 @@ bool Network::BeginClient(const char* host, unsigned short port)
 		key.SavePrivate(privkey);
 		SDL_RWclose(privkey);
 
-		const utf8 *publicKeyHash = key.PublicKeyHash().c_str();
+		const std::string hash = key.PublicKeyHash();
+		const utf8 *publicKeyHash = hash.c_str();
 		network_get_public_key_path(keyPath, sizeof(keyPath), gConfigNetwork.player_name, publicKeyHash);
 		Console::WriteLine("Key generated, saving public bits as %s", keyPath);
 		SDL_RWops *pubkey = SDL_RWFromFile(keyPath, "wb+");


### PR DESCRIPTION
Previously `.c_str()` accessed temporary object, which resulted in funky key names, like `janisozaur-(��(��927f130286085138679903105529d56f.pubkey`