### PR TITLE
Add command to set vehicle friction

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -476,19 +476,28 @@ static int cc_rides(const utf8 **argv, int argc)
 				bool int_valid[2] = { 0 };
 				int ride_index = console_parse_int(argv[2], &int_valid[0]);
 				int friction = console_parse_int(argv[3], &int_valid[1]);
-
-				if (int_valid[0] && int_valid[1] && (friction > 0) && (get_ride(ride_index)->type != RIDE_TYPE_NULL)) {
-					rct_ride *ride = get_ride(ride_index);
-					for (int i = 0; i < ride->num_vehicles; i++) {
-						uint16 vehicle_index = ride->vehicles[i];
- 						while (vehicle_index != SPRITE_INDEX_NULL) {
-							rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
-							vehicle->friction=friction;
-							vehicle_index=vehicle->next_vehicle_on_train;
+					
+					if (ride_index < 0) {
+						console_printf("Ride index must not be negative");
+					} else if (!int_valid[0] || !int_valid[1]) {
+						console_printf("This command expects integer arguments");
+					} else {
+						rct_ride *ride = get_ride(ride_index);
+						if (friction <= 0) {
+							console_printf("Friction value must be strictly positive");
+						} else if (ride->type == RIDE_TYPE_NULL) {
+							console_printf("No ride found with index %d",ride_index);
+						} else {
+							for (int i = 0; i < ride->num_vehicles; i++) {
+								uint16 vehicle_index = ride->vehicles[i];
+ 								while (vehicle_index != SPRITE_INDEX_NULL) {
+									rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
+									vehicle->friction=friction;
+									vehicle_index=vehicle->next_vehicle_on_train;
+								}
+							}			
 						}
-					}			
-				}
-			}
+					}			}
 		}
 	} else {
 		console_printf("subcommands: list, set");

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -481,11 +481,11 @@ static int cc_rides(const utf8 **argv, int argc)
 					rct_ride *ride = get_ride(ride_index);
 					for (int i = 0; i < ride->num_vehicles; i++) {
 						uint16 vehicle_index = ride->vehicles[i];
- 						do {
+ 						while (vehicle_index != SPRITE_INDEX_NULL) {
 							rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
 							vehicle->friction=friction;
 							vehicle_index=vehicle->next_vehicle_on_train;
-						}while (vehicle_index != SPRITE_INDEX_NULL);
+						}
 					}			
 				}
 			}

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -472,6 +472,22 @@ static int cc_rides(const utf8 **argv, int argc)
 						ride->subtype = int_val[2];
 					}
 				}
+			} else if (strcmp(argv[1], "friction") == 0) {
+				bool int_valid[2] = { 0 };
+				int ride_index = console_parse_int(argv[2], &int_valid[0]);
+				int friction = console_parse_int(argv[3], &int_valid[1]);
+
+				if (int_valid[0] && int_valid[1] && (friction > 0) && (get_ride(ride_index)->type != RIDE_TYPE_NULL)) {
+					rct_ride *ride = get_ride(ride_index);
+					for (int i = 0; i < ride->num_vehicles; i++) {
+						uint16 vehicle_index = ride->vehicles[i];
+ 						do {
+							rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
+							vehicle->friction=friction;
+							vehicle_index=vehicle->next_vehicle_on_train;
+						}while (vehicle_index != SPRITE_INDEX_NULL);
+					}			
+				}
 			}
 		}
 	} else {

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -477,27 +477,28 @@ static int cc_rides(const utf8 **argv, int argc)
 				int ride_index = console_parse_int(argv[2], &int_valid[0]);
 				int friction = console_parse_int(argv[3], &int_valid[1]);
 					
-					if (ride_index < 0) {
-						console_printf("Ride index must not be negative");
-					} else if (!int_valid[0] || !int_valid[1]) {
-						console_printf("This command expects integer arguments");
+				if (ride_index < 0) {
+					console_printf("Ride index must not be negative");
+				} else if (!int_valid[0] || !int_valid[1]) {
+					console_printf("This command expects integer arguments");
+				} else {
+					rct_ride *ride = get_ride(ride_index);
+					if (friction <= 0) {
+						console_printf("Friction value must be strictly positive");
+					} else if (ride->type == RIDE_TYPE_NULL) {
+						console_printf("No ride found with index %d",ride_index);
 					} else {
-						rct_ride *ride = get_ride(ride_index);
-						if (friction <= 0) {
-							console_printf("Friction value must be strictly positive");
-						} else if (ride->type == RIDE_TYPE_NULL) {
-							console_printf("No ride found with index %d",ride_index);
-						} else {
-							for (int i = 0; i < ride->num_vehicles; i++) {
-								uint16 vehicle_index = ride->vehicles[i];
- 								while (vehicle_index != SPRITE_INDEX_NULL) {
-									rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
-									vehicle->friction=friction;
-									vehicle_index=vehicle->next_vehicle_on_train;
-								}
-							}			
-						}
-					}			}
+						for (int i = 0; i < ride->num_vehicles; i++) {
+							uint16 vehicle_index = ride->vehicles[i];
+ 							while (vehicle_index != SPRITE_INDEX_NULL) {
+								rct_vehicle *vehicle=GET_VEHICLE(vehicle_index);
+								vehicle->friction=friction;
+								vehicle_index=vehicle->next_vehicle_on_train;
+							}
+						}			
+					}
+				}
+			}
 		}
 	} else {
 		console_printf("subcommands: list, set");


### PR DESCRIPTION
This adds a new command "rides set friction" which makes it possible to change the friction of ride vehicles while the ride is running. The syntax is "rides set friction <ride index> <friction value>". Every car currently on the track will have its friction updated to the specified value.

There is no provision for setting a different friction value on each train, because I couldn't think of a use for that, but that could also be implemented if it was desired. There is no reason to allow setting friction per-vehicle because all that matters is the total for the train - per vehicle friction values are only meaningful in .DAT files.

Double closing or building on the ride will reset the friction because the new values are tied to the vehicle and not the ride itself; I don't think there's a way around this without having to modify the ride entry as rides themselves don't have friction values associated with them.