### PR TITLE
Fix #3571 and made scrolling in windowed mode more generic

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1612,13 +1612,13 @@ void game_handle_edge_scroll()
 	// Scroll left / right
 	if (gCursorState.x == 0)
 		scrollX = -1;
-	else if (gCursorState.x == gScreenWidth - 1)
+	else if (gCursorState.x >= gScreenWidth - 1)
 		scrollX = 1;
 
 	// Scroll up / down
 	if (gCursorState.y == 0)
 		scrollY = -1;
-	else if (gCursorState.y == gScreenHeight - 1)
+	else if (gCursorState.y >= gScreenHeight - 1)
 		scrollY = 1;
 
 	// Scroll viewport


### PR DESCRIPTION
Fix bug #3571
And now in windowed mode when you go out of window the map scroll always in when Scroll view when pointer at screen edge is enabled.
In the old situation that only happens left and above the window