### PR TITLE
Rework keyboard handling to use keycodes (allowing for non-qwerty layouts)

### DIFF
--- a/src/openrct2/config/KeyboardShortcuts.cpp
+++ b/src/openrct2/config/KeyboardShortcuts.cpp
@@ -28,78 +28,77 @@ extern "C"
 }
 
 // Current keyboard shortcuts
-uint16 gShortcutKeys[SHORTCUT_COUNT];
+keypress gShortcutKeys[SHORTCUT_COUNT];
 
 namespace KeyboardShortcuts
 {
     // Default keyboard shortcuts
-    static const uint16 _defaultShortcutKeys[SHORTCUT_COUNT] =
-    {
-        SDL_SCANCODE_BACKSPACE,                     // SHORTCUT_CLOSE_TOP_MOST_WINDOW
-        SHIFT | SDL_SCANCODE_BACKSPACE,             // SHORTCUT_CLOSE_ALL_FLOATING_WINDOWS
-        SDL_SCANCODE_ESCAPE,                        // SHORTCUT_CANCEL_CONSTRUCTION_MODE
-        SDL_SCANCODE_PAUSE,                         // SHORTCUT_PAUSE_GAME
-        SDL_SCANCODE_PAGEUP,                        // SHORTCUT_ZOOM_VIEW_OUT
-        SDL_SCANCODE_PAGEDOWN,                      // SHORTCUT_ZOOM_VIEW_IN
-        SDL_SCANCODE_RETURN,                        // SHORTCUT_ROTATE_VIEW_CLOCKWISE
-        SHIFT | SDL_SCANCODE_RETURN,                // SHORTCUT_ROTATE_VIEW_ANTICLOCKWISE
-        SDL_SCANCODE_Z,                             // SHORTCUT_ROTATE_CONSTRUCTION_OBJECT
-        SDL_SCANCODE_1,                             // SHORTCUT_UNDERGROUND_VIEW_TOGGLE
-        SDL_SCANCODE_H,                             // SHORTCUT_REMOVE_BASE_LAND_TOGGLE
-        SDL_SCANCODE_V,                             // SHORTCUT_REMOVE_VERTICAL_LAND_TOGGLE
-        SDL_SCANCODE_3,                             // SHORTCUT_SEE_THROUGH_RIDES_TOGGLE
-        SDL_SCANCODE_4,                             // SHORTCUT_SEE_THROUGH_SCENERY_TOGGLE
-        SDL_SCANCODE_5,                             // SHORTCUT_INVISIBLE_SUPPORTS_TOGGLE
-        SDL_SCANCODE_6,                             // SHORTCUT_INVISIBLE_PEOPLE_TOGGLE
-        SDL_SCANCODE_8,                             // SHORTCUT_HEIGHT_MARKS_ON_LAND_TOGGLE
-        SDL_SCANCODE_9,                             // SHORTCUT_HEIGHT_MARKS_ON_RIDE_TRACKS_TOGGLE
-        SDL_SCANCODE_0,                             // SHORTCUT_HEIGHT_MARKS_ON_PATHS_TOGGLE
-        SDL_SCANCODE_F1,                            // SHORTCUT_ADJUST_LAND
-        SDL_SCANCODE_F2,                            // SHORTCUT_ADJUST_WATER
-        SDL_SCANCODE_F3,                            // SHORTCUT_BUILD_SCENERY
-        SDL_SCANCODE_F4,                            // SHORTCUT_BUILD_PATHS
-        SDL_SCANCODE_F5,                            // SHORTCUT_BUILD_NEW_RIDE
-        SDL_SCANCODE_F,                             // SHORTCUT_SHOW_FINANCIAL_INFORMATION
-        SDL_SCANCODE_D,                             // SHORTCUT_SHOW_RESEARCH_INFORMATION
-        SDL_SCANCODE_R,                             // SHORTCUT_SHOW_RIDES_LIST
-        SDL_SCANCODE_P,                             // SHORTCUT_SHOW_PARK_INFORMATION
-        SDL_SCANCODE_G,                             // SHORTCUT_SHOW_GUEST_LIST
-        SDL_SCANCODE_S,                             // SHORTCUT_SHOW_STAFF_LIST
-        SDL_SCANCODE_M,                             // SHORTCUT_SHOW_RECENT_MESSAGES
-        SDL_SCANCODE_TAB,                           // SHORTCUT_SHOW_MAP
-        PLATFORM_MODIFIER | SDL_SCANCODE_S,         // SHORTCUT_SCREENSHOT
-        SDL_SCANCODE_MINUS,                         // SHORTCUT_REDUCE_GAME_SPEED,
-        SDL_SCANCODE_EQUALS,                        // SHORTCUT_INCREASE_GAME_SPEED,
-        PLATFORM_MODIFIER | ALT | SDL_SCANCODE_C,   // SHORTCUT_OPEN_CHEAT_WINDOW,
-        SDL_SCANCODE_T,                             // SHORTCUT_REMOVE_TOP_BOTTOM_TOOLBAR_TOGGLE,
-        SDL_SCANCODE_UP,                            // SHORTCUT_SCROLL_MAP_UP
-        SDL_SCANCODE_LEFT,                          // SHORTCUT_SCROLL_MAP_LEFT
-        SDL_SCANCODE_DOWN,                          // SHORTCUT_SCROLL_MAP_DOWN
-        SDL_SCANCODE_RIGHT,                         // SHORTCUT_SCROLL_MAP_RIGHT
-        SDL_SCANCODE_C,                             // SHORTCUT_OPEN_CHAT_WINDOW
-        PLATFORM_MODIFIER | SDL_SCANCODE_F10,       // SHORTCUT_QUICK_SAVE_GAME
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_SHOW_OPTIONS
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_MUTE_SOUND
-        ALT | SDL_SCANCODE_RETURN,                  // SHORTCUT_WINDOWED_MODE_TOGGLE
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_SHOW_MULTIPLAYER
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_PAINT_ORIGINAL_TOGGLE
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_DEBUG_PAINT_TOGGLE
-        SHORTCUT_UNDEFINED,                         // SHORTCUT_SEE_THROUGH_PATHS_TOGGLE
-        SDL_SCANCODE_KP_4,                          // SHORTCUT_RIDE_CONSTRUCTION_TURN_LEFT
-        SDL_SCANCODE_KP_6,                          // SHORTCUT_RIDE_CONSTRUCTION_TURN_RIGHT
-        SDL_SCANCODE_KP_5,                          // SHORTCUT_RIDE_CONSTRUCTION_USE_TRACK_DEFAULT
-        SDL_SCANCODE_KP_2,                          // SHORTCUT_RIDE_CONSTRUCTION_SLOPE_DOWN
-        SDL_SCANCODE_KP_8,                          // SHORTCUT_RIDE_CONSTRUCTION_SLOPE_UP
-        SDL_SCANCODE_KP_PLUS,                       // SHORTCUT_RIDE_CONSTRUCTION_CHAIN_LIFT_TOGGLE
-        SDL_SCANCODE_KP_1,                          // SHORTCUT_RIDE_CONSTRUCTION_BANK_LEFT
-        SDL_SCANCODE_KP_3,                          // SHORTCUT_RIDE_CONSTRUCTION_BANK_RIGHT
-        SDL_SCANCODE_KP_7,                          // SHORTCUT_RIDE_CONSTRUCTION_PREVIOUS_TRACK
-        SDL_SCANCODE_KP_9,                          // SHORTCUT_RIDE_CONSTRUCTION_NEXT_TRACK
-        SDL_SCANCODE_KP_0,                          // SHORTCUT_RIDE_CONSTRUCTION_BUILD_CURRENT
-        SDL_SCANCODE_KP_MINUS,                      // SHORTCUT_RIDE_CONSTRUCTION_DEMOLISH_CURRENT
+    static const keypress _defaultShortcutKeys[SHORTCUT_COUNT] = {
+        { SDLK_BACKSPACE,   KMOD_NONE },                        // SHORTCUT_CLOSE_TOP_MOST_WINDOW
+        { SDLK_BACKSPACE,   KMOD_SHIFT },                       // SHORTCUT_CLOSE_ALL_FLOATING_WINDOWS
+        { SDLK_ESCAPE,      KMOD_NONE },                        // SHORTCUT_CANCEL_CONSTRUCTION_MODE
+        { SDLK_PAUSE,       KMOD_NONE },                        // SHORTCUT_PAUSE_GAME
+        { SDLK_PAGEUP,      KMOD_NONE },                        // SHORTCUT_ZOOM_VIEW_OUT
+        { SDLK_PAGEDOWN,    KMOD_NONE },                        // SHORTCUT_ZOOM_VIEW_IN
+        { SDLK_RETURN,      KMOD_NONE },                        // SHORTCUT_ROTATE_VIEW_CLOCKWISE
+        { SDLK_RETURN,      KMOD_SHIFT },                       // SHORTCUT_ROTATE_VIEW_ANTICLOCKWISE
+        { SDLK_z,           KMOD_NONE },                        // SHORTCUT_ROTATE_CONSTRUCTION_OBJECT
+        { SDLK_1,           KMOD_NONE },                        // SHORTCUT_UNDERGROUND_VIEW_TOGGLE
+        { SDLK_h,           KMOD_NONE },                        // SHORTCUT_REMOVE_BASE_LAND_TOGGLE
+        { SDLK_v,           KMOD_NONE },                        // SHORTCUT_REMOVE_VERTICAL_LAND_TOGGLE
+        { SDLK_3,           KMOD_NONE },                        // SHORTCUT_SEE_THROUGH_RIDES_TOGGLE
+        { SDLK_4,           KMOD_NONE },                        // SHORTCUT_SEE_THROUGH_SCENERY_TOGGLE
+        { SDLK_5,           KMOD_NONE },                        // SHORTCUT_INVISIBLE_SUPPORTS_TOGGLE
+        { SDLK_6,           KMOD_NONE },                        // SHORTCUT_INVISIBLE_PEOPLE_TOGGLE
+        { SDLK_8,           KMOD_NONE },                        // SHORTCUT_HEIGHT_MARKS_ON_LAND_TOGGLE
+        { SDLK_9,           KMOD_NONE },                        // SHORTCUT_HEIGHT_MARKS_ON_RIDE_TRACKS_TOGGLE
+        { SDLK_0,           KMOD_NONE },                        // SHORTCUT_HEIGHT_MARKS_ON_PATHS_TOGGLE
+        { SDLK_F1,          KMOD_NONE },                        // SHORTCUT_ADJUST_LAND
+        { SDLK_F2,          KMOD_NONE },                        // SHORTCUT_ADJUST_WATER
+        { SDLK_F3,          KMOD_NONE },                        // SHORTCUT_BUILD_SCENERY
+        { SDLK_F4,          KMOD_NONE },                        // SHORTCUT_BUILD_PATHS
+        { SDLK_F5,          KMOD_NONE },                        // SHORTCUT_BUILD_NEW_RIDE
+        { SDLK_f,           KMOD_NONE },                        // SHORTCUT_SHOW_FINANCIAL_INFORMATION
+        { SDLK_d,           KMOD_NONE },                        // SHORTCUT_SHOW_RESEARCH_INFORMATION
+        { SDLK_r,           KMOD_NONE },                        // SHORTCUT_SHOW_RIDES_LIST
+        { SDLK_p,           KMOD_NONE },                        // SHORTCUT_SHOW_PARK_INFORMATION
+        { SDLK_g,           KMOD_NONE },                        // SHORTCUT_SHOW_GUEST_LIST
+        { SDLK_s,           KMOD_NONE },                        // SHORTCUT_SHOW_STAFF_LIST
+        { SDLK_m,           KMOD_NONE },                        // SHORTCUT_SHOW_RECENT_MESSAGES
+        { SDLK_TAB,         KMOD_NONE },                        // SHORTCUT_SHOW_MAP
+        { SDLK_s,           PLATFORM_MODIFIER },                // SHORTCUT_SCREENSHOT
+        { SDLK_MINUS,       KMOD_NONE },                        // SHORTCUT_REDUCE_GAME_SPEED,
+        { SDLK_EQUALS,      KMOD_NONE },                        // SHORTCUT_INCREASE_GAME_SPEED,
+        { SDLK_c,           PLATFORM_MODIFIER | KMOD_ALT },     // SHORTCUT_OPEN_CHEAT_WINDOW,
+        { SDLK_t,           KMOD_NONE },                        // SHORTCUT_REMOVE_TOP_BOTTOM_TOOLBAR_TOGGLE,
+        { SDLK_UP,          KMOD_NONE },                        // SHORTCUT_SCROLL_MAP_UP
+        { SDLK_LEFT,        KMOD_NONE },                        // SHORTCUT_SCROLL_MAP_LEFT
+        { SDLK_DOWN,        KMOD_NONE },                        // SHORTCUT_SCROLL_MAP_DOWN
+        { SDLK_RIGHT,       KMOD_NONE },                        // SHORTCUT_SCROLL_MAP_RIGHT
+        { SDLK_c,           KMOD_NONE },                        // SHORTCUT_OPEN_CHAT_WINDOW
+        { SDLK_F10,         PLATFORM_MODIFIER },                // SHORTCUT_QUICK_SAVE_GAME
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_SHOW_OPTIONS
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_MUTE_SOUND
+        { SDLK_RETURN,      KMOD_ALT },                         // SHORTCUT_WINDOWED_MODE_TOGGLE
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_SHOW_MULTIPLAYER
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_PAINT_ORIGINAL_TOGGLE
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_DEBUG_PAINT_TOGGLE
+        SHORTCUT_UNDEFINED,                                     // SHORTCUT_SEE_THROUGH_PATHS_TOGGLE
+        { SDLK_KP_4,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_TURN_LEFT
+        { SDLK_KP_6,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_TURN_RIGHT
+        { SDLK_KP_5,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_USE_TRACK_DEFAULT
+        { SDLK_KP_2,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_SLOPE_DOWN
+        { SDLK_KP_8,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_SLOPE_UP
+        { SDLK_KP_PLUS,     KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_CHAIN_LIFT_TOGGLE
+        { SDLK_KP_1,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_BANK_LEFT
+        { SDLK_KP_3,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_BANK_RIGHT
+        { SDLK_KP_7,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_PREVIOUS_TRACK
+        { SDLK_KP_9,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_NEXT_TRACK
+        { SDLK_KP_0,        KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_BUILD_CURRENT
+        { SDLK_KP_MINUS,    KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_DEMOLISH_CURRENT
     };
 
-    constexpr sint32 CURRENT_FILE_VERSION = 1;
+    constexpr sint32 CURRENT_FILE_VERSION = 2;
 
     static void Reset()
     {
@@ -135,7 +134,7 @@ extern "C"
             {
                 for (sint32 i = 0; i < SHORTCUT_COUNT; i++)
                 {
-                    gShortcutKeys[i] = fs.ReadValue<uint16>();
+                    gShortcutKeys[i] = fs.ReadValue<keypress>();
                 }
                 result = true;
             }
@@ -161,7 +160,7 @@ extern "C"
             fs.WriteValue<uint16>(KeyboardShortcuts::CURRENT_FILE_VERSION);
             for (sint32 i = 0; i < SHORTCUT_COUNT; i++)
             {
-                fs.WriteValue<uint16>(gShortcutKeys[i]);
+                fs.WriteValue<keypress>(gShortcutKeys[i]);
             }
             result = true;
         }

--- a/src/openrct2/config/KeyboardShortcuts.cpp
+++ b/src/openrct2/config/KeyboardShortcuts.cpp
@@ -98,7 +98,7 @@ namespace KeyboardShortcuts
         { SDLK_KP_MINUS,    KMOD_NONE },                        // SHORTCUT_RIDE_CONSTRUCTION_DEMOLISH_CURRENT
     };
 
-    constexpr sint32 CURRENT_FILE_VERSION = 2;
+    constexpr uint16 CURRENT_FILE_VERSION = 2;
 
     static void Reset()
     {

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -60,7 +60,6 @@ static uint8 _currentScrollArea;
 
 static uint8 _inputState;
 static uint8 _inputFlags;
-uint8 gInputPlaceObjectModifier;
 
 sint32 gInputDragLastX;
 sint32 gInputDragLastY;
@@ -1689,14 +1688,4 @@ INPUT_STATE input_get_state()
 void reset_tooltip_not_shown()
 {
 	_tooltipNotShownTicks = 0;
-}
-
-void input_reset_place_obj_modifier()
-{
-	gInputPlaceObjectModifier = PLACE_OBJECT_MODIFIER_NONE;
-}
-
-bool input_test_place_object_modifier(PLACE_OBJECT_MODIFIER modifier)
-{
-	return gInputPlaceObjectModifier & modifier;
 }

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1498,14 +1498,12 @@ void game_handle_keyboard_input()
  */
 sint32 get_next_key(keypress *keypress)
 {
-
 	if (gCurKeyNum >= gNumKeysPressed)
 		return -1;
 
 	*keypress = gKeysPressed[gCurKeyNum];
 
 	++gCurKeyNum;
-
 	return 0;
 }
 

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -88,7 +88,7 @@ void invalidate_scroll();
 static rct_mouse_data* get_mouse_input();
 void map_element_right_click(sint32 type, rct_map_element *mapElement, sint32 x, sint32 y);
 sint32 sub_6EDE88(sint32 x, sint32 y, rct_map_element **mapElement, sint32 *outX, sint32 *outY);
-sint32 get_next_key(keypress *keypress);
+sint32 get_next_key(keypress *kp);
 static void game_handle_input_mouse(sint32 x, sint32 y, sint32 state);
 void game_handle_edge_scroll();
 void game_handle_key_scroll();
@@ -1503,12 +1503,12 @@ void game_handle_keyboard_input()
  *
  *  rct2: 0x00406CD2
  */
-sint32 get_next_key(keypress *keypress)
+sint32 get_next_key(keypress *kp)
 {
 	if (gCurKeyNum >= gNumKeysPressed)
 		return -1;
 
-	*keypress = gKeysPressed[gCurKeyNum];
+	*kp = gKeysPressed[gCurKeyNum];
 
 	++gCurKeyNum;
 	return 0;

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1403,6 +1403,8 @@ void title_handle_keyboard_input()
 	rct_window *w;
 	keypress key;
 
+	gCurKeyNum = 0;
+
 	if (gOpenRCT2Headless) {
 		return;
 	}
@@ -1459,6 +1461,8 @@ void game_handle_keyboard_input()
 {
 	rct_window *w;
 	keypress key;
+
+	gCurKeyNum = 0;
 
 	if (!gConsoleOpen) {
 		// Handle mouse scrolling
@@ -1526,12 +1530,18 @@ void game_handle_keyboard_input()
  */
 sint32 get_next_key(keypress *keypress)
 {
-	if (gNumKeysPressed < 1)
+	static int cur_key = 0;
+
+	if (gNumKeysPressed < 1) {
+		cur_key = 0;
 		return -1;
+	}
 
 	--gNumKeysPressed;
 
-	*keypress = gKeysPressed[gNumKeysPressed];
+	*keypress = gKeysPressed[cur_key];
+
+	++cur_key;
 
 	return 0;
 }

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1470,10 +1470,14 @@ void game_handle_keyboard_input()
 				console_toggle();
 			}
 			continue;
-		} else if (gConsoleOpen) {
+		}
+
+		if (gConsoleOpen) {
 			console_input(key.keycode);
 			continue;
-		} else if (gChatOpen) {
+		}
+
+		if (gChatOpen) {
 			chat_input(key.keycode);
 			continue;
 		}
@@ -1481,13 +1485,17 @@ void game_handle_keyboard_input()
 		w = window_find_by_class(WC_CHANGE_KEYBOARD_SHORTCUT);
 		if (w != NULL) {
 			keyboard_shortcut_set(key);
-		} else {
-			w = window_find_by_class(WC_TEXTINPUT);
-			if (w != NULL) {
-				window_text_input_key(w, key.keycode);
-			} else if (!gUsingWidgetTextBox) {
-				keyboard_shortcut_handle(key);
-			}
+			continue;
+		}
+
+		w = window_find_by_class(WC_TEXTINPUT);
+		if (w != NULL) {
+			window_text_input_key(w, key.keycode);
+			continue;
+		}
+
+		if (!gUsingWidgetTextBox) {
+			keyboard_shortcut_handle(key);
 		}
 	}
 }
@@ -1615,21 +1623,28 @@ void game_handle_key_scroll()
 	rct_window *textWindow;
 
 	textWindow = window_find_by_class(WC_TEXTINPUT);
-	if (textWindow || gUsingWidgetTextBox) return;
-	if (gChatOpen) return;
+	if (textWindow || gUsingWidgetTextBox)
+		return;
+	if (gChatOpen)
+		return;
 
 	scrollX = 0;
 	scrollY = 0;
 
-	if (gKeysHeld[0])
-		scrollY = -1;
-	else if (gKeysHeld[2])
-		scrollY = 1;
-
-	if (gKeysHeld[1])
-		scrollX = -1;
-	else if (gKeysHeld[3])
-		scrollX = 1;
+	for (int i = 0; i < 4 && gMapKeysStack[i] != 0; i++) {
+		int val = gMapKeysStack[i];
+		if (val == SHORTCUT_SCROLL_MAP_UP || val == SHORTCUT_SCROLL_MAP_DOWN) {
+			scrollY = val - SHORTCUT_SCROLL_MAP_UP - 1;
+			break;
+		}
+	}
+	for (int i = 0; i < 4 && gMapKeysStack[i] != 0; i++) {
+		int val = gMapKeysStack[i];
+		if (val == SHORTCUT_SCROLL_MAP_LEFT || val == SHORTCUT_SCROLL_MAP_RIGHT) {
+			scrollX = val - SHORTCUT_SCROLL_MAP_LEFT - 1;
+			break;
+		}
+	}
 
 	// Scroll viewport
 	if (scrollX != 0) {

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1634,19 +1634,13 @@ void game_handle_key_scroll()
 	scrollX = 0;
 	scrollY = 0;
 
-	for (int i = 0; i < 4 && gMapKeysStack[i] != 0; i++) {
-		int val = gMapKeysStack[i];
-		if (val == SHORTCUT_SCROLL_MAP_UP || val == SHORTCUT_SCROLL_MAP_DOWN) {
-			scrollY = val - SHORTCUT_SCROLL_MAP_UP - 1;
-			break;
-		}
-	}
-	for (int i = 0; i < 4 && gMapKeysStack[i] != 0; i++) {
-		int val = gMapKeysStack[i];
-		if (val == SHORTCUT_SCROLL_MAP_LEFT || val == SHORTCUT_SCROLL_MAP_RIGHT) {
-			scrollX = val - SHORTCUT_SCROLL_MAP_LEFT - 1;
-			break;
-		}
+	for (int i = 0; i < 2; ++i) {
+		int valX = gMapKeysStackHorizontal[i];
+		int valY = gMapKeysStackVertical[i];
+		if (valX)
+			scrollX = valX - SHORTCUT_SCROLL_MAP_LEFT - 1;
+		if (valY)
+			scrollY = valY - SHORTCUT_SCROLL_MAP_UP - 1;
 	}
 
 	// Scroll viewport

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1434,6 +1434,8 @@ void title_handle_keyboard_input()
 			}
 		}
 	}
+
+	gNumKeysPressed = 0;
 }
 
 /**
@@ -1497,6 +1499,8 @@ void game_handle_keyboard_input()
 			keyboard_shortcut_handle(key);
 		}
 	}
+
+	gNumKeysPressed = 0;
 }
 
 /**

--- a/src/openrct2/input.h
+++ b/src/openrct2/input.h
@@ -64,19 +64,11 @@ typedef enum INPUT_STATE {
 	INPUT_STATE_SCROLL_RIGHT
 } INPUT_STATE;
 
-typedef enum PLACE_OBJECT_MODIFIER {
-	PLACE_OBJECT_MODIFIER_NONE = 0,
-	PLACE_OBJECT_MODIFIER_SHIFT_Z = (1 << 0),
-	PLACE_OBJECT_MODIFIER_COPY_Z = (1 << 1),
-} PLACE_OBJECT_MODIFIER;
-
 typedef struct widget_ref {
 	rct_windowclass window_classification;
 	rct_windownumber window_number;
 	rct_widgetindex widget_index;
 } widget_ref;
-
-extern uint8 gInputPlaceObjectModifier;
 
 extern sint32 gInputDragLastX;
 extern sint32 gInputDragLastY;
@@ -103,8 +95,6 @@ void store_mouse_input(sint32 state, sint32 x, sint32 y);
 void input_set_flag(INPUT_FLAGS flag, bool on);
 bool input_test_flag(INPUT_FLAGS flag);
 void input_reset_flags();
-
-bool input_test_place_object_modifier(PLACE_OBJECT_MODIFIER modifier);
 
 void input_set_state(INPUT_STATE state);
 INPUT_STATE input_get_state();

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -180,17 +180,17 @@ void chat_history_add(const char *src)
 	network_append_chat_log(src);
 }
 
-void chat_input(sint32 c)
+void chat_input(SDL_Keycode key)
 {
-	switch (c) {
-	case SDL_SCANCODE_RETURN:
+	switch (key) {
+	case SDLK_RETURN:
 		if (strlen(_chatCurrentLine) > 0) {
 			network_send_chat(_chatCurrentLine);
 		}
 		chat_clear_input();
 		chat_close();
 		return;
-	case SDL_SCANCODE_ESCAPE:
+	case SDLK_ESCAPE:
 		chat_close();
 		return;
 	}

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -248,14 +248,14 @@ void console_draw(rct_drawpixelinfo *dpi)
 	gfx_fill_rect(dpi, _consoleLeft, _consoleBottom - 0, _consoleRight, _consoleBottom - 0, 12);
 }
 
-void console_input(sint32 c)
+void console_input(SDL_Keycode key)
 {
-	switch (c) {
-	case SDL_SCANCODE_ESCAPE:
+	switch (key) {
+	case SDLK_ESCAPE:
 		console_clear_input();
 		console_refresh_caret();
 		break;
-	case SDL_SCANCODE_RETURN:
+	case SDLK_RETURN:
 		if (_consoleCurrentLine[0] != 0) {
 			console_history_add(_consoleCurrentLine);
 			console_execute(_consoleCurrentLine);
@@ -264,7 +264,7 @@ void console_input(sint32 c)
 			console_refresh_caret();
 		}
 		break;
-	case SDL_SCANCODE_UP:
+	case SDLK_UP:
 		if (_consoleHistoryIndex > 0) {
 			_consoleHistoryIndex--;
 			memcpy(_consoleCurrentLine, _consoleHistory[_consoleHistoryIndex], 256);
@@ -272,7 +272,7 @@ void console_input(sint32 c)
 		textinputbuffer_recalculate_length(&gTextInput);
 		gTextInput.selection_offset = strlen(_consoleCurrentLine);
 		break;
-	case SDL_SCANCODE_DOWN:
+	case SDLK_DOWN:
 		if (_consoleHistoryIndex < _consoleHistoryCount - 1) {
 			_consoleHistoryIndex++;
 			memcpy(_consoleCurrentLine, _consoleHistory[_consoleHistoryIndex], 256);

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -15,7 +15,6 @@
 #pragma endregion
 
 #include <stdarg.h>
-#include <SDL_scancode.h>
 
 #include "../config/Config.h"
 #include "../drawing/drawing.h"

--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -66,7 +66,7 @@ void keyboard_shortcut_set(keypress key)
 static sint32 keyboard_shortcut_get_from_key(keypress key)
 {
 	for (sint32 i = 0; i < SHORTCUT_COUNT; i++) {
-		if (platform_compare_keypress(key, gShortcutKeys[i])) {
+		if (platform_keypress_equals(key, gShortcutKeys[i])) {
 			return i;
 		}
 	}
@@ -77,7 +77,7 @@ static sint32 keyboard_shortcut_get_from_key(keypress key)
  *
  *  rct2: 0x006E3E68
  */
-void keyboard_shortcut_handle(sint32 key)
+void keyboard_shortcut_handle(keypress key)
 {
 	sint32 shortcut = keyboard_shortcut_get_from_key(key);
 	if (shortcut != -1)
@@ -103,11 +103,11 @@ void keyboard_shortcut_format_string(char *buffer, size_t size, keypress shortcu
 	*buffer = 0;
 	if (platform_keypress_equals(shortcut_key, (keypress)SHORTCUT_UNDEFINED))
 		return;
-	if (shortcutKey & KMOD_SHIFt) {
+	if (shortcut_key.mod & KMOD_SHIFT) {
 		format_string(formatBuffer, 256, STR_SHIFT_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	if (shortcutKey & KMOD_CTRL) {
+	if (shortcut_key.mod & KMOD_CTRL) {
 		format_string(formatBuffer, 256, STR_CTRL_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}
@@ -119,7 +119,7 @@ void keyboard_shortcut_format_string(char *buffer, size_t size, keypress shortcu
 #endif
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	if (shortcutKey & KMOD_GUI) {
+	if (shortcut_key.mod & KMOD_GUI) {
 		format_string(formatBuffer, 256, STR_CMD_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}

--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -43,14 +43,14 @@ static const shortcut_action shortcut_table[SHORTCUT_COUNT];
  *
  *  rct2: 0x006E3E91
  */
-void keyboard_shortcut_set(sint32 key)
+void keyboard_shortcut_set(keypress key)
 {
 	sint32 i;
 
 	// Unmap shortcut that already uses this key
 	for (i = 0; i < SHORTCUT_COUNT; i++) {
-		if (key == gShortcutKeys[i]) {
-			gShortcutKeys[i] = SHORTCUT_UNDEFINED;
+		if (platform_compare_keypress(key, gShortcutKeys[i])) {
+			gShortcutKeys[i] = (keypress)SHORTCUT_UNDEFINED;
 			break;
 		}
 	}
@@ -62,10 +62,10 @@ void keyboard_shortcut_set(sint32 key)
 	config_shortcut_keys_save();
 }
 
-static sint32 keyboard_shortcut_get_from_key(sint32 key)
+static sint32 keyboard_shortcut_get_from_key(keypress key)
 {
 	for (sint32 i = 0; i < SHORTCUT_COUNT; i++) {
-		if (key == gShortcutKeys[i]) {
+		if (platform_compare_keypress(key, gShortcutKeys[i])) {
 			return i;
 		}
 	}
@@ -94,22 +94,24 @@ void keyboard_shortcut_handle_command(sint32 shortcutIndex)
 	}
 }
 
-void keyboard_shortcut_format_string(char *buffer, size_t size, uint16 shortcutKey)
+void keyboard_shortcut_format_string(char *buffer, size_t size, keypress shortcut_key)
 {
 	char formatBuffer[256];
 
-	if (size == 0) return;
+	if (size == 0)
+		return;
 	*buffer = 0;
-	if (shortcutKey == SHORTCUT_UNDEFINED) return;
-	if (shortcutKey & 0x100) {
+	if (platform_shortcut_is_undefined(shortcut_key))
+		return;
+	if (shortcutKey & KMOD_SHIFt) {
 		format_string(formatBuffer, 256, STR_SHIFT_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	if (shortcutKey & 0x200) {
+	if (shortcutKey & KMOD_CTRL) {
 		format_string(formatBuffer, 256, STR_CTRL_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	if (shortcutKey & 0x400) {
+	if (shortcut_key.mod & KMOD_ALT) {
 #ifdef __MACOSX__
 		format_string(formatBuffer, 256, STR_OPTION_PLUS, NULL);
 #else
@@ -117,11 +119,11 @@ void keyboard_shortcut_format_string(char *buffer, size_t size, uint16 shortcutK
 #endif
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	if (shortcutKey & 0x800) {
+	if (shortcutKey & KMOD_GUI) {
 		format_string(formatBuffer, 256, STR_CMD_PLUS, NULL);
 		safe_strcat(buffer, formatBuffer, size);
 	}
-	safe_strcat(buffer, SDL_GetScancodeName(shortcutKey & 0xFF), size);
+	safe_strcat(buffer, SDL_GetKeyName(shortcut_key.keycode), size);
 }
 
 #pragma region Shortcut Commands

--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -79,14 +79,13 @@ static sint32 keyboard_shortcut_get_from_key(keypress key)
 void keyboard_shortcut_handle(sint32 key)
 {
 	sint32 shortcut = keyboard_shortcut_get_from_key(key);
-	if (shortcut != -1) {
+	if (shortcut != -1)
 		keyboard_shortcut_handle_command(shortcut);
-	}
 }
 
 void keyboard_shortcut_handle_command(sint32 shortcutIndex)
 {
-	if (shortcutIndex >= 0 && shortcutIndex < countof(shortcut_table)) {
+	if (shortcutIndex >= 0 && shortcutIndex < SHORTCUT_COUNT) {
 		shortcut_action action = shortcut_table[shortcutIndex];
 		if (action != NULL) {
 			action();

--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -60,6 +60,7 @@ void keyboard_shortcut_set(keypress key)
 	window_close_by_class(WC_CHANGE_KEYBOARD_SHORTCUT);
 	window_invalidate_by_class(WC_KEYBOARD_SHORTCUT_LIST);
 	config_shortcut_keys_save();
+	platform_map_keys_stack_clear();
 }
 
 static sint32 keyboard_shortcut_get_from_key(keypress key)

--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -49,7 +49,7 @@ void keyboard_shortcut_set(keypress key)
 
 	// Unmap shortcut that already uses this key
 	for (i = 0; i < SHORTCUT_COUNT; i++) {
-		if (platform_compare_keypress(key, gShortcutKeys[i])) {
+		if (platform_keypress_equals(key, gShortcutKeys[i])) {
 			gShortcutKeys[i] = (keypress)SHORTCUT_UNDEFINED;
 			break;
 		}
@@ -100,7 +100,7 @@ void keyboard_shortcut_format_string(char *buffer, size_t size, keypress shortcu
 	if (size == 0)
 		return;
 	*buffer = 0;
-	if (platform_shortcut_is_undefined(shortcut_key))
+	if (platform_keypress_equals(shortcut_key, (keypress)SHORTCUT_UNDEFINED))
 		return;
 	if (shortcutKey & KMOD_SHIFt) {
 		format_string(formatBuffer, 256, STR_SHIFT_PLUS, NULL);

--- a/src/openrct2/interface/keyboard_shortcut.h
+++ b/src/openrct2/interface/keyboard_shortcut.h
@@ -18,16 +18,17 @@
 #define _INTERFACE_KEYBOARD_SHORTCUT_H_
 
 #include "../common.h"
+#include "../platform/platform.h"
 
-#define SHORTCUT_UNDEFINED 0xFFFF
+#define SHORTCUT_UNDEFINED KEYBOARD_KEYPRESS_UNDEFINED
 
 /** The current shortcut being changed. */
 extern uint8 gKeyboardShortcutChangeId;
 
-void keyboard_shortcut_set(sint32 key);
-void keyboard_shortcut_handle(sint32 key);
+void keyboard_shortcut_set(keypress key);
+void keyboard_shortcut_handle(keypress key);
 void keyboard_shortcut_handle_command(sint32 shortcutIndex);
-void keyboard_shortcut_format_string(char *buffer, size_t size, uint16 shortcutKey);
+void keyboard_shortcut_format_string(char *buffer, size_t size, keypress shortcutKey);
 
 void config_reset_shortcut_keys();
 bool config_shortcut_keys_load();

--- a/src/openrct2/interface/keyboard_shortcut.h
+++ b/src/openrct2/interface/keyboard_shortcut.h
@@ -108,6 +108,6 @@ enum {
 	SHORTCUT_COUNT
 };
 
-extern uint16 gShortcutKeys[SHORTCUT_COUNT];
+extern keypress gShortcutKeys[SHORTCUT_COUNT];
 
 #endif

--- a/src/openrct2/intro.c
+++ b/src/openrct2/intro.c
@@ -232,7 +232,8 @@ static void screen_intro_process_mouse_input()
  */
 static void screen_intro_process_keyboard_input()
 {
-	if (gLastKeyPressed != 0) {
+	// Skip intro part if any key is pressed
+	if (!platform_keypress_equals(gLastKeyPressed, (keypress)KEYBOARD_KEYPRESS_UNDEFINED)) {
 		screen_intro_skip_part();
 	}
 }

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -129,7 +129,7 @@ typedef struct {
 
 extern openrct2_cursor gCursorState;
 extern keypress *gKeysPressed;
-extern bool gKeysHeld[]; // Some shortcuts (map scroll) check if keys are held
+extern int gMapKeysStack[]; // State for map scroll shortcut keys
 extern bool gModsHeld[];
 extern sint32 gNumKeysPressed;
 extern sint32 gCurKeyNum;
@@ -176,6 +176,7 @@ bool platform_check_alt(void);
 bool platform_check_ctrl(void);
 bool platform_check_gui(void);
 bool platform_check_shift(void);
+void platform_map_keys_stack_clear(void);
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath, size_t outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -64,9 +64,9 @@
 #define ALT 0x400
 #define CMD 0x800
 #ifdef __MACOSX__
-	#define PLATFORM_MODIFIER CMD
+	#define PLATFORM_MODIFIER KMOD_GUI
 #else
-	#define PLATFORM_MODIFIER CTRL
+	#define PLATFORM_MODIFIER KMOD_CTRL
 #endif
 
 typedef struct resolution {

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -44,6 +44,9 @@
 #define KEYBOARD_KEYPRESS_UNDEFINED { SDLK_UNKNOWN, KMOD_NONE }
 #define KEYBOARD_KEYPRESSES_PER_UPDATE 16
 
+// Number of modifier keys - 2xA, 2xC, 2xGUI, 2xS
+#define MODS_NUM_HELD (SDLK_RGUI - SDLK_LCTRL + 1)
+
 #define INVALID_HANDLE -1
 
 #define TOUCH_DOUBLE_TIMEOUT 300
@@ -127,7 +130,9 @@ typedef struct {
 extern openrct2_cursor gCursorState;
 extern keypress *gKeysPressed;
 extern bool gKeysHeld[]; // Some shortcuts (map scroll) check if keys are held
+extern bool gModsHeld[];
 extern sint32 gNumKeysPressed;
+extern sint32 gCurKeyNum;
 extern keypress gLastKeyPressed;
 
 extern textinputbuffer gTextInput;
@@ -159,12 +164,7 @@ void platform_toggle_windowed_mode();
 void platform_set_cursor(uint8 cursor);
 void platform_refresh_video();
 void platform_process_messages();
-<<<<<<< HEAD:src/openrct2/platform/platform.h
-sint32 platform_scancode_to_rct_keycode(sint32 sdl_key);
 void platform_start_text_input(utf8 *buffer, sint32 max_length);
-=======
-void platform_start_text_input(utf8 *buffer, int max_length);
->>>>>>> 72f796e... Removed all usage of scancodes. Old global modifier state worked into new system.:src/platform/platform.h
 void platform_stop_text_input();
 bool platform_is_input_active();
 void platform_get_date_utc(rct2_date *out_date);
@@ -176,7 +176,6 @@ bool platform_check_alt(void);
 bool platform_check_ctrl(void);
 bool platform_check_gui(void);
 bool platform_check_shift(void);
-bool platform_check_mode(void);
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath, size_t outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -129,7 +129,8 @@ typedef struct {
 
 extern openrct2_cursor gCursorState;
 extern keypress *gKeysPressed;
-extern int gMapKeysStack[]; // State for map scroll shortcut keys
+extern int gMapKeysStackHorizontal[2]; // State for map scroll shortcut keys
+extern int gMapKeysStackVertical[2];
 extern bool gModsHeld[];
 extern sint32 gNumKeysPressed;
 extern sint32 gCurKeyNum;

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -41,6 +41,9 @@
 #define KEYBOARD_PRIMARY_MODIFIER KMOD_CTRL
 #endif
 
+#define KEYBOARD_KEYPRESS_UNDEFINED { SDLK_UNKNOWN, KMOD_NONE }
+#define KEYBOARD_KEYPRESSES_PER_UPDATE 16
+
 #define INVALID_HANDLE -1
 
 #define TOUCH_DOUBLE_TIMEOUT 300
@@ -116,9 +119,15 @@ typedef struct file_dialog_desc {
 	} filters[8];
 } file_dialog_desc;
 
+typedef struct {
+	SDL_Keycode keycode;
+	uint16 mod;
+} keypress;
+
 extern openrct2_cursor gCursorState;
-extern const uint8 *gKeysState;
-extern uint8 *gKeysPressed;
+extern const unsigned char *gKeysState;
+extern keypress *gKeysPressed;
+extern sint32 gNumKeysPressed;
 extern uint32 gLastKeyPressed;
 
 extern textinputbuffer gTextInput;
@@ -158,6 +167,8 @@ void platform_get_date_utc(rct2_date *out_date);
 void platform_get_time_utc(rct2_time *out_time);
 void platform_get_date_local(rct2_date *out_date);
 void platform_get_time_local(rct2_time *out_time);
+#define platform_compare_keypress(k1, k2) (((k1).keycode == (k2).keycode) && (((k1).mod == (k2).mod)))
+#define platform_shortcut_is_undefined(k) platform_compare_keypress((k), (keypress)SHORTCUT_UNDEFINED)
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath, size_t outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -125,10 +125,10 @@ typedef struct {
 } keypress;
 
 extern openrct2_cursor gCursorState;
-extern const unsigned char *gKeysState;
 extern keypress *gKeysPressed;
+extern bool gKeysHeld[]; // Some shortcuts (map scroll) check if keys are held
 extern sint32 gNumKeysPressed;
-extern uint32 gLastKeyPressed;
+extern keypress gLastKeyPressed;
 
 extern textinputbuffer gTextInput;
 extern bool gTextInputCompositionActive;
@@ -159,16 +159,24 @@ void platform_toggle_windowed_mode();
 void platform_set_cursor(uint8 cursor);
 void platform_refresh_video();
 void platform_process_messages();
+<<<<<<< HEAD:src/openrct2/platform/platform.h
 sint32 platform_scancode_to_rct_keycode(sint32 sdl_key);
 void platform_start_text_input(utf8 *buffer, sint32 max_length);
+=======
+void platform_start_text_input(utf8 *buffer, int max_length);
+>>>>>>> 72f796e... Removed all usage of scancodes. Old global modifier state worked into new system.:src/platform/platform.h
 void platform_stop_text_input();
 bool platform_is_input_active();
 void platform_get_date_utc(rct2_date *out_date);
 void platform_get_time_utc(rct2_time *out_time);
 void platform_get_date_local(rct2_date *out_date);
 void platform_get_time_local(rct2_time *out_time);
-#define platform_compare_keypress(k1, k2) (((k1).keycode == (k2).keycode) && (((k1).mod == (k2).mod)))
-#define platform_shortcut_is_undefined(k) platform_compare_keypress((k), (keypress)SHORTCUT_UNDEFINED)
+bool platform_keypress_equals(keypress k1, keypress k2);
+bool platform_check_alt(void);
+bool platform_check_ctrl(void);
+bool platform_check_gui(void);
+bool platform_check_shift(void);
+bool platform_check_mode(void);
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath, size_t outSize);

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -41,8 +41,9 @@ typedef void(*update_palette_func)(const uint8*, sint32, sint32);
 
 openrct2_cursor gCursorState;
 bool gModsHeld[MODS_NUM_HELD] = { 0 };
-int gMapKeysStack[4] = { 0 };
+sint32 gMapKeysStack[4] = { 0 };
 keypress *gKeysPressed;
+sint32 gCurKeyNum;
 sint32 gNumKeysPressed;
 keypress gLastKeyPressed;
 textinputbuffer gTextInput;

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -41,7 +41,8 @@ typedef void(*update_palette_func)(const uint8*, sint32, sint32);
 
 openrct2_cursor gCursorState;
 bool gModsHeld[MODS_NUM_HELD] = { 0 };
-int gMapKeysStack[4] = { 0 };
+int gMapKeysStackHorizontal[2] = { 0 };
+int gMapKeysStackVertical[2] = { 0 };
 keypress *gKeysPressed;
 sint32 gCurKeyNum;
 sint32 gNumKeysPressed;
@@ -915,39 +916,34 @@ static void platform_filter_keypress(keypress *key)
 
 static inline void platform_map_keys_stack_insert(int val)
 {
-	int i;
-
-	for (i = 0; i < 3; ++i) {
-		if (val == gMapKeysStack[i]) {
-			break;
-		}
+	if (val == SHORTCUT_SCROLL_MAP_LEFT || val == SHORTCUT_SCROLL_MAP_RIGHT) {
+		if (gMapKeysStackHorizontal[0])
+			gMapKeysStackHorizontal[1] = val;
+		else
+			gMapKeysStackHorizontal[0] = val;
+	} else {
+		if (gMapKeysStackVertical[0])
+			gMapKeysStackVertical[1] = val;
+		else
+			gMapKeysStackVertical[0] = val;
 	}
-
-	for (int j = i; j > 0; --j) {
-		gMapKeysStack[j] = gMapKeysStack[j-1];
-	}
-
-	gMapKeysStack[0] = val;
 }
 
 static inline void platform_map_keys_stack_remove(int val)
 {
-	int i;
-
-	for (i = 0; i < 3; ++i) {
-		if (val == gMapKeysStack[i]) {
-			break;
-		}
+	if (val == SHORTCUT_SCROLL_MAP_LEFT || val == SHORTCUT_SCROLL_MAP_RIGHT) {
+		if (gMapKeysStackHorizontal[0] == val)
+			gMapKeysStackHorizontal[0] = gMapKeysStackHorizontal[1];
+		gMapKeysStackHorizontal[1] = 0;
+	} else {
+		if (gMapKeysStackVertical[0] == val)
+			gMapKeysStackVertical[0] = gMapKeysStackVertical[1];
+		gMapKeysStackVertical[1] = 0;
 	}
-
-	for (int j = i; j < 3; ++j) {
-		gMapKeysStack[j] = gMapKeysStack[j+1];
-	}
-
-	gMapKeysStack[3] = 0;
 }
 
 void platform_map_keys_stack_clear(void)
 {
-	memset(gMapKeysStack, 0x0, sizeof(gMapKeysStack));
+	memset(gMapKeysStackHorizontal, 0, sizeof(gMapKeysStackHorizontal));
+	memset(gMapKeysStackVertical, 0, sizeof(gMapKeysStackVertical));
 }

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -41,7 +41,7 @@ typedef void(*update_palette_func)(const uint8*, sint32, sint32);
 
 openrct2_cursor gCursorState;
 bool gModsHeld[MODS_NUM_HELD] = { 0 };
-sint32 gMapKeysStack[4] = { 0 };
+int gMapKeysStack[4] = { 0 };
 keypress *gKeysPressed;
 sint32 gCurKeyNum;
 sint32 gNumKeysPressed;
@@ -918,7 +918,7 @@ static inline void platform_map_keys_stack_insert(int val)
 	int i;
 
 	for (i = 0; i < 3; ++i) {
-		if (val == gMapKeysStack[i] ) {
+		if (val == gMapKeysStack[i]) {
 			break;
 		}
 	}

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -317,7 +317,8 @@ void platform_process_messages()
 	while (SDL_PollEvent(&e)) {
 
 		// Multiple window events per update must be handled; ignore inputs.
-		if (skip && (e.type != SDL_WINDOWEVENT))
+		if (skip && !(e.type == SDL_WINDOWEVENT ||
+					  e.type == SDL_QUIT))
 			continue;
 
 		switch (e.type) {

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -303,7 +303,6 @@ void platform_process_messages()
 
 	keypress key = KEYBOARD_KEYPRESS_UNDEFINED;
 	gLastKeyPressed = key;
-	gNumKeysPressed = 0;
 
 	int mod_held_idx;
 
@@ -659,6 +658,7 @@ void platform_init()
 {
 	platform_create_window();
 	gKeysPressed = calloc(sizeof(keypress), KEYBOARD_KEYPRESSES_PER_UPDATE);
+	gNumKeysPressed = 0;
 
 	// Set the highest palette entry to white.
 	// This fixes a bug with the TT:rainbow road due to the

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -154,7 +154,6 @@ bool rct2_init()
 
 	config_reset_shortcut_keys();
 	config_shortcut_keys_load();
-	input_reset_place_obj_modifier();
 	// config_load();
 
 	if (!gfx_load_g1()) {

--- a/src/openrct2/windows/map_tooltip.c
+++ b/src/openrct2/windows/map_tooltip.c
@@ -92,7 +92,8 @@ void window_map_tooltip_update_visibility()
 
 	if (_cursorHoldDuration < 25 ||
 		stringId == STR_NONE ||
-		(input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z)) ||
+		platform_check_ctrl() ||
+		platform_check_shift() ||
 		window_find_by_class(WC_ERROR) != NULL
 	) {
 		window_close_by_class(WC_MAP_TOOLTIP);

--- a/src/openrct2/windows/ride_construction.c
+++ b/src/openrct2/windows/ride_construction.c
@@ -2062,7 +2062,7 @@ static bool ride_get_place_position_from_screen_position(sint32 screenX, sint32 
 	rct_viewport *viewport;
 
 	if (!_trackPlaceCtrlState) {
-		if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_COPY_Z) {
+		if (platform_check_ctrl()) {
 			get_map_coordinates_from_pos(screenX, screenY, 0xFCCA, &mapX, &mapY, &interactionType, &mapElement, &viewport);
 			if (interactionType != 0) {
 				_trackPlaceCtrlZ = mapElement->base_height * 8;
@@ -2070,20 +2070,20 @@ static bool ride_get_place_position_from_screen_position(sint32 screenX, sint32 
 			}
 		}
 	} else {
-		if (!(gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_COPY_Z)) {
+		if (!platform_check_ctrl()) {
 			_trackPlaceCtrlState = false;
 		}
 	}
 
 	if (!_trackPlaceShiftState) {
-		if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z) {
+		if (platform_check_shift()) {
 			_trackPlaceShiftState = true;
 			_trackPlaceShiftStartScreenX = screenX;
 			_trackPlaceShiftStartScreenY = screenY;
 			_trackPlaceShiftZ = 0;
 		}
 	} else {
-		if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z) {
+		if (platform_check_shift()) {
 			_trackPlaceShiftZ = floor2(_trackPlaceShiftStartScreenY - screenY + 4, 8);
 			screenX = _trackPlaceShiftStartScreenX;
 			screenY = _trackPlaceShiftStartScreenY;

--- a/src/openrct2/windows/text_input.c
+++ b/src/openrct2/windows/text_input.c
@@ -329,12 +329,10 @@ static void window_text_input_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	}
 }
 
-void window_text_input_key(rct_window* w, sint32 key)
+void window_text_input_key(rct_window* w, SDL_Keycode key)
 {
-	char new_char = platform_scancode_to_rct_keycode(0xFF&key);
-
 	// If the return button is pressed stop text input
-	if (new_char == '\r'){
+	if (key == SDLK_RETURN){
 		platform_stop_text_input();
 		window_close(w);
 		rct_window* calling_w = window_find_by_number(calling_class, calling_number);

--- a/src/openrct2/windows/top_toolbar.c
+++ b/src/openrct2/windows/top_toolbar.c
@@ -1039,7 +1039,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
 		gSceneryShiftPressed = false;
 	} else {
 		if (!gSceneryCtrlPressed) {
-			if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z)) {
+			if (platform_check_ctrl()) {
 				// CTRL pressed
 				rct_map_element* map_element;
 				uint16 flags =
@@ -1058,14 +1058,14 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
 				}
 			}
 		} else {
-			if (!(input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z))) {
+			if (!platform_check_ctrl()) {
 				// CTRL not pressed
 				gSceneryCtrlPressed = false;
 			}
 		}
 
 		if (!gSceneryShiftPressed) {
-			if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_SHIFT_Z)) {
+			if (platform_check_shift()) {
 				// SHIFT pressed
 				gSceneryShiftPressed = true;
 				gSceneryShiftPressX = x;
@@ -1074,7 +1074,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
 			}
 		}
 		else{
-			if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_SHIFT_Z)) {
+			if (platform_check_shift()) {
 				// SHIFT pressed
 				gSceneryShiftPressZOffset = (gSceneryShiftPressY - y + 4) & 0xFFF8;
 


### PR DESCRIPTION
This PR removes (most of the) usage of scancodes for keyboard input, allowing for keyboard layouts other than qwerty. This should fix #3177.

Current issues
- None?

The old code had a 256-long array of chars indexed by scancodes, where the value at subscript `i` would be `1` if scancode `i` had been pressed during this update. This has been reworked to be an array of `keypress` structs:

``` C
typedef struct {
    SDL_Keycode keycode;
    uint16 mod;
} keypress;
```

This allows for a wider range of possible shortcuts (media keys, meta/super key as a modifier on windows/linux) in addition to supporting different keyboard layouts, while staying relatively compact and platform agnostic.

Furthermore, modifier handling for shortcuts has been decoupled from `gInputPlaceObjectModifier` and the global per-update modifier state, instead favoring separate modifiers recorded for each keypress. This will let the user trigger shortcut combinations such as `C-s` and `S-k` in one update cycle without triggering potentially undefined behavior in the shortcut handling.

Shortcut keys that need to be held (map scrolling) and modifiers (used in object placement) now have their own separate minimal state. This is similar to the old system, but is now handled as part of keyboard input instead of separately getting the entire keyboard state.

An additional possible significant change: On _gain_ or _loss_ of window focus, all non-window events are ignored. This makes sure no input is handled if the window loses focus on in the same update as the keys were pressed. Allows e.g. binding TAB to _underground view_ without triggering the _underground view_ shortcut every time you _alt-TAB_ away from the game. Multiple window events per update are still handled, as I'm sure there would have been issues at some point where people would manage to lose and subsequently gain focus within one game update, thereby blocking inputs indefinitely.

This should now be ready for testing. @marijnvdwerf had problems where keyboard input will randomly not register _keycodes_ properly thus ignoring the input (though the _scancodes_ are fine). Please report if you have this issue and provide relevant output given by [this branch](https://github.com/Goddesen/OpenRCT2/tree/3908_debug).
