### PR TITLE
[Minor fix] Fix #3839

### DIFF
--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -3075,7 +3075,7 @@ static void window_ride_construction_update_widgets(rct_window *w)
 	}
 
 	int x;
-	if ((is_track_enabled(TRACK_LIFT_HILL) && _currentTrackCurve < 256) || gCheatsEnableChainLiftOnAllTrack) {
+	if ((is_track_enabled(TRACK_LIFT_HILL) && _currentTrackCurve < 256) || (gCheatsEnableChainLiftOnAllTrack && ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_TRACK))) {
 		window_ride_construction_widgets[WIDX_CHAIN_LIFT].type = WWT_FLATBTN;
 		x = 9;
 	} else {


### PR DESCRIPTION
This prevents that shops and flat rides can be set with chains if the cheat "Chain Lift On All Track" is enabled.

PS: I am a newbie C programmer, please be patient, any feedback is valid :P