### PR TITLE
Enable diagonal steep slopes for the junior coaster

### DIFF
--- a/src/ride/track_paint.c
+++ b/src/ride/track_paint.c
@@ -924,6 +924,12 @@ void track_paint(uint8 direction, int height, rct_map_element *mapElement)
 			case TRACK_ELEM_60_DEG_DOWN:
 			case TRACK_ELEM_25_DEG_DOWN_TO_60_DEG_DOWN:
 			case TRACK_ELEM_60_DEG_DOWN_TO_25_DEG_DOWN:
+			case TRACK_ELEM_DIAG_60_DEG_UP:
+			case TRACK_ELEM_DIAG_25_DEG_UP_TO_60_DEG_UP:
+			case TRACK_ELEM_DIAG_60_DEG_UP_TO_25_DEG_UP:
+			case TRACK_ELEM_DIAG_60_DEG_DOWN:
+			case TRACK_ELEM_DIAG_25_DEG_DOWN_TO_60_DEG_DOWN:
+			case TRACK_ELEM_DIAG_60_DEG_DOWN_TO_25_DEG_DOWN:
 				rideType = RIDE_TYPE_WATER_COASTER;
 				break;
 


### PR DESCRIPTION
It was pointed out in [this thread](https://openrct2.org/forums/topic/1449-crash-when-building-a-steep-slope-in-junior-roller-coaster/) that though steep slopes are now enabled on the junior coaster track, this is not true of diagonal slopes. Since the required sprites to do so are already available, I figured they should be enabled.

This PR modifies track_paint.c to draw the correct sprites instead of crashing when steep slopes are used. This is done the same way the other steep slopes are - by switching to water coaster track when drawing these pieces..