### PR TITLE
Add parameter to utf8_remove_formatting to allow colour codes (fixes #3638)

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -696,7 +696,7 @@ void game_convert_strings_to_utf8()
 
 		if (!str_is_null_or_empty(userString)) {
 			rct2_to_utf8_self(userString, 32);
-			utf8_remove_formatting(userString);
+			utf8_remove_formatting(userString, true);
 		}
 	}
 

--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -186,7 +186,7 @@ int utf8_get_format_code_arg_length(int codepoint)
 	}
 }
 
-void utf8_remove_formatting(utf8* string) {
+void utf8_remove_formatting(utf8* string, bool allowColours) {
 	utf8* readPtr = string;
 	utf8* writePtr = string;
 
@@ -196,8 +196,7 @@ void utf8_remove_formatting(utf8* string) {
 		if (code == 0) {
 			*writePtr = 0;
 			break;
-		}
-		else if (!utf8_is_format_code(code)) {
+		} else if (!utf8_is_format_code(code) || (allowColours && utf8_is_colour_code(code))) {
 			writePtr = utf8_write_codepoint(writePtr, code);
 		}
 	}

--- a/src/localisation/localisation.h
+++ b/src/localisation/localisation.h
@@ -27,7 +27,7 @@ bool utf8_is_colour_code(int codepoint);
 bool utf8_should_use_sprite_for_codepoint(int codepoint);
 int font_sprite_get_codepoint_offset(int codepoint);
 int utf8_get_format_code_arg_length(int codepoint);
-void utf8_remove_formatting(utf8* string);
+void utf8_remove_formatting(utf8* string, bool allowColours);
 
 void format_string(char *dest, rct_string_id format, void *args);
 void format_string_raw(char *dest, char *src, void *args);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -920,7 +920,7 @@ void Network::AppendChatLog(const utf8 *text)
 			strftime(buffer, sizeof(buffer), "[%Y/%m/%d %H:%M:%S] ", tmInfo);
 
 			String::Append(buffer, sizeof(buffer), text);
-			utf8_remove_formatting(buffer);
+			utf8_remove_formatting(buffer, false);
 			String::Append(buffer, sizeof(buffer), platform_get_new_line());
 
 			SDL_RWwrite(_chatLogStream, buffer, strlen(buffer), 1);

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -634,7 +634,7 @@ void platform_process_messages()
 				if (SDL_HasClipboardText()) {
 					utf8* text = SDL_GetClipboardText();
 
-					utf8_remove_formatting(text);
+					utf8_remove_formatting(text, false);
 					textinputbuffer_insert(&gTextInput, text);
 
 					SDL_free(text);
@@ -683,7 +683,7 @@ void platform_process_messages()
 
 			utf8* newText = e.text.text;
 
-			utf8_remove_formatting(newText);
+			utf8_remove_formatting(newText, false);
 			textinputbuffer_insert(&gTextInput, newText);
 
 			console_refresh_caret();


### PR DESCRIPTION
This pull request extends `utf8_remove_formatting` to include a parameter that indicates if colour formatting codes should be ignored.

This parameter is currently only set to true in `game_convert_strings_to_utf8` where user strings are loaded from save files. This is necessary for coloured signs to work.

Sorry for the delay, I've been a bit busy lately.