### PR TITLE
Reset sprite quadrant placements as part of sprite reset command

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -270,13 +270,13 @@ void game_update()
 			// make sure client doesn't fall behind the server too much
 			numUpdates += 10;
 		}
-	} else {
-		if (game_is_paused()) {
-			numUpdates = 0;
-			// Update the animation list. Note this does not 
-			// increment the map animation.
-			map_animation_invalidate_all();
-		}
+	}
+
+	if (game_is_paused()) {
+		numUpdates = 0;
+		// Update the animation list. Note this does not
+		// increment the map animation.
+		map_animation_invalidate_all();
 	}
 
 	// Update the game one or more times

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -411,7 +411,7 @@ static void openrct2_loop()
 				if (!sprite_should_tween(get_sprite(i)))
 					continue;
 
-				sprite_move(
+				sprite_move_interframe(
 					_spritelocations2[i].x + (sint16)((_spritelocations1[i].x - _spritelocations2[i].x) * nudge),
 					_spritelocations2[i].y + (sint16)((_spritelocations1[i].y - _spritelocations2[i].y) * nudge),
 					_spritelocations2[i].z + (sint16)((_spritelocations1[i].z - _spritelocations2[i].z) * nudge),
@@ -434,7 +434,7 @@ static void openrct2_loop()
 					continue;
 
 				invalidate_sprite_2(get_sprite(i));
-				sprite_move(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
+				sprite_move_interframe(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
 			}
 			network_update();
 		} else {

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -411,7 +411,7 @@ static void openrct2_loop()
 				if (!sprite_should_tween(get_sprite(i)))
 					continue;
 
-				sprite_move_interframe(
+				sprite_set_coordinates(
 					_spritelocations2[i].x + (sint16)((_spritelocations1[i].x - _spritelocations2[i].x) * nudge),
 					_spritelocations2[i].y + (sint16)((_spritelocations1[i].y - _spritelocations2[i].y) * nudge),
 					_spritelocations2[i].z + (sint16)((_spritelocations1[i].z - _spritelocations2[i].z) * nudge),
@@ -434,7 +434,7 @@ static void openrct2_loop()
 					continue;
 
 				invalidate_sprite_2(get_sprite(i));
-				sprite_move_interframe(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
+				sprite_set_coordinates(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
 			}
 			network_update();
 		} else {

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -366,14 +366,11 @@ void S6Importer::Import()
         throw ObjectLoadException();
     }
     map_update_tile_pointers();
+    reset_all_sprite_quadrant_placements();
+    reset_sprite_spatial_index();
     if (network_get_mode() == NETWORK_MODE_CLIENT)
     {
-        reset_sprite_spatial_index();
         game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, 0, GAME_COMMAND_RESET_SPRITES, 0, 0);
-    }
-    else
-    {
-        reset_sprite_spatial_index();
     }
     game_convert_strings_to_utf8();
     if (FixIssues)

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -162,6 +162,7 @@ void reset_sprite_spatial_index()
 void game_command_reset_sprites(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
 {
 	if (*ebx & GAME_COMMAND_FLAG_APPLY) {
+		reset_all_sprite_quadrant_placements();
 		reset_sprite_spatial_index();
 	}
 	*ebx = 0;
@@ -512,6 +513,32 @@ void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite* sprite){
 	sprite->unknown.sprite_right = new_x + sprite->unknown.sprite_width;
 	sprite->unknown.sprite_top = new_y - sprite->unknown.sprite_height_negative;
 	sprite->unknown.sprite_bottom = new_y + sprite->unknown.sprite_height_positive;
+	sprite->unknown.x = x;
+	sprite->unknown.y = y;
+	sprite->unknown.z = z;
+}
+
+void sprite_move_interframe(sint16 x, sint16 y, sint16 z, rct_sprite* sprite){
+	sint16 new_x = x, new_y = y, start_x = x;
+	switch (get_current_rotation()){
+	case 0:
+		new_x = new_y - new_x;
+		new_y = (new_y + start_x) / 2 - z;
+		break;
+	case 1:
+		new_x = -new_y - new_x;
+		new_y = (new_y - start_x) / 2 - z;
+		break;
+	case 2:
+		new_x = -new_y + new_x;
+		new_y = (-new_y - start_x) / 2 - z;
+		break;
+	case 3:
+		new_x = new_y + new_x;
+		new_y = (-new_y + start_x) / 2 - z;
+		break;
+	}
+
 	sprite->unknown.x = x;
 	sprite->unknown.y = y;
 	sprite->unknown.z = z;

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -518,27 +518,7 @@ void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite* sprite){
 	sprite->unknown.z = z;
 }
 
-void sprite_move_interframe(sint16 x, sint16 y, sint16 z, rct_sprite* sprite){
-	sint16 new_x = x, new_y = y, start_x = x;
-	switch (get_current_rotation()){
-	case 0:
-		new_x = new_y - new_x;
-		new_y = (new_y + start_x) / 2 - z;
-		break;
-	case 1:
-		new_x = -new_y - new_x;
-		new_y = (new_y - start_x) / 2 - z;
-		break;
-	case 2:
-		new_x = -new_y + new_x;
-		new_y = (-new_y - start_x) / 2 - z;
-		break;
-	case 3:
-		new_x = new_y + new_x;
-		new_y = (-new_y + start_x) / 2 - z;
-		break;
-	}
-
+void sprite_set_coordinates(sint16 x, sint16 y, sint16 z, rct_sprite *sprite){
 	sprite->unknown.x = x;
 	sprite->unknown.y = y;
 	sprite->unknown.z = z;

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -401,6 +401,7 @@ void sprite_clear_all_unused();
 void move_sprite_to_list(rct_sprite *sprite, uint8 cl);
 void sprite_misc_update_all();
 void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite* sprite);
+void sprite_move_interframe(sint16 x, sint16 y, sint16 z, rct_sprite* sprite);
 void invalidate_sprite_0(rct_sprite* sprite);
 void invalidate_sprite_1(rct_sprite *sprite);
 void invalidate_sprite_2(rct_sprite *sprite);

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -401,7 +401,7 @@ void sprite_clear_all_unused();
 void move_sprite_to_list(rct_sprite *sprite, uint8 cl);
 void sprite_misc_update_all();
 void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite* sprite);
-void sprite_move_interframe(sint16 x, sint16 y, sint16 z, rct_sprite* sprite);
+void sprite_set_coordinates(sint16 x, sint16 y, sint16 z, rct_sprite *sprite);
 void invalidate_sprite_0(rct_sprite* sprite);
 void invalidate_sprite_1(rct_sprite *sprite);
 void invalidate_sprite_2(rct_sprite *sprite);


### PR DESCRIPTION
This addresses some sources of desyncs in multiplayer.

@zsilencer I took your commit from https://github.com/janisozaur/OpenRCT2/pull/15/commits/c6fd4b7b1cc8c84d8fce73e755fab6b477504856 and did minor refactor. I have tested it against live server as well running version from before this change, it worked correctly with it, so shouldn't affect non-updated players.

So far I have not triggered any desync while idling but @zsilencer says he managed to get some.