### PR TITLE
Removing green background box on the logo

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -49,6 +49,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Michał Janiszewski (janisozaur) - Linux port, crash handling, security, misc.
 * Kelson Blakewood (spacek531) - title sequence for 0.0.4
 * Hugo Wallenburg (Goddesen) - Misc.
+* (Nubbie) - Misc, user friendlyness
 
 ## Bug fixes
 * (halfbro)

--- a/contributors.md
+++ b/contributors.md
@@ -49,7 +49,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Michał Janiszewski (janisozaur) - Linux port, crash handling, security, misc.
 * Kelson Blakewood (spacek531) - title sequence for 0.0.4
 * Hugo Wallenburg (Goddesen) - Misc.
-* (Nubbie) - Misc, user-friendliness
+* (Nubbie) - Misc, UX
 
 ## Bug fixes
 * (halfbro)

--- a/contributors.md
+++ b/contributors.md
@@ -49,7 +49,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Michał Janiszewski (janisozaur) - Linux port, crash handling, security, misc.
 * Kelson Blakewood (spacek531) - title sequence for 0.0.4
 * Hugo Wallenburg (Goddesen) - Misc.
-* (Nubbie) - Misc, user friendlyness
+* (Nubbie) - Misc, user-friendliness
 
 ## Bug fixes
 * (halfbro)

--- a/src/title.c
+++ b/src/title.c
@@ -494,9 +494,6 @@ void DrawOpenRCT2(rct_drawpixelinfo *dpi, int x, int y)
 {
 	utf8 buffer[256];
 
-	// Draw background
-	gfx_fill_rect_inset(dpi, x, y, x + 128, y + 20, TRANSLUCENT(COLOUR_DARK_GREEN), 0x8);
-
 	// Write format codes
 	utf8 *ch = buffer;
 	ch = utf8_write_codepoint(ch, FORMAT_MEDIUMFONT);

--- a/src/windows/title_logo.c
+++ b/src/windows/title_logo.c
@@ -80,7 +80,7 @@ void window_title_logo_open()
 		WC_TITLE_LOGO,
 		WF_STICK_TO_BACK | WF_TRANSPARENT
 	);
-	window->widgets = (rct_widget*)0x9A9638; // mouse move bug in original game, keep this address and no crash happens
+	window->widgets = (rct_widget*)0x009A9658; // mouse move bug in original game, keep this address and no crash happens
 	window_init_scroll_widgets(window);
 	window->colours[0] = 129;
 	window->colours[1] = 129;

--- a/src/windows/title_logo.c
+++ b/src/windows/title_logo.c
@@ -80,7 +80,7 @@ void window_title_logo_open()
 		WC_TITLE_LOGO,
 		WF_STICK_TO_BACK | WF_TRANSPARENT
 	);
-	window->widgets = (rct_widget*)0x009A9658; // mouse move bug in original game, keep this address and no crash happens
+	window->widgets = (rct_widget*)0x9A9638; // mouse move bug in original game, keep this address and no crash happens
 	window_init_scroll_widgets(window);
 	window->colours[0] = 129;
 	window->colours[1] = 129;


### PR DESCRIPTION
### Bug 1: Green background 
![esgegs](https://cloud.githubusercontent.com/assets/17282384/15992237/74e33294-30c8-11e6-9f6b-af3737e92dc8.png)

**Optional:** Making the background fit the text, no idea why it's there tho
