### PR TITLE
Fix #4060: Block brakes have a different behaviour from RCT2.

### DIFF
--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5476,14 +5476,16 @@ static void check_and_apply_block_section_stop_site(rct_vehicle *vehicle)
 	case TRACK_ELEM_CABLE_LIFT_HILL:
 	case TRACK_ELEM_DIAG_25_DEG_UP_TO_FLAT:
 	case TRACK_ELEM_DIAG_60_DEG_UP_TO_FLAT:
-		if(ride_is_block_sectioned(ride) && track_element_is_lift_hill(trackElement)) {
-			if (trackElement->flags & MAP_ELEMENT_FLAG_BLOCK_BREAK_CLOSED) {
-				RCT2_GLOBAL(0x00F64E18, uint32) |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_10;
-				vehicle->acceleration = 0;
-				if (vehicle->velocity <= 0x20000) {
-					vehicle->velocity = 0;
+		if(ride_is_block_sectioned(ride)){
+			if(trackType == TRACK_ELEM_CABLE_LIFT_HILL || track_element_is_lift_hill(trackElement)) {
+				if (trackElement->flags & MAP_ELEMENT_FLAG_BLOCK_BREAK_CLOSED) {
+					RCT2_GLOBAL(0x00F64E18, uint32) |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_10;
+					vehicle->acceleration = 0;
+					if (vehicle->velocity <= 0x20000) {
+						vehicle->velocity = 0;
+					}
+					vehicle->velocity -= vehicle->velocity >> 3;
 				}
-				vehicle->velocity -= vehicle->velocity >> 3;
 			}
 		}
 

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5421,7 +5421,11 @@ void apply_block_brakes(rct_vehicle *vehicle, bool is_block_brake_closed)
 			vehicle->velocity -= vehicle->velocity >> 3;
 		}
 	} else {
-		apply_non_stop_block_brake(vehicle, is_block_brake_closed);
+#ifdef NEW_BLOCK_BRAKES
+		apply_non_stop_block_brake(vehicle, false);
+#else
+		apply_non_stop_block_brake(vehicle, true);
+#endif
 	}
 }
 

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5479,12 +5479,7 @@ static void check_and_apply_block_section_stop_site(rct_vehicle *vehicle)
 		if(ride_is_block_sectioned(ride)){
 			if(trackType == TRACK_ELEM_CABLE_LIFT_HILL || track_element_is_lift_hill(trackElement)) {
 				if (trackElement->flags & MAP_ELEMENT_FLAG_BLOCK_BREAK_CLOSED) {
-					RCT2_GLOBAL(0x00F64E18, uint32) |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_10;
-					vehicle->acceleration = 0;
-					if (vehicle->velocity <= 0x20000) {
-						vehicle->velocity = 0;
-					}
-					vehicle->velocity -= vehicle->velocity >> 3;
+					apply_block_brakes(vehicle, true);
 				}
 			}
 		}

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5472,8 +5472,16 @@ static void check_and_apply_block_section_stop_site(rct_vehicle *vehicle)
 	case TRACK_ELEM_CABLE_LIFT_HILL:
 	case TRACK_ELEM_DIAG_25_DEG_UP_TO_FLAT:
 	case TRACK_ELEM_DIAG_60_DEG_UP_TO_FLAT:
-		if (ride_is_block_sectioned(ride))
-			apply_block_brakes(vehicle, trackElement->flags & MAP_ELEMENT_FLAG_BLOCK_BREAK_CLOSED);
+		if(ride_is_block_sectioned(ride) && track_element_is_lift_hill(trackElement)) {
+			if (trackElement->flags & MAP_ELEMENT_FLAG_BLOCK_BREAK_CLOSED) {
+				RCT2_GLOBAL(0x00F64E18, uint32) |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_10;
+				vehicle->acceleration = 0;
+				if (vehicle->velocity <= 0x20000) {
+					vehicle->velocity = 0;
+				}
+				vehicle->velocity -= vehicle->velocity >> 3;
+			}
+		}
 
 		break;
 	}


### PR DESCRIPTION
Fix a lift chain bug and reverts a new block-brake behaviour introduced in #4017.