### PR TITLE
Allow 31 trains per ride (cheat and tooltip), solves #3537

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4116,8 +4116,8 @@ STR_5806    :Toggle windowed mode
 STR_5807    :{WINDOW_COLOUR_2}Number of rides: {BLACK}{COMMA16}
 STR_5808    :{WINDOW_COLOUR_2}Number of shops and stalls: {BLACK}{COMMA16}
 STR_5809    :{WINDOW_COLOUR_2}Number of information kiosks and other facilities: {BLACK}{COMMA16}
-STR_5810    :Disable train length limit
-STR_5811    :{SMALLFONT}{BLACK}If checked, you can have up to{NEWLINE}255 cars per train
+STR_5810    :Disable vehicle limits
+STR_5811    :{SMALLFONT}{BLACK}If checked, you can have up to{NEWLINE}255 cars per train and 31{NEWLINE}trains per ride
 STR_5812    :Show multiplayer window
 STR_5813    :{OPENQUOTES}{STRING}{ENDQUOTES}
 STR_5814    :{WINDOW_COLOUR_1}{OPENQUOTES}{STRING}{ENDQUOTES}
@@ -4230,6 +4230,8 @@ STR_5918    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{COM
 STR_5919    :{COMMA16}
 STR_5920    :Render weather effects
 STR_5921    :{SMALLFONT}{BLACK}If enabled, rain and gloomy colours will be rendered during storms.
+STR_5922    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{SMALLFONT}{BLACK}Max {STRINGID}
+STR_5923    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{SMALLFONT}{BLACK}Max {COMMA16} {STRINGID} per train
 
 #############
 # Scenarios #

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -3572,6 +3572,8 @@ enum {
 	STR_COMMA16 = 5919,
 	STR_RENDER_WEATHER_EFFECTS = 5920,
 	STR_RENDER_WEATHER_EFFECTS_TIP = 5921,
+	STR_MAX_VEHICLES_TIP = 5922,
+	STR_MAX_CARS_PER_TRAIN_TIP = 5923,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -7641,13 +7641,17 @@ void ride_update_max_vehicles(int rideIndex)
 		ride->max_trains = maxNumTrains;
 
 		numCarsPerTrain = min(ride->proposed_num_cars_per_train, newCarsPerTrain);
-		numVehicles = min(ride->proposed_num_vehicles, maxNumTrains);
 	} else {
 		ride->max_trains = rideEntry->cars_per_flat_ride;
 		ride->min_max_cars_per_train = rideEntry->max_cars_in_train | (rideEntry->min_cars_in_train << 4);
 		numCarsPerTrain = rideEntry->max_cars_in_train;
-		numVehicles = min(ride->proposed_num_vehicles, rideEntry->cars_per_flat_ride);
+		maxNumTrains = rideEntry->cars_per_flat_ride;
 	}
+	
+	if (gCheatsDisableTrainLengthLimit) {
+		maxNumTrains = 31;
+	}
+	numVehicles = min(ride->proposed_num_vehicles, maxNumTrains);
 
 	// Refresh new current num vehicles / num cars per vehicle
 	if (numVehicles != ride->num_vehicles || numCarsPerTrain != ride->num_cars_per_train) {

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -246,10 +246,10 @@ static rct_widget window_ride_vehicle_widgets[] = {
 	{ WWT_DROPDOWN,			1,	7,		308,	50,		61,		0xFFFFFFFF,									STR_NONE										},
 	{ WWT_DROPDOWN_BUTTON,	1,	297,	307,	51,		60,		STR_DROPDOWN_GLYPH,							STR_NONE										},
 	{ WWT_SCROLL,			1,	7,		308,	141,	183,	0,											STR_NONE										},
-	{ WWT_SPINNER,			1,	7,		151,	190,	201,	STR_RIDE_VEHICLE_COUNT,						STR_NONE										},
+	{ WWT_SPINNER,			1,	7,		151,	190,	201,	STR_RIDE_VEHICLE_COUNT,						STR_MAX_VEHICLES_TIP							},
 	{ WWT_DROPDOWN_BUTTON,	1,	140,	150,	191,	195,	STR_NUMERIC_UP,								STR_NONE										},
 	{ WWT_DROPDOWN_BUTTON,	1,	140,	150,	196,	200,	STR_NUMERIC_DOWN,							STR_NONE										},
-	{ WWT_SPINNER,			1,	164,	308,	190,	201,	STR_1_CAR_PER_TRAIN,						STR_NONE										},
+	{ WWT_SPINNER,			1,	164,	308,	190,	201,	STR_1_CAR_PER_TRAIN,						STR_MAX_CARS_PER_TRAIN_TIP										},
 	{ WWT_DROPDOWN_BUTTON,	1,	297,	307,	191,	195,	STR_NUMERIC_UP,								STR_NONE										},
 	{ WWT_DROPDOWN_BUTTON,	1,	297,	307,	196,	200,	STR_NUMERIC_DOWN,							STR_NONE										},
 
@@ -2878,7 +2878,7 @@ static void window_ride_vehicle_invalidate(rct_window *w)
 	}
 
 	// Trains
-	if (rideEntry->cars_per_flat_ride > 1) {
+	if (rideEntry->cars_per_flat_ride > 1 || gCheatsDisableTrainLengthLimit) {
 		window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS].type = WWT_SPINNER;
 		window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_INCREASE].type = WWT_DROPDOWN_BUTTON;
 		window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_DECREASE].type = WWT_DROPDOWN_BUTTON;
@@ -2909,6 +2909,22 @@ static void window_ride_vehicle_invalidate(rct_window *w)
 	}
 	set_format_arg(8, rct_string_id, stringId);
 	set_format_arg(10, uint16, ride->num_vehicles);
+
+	stringId = RideComponentNames[vehicleType].count;
+	if (ride->max_trains > 1) {
+		stringId = RideComponentNames[vehicleType].count_plural;
+	}
+	set_format_arg(12, rct_string_id, stringId);
+	set_format_arg(14, uint16, ride->max_trains);
+
+	set_format_arg(16, uint16, max(1, ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars);
+
+	stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].singular;
+	if ((ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars > 1) {
+		stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].plural;
+	}
+
+	set_format_arg(18, rct_string_id, stringId);
 
 	window_ride_anchor_border_widgets(w);
 	window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_10);


### PR DESCRIPTION
Changes the disable train lenght limit cheat to also disable the limit on the number of trains and renames it to 'disable vehicle limits'. Now any tracked ride can have up to 31 trains with 255 cars each. To reduce confusion, I also added a tooltip to the spinners on the vehicle tab that show the original limit (even if the cheat is turned on).
![trainlimittooltip](https://cloud.githubusercontent.com/assets/13868449/18226976/c29b82a4-7216-11e6-883d-08eeae985bed.jpg)
