### PR TITLE
Refactor access to g_sprite_list

### DIFF
--- a/src/cheats.c
+++ b/src/cheats.c
@@ -110,7 +110,7 @@ static void cheat_remove_litter()
 	uint16 spriteIndex, nextSpriteIndex;
 
 	for (spriteIndex = gSpriteListHead[SPRITE_LIST_LITTER]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
-		litter = &(g_sprite_list[spriteIndex].litter);
+		litter = &(get_sprite(spriteIndex)->litter);
 		nextSpriteIndex = litter->next;
 		sprite_remove((rct_sprite*)litter);
 	}
@@ -321,7 +321,7 @@ static void cheat_remove_all_guests()
 	uint16 spriteIndex, nextSpriteIndex;
 
 	for (spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
-		peep = &(g_sprite_list[spriteIndex].peep);
+		peep = &(get_sprite(spriteIndex)->peep);
 		nextSpriteIndex = peep->next;
 		if (peep->type == PEEP_TYPE_GUEST) {
 			peep_remove(peep);

--- a/src/core/Guard.cpp
+++ b/src/core/Guard.cpp
@@ -30,6 +30,15 @@
 extern "C"
 {
     #include "../openrct2.h"
+
+    void openrct2_assert(bool expression, const char * message, ...)
+    {
+        va_list args;
+        va_start(args, message);
+        Guard::Assert_VA(expression, message, args);
+        va_end(args);
+    }
+
 }
 
 namespace Guard

--- a/src/editor.c
+++ b/src/editor.c
@@ -412,7 +412,7 @@ static void editor_clear_map_for_editing()
 
 	//
 	for (int i = 0; i < MAX_SPRITES; i++) {
-		rct_sprite *sprite = &g_sprite_list[i];
+		rct_sprite *sprite = get_sprite(i);
 		user_string_free(sprite->unknown.name_string_idx);
 	}
 

--- a/src/game.c
+++ b/src/game.c
@@ -876,7 +876,7 @@ void game_load_init()
 void reset_all_sprite_quadrant_placements()
 {
 	for (size_t i = 0; i < MAX_SPRITES; i++) {
-		rct_sprite *spr = &g_sprite_list[i];
+		rct_sprite *spr = get_sprite(i);
 		if (spr->unknown.sprite_identifier != SPRITE_IDENTIFIER_NULL) {
 			sprite_move(spr->unknown.x, spr->unknown.y, spr->unknown.z, spr);
 		}

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -162,7 +162,7 @@ void viewport_create(rct_window *w, int x, int y, int width, int height, int zoo
 
 	if (flags & VIEWPORT_FOCUS_TYPE_SPRITE){
 		w->viewport_target_sprite = sprite;
-		rct_sprite* center_sprite = &g_sprite_list[sprite];
+		rct_sprite* center_sprite = get_sprite(sprite);
 		center_x = center_sprite->unknown.x;
 		center_y = center_sprite->unknown.y;
 		center_z = center_sprite->unknown.z;
@@ -594,7 +594,7 @@ void viewport_update_position(rct_window *window)
 void viewport_update_sprite_follow(rct_window *window)
 {
 	if (window->viewport_target_sprite != -1 && window->viewport){
-		rct_sprite* sprite = &g_sprite_list[window->viewport_target_sprite];
+		rct_sprite* sprite = get_sprite(window->viewport_target_sprite);
 
 		int height = (map_element_height(0xFFFF & sprite->unknown.x, 0xFFFF & sprite->unknown.y) & 0xFFFF) - 16;
 		int underground = sprite->unknown.z < height;

--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -1294,7 +1294,7 @@ void window_scroll_to_viewport(rct_window *w)
 		return;
 
 	if (w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_SPRITE) {
-		rct_sprite *sprite = &(g_sprite_list[w->viewport_focus_sprite.sprite_id]);
+		rct_sprite *sprite = get_sprite(w->viewport_focus_sprite.sprite_id);
 		x = sprite->unknown.x;
 		y = sprite->unknown.y;
 		z = sprite->unknown.z;

--- a/src/management/news_item.c
+++ b/src/management/news_item.c
@@ -229,10 +229,10 @@ void news_item_get_subject_location(int type, int subject, int *x, int *y, int *
 		}
 
 		// Find the first car of the train peep is on
-		vehicle = &(g_sprite_list[ride->vehicles[peep->current_train]]).vehicle;
+		vehicle = &(get_sprite(ride->vehicles[peep->current_train])->vehicle);
 		// Find the actual car peep is on
 		for (i = 0; i < peep->current_car; i++)
-			vehicle = &(g_sprite_list[vehicle->next_vehicle_on_train]).vehicle;
+			vehicle = &(get_sprite(vehicle->next_vehicle_on_train)->vehicle);
 		*x = vehicle->x;
 		*y = vehicle->y;
 		*z = vehicle->z;

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -386,9 +386,9 @@ static void openrct2_loop()
 			while (uncapTick <= currentTick && currentTick - uncapTick > 25) {
 				// Get the original position of each sprite
 				for (uint16 i = 0; i < MAX_SPRITES; i++) {
-					_spritelocations1[i].x = g_sprite_list[i].unknown.x;
-					_spritelocations1[i].y = g_sprite_list[i].unknown.y;
-					_spritelocations1[i].z = g_sprite_list[i].unknown.z;
+					_spritelocations1[i].x = get_sprite(i)->unknown.x;
+					_spritelocations1[i].y = get_sprite(i)->unknown.y;
+					_spritelocations1[i].z = get_sprite(i)->unknown.z;
 				}
 
 				// Update the game so the sprite positions update
@@ -396,9 +396,9 @@ static void openrct2_loop()
 
 				// Get the next position of each sprite
 				for (uint16 i = 0; i < MAX_SPRITES; i++) {
-					_spritelocations2[i].x = g_sprite_list[i].unknown.x;
-					_spritelocations2[i].y = g_sprite_list[i].unknown.y;
-					_spritelocations2[i].z = g_sprite_list[i].unknown.z;
+					_spritelocations2[i].x = get_sprite(i)->unknown.x;
+					_spritelocations2[i].y = get_sprite(i)->unknown.y;
+					_spritelocations2[i].z = get_sprite(i)->unknown.z;
 				}
 
 				uncapTick += 25;
@@ -408,16 +408,16 @@ static void openrct2_loop()
 			// tick and the next tick.
 			float nudge = 1 - ((float)(currentTick - uncapTick) / 25);
 			for (uint16 i = 0; i < MAX_SPRITES; i++) {
-				if (!sprite_should_tween(&g_sprite_list[i]))
+				if (!sprite_should_tween(get_sprite(i)))
 					continue;
 
 				sprite_move(
 					_spritelocations2[i].x + (sint16)((_spritelocations1[i].x - _spritelocations2[i].x) * nudge),
 					_spritelocations2[i].y + (sint16)((_spritelocations1[i].y - _spritelocations2[i].y) * nudge),
 					_spritelocations2[i].z + (sint16)((_spritelocations1[i].z - _spritelocations2[i].z) * nudge),
-					&g_sprite_list[i]
+					get_sprite(i)
 				);
-				invalidate_sprite_2(&g_sprite_list[i]);
+				invalidate_sprite_2(get_sprite(i));
 			}
 
 			platform_draw();
@@ -430,11 +430,11 @@ static void openrct2_loop()
 
 			// Restore the real positions of the sprites so they aren't left at the mid-tween positions
 			for (uint16 i = 0; i < MAX_SPRITES; i++) {
-				if (!sprite_should_tween(&g_sprite_list[i]))
+				if (!sprite_should_tween(get_sprite(i)))
 					continue;
 
-				invalidate_sprite_2(&g_sprite_list[i]);
-				sprite_move(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, &g_sprite_list[i]);
+				invalidate_sprite_2(get_sprite(i));
+				sprite_move(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
 			}
 			network_update();
 		} else {
@@ -471,9 +471,9 @@ void openrct2_finish()
 void openrct2_reset_object_tween_locations()
 {
 	for (uint16 i = 0; i < MAX_SPRITES; i++) {
-		_spritelocations1[i].x = _spritelocations2[i].x = g_sprite_list[i].unknown.x;
-		_spritelocations1[i].y = _spritelocations2[i].y = g_sprite_list[i].unknown.y;
-		_spritelocations1[i].z = _spritelocations2[i].z = g_sprite_list[i].unknown.z;
+		_spritelocations1[i].x = _spritelocations2[i].x = get_sprite(i)->unknown.x;
+		_spritelocations1[i].y = _spritelocations2[i].y = get_sprite(i)->unknown.y;
+		_spritelocations1[i].z = _spritelocations2[i].z = get_sprite(i)->unknown.z;
 	}
 }
 

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -52,6 +52,7 @@ void openrct2_dispose();
 void openrct2_finish();
 void openrct2_reset_object_tween_locations();
 bool openrct2_setup_rct2_segment();
+void openrct2_assert(bool expression, const char * message, ...);
 
 int cmdline_run(const char **argv, int argc);
 

--- a/src/paint/sprite/sprite.c
+++ b/src/paint/sprite/sprite.c
@@ -43,8 +43,8 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
 	if (dpi->zoom_level > 2) return;
 
 
-	for (rct_sprite* spr = &g_sprite_list[sprite_idx]; sprite_idx != SPRITE_INDEX_NULL; sprite_idx = spr->unknown.next_in_quadrant) {
-		spr = &g_sprite_list[sprite_idx];
+	for (rct_sprite* spr = get_sprite(sprite_idx); sprite_idx != SPRITE_INDEX_NULL; sprite_idx = spr->unknown.next_in_quadrant) {
+		spr = get_sprite(sprite_idx);
 		dpi = unk_140E9A8;
 
 		if (dpi->y + dpi->height <= spr->unknown.sprite_top) continue;

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -378,7 +378,7 @@ void peep_update_all()
 	spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP];
 	i = 0;
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		peep = &(g_sprite_list[spriteIndex].peep);
+		peep = &(get_sprite(spriteIndex)->peep);
 		spriteIndex = peep->next;
 
 		if ((i & 0x7F) != (gCurrentTicks & 0x7F)) {
@@ -469,7 +469,7 @@ static uint8 peep_assess_surroundings(sint16 center_x, sint16 center_y, sint16 c
 
 	rct_litter* litter;
 	for (uint16 sprite_idx = gSpriteListHead[SPRITE_LIST_LITTER]; sprite_idx != SPRITE_INDEX_NULL; sprite_idx = litter->next) {
-		litter = &(g_sprite_list[sprite_idx].litter);
+		litter = &(get_sprite(sprite_idx)->litter);
 
 		sint16 dist_x = abs(litter->x - center_x);
 		sint16 dist_y = abs(litter->y - center_y);
@@ -4766,7 +4766,7 @@ static int peep_update_walking_find_bench(rct_peep* peep){
 	uint8 free_edge = 3;
 
 	for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant){
-		sprite = &g_sprite_list[sprite_id];
+		sprite = get_sprite(sprite_id);
 
 		if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2) continue;
 
@@ -5552,7 +5552,7 @@ static int peep_update_patrolling_find_sweeping(rct_peep* peep){
 		sprite_id != 0xFFFF;
 		sprite_id = sprite->unknown.next_in_quadrant){
 
-		sprite = &g_sprite_list[sprite_id];
+		sprite = get_sprite(sprite_id);
 
 		if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_LITTER * 2) continue;
 
@@ -5794,7 +5794,7 @@ static void peep_update_walking(rct_peep* peep){
 
 	uint16 sprite_id = sprite_get_first_in_quadrant(peep->x, peep->y);
 	for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant){
-		sprite = &g_sprite_list[sprite_id];
+		sprite = get_sprite(sprite_id);
 
 		if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2) continue;
 
@@ -7344,7 +7344,7 @@ static int peep_footpath_move_forward(rct_peep* peep, sint16 x, sint16 y, rct_ma
 	uint8 sick_count = 0;
 	uint16 sprite_id = sprite_get_first_in_quadrant(x, y);
 	for (rct_sprite* sprite; sprite_id != 0xFFFF; sprite_id = sprite->unknown.next_in_quadrant){
-		sprite = &g_sprite_list[sprite_id];
+		sprite = get_sprite(sprite_id);
 		if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP){
 			rct_peep* other_peep = (rct_peep*)sprite;
 			if (other_peep->state != PEEP_STATE_WALKING)

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -579,7 +579,7 @@ enum {
 };
 
 /** Helper macro until rides are stored in this module. */
-#define GET_PEEP(sprite_index) &(g_sprite_list[sprite_index].peep)
+#define GET_PEEP(sprite_index) &(get_sprite(sprite_index)->peep)
 
 /**
  * Helper macro loop for enumerating through all the peeps. To avoid needing a end loop counterpart, statements are

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -323,7 +323,7 @@ void game_command_set_staff_order(int *eax, int *ebx, int *ecx, int *edx, int *e
 		return;
 	}
 	if (*ebx & GAME_COMMAND_FLAG_APPLY) {
-		rct_peep *peep = &g_sprite_list[sprite_id].peep;
+		rct_peep *peep = &get_sprite(sprite_id)->peep;
 		if(order_id & 0x80){ // change costume
 			uint8 sprite_type = order_id & ~0x80;
 			sprite_type += 4;
@@ -362,7 +362,7 @@ void game_command_set_staff_patrol(int *eax, int *ebx, int *ecx, int *edx, int *
 			log_warning("Invalid sprite id %u", sprite_id);
 			return;
 		}
-		rct_sprite *sprite = &g_sprite_list[sprite_id];
+		rct_sprite *sprite = get_sprite(sprite_id);
 		if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_PEEP || sprite->peep.type != PEEP_TYPE_STAFF)
 		{
 			*ebx = MONEY32_UNDEFINED;
@@ -414,7 +414,7 @@ void game_command_fire_staff_member(int *eax, int *ebx, int *ecx, int *edx, int 
 			*ebx = MONEY32_UNDEFINED;
 			return;
 		}
-		rct_peep *peep = &g_sprite_list[sprite_id].peep;
+		rct_peep *peep = &get_sprite(sprite_id)->peep;
 		if (peep->sprite_identifier != SPRITE_IDENTIFIER_PEEP || peep->type != PEEP_TYPE_STAFF)
 		{
 			log_warning("Invalid game command, peep->sprite_identifier = %u, peep->type = %u", peep->sprite_identifier, peep->type);
@@ -592,7 +592,7 @@ static uint8 staff_handyman_direction_to_nearest_litter(rct_peep* peep){
 	rct_litter* litter = NULL;
 	
 	for (uint16 litterIndex = gSpriteListHead[SPRITE_LIST_LITTER]; litterIndex != 0xFFFF; litterIndex = litter->next){
-		litter = &g_sprite_list[litterIndex].litter;
+		litter = &get_sprite(litterIndex)->litter;
 		
 		uint16 distance = 
 			abs(litter->x - peep->x) + 

--- a/src/rct2/S6Exporter.cpp
+++ b/src/rct2/S6Exporter.cpp
@@ -251,7 +251,7 @@ void S6Exporter::Export()
     memcpy(_s6.map_elements, gMapElements, sizeof(_s6.map_elements));
 
     _s6.dword_010E63B8 = RCT2_GLOBAL(0x0010E63B8, uint32);
-    memcpy(_s6.sprites, g_sprite_list, sizeof(_s6.sprites));
+    memcpy(_s6.sprites, get_sprite(0), sizeof(_s6.sprites));
 
     for (int i = 0; i < NUM_SPRITE_LISTS; i++)
     {

--- a/src/rct2/S6Exporter.cpp
+++ b/src/rct2/S6Exporter.cpp
@@ -251,7 +251,10 @@ void S6Exporter::Export()
     memcpy(_s6.map_elements, gMapElements, sizeof(_s6.map_elements));
 
     _s6.dword_010E63B8 = RCT2_GLOBAL(0x0010E63B8, uint32);
-    memcpy(_s6.sprites, get_sprite(0), sizeof(_s6.sprites));
+    for (int i = 0; i < MAX_SPRITES; i++)
+    {
+        memcpy(&_s6.sprites[i], get_sprite(i), sizeof(rct_sprite));
+    }
 
     for (int i = 0; i < NUM_SPRITE_LISTS; i++)
     {

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -169,7 +169,7 @@ void S6Importer::Import()
     memcpy(gMapElements, _s6.map_elements, sizeof(_s6.map_elements));
 
     RCT2_GLOBAL(0x0010E63B8, uint32) = _s6.dword_010E63B8;
-    memcpy(g_sprite_list, _s6.sprites, sizeof(_s6.sprites));
+    memcpy(get_sprite(0), _s6.sprites, sizeof(_s6.sprites));
 
     for (int i = 0; i < NUM_SPRITE_LISTS; i++)
     {

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -169,7 +169,10 @@ void S6Importer::Import()
     memcpy(gMapElements, _s6.map_elements, sizeof(_s6.map_elements));
 
     RCT2_GLOBAL(0x0010E63B8, uint32) = _s6.dword_010E63B8;
-    memcpy(get_sprite(0), _s6.sprites, sizeof(_s6.sprites));
+    for (int i = 0; i < MAX_SPRITES; i++)
+    {
+        memcpy(get_sprite(i), &_s6.sprites[i], sizeof(rct_sprite));
+    }
 
     for (int i = 0; i < NUM_SPRITE_LISTS; i++)
     {

--- a/src/ride/gentle/crooked_house.c
+++ b/src/ride/gentle/crooked_house.c
@@ -60,7 +60,7 @@ static void sub_88ABA4(uint8 direction, uint8 x_offset, uint8 y_offset, uint32 s
 
 	if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK) {
 		if (ride->vehicles[0] != (uint16)-1) {
-			rct_sprite *sprite = &g_sprite_list[ride->vehicles[0]];
+			rct_sprite *sprite = get_sprite(ride->vehicles[0]);
 			gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
 			RCT2_GLOBAL(0x9DE578, rct_sprite *) = sprite;
 		}

--- a/src/ride/gentle/mini_golf.c
+++ b/src/ride/gentle/mini_golf.c
@@ -983,7 +983,7 @@ void vehicle_visual_mini_golf_player(int x, int imageDirection, int y, int z, rc
 	}
 
 	rct_ride_entry *rideType = get_ride_entry(get_ride(vehicle->ride)->subtype);
-	rct_sprite *sprite = &g_sprite_list[vehicle->peep[0]];
+	rct_sprite *sprite = get_sprite(vehicle->peep[0]);
 
 	uint32 eax = RCT2_ADDRESS(0x008B8F74, uint32)[vehicle->var_D4];
 	uint32 ebx = (RCT2_GLOBAL(eax + vehicle->var_C5, uint8) << 2) + (imageDirection >> 3);

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -817,8 +817,8 @@ void ride_get_status(int rideIndex, int *formatSecondary, int *argument)
 		*formatSecondary = STR_TEST_RUN;
 		return;
 	}
-	rct_peep *peep = GET_PEEP(ride->race_winner);
-	if (ride->mode == RIDE_MODE_RACE && !(ride->lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING) && ride->race_winner != 0xFFFF && peep->sprite_identifier == SPRITE_IDENTIFIER_PEEP) {
+	if (ride->mode == RIDE_MODE_RACE && !(ride->lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING) && ride->race_winner != 0xFFFF && (GET_PEEP(ride->race_winner))->sprite_identifier == SPRITE_IDENTIFIER_PEEP) {
+		rct_peep *peep = GET_PEEP(ride->race_winner);
 		if (peep->name_string_idx == STR_GUEST_X) {
 			*argument = peep->id;
 			*formatSecondary = STR_RACE_WON_BY_GUEST;

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -2481,7 +2481,7 @@ static void ride_mechanic_status_update(int rideIndex, int mechanicStatus)
 		ride_call_closest_mechanic(rideIndex);
 		break;
 	case RIDE_MECHANIC_STATUS_HEADING:
-		mechanic = &(g_sprite_list[ride->mechanic].peep);
+		mechanic = &(get_sprite(ride->mechanic)->peep);
 		if (
 			!peep_is_mechanic(mechanic) ||
 			(mechanic->state != PEEP_STATE_HEADING_TO_INSPECTION && mechanic->state != PEEP_STATE_ANSWERING) ||
@@ -2493,7 +2493,7 @@ static void ride_mechanic_status_update(int rideIndex, int mechanicStatus)
 		}
 		break;
 	case RIDE_MECHANIC_STATUS_FIXING:
-		mechanic = &(g_sprite_list[ride->mechanic].peep);
+		mechanic = &(get_sprite(ride->mechanic)->peep);
 		if (
 			!peep_is_mechanic(mechanic) ||
 			(
@@ -2642,7 +2642,7 @@ rct_peep *ride_get_assigned_mechanic(rct_ride *ride)
 			ride->mechanic_status == 3 ||
 			ride->mechanic_status == 4
 		) {
-			peep = &(g_sprite_list[ride->mechanic].peep);
+			peep = &(get_sprite(ride->mechanic)->peep);
 			if (peep_is_mechanic(peep))
 				return peep;
 		}

--- a/src/ride/station.c
+++ b/src/ride/station.c
@@ -101,7 +101,7 @@ static void ride_update_station_bumpercar(rct_ride *ride, int stationIndex)
 		dl = dx & 0xFF;
 		dh = (dx >> 8) & 0xFF;
 		for (i = 0; i < ride->num_vehicles; i++) {
-			vehicle = &(g_sprite_list[ride->vehicles[i]].vehicle);
+			vehicle = &(get_sprite(ride->vehicles[i])->vehicle);
 			if (vehicle->var_CE < dh || (vehicle->var_CE < dh && vehicle->sub_state > dl))
 				continue;
 
@@ -116,7 +116,7 @@ static void ride_update_station_bumpercar(rct_ride *ride, int stationIndex)
 	} else {
 		// Check if all vehicles are ready to go
 		for (i = 0; i < ride->num_vehicles; i++) {
-			vehicle = &(g_sprite_list[ride->vehicles[i]].vehicle);
+			vehicle = &(get_sprite(ride->vehicles[i])->vehicle);
 			if (vehicle->status != VEHICLE_STATUS_WAITING_TO_DEPART) {
 				ride->station_depart[stationIndex] &= ~STATION_DEPART_FLAG;
 				return;
@@ -186,11 +186,11 @@ static void ride_update_station_race(rct_ride *ride, int stationIndex)
 	if (ride->lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING) {
 		numLaps = ride->num_laps;
 		for (i = 0; i < ride->num_vehicles; i++) {
-			vehicle = &(g_sprite_list[ride->vehicles[i]].vehicle);
+			vehicle = &(get_sprite(ride->vehicles[i])->vehicle);
 			if (vehicle->status != VEHICLE_STATUS_WAITING_TO_DEPART && vehicle->num_laps >= numLaps) {
 				// Found a winner
 				if (vehicle->num_peeps != 0) {
-					peep = &(g_sprite_list[vehicle->peep[0]].peep);
+					peep = &(get_sprite(vehicle->peep[0])->peep);
 					ride->race_winner = peep->sprite_index;
 					ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
 				}
@@ -210,7 +210,7 @@ static void ride_update_station_race(rct_ride *ride, int stationIndex)
 	} else {
 		// Check if all vehicles are ready to go
 		for (i = 0; i < ride->num_vehicles; i++) {
-			vehicle = &(g_sprite_list[ride->vehicles[i]].vehicle);
+			vehicle = &(get_sprite(ride->vehicles[i])->vehicle);
 			if (vehicle->status != VEHICLE_STATUS_WAITING_TO_DEPART && vehicle->status != VEHICLE_STATUS_DEPARTING) {
 				if (ride->station_depart[stationIndex] & STATION_DEPART_FLAG){
 					ride->station_depart[stationIndex] &= ~STATION_DEPART_FLAG;
@@ -244,7 +244,7 @@ static void ride_race_init_vehicle_speeds(rct_ride *ride)
 	int i;
 
 	for (i = 0; i < ride->num_vehicles; i++) {
-		vehicle = &g_sprite_list[ride->vehicles[i]].vehicle;
+		vehicle = &get_sprite(ride->vehicles[i])->vehicle;
 		vehicle->update_flags &= ~VEHICLE_UPDATE_FLAG_6;
 
 		rideEntry = get_ride_entry(vehicle->ride_subtype);
@@ -252,7 +252,7 @@ static void ride_race_init_vehicle_speeds(rct_ride *ride)
 		vehicle->speed = (scenario_rand() & 16) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
 
 		if (vehicle->num_peeps != 0) {
-			rct_peep *peep = &g_sprite_list[vehicle->peep[0]].peep;
+			rct_peep *peep = &get_sprite(vehicle->peep[0])->peep;
 
 			switch (peep_get_easteregg_name_id(peep)) {
 			case EASTEREGG_PEEP_NAME_MICHAEL_SCHUMACHER:

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -8289,7 +8289,8 @@ int vehicle_update_track_motion(rct_vehicle *vehicle, int *outStation)
 	RCT2_GLOBAL(0x00F64E00, rct_vehicle*) = vehicle;
 
 	uint16 spriteId = vehicle->sprite_index;
-	for (rct_vehicle* car = vehicle; spriteId != 0xFFFF; car = GET_VEHICLE(spriteId)) {
+	while (spriteId != 0xFFFF) {
+		rct_vehicle* car = GET_VEHICLE(spriteId);
 		vehicleEntry = vehicle_get_vehicle_entry(car);
 
 		// Swinging cars

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -5473,8 +5473,9 @@ bool vehicle_update_bumper_car_collision(rct_vehicle *vehicle, sint16 x, sint16 
 	uint8 rideIndex = vehicle->ride;
 	for (sint32* ebp = RCT2_ADDRESS(0x009A37C4, sint32); ebp <= RCT2_ADDRESS(0x009A37E4, sint32); ebp++) {
 		uint16 spriteIdx = gSpriteSpatialIndex[location];
-		for (rct_vehicle* vehicle2 = GET_VEHICLE(spriteIdx); spriteIdx != 0xFFFF; spriteIdx = vehicle2->next_in_quadrant) {
-			vehicle2 = GET_VEHICLE(spriteIdx);
+		while (spriteIdx != 0xFFFF) {
+			rct_vehicle* vehicle2 = GET_VEHICLE(spriteIdx);
+			spriteIdx = vehicle2->next_in_quadrant;
 
 			if (vehicle2 == vehicle)
 				continue;

--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -611,8 +611,8 @@ void vehicle_sounds_update()
 				}
 			}
 			gVehicleSoundParamsListEnd = &gVehicleSoundParamsList[0];
-			for (uint16 i = gSpriteListHead[SPRITE_LIST_VEHICLE]; i != SPRITE_INDEX_NULL; i = g_sprite_list[i].vehicle.next) {
-				vehicle_update_sound_params(&g_sprite_list[i].vehicle);
+			for (uint16 i = gSpriteListHead[SPRITE_LIST_VEHICLE]; i != SPRITE_INDEX_NULL; i = get_sprite(i)->vehicle.next) {
+				vehicle_update_sound_params(&get_sprite(i)->vehicle);
 			}
 			for(int i = 0; i < countof(gVehicleSoundList); i++){
 				rct_vehicle_sound* vehicle_sound = &gVehicleSoundList[i];
@@ -730,7 +730,7 @@ void vehicle_sounds_update()
 				}
 
 				// do sound1 stuff, track noise
-				rct_sprite* sprite = &g_sprite_list[vehicle_sound_params->id];
+				rct_sprite* sprite = get_sprite(vehicle_sound_params->id);
 				int volume = sprite->vehicle.sound1_volume;
 				volume *= vol1;
 				volume = volume / 8;
@@ -781,7 +781,7 @@ void vehicle_sounds_update()
 					}
 				}
 			label87: // do sound2 stuff, screams
-				sprite = &g_sprite_list[vehicle_sound_params->id];
+				sprite = get_sprite(vehicle_sound_params->id);
 				volume = sprite->vehicle.sound2_volume;
 				volume *= vol1;
 				volume = (uint16)volume / 8;
@@ -862,7 +862,7 @@ void vehicle_update_all()
 
 	sprite_index = gSpriteListHead[SPRITE_LIST_VEHICLE];
 	while (sprite_index != SPRITE_INDEX_NULL) {
-		vehicle = &(g_sprite_list[sprite_index].vehicle);
+		vehicle = &(get_sprite(sprite_index)->vehicle);
 		sprite_index = vehicle->next;
 
 		vehicle_update(vehicle);
@@ -4636,7 +4636,7 @@ static int vehicle_update_scream_sound(rct_vehicle *vehicle)
 
 		spriteIndex = vehicle->sprite_index;
 		do {
-			vehicle2 = &(g_sprite_list[spriteIndex].vehicle);
+			vehicle2 = &(get_sprite(spriteIndex)->vehicle);
 			if (vehicle2->vehicle_sprite_type < 1)
 				continue;
 			if (vehicle2->vehicle_sprite_type <= 4)
@@ -4654,7 +4654,7 @@ static int vehicle_update_scream_sound(rct_vehicle *vehicle)
 
 	spriteIndex = vehicle->sprite_index;
 	do {
-		vehicle2 = &(g_sprite_list[spriteIndex].vehicle);
+		vehicle2 = &(get_sprite(spriteIndex)->vehicle);
 		if (vehicle2->vehicle_sprite_type < 5)
 			continue;
 		if (vehicle2->vehicle_sprite_type <= 8)
@@ -8584,7 +8584,7 @@ int vehicle_get_total_num_peeps(rct_vehicle *vehicle)
 		if (spriteIndex == SPRITE_INDEX_NULL)
 			break;
 
-		vehicle = &(g_sprite_list[spriteIndex].vehicle);
+		vehicle = &(get_sprite(spriteIndex)->vehicle);
 	}
 
 	return numPeeps;

--- a/src/ride/vehicle.h
+++ b/src/ride/vehicle.h
@@ -388,6 +388,6 @@ bool vehicle_update_bumper_car_collision(rct_vehicle *vehicle, sint16 x, sint16 
 extern rct_vehicle *gCurrentVehicle;
 
 /** Helper macro until rides are stored in this module. */
-#define GET_VEHICLE(sprite_index) &(g_sprite_list[sprite_index].vehicle)
+#define GET_VEHICLE(sprite_index) &(get_sprite(sprite_index)->vehicle)
 
 #endif

--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -532,7 +532,7 @@ void window_guest_open(rct_peep* peep){
  *  rct2: 0x006987A6
  */
 void window_guest_disable_widgets(rct_window* w){
-	rct_peep* peep = &g_sprite_list[w->number].peep;
+	rct_peep* peep = &get_sprite(w->number)->peep;
 	uint64 disabled_widgets = 0;
 
 	if (peep_can_be_picked_up(peep)){
@@ -648,7 +648,7 @@ void window_guest_overview_mouse_up(rct_window *w, int widgetIndex)
 		window_scroll_to_viewport(w);
 		break;
 	case WIDX_TRACK:
-		g_sprite_list[w->number].peep.peep_flags ^= PEEP_FLAGS_TRACKING;
+		get_sprite(w->number)->peep.peep_flags ^= PEEP_FLAGS_TRACKING;
 		break;
 	}
 }

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1600,7 +1600,7 @@ rct_window *window_ride_open_vehicle(rct_vehicle *vehicle)
 				numPeepsLeft--;
 				w2 = window_find_by_number(WC_PEEP, peepSpriteIndex);
 				if (w2 == NULL) {
-					rct_peep *peep = &(g_sprite_list[peepSpriteIndex].peep);
+					rct_peep *peep = &(get_sprite(peepSpriteIndex)->peep);
 					window_guest_open(peep);
 					openedPeepWindow = 1;
 
@@ -2184,7 +2184,7 @@ static void window_ride_main_update(rct_window *w)
 			if (vehicleSpriteIndex == 0xFFFF)
 				return;
 
-			vehicle = &(g_sprite_list[vehicleSpriteIndex].vehicle);
+			vehicle = &(get_sprite(vehicleSpriteIndex)->vehicle);
 			if (
 				vehicle->status != 4 &&
 				vehicle->status != 22 &&
@@ -2349,7 +2349,7 @@ static rct_string_id window_ride_get_status_vehicle(rct_window *w, void *argumen
 	if (vehicleSpriteIndex == 0xFFFF)
 		return 0;
 
-	vehicle = &(g_sprite_list[vehicleSpriteIndex].vehicle);
+	vehicle = &(get_sprite(vehicleSpriteIndex)->vehicle);
 	if (vehicle->status != VEHICLE_STATUS_CRASHING && vehicle->status != VEHICLE_STATUS_CRASHED) {
 		int trackType = vehicle->track_type >> 2;
 		if (trackType == TRACK_ELEM_BLOCK_BRAKES ||
@@ -3726,11 +3726,11 @@ static void window_ride_maintenance_dropdown(rct_window *w, int widgetIndex, int
 			case BREAKDOWN_RESTRAINTS_STUCK_OPEN:
 			case BREAKDOWN_DOORS_STUCK_CLOSED:
 			case BREAKDOWN_DOORS_STUCK_OPEN:
-				vehicle = &(g_sprite_list[ride->vehicles[ride->broken_vehicle]].vehicle);
+				vehicle = &(get_sprite(ride->vehicles[ride->broken_vehicle])->vehicle);
 				vehicle->update_flags &= ~VEHICLE_UPDATE_FLAG_BROKEN_CAR;
 				break;
 			case BREAKDOWN_VEHICLE_MALFUNCTION:
-				vehicle = &(g_sprite_list[ride->vehicles[ride->broken_vehicle]].vehicle);
+				vehicle = &(get_sprite(ride->vehicles[ride->broken_vehicle])->vehicle);
 				vehicle->update_flags &= ~VEHICLE_UPDATE_FLAG_BROKEN_TRAIN;
 				break;
 			}
@@ -3915,7 +3915,7 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 			if (stringId == STR_CALLING_MECHANIC) {
 				gfx_draw_string_left_wrapped(dpi, NULL, x + 4, y, 280, stringId, 0);
 			} else {
-				mechanicSprite = &(g_sprite_list[ride->mechanic].peep);
+				mechanicSprite = &(get_sprite(ride->mechanic)->peep);
 				if (peep_is_mechanic(mechanicSprite)) {
 					set_format_arg(0, uint16, mechanicSprite->name_string_idx);
 					set_format_arg(2, uint32, mechanicSprite->id);

--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -337,7 +337,7 @@ rct_window *window_staff_open(rct_peep* peep)
 	window_staff_disable_widgets(w);
 	window_init_scroll_widgets(w);
 	window_staff_viewport_init(w);
-	if (g_sprite_list[w->number].peep.state == PEEP_STATE_PICKED)
+	if (get_sprite(w->number)->peep.state == PEEP_STATE_PICKED)
 		window_event_mouse_up_call(w, WIDX_CHECKBOX_3);
 
 	return w;
@@ -349,7 +349,7 @@ rct_window *window_staff_open(rct_peep* peep)
 */
 void window_staff_disable_widgets(rct_window* w)
 {
-	rct_peep* peep = &g_sprite_list[w->number].peep;
+	rct_peep* peep = &get_sprite(w->number)->peep;
 	uint64 disabled_widgets = (1 << WIDX_TAB_4);
 
 	if (peep->staff_type == STAFF_TYPE_SECURITY){

--- a/src/windows/staff_fire_prompt.c
+++ b/src/windows/staff_fire_prompt.c
@@ -107,7 +107,7 @@ void window_staff_fire_prompt_open(rct_peep* peep)
 */
 static void window_staff_fire_mouseup(rct_window *w, int widgetIndex)
 {
-	rct_peep* peep = &g_sprite_list[w->number].peep;
+	rct_peep* peep = &get_sprite(w->number)->peep;
 
 	switch (widgetIndex){
 	case WIDX_YES:
@@ -132,7 +132,7 @@ static void window_staff_fire_paint(rct_window *w, rct_drawpixelinfo *dpi)
 {
 	window_draw_widgets(w, dpi);
 
-	rct_peep* peep = &g_sprite_list[w->number].peep;
+	rct_peep* peep = &get_sprite(w->number)->peep;
 
 	set_format_arg(0, uint16, peep->name_string_idx);
 	set_format_arg(2, uint32, peep->id);

--- a/src/windows/staff_list.c
+++ b/src/windows/staff_list.c
@@ -225,7 +225,7 @@ static void window_staff_list_mouseup(rct_window *w, int widgetIndex)
 			rct_window* window = window_find_by_class(WC_STAFF_LIST);
 			window_invalidate(window);
 		} else {
-			window_staff_open(&g_sprite_list[newStaffId].peep);
+			window_staff_open(&get_sprite(newStaffId)->peep);
 		}
 
 		break;

--- a/src/world/duck.c
+++ b/src/world/duck.c
@@ -318,7 +318,7 @@ void duck_remove_all()
 	uint16 spriteIndex, nextSpriteIndex;
 
 	for (spriteIndex = gSpriteListHead[SPRITE_LIST_MISC]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
-		sprite = &(g_sprite_list[spriteIndex].unknown);
+		sprite = &(get_sprite(spriteIndex)->unknown);
 		nextSpriteIndex = sprite->next;
 		if (sprite->misc_identifier == SPRITE_MISC_DUCK)
 			sprite_remove((rct_sprite*)sprite);

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -776,7 +776,7 @@ void footpath_remove_litter(int x, int y, int z)
 {
 	uint16 spriteIndex = sprite_get_first_in_quadrant(x, y);
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		rct_litter *sprite = &g_sprite_list[spriteIndex].litter;
+		rct_litter *sprite = &get_sprite(spriteIndex)->litter;
 		uint16 nextSpriteIndex = sprite->next_in_quadrant;
 		if (sprite->linked_list_type_offset == SPRITE_LIST_LITTER * 2) {
 			int distanceZ = abs(sprite->z - z);
@@ -797,7 +797,7 @@ void footpath_interrupt_peeps(int x, int y, int z)
 {
 	uint16 spriteIndex = sprite_get_first_in_quadrant(x, y);
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		rct_peep *peep = &g_sprite_list[spriteIndex].peep;
+		rct_peep *peep = &get_sprite(spriteIndex)->peep;
 		uint16 nextSpriteIndex = peep->next_in_quadrant;
 		if (peep->linked_list_type_offset == SPRITE_LIST_PEEP * 2) {
 			if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING) {

--- a/src/world/map_animation.c
+++ b/src/world/map_animation.c
@@ -198,7 +198,7 @@ static bool map_animation_invalidate_small_scenery(int x, int y, int baseZ)
 
 				uint16 spriteIdx = sprite_get_first_in_quadrant(x2, y2);
 				for (; spriteIdx != 0xFFFF; spriteIdx = sprite->unknown.next_in_quadrant) {
-					sprite = &g_sprite_list[spriteIdx];
+					sprite = get_sprite(spriteIdx);
 					if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
 						continue;
 

--- a/src/world/park.c
+++ b/src/world/park.c
@@ -279,7 +279,7 @@ int calculate_park_rating()
 
 		num_litter = 0;
 		for (sprite_idx = gSpriteListHead[SPRITE_LIST_LITTER]; sprite_idx != SPRITE_INDEX_NULL; sprite_idx = litter->next) {
-			litter = &(g_sprite_list[sprite_idx].litter);
+			litter = &(get_sprite(sprite_idx)->litter);
 
 			// Ignore recently dropped litter
 			if (litter->creationTick - gScenarioTicks >= 7680)

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -24,6 +24,7 @@
 #include "../scenario.h"
 #include "fountain.h"
 #include "sprite.h"
+#include "../openrct2.h"
 
 uint16 *gSpriteListHead = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_HEAD, uint16);
 uint16 *gSpriteListCount = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, uint16);
@@ -34,7 +35,7 @@ rct_sprite* sprite_list = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
 
 rct_sprite *get_sprite(size_t sprite_idx)
 {
-	assert(sprite_idx < MAX_SPRITES);
+	openrct2_assert(sprite_idx < MAX_SPRITES, "Tried getting sprite %u", sprite_idx);
 	return &sprite_list[sprite_idx];
 }
 

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -34,7 +34,7 @@ rct_sprite* sprite_list = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
 
 rct_sprite *get_sprite(size_t sprite_idx)
 {
-	//assert(sprite_idx < MAX_SPRITES);
+	assert(sprite_idx < MAX_SPRITES);
 	return &sprite_list[sprite_idx];
 }
 

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -25,12 +25,18 @@
 #include "fountain.h"
 #include "sprite.h"
 
-rct_sprite* g_sprite_list = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
-
 uint16 *gSpriteListHead = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_HEAD, uint16);
 uint16 *gSpriteListCount = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, uint16);
 
 uint16 *gSpriteSpatialIndex = (uint16*)0xF1EF60;
+
+rct_sprite* sprite_list = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
+
+rct_sprite *get_sprite(size_t sprite_idx)
+{
+	//assert(sprite_idx < MAX_SPRITES);
+	return &sprite_list[sprite_idx];
+}
 
 uint16 sprite_get_first_in_quadrant(int x, int y)
 {
@@ -92,7 +98,7 @@ void invalidate_sprite_2(rct_sprite *sprite)
 void reset_sprite_list()
 {
 	RCT2_GLOBAL(RCT2_ADDRESS_SAVED_AGE, uint16) = 0;
-	memset(g_sprite_list, 0, sizeof(rct_sprite) * MAX_SPRITES);
+	memset(sprite_list, 0, sizeof(rct_sprite) * MAX_SPRITES);
 
 	for (int i = 0; i < NUM_SPRITE_LISTS; i++) {
 		gSpriteListHead[i] = SPRITE_INDEX_NULL;
@@ -101,8 +107,8 @@ void reset_sprite_list()
 
 	rct_sprite* previous_spr = (rct_sprite*)SPRITE_INDEX_NULL;
 
-	rct_sprite* spr = g_sprite_list;
 	for (int i = 0; i < MAX_SPRITES; ++i){
+		rct_sprite *spr = get_sprite(i);
 		spr->unknown.sprite_identifier = SPRITE_IDENTIFIER_NULL;
 		spr->unknown.sprite_index = i;
 		spr->unknown.next = SPRITE_INDEX_NULL;
@@ -135,7 +141,7 @@ void reset_sprite_spatial_index()
 {
 	memset(gSpriteSpatialIndex, -1, 0x10001 * sizeof(uint16));
 	for (size_t i = 0; i < MAX_SPRITES; i++) {
-		rct_sprite *spr = &g_sprite_list[i];
+		rct_sprite *spr = get_sprite(i);
 		if (spr->unknown.sprite_identifier != SPRITE_IDENTIFIER_NULL) {
 			uint32 index;
 			if (spr->unknown.x == SPRITE_LOCATION_NULL) {
@@ -171,7 +177,7 @@ void sprite_clear_all_unused()
 
 	spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		sprite = &g_sprite_list[spriteIndex].unknown;
+		sprite = &get_sprite(spriteIndex)->unknown;
 		nextSpriteIndex = sprite->next;
 		previousSpriteIndex = sprite->previous;
 		memset(sprite, 0, sizeof(rct_sprite));
@@ -202,7 +208,7 @@ rct_sprite *create_sprite(uint8 bl)
 		return NULL;
 	}
 
-	rct_unk_sprite *sprite = &(g_sprite_list[gSpriteListHead[SPRITE_LIST_NULL]]).unknown;
+	rct_unk_sprite *sprite = &(get_sprite(gSpriteListHead[SPRITE_LIST_NULL]))->unknown;
 
 	move_sprite_to_list((rct_sprite *)sprite, (uint8)linkedListTypeOffset);
 
@@ -247,12 +253,12 @@ void move_sprite_to_list(rct_sprite *sprite, uint8 newListOffset)
 		gSpriteListHead[oldList] = unkSprite->next;
 	} else {
 		// Hook up sprite->previous->next to sprite->next, removing the sprite from its old list
-		g_sprite_list[unkSprite->previous].unknown.next = unkSprite->next;
+		get_sprite(unkSprite->previous)->unknown.next = unkSprite->next;
 	}
 
 	// Similarly, hook up sprite->next->previous to sprite->previous
 	if (unkSprite->next != SPRITE_INDEX_NULL) {
-		g_sprite_list[unkSprite->next].unknown.previous = unkSprite->previous;
+		get_sprite(unkSprite->next)->unknown.previous = unkSprite->previous;
 	}
 
 	unkSprite->previous = SPRITE_INDEX_NULL; // We become the new head of the target list, so there's no previous sprite
@@ -264,7 +270,7 @@ void move_sprite_to_list(rct_sprite *sprite, uint8 newListOffset)
 	if (unkSprite->next != SPRITE_INDEX_NULL)
 	{
 		// Fix the chain by settings sprite->next->previous to sprite_index
-		g_sprite_list[unkSprite->next].unknown.previous = unkSprite->sprite_index;
+		get_sprite(unkSprite->next)->unknown.previous = unkSprite->sprite_index;
 	}
 
 	// These globals are probably counters for each sprite list?
@@ -407,7 +413,7 @@ void sprite_misc_update_all()
 
 	spriteIndex = gSpriteListHead[SPRITE_LIST_MISC];
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		sprite = &g_sprite_list[spriteIndex];
+		sprite = get_sprite(spriteIndex);
 		spriteIndex = sprite->unknown.next;
 		sprite_misc_update(sprite);
 	}
@@ -442,10 +448,10 @@ void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite* sprite){
 
 	if (new_position != current_position){
 		uint16* sprite_idx = &gSpriteSpatialIndex[current_position];
-		rct_sprite* sprite2 = &g_sprite_list[*sprite_idx];
+		rct_sprite* sprite2 = get_sprite(*sprite_idx);
 		while (sprite != sprite2){
 			sprite_idx = &sprite2->unknown.next_in_quadrant;
-			sprite2 = &g_sprite_list[*sprite_idx];
+			sprite2 = get_sprite(*sprite_idx);
 		}
 		*sprite_idx = sprite->unknown.next_in_quadrant;
 
@@ -509,7 +515,7 @@ void sprite_remove(rct_sprite *sprite)
 
 	uint16 *spriteIndex = &gSpriteSpatialIndex[quadrantIndex];
 	rct_sprite *quadrantSprite;
-	while ((quadrantSprite = &g_sprite_list[*spriteIndex]) != sprite) {
+	while ((quadrantSprite = get_sprite(*spriteIndex)) != sprite) {
 		spriteIndex = &quadrantSprite->unknown.next_in_quadrant;
 	}
 	*spriteIndex = sprite->unknown.next_in_quadrant;
@@ -562,7 +568,7 @@ void litter_create(int x, int y, int z, int direction, int type)
 		newestLitter = NULL;
 		newestLitterCreationTick = 0;
 		for (spriteIndex = gSpriteListHead[SPRITE_LIST_LITTER]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
-			litter = &(g_sprite_list[spriteIndex].litter);
+			litter = &get_sprite(spriteIndex)->litter;
 			nextSpriteIndex = litter->next;
 			if (newestLitterCreationTick <= litter->creationTick) {
 				newestLitterCreationTick = litter->creationTick;
@@ -600,7 +606,7 @@ void litter_remove_at(int x, int y, int z)
 {
 	uint16 spriteIndex = sprite_get_first_in_quadrant(x, y);
 	while (spriteIndex != SPRITE_INDEX_NULL) {
-		rct_sprite *sprite = &g_sprite_list[spriteIndex];
+		rct_sprite *sprite = get_sprite(spriteIndex);
 		uint16 nextSpriteIndex = sprite->unknown.next_in_quadrant;
 		if (sprite->unknown.linked_list_type_offset == SPRITE_LIST_LITTER * 2) {
 			rct_litter *litter = &sprite->litter;

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -384,8 +384,7 @@ enum {
 	SPRITE_FLAGS_PEEP_FLASHING = 1 << 9, // Peep belongs to highlighted group (flashes red on map)
 };
 
-// rct2: 0x010E63BC
-extern rct_sprite* g_sprite_list;
+rct_sprite *get_sprite(size_t sprite_idx);
 
 // rct2: 0x00982708
 extern rct_sprite_entry g_sprite_entries[48];


### PR DESCRIPTION
Hide `g_sprite_list` behind accessor function with a check. `assert` is
temporarily disabled, as it breaks nearly every park.