### PR TITLE
Fix #2081: Prevent infinite loop

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: Implementation of the user-defined currency
 - Feature: Add ability to rotate map elements with the tile inspector.
 - Feature: Add ride console command for diagnostics and changing vehicle type.
+- Feature: Allow selecting corners when using the mountain tool.
 - Feature: Allow setting ownership of map edges.
 - Feature: Allow up to 255 cars per train.
 - Feature: Importing SV4 and SC4 files with rides.
@@ -28,6 +29,7 @@
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
 - Fix: [#1038] Guest List is out of order.
+- Fix: [#2081] Game hangs when track has infinite loop.
 - Fix: [#2754] Dragging scrollview fails when scaled.
 - Fix: [#3210] Scenery window scrolls too far.
 - Fix: [#3282] Launched Freefall ride ratings are fixed for Downward Launch (original bug).


### PR DESCRIPTION
Adds an extra iterator that steps forward at half the speed of the normal iterator. If they ever meet, there's a loop in the track and the track is classified as incomplete.
![happy park sb 2016-08-31 17-49-44](https://cloud.githubusercontent.com/assets/13868449/18136378/721da014-6fa5-11e6-989e-faf06a00c76e.png)
