### PR TITLE
Fix GetOpenGLVersion()

### DIFF
--- a/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -393,15 +393,13 @@ public:
 private:
     static OpenGLVersion GetOpenGLVersion()
     {
-        OpenGLVersion version;
-        if (SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &version.Major) == 0)
-        {
-            if (SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &version.Minor) == 0)
-            {
-                return version;
-            }
-        }
-        return { 0, 0 };
+        CheckGLError(); // Clear Any Errors
+        OpenGLVersion version = { 0, 0 };
+        glGetIntegerv(GL_MAJOR_VERSION, &version.Major);
+        if (glGetError() != GL_NO_ERROR) return { 0, 0 };
+        glGetIntegerv(GL_MINOR_VERSION, &version.Minor);
+        if (glGetError() != GL_NO_ERROR) return { 0, 0 };
+        return version;
     }
 
     void ConfigureBits(uint32 width, uint32 height, uint32 pitch)


### PR DESCRIPTION
NOTE: This requires a function that was declared in #4147. To prevent merge conflicts, I have opted to not include the code to declare the `glGetIntegerv` function pointer in this PR. This means that the AppVeyor build will fail until that PR has been merged. EDIT: It passed? I'm so confused.

This PR is in response to the research I did on #4047. The implementation currently in the code will not work based on what I saw. The `SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &major);` and `SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minor);` lines don't fetch the version retrieved, but the version requested. The solution I have here is the one I found worked consistently in my test case, and the one I suggested in [my comment](https://github.com/OpenRCT2/OpenRCT2/issues/4047#issuecomment-233268891).