### PR TITLE
Typo fix: Correct int_valid to int_val

### DIFF
--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -848,7 +848,7 @@ static int cc_set(const utf8 **argv, int argc)
 			console_execute_silent("get paint_segments");
 		}
 		else if (strcmp(argv[0], "window_limit") == 0 && invalidArguments(&invalidArgs, int_valid[0])) {
-			window_set_window_limit(int_valid[0]);
+			window_set_window_limit(int_val[0]);
 			console_execute_silent("get window_limit");
 		}
 		else if (invalidArgs) {


### PR DESCRIPTION
I was skimming my merged code and noticed this somehow slipped by me this entire time. Oops!