### PR TITLE
Minor issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 **OS:** [e.g. Windows 10]
 **Version:** [e.g. 0.0.5]
-**Commit/Build:** [e.g. 426e106]
+**Commit/Build:** [e.g. 426e106 You can find it at the left bottom corner of the main menu]
 
 [Explanation of the issue...]
 
@@ -13,8 +13,8 @@
 1. [step 1]
 2. [step 2]
 
-**Dump file**
-[If you have a dump file: zip it before you drag & drop it here.]
+**Dump file:**
+[In case the game asked you to provide one after the game crashed: zip it before you drag & drop it here. You can find it at %userprofile%\documents\OpenRCT2 Look for the latest .DMP file]
 
 **Screenshots / Video:**
 [Drag & drop screenshots here. Use https://vid.me to upload video.]

--- a/contributors.md
+++ b/contributors.md
@@ -91,7 +91,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * English (UK) - Ted John (IntelOrca), (Tinytimrob)
 * English (US) - Ted John (IntelOrca), Michael Steenbeek (Gymnasiast); small fixes: (LRFLEW), (mike-koch), Harry Lam (daihakken)
 * Czech - Martin Černáč (octaroot), (Clonewayx), Tomáš Pazdiora (Aroidzap)
-* Dutch - Michael Steenbeek (Gymnasiast), Yannic Geurts (xzbobzx), (mrtnptrs), Thomas den Hollander (ThomasdenH), (hostbrute),  Marijn van de Werf (marijnvdwerf); reviewing and discussion: Aaron van Geffen (AaronVanGeffen), (Balletie) and Sijmen Schoon (Vijfhoek).
+* Dutch - Michael Steenbeek (Gymnasiast), Yannic Geurts (xzbobzx), Maarten Peters (mrtnptrs), Thomas den Hollander (ThomasdenH), (hostbrute),  Marijn van de Werf (marijnvdwerf); reviewing and discussion: Aaron van Geffen (AaronVanGeffen), (Balletie) and Sijmen Schoon (Vijfhoek).
 * Finnish - (DJHasis), (Zode), (TheWing)
 * French - (fbourigault), Joël Troch (JoelTroch), Michael Steenbeek (Gymnasiast), Romain Vigier (rvgr),  (AziasYur), Hugo Courtial (s0r00t), David Delobel (incyclum)
 * German - (danidoedel), (atmaxinger), (Yepoleb), Daniel Kessel (dkessel), Leon (AllGoodNamesAreTaken), (raidcookie)


### PR DESCRIPTION
To make it easier for bug reporters to know where to find the commit number, the dump file and when it's neccesary.