### PR TITLE
Speedup calculate_checksum by ~9%

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1815,14 +1815,14 @@ void *object_aligned_alloc_pad(size_t alignment, size_t size)
 	//  - the object
 	//  - extra zero-padded space to bring object size to a multiple of 32
 	//  - extra space for alignment
-	void *ptr = (uint8 *)malloc(sizeof(size_t) + sizeof(void *) + size + alignment - 1 + zero_pad);
+	void *ptr = (uint8 *)malloc(sizeof(size_t) + sizeof(uint8 *) + size + alignment - 1 + zero_pad);
 	if (ptr == NULL) {
 		log_error("Failed to allocate memory for object.");
 		assert(false);
 	}
 
 	// Align chunk pointer on boundary.
-	void *ptr_aligned = (void *)((uint8 *)ptr + sizeof(size_t) + sizeof(void *) + alignment - 1 - (size % alignment));
+	void *ptr_aligned = (void *)((uint8 *)ptr + sizeof(size_t) + sizeof(uint8 *) + alignment - 1 - (size % alignment));
 
 	// Save alignment for realloc
 	((size_t *)ptr_aligned)[-2] = alignment;
@@ -1830,7 +1830,7 @@ void *object_aligned_alloc_pad(size_t alignment, size_t size)
 	((void **)ptr_aligned)[-1] = ptr;
 
 	// Zero-pad object up to a multiple of alignment
-	memset(ptr_aligned + size, 0x00, zero_pad);
+	memset((uint8 *)ptr_aligned + size, 0x00, zero_pad);
 
 	return ptr_aligned;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -96,7 +96,7 @@ int object_load_file(int groupIndex, const rct_object_entry *entry, int* chunkSi
 		return 0;
 	}
 
-	int calculatedChecksum = object_calculate_checksum(&openedEntry, chunk, *chunkSize);
+	uint32 calculatedChecksum = object_calculate_checksum(&openedEntry, chunk, *chunkSize);
 
 	// Calculate and check checksum
 	if (calculatedChecksum != openedEntry.checksum && !gConfigGeneral.allow_loading_with_incorrect_checksum) {
@@ -207,7 +207,7 @@ int write_object_file(SDL_RWops *rw, rct_object_entry* entry)
 
 
 	//Check if content of object file matches the stored checksum. If it does not, then fix it.
-	int calculated_checksum = object_calculate_checksum(entry, chunk, installed_entry->chunk_size);
+	uint32 calculated_checksum = object_calculate_checksum(entry, chunk, installed_entry->chunk_size);
 	if(entry->checksum != calculated_checksum) {
 		//Store the current length of the header - it's the offset at which we will write the extra bytes
 		int salt_offset = chunkHeader.length;

--- a/src/object.c
+++ b/src/object.c
@@ -1806,7 +1806,7 @@ char *object_get_name(rct_object_entry *entry)
 
 void *object_aligned_alloc_pad(size_t alignment, size_t size)
 {
-	int remainder = size % alignment;
+	size_t remainder = size % alignment;
 	size_t zero_pad = (remainder > 0) ? (alignment - remainder) : 0;
 
 	// Allocate enough space for ...:
@@ -1856,10 +1856,10 @@ void *object_realloc_chunk(void *chunk, size_t size)
 	void *ptr_new, *ptr_new_chunk;
 	void *ptr_old = ((void **)chunk)[-1];
 
-	int alignment = ((size_t *)chunk)[-2];
-	int remainder = size % alignment;
-	int zero_pad = (remainder > 0) ? (alignment - remainder) : 0;
-	int offset = (uint8 *)chunk - (uint8 *)ptr_old;
+	size_t alignment = ((size_t *)chunk)[-2];
+	size_t remainder = size % alignment;
+	size_t zero_pad = (remainder > 0) ? (alignment - remainder) : 0;
+	size_t offset = (size_t)((uint8 *)chunk - (uint8 *)ptr_old);
 
 	ptr_new = realloc(ptr_old, offset + size + zero_pad);
 	if (ptr_new == NULL) {

--- a/src/object.c
+++ b/src/object.c
@@ -423,7 +423,7 @@ int object_entry_compare(const rct_object_entry *a, const rct_object_entry *b)
 	return 1;
 }
 
-uint32 object_calculate_checksum(const rct_object_entry *__restrict__ entry, const uint8 *__restrict__ data, int dataLength)
+uint32 object_calculate_checksum(const rct_object_entry *RESTRICT entry, const uint8 *RESTRICT data, int dataLength)
 {
 	const uint8 *entry_bytes = (uint8 *)entry;
 	uint32 checksum = 0xF369A75B;

--- a/src/object.c
+++ b/src/object.c
@@ -434,7 +434,14 @@ int object_calculate_checksum(const rct_object_entry *entry, const uint8 *data, 
 		checksum ^= entryBytePtr[i];
 		checksum = rol32(checksum, 11);
 	}
-	for (int i = 0; i < dataLength; i++) {
+	const int dataLength32 = dataLength - (dataLength & 31);
+	for (int i = 0; i < 32; i++) {
+		for (int j = i; j < dataLength32; j+= 32) {
+			checksum ^= data[j];
+		}
+		checksum = rol32(checksum, 11);
+	}
+	for (int i = dataLength32; i < dataLength; i++) {
 		checksum ^= data[i];
 		checksum = rol32(checksum, 11);
 	}

--- a/src/object.h
+++ b/src/object.h
@@ -126,12 +126,13 @@ int object_get_scenario_text(rct_object_entry *entry);
 void object_free_scenario_text();
 uintptr_t object_get_length(const rct_object_entry *entry);
 int object_entry_compare(const rct_object_entry *a, const rct_object_entry *b);
-uint32 object_calculate_checksum(const rct_object_entry *entry, const uint8 *data, int dataLength);
+uint32 object_calculate_checksum(const rct_object_entry *RESTRICT entry, const uint8 *RESTRICT data, int dataLength);
 rct_object_entry *object_get_next(const rct_object_entry *entry);
 int write_object_file(SDL_RWops* rw, rct_object_entry* entry);
 void reset_loaded_objects();
 int find_object_in_entry_group(rct_object_entry* entry, uint8* entry_type, uint8* entry_index);
 void object_create_identifier_name(char* string_buffer, const rct_object_entry* object);
+uint8 *object_alloc_chunk(SDL_RWops *rw, int *size);
 
 rct_object_entry *object_list_find_by_name(const char *name);
 rct_object_entry *object_list_find(rct_object_entry *entry);

--- a/src/object.h
+++ b/src/object.h
@@ -132,7 +132,10 @@ int write_object_file(SDL_RWops* rw, rct_object_entry* entry);
 void reset_loaded_objects();
 int find_object_in_entry_group(rct_object_entry* entry, uint8* entry_type, uint8* entry_index);
 void object_create_identifier_name(char* string_buffer, const rct_object_entry* object);
+void *object_aligned_alloc_pad(size_t alignment, size_t size);
+void *object_realloc_chunk(void *chunk, size_t size);
 uint8 *object_alloc_chunk(SDL_RWops *rw, int *size);
+void object_free_chunk(void *chunk);
 
 rct_object_entry *object_list_find_by_name(const char *name);
 rct_object_entry *object_list_find(rct_object_entry *entry);

--- a/src/object.h
+++ b/src/object.h
@@ -126,7 +126,7 @@ int object_get_scenario_text(rct_object_entry *entry);
 void object_free_scenario_text();
 uintptr_t object_get_length(const rct_object_entry *entry);
 int object_entry_compare(const rct_object_entry *a, const rct_object_entry *b);
-int object_calculate_checksum(const rct_object_entry *entry, const uint8 *data, int dataLength);
+uint32 object_calculate_checksum(const rct_object_entry *entry, const uint8 *data, int dataLength);
 rct_object_entry *object_get_next(const rct_object_entry *entry);
 int write_object_file(SDL_RWops* rw, rct_object_entry* entry);
 void reset_loaded_objects();


### PR DESCRIPTION
Skips unnecessary `rol32`s

This is a very simple optimisation, I have also tried something much more fancy, which yields to SIMDification very well, but I couldn't prove it was any better than this.

The "more fancy" change in question:

```diff
diff --git a/src/object.c b/src/object.c
index 85e423f..88201bd 100644
--- a/src/object.c
+++ b/src/object.c
@@ -434,14 +434,19 @@ int object_calculate_checksum(const rct_object_entry *entry, const uint8 *data,
                checksum ^= entryBytePtr[i];
                checksum = rol32(checksum, 11);
        }
-       const int dataLength32 = dataLength - (dataLength & 31);
+       const int dataLength32 = dataLength / 32;
+       uint8 * temp = malloc(dataLength32);
        for (int i = 0; i < 32; i++) {
-               for (int j = i; j < dataLength32; j+= 32) {
-                       checksum ^= data[j];
+               for (int j = 0; j < dataLength32; j++) {
+                       temp[j] = data[i + j * 32];
+               }
+               for (int j = 0; j < dataLength32; j++) {
+                       checksum ^= temp[j];
                }
                checksum = rol32(checksum, 11);
        }
-       for (int i = dataLength32; i < dataLength; i++) {
+       free(temp);
+       for (int i = dataLength & ~(31); i < dataLength; i++) {
                checksum ^= data[i];
                checksum = rol32(checksum, 11);
        }
```

See how well compiler can optimise it: https://gist.github.com/janisozaur/f199e28431c29bbd13633067a7373c65 and especially around this area: https://gist.github.com/janisozaur/f199e28431c29bbd13633067a7373c65#file-checksum_with_sources-s-L318 (in this gist is also my test code)