### PR TITLE
Modify object selection to only research selected item

### DIFF
--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -775,8 +775,7 @@ static void window_editor_object_selection_close(rct_window *w)
 	}
 	else {
 		// Used for in-game object selection cheat
-		research_reset_items();
-		research_populate_list_researched();
+		// This resets the ride selection list and resets research to 0 on current item
 		gSilentResearch = true;
 		sub_684AC3();
 		gSilentResearch = false;
@@ -1985,6 +1984,20 @@ static void editor_load_selected_objects()
 				int chunk_size;
 				if (!object_load_chunk(-1, installed_entry, &chunk_size)) {
 					log_error("Failed to load entry %.8s", installed_entry->name);
+				}
+
+				// For in game use (cheat)
+				if (!(gScreenFlags & SCREEN_FLAGS_EDITOR)) {
+					// Defaults selected items to researched.
+					if (find_object_in_entry_group(installed_entry, &entry_type, &entry_index)) {
+						if (entry_type == OBJECT_TYPE_RIDE) {
+							rct_ride_entry* rideType = get_ride_entry(entry_index);
+							research_insert(1, 0x10000 | (rideType->ride_type[0] << 8) | entry_index, rideType->category[0]);
+						}
+						else if (entry_type == OBJECT_TYPE_SCENERY_SETS) {
+							research_insert(1, entry_index, RESEARCH_CATEGORY_SCENERYSET);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
 This is only for when adding new objects during a game. Its to prevent the research list from being reset every time you make a change. 

Requested in https://openrct2.org/forums/topic/1310-problem-with-set-in-console/ (the second part of the query). @Charlieep

The reason this was like this before was to hide a bug we had with research that bug has long been fixed so I see no reason why this shouldn't happen.