### PR TITLE
Fix incorrect variable name in posix.c log statement

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -65,6 +65,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Josué Acevedo (Wirlie)
 * Martin Černáč (octaroot)
 * (marcovmun)
+* Sven Slootweg (joepie91)
 
 ## Toolchain
 * (Balletie) - OSX

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -724,7 +724,7 @@ void platform_resolve_openrct_data_path()
 
 	if (gCustomOpenrctDataPath[0] != 0) {
 		if (realpath(gCustomOpenrctDataPath, _openrctDataDirectoryPath)) {
-			log_error("Could not resolve path \"%s\"", gCustomUserDataPath);
+			log_error("Could not resolve path \"%s\"", gCustomOpenrctDataPath);
 			return;
 		}
 


### PR DESCRIPTION
This was probably a copy-pasting error. I don't actually speak C, so I can't know for sure whether this will fix it properly :)