### PR TITLE
Skip drawing windows that are completely covered by another window.  …

### DIFF
--- a/src/drawing/drawing.c
+++ b/src/drawing/drawing.c
@@ -196,6 +196,7 @@ void window_draw_all(rct_drawpixelinfo *dpi, short left, short top, short right,
 		if (w->flags & WF_TRANSPARENT) continue;
 		if (right <= w->x || bottom <= w->y) continue;
 		if (left >= w->x + w->width || top >= w->y + w->height) continue;
+		if (!window_is_visible(w)) continue;
 
 		window_draw(&windowDPI, w, left, top, right, bottom);
 	}

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -1476,10 +1476,12 @@ void window_draw(rct_drawpixelinfo *dpi, rct_window *w, int left, int top, int r
 	if (left >= right) return;
 	if (top >= bottom) return;
 
+	if (!window_is_visible(w)) return;
+
 	// Draw the window in this region
 	for (rct_window *v = w; v < RCT2_NEW_WINDOW; v++) {
 		// Don't draw overlapping opaque windows, they won't have changed
-		if (w == v || (v->flags & WF_TRANSPARENT)) {
+		if ((w == v || (v->flags & WF_TRANSPARENT)) && window_is_visible(v)) {
 			window_draw_single(dpi, v, left, top, right, bottom);
 		}
 	}
@@ -2480,24 +2482,21 @@ void window_update_textbox()
 
 bool window_is_visible(rct_window* w)
 {
-	if (w->viewport == NULL)
+	// only consider viewports, consider the main window always visible
+	if (w == NULL || w->viewport == NULL || w->classification == WC_MAIN_WINDOW)
 	{
 		// default to previous behavior
 		return true;
 	}
 
-	// consider main window always visible
-	if (w->classification == WC_MAIN_WINDOW)
-		return true;
-
-	for (rct_window *w_other = g_window_list; w < RCT2_NEW_WINDOW; w_other++)
+	// start from the window above the current
+	for (rct_window *w_other = (w+1); w_other < RCT2_NEW_WINDOW; w_other++)
 	{
 		// if covered by a higher window, no rendering needed
-		if (w_other > w
-			&& w_other->x <= w->x
+		if (w_other->x <= w->x
 			&& w_other->y <= w->y
-			&& (w_other->x + w_other->width) >= (w->x + w->width)
-			&& (w_other->y + w_other->height) >= (w->y + w->height))
+			&& w_other->x + w_other->width >= w->x + w->width
+			&& w_other->y + w_other->height >= w->y + w->height)
 		{
 			return false;
 		}

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -146,7 +146,7 @@ void window_dispatch_update_all()
 void window_update_all_viewports()
 {
 	for (rct_window *w = g_window_list; w < RCT2_NEW_WINDOW; w++)
-		if (w->viewport != NULL)
+		if (w->viewport != NULL && window_is_visible(w))
 			viewport_update_position(w);
 }
 
@@ -2476,4 +2476,33 @@ void window_update_textbox()
 		widget_invalidate(w, gCurrentTextBox.widget_index);
 		window_event_textinput_call(w, gCurrentTextBox.widget_index, gTextBoxInput);
 	}
+}
+
+bool window_is_visible(rct_window* w)
+{
+	if (w->viewport == NULL)
+	{
+		// default to previous behavior
+		return true;
+	}
+
+	// consider main window always visible
+	if (w->classification == WC_MAIN_WINDOW)
+		return true;
+
+	for (rct_window *w_other = g_window_list; w < RCT2_NEW_WINDOW; w_other++)
+	{
+		// if covered by a higher window, no rendering needed
+		if (w_other > w
+			&& w_other->x <= w->x
+			&& w_other->y <= w->y
+			&& (w_other->x + w_other->width) >= (w->x + w->width)
+			&& (w_other->y + w_other->height) >= (w->y + w->height))
+		{
+			return false;
+		}
+	}
+
+	// default to previous behavior
+	return true;
 }

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -729,6 +729,8 @@ void window_cancel_textbox();
 void window_update_textbox_caret();
 void window_update_textbox();
 
+bool window_is_visible(rct_window* w);
+
 bool land_tool_is_active();
 
 //Cheat: in-game land ownership editor


### PR DESCRIPTION
…This helps in preventing many windows from bringing the game to a crawl, such as viewing many staff at once on top of each other.

You can recreate the issue by opening many (dozen or so) staff at the same time that cover each other.  The frame rate will continue to drop with each additional window.  With this update the frame rate will hold when the windows are stacked over each other.  This should help in cases such as dropping many new handymen at once since the windows are opened at the same location.