### PR TITLE
Fix #1432: Sandbox mode reducing map size causes game to freeze

### DIFF
--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4549,7 +4549,7 @@ static void clear_elements_at(int x, int y)
 			gGameCommandErrorTitle = STR_CANT_REMOVE_THIS;
 			game_do_command(
 				x,
-				(GAME_COMMAND_FLAG_APPLY) | (mapElement->type & MAP_ELEMENT_DIRECTION_MASK),
+				(GAME_COMMAND_FLAG_APPLY) | ((mapElement->type & MAP_ELEMENT_DIRECTION_MASK) << 8),
 				y,
 				(mapElement->base_height) | (((mapElement->properties.scenerymultiple.type >> 8) >> 2) << 8),
 				GAME_COMMAND_REMOVE_LARGE_SCENERY,

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4556,7 +4556,6 @@ static void clear_elements_at(int x, int y)
 				0,
 				0
 			);
-			map_element_remove(mapElement);
 			break;
 		case MAP_ELEMENT_TYPE_BANNER:
 			gGameCommandErrorTitle = STR_CANT_REMOVE_THIS;

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4556,6 +4556,7 @@ static void clear_elements_at(int x, int y)
 				0,
 				0
 			);
+			map_element_remove(mapElement);
 			break;
 		case MAP_ELEMENT_TYPE_BANNER:
 			gGameCommandErrorTitle = STR_CANT_REMOVE_THIS;


### PR DESCRIPTION
The freeze was caused by the game command responsible of deleting multiple-scenery don't update the pointer, which causes an infinite loop.