### PR TITLE
Prevent rendering of hidden windows.

### DIFF
--- a/src/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/drawing/engines/SoftwareDrawingEngine.cpp
@@ -530,14 +530,14 @@ private:
         _dirtyGrid.Blocks = new uint8[_dirtyGrid.BlockColumns * _dirtyGrid.BlockRows];
     }
 
-	static void ResetWindowVisbilities()
+    static void ResetWindowVisbilities()
     {
-		// reset window visibilty status to unknown
-		for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
-		{
-			w->visibility = VC_UNKNOWN;
-			if (w->viewport != NULL) w->viewport->visibility = VC_UNKNOWN;
-		}
+        // reset window visibilty status to unknown
+        for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
+        {
+            w->visibility = VC_UNKNOWN;
+            if (w->viewport != NULL) w->viewport->visibility = VC_UNKNOWN;
+        }
     }
 
     void DrawAllDirtyBlocks()

--- a/src/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/drawing/engines/SoftwareDrawingEngine.cpp
@@ -365,7 +365,7 @@ public:
             _rainDrawer.SetDPI(&_bitsDPI);
             _rainDrawer.Restore();
 
-			ResetWindowVisbilities();
+            ResetWindowVisbilities();
 
             // Redraw dirty regions before updating the viewports, otherwise
             // when viewports get panned, they copy dirty pixels

--- a/src/drawing/engines/SoftwareDrawingEngine.cpp
+++ b/src/drawing/engines/SoftwareDrawingEngine.cpp
@@ -365,6 +365,8 @@ public:
             _rainDrawer.SetDPI(&_bitsDPI);
             _rainDrawer.Restore();
 
+			ResetWindowVisbilities();
+
             // Redraw dirty regions before updating the viewports, otherwise
             // when viewports get panned, they copy dirty pixels
             DrawAllDirtyBlocks();
@@ -526,6 +528,16 @@ private:
 
         delete [] _dirtyGrid.Blocks;
         _dirtyGrid.Blocks = new uint8[_dirtyGrid.BlockColumns * _dirtyGrid.BlockRows];
+    }
+
+	static void ResetWindowVisbilities()
+    {
+		// reset window visibilty status to unknown
+		for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
+		{
+			w->visibility = VC_UNKNOWN;
+			if (w->viewport != NULL) w->viewport->visibility = VC_UNKNOWN;
+		}
     }
 
     void DrawAllDirtyBlocks()

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1396,6 +1396,23 @@ void get_map_coordinates_from_pos(int screenX, int screenY, int flags, sint16 *x
  */
 void viewport_invalidate(rct_viewport *viewport, int left, int top, int right, int bottom)
 {
+	// if unknown viewport visibility, use the containing window to discover the status
+	if (viewport->visibility == VC_UNKNOWN)
+	{
+		for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
+		{
+			if (w->classification != WC_MAIN_WINDOW && w->viewport != NULL && w->viewport == viewport)
+			{
+				// note, window_is_visible will update viewport->visibility, so this should have a low hit count
+				if (!window_is_visible(w)) {
+					return;
+				}
+			}
+		}
+	}
+
+	if (viewport->visibility == VC_COVERED) return;
+
 	int viewportLeft = viewport->view_x;
 	int viewportTop = viewport->view_y;
 	int viewportRight = viewport->view_x + viewport->view_width;

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -146,7 +146,7 @@ void window_dispatch_update_all()
 void window_update_all_viewports()
 {
 	for (rct_window *w = g_window_list; w < RCT2_NEW_WINDOW; w++)
-		if (w->viewport != NULL)
+		if (w->viewport != NULL && window_is_visible(w))
 			viewport_update_position(w);
 }
 
@@ -1476,10 +1476,12 @@ void window_draw(rct_drawpixelinfo *dpi, rct_window *w, int left, int top, int r
 	if (left >= right) return;
 	if (top >= bottom) return;
 
+	if (!window_is_visible(w)) return;
+
 	// Draw the window in this region
 	for (rct_window *v = w; v < RCT2_NEW_WINDOW; v++) {
 		// Don't draw overlapping opaque windows, they won't have changed
-		if (w == v || (v->flags & WF_TRANSPARENT)) {
+		if ((w == v || (v->flags & WF_TRANSPARENT)) && window_is_visible(v)) {
 			window_draw_single(dpi, v, left, top, right, bottom);
 		}
 	}
@@ -2476,4 +2478,30 @@ void window_update_textbox()
 		widget_invalidate(w, gCurrentTextBox.widget_index);
 		window_event_textinput_call(w, gCurrentTextBox.widget_index, gTextBoxInput);
 	}
+}
+
+bool window_is_visible(rct_window* w)
+{
+	// only consider viewports, consider the main window always visible
+	if (w == NULL || w->viewport == NULL || w->classification == WC_MAIN_WINDOW)
+	{
+		// default to previous behavior
+		return true;
+	}
+
+	// start from the window above the current
+	for (rct_window *w_other = (w+1); w_other < RCT2_NEW_WINDOW; w_other++)
+	{
+		// if covered by a higher window, no rendering needed
+		if (w_other->x <= w->x
+			&& w_other->y <= w->y
+			&& w_other->x + w_other->width >= w->x + w->width
+			&& w_other->y + w_other->height >= w->y + w->height)
+		{
+			return false;
+		}
+	}
+
+	// default to previous behavior
+	return true;
 }

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -85,6 +85,7 @@ typedef struct rct_viewport {
 	uint8 zoom;						// 0x10
 	uint8 var_11;
 	uint16 flags;					// 0x12
+	uint8 visibility;				// VISIBILITY_CACHE
 } rct_viewport;
 
 /**
@@ -288,6 +289,7 @@ typedef struct rct_window {
 	sint8 var_4B8;
 	sint8 var_4B9;
 	uint8 colours[6];			// 0x4BA
+	uint8 visibility;			// VISIBILITY_CACHE
 } rct_window;
 
 #define RCT_WINDOW_RIGHT(w) (w->x + w->width)
@@ -491,6 +493,13 @@ enum {
 	MODAL_RESULT_FAIL = -1,
 	MODAL_RESULT_CANCEL,
 	MODAL_RESULT_OK
+};
+
+enum VISIBILITY_CACHE
+{
+	VC_UNKNOWN = 0,
+	VC_VISIBLE = 1,
+	VC_COVERED = 2
 };
 
 typedef void (*modal_callback)(int result);

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -729,6 +729,8 @@ void window_cancel_textbox();
 void window_update_textbox_caret();
 void window_update_textbox();
 
+bool window_is_visible(rct_window* w);
+
 bool land_tool_is_active();
 
 //Cheat: in-game land ownership editor

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -497,9 +497,9 @@ enum {
 
 enum VISIBILITY_CACHE
 {
-	VC_UNKNOWN = 0,
-	VC_VISIBLE = 1,
-	VC_COVERED = 2
+	VC_UNKNOWN,
+	VC_VISIBLE,
+	VC_COVERED
 };
 
 typedef void (*modal_callback)(int result);


### PR DESCRIPTION
This is a cleaner pull request for #3985 (deleted the fork to get one free of the merge).

This simply prevents rendering of windows with a viewport that are covered by another window (at least covering it, they can be bigger).