### PR TITLE
Explicitly request OpenGL 3.3 context

### DIFF
--- a/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -247,6 +247,10 @@ public:
     {
         _window = window;
 
+
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
         _context = SDL_GL_CreateContext(_window);
         SDL_GL_MakeCurrent(_window, _context);
 


### PR DESCRIPTION
This is required for non-nv cards to properly provide OpenGL 3.3 context to avoid things like
```
Error compiling /home/janisozaur/workspace/OpenRCT2/build-native/data/shaders/drawimage.vert
0:1(10): error: GLSL 3.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, and 3.00 ES

ERROR[/home/janisozaur/workspace/OpenRCT2/src/drawing/NewDrawing.cpp:96 (drawing_engine_init)]: Unable to initialise drawing engine. Falling back to software.
```

But on the other hand causes this: https://files.gitter.im/janisozaur/xbHw/OpenRCT2_127.png on Linux/nv & Linux/Intel.