### PR TITLE
Fix window limit count accuracy

### DIFF
--- a/src/interface/window.c
+++ b/src/interface/window.c
@@ -35,7 +35,7 @@
 #define RCT2_LAST_WINDOW		(gWindowNextSlot - 1)
 #define RCT2_NEW_WINDOW			(gWindowNextSlot)
 
-rct_window g_window_list[WINDOW_LIMIT_MAX];
+rct_window g_window_list[WINDOW_LIMIT_MAX + WINDOW_LIMIT_RESERVED];
 rct_window * gWindowFirst;
 rct_window * gWindowNextSlot;
 
@@ -355,7 +355,7 @@ static void window_close_surplus(int cap, sint8 avoid_classification)
 		}
 	}
 	//difference between amount open and cap = amount to close
-	diff = count - cap; 
+	diff = count - WINDOW_LIMIT_RESERVED - cap; 
 	for (i = 0; i < diff; i++) {
 		rct_window *w = NULL;
 		//iterates through the list until it finds the newest window, or a window that can be closed
@@ -402,7 +402,8 @@ void window_set_window_limit(int value)
 rct_window *window_create(int x, int y, int width, int height, rct_window_event_list *event_handlers, rct_windowclass cls, uint16 flags)
 {
 	// Check if there are any window slots left
-	if (RCT2_NEW_WINDOW >= &(g_window_list[gConfigGeneral.window_limit])) {
+	// include WINDOW_LIMIT_RESERVED for items such as the main viewport and toolbars to not appear to be counted.
+	if (RCT2_NEW_WINDOW >= &(g_window_list[gConfigGeneral.window_limit + WINDOW_LIMIT_RESERVED])) {
 		rct_window *w = NULL;
 		// Close least recently used window
 		for (w = g_window_list; w < RCT2_NEW_WINDOW; w++)

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -515,11 +515,12 @@ extern modal_callback gLoadSaveCallback;
 
 typedef void (*close_callback)();
 
-#define WINDOW_LIMIT_MIN 8
+#define WINDOW_LIMIT_MIN 4
 #define WINDOW_LIMIT_MAX 64
+#define WINDOW_LIMIT_RESERVED 4 // Used to reserve room for the main viewport, toolbars, etc.
 
 // rct2: 0x01420078
-extern rct_window g_window_list[WINDOW_LIMIT_MAX];
+extern rct_window g_window_list[WINDOW_LIMIT_MAX + WINDOW_LIMIT_RESERVED];
 
 extern rct_window * gWindowFirst;
 extern rct_window * gWindowNextSlot;


### PR DESCRIPTION
This is to address the issue that people are having by a window limit setting of 8 appearing as though it's only allowing 4 windows. The game, by default, creates the viewport and toolbars, tooltips, etcs, by using the window functions, so they are counted as windows. But because these items do not have the close button and draggable top bar, people do not interpret them as windows visually, thus if a window limit is set to 8, the game will count the top toolbar, viewport, bottom toolbar, dropdowns, and tooltips as windows, along with whatever else is open. This solves it by preserving a few extra slots that a user will never be able to reach when setting the limit, thus making the internal window limit actually bigger than what it appears to be.