### PR TITLE
Fix guest sorting.

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -10347,8 +10347,19 @@ static int peep_compare(const void *sprite_index_a, const void *sprite_index_b)
 		peep_b->name_string_idx >= 0xA000 && peep_b->name_string_idx < 0xE000
 	);
 	if (both_have_generated_names) {
-		// This assumes the names are ordered alphabetically
-		return peep_a->name_string_idx - peep_b->name_string_idx;
+		rct_string_id peep_a_format = peep_a->name_string_idx + 0xA000;
+		rct_string_id peep_b_format = peep_b->name_string_idx + 0xA000;
+
+		uint16 peep_a_name = (peep_a_format % countof(real_names));
+		uint16 peep_b_name = (peep_b_format % countof(real_names));
+
+		if (peep_a_name == peep_b_name) {
+			uint16 peep_a_initial = ((peep_a_format >> 10) % countof(real_name_initials));
+			uint16 peep_b_initial = ((peep_b_format >> 10) % countof(real_name_initials));
+			return peep_a_initial - peep_b_initial;
+		} else {
+			return peep_a_name - peep_b_name;
+		}
 	}
 
 	// At least one of them has a custom name assigned


### PR DESCRIPTION
Issue: https://github.com/OpenRCT2/OpenRCT2/pull/4006#issuecomment-231418775. 

I've noticed that the problem has to do with the initial letter of the surname, the list is sorted in a wrong way from A to Z + the initial.

In this way:
[A-Z] B.
[A-Z] C.
[A-Z] D.
etc...

Now, this sorts the initial of the surname correctly (name + initial).

**Screenshots:**
_Left: The Problem | Right: The fix._
![scr54](https://cloud.githubusercontent.com/assets/7508197/16711538/17c2993c-4627-11e6-984e-ba5eb8323751.png)

Demo of this fix with large lists:
![openrct2 bug](https://cloud.githubusercontent.com/assets/7508197/16711542/3cb7ff8e-4627-11e6-8c71-1c5099123d07.png)

PS: Sorry if I've written this with misspellings, I'm not very good with English xP