### PR TITLE
Fix alternative vehicles not showing up, fixes #3806

### DIFF
--- a/src/management/research.c
+++ b/src/management/research.c
@@ -203,7 +203,7 @@ void research_finish_item(sint32 entryIndex)
 					rideEntry2->ride_type[1] == base_ride_type ||
 					rideEntry2->ride_type[2] == base_ride_type
 				) {
-					ride_entry_set_invented(rideEntryIndex);
+					ride_entry_set_invented(i);
 				}
 			}
 		}


### PR DESCRIPTION
This error was introduced with https://github.com/OpenRCT2/OpenRCT2/commit/aa929e1593e7a2adcc0c5886c2693c3e2ec407fa (see line 204 in `src/management/research.c` in that commit).