### PR TITLE
Checksum sprites occasionally in multiplayer

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1086,7 +1086,7 @@ void Network::Server_Send_TICK()
 	*packet << (uint32)NETWORK_COMMAND_TICK << (uint32)gCurrentTicks << (uint32)gScenarioSrand0;
 	uint32 flags = 0;
 	// Simple counter which limits how often a sprite checksum gets sent.
-	// This can get somewhat expensive, so we don't want to push it every from in release,
+	// This can get somewhat expensive, so we don't want to push it every tick in release,
 	// but debug version can check more often.
 	static int checksum_counter = 0;
 	checksum_counter++;

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -43,6 +43,7 @@ extern "C" {
 #include "../game.h"
 #include "../platform/platform.h"
 #include "../localisation/string_ids.h"
+#include <openssl/evp.h>
 #ifdef __cplusplus
 }
 #endif // __cplusplus
@@ -76,6 +77,10 @@ extern "C" {
 #include "NetworkPlayer.h"
 #include "NetworkUser.h"
 #include "TcpSocket.h"
+
+enum {
+	NETWORK_TICK_FLAG_CHECKSUMS = 1 << 0,
+};
 
 class Network
 {
@@ -191,6 +196,7 @@ private:
 	uint32 server_tick = 0;
 	uint32 server_srand0 = 0;
 	uint32 server_srand0_tick = 0;
+	char server_sprite_hash[EVP_MAX_MD_SIZE + 1];
 	uint8 player_id = 0;
 	std::list<std::unique_ptr<NetworkConnection>> client_connection_list;
 	std::multiset<GameCommand> game_command_queue;

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -63,6 +63,11 @@ bool gOpenRCT2Headless = false;
 bool gOpenRCT2ShowChangelog;
 bool gOpenRCT2SilentBreakpad;
 
+#ifndef DISABLE_NETWORK
+// OpenSSL's message digest context used for calculating sprite checksums
+EVP_MD_CTX *gHashCTX = NULL;
+#endif // DISABLE_NETWORK
+
 /** If set, will end the OpenRCT2 game loop. Intentially private to this module so that the flag can not be set back to 0. */
 int _finished;
 
@@ -175,6 +180,11 @@ static void openrct2_copy_original_user_files_over()
 bool openrct2_initialise()
 {
 	utf8 userPath[MAX_PATH];
+
+#ifndef DISABLE_NETWORK
+	gHashCTX = EVP_MD_CTX_create();
+	assert(gHashCTX != NULL);
+#endif // DISABLE_NETWORK
 
 	platform_resolve_openrct_data_path();
 	platform_resolve_user_data_path();
@@ -336,6 +346,9 @@ void openrct2_dispose()
 	language_close_all();
 	rct2_dispose();
 	config_release();
+#ifndef DISABLE_NETWORK
+	EVP_MD_CTX_destroy(gHashCTX);
+#endif // DISABLE_NETWORK
 	platform_free();
 }
 

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -20,6 +20,10 @@
 #include "common.h"
 #include "platform/platform.h"
 
+#ifndef DISABLE_NETWORK
+#include <openssl/evp.h>
+#endif // DISABLE_NETWORK
+
 enum {
 	STARTUP_ACTION_INTRO,
 	STARTUP_ACTION_TITLE,
@@ -38,6 +42,10 @@ extern utf8 gCustomOpenrctDataPath[MAX_PATH];
 extern utf8 gCustomPassword[MAX_PATH];
 extern bool gOpenRCT2Headless;
 extern bool gOpenRCT2ShowChangelog;
+
+#ifndef DISABLE_NETWORK
+extern EVP_MD_CTX *gHashCTX;
+#endif // DISABLE_NETWORK
 
 #ifndef DISABLE_NETWORK
 extern int gNetworkStart;

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -205,7 +205,7 @@ const char * sprite_checksum()
 }
 #else
 
-char * sprite_checksum()
+const char * sprite_checksum()
 {
 	return NULL;
 }

--- a/src/world/sprite.c
+++ b/src/world/sprite.c
@@ -168,6 +168,50 @@ void game_command_reset_sprites(int* eax, int* ebx, int* ecx, int* edx, int* esi
 	*ebx = 0;
 }
 
+#ifndef DISABLE_NETWORK
+
+static unsigned char _spriteChecksum[EVP_MAX_MD_SIZE + 1];
+
+const char * sprite_checksum()
+{
+	if (EVP_DigestInit_ex(gHashCTX, EVP_sha1(), NULL) <= 0)
+	{
+		openrct2_assert(false, "Failed to initialise SHA1 engine");
+	}
+	for (size_t i = 0; i < MAX_SPRITES; i++)
+	{
+		rct_sprite *sprite = get_sprite(i);
+		if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_NULL)
+		{
+			if (EVP_DigestUpdate(gHashCTX, sprite, sizeof(rct_sprite)) <= 0)
+			{
+				openrct2_assert(false, "Failed to update digest");
+			}
+		}
+	}
+	unsigned char localhash[EVP_MAX_MD_SIZE + 1];
+	unsigned int size = sizeof(localhash);
+	EVP_DigestFinal(gHashCTX, localhash, &size);
+	assert(size <= sizeof(localhash));
+	localhash[sizeof(localhash) - 1] = '\0';
+	char *x = (char *)_spriteChecksum;
+	for (unsigned int i = 0; i < size; i++)
+	{
+		sprintf(x, "%02x", localhash[i]);
+		x += 2;
+	}
+	*x = '\0';
+	return (char *)_spriteChecksum;
+}
+#else
+
+char * sprite_checksum()
+{
+	return NULL;
+}
+
+#endif // DISABLE_NETWORK
+
 /**
  * Clears all the unused sprite memory to zero. Probably so that it can be compressed better when saving.
  *  rct2: 0x0069EBA4

--- a/src/world/sprite.h
+++ b/src/world/sprite.h
@@ -441,4 +441,6 @@ void crashed_vehicle_particle_update(rct_crashed_vehicle_particle *particle);
 void crash_splash_create(int x, int y, int z);
 void crash_splash_update(rct_crash_splash *splash);
 
+const char *sprite_checksum();
+
 #endif


### PR DESCRIPTION
This creates a checksum (SHA1) every so often on server and sends this
value together with PRNG seed for client to check it has still not
desynced.

It's useful to detect a desync early on, as PRNG seeds may remain
unchanged for some more time, while damage may have already been caused.

This commit was extracted from #4176 as it was deemed it's not necessary to update network version, as `NetworkPacket` will return `0` for non-existent data.

It was tested with configurations:
* new client against old (public) server
* old client against new server
* new client against new server

and all work as expected.