### PR TITLE
Add `restrict` for drawing function

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -34,6 +34,23 @@
 #define PLATFORM_X86
 #endif
 
+// C99's restrict keywords guarantees the pointer in question, for the whole of its lifetime,
+// will be the only way to access a given memory region. In other words: there is no other pointer
+// aliasing the same memory area. Using it lets compiler generate better code. If your compiler
+// does not support it, feel free to drop it, at some performance hit.
+#ifdef __cplusplus
+	#if __GNUC__
+		#define RESTRICT __restrict__
+	#endif
+#else
+	#if __GNUC__
+		#define RESTRICT restrict
+	#endif
+#endif
+#ifndef RESTRICT
+	#define RESTRICT
+#endif
+
 #ifdef PLATFORM_X86
 	#ifndef FASTCALL
 		#ifdef __GNUC__

--- a/src/drawing/drawing.h
+++ b/src/drawing/drawing.h
@@ -135,7 +135,7 @@ void gfx_unload_g2();
 rct_g1_element* gfx_get_g1_element(int image_id);
 void sub_68371D();
 void FASTCALL gfx_bmp_sprite_to_buffer(uint8* palette_pointer, uint8* unknown_pointer, uint8* source_pointer, uint8* dest_pointer, rct_g1_element* source_image, rct_drawpixelinfo *dest_dpi, int height, int width, int image_type);
-void FASTCALL gfx_rle_sprite_to_buffer(const uint8* source_bits_pointer, uint8* dest_bits_pointer, const uint8* palette_pointer, const rct_drawpixelinfo *dpi, int image_type, int source_y_start, int height, int source_x_start, int width);
+void FASTCALL gfx_rle_sprite_to_buffer(const uint8* RESTRICT source_bits_pointer, uint8* RESTRICT dest_bits_pointer, const uint8* RESTRICT palette_pointer, const rct_drawpixelinfo * RESTRICT dpi, int image_type, int source_y_start, int height, int source_x_start, int width);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo *dpi, int image_id, int x, int y, uint32 tertiary_colour);
 void FASTCALL gfx_draw_sprite_palette_set(rct_drawpixelinfo *dpi, int image_id, int x, int y, uint8* palette_pointer, uint8* unknown_pointer);
 void FASTCALL gfx_draw_sprite_raw_masked(rct_drawpixelinfo *dpi, int x, int y, int maskImage, int colourImage);

--- a/src/drawing/drawing_fast.cpp
+++ b/src/drawing/drawing_fast.cpp
@@ -25,10 +25,10 @@ extern "C"
 #define less_or_equal_zero_mask(val) (((val - 1) >> (sizeof(val) * 8 - 1)))
 
 template<int image_type, int zoom_level>
-static void FASTCALL DrawRLESprite2(const uint8* source_bits_pointer,
-                                      uint8* dest_bits_pointer,
-                                      const uint8* palette_pointer,
-                                      const rct_drawpixelinfo *dpi,
+static void FASTCALL DrawRLESprite2(const uint8* RESTRICT source_bits_pointer,
+                                      uint8* RESTRICT dest_bits_pointer,
+                                      const uint8* RESTRICT palette_pointer,
+                                      const rct_drawpixelinfo *RESTRICT dpi,
                                       int source_y_start,
                                       int height,
                                       int source_x_start,
@@ -171,10 +171,10 @@ extern "C"
      * This function copies the sprite data onto the screen
      *  rct2: 0x0067AA18
      */
-    void FASTCALL gfx_rle_sprite_to_buffer(const uint8* source_bits_pointer,
-                                             uint8* dest_bits_pointer,
-                                             const uint8* palette_pointer,
-                                             const rct_drawpixelinfo *dpi,
+    void FASTCALL gfx_rle_sprite_to_buffer(const uint8* RESTRICT source_bits_pointer,
+                                             uint8* RESTRICT dest_bits_pointer,
+                                             const uint8* RESTRICT palette_pointer,
+                                             const rct_drawpixelinfo * RESTRICT dpi,
                                              int image_type,
                                              int source_y_start,
                                              int height,


### PR DESCRIPTION
Adds C99's `restrict` keyword to let compiler generate better code.

In case of GCC 6.1.1 compiled with `-O3` for AVX2 capable machine:

|                    | with `restrict`                    | without `restrict`                 |
|--------------------|------------------------------------|------------------------------------|
| lines/instructions | 1690                               | 1856                               |
| bytes              | 0x13db                             | 0x15cb                             |
| listing            | http://hastebin.com/pelixupaqe.txt | http://hastebin.com/regoqiyuwi.txt |

Unfortunately, I couldn't find a way for MSVC to support that properly.