### PR TITLE
Path finding fixes and optimisations

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -59,11 +59,6 @@ uint8 _peepPathFindFewestNumSteps;
  * be declared properly. */
 rct_xyz8 _peepPathFindHistory[16];
 
-/* Configure peep pathfinding logging:
- * 0: logging disabled
- * 1+: logging enable; larger value = more detailed logging. */
-int _peepPathFindLog = 0;
-
 enum {
 	PATH_SEARCH_DEAD_END,
 	PATH_SEARCH_RIDE_EXIT,
@@ -8191,17 +8186,19 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 
 	++counter;
 	if (--_peepPathFindTilesChecked < 0) {
-		fprintf(stderr, "WARNING: Path finding search limit (maxTilesChecked) exceeded - expect path finding problems!\n");
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; TilesChecked < 0; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		log_warning("WARNING: Path finding search limit (maxTilesChecked) exceeded - expect path finding problems!\n");
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Return from %d,%d,%d; TilesChecked < 0; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return score;
 	}
 
 	/* If counter (# steps taken) exceeds the limit, the current search
 	 * path ends here */
 	if (counter > 200) {
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; counter > 200; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Return from %d,%d,%d; counter > 200; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return score;
 	}
 
@@ -8210,8 +8207,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 	if ((_peepPathFindHistory[0].x == (uint8)(x >> 5)) &&
 		(_peepPathFindHistory[0].y == (uint8)(y >> 5)) &&
 		(_peepPathFindHistory[0].z == (uint8)z)) {
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; At start; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Return from %d,%d,%d; At start; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return score;
 	}
 
@@ -8230,8 +8228,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 		/* If this tile is the search goal (score == 0) the current
 		 * search path ends here */
 		if (score == 0) {
-			if (_peepPathFindLog > 1)
-				fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; At goal; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+			#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+				log_information("[%03d] Return from %d,%d,%d; At goal; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+			#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 			return score;
 		}
 	}
@@ -8275,8 +8274,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 	/* If no tile of interest (for continuing the current search path)
 	 * was found, the current search path ends here. */
 	if (!found) {
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; Not found; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Return from %d,%d,%d; Not found; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return score;
 	}
 
@@ -8284,8 +8284,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 	uint8 edges = path_get_permitted_edges(path);
 	z = path->base_height;
 
-	if (_peepPathFindLog > 1)
-		fprintf(stderr, "DEBUG: [%03d] Path %d,%d,%d; 0123:%d%d%d%d; Reverse: %d\n", counter, x >> 5, y >> 5, z, edges & 1, (edges & 2) >> 1, (edges & 4) >> 2, (edges & 8) >> 3, test_edge ^ 2);
+	#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+		log_information("[%03d] Path %d,%d,%d; 0123:%d%d%d%d; Reverse: %d\n", counter, x >> 5, y >> 5, z, edges & 1, (edges & 2) >> 1, (edges & 4) >> 2, (edges & 8) >> 3, test_edge ^ 2);
+	#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 
 	/* Remove the reverse edge (i.e. the edge back to the previous tile
 	 * in the current search path */
@@ -8295,8 +8296,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 	/* If there are no other edges, this is a dead end - the current search
 	 * path ends here. */
 	if (test_edge == -1) {
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; Dead end; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Return from %d,%d,%d; Dead end; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return score;
 	}
 
@@ -8309,8 +8311,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 		}
 		_peepPathFindQueueRideIndex = true;
 
-		if (_peepPathFindLog > 1)
-			fprintf(stderr, "DEBUG: [%03d] Recurse from %d,%d,%d direction: %d; Segment; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+			log_information("[%03d] Recurse from %d,%d,%d direction: %d; Segment; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		return peep_pathfind_heuristic_search(x, y, z, counter, score, test_edge);
 	}
 
@@ -8350,8 +8353,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 		/* If junction search limit is reached, the current search
 		 * path ends here */
 		if (_peepPathFindNumJunctions < 0) {
-			if (_peepPathFindLog > 1)
-				fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; NumJunctions < 0; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+			#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+				log_information("[%03d] Return from %d,%d,%d; NumJunctions < 0; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+			#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 			return score;
 		}
 
@@ -8363,8 +8367,9 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 			if ((_peepPathFindHistory[junctionNum].x == (uint8)(x >> 5)) &&
 				(_peepPathFindHistory[junctionNum].y == (uint8)(y >> 5)) &&
 				(_peepPathFindHistory[junctionNum].z == (uint8)z)) {
-				if (_peepPathFindLog > 1)
-					fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; Loop; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+				#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+					log_information("[%03d] Return from %d,%d,%d; Loop; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+				#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 				return score;
 			}
 		}
@@ -8393,18 +8398,19 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 			footpath_element_get_slope_direction(path) == test_edge) {
 			height += 2;
 		}
-		if (_peepPathFindLog > 1) {
+		#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 			if (thin_junction == true)
-				fprintf(stderr, "DEBUG: [%03d] Recurse from %d,%d,%d direction: %d; Thin-Junction; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
+				log_information("[%03d] Recurse from %d,%d,%d direction: %d; Thin-Junction; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
 			else
-				fprintf(stderr, "DEBUG: [%03d] Recurse from %d,%d,%d direction: %d; Wide-Junction; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
-		}
+				log_information("[%03d] Recurse from %d,%d,%d direction: %d; Wide-Junction; Score: %d\n", counter, x >> 5, y >> 5, z, test_edge, score);
+		#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 		score = peep_pathfind_heuristic_search(x, y, height, counter, score, test_edge);
 		_peepPathFindNumJunctions = savedNumJunctions;
 	} while ((test_edge = bitscanforward(edges)) != -1);
 
-	if (_peepPathFindLog > 1)
-		fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; Best Junction; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+	#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
+		log_information("[%03d] Return from %d,%d,%d; Best Junction; Score: %d\n", counter, x >> 5, y >> 5, z, score);
+	#endif // defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 	return score;
 }
 
@@ -8495,8 +8501,9 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		uint16 best_score = 0xFFFF;
 		uint8 best_sub = 0xFF;
 
-		if (_peepPathFindLog > 0)
-			fprintf(stderr, "DEBUG: Pathfind start for goal %d,%d,%d from %d,%d,%d\n", goal.x, goal.y, goal.z, x >> 5, y >> 5, z);
+		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+			log_verbose("Pathfind start for goal %d,%d,%d from %d,%d,%d\n", goal.x, goal.y, goal.z, x >> 5, y >> 5, z);
+		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 		/* Call the search heuristic on each edge, keeping track of the
 		 * edge that gives the best (i.e. smallest) value (best_score)
@@ -8531,8 +8538,9 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 			}
 
 			uint16 score = peep_pathfind_heuristic_search(x, y, height, 0, 0xFFFF, test_edge);
-			if (_peepPathFindLog > 0)
-				fprintf(stderr, "DEBUG: Pathfind test edge: %d score: %d steps: %d\n", test_edge, score, _peepPathFindFewestNumSteps);
+			#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+				log_verbose("Pathfind test edge: %d score: %d steps: %d\n", test_edge, score, _peepPathFindFewestNumSteps);
+			#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 			if (score < best_score || (score == best_score && _peepPathFindFewestNumSteps < best_sub)) {
 				chosen_edge = test_edge;
@@ -8540,8 +8548,9 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 				best_sub = _peepPathFindFewestNumSteps;
 			}
 		}
-		if (_peepPathFindLog > 0)
-			fprintf(stderr,"DEBUG: Pathfind best edge %d with score %d\n", chosen_edge, best_score);
+		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+			log_verbose("Pathfind best edge %d with score %d\n", chosen_edge, best_score);
+		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 	}
 
 	/* This is a new goal for the peep. Store it and reset the peep's

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8126,27 +8126,27 @@ static int guest_path_find_aimless(rct_peep* peep, uint8 edges){
  */
 static uint8 peep_pathfind_get_max_number_junctions(rct_peep* peep){
 	if (peep->type == PEEP_TYPE_STAFF)
-		return 10;
+		return 8;
 
 	if ((peep->peep_flags & PEEP_FLAGS_2)){
 		if ((scenario_rand() & 0xFFFF) <= 7281)
 			peep->peep_flags &= ~PEEP_FLAGS_2;
 
-		return 10;
+		return 8;
 	}
 
 	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK &&
 		peep->peep_is_lost_countdown < 90){
-		return 10;
+		return 8;
 	}
 
 	if (peep->item_standard_flags & PEEP_ITEM_MAP)
-		return 9;
+		return 7;
 
 	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
-		return 9;
+		return 7;
 
-	return 7;
+	return 5;
 }
 
 /**

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8533,18 +8533,15 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 			_peepPathFindQueueRideIndex = false;
 			_peepPathFindNumJunctions = maxNumJunctions;
 
-			/* Initialise _peepPathFindHistory.
-			 * The pathfinding will only use elements
+			// Initialise _peepPathFindHistory.
+			memset(_peepPathFindHistory, 0xFF, sizeof(_peepPathFindHistory));
+
+			/* The pathfinding will only use elements
 			 * 1..maxNumJunctions, so the starting point is
 			 * placed in element 0 */
 			_peepPathFindHistory[0].x = (uint8)(x >> 5);
 			_peepPathFindHistory[0].y = (uint8)(y >> 5);
 			_peepPathFindHistory[0].z = (uint8)z;
-			for (int junctionIndex = 1; junctionIndex < 16; junctionIndex++) {
-				_peepPathFindHistory[junctionIndex].x = 0xFF;
-				_peepPathFindHistory[junctionIndex].y = 0xFF;
-				_peepPathFindHistory[junctionIndex].z = 0xFF;
-			}
 
 			uint16 score = peep_pathfind_heuristic_search(x, y, height, 0, 0xFFFF, test_edge);
 			#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8993,7 +8993,7 @@ static int guest_path_finding(rct_peep* peep)
 	uint8 closestStationNum;
 
 	int numEntranceStations = 0;
-	uint entranceStations = 0;
+	uint8 entranceStations = 0;
 
 	for (uint8 stationNum = 0; stationNum < 4; ++stationNum){
 		if (ride->entrances[stationNum] == 0xFFFF) // stationNum has no entrance (so presumably an exit only station).

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8126,27 +8126,27 @@ static int guest_path_find_aimless(rct_peep* peep, uint8 edges){
  */
 static uint8 peep_pathfind_get_max_number_junctions(rct_peep* peep){
 	if (peep->type == PEEP_TYPE_STAFF)
-		return 16;
+		return 8;
 
 	if ((peep->peep_flags & PEEP_FLAGS_2)){
 		if ((scenario_rand() & 0xFFFF) <= 7281)
 			peep->peep_flags &= ~PEEP_FLAGS_2;
 
-		return 16;
+		return 8;
 	}
 
 	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK &&
 		peep->peep_is_lost_countdown < 90){
-		return 16;
+		return 8;
 	}
 
 	if (peep->item_standard_flags & PEEP_ITEM_MAP)
-		return 14;
+		return 7;
 
 	if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
-		return 14;
+		return 7;
 
-	return 10;
+	return 5;
 }
 
 /**
@@ -8191,6 +8191,7 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 
 	++counter;
 	if (--_peepPathFindTilesChecked < 0) {
+		fprintf(stderr, "WARNING: Path finding search limit (maxTilesChecked) exceeded - expect path finding problems!\n");
 		if (_peepPathFindLog > 1)
 			fprintf(stderr, "DEBUG: [%03d] Return from %d,%d,%d; TilesChecked < 0; Score: %d\n", counter, x >> 5, y >> 5, z, score);
 		return score;
@@ -8333,28 +8334,6 @@ static uint16 peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, uint8 
 		if (footpath_element_next_in_direction(x, y, z, path, prescan_edge) != PATH_SEARCH_WIDE) {
 			thin_count++;
 		}
-		/*sint16 prescan_x = x + TileDirectionDelta[prescan_edge].x;
-		sint16 prescan_y = y + TileDirectionDelta[prescan_edge].y;
-		rct_map_element *prescan_path = map_get_first_element_at(prescan_x / 32, prescan_y / 32);
-		do {
-			if (map_element_get_type(prescan_path) != MAP_ELEMENT_TYPE_PATH) continue;
-
-			if (footpath_element_is_sloped(prescan_path)) {
-				if (
-					(footpath_element_get_slope_direction(prescan_path) == prescan_edge && prescan_path->base_height == z ) || 
-					((footpath_element_get_slope_direction(prescan_path) ^ 2) == prescan_edge && prescan_path->base_height + 2 == z)) {
-					thin_count++;
-					break;
-				}
-			} else { // Not sloped.
-				if (prescan_path->base_height == z &&
-					!footpath_element_is_wide(prescan_path)) {
-					thin_count++;
-					break;
-				}
-			}
-		} while (!map_element_is_last_for_tile(prescan_path++));
-		*/
 
 		if (thin_count > 2) {
 			thin_junction = true;

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -489,7 +489,7 @@ typedef struct rct_peep {
 	uint8 pad_77;
 	union{
 		uint8 maze_last_edge;			// 0x78
-		uint8 var_78;	//Direction ?
+		uint8 direction;	//Direction ?
 	};
 	uint8 var_79;
 	uint16 time_in_queue;			// 0x7A

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -811,9 +811,9 @@ static int staff_path_finding_handyman(rct_peep* peep)
 						direction = litterDirection;
 					}
 				} else {
-					pathDirections &= ~(1 << (peep->var_78 ^ (1 << 1)));
+					pathDirections &= ~(1 << (peep->direction ^ (1 << 1)));
 					if (pathDirections == 0) {
-						pathDirections |= 1 << (peep->var_78 ^ (1 << 1));
+						pathDirections |= 1 << (peep->direction ^ (1 << 1));
 					}
 				}
 
@@ -840,7 +840,7 @@ static int staff_path_finding_handyman(rct_peep* peep)
 		chosenTile.y = peep->next_y + TileDirectionDelta[direction].y;
 	}
 
-	peep->var_78 = direction;
+	peep->direction = direction;
 	peep->destination_x = chosenTile.x + 16;
 	peep->destination_y = chosenTile.y + 16;
 	peep->destination_tolerence = 3;
@@ -938,8 +938,8 @@ static uint8 staff_mechanic_direction_surface(rct_peep* peep) {
  */
 static uint8 staff_mechanic_direction_path_rand(rct_peep* peep, uint8 pathDirections) {
 	if (scenario_rand() & 1) {
-		if (pathDirections & (1 << peep->var_78))
-			return peep->var_78;
+		if (pathDirections & (1 << peep->direction))
+			return peep->direction;
 	}
 	
 	// Modified from original to spam scenario_rand less
@@ -950,7 +950,7 @@ static uint8 staff_mechanic_direction_path_rand(rct_peep* peep, uint8 pathDirect
 			return direction;
 	}
 	// This will never happen as pathDirections always has a bit set.
-	return peep->var_78;
+	return peep->direction;
 }
 
 /**
@@ -968,9 +968,9 @@ static uint8 staff_mechanic_direction_path(rct_peep* peep, uint8 validDirections
 		return staff_mechanic_direction_surface(peep);
 	}
 
-	pathDirections &= ~(1 << (peep->var_78 ^ (1 << 1)));
+	pathDirections &= ~(1 << (peep->direction ^ (1 << 1)));
 	if (pathDirections == 0) {
-		pathDirections |= (1 << (peep->var_78 ^ (1 << 1)));
+		pathDirections |= (1 << (peep->direction ^ (1 << 1)));
 	}
 
 	direction = bitscanforward(pathDirections);
@@ -1085,7 +1085,7 @@ static int staff_path_finding_mechanic(rct_peep* peep) {
 		chosenTile.y = peep->next_y + TileDirectionDelta[direction].y;
 	}
 
-	peep->var_78 = direction;
+	peep->direction = direction;
 	peep->destination_x = chosenTile.x + 16;
 	peep->destination_y = chosenTile.y + 16;
 	peep->destination_tolerence = (scenario_rand() & 7) + 2;
@@ -1108,9 +1108,9 @@ static uint8 staff_direction_path(rct_peep* peep, uint8 validDirections, rct_map
 		return staff_direction_surface(peep, scenario_rand() & 3);
 	}
 
-	pathDirections &= ~(1 << (peep->var_78 ^ (1 << 1)));
+	pathDirections &= ~(1 << (peep->direction ^ (1 << 1)));
 	if (pathDirections == 0) {
-		pathDirections |= (1 << (peep->var_78 ^ (1 << 1)));
+		pathDirections |= (1 << (peep->direction ^ (1 << 1)));
 	}
 
 	direction = bitscanforward(pathDirections);
@@ -1162,7 +1162,7 @@ static int staff_path_finding_misc(rct_peep* peep) {
 		chosenTile.y = peep->next_y + TileDirectionDelta[direction].y;
 	}
 
-	peep->var_78 = direction;
+	peep->direction = direction;
 	peep->destination_x = chosenTile.x + 16;
 	peep->destination_y = chosenTile.y + 16;
 	peep->destination_tolerence = (scenario_rand() & 7) + 2;

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -1751,6 +1751,9 @@ void footpath_update_path_wide_flags(int x, int y)
 		if (footpath_element_is_sloped(mapElement))
 			continue;
 
+		if ((mapElement->properties.path.edges & 0xF) == 0)
+			continue;
+
 		uint8 height = mapElement->base_height;
 
 		// pathList is a list of elements, set by sub_6A8ACF adjacent to x,y

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -1740,9 +1740,9 @@ void footpath_update_path_wide_flags(int x, int y)
 	footpath_clear_wide(x, y);
 	y -= 0x20;
 
-	if (!(x & 0xE0))
+	if (!(x & 0xFFE0))
 		return;
-	if (!(y & 0xE0))
+	if (!(y & 0xFFE0))
 		return;
 
 	rct_map_element *mapElement = map_get_first_element_at(x / 32, y / 32);

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -1740,11 +1740,6 @@ void footpath_update_path_wide_flags(int x, int y)
 	footpath_clear_wide(x, y);
 	y -= 0x20;
 
-	if (!(x & 0xFFE0))
-		return;
-	if (!(y & 0xFFE0))
-		return;
-
 	rct_map_element *mapElement = map_get_first_element_at(x / 32, y / 32);
 	do {
 		if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_PATH)

--- a/src/world/park.c
+++ b/src/world/park.c
@@ -494,7 +494,7 @@ static rct_peep *park_generate_new_guest()
 
 			peep->destination_tolerence = 5;
 			peep->var_76 = 0;
-			peep->var_78 = spawn.direction;
+			peep->direction = spawn.direction;
 			peep->var_37 = 0;
 			peep->state = PEEP_STATE_ENTERING_PARK;
 		}


### PR DESCRIPTION
Fix following problems with path finding:
- tiles in wide paths are always treated as junctions
- no loop detection (becomes necessary once the previous point is resolved)

Adjust maxNumJunctions limit per the above fixes to retain game balance.
Add miscellaneous performance optimisations.
Add comments documenting the path finding algorithm.