### PR TITLE
Defer instantiation of TextureCache until OpenGL is initialized

### DIFF
--- a/src/drawing/NewDrawing.cpp
+++ b/src/drawing/NewDrawing.cpp
@@ -92,11 +92,13 @@ extern "C"
                 if (_drawingEngineType == DRAWING_ENGINE_SOFTWARE)
                 {
                     _drawingEngineType = DRAWING_ENGINE_NONE;
+                    log_error(ex.GetMessage());
                     log_fatal("Unable to initialise a drawing engine.");
                     exit(-1);
                 }
                 else
                 {
+                    log_error(ex.GetMessage());
                     log_error("Unable to initialise drawing engine. Falling back to software.");
 
                     // Fallback to software

--- a/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -503,7 +503,6 @@ IDrawingEngine * DrawingEngineFactory::CreateOpenGL()
 OpenGLDrawingContext::OpenGLDrawingContext(OpenGLDrawingEngine * engine)
 {
     _engine = engine;
-    _textureCache = new TextureCache();
 }
 
 OpenGLDrawingContext::~OpenGLDrawingContext()
@@ -522,6 +521,7 @@ IDrawingEngine * OpenGLDrawingContext::GetEngine()
 
 void OpenGLDrawingContext::Initialise()
 {
+    _textureCache = new TextureCache();
     _drawImageShader = new DrawImageShader();
     _drawLineShader = new DrawLineShader();
     _fillRectShader = new FillRectShader();


### PR DESCRIPTION
Right now the TextureCache is instantiated before OpenGL is initialized. If something goes wrong during the initialization of OpenGL the destructor of TextureCache is called, which performs a call to the (uninitialized) function glDeleteTextures. This causes the game to crash.

This PR addresses this issue by deferring the instantiation of TextureCache until OpenGL is initialized.

The second commit adds logging for the exception messages which caused a rendering engine to fail to give better feedback about what exactly went wrong.