### PR TITLE
Try loading rct2 segments for x86-64 just like for i386

### DIFF
--- a/distribution/linux/ld_script_x86_64.xc
+++ b/distribution/linux/ld_script_x86_64.xc
@@ -54,6 +54,8 @@ SECTIONS
   .plt            : { *(.plt) *(.iplt) }
 .plt.got        : { *(.plt.got) }
 .plt.bnd        : { *(.plt.bnd) }
+.rct2_text      0x401000 : { *(.rct2_text) }
+.rct2_data               : { *(.rct2_data) }
   .text           :
   {
     *(.text.unlikely .text.*_unlikely .text.unlikely.*)


### PR DESCRIPTION
This shifts focus away from illegal accesses to RCT2 memory to fixing up
the pointers we use