### PR TITLE
Ensure _windowNewRideHighlightedItem is accessed properly

### DIFF
--- a/src/windows/new_ride.c
+++ b/src/windows/new_ride.c
@@ -391,6 +391,7 @@ static void window_new_ride_scroll_to_focused_ride(rct_window *w)
 
 	// Find row index of the focused ride type
 	rct_widget *listWidget = &window_new_ride_widgets[WIDX_RIDE_LIST];
+	assert(_windowNewRideCurrentTab < countof(_windowNewRideHighlightedItem));
 	int focusRideType = _windowNewRideHighlightedItem[_windowNewRideCurrentTab].ride_type_and_entry;
 	int count = 0, row = 0;
 	ride_list_item *listItem = _windowNewRideListItems;


### PR DESCRIPTION
Similar to https://github.com/OpenRCT2/OpenRCT2/pull/4395 but more aggressive, as I couldn't find nicer way around it.
