### PR TITLE
Option to set window limit

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4205,6 +4205,7 @@ STR_5893    :Exchange Rate
 STR_5894    :Enter the exchange rate
 STR_5895    :Save Track
 STR_5896    :Track save failed!
+STR_5897    :Window limit:
 
 #############
 # Scenarios #

--- a/src/config.c
+++ b/src/config.c
@@ -226,7 +226,7 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, last_save_landscape_directory),   "last_landscape_directory",     CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
 	{ offsetof(general_configuration, last_save_scenario_directory),    "last_scenario_directory",      CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
 	{ offsetof(general_configuration, last_save_track_directory),       "last_track_directory",         CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
-	{ offsetof(general_configuration, window_limit),					"window_limit",					CONFIG_VALUE_TYPE_UINT8,		MAX_WINDOW_COUNT,				NULL					},
+	{ offsetof(general_configuration, window_limit),					"window_limit",					CONFIG_VALUE_TYPE_UINT8,		WINDOW_LIMIT_MAX,				NULL					},
 	
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -226,6 +226,8 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, last_save_landscape_directory),   "last_landscape_directory",     CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
 	{ offsetof(general_configuration, last_save_scenario_directory),    "last_scenario_directory",      CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
 	{ offsetof(general_configuration, last_save_track_directory),       "last_track_directory",         CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
+	{ offsetof(general_configuration, window_limit),					"window_limit",					CONFIG_VALUE_TYPE_UINT8,		MAX_WINDOW_COUNT,				NULL					},
+	
 };
 
 config_property_definition _interfaceDefinitions[] = {

--- a/src/config.h
+++ b/src/config.h
@@ -196,6 +196,7 @@ typedef struct general_configuration {
 	utf8string last_save_landscape_directory;
 	utf8string last_save_scenario_directory;
 	utf8string last_save_track_directory;
+	uint8 window_limit;
 } general_configuration;
 
 typedef struct interface_configuration {

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -671,6 +671,9 @@ static int cc_get(const utf8 **argv, int argc)
 		else if (strcmp(argv[0], "paint_segments") == 0) {
 			console_printf("paint_segments %d", gShowSupportSegmentHeights);
 		}
+		else if (strcmp(argv[0], "window_limit") == 0) {
+			console_printf("window_limit %d", gConfigGeneral.window_limit);
+		}
 		else {
 			console_writeline_warning("Invalid variable.");
 		}
@@ -843,6 +846,10 @@ static int cc_set(const utf8 **argv, int argc)
 			gShowSupportSegmentHeights = (bool)(int_val[0]);
 			gfx_invalidate_screen();
 			console_execute_silent("get paint_segments");
+		}
+		else if (strcmp(argv[0], "window_limit") == 0 && invalidArguments(&invalidArgs, int_valid[0])) {
+			window_set_window_limit(int_valid[0]);
+			console_execute_silent("get window_limit");
 		}
 		else if (invalidArgs) {
 			console_writeline_error("Invalid arguments.");
@@ -1032,6 +1039,7 @@ utf8* console_variable_table[] = {
 	"location",
 	"window_scale",
 	"paint_segments",
+	"window_limit",
 };
 utf8* console_window_table[] = {
 	"object_selection",

--- a/src/interface/viewport.h
+++ b/src/interface/viewport.h
@@ -85,7 +85,7 @@ typedef struct viewport_interaction_info {
 	};
 } viewport_interaction_info;
 
-#define MAX_VIEWPORT_COUNT MAX_WINDOW_COUNT
+#define MAX_VIEWPORT_COUNT WINDOW_LIMIT_MAX
 
 #define gSavedViewX				RCT2_GLOBAL(RCT2_ADDRESS_SAVED_VIEW_X, sint16)
 #define gSavedViewY				RCT2_GLOBAL(RCT2_ADDRESS_SAVED_VIEW_Y, sint16)

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -349,7 +349,7 @@ static void window_all_wheel_input()
 			return;
 }
 
-void window_close_surplus(int cap, sint8 avoid_classification)
+static void window_close_surplus(int cap, sint8 avoid_classification)
 {
 	int count, i, diff;
 	//find the amount of windows that are currently open

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -35,7 +35,7 @@
 #define RCT2_LAST_WINDOW		(gWindowNextSlot - 1)
 #define RCT2_NEW_WINDOW			(gWindowNextSlot)
 
-rct_window g_window_list[MAX_WINDOW_COUNT];
+rct_window g_window_list[WINDOW_LIMIT_MAX];
 rct_window * gWindowFirst;
 rct_window * gWindowNextSlot;
 
@@ -353,7 +353,7 @@ void window_close_surplus(int cap, sint8 avoid_classification)
 {
 	int count, i, diff;
 	//find the amount of windows that are currently open
-	for (i = 0; i < MAX_WINDOW_COUNT; i++) {
+	for (i = 0; i < WINDOW_LIMIT_MAX; i++) {
 		if (&g_window_list[i] == RCT2_NEW_WINDOW) {
 			count = i;
 			break;
@@ -382,7 +382,7 @@ void window_close_surplus(int cap, sint8 avoid_classification)
 void window_set_window_limit(int value) 
 {
 	int prev = gConfigGeneral.window_limit;
-	int val = clamp(value, MIN_WINDOW_COUNT, MAX_WINDOW_COUNT);
+	int val = clamp(value, WINDOW_LIMIT_MIN, WINDOW_LIMIT_MAX);
 	gConfigGeneral.window_limit = val;
 	config_save_default();
 	// Checks if value decreases and then closes surplus

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -515,11 +515,11 @@ extern modal_callback gLoadSaveCallback;
 
 typedef void (*close_callback)();
 
-#define MIN_WINDOW_COUNT 8
-#define MAX_WINDOW_COUNT 64
+#define WINDOW_LIMIT_MIN 8
+#define WINDOW_LIMIT_MAX 64
 
 // rct2: 0x01420078
-extern rct_window g_window_list[MAX_WINDOW_COUNT];
+extern rct_window g_window_list[WINDOW_LIMIT_MAX];
 
 extern rct_window * gWindowFirst;
 extern rct_window * gWindowNextSlot;

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -515,6 +515,7 @@ extern modal_callback gLoadSaveCallback;
 
 typedef void (*close_callback)();
 
+#define MIN_WINDOW_COUNT 8
 #define MAX_WINDOW_COUNT 64
 
 // rct2: 0x01420078
@@ -532,6 +533,9 @@ extern uint16 gWindowMapFlashingFlags;
 void window_dispatch_update_all();
 void window_update_all_viewports();
 void window_update_all();
+
+void window_set_window_limit(int value);
+
 rct_window *window_create(int x, int y, int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags);
 rct_window *window_create_auto_pos(int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags);
 rct_window *window_create_centred(int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags);

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -1129,7 +1129,7 @@ enum {
 	STR_NUMBER_OF_ROTATIONS = 1869,
 	STR_NUMBER_OF_ROTATIONS_TIP = 1870,
 	STR_ARG18_COMMA16 = 1871, // Should probably be in RIDE domain
-	STR_COMMA16 = 1872, // Unused
+	STR_COMMA16 = 1872,
 	STR_INCOME_PER_HOUR = 1873,
 	STR_PROFIT_PER_HOUR = 1874,
 	STR_GUEST_ITEM_FORMAT = 1875,
@@ -3329,6 +3329,8 @@ enum {
 	STR_FILE_DIALOG_TITLE_SAVE_TRACK = 5895,
 	STR_TRACK_SAVE_FAILED = 5896,
 	
+	STR_WINDOW_LIMIT = 5897,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -161,6 +161,9 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_AUTO_OPEN_SHOPS,
 	WIDX_DEFAULT_INSPECTION_INTERVAL,
 	WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
+	WIDX_WINDOW_LIMIT,
+	WIDX_WINDOW_LIMIT_UP,
+	WIDX_WINDOW_LIMIT_DOWN,
 
 	// Twitch
 	WIDX_CHANNEL_BUTTON = WIDX_PAGE_START,
@@ -308,6 +311,9 @@ static rct_widget window_options_misc_widgets[] = {
 	{ WWT_CHECKBOX,			2,	10,		299,	219,	230,	STR_AUTO_OPEN_SHOPS,						STR_AUTO_OPEN_SHOPS_TIP },							// Automatically open shops & stalls
 	{ WWT_DROPDOWN,			1,	155,	299,	234,	245,	STR_NONE,									STR_NONE },											// Default inspection time dropdown
 	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	235,	244,	STR_DROPDOWN_GLYPH,							STR_DEFAULT_INSPECTION_INTERVAL_TIP },				// Default inspection time dropdown button
+	{ WWT_SPINNER,			1,	155,	299,	249,	260,	STR_NONE,									STR_NONE },								// Window limit
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	250,	254,	STR_NUMERIC_UP,								STR_NONE },											// Window limit up
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	255,	259,	STR_NUMERIC_DOWN,							STR_NONE },											// Window limit down
 	{ WIDGETS_END },
 };
 
@@ -514,7 +520,10 @@ static uint32 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_STAY_CONNECTED_AFTER_DESYNC) |
 	(1 << WIDX_AUTO_OPEN_SHOPS) |
 	(1 << WIDX_DEFAULT_INSPECTION_INTERVAL) |
-	(1 << WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN),
+	(1 << WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN) |
+	(1 << WIDX_WINDOW_LIMIT) |
+	(1 << WIDX_WINDOW_LIMIT_UP) |
+	(1 << WIDX_WINDOW_LIMIT_DOWN),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
 	(1 << WIDX_CHANNEL_BUTTON) |
@@ -781,6 +790,7 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 			gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
 			config_save_default();
 			window_invalidate(w);
+			break;
 		}
 		break;
 
@@ -1120,6 +1130,20 @@ static void window_options_mousedown(int widgetIndex, rct_window*w, rct_widget* 
 
 			window_options_show_dropdown(w, widget, 7);
 			dropdown_set_checked(gConfigGeneral.default_inspection_interval, true);
+			break;
+		case WIDX_WINDOW_LIMIT_UP:
+			i = gConfigGeneral.window_limit;
+			if (i < MAX_WINDOW_COUNT) {
+				window_set_window_limit(++i);
+			}
+			window_invalidate(w);
+			break;
+		case WIDX_WINDOW_LIMIT_DOWN:
+			i = gConfigGeneral.window_limit;
+			if (i > MIN_WINDOW_COUNT) {
+				window_set_window_limit(--i);
+			}
+			window_invalidate(w);
 			break;
 		}
 		break;
@@ -1564,6 +1588,8 @@ static void window_options_invalidate(rct_window *w)
 		if (gParkFlags & PARK_FLAGS_LOCK_REAL_NAMES_OPTION)
 			w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
 
+		w->hold_down_widgets |= (1 << WIDX_WINDOW_LIMIT_UP) | (1 << WIDX_WINDOW_LIMIT_DOWN);
+		
 		// save plugin data checkbox: visible or not
 		window_options_misc_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 
@@ -1593,6 +1619,9 @@ static void window_options_invalidate(rct_window *w)
 		window_options_misc_widgets[WIDX_AUTO_OPEN_SHOPS].type = WWT_CHECKBOX;
 		window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].type = WWT_DROPDOWN;
 		window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
+		window_options_misc_widgets[WIDX_WINDOW_LIMIT].type = WWT_SPINNER;
+		window_options_misc_widgets[WIDX_WINDOW_LIMIT_UP].type = WWT_DROPDOWN_BUTTON;
+		window_options_misc_widgets[WIDX_WINDOW_LIMIT_DOWN].type = WWT_DROPDOWN_BUTTON;
 		break;
 
 	case WINDOW_OPTIONS_PAGE_TWITCH:
@@ -1789,6 +1818,15 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 			w->colours[1],
 			w->x + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].left + 1,
 			w->y + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top
+		);
+		gfx_draw_string_left(dpi, STR_WINDOW_LIMIT, w, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_WINDOW_LIMIT].top + 1);
+		gfx_draw_string_left(
+			dpi,
+			STR_COMMA16,
+			&gConfigGeneral.window_limit,
+			w->colours[1],
+			w->x + window_options_misc_widgets[WIDX_WINDOW_LIMIT].left + 1,
+			w->y + window_options_misc_widgets[WIDX_WINDOW_LIMIT].top
 		);
 		break;
 	}

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -1133,14 +1133,14 @@ static void window_options_mousedown(int widgetIndex, rct_window*w, rct_widget* 
 			break;
 		case WIDX_WINDOW_LIMIT_UP:
 			i = gConfigGeneral.window_limit;
-			if (i < MAX_WINDOW_COUNT) {
+			if (i < WINDOW_LIMIT_MAX) {
 				window_set_window_limit(++i);
 			}
 			window_invalidate(w);
 			break;
 		case WIDX_WINDOW_LIMIT_DOWN:
 			i = gConfigGeneral.window_limit;
-			if (i > MIN_WINDOW_COUNT) {
+			if (i > WINDOW_LIMIT_MIN) {
 				window_set_window_limit(--i);
 			}
 			window_invalidate(w);


### PR DESCRIPTION
EDIT: I have fixed the underlying issues below. What this does is allows a limit to be set on the number of windows that are open at a time. This will help problems related to windows with viewpoint frames, overflowing of staff members when hiring, and aid for people who have small screens and have no reason for alot of windows.


--Original post below--
I am currently having issues figuring out how to go about tracking if the amount of windows currently open are overflowing the newly set limit, and I don't think making a seperate int value that stores the amount of windows open would be very optimal. A goal is to keep this pull request as minimal and simple as possible, and not to modify too much of the core engine (as i am trying to ease myself into this idea of group development), so I was wondering if i could get some help with finding out how to tackle the "if there is 14 windows open and the limit is set to 10, close 4 windows (without closing the options window)" situation.

Somewhere along the lines of trial-and-error with attempting to fix the issue above, i noticed there would be a glitch that would cause the viewports to glitch out or be a nullptr, followed by get_window_main() becoming a nullptr. I am fairly certain it is to do with the above issue, but I am not certain if i fixed it yet, but I would prefer if this was to be tested a few times by others after i possibly get some guidance on how to properly execute what i'm attempting to do. 
