### PR TITLE
Validate access to RideConfigurationStringIds

### DIFF
--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -2136,6 +2136,7 @@ static void window_ride_construction_invalidate(rct_window *w)
 
 	stringId = STR_RIDE_CONSTRUCTION_SPECIAL;
 	if (_currentTrackCurve >= 256) {
+		assert(_currentTrackCurve - 256 < countof(RideConfigurationStringIds));
 		stringId = RideConfigurationStringIds[_currentTrackCurve - 256];
 		if (stringId == STR_RAPIDS && ride->type == RIDE_TYPE_CAR_RIDE)
 			stringId = STR_LOG_BUMPS;


### PR DESCRIPTION
This can be triggered by starting a new park (I usually chose "Build your own six flags"), then placing `haunted house`. This is likely the same reason we have #4079.
