### PR TITLE
Group improvements (duplicate and reorder groups)

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4222,6 +4222,9 @@ STR_5910    :Apply
 STR_5911    :See-Through Paths
 STR_5912    :See-through paths toggle
 STR_5913    :Chat
+STR_5914    :Duplicate
+STR_5915    :Move Up
+STR_5916    :Move Down
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -3346,6 +3346,9 @@ enum {
 	STR_SEE_THROUGH_PATHS = 5911,
 	STR_SHORTCUT_SEE_THROUGH_PATHS_TOGGLE = 5912,
 	STR_CHAT = 5913,
+	STR_DUPLICATE = 5914,
+	STR_MOVE_UP = 5915,
+	STR_MOVE_DOWN = 5916,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/network/NetworkUser.cpp
+++ b/src/network/NetworkUser.cpp
@@ -192,6 +192,19 @@ void NetworkUserManager::UnsetUsersOfGroup(uint8 groupId)
     }
 }
 
+void NetworkUserManager::MoveUsersOfGroupToGroup(uint8 source_id, uint8 dest_id)
+{
+    for (const auto &kvp : _usersByHash)
+    {
+        NetworkUser * networkUser = kvp.second;
+        if (networkUser->GroupId.HasValue() &&
+            networkUser->GroupId.GetValue() == source_id)
+        {
+            networkUser->GroupId = dest_id;
+        }
+    }
+}
+
 void NetworkUserManager::RemoveUser(const std::string &hash)
 {
     NetworkUser * networkUser = GetUserByHash(hash);

--- a/src/network/NetworkUser.h
+++ b/src/network/NetworkUser.h
@@ -53,6 +53,7 @@ public:
     void Save();
 
     void UnsetUsersOfGroup(uint8 groupId);
+    void MoveUsersOfGroupToGroup(uint8 source_id, uint8 dest_id);
     void RemoveUser(const std::string &hash);
 
     NetworkUser * GetUserByHash(const std::string &hash);

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus
@@ -111,6 +111,8 @@ public:
 	void AdvertiseHeartbeat();
 	NetworkGroup* AddGroup();
 	void RemoveGroup(uint8 id);
+	NetworkGroup* DuplicateGroup(uint8 id);
+	bool SwapGroup(uint8 id_a, uint8 id_b);
 	uint8 GetDefaultGroup();
 	uint8 GetGroupIDByHash(const std::string &keyhash);
 	void SetDefaultGroup(uint8 id);


### PR DESCRIPTION
This adds the ability to duplicate and move up or down groups in the list, making it easier for group management.  from what i have tested it seems to work, although i am not even sure if i am approaching the group swapping reasonably, as i might be missing some more obvious approach.

[http://i.imgur.com/MdTmgtt.png](http://i.imgur.com/MdTmgtt.png)

Later on (bucket list ideas)...
I may later on make a confirmation prompt for removing a group (or even merging all the current prompts such as fire staff, delete track, demolish ride, etc, into a single confirm prompt that can be used for multiple reasons), and i'd like to rewrite the dropdown window to allow linking which window opens the dropdown, that way it can reload the groups if a group is moved up or down, or i may create a column to the left of the permissions list that displays the selected group and allow drag and drop arrangement (similar to the inventions list editor window), but these are bigger projects that will have to wait until later (especially the seperate draggable group list, as i will need to study how the inventions list works)..
