### PR TITLE
Handle SDL builds which already have HAVE_MATH_H defined

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -20,7 +20,9 @@
 #include "../common.h"
 
 #ifdef __WINDOWS__
-#define HAVE_MATH_H
+	#ifndef HAVE_MATH_H
+		#define HAVE_MATH_H
+	#endif
 #endif // __WINDOWS__
 
 #include <SDL.h>

--- a/src/rct2.h
+++ b/src/rct2.h
@@ -18,6 +18,7 @@
 #define _RCT2_H_
 
 #include <SDL_platform.h>
+#include <SDL_config.h>
 
 #ifndef _USE_MATH_DEFINES
 	#define _USE_MATH_DEFINES


### PR DESCRIPTION
ArchLinux's SDL2 build for mingw already has HAVE_MATH_H define, this
fixes warnings I was getting, as they are now upgraded to errors.