### PR TITLE
Removing 'the green box' on the title screen (Moved to #3863)

### DIFF
--- a/src/title.c
+++ b/src/title.c
@@ -494,9 +494,6 @@ void DrawOpenRCT2(rct_drawpixelinfo *dpi, int x, int y)
 {
 	utf8 buffer[256];
 
-	// Draw background
-	gfx_fill_rect_inset(dpi, x, y, x + 128, y + 20, TRANSLUCENT(COLOUR_DARK_GREEN), 0x8);
-
 	// Write format codes
 	utf8 *ch = buffer;
 	ch = utf8_write_codepoint(ch, FORMAT_MEDIUMFONT);


### PR DESCRIPTION
![esgegs](https://cloud.githubusercontent.com/assets/17282384/15987996/05aef850-3040-11e6-8be9-de99586dcbbb.png)

**Optional:** Making the background fit the text, no idea why it's there tho