### PR TITLE
Fix #4031: Costs of land rights not displayed when hovering a tile.

### DIFF
--- a/src/windows/park.c
+++ b/src/windows/park.c
@@ -798,7 +798,7 @@ void window_park_entrance_tool_update_land_rights(sint16 x, sint16 y)
 		0x4,
 		gMapSelectPositionA.y,
 		LandRightsMode ? 0x00E : 0x20F,
-		35,
+		GAME_COMMAND_BUY_LAND_RIGHTS,
 		gMapSelectPositionB.x,
 		gMapSelectPositionB.y
 		);


### PR DESCRIPTION
Introduced by 1e35c05578a61db15f8b7bb48e71a7586ffc8517 because this command uses a "magic value" instead of the enum value.