### PR TITLE
Turn off zero clearance when placing down entrances (Ghost entrances - fix for editor and SP usage)

### DIFF
--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -314,6 +314,7 @@ static void window_map_mouseup(rct_window *w, int widgetIndex)
 		break;
 	case WIDX_BUILD_PARK_ENTRANCE:
 		window_invalidate(w);
+		gCheatsDisableClearanceChecks = false;				//Fixes a bug with ghost entrences being placed which can't be removed
 		if (tool_set(w, widgetIndex, 2))
 			break;
 


### PR DESCRIPTION
If the cheat 'Zero clearance' is on while you build a entrance, it glitches out and only produce a ghost entrance which can't be deleted nor used
This fixes it by turning off the cheat to eliminate this problem

Fixes the issue down here: https://openrct2.org/forums/topic/1546-list-of-ideas/#comment-9232
And

>Flint "Duck Mechanic" Webber - Today at 2:13 AM
yeaaah, @Nubbie and any body who works on the game could you make it so that cheats turn off when you go into the editor? that's what causes that

Question:
* Better to try and fix the problem itself or should it be a temporary solution?

Issues:
* Doesn't stop anyone from turning it on again (multiplayer)
* People without the cheat permission won't be able to turn it off still resulting in the ghosting