### PR TITLE
Fix assertion getting hit on valid path types

### DIFF
--- a/src/rct1/S4Importer.h
+++ b/src/rct1/S4Importer.h
@@ -54,7 +54,7 @@ private:
     uint8 _smallSceneryTypeToEntryMap[256];
     uint8 _largeSceneryTypeToEntryMap[256];
     uint8 _wallTypeToEntryMap[256];
-    uint8 _pathTypeToEntryMap[16];
+    uint8 _pathTypeToEntryMap[24];
     uint8 _pathAdditionTypeToEntryMap[16];
     uint8 _sceneryThemeTypeToEntryMap[24];
 


### PR DESCRIPTION
The current values of 16 means any park with roads or tiled paths (brown/grey/red/green) will hit the assertion. Valid up to and including 23 are valid, so adjust the value of the map accordingly.