### PR TITLE
Fix #4080 - Adding a error message when the track can't load

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4206,6 +4206,7 @@ STR_5894    :Enter the exchange rate
 STR_5895    :Save Track
 STR_5896    :Track save failed!
 STR_5897    :Window limit:
+STR_5898    :{BLACK}Can't load the track, the file might be {newline}corrupted, broken or missing!
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -3328,8 +3328,8 @@ enum {
 	STR_RATE_INPUT_DESC = 5894,
 	STR_FILE_DIALOG_TITLE_SAVE_TRACK = 5895,
 	STR_TRACK_SAVE_FAILED = 5896,
-	
 	STR_WINDOW_LIMIT = 5897,
+	STR_TRACK_LOAD_FAILED_ERROR = 5898,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -181,7 +181,10 @@ static void window_track_list_close(rct_window *w)
 static void window_track_list_select(rct_window *w, int index)
 {
 	w->track_list.var_480 = index;
-
+	if (_loadedTrackDesign == NULL)
+		window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
+	else
+	
 	audio_play_sound_panned(SOUND_CLICK_1, w->x + (w->width / 2), 0, 0, 0);
 	if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
 		if (index == 0) {

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -180,12 +180,13 @@ static void window_track_list_close(rct_window *w)
  */
 static void window_track_list_select(rct_window *w, int index)
 {
-	w->track_list.var_480 = index;
-	if (_loadedTrackDesign == NULL) // Displays a message if the ride can't load, fix #4080
-		{
-			window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
-			return; 
-		}
+    w->track_list.var_480 = index;
+
+     // Displays a message if the ride can't load, fix #4080
+    if (_loadedTrackDesign == NULL) {
+            window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
+            return; 
+    }
 	
 	audio_play_sound_panned(SOUND_CLICK_1, w->x + (w->width / 2), 0, 0, 0);
 	if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -180,14 +180,14 @@ static void window_track_list_close(rct_window *w)
  */
 static void window_track_list_select(rct_window *w, int index)
 {
-    w->track_list.var_480 = index;
+	w->track_list.var_480 = index;
 
-    // Displays a message if the ride can't load, fix #4080
-    if (_loadedTrackDesign == NULL) {
-        window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
-        return; 
-    }
-	
+	// Displays a message if the ride can't load, fix #4080
+	if (_loadedTrackDesign == NULL) {
+		window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
+		return; 
+	}
+
 	audio_play_sound_panned(SOUND_CLICK_1, w->x + (w->width / 2), 0, 0, 0);
 	if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
 		if (index == 0) {

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -181,9 +181,11 @@ static void window_track_list_close(rct_window *w)
 static void window_track_list_select(rct_window *w, int index)
 {
 	w->track_list.var_480 = index;
-	if (_loadedTrackDesign == NULL)
-		window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
-	else
+	if (_loadedTrackDesign == NULL) // Displays a message if the ride can't load, fix #4080
+		{
+			window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
+			return; 
+		}
 	
 	audio_play_sound_panned(SOUND_CLICK_1, w->x + (w->width / 2), 0, 0, 0);
 	if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {

--- a/src/windows/track_list.c
+++ b/src/windows/track_list.c
@@ -182,10 +182,10 @@ static void window_track_list_select(rct_window *w, int index)
 {
     w->track_list.var_480 = index;
 
-     // Displays a message if the ride can't load, fix #4080
+    // Displays a message if the ride can't load, fix #4080
     if (_loadedTrackDesign == NULL) {
-            window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
-            return; 
+        window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
+        return; 
     }
 	
 	audio_play_sound_panned(SOUND_CLICK_1, w->x + (w->width / 2), 0, 0, 0);


### PR DESCRIPTION
Potential fix for: #4080

This will make a pop up message appear with a warning message, telling the player that something is wrong instead of not indicating anything 

![asasg](https://cloud.githubusercontent.com/assets/17282384/16890587/4ae2498e-4af0-11e6-96b9-f1dc078a3151.png)
