### PR TITLE
Fix another cause of #4204

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -456,7 +456,6 @@ static void openrct2_loop()
 				invalidate_sprite_2(get_sprite(i));
 				sprite_set_coordinates(_spritelocations2[i].x, _spritelocations2[i].y, _spritelocations2[i].z, get_sprite(i));
 			}
-			network_update();
 		} else {
 			uncapTick = 0;
 			currentTick = SDL_GetTicks();


### PR DESCRIPTION
The bug was only occurring when I had uncap fps on.
What appeared to be happening is the sprite locations were restored from tween to real positions, except this extra unnecessary network_update was sometimes modifying sprites because of a game command.  Then the next loop would happen fast enough that the logic wouldn't update, it would just draw more tweens.  So, the sprites would be "restored" to an invalid location.
I can't get it to crash anymore but maybe other people can test.