### PR TITLE
Don't assert() when object's checksum cannot be fixed

### DIFF
--- a/src/object/ObjectRepository.cpp
+++ b/src/object/ObjectRepository.cpp
@@ -518,7 +518,7 @@ private:
                     int newRealChecksum = object_calculate_checksum(entry, newData, newDataSize);
                     if (newRealChecksum != entry->checksum)
                     {
-                        Guard::Fail("CalculateExtraBytesToFixChecksum failed to fix checksum.");
+                        Console::Error::WriteLine("CalculateExtraBytesToFixChecksum failed to fix checksum.");
 
                         // Save old data form
                         SaveObject(path, entry, data, dataSize, false);


### PR DESCRIPTION
There's no reason to do assert(false) like Fail() does when object
failed to get its checksum fixed.