### PR TITLE
Background for chat, fixes #3849

### DIFF
--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -81,8 +81,8 @@ void chat_draw(rct_drawpixelinfo * dpi)
 		return;
 	}
 	_chatLeft = 10;
-	_chatTop = gScreenHeight - 40 - ((CHAT_HISTORY_SIZE + 1) * 10);
-	_chatRight = gScreenWidth - 10;
+	_chatTop = gScreenHeight - 100 - ((CHAT_HISTORY_SIZE + 1) * 10);
+	_chatRight = gScreenWidth - 500;
 	_chatBottom = gScreenHeight - 45;
 	char lineBuffer[CHAT_INPUT_SIZE + 10];
 	char* lineCh = lineBuffer;
@@ -99,6 +99,8 @@ void chat_draw(rct_drawpixelinfo * dpi)
 		gfx_draw_string(dpi, lineBuffer, 255, x, y);
 	}
 	if (gChatOpen) {
+		gfx_fill_rect(dpi, _chatLeft, _chatTop, _chatRight, _chatBottom, 0x2000000 | 50); 	// Background
+		
 		lineCh = utf8_write_codepoint(lineCh, FORMAT_OUTLINE);
 		lineCh = utf8_write_codepoint(lineCh, FORMAT_CELADON);
 		safe_strcpy(lineCh, _chatCurrentLine, CHAT_INPUT_SIZE);

--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -106,6 +106,7 @@ void chat_draw(rct_drawpixelinfo * dpi)
 		safe_strcpy(lineCh, _chatCurrentLine, CHAT_INPUT_SIZE);
 		y = _chatBottom - 15;
 		gfx_set_dirty_blocks(x, y, x + gfx_get_string_width(lineBuffer) + 7, y + 12);
+		gfx_fill_rect(dpi, x, y, x + _chatRight + 7, y + 12, 0x2000000 | 52);	// Textbox background
 		gfx_draw_string(dpi, lineBuffer, 255, x, y);
 		if (_chatCaretTicks < 15) {
 			memcpy(lineBuffer, _chatCurrentLine, gTextInput.selection_offset);


### PR DESCRIPTION
Well.. this is going to be fun..
_Have very little knowledge about programming so in the end, this might not even get merged at all. Will just try to give it a shot. Have no problems against heavy criticism etc and I hope this isn't seen as an obstacle or being offensive, like always, closing the PR and/or 'taking it' is always a option. If any of the things said above happens, sorry_  

This is for my issue: #3849 to add a limit before it switches row + getting a background to make it easier to see
_Thanks Broxzier for showing how to use transparent windows in PR #3370 :+1:_ 

**The goal (not final layout):**
![concept](https://cloud.githubusercontent.com/assets/17282384/15946831/d95ff478-2e98-11e6-853b-6daa18ccd181.png)

**The problems:**
- Flickering background
- 'Drags out' (leaving traces after it)
- Sizes
- Font being rendered behind background
- 'Too simple' 
- Colors?
- Text runs outside the box / no limit / doesn't change row

