### PR TITLE
Fix corrupted tcp stream when pinging while sending packets

### DIFF
--- a/src/network/NetworkConnection.cpp
+++ b/src/network/NetworkConnection.cpp
@@ -121,7 +121,17 @@ void NetworkConnection::QueuePacket(std::unique_ptr<NetworkPacket> packet, bool 
         packet->size = (uint16)packet->data->size();
         if (front)
         {
-            _outboundPackets.push_front(std::move(packet));
+            // If the first packet was already partially sent add new packet to second position
+            if (_outboundPackets.size() > 0 && _outboundPackets.front()->transferred > 0)
+            {
+                auto it = _outboundPackets.begin();
+                it++; // Second position
+                _outboundPackets.insert(it, std::move(packet));
+            }
+            else
+            {
+                _outboundPackets.push_front(std::move(packet));
+            }
         }
         else
         {


### PR DESCRIPTION
If a packet is pushed to the front of the queue (e.g. ping) while the first packet is already partially transmitted it will corrupt the tcp stream because now the new packet data is written instead of the rest of the previous packet.

This pull request fixes this by checking if the first packet in the queue is already partially written to the stream. If this is the case the new packet is inserted at the second position instead.