### PR TITLE
Add option to disable weather gloom and rain effects

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4228,6 +4228,9 @@ STR_5916    :{COMMA16} player
 STR_5917    :{COMMA16} players
 STR_5918    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{COMMA16}
 STR_5919    :{COMMA16}
+STR_5920    :Render weather effects
+STR_5921    :{SMALLFONT}{BLACK}If enabled, rain and gloomy colours will be rendered during storms.
+
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4231,7 +4231,6 @@ STR_5919    :{COMMA16}
 STR_5920    :Render weather effects
 STR_5921    :{SMALLFONT}{BLACK}If enabled, rain and gloomy colours will be rendered during storms.
 
-
 #############
 # Scenarios #
 ################

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.0.5 (in development)
 ------------------------------------------------------------------------
+- Feature: Ability to disable rendering of weather effects and gloom
 - Feature: New view option: "See-Through Paths"
 - Feature: Add cheat to reset date.
 - Feature: Add OpenGL drawing engine.
@@ -8,7 +9,7 @@
 - Feature: Add ride console command for diagnostics and changing vehicle type.
 - Feature: Allow selecting corners when using the mountain tool.
 - Feature: Allow setting ownership of map edges.
-- Feature: Allow up to 255 cars per train.
+- Feature: Allow up to 255 cars per train and 32 track units per station
 - Feature: Importing SV4 and SC4 files with rides.
 - Feature: Filter Object Selection Window by "Selected only" and "Non-selected only"
 - Feature: Allow raising terrain to 64 in-game units.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,7 +9,7 @@
 - Feature: Add ride console command for diagnostics and changing vehicle type.
 - Feature: Allow selecting corners when using the mountain tool.
 - Feature: Allow setting ownership of map edges.
-- Feature: Allow up to 255 cars per train and 32 track units per station
+- Feature: Allow up to 255 cars per train.
 - Feature: Importing SV4 and SC4 files with rides.
 - Feature: Filter Object Selection Window by "Selected only" and "Non-selected only"
 - Feature: Allow raising terrain to 64 in-game units.

--- a/src/config.c
+++ b/src/config.c
@@ -227,6 +227,8 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, last_save_track_directory),       "last_track_directory",         CONFIG_VALUE_TYPE_STRING,       { .value_string = NULL },       NULL                    },
 	{ offsetof(general_configuration, window_limit),					"window_limit",					CONFIG_VALUE_TYPE_UINT8,		WINDOW_LIMIT_MAX,				NULL					},
 	{ offsetof(general_configuration, zoom_to_cursor),					"zoom_to_cursor",				CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
+	{ offsetof(general_configuration, render_weather_effects),			"render_weather_effects",		CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
+	{ offsetof(general_configuration, render_weather_gloom),			"render_weather_gloom",			CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
 };
 
 config_property_definition _interfaceDefinitions[] = {

--- a/src/config.h
+++ b/src/config.h
@@ -200,6 +200,8 @@ typedef struct general_configuration {
 	utf8string last_save_track_directory;
 	uint8 window_limit;
 	uint8 zoom_to_cursor;
+	uint8 render_weather_effects;
+	uint8 render_weather_gloom;
 } general_configuration;
 
 typedef struct interface_configuration {

--- a/src/drawing/Rain.cpp
+++ b/src/drawing/Rain.cpp
@@ -19,6 +19,7 @@ extern "C"
     #include "../interface/window.h"
     #include "../world/climate.h"
     #include "drawing.h"
+    #include "../config.h"
 }
 
 #include "IDrawingEngine.h"
@@ -86,6 +87,9 @@ static void DrawRainWindow(IRainDrawer * rainDrawer,
                            sint16 bottom,
                            uint32 rainType)
 {
+    if (!gConfigGeneral.render_weather_effects)
+        return;
+
     rct_window * newWindow = gWindowNextSlot;
     rct_window * w = original_w + 1; // Start from second window
     for (; ; w++)

--- a/src/game.c
+++ b/src/game.c
@@ -186,7 +186,7 @@ void update_palette_effects()
 		int q = 0;
 		extern const sint32 WeatherColours[4];
 		int weather_colour = WeatherColours[gClimateCurrentWeatherGloom];
-		if (weather_colour != -1) {
+		if (weather_colour != -1 && gConfigGeneral.render_weather_gloom) {
 			q = 1;
 			if (weather_colour != 0x2000031) {
 				q = 2;

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -777,7 +777,7 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, in
 		paint_quadrant_ps();
 
 		int weather_colour = WeatherColours[gClimateCurrentWeatherGloom];
-		if ((weather_colour != -1) && (!(gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)) && !gTrackDesignSaveMode) {
+		if ((weather_colour != -1) && (!(gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)) && !gTrackDesignSaveMode && gConfigGeneral.render_weather_gloom) {
 			gfx_fill_rect(dpi2, dpi2->x, dpi2->y, dpi2->width + dpi2->x - 1, dpi2->height + dpi2->y - 1, weather_colour);
 		}
 		viewport_draw_money_effects();

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -777,16 +777,20 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, in
 		paint_quadrant_ps();
 
 		int weather_colour = WeatherColours[gClimateCurrentWeatherGloom];
-		if ((weather_colour != -1) 
+		if (
+			(weather_colour != -1) 
 			&& (!(gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)) 
-			&& (!gTrackDesignSaveMode)
-			&& (gConfigGeneral.render_weather_gloom)) {
-				gfx_fill_rect(dpi2, 
-							  dpi2->x, 
-							  dpi2->y, 
-							  dpi2->width + dpi2->x - 1, 
-							  dpi2->height + dpi2->y - 1, 
-							  weather_colour);
+			&& (!gTrackDesignSaveMode) 
+			&& (gConfigGeneral.render_weather_gloom)
+		) {
+			gfx_fill_rect(
+				dpi2, 
+				dpi2->x, 
+				dpi2->y, 
+				dpi2->width + dpi2->x - 1, 
+				dpi2->height + dpi2->y - 1, 
+				weather_colour
+			);
 		}
 		
 		viewport_draw_money_effects();

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -777,12 +777,23 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, in
 		paint_quadrant_ps();
 
 		int weather_colour = WeatherColours[gClimateCurrentWeatherGloom];
-		if ((weather_colour != -1) && (!(gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)) && !gTrackDesignSaveMode && gConfigGeneral.render_weather_gloom) {
-			gfx_fill_rect(dpi2, dpi2->x, dpi2->y, dpi2->width + dpi2->x - 1, dpi2->height + dpi2->y - 1, weather_colour);
+		if ((weather_colour != -1) 
+			&& (!(gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)) 
+			&& (!gTrackDesignSaveMode)
+			&& (gConfigGeneral.render_weather_gloom)) {
+				gfx_fill_rect(dpi2, 
+							  dpi2->x, 
+							  dpi2->y, 
+							  dpi2->width + dpi2->x - 1, 
+							  dpi2->height + dpi2->y - 1, 
+							  weather_colour);
 		}
+		
 		viewport_draw_money_effects();
 	}
 }
+
+
 
 /**
  *

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -3570,6 +3570,8 @@ enum {
 	STR_MULTIPLAYER_PLAYER_COUNT_PLURAL = 5917,
 	STR_SERVER_MAX_PLAYERS_VALUE = 5918,
 	STR_COMMA16 = 5919,
+	STR_RENDER_WEATHER_EFFECTS = 5920,
+	STR_RENDER_WEATHER_EFFECTS_TIP = 5921,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -97,7 +97,8 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_DAY_NIGHT_CHECKBOX,
 	WIDX_UPPER_CASE_BANNERS_CHECKBOX,
 	WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
-
+	WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
+	
 	// Culture / Units
 	WIDX_LANGUAGE = WIDX_PAGE_START,
 	WIDX_LANGUAGE_DROPDOWN,
@@ -224,14 +225,15 @@ static rct_widget window_options_display_widgets[] = {
 static rct_widget window_options_rendering_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
 #define FRAME_RENDERING_START 53
-	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,	FRAME_RENDERING_START + 106,	STR_RENDERING_GROUP,			STR_NONE },								// Rendering group
-	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,	FRAME_RENDERING_START + 26,		STR_TILE_SMOOTHING, 			STR_TILE_SMOOTHING_TIP },				// Landscape smoothing
-	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,	FRAME_RENDERING_START + 41,		STR_GRIDLINES,					STR_GRIDLINES_TIP },					// Gridlines
-	{ WWT_DROPDOWN,			1,	155,	299,	FRAME_RENDERING_START + 45,	FRAME_RENDERING_START + 55,		STR_NONE,						STR_NONE },								// Construction marker
-	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	FRAME_RENDERING_START + 46,	FRAME_RENDERING_START + 54,		STR_DROPDOWN_GLYPH,				STR_CONSTRUCTION_MARKER_COLOUR_TIP },
-	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 60,	FRAME_RENDERING_START + 71,		STR_CYCLE_DAY_NIGHT,			STR_CYCLE_DAY_NIGHT_TIP },				// Cycle day-night
-	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 75,	FRAME_RENDERING_START + 86,		STR_UPPERCASE_BANNERS,			STR_UPPERCASE_BANNERS_TIP },			// Uppercase banners
-	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 90,	FRAME_RENDERING_START + 101,	STR_DISABLE_LIGHTNING_EFFECT,	STR_DISABLE_LIGHTNING_EFFECT_TIP },		// Disable lightning effect
+	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,		FRAME_RENDERING_START + 136,	STR_RENDERING_GROUP,			STR_NONE },								// Rendering group
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,		FRAME_RENDERING_START + 26,		STR_TILE_SMOOTHING, 			STR_TILE_SMOOTHING_TIP },				// Landscape smoothing
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,		FRAME_RENDERING_START + 41,		STR_GRIDLINES,					STR_GRIDLINES_TIP },					// Gridlines
+	{ WWT_DROPDOWN,			1,	155,	299,	FRAME_RENDERING_START + 45,		FRAME_RENDERING_START + 55,		STR_NONE,						STR_NONE },								// Construction marker
+	{ WWT_DROPDOWN_BUTTON,	1,	288,	298,	FRAME_RENDERING_START + 46,		FRAME_RENDERING_START + 54,		STR_DROPDOWN_GLYPH,				STR_CONSTRUCTION_MARKER_COLOUR_TIP },
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 60,		FRAME_RENDERING_START + 71,		STR_CYCLE_DAY_NIGHT,			STR_CYCLE_DAY_NIGHT_TIP },				// Cycle day-night
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 75,		FRAME_RENDERING_START + 86,		STR_UPPERCASE_BANNERS,			STR_UPPERCASE_BANNERS_TIP },			// Uppercase banners
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 90,		FRAME_RENDERING_START + 101,	STR_DISABLE_LIGHTNING_EFFECT,	STR_DISABLE_LIGHTNING_EFFECT_TIP },		// Disable lightning effect
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 105,	FRAME_RENDERING_START + 116,	STR_RENDER_WEATHER_EFFECTS,		STR_RENDER_WEATHER_EFFECTS_TIP },		// Render weather effects
 #undef FRAME_RENDERING_START
 	{ WIDGETS_END },
 };
@@ -463,7 +465,8 @@ static uint32 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
 	(1 << WIDX_DAY_NIGHT_CHECKBOX) |
 	(1 << WIDX_UPPER_CASE_BANNERS_CHECKBOX) |
-	(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX),
+	(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX) |
+	(1 << WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
 	(1 << WIDX_LANGUAGE) |
@@ -650,6 +653,12 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 			gConfigGeneral.disable_lightning_effect ^= 1;
 			config_save_default();
 			window_invalidate(w);
+			break;
+		case WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX:
+			gConfigGeneral.render_weather_effects ^= 1;
+			gConfigGeneral.render_weather_gloom = gConfigGeneral.render_weather_effects;
+			config_save_default();
+			gfx_invalidate_screen();
 			break;
 		}
 		break;
@@ -1462,6 +1471,7 @@ static void window_options_invalidate(rct_window *w)
 		widget_set_checkbox_value(w, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
 		widget_set_checkbox_value(w, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
 		widget_set_checkbox_value(w, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, gConfigGeneral.disable_lightning_effect);
+		widget_set_checkbox_value(w, WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX, gConfigGeneral.render_weather_effects || gConfigGeneral.render_weather_gloom);
 
 		// construction marker: white/translucent
 		static const rct_string_id construction_marker_colours[] = {
@@ -1477,6 +1487,7 @@ static void window_options_invalidate(rct_window *w)
 		window_options_rendering_widgets[WIDX_DAY_NIGHT_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_rendering_widgets[WIDX_UPPER_CASE_BANNERS_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_rendering_widgets[WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX].type = WWT_CHECKBOX;
+		window_options_rendering_widgets[WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX].type = WWT_CHECKBOX;
 		break;
 
 	case WINDOW_OPTIONS_PAGE_CULTURE:

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -657,9 +657,6 @@ static void window_options_mouseup(rct_window *w, int widgetIndex)
 		case WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX:
 			gConfigGeneral.render_weather_effects ^= 1;
 			gConfigGeneral.render_weather_gloom = gConfigGeneral.render_weather_effects;
-			if (!gConfigGeneral.render_weather_effects) {
-				gConfigGeneral.disable_lightning_effect = true;
-			}
 			config_save_default();
 			window_invalidate(w);
 			gfx_invalidate_screen();
@@ -1478,10 +1475,6 @@ static void window_options_invalidate(rct_window *w)
 		widget_set_checkbox_value(w, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, gConfigGeneral.disable_lightning_effect);
 		if (!gConfigGeneral.render_weather_effects && !gConfigGeneral.render_weather_gloom) {
 			widget_set_checkbox_value(w, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, true);
-			if (!gConfigGeneral.disable_lightning_effect) {
-				gConfigGeneral.disable_lightning_effect = true;
-				config_save_default();
-			}
 			w->enabled_widgets &= ~(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
 			w->disabled_widgets |= (1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
 		}

--- a/src/world/climate.c
+++ b/src/world/climate.c
@@ -296,15 +296,14 @@ static void climate_update_thunder_sound()
 
 static void climate_update_lightning()
 {
-	if (_lightningTimer == 0)
+	if (_lightningTimer == 0 || gConfigGeneral.disable_lightning_effect || 
+		(!gConfigGeneral.render_weather_effects && !gConfigGeneral.render_weather_gloom))
 		return;
-
-	if (!gConfigGeneral.disable_lightning_effect) {
-		_lightningTimer--;
-		if (gClimateLightningFlash == 0)
-			if ((util_rand() & 0xFFFF) <= 0x2000)
-				gClimateLightningFlash = 1;
-	}
+	
+	_lightningTimer--;
+	if (gClimateLightningFlash == 0)
+		if ((util_rand() & 0xFFFF) <= 0x2000)
+			gClimateLightningFlash = 1;
 }
 
 static void climate_update_thunder()


### PR DESCRIPTION
I've always hated the gloomy colours when it rains, I mean it's nice when not building anything, but if I'm designing something I want to be able to see it in its entirety but that will be addressed later. I've also noticed that when streaming, if it begins to rain it can add excessive noise to the video stream and distort the image. One could freeze the weather, but that will remove game logic such as plants getting watered, increase in umbrella sales, etc. This allows a user to disable the rendering of the weather gloom and effects while still keeping core gameplay normal. 

For now this is not yet finished as I may consider adding that option to only disable gloom when in construction mode. I also noticed that VS merged changes in the solution and project user file, which I need to remove. But for now I'm posting this commit (via phone) because I'm not sure when I will have time to get on my computer again (swing shift jobs suck), and this can get some feedback in the meantime.