### PR TITLE
Lower requested OpenGL context to 3.1, fixes #3867

### DIFF
--- a/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -250,7 +250,7 @@ public:
 
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
         _context = SDL_GL_CreateContext(_window);
         SDL_GL_MakeCurrent(_window, _context);
 


### PR DESCRIPTION
Seems to work (see #3867) but I'm not certain if this is the best thing to do, given how GL3.1 only had `full context` and `forward-compatible context` (https://en.wikipedia.org/wiki/OpenGL#OpenGL_3.1), not `Core Profile`.

This would also take care of @LRFLEW's request to have GL3.2