### PR TITLE
CMake: improve check for OpenGL support on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,8 @@ if (NOT DISABLE_OPENGL)
 		# Curl depends on openssl and ws2 in mingw builds, but is not wired up in pkg-config
 		set(GLLIBS opengl32)
 	else (WIN32)
-		PKG_CHECK_MODULES(GL REQUIRED gl)
-		set(GLLIBS ${GL_LIBRARIES})
+		find_package(OpenGL REQUIRED)
+		set(GLLIBS ${OPENGL_LIBRARY})
 	endif (WIN32)
 endif (NOT DISABLE_OPENGL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,9 +196,13 @@ if (NOT DISABLE_OPENGL)
 	if (WIN32)
 		# Curl depends on openssl and ws2 in mingw builds, but is not wired up in pkg-config
 		set(GLLIBS opengl32)
-	else (WIN32)
+	elseif (APPLE)
+		# GL doesn't work nicely with macOS, while find_package doesn't work with multiarch on Ubuntu.
 		find_package(OpenGL REQUIRED)
 		set(GLLIBS ${OPENGL_LIBRARY})
+	else (WIN32)
+		PKG_CHECK_MODULES(GL REQUIRED gl)
+		set(GLLIBS ${GL_LIBRARIES})
 	endif (WIN32)
 endif (NOT DISABLE_OPENGL)
 


### PR DESCRIPTION
CMake seems to have trouble with the `gl` module on macOS. This PR changes it to use find_package with `OpenGL` instead, which works for me on both macOS and Arch Linux.