### PR TITLE
Assert var2CTotal does not overflow, it's undefined for signed types

### DIFF
--- a/src/ride/cable_lift.c
+++ b/src/ride/cable_lift.c
@@ -479,6 +479,7 @@ int cable_lift_update_track_motion(rct_vehicle *cableLift)
 		rct_vehicle* vehicle = GET_VEHICLE(spriteId);
 		vehicleCount++;
 		frictionTotal += vehicle->friction;
+		assert(INT32_MAX - var2CTotal >= vehicle->acceleration);
 		var2CTotal += vehicle->acceleration;
 		spriteId = vehicle->next_vehicle_on_train;
 	}


### PR DESCRIPTION
Gets triggered on OpenRCT2 group park 3.68, mentioned here https://github.com/OpenRCT2/OpenRCT2/issues/4070#issuecomment-232492235
