### PR TITLE
Set default cheats in configuration (workaround for #4005)

### DIFF
--- a/src/cheats.c
+++ b/src/cheats.c
@@ -426,22 +426,22 @@ void game_command_cheat(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* e
 
 void cheats_reset()
 {
-	gCheatsSandboxMode = false;
-	gCheatsDisableClearanceChecks = false;
-	gCheatsDisableSupportLimits = false;
-	gCheatsShowAllOperatingModes = false;
-	gCheatsShowVehiclesFromOtherTrackTypes = false;
-	gCheatsDisableTrainLengthLimit = false;
-	gCheatsEnableChainLiftOnAllTrack = false;
-	gCheatsFastLiftHill = false;
-	gCheatsDisableBrakesFailure = false;
-	gCheatsDisableAllBreakdowns = false;
-	gCheatsUnlockAllPrices = false;
-	gCheatsBuildInPauseMode = false;
-	gCheatsIgnoreRideIntensity = false;
-	gCheatsDisableVandalism = false;
-	gCheatsDisableLittering = false;
-	gCheatsNeverendingMarketing = false;
-	gCheatsFreezeClimate = false;
-	gCheatsDisablePlantAging = false;
+	gCheatsSandboxMode = gConfigCheats.sandbox_mode;
+	gCheatsDisableClearanceChecks = gConfigCheats.disable_clearance_checks;
+	gCheatsDisableSupportLimits = gConfigCheats.disable_support_limits;
+	gCheatsShowAllOperatingModes = gConfigCheats.show_all_operating_modes;
+	gCheatsShowVehiclesFromOtherTrackTypes = gConfigCheats.show_vehicles_from_other_track_types;
+	gCheatsDisableTrainLengthLimit = gConfigCheats.disable_train_length_limit;
+	gCheatsEnableChainLiftOnAllTrack = gConfigCheats.enable_chain_lift_on_all_track;
+	gCheatsFastLiftHill = gConfigCheats.fast_lift_hill;
+	gCheatsDisableBrakesFailure = gConfigCheats.disable_breaks_failure;
+	gCheatsDisableAllBreakdowns = gConfigCheats.disable_all_breakdowns;
+	gCheatsUnlockAllPrices = gConfigCheats.unlock_all_prices;
+	gCheatsBuildInPauseMode = gConfigCheats.build_in_pause_mode;
+	gCheatsIgnoreRideIntensity = gConfigCheats.ignore_ride_intensity;
+	gCheatsDisableVandalism = gConfigCheats.disable_vandalism;
+	gCheatsDisableLittering = gConfigCheats.disable_littering;
+	gCheatsNeverendingMarketing = gConfigCheats.neverending_marketing;
+	gCheatsFreezeClimate = gConfigCheats.freeze_climate;
+	gCheatsDisablePlantAging = gConfigCheats.disable_plant_aging;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -314,6 +314,48 @@ config_property_definition _fontsDefinitions[] = {
 	{ offsetof(font_configuration, height_big),				"height_big",			CONFIG_VALUE_TYPE_UINT8,		20,								NULL			}
 };
 
+/*uint8 sandbox_mode,
+		disable_clearance_checks,
+		disable_support_limits,
+		show_all_operating_modes,
+		show_vehicles_from_other_track_types,
+		fast_lift_hill,
+		disable_breaks_failure,
+		disable_all_breakdowns,
+		unlock_all_prices,
+		build_in_pause_mode,
+		ignore_ride_intensity,
+		disable_vandalism,
+		disable_littering,
+		neverending_marketing,
+		freeze_climate,
+		disable_train_length_limit,
+		disable_plant_aging,
+		enable_chain_lift_on_all_track;
+*/
+
+config_property_definition _cheatsDefinitions[] = {
+	{ offsetof(cheats_configuration, sandbox_mode),							"sandbox_mode",							CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_clearance_checks),				"disable_clearance_checks",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_support_limits),				"disable_support_limits",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, show_all_operating_modes),				"show_all_operating_modes",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, show_vehicles_from_other_track_types),	"show_vehicles_from_other_track_types",	CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, fast_lift_hill),						"fast_lift_hill",						CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_breaks_failure),				"disable_breaks_failure",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_all_breakdowns),				"disable_all_breakdowns",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, unlock_all_prices),					"unlock_all_prices",					CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, build_in_pause_mode),					"build_in_pause_mode",					CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, ignore_ride_intensity),				"ignore_ride_intensity",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_vandalism),					"disable_vandalism",					CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_littering),					"disable_littering",					CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, neverending_marketing),				"neverending_marketing",				CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, freeze_climate),						"freeze_climate",						CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_train_length_limit),			"disable_train_length_limit",			CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, disable_plant_aging),					"disable_plant_aging",					CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+	{ offsetof(cheats_configuration, enable_chain_lift_on_all_track),		"enable_chain_lift_on_all_track",		CONFIG_VALUE_TYPE_BOOLEAN, false,		NULL },
+};
+
+
 config_section_definition _sectionDefinitions[] = {
 	{ &gConfigGeneral, "general", _generalDefinitions, countof(_generalDefinitions) },
 	{ &gConfigInterface, "interface", _interfaceDefinitions, countof(_interfaceDefinitions) },
@@ -321,7 +363,8 @@ config_section_definition _sectionDefinitions[] = {
 	{ &gConfigTwitch, "twitch", _twitchDefinitions, countof(_twitchDefinitions) },
 	{ &gConfigNetwork, "network", _networkDefinitions, countof(_networkDefinitions) },
 	{ &gConfigNotifications, "notifications", _notificationsDefinitions, countof(_notificationsDefinitions) },
-	{ &gConfigFonts, "fonts", _fontsDefinitions, countof(_fontsDefinitions) }
+	{ &gConfigFonts, "fonts", _fontsDefinitions, countof(_fontsDefinitions) },
+	{ &gConfigCheats, "default_cheats", _cheatsDefinitions, countof(_cheatsDefinitions) },
 };
 
 #pragma endregion
@@ -334,6 +377,7 @@ network_configuration gConfigNetwork;
 notification_configuration gConfigNotifications;
 font_configuration gConfigFonts;
 title_sequences_configuration gConfigTitleSequences;
+cheats_configuration gConfigCheats;
 
 static bool config_open(const utf8string path);
 static bool config_save(const utf8string path);

--- a/src/config.h
+++ b/src/config.h
@@ -283,6 +283,28 @@ typedef struct font_configuration {
 	uint8 height_big;
 } font_configuration;
 
+typedef struct cheats_configuration {
+	uint8 sandbox_mode,
+		disable_clearance_checks,
+		disable_support_limits,
+		show_all_operating_modes,
+		show_vehicles_from_other_track_types,
+		fast_lift_hill,
+		disable_breaks_failure,
+		disable_all_breakdowns,
+		unlock_all_prices,
+		build_in_pause_mode,
+		ignore_ride_intensity,
+		disable_vandalism,
+		disable_littering,
+		neverending_marketing,
+		freeze_climate,
+		disable_train_length_limit,
+		disable_plant_aging,
+		enable_chain_lift_on_all_track;
+} cheats_configuration;
+
+
 // Define structures for any other settings here
 typedef struct theme_features {
 	uint8 rct1_ride_lights;
@@ -336,6 +358,7 @@ extern network_configuration gConfigNetwork;
 extern notification_configuration gConfigNotifications;
 extern font_configuration gConfigFonts;
 extern title_sequences_configuration gConfigTitleSequences;
+extern cheats_configuration gConfigCheats;
 
 extern uint16 gShortcutKeys[SHORTCUT_COUNT];
 


### PR DESCRIPTION
This allows the setting of default cheats inside the configuration. instead of reset_cheats setting all the booleans to false, it loads the values stored in the default_cheats section. this also will allow auto-enabling of some cheats commonly used, such as if you almost always enable "disable breaks failure" the minute you enter a game, this will pretty much enable it for you on start. 