### PR TITLE
Update height check for slopes to match new limits. Fixes #3792.

### DIFF
--- a/src/world/map.c
+++ b/src/world/map.c
@@ -1653,7 +1653,7 @@ static money32 map_set_land_height(int flags, int x, int y, int height, int styl
 	if (height > 142) {
 		gGameCommandErrorText = STR_TOO_HIGH;
 		return MONEY32_UNDEFINED;
-	} else if (height == 62 && (style & 0x1F) != 0) {
+	} else if (height > 140 && (style & 0x1F) != 0) {
 		gGameCommandErrorText = STR_TOO_HIGH;
 		return MONEY32_UNDEFINED;
 	}


### PR DESCRIPTION
#3792: The issue was not with the mountain tool itself, but with height limit checking for slopes. It was checked only to not be exactly +24 units.
Previously you could bypass this by heightening a flat piece of land to over +24 and subsequently making it sloped. In this case you could bypass the height limit by 1, having a sloped tile at +65.

Fixed so that it corresponds to the updated height limits. No part of the tile can now exceed +64.