### PR TITLE
Chain lift cheat

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4181,6 +4181,8 @@ STR_5869    :{WINDOW_COLOUR_2}Provider Website: {BLACK}{STRING}
 STR_5870    :{SMALLFONT}{BLACK}Show server information
 STR_5871    :Plants don't age.
 STR_5872    :{SMALLFONT}{BLACK}Disable plant aging such that they don't wilt.
+STR_5873    :Enable chain lift on all track
+STR_5874    :{SMALLFONT}{BLACK}Allows any piece of track to be made into a chain lift
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4181,7 +4181,7 @@ STR_5869    :{WINDOW_COLOUR_2}Provider Website: {BLACK}{STRING}
 STR_5870    :{SMALLFONT}{BLACK}Show server information
 STR_5871    :Plants don't age.
 STR_5872    :{SMALLFONT}{BLACK}Disable plant aging such that they don't wilt.
-STR_5873    :Enable chain lift on all track
+STR_5873    :Allow chain lifts on all track pieces
 STR_5874    :{SMALLFONT}{BLACK}Allows any piece of track to be made into a chain lift
 
 #############

--- a/src/cheats.c
+++ b/src/cheats.c
@@ -384,6 +384,7 @@ void game_command_cheat(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* e
 			case CHEAT_DISABLEBRAKESFAILURE: gCheatsDisableBrakesFailure = !gCheatsDisableBrakesFailure; break;
 			case CHEAT_DISABLEALLBREAKDOWNS: gCheatsDisableAllBreakdowns = !gCheatsDisableAllBreakdowns; break;
 			case CHEAT_DISABLETRAINLENGTHLIMIT: gCheatsDisableTrainLengthLimit = !gCheatsDisableTrainLengthLimit; break;
+			case CHEAT_ENABLECHAINLIFTONALLTRACK: gCheatsEnableChainLiftOnAllTrack = !gCheatsEnableChainLiftOnAllTrack; break;
 			case CHEAT_UNLOCKALLPRICES: gCheatsUnlockAllPrices = !gCheatsUnlockAllPrices; window_invalidate_by_class(WC_RIDE); window_invalidate_by_class(WC_PARK_INFORMATION); break;
 			case CHEAT_BUILDINPAUSEMODE: gCheatsBuildInPauseMode = !gCheatsBuildInPauseMode; break;
 			case CHEAT_IGNORERIDEINTENSITY: gCheatsIgnoreRideIntensity = !gCheatsIgnoreRideIntensity; break;
@@ -430,6 +431,8 @@ void cheats_reset()
 	gCheatsDisableSupportLimits = false;
 	gCheatsShowAllOperatingModes = false;
 	gCheatsShowVehiclesFromOtherTrackTypes = false;
+	gCheatsDisableTrainLengthLimit = false;
+	gCheatsEnableChainLiftOnAllTrack=false;
 	gCheatsFastLiftHill = false;
 	gCheatsDisableBrakesFailure = false;
 	gCheatsDisableAllBreakdowns = false;

--- a/src/cheats.c
+++ b/src/cheats.c
@@ -42,6 +42,7 @@ bool gCheatsNeverendingMarketing = false;
 bool gCheatsFreezeClimate = false;
 bool gCheatsDisableTrainLengthLimit = false;
 bool gCheatsDisablePlantAging = false;
+bool gCheatsEnableChainLiftOnAllTrack = false;
 
 int park_rating_spinner_value;
 

--- a/src/cheats.c
+++ b/src/cheats.c
@@ -432,7 +432,7 @@ void cheats_reset()
 	gCheatsShowAllOperatingModes = false;
 	gCheatsShowVehiclesFromOtherTrackTypes = false;
 	gCheatsDisableTrainLengthLimit = false;
-	gCheatsEnableChainLiftOnAllTrack=false;
+	gCheatsEnableChainLiftOnAllTrack = false;
 	gCheatsFastLiftHill = false;
 	gCheatsDisableBrakesFailure = false;
 	gCheatsDisableAllBreakdowns = false;

--- a/src/cheats.h
+++ b/src/cheats.h
@@ -36,6 +36,8 @@ extern bool gCheatsNeverendingMarketing;
 extern bool gCheatsFreezeClimate;
 extern bool gCheatsDisableTrainLengthLimit;
 extern bool gCheatsDisablePlantAging;
+extern bool gCheatsEnableChainLiftOnAllTrack;
+
 
 enum {
 	CHEAT_SANDBOXMODE,
@@ -44,6 +46,7 @@ enum {
 	CHEAT_SHOWALLOPERATINGMODES,
 	CHEAT_SHOWVEHICLESFROMOTHERTRACKTYPES,
 	CHEAT_DISABLETRAINLENGTHLIMIT,
+	CHEAT_ENABLECHAINLIFTONALLTRACK,
 	CHEAT_FASTLIFTHILL,
 	CHEAT_DISABLEBRAKESFAILURE,
 	CHEAT_DISABLEALLBREAKDOWNS,

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -2647,6 +2647,9 @@ enum {
 	STR_CHEAT_DISABLE_PLANT_AGING = 5871,
 	STR_CHEAT_DISABLE_PLANT_AGING_TIP = 5872,
 
+	STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK = 5873,
+	STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP = 5874,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -54,7 +54,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/rct2/S6Exporter.cpp
+++ b/src/rct2/S6Exporter.cpp
@@ -550,6 +550,7 @@ extern "C"
         SDL_WriteU8(rw, gCheatsDisableClearanceChecks);
         SDL_WriteU8(rw, gCheatsDisableSupportLimits);
         SDL_WriteU8(rw, gCheatsDisableTrainLengthLimit);
+	SDL_WriteU8(rw, gCheatsEnableChainLiftOnAllTrack);
         SDL_WriteU8(rw, gCheatsShowAllOperatingModes);
         SDL_WriteU8(rw, gCheatsShowVehiclesFromOtherTrackTypes);
         SDL_WriteU8(rw, gCheatsFastLiftHill);

--- a/src/rct2/S6Exporter.cpp
+++ b/src/rct2/S6Exporter.cpp
@@ -550,7 +550,7 @@ extern "C"
         SDL_WriteU8(rw, gCheatsDisableClearanceChecks);
         SDL_WriteU8(rw, gCheatsDisableSupportLimits);
         SDL_WriteU8(rw, gCheatsDisableTrainLengthLimit);
-	SDL_WriteU8(rw, gCheatsEnableChainLiftOnAllTrack);
+        SDL_WriteU8(rw, gCheatsEnableChainLiftOnAllTrack);
         SDL_WriteU8(rw, gCheatsShowAllOperatingModes);
         SDL_WriteU8(rw, gCheatsShowVehiclesFromOtherTrackTypes);
         SDL_WriteU8(rw, gCheatsFastLiftHill);

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -515,7 +515,7 @@ extern "C"
         gCheatsDisableClearanceChecks = SDL_ReadU8(rw) != 0;
         gCheatsDisableSupportLimits = SDL_ReadU8(rw) != 0;
         gCheatsDisableTrainLengthLimit = SDL_ReadU8(rw) != 0;
-	gCheatsEnableChainLiftOnAllTrack = SDL_ReadU8(rw) != 0;
+        gCheatsEnableChainLiftOnAllTrack = SDL_ReadU8(rw) != 0;
         gCheatsShowAllOperatingModes = SDL_ReadU8(rw) != 0;
         gCheatsShowVehiclesFromOtherTrackTypes = SDL_ReadU8(rw) != 0;
         gCheatsFastLiftHill = SDL_ReadU8(rw) != 0;

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -515,6 +515,7 @@ extern "C"
         gCheatsDisableClearanceChecks = SDL_ReadU8(rw) != 0;
         gCheatsDisableSupportLimits = SDL_ReadU8(rw) != 0;
         gCheatsDisableTrainLengthLimit = SDL_ReadU8(rw) != 0;
+	gCheatsEnableChainLiftOnAllTrack = SDL_ReadU8(rw) != 0;
         gCheatsShowAllOperatingModes = SDL_ReadU8(rw) != 0;
         gCheatsShowVehiclesFromOtherTrackTypes = SDL_ReadU8(rw) != 0;
         gCheatsFastLiftHill = SDL_ReadU8(rw) != 0;

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -1540,7 +1540,9 @@ void ride_construction_set_default_next_piece()
 		// Set track slope and lift hill
 		_currentTrackSlopeEnd = slope;
 		_previousTrackSlopeEnd = slope;
-		_currentTrackLiftHill = track_element_is_lift_hill(mapElement);
+		if (!gCheatsEnableChainLiftOnAllTrack) {
+			_currentTrackLiftHill = track_element_is_lift_hill(mapElement);
+		}
 		break;
 	}
 }

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -653,7 +653,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 				return MONEY32_UNDEFINED;
 			}
 		}
-		if ((edx_flags & (1 << 0)) && !(enabledTrackPieces & (1ULL << TRACK_LIFT_HILL_STEEP))) {
+		if ((edx_flags & (1 << 0)) && !(enabledTrackPieces & (1ULL << TRACK_LIFT_HILL_STEEP)) && !gCheatsEnableChainLiftOnAllTrack) {
 			if (RCT2_ADDRESS(0x0099423C, uint16)[type] & 0x400) {
 				gGameCommandErrorText = STR_TOO_STEEP_FOR_LIFT_HILL;
 				return MONEY32_UNDEFINED;

--- a/src/windows/cheats.c
+++ b/src/windows/cheats.c
@@ -120,6 +120,7 @@ enum WINDOW_CHEATS_WIDGET_IDX {
 	WIDX_SHOW_ALL_OPERATING_MODES,
 	WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES,
 	WIDX_DISABLE_TRAIN_LENGTH_LIMITS,
+	WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK
 };
 
 #pragma region MEASUREMENTS
@@ -248,6 +249,7 @@ static rct_widget window_cheats_rides_widgets[] = {
 	{ WWT_CHECKBOX,			2,		XPL(0),					OWPL,					YPL(7),			OHPL(7),		STR_CHEAT_SHOW_ALL_OPERATING_MODES,	STR_NONE }, 							// Show all operating modes
 	{ WWT_CHECKBOX,			2,		XPL(0),					OWPL,					YPL(6),			OHPL(6),		STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES,	STR_NONE }, 				// Show vehicles from other track types
 	{ WWT_CHECKBOX,			2,		XPL(0),					OWPL,					YPL(12),		OHPL(12),		STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,	STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP },	// Disable train length limits
+	{ WWT_CHECKBOX,			2,		XPL(0),					OWPL,					YPL(13),		OHPL(13),		STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,	STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP },	// Enable chain lift on all track
 	{ WIDGETS_END },
 };
 
@@ -419,7 +421,7 @@ static uint64 window_cheats_page_enabled_widgets[] = {
 	(1ULL << WIDX_CLOSE) | (1ULL << WIDX_TAB_1) | (1ULL << WIDX_TAB_2) | (1ULL << WIDX_TAB_3) | (1ULL << WIDX_TAB_4) | (1ULL << WIDX_RENEW_RIDES) |
 		(1ULL << WIDX_MAKE_DESTRUCTIBLE) | (1ULL << WIDX_FIX_ALL) | (1ULL << WIDX_FAST_LIFT_HILL) | (1ULL << WIDX_DISABLE_BRAKES_FAILURE) |
 		(1ULL << WIDX_DISABLE_ALL_BREAKDOWNS) | (1ULL << WIDX_BUILD_IN_PAUSE_MODE) | (1ULL << WIDX_RESET_CRASH_STATUS) | (1ULL << WIDX_10_MINUTE_INSPECTIONS) |
-		(1ULL << WIDX_SHOW_ALL_OPERATING_MODES) | (1ULL << WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES) |(1ULL << WIDX_DISABLE_TRAIN_LENGTH_LIMITS)
+		(1ULL << WIDX_SHOW_ALL_OPERATING_MODES) | (1ULL << WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES) | (1ULL << WIDX_DISABLE_TRAIN_LENGTH_LIMITS) | (1ULL << WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK)
 };
 
 static rct_string_id window_cheats_page_titles[] = {
@@ -741,6 +743,9 @@ static void window_cheats_rides_mouseup(rct_window *w, int widgetIndex)
 			window_error_open(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
 		}
 		break;
+	case WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK:
+		game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_ENABLECHAINLIFTONALLTRACK, 0, GAME_COMMAND_CHEAT, 0, 0);
+		break;
 	}
 }
 
@@ -812,6 +817,7 @@ static void window_cheats_invalidate(rct_window *w)
 		widget_set_checkbox_value(w, WIDX_SHOW_ALL_OPERATING_MODES, gCheatsShowAllOperatingModes);
 		widget_set_checkbox_value(w, WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES, gCheatsShowVehiclesFromOtherTrackTypes);
 		widget_set_checkbox_value(w, WIDX_DISABLE_TRAIN_LENGTH_LIMITS, gCheatsDisableTrainLengthLimit);
+		widget_set_checkbox_value(w, WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK, gCheatsEnableChainLiftOnAllTrack);
 		break;
 	}
 

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -1061,7 +1061,7 @@ static void window_ride_construction_resize(rct_window *w)
 	if (_currentTrackCurve != TRACK_CURVE_NONE && _currentTrackSlopeEnd == TRACK_SLOPE_DOWN_60) {
 		disabledWidgets |= (1ULL << WIDX_SLOPE_DOWN);
 	}
-	if (_currentTrackLiftHill & 1) {
+	if ((_currentTrackLiftHill & 1) && !gCheatsEnableChainLiftOnAllTrack) {
 		if (_currentTrackSlopeEnd != TRACK_SLOPE_NONE && !is_track_enabled(TRACK_LIFT_HILL_CURVE)) {
 			disabledWidgets |=
 				(1ULL << WIDX_LEFT_CURVE_SMALL) |
@@ -1220,7 +1220,10 @@ static void window_ride_construction_resize(rct_window *w)
 		disabledWidgets &= ~(1ULL << WIDX_BANK_RIGHT);
 	}
 	
-	disabledWidgets &=~(1ULL<<WIDX_CHAIN_LIFT);	
+	//If chain lift cheat is enabled then show the chain lift widget no matter what
+	if(gCheatsEnableChainLiftOnAllTrack) {
+		disabledWidgets &=~(1ULL<<WIDX_CHAIN_LIFT);	
+	}
 
 	// Set and invalidate the changed widgets
 	uint64 currentDisabledWidgets = w->disabled_widgets;
@@ -3072,7 +3075,7 @@ static void window_ride_construction_update_widgets(rct_window *w)
 	}
 
 	int x;
-	if (is_track_enabled(TRACK_LIFT_HILL) && _currentTrackCurve < 256) {
+	if ((is_track_enabled(TRACK_LIFT_HILL) && _currentTrackCurve < 256) || gCheatsEnableChainLiftOnAllTrack) {
 		window_ride_construction_widgets[WIDX_CHAIN_LIFT].type = WWT_FLATBTN;
 		x = 9;
 	} else {

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -1222,7 +1222,7 @@ static void window_ride_construction_resize(rct_window *w)
 	
 	//If chain lift cheat is enabled then show the chain lift widget no matter what
 	if(gCheatsEnableChainLiftOnAllTrack) {
-		disabledWidgets &=~(1ULL<<WIDX_CHAIN_LIFT);	
+		disabledWidgets &= ~(1ULL<<WIDX_CHAIN_LIFT);	
 	}
 
 	// Set and invalidate the changed widgets

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -1219,6 +1219,8 @@ static void window_ride_construction_resize(rct_window *w)
 		disabledWidgets &= ~(1ULL << WIDX_BANK_STRAIGHT);
 		disabledWidgets &= ~(1ULL << WIDX_BANK_RIGHT);
 	}
+	
+	disabledWidgets &=~(1ULL<<WIDX_CHAIN_LIFT);	
 
 	// Set and invalidate the changed widgets
 	uint64 currentDisabledWidgets = w->disabled_widgets;
@@ -2623,8 +2625,8 @@ static bool sub_6CA2DF(int *_trackType, int *_trackDirection, int *_rideIndex, i
 		do_loc_6CAF26 = true;
 	}
 
-	if (do_loc_6CAF26) {
-		edxRS16 &= 0xFFFE; // unsets 0x1
+	if (do_loc_6CAF26 && !gCheatsEnableChainLiftOnAllTrack) {
+		edxRS16 &= 0xFFFE; //unsets 0x1
 		_currentTrackLiftHill &= 0xFE;
 
 		if (trackType == TRACK_ELEM_LEFT_CURVED_LIFT_HILL || trackType == TRACK_ELEM_RIGHT_CURVED_LIFT_HILL) {


### PR DESCRIPTION
This cheat allows any piece to be made into a track piece. When enabled, the chain lift button in the ride construction window is always shown, and pieces that cannot normally have chain will not be hidden when chain lift is toggled. It also suppresses the "too steep for lift hill" message that you get on rides that allow steep chains but only under limited circumstances (mostly the looping and inverted shuttle coasters). If the track piece does not have sprites for a lift hill then the default sprite is shown instead, but it will still function as a lift.

This may need a bit more testing - there are several places in which the chain lift is toggled and I wasn't sure what all of them were for - there may be an edge case in which this cheat doesn't work that I haven't found yet.