### PR TITLE
Fix #4013: Scroll bar can get tiny for extremely long lists

### DIFF
--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -95,11 +95,11 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 		scroll->v_thumb_bottom = min(y, view_size);
 
 		if(scroll->v_thumb_bottom - scroll->v_thumb_top < 20) {
-			float percent = (scroll->v_thumb_bottom*1.0)/view_size;
+			double percent = (scroll->v_thumb_bottom*1.0)/view_size;
 			printf("percent: %f\n", percent);
 
-			scroll->v_thumb_top = (uint16) lroundf(scroll->v_thumb_top - (20*percent));
-			scroll->v_thumb_bottom = (uint16) lroundf(scroll->v_thumb_bottom + (20*(1-percent)));
+			scroll->v_thumb_top = (uint16) lround(scroll->v_thumb_top - (20*percent));
+			scroll->v_thumb_bottom = (uint16) lround(scroll->v_thumb_bottom + (20*(1-percent)));
 		}
 	}
 

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -73,6 +73,13 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 		x += 11;
 		view_size += 10;
 		scroll->h_thumb_right = min(x, view_size);
+
+		if(scroll->h_thumb_right - scroll->h_thumb_left < 20) {
+			double barPosition = (scroll->h_thumb_right * 1.0) / view_size;
+
+			scroll->h_thumb_left = (uint16) lround(scroll->h_thumb_left - (20 * barPosition));
+			scroll->h_thumb_right = (uint16) lround(scroll->h_thumb_right + (20 * (1 - barPosition)));
+		}
 	}
 
 	if (scroll->flags & VSCROLLBAR_VISIBLE) {
@@ -95,11 +102,10 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 		scroll->v_thumb_bottom = min(y, view_size);
 
 		if(scroll->v_thumb_bottom - scroll->v_thumb_top < 20) {
-			double percent = (scroll->v_thumb_bottom*1.0)/view_size;
-			printf("percent: %f\n", percent);
+			double barPosition = (scroll->v_thumb_bottom * 1.0) / view_size;
 
-			scroll->v_thumb_top = (uint16) lround(scroll->v_thumb_top - (20*percent));
-			scroll->v_thumb_bottom = (uint16) lround(scroll->v_thumb_bottom + (20*(1-percent)));
+			scroll->v_thumb_top = (uint16) lround(scroll->v_thumb_top - (20 * barPosition));
+			scroll->v_thumb_bottom = (uint16) lround(scroll->v_thumb_bottom + (20 * (1 - barPosition)));
 		}
 	}
 

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -96,8 +96,8 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 			float percent = (scroll->v_thumb_bottom*1.0)/view_size;
 			printf("percent: %f\n", percent);
 
-			scroll->v_thumb_top = scroll->v_thumb_top - (20*percent);
-			scroll->v_thumb_bottom = scroll->v_thumb_bottom + (20*(1-percent));
+			scroll->v_thumb_top = (uint16) scroll->v_thumb_top - (20*percent);
+			scroll->v_thumb_bottom = (uint16) scroll->v_thumb_bottom + (20*(1-percent));
 		}
 	}
 

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -24,6 +24,8 @@
 #include "../localisation/localisation.h"
 #include "../util/util.h"
 
+#include <math.h>
+
 static void widget_frame_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex);
 static void widget_resize_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex);
 static void widget_button_draw(rct_drawpixelinfo *dpi, rct_window *w, int widgetIndex);
@@ -96,8 +98,8 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 			float percent = (scroll->v_thumb_bottom*1.0)/view_size;
 			printf("percent: %f\n", percent);
 
-			scroll->v_thumb_top = (uint16) scroll->v_thumb_top - (20*percent);
-			scroll->v_thumb_bottom = (uint16) scroll->v_thumb_bottom + (20*(1-percent));
+			scroll->v_thumb_top = (uint16) lroundf(scroll->v_thumb_top - (20*percent));
+			scroll->v_thumb_bottom = (uint16) lroundf(scroll->v_thumb_bottom + (20*(1-percent)));
 		}
 	}
 

--- a/src/interface/widget.c
+++ b/src/interface/widget.c
@@ -91,7 +91,16 @@ void widget_scroll_update_thumbs(rct_window *w, int widget_index)
 		y += 11;
 		view_size += 10;
 		scroll->v_thumb_bottom = min(y, view_size);
+
+		if(scroll->v_thumb_bottom - scroll->v_thumb_top < 20) {
+			float percent = (scroll->v_thumb_bottom*1.0)/view_size;
+			printf("percent: %f\n", percent);
+
+			scroll->v_thumb_top = scroll->v_thumb_top - (20*percent);
+			scroll->v_thumb_bottom = scroll->v_thumb_bottom + (20*(1-percent));
+		}
 	}
+
 }
 
 /**


### PR DESCRIPTION
WARNING: This is not a 'real' solution, but a hack with the drawing parameters to have bigger scrollbars when the list being scrolled is too large.

Because of that, the scrollbar moves slightly slower than the mouse pointer actually do, so the pointer will ended up pointing ahead the scrollbar.

This would better implemented while rewriting UI system.

Currently, only vertical scrollbars are implemented. If this hack is approved, then the horizontal bars can be implemented before merge.