### PR TITLE
Crash fix: Prevent set_load_objects_fail_reason from reading a null object

### DIFF
--- a/src/object_list.c
+++ b/src/object_list.c
@@ -486,6 +486,11 @@ int check_object_entry(rct_object_entry *entry)
  */
 void object_create_identifier_name(char* string_buffer, const rct_object_entry* object)
 {
+	if (object == NULL) {
+		strcat(string_buffer, "NULL_ID");
+		return;
+	}
+
 	for (uint8 i = 0; i < 8; ++i){
 		if (object->name[i] != ' '){
 			*string_buffer++ = object->name[i];
@@ -517,7 +522,14 @@ void set_load_objects_fail_reason()
 	rct_object_entry *object;
 	memcpy(&object, gCommonFormatArgs, sizeof(rct_object_entry*));
 	
-	int expansion = (object->flags & 0xFF) >> 4;
+	int expansion;
+	if (object != NULL) {
+		expansion = (object->flags & 0xFF) >> 4;
+	}
+	else {
+		expansion = 0;
+	}
+
 	if (expansion == 0 ||
 		expansion == 8 ||
 		RCT2_GLOBAL(RCT2_ADDRESS_EXPANSION_FLAGS, uint16) & (1 << expansion)


### PR DESCRIPTION
I was loading a server and the game crashed, pointing to a null exception in set_load_objects_fail_reason. this patch doesn't necessarily fix whatever causes the object to be null, but instead stops the crash by showing "null_id" when the object is null. 

http://imgur.com/OwzhmgH

**EDIT:** It turns out it also does it with my "devtest" scenario placeholder as well. i believe the only custom scenery item in this park is cBass's black tile. the glitch happens if you host a server of the scenario and then open a client and connect to that (open the server copy outside of VS and then load the client inside VS to get the breakpoints to trigger).. I'm going to make a copy of this scenario with only the used items selected to test if it's the cBass black tile that's causing this specific instance. https://drive.google.com/open?id=0B5rz4tJ-XWSNbFN3ZEdJWXFXUkk
