### PR TITLE
Fix segfault when passing invalid arguments to ride set type

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -474,13 +474,13 @@ static int cc_rides(const utf8 **argv, int argc)
 					console_printf("No ride entry found for given subtype");
 				} else {
 					rct_ride *ride = get_ride(ride_index);
-					if(ride->type != RIDE_TYPE_NULL) {
+					if (ride->type != RIDE_TYPE_NULL) {
 						ride->type = type;
 						if (int_valid[2]) {
 							ride->subtype = subtype;
 						}
 					} else {
-						console_printf("No ride found with index %d",ride_index);
+						console_printf("No ride found with index %d", ride_index);
 					}
 				}
 			}

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -465,10 +465,13 @@ static int cc_rides(const utf8 **argv, int argc)
 				if (argc > 4) {
 					subtype = console_parse_int(argv[4], &int_valid[2]);
 				}
-				if (!int_valid[0] || !int_valid[1] || (argc > 4 && !int_valid[2])) {
+				if (!int_valid[0] || !int_valid[1]) {
 					console_printf("This command expects integer arguments");
 				} else if (ride_index < 0) {
 					console_printf("Ride index must not be negative");
+				} else if (argc > 4 && (!int_valid[2] || (subtype < 0 || subtype >= object_entry_group_counts[OBJECT_TYPE_RIDE])))
+				{
+					console_printf("No ride entry found for given subtype");
 				} else {
 					rct_ride *ride = get_ride(ride_index);
 					if(ride->type != RIDE_TYPE_NULL) {

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -458,18 +458,26 @@ static int cc_rides(const utf8 **argv, int argc)
 				return 0;
 			}
 			if (strcmp(argv[1], "type") == 0) {
-				int int_val[3];
+				int subtype;
 				bool int_valid[3] = { 0 };
-				int_val[0] = console_parse_int(argv[2], &int_valid[0]);
-				int_val[1] = console_parse_int(argv[3], &int_valid[1]);
+				int ride_index = console_parse_int(argv[2], &int_valid[0]);
+				int type = console_parse_int(argv[3], &int_valid[1]);
 				if (argc > 4) {
-					int_val[2] = console_parse_int(argv[4], &int_valid[2]);
+					subtype = console_parse_int(argv[4], &int_valid[2]);
 				}
-				if (int_valid[0] && int_valid[1] && (get_ride(int_val[0])->type != RIDE_TYPE_NULL)) {
-					rct_ride *ride = get_ride(int_val[0]);
-					ride->type = int_val[1];
-					if (int_valid[2]) {
-						ride->subtype = int_val[2];
+				if (!int_valid[0] || !int_valid[1] || (argc > 4 && !int_valid[2])) {
+					console_printf("This command expects integer arguments");
+				} else if (ride_index < 0) {
+					console_printf("Ride index must not be negative");
+				} else {
+					rct_ride *ride = get_ride(ride_index);
+					if(ride->type != RIDE_TYPE_NULL) {
+						ride->type = type;
+						if (int_valid[2]) {
+							ride->subtype = subtype;
+						}
+					} else {
+						console_printf("No ride found with index %d",ride_index);
 					}
 				}
 			}


### PR DESCRIPTION
I noticed that the ride set type command did not check whether the supplied ride index was valid and would segfault if an out of range or negative index was supplied. I have added checks to prevent this, and also made it print a message to the console if the command fails for any reason. This should make it clearer whether the command did or didn't work.

This does nothing about the segfault you get if you set the ride type to one that doesn't have all the necessary track pieces - that would be desirable but I'm not sure how to go about preventing it.