### PR TITLE
Partially integrate gCurrentViewportFlags

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -38,7 +38,6 @@
 #include "window.h"
 
 //#define DEBUG_SHOW_DIRTY_BOX
-uint32 gCurrentViewportFlags = 0;
 uint8 gShowGridLinesRefCount;
 uint8 gShowLandRightsRefCount;
 uint8 gShowConstuctionRightsRefCount;
@@ -56,6 +55,7 @@ sint16 gSavedViewY;
 uint8 gSavedViewZoom;
 uint8 gSavedViewRotation;
 uint8 gCurrentRotation;
+uint32 gCurrentViewportFlags = 0;
 #endif
 
 uint32 gUnkEDF81C;
@@ -692,10 +692,6 @@ const sint32 WeatherColours[] = {
  */
 void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, int top, int right, int bottom){
 	gCurrentViewportFlags = viewport->flags;
-	//This should still be updated until the rest of supports, etc, is reverse-engineered. Otherwise
-	// supports for unimplemented rollercoasters will still appear even if "invisible supports"
-	// are enabled.
-	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint16) = (uint16)viewport->flags;
 	RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_ZOOM, uint16) = viewport->zoom;
 
 	uint16 width = right - left;

--- a/src/interface/viewport.h
+++ b/src/interface/viewport.h
@@ -88,8 +88,6 @@ typedef struct viewport_interaction_info {
 
 #define MAX_VIEWPORT_COUNT WINDOW_LIMIT_MAX
 
-extern uint32 gCurrentViewportFlags;
-
 /**
  * A reference counter for whether something is forcing the grid lines to show. When the counter
  * is decremented to 0, the grid lines are hidden.
@@ -109,6 +107,7 @@ extern sint16 gSavedViewY;
 extern uint8 gSavedViewZoom;
 extern uint8 gSavedViewRotation;
 extern uint8 gCurrentRotation;
+extern uint32 gCurrentViewportFlags;
 #else
 	#define unk_EE7884 RCT2_GLOBAL(0x00EE7884, paint_struct*)
 	#define unk_EE7888 RCT2_GLOBAL(0x00EE7888, paint_struct*)
@@ -117,6 +116,7 @@ extern uint8 gCurrentRotation;
 	#define gSavedViewZoom			RCT2_GLOBAL(RCT2_ADDRESS_SAVED_VIEW_ZOOM, uint8)
 	#define gSavedViewRotation		RCT2_GLOBAL(RCT2_ADDRESS_SAVED_VIEW_ROTATION, uint8)
 	#define gCurrentRotation		RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_ROTATION, uint8)
+	#define gCurrentViewportFlags	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS, uint32)
 #endif
 
 extern uint32 gUnkEDF81C;


### PR DESCRIPTION
The two bytes after `RCT2_ADDRESS_CURRENT_VIEWPORT_FLAGS` don't seem to be used, according to IDA. As far as I understand endianness, updating from an uin16 to an uint32 should be save.