### PR TITLE
Fixes _scenarioFileName pointing to deleted memory

### DIFF
--- a/src/scenario.c
+++ b/src/scenario.c
@@ -302,7 +302,7 @@ static void scenario_end()
 void scenario_set_filename(const char *value)
 {
 	substitute_path(_scenarioPath, gRCT2AddressScenariosPath, value);
-	_scenarioFileName = path_get_filename(value);
+	_scenarioFileName = path_get_filename(_scenarioPath);
 }
 
 /**


### PR DESCRIPTION
`_scenarioFileName` was pointing to memory from the S6Importer, which gets removed after loading.