### PR TITLE
Prevent going over _windowNewRideListItems

### DIFF
--- a/src/windows/new_ride.c
+++ b/src/windows/new_ride.c
@@ -669,7 +669,7 @@ static void window_new_ride_scrollgetsize(rct_window *w, int scrollIndex, int *w
 	ride_list_item *listItem = _windowNewRideListItems;
 
 	int count = 0;
-	while (listItem->type != 255 || listItem->entry_index != 255) {
+	while ((listItem < &_windowNewRideListItems[countof(_windowNewRideListItems) - 1]) && (listItem->type != 255 || listItem->entry_index != 255)) {
 		count++;
 		listItem++;
 	}


### PR DESCRIPTION
Though this may not be preferred way of fixing it, as it may only hide the bug instead of solving it
