### PR TITLE
Fixes to -Wall compilation

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -252,6 +252,7 @@ bool Source_SampleStream::LoadWAV(SDL_RWops* rw)
 		return false;
 	}
 	Uint32 chunk_size = SDL_ReadLE32(rw);
+	(void)chunk_size;
 	Uint32 chunk_format = SDL_ReadLE32(rw);
 	const Uint32 WAVE = 0x45564157;
 	if (chunk_format != WAVE) {

--- a/src/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/drawing/engines/SoftwareDrawingEngine.cpp
@@ -668,7 +668,7 @@ private:
         {
             uint8 * src = _bits;
             int padding = pitch - (_width * 4);
-            if (pitch == _width * 4) {
+            if ((uint32)pitch == _width * 4) {
                 uint32 * dst = (uint32 *)pixels;
                 for (int i = _width * _height; i > 0; i--)
                 {
@@ -677,7 +677,7 @@ private:
             }
             else
             {
-                if (pitch == (_width * 2) + padding)
+                if ((uint32)pitch == (_width * 2) + padding)
                 {
                     uint16 * dst = (uint16 *)pixels;
                     for (sint32 y = (sint32)_height; y > 0; y--) {
@@ -691,7 +691,7 @@ private:
                 }
                 else
                 {
-                    if (pitch == _width + padding)
+                    if ((uint32)pitch == _width + padding)
                     {
                         uint8 * dst = (uint8 *)pixels;
                         for (sint32 y = (sint32)_height; y > 0; y--) {

--- a/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -319,9 +319,6 @@ public:
 
         // Scale up to window
         _screenFramebuffer->Bind();
-
-        sint32 width = _screenFramebuffer->GetWidth();
-        sint32 height = _screenFramebuffer->GetHeight();
         _copyFramebufferShader->Use();
         _copyFramebufferShader->SetTexture(_swapFramebuffer->GetTargetFramebuffer()
                                                            ->GetTexture());

--- a/src/input.c
+++ b/src/input.c
@@ -1662,7 +1662,9 @@ void game_handle_key_scroll()
 		const int SHIFT = 0x100;
 		const int CTRL = 0x200;
 		const int ALT = 0x400;
+#ifdef __MACOSX__
 		const int CMD = 0x800;
+#endif
 
 		uint16 shortcutKey = gShortcutKeys[shortcutId];
 		uint8 scancode = shortcutKey & 0xFF;

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -294,8 +294,6 @@ static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetInd
 	// Resolve the absolute ltrb
 	int l = w->x + widget->left;
 	int t = w->y + widget->top;
-	int r = w->x + widget->right;
-	int b = w->y + widget->bottom;
 
 	// Get the colour and image
 	uint8 colour = w->colours[widget->colour] & 0x7F;
@@ -387,8 +385,6 @@ static void widget_text_unknown(rct_drawpixelinfo *dpi, rct_window *w, int widge
 	// Resolve the absolute ltrb
 	int l = w->x + widget->left;
 	int t = w->y + widget->top;
-	int r = w->x + widget->right;
-	int b = w->y + widget->bottom;
 
 	int stringId = widget->image;
 	if (stringId == -1)
@@ -441,7 +437,6 @@ static void widget_text(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex)
 	int l = w->x + widget->left;
 	int t = w->y + widget->top;
 	int r = w->x + widget->right;
-	int b = w->y + widget->bottom;
 
 	if (widget->image == (uint32)-2 || widget->image == (uint32)-1)
 		return;
@@ -845,8 +840,6 @@ static void widget_draw_image(rct_drawpixelinfo *dpi, rct_window *w, int widgetI
 	// Resolve the absolute ltrb
 	int l = w->x + widget->left;
 	int t = w->y + widget->top;
-	int r = w->x + widget->right;
-	int b = w->y + widget->bottom;
 
 	// Get the colour
 	uint8 colour = w->colours[widget->colour] & 0x7F;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1428,7 +1428,9 @@ void Network::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& 
 
 void Network::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet)
 {
-	packet >> (uint32&)connection.AuthStatus >> (uint8&)player_id;
+	uint32 auth_status;
+	packet >> auth_status >> (uint8&)player_id;
+	connection.AuthStatus = (NETWORK_AUTH)auth_status;
 	switch(connection.AuthStatus) {
 	case NETWORK_AUTH_OK:
 		Client_Send_GAMEINFO();
@@ -2347,7 +2349,7 @@ void network_send_password(const char* password)
 	const std::string pubkey = gNetwork.key.PublicKeyString();
 	size_t sigsize;
 	char *signature;
-	bool ok = gNetwork.key.Sign(gNetwork.challenge.data(), gNetwork.challenge.size(), &signature, &sigsize);
+	gNetwork.key.Sign(gNetwork.challenge.data(), gNetwork.challenge.size(), &signature, &sigsize);
 	// Don't keep private key in memory. There's no need and it may get leaked
 	// when process dump gets collected at some point in future.
 	gNetwork.key.Unload();

--- a/src/network/twitch.cpp
+++ b/src/network/twitch.cpp
@@ -468,7 +468,7 @@ namespace Twitch
             size_t memberIndex = SIZE_MAX;
             FOR_ALL_GUESTS(spriteIndex, peep)
             {
-                int originalMemberIndex = memberIndex;
+                size_t originalMemberIndex = memberIndex;
                 for (size_t i = memberIndex + 1; i < members.GetCount(); i++)
                 {
                     if (!members[i].Exists)

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -518,7 +518,7 @@ bool openrct2_setup_rct2_segment()
 	// could have already taken the space we need.
 
 	// TODO: UGLY, UGLY HACK!
-	off_t file_size = 6750208;
+	//off_t file_size = 6750208;
 
 	int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
 	int pageSize = getpagesize();

--- a/src/paint/map_element/fence.c
+++ b/src/paint/map_element/fence.c
@@ -132,7 +132,6 @@ void fence_paint_wall(uint32 frameNum, const rct_scenery_entry * sceneryEntry, u
  */
 void fence_paint(uint8 direction, int height, rct_map_element * map_element)
 {
-	rct_drawpixelinfo * dpi = unk_140E9A8;
     gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
 
 	rct_scenery_entry * sceneryEntry = get_wall_entry(map_element->properties.fence.type);
@@ -158,7 +157,6 @@ void fence_paint(uint8 direction, int height, rct_map_element * map_element)
         imageColourFlags &= 0x0DFFFFFFF;
     }
 
-    int clearanceHeight = ceil2(map_element->clearance_height * 8 + 15, 16);
     if (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, sint16) < height) {
         RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, sint16) = height;
         RCT2_GLOBAL(0x141E9DA, uint8) = 0x20;

--- a/src/paint/map_element/path.c
+++ b/src/paint/map_element/path.c
@@ -674,7 +674,6 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
 
 	gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
-	uint32 ecx = get_current_rotation();
 	bool word_F3F038 = false;
 
 	uint32 sceneryImageFlags = 0;
@@ -846,8 +845,6 @@ void loc_6A37C9(rct_map_element * mapElement, int height, rct_footpath_entry * f
 		path_a_supports_paint_setup(1, ax, height, imageFlags, footpathEntry, NULL);
 	}
 
-	sint16 x = RCT2_GLOBAL(0x009DE56A, sint16), y = RCT2_GLOBAL(0x009DE56E, sint16);
-
 	height += 32;
 	if (footpath_element_is_sloped(mapElement)) {
 		height += 16;
@@ -888,7 +885,6 @@ void loc_6A37C9(rct_map_element * mapElement, int height, rct_footpath_entry * f
 
 void loc_6A3B57(rct_map_element* mapElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags)
 {
-	uint8 type = footpath_element_get_type(mapElement);
 	// Rol edges around rotation
 	uint8 edges = ((mapElement->properties.path.edges << get_current_rotation()) & 0xF) |
 		(((mapElement->properties.path.edges & 0xF) << get_current_rotation()) >> 4);
@@ -970,8 +966,6 @@ void loc_6A3B57(rct_map_element* mapElement, sint16 height, rct_footpath_entry* 
 			path_b_supports_paint_setup(supports[i], ax, height, imageFlags);
 		}
 	}
-	
-	sint16 x = RCT2_GLOBAL(0x009DE56A, sint16), y = RCT2_GLOBAL(0x009DE56E, sint16);
 
 	height += 32;
 	if (footpath_element_is_sloped(mapElement)) {

--- a/src/paint/map_element/scenery_multiple.c
+++ b/src/paint/map_element/scenery_multiple.c
@@ -139,7 +139,7 @@ void scenery_multiple_sign_paint_line(const utf8 *str, rct_large_scenery_text *t
 				}
 			}
 		}
-		int image_id = textImage + glyph_offset + glyph_type | textColour;
+		int image_id = (textImage + glyph_offset + glyph_type) | textColour;
 		if (direction == 3) {
 			paint_attach_to_previous_ps(image_id, x_offset, -div_to_minus_infinity(acc, 2));
 		} else {
@@ -255,7 +255,6 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
 			textColour = COLOUR_GREY;
 		}
 		textColour = (textColour << 19) | 0x20000000;
-		uint32 dword_F4388A = textColour;
 		uint32 bannerIndex = (mapElement->type & 0xC0) | ((mapElement->properties.scenerymultiple.colour[0] & 0xE0) >> 2) | ((mapElement->properties.scenerymultiple.colour[1] & 0xE0) >> 5);
 		rct_banner *banner = &gBanners[bannerIndex];
 		rct_string_id stringId = banner->string_idx;
@@ -293,7 +292,6 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
 					for (int i = 0; i < 2; i++) {
 						utf8 str1[64] = {0};
 						utf8 *dst = str1;
-						const utf8 *dstend = dst + sizeof(str1);
 						utf8 *srcold = src;
 						utf8 *spacesrc = 0;
 						utf8 *spacedst = 0;

--- a/src/paint/map_element/surface.c
+++ b/src/paint/map_element/surface.c
@@ -1163,7 +1163,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 				sub_98196C(2624, 0, 0, 32, 32, 16, spawn->z * 16, rotation);
 
 				int offset = ((spawn->direction ^ 2) + rotation) & 3;
-				uint32 image_id = 3111 + offset | 0x20380000;
+				uint32 image_id = (3111 + offset) | 0x20380000;
 				sub_98196C(image_id, 0, 0, 32, 32, 19, spawn->z * 16, rotation);
 			}
 		}

--- a/src/paint/sprite/peep.c
+++ b/src/paint/sprite/peep.c
@@ -49,19 +49,19 @@ void peep_paint(rct_peep * peep, int imageDirection)
 	sub_98197C(imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 3, get_current_rotation());
 
 	if (baseImageId >= 10717 && baseImageId < 10749) {
-		imageId = baseImageId + 32 | peep->hat_colour << 19 | 0x20000000;
+		imageId = (baseImageId + 32) | peep->hat_colour << 19 | 0x20000000;
 		sub_98199C(imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 3, get_current_rotation());
 		return;
 	}
 
 	if (baseImageId >= 10781 && baseImageId < 10813) {
-		imageId = baseImageId + 32 | peep->balloon_colour << 19 | 0x20000000;
+		imageId = (baseImageId + 32) | peep->balloon_colour << 19 | 0x20000000;
 		sub_98199C(imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 3, get_current_rotation());
 		return;
 	}
 
 	if (baseImageId >= 11197 && baseImageId < 11229) {
-		imageId = baseImageId + 32 | peep->umbrella_colour << 19 | 0x20000000;
+		imageId = (baseImageId + 32) | peep->umbrella_colour << 19 | 0x20000000;
 		sub_98199C(imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 3, get_current_rotation());
 		return;
 	}

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -64,9 +64,6 @@ static const int _fullscreen_modes[] = { 0, SDL_WINDOW_FULLSCREEN, SDL_WINDOW_FU
 static unsigned int _lastGestureTimestamp;
 static float _gestureRadius;
 
-static uint32 _pixelBeforeOverlay;
-static uint32 _pixelAfterOverlay;
-
 static void platform_create_window();
 static void platform_load_cursors();
 static void platform_unload_cursors();

--- a/src/rct1/S4Importer.cpp
+++ b/src/rct1/S4Importer.cpp
@@ -1508,7 +1508,7 @@ int S4Importer::GetSCNumber()
         utf8 digitBuffer[maxDigits + 1];
         utf8 * dst = digitBuffer;
         const utf8 * src = fileName + 2;
-        for (int i = 0; i < maxDigits && *src != '.'; i++)
+		for (size_t i = 0; i < maxDigits && *src != '.'; i++)
         {
             *dst++ = *src++;
         }

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -106,8 +106,6 @@ void S6Importer::LoadScenario(const utf8 * path)
 
 void S6Importer::LoadSavedGame(SDL_RWops *rw)
 {
-    auto meh = SDL_RWtell(rw);
-
     sawyercoding_read_chunk_safe(rw, &_s6.header, sizeof(_s6.header));
     if (_s6.header.type != S6_TYPE_SAVEDGAME)
     {

--- a/src/ride/thrill/swinging_inverter_ship.c
+++ b/src/ride/thrill/swinging_inverter_ship.c
@@ -121,7 +121,6 @@ static void paint_swinging_inverter_ship(uint8 rideIndex, uint8 trackSequence, u
 	uint8 relativeTrackSequence = track_map_1x4[direction][trackSequence];
 
 	rct_ride * ride = get_ride(rideIndex);
-	rct_xy16 position = {RCT2_GLOBAL(0x009DE56A, sint16), RCT2_GLOBAL(0x009DE56E, sint16)};
 
 	uint32 imageId;
 

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -7277,12 +7277,6 @@ bool vehicle_update_track_motion_backwards_get_new_track(rct_vehicle *vehicle, u
 	vehicle->track_direction |= direction;
 	vehicle->break_speed = (mapElement->properties.track.sequence >> 4) << 1;
 
-	const rct_vehicle_info* moveInfo = vehicle_get_move_info(
-		vehicle->var_CD,
-		vehicle->track_type,
-		0
-		);
-
 	// There are two bytes before the move info list
 	uint16 trackTotalProgress = vehicle_get_move_info_size(vehicle->var_CD, vehicle->track_type);
 	*progress = trackTotalProgress - 1;

--- a/src/ride/water/river_rapids.c
+++ b/src/ride/water/river_rapids.c
@@ -615,31 +615,31 @@ static void paint_river_rapids_track_waterfall(uint8 rideIndex, uint8 trackSeque
 		imageId = (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_SE_NW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_BASE_NE_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_BASE_NE_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98199C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_TOP_NE_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_TOP_NE_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 1, 32, 27, height, 4, 0, height + 17, get_current_rotation());
 
 		imageId = (direction == 1 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_NW_SE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_SE_NW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 1, 32, 27, height, 27, 0, height + 17, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_SIDE_SW_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_SIDE_SW_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98199C(imageId, 0, 0, 1, 32, 27, height, 27, 0, height + 17, get_current_rotation());
 	} else {
 		imageId = (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_NE_SW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_BASE_NW_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_BASE_NW_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98199C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_TOP_NW_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_TOP_NW_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 1, 27, height, 0, 4, height + 17, get_current_rotation());
 
 		imageId = (direction == 0 ? SPR_RIVER_RAPIDS_WATERFALL_FRONT_SW_NE : SPR_RIVER_RAPIDS_WATERFALL_FRONT_NE_SW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 1, 27, height, 0, 27, height + 17, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_WATERFALL_SIDE_SE_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_WATERFALL_SIDE_SE_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98199C(imageId, 0, 0, 32, 1, 27, height, 0, 27, height + 17, get_current_rotation());
 	}
 
@@ -663,13 +663,13 @@ static void paint_river_rapids_track_rapids(uint8 rideIndex, uint8 trackSequence
 	uint16 frameNum = (gScenarioTicks / 2) & 7;
 
 	if (direction & 1) {
-		imageId = SPR_RIVER_RAPIDS_RAPIDS_NW_SE_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_RAPIDS_NW_SE_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
 
 		imageId = SPR_RIVER_RAPIDS_RAPIDS_FRONT_NW_SE | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 1, 32, 11, height, 27, 0, height + 17, get_current_rotation());
 	} else {
-		imageId = SPR_RIVER_RAPIDS_RAPIDS_SW_NE_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_RAPIDS_SW_NE_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
 
 		imageId = SPR_RIVER_RAPIDS_RAPIDS_FRONT_SW_NE | RCT2_GLOBAL(0x00F44198, uint32);
@@ -756,7 +756,7 @@ static void paint_river_rapids_track_whirlpool(uint8 rideIndex, uint8 trackSeque
 		imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_NW_SE : SPR_RIVER_RAPIDS_FLAT_SE_NW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
 
 		imageId = (direction == 1 ? SPR_RIVER_RAPIDS_FLAT_FRONT_NW_SE : SPR_RIVER_RAPIDS_FLAT_FRONT_SE_NW) | RCT2_GLOBAL(0x00F44198, uint32);
@@ -765,7 +765,7 @@ static void paint_river_rapids_track_whirlpool(uint8 rideIndex, uint8 trackSeque
 		imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_SW_NE : SPR_RIVER_RAPIDS_FLAT_NE_SW) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
 
-		imageId = SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum | RCT2_GLOBAL(0x00F44198, uint32);
+		imageId = (SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 + frameNum) | RCT2_GLOBAL(0x00F44198, uint32);
 		sub_98197C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
 
 		imageId = (direction == 0 ? SPR_RIVER_RAPIDS_FLAT_FRONT_SW_NE : SPR_RIVER_RAPIDS_FLAT_FRONT_NE_SW) | RCT2_GLOBAL(0x00F44198, uint32);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -153,9 +153,8 @@ bool readentirefile(const utf8 *path, void **outBuffer, int *outLength)
 
 int bitscanforward(int source)
 {
-	int i;
-
 	#if _MSC_VER >= 1400 // Visual Studio 2005
+		int i;
 		uint8 success = _BitScanForward(&i, source);
 		return success != 0 ? i : -1;
 	#elif __GNUC__
@@ -166,7 +165,7 @@ int bitscanforward(int source)
 	// This is a low-hanging optimisation boost, check if your compiler offers
 	// any intrinsic.
 	// cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
-	for (i = 0; i < 32; i++)
+	for (int i = 0; i < 32; i++)
 		if (source & (1u << i))
 			return i;
 


### PR DESCRIPTION
By default, not all warnings are enabled. This change makes sure that
the project compiles correctly with following options turned on:

    -Wall -Wno-unused-but-set-variable -Wno-missing-braces \
    -Wno-unknown-pragmas -Wno-unused-function