### PR TITLE
Fix peep interactions with provisional paths

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -364,8 +364,11 @@ void game_logic_update()
 	scenario_update();
 	climate_update();
 	map_update_tiles();
+	// Temporarily remove provisional paths to prevent peep from interacting with them
+	map_remove_provisional_elements();
 	map_update_path_wide_flags();
 	peep_update_all();
+	map_restore_provisional_elements();
 	vehicle_update_all();
 	sprite_misc_update_all();
 	ride_update_all();

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -220,7 +220,7 @@ static money32 footpath_element_insert(int type, int x, int y, int z, int slope,
 		mapElement->properties.path.additions = pathItemType;
 		mapElement->properties.path.addition_status = 255;
 		mapElement->flags &= ~MAP_ELEMENT_FLAG_BROKEN;
-		if (flags & (1 << 6))
+		if (flags & GAME_COMMAND_FLAG_GHOST)
 			mapElement->flags |= MAP_ELEMENT_FLAG_GHOST;
 
 		footpath_queue_chain_reset();

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -34,6 +34,8 @@ void sub_6A7642(int x, int y, rct_map_element *mapElement);
 
 uint8 gFootpathProvisionalFlags;
 rct_xyz16 gFootpathProvisionalPosition;
+uint8 gFootpathProvisionalType;
+uint8 gFootpathProvisionalSlope;
 uint8 gFootpathConstructionMode;
 uint16 gFootpathSelectedId;
 uint8 gFootpathSelectedType;
@@ -614,9 +616,11 @@ money32 footpath_provisional_set(int type, int x, int y, int z, int slope)
 
 	cost = footpath_place(type, x, y, z, slope, GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_5 | GAME_COMMAND_FLAG_4 | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_APPLY);
 	if (cost != MONEY32_UNDEFINED) {
+		gFootpathProvisionalType = type;
 		gFootpathProvisionalPosition.x = x;
 		gFootpathProvisionalPosition.y = y;
 		gFootpathProvisionalPosition.z = z & 0xFF;
+		gFootpathProvisionalSlope = slope;
 		gFootpathProvisionalFlags |= PROVISIONAL_PATH_FLAG_1;
 
 		if (gFootpathGroundFlags & ELEMENT_IS_UNDERGROUND) {

--- a/src/world/footpath.h
+++ b/src/world/footpath.h
@@ -52,6 +52,8 @@ enum {
 
 extern uint8 gFootpathProvisionalFlags;
 extern rct_xyz16 gFootpathProvisionalPosition;
+extern uint8 gFootpathProvisionalType;
+extern uint8 gFootpathProvisionalSlope;
 extern uint8 gFootpathConstructionMode;
 extern uint16 gFootpathSelectedId;
 extern uint8 gFootpathSelectedType;

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -4442,6 +4442,28 @@ static void map_set_grass_length(int x, int y, rct_map_element *mapElement, int 
 	map_invalidate_tile(x, y, z0, z1);
 }
 
+void map_remove_provisional_elements()
+{
+	if (gFootpathProvisionalFlags & PROVISIONAL_PATH_FLAG_1)
+	{
+		footpath_provisional_remove();
+		gFootpathProvisionalFlags |= PROVISIONAL_PATH_FLAG_1;
+	}
+}
+
+void map_restore_provisional_elements()
+{
+	if (gFootpathProvisionalFlags & PROVISIONAL_PATH_FLAG_1)
+	{
+		gFootpathProvisionalFlags &= ~PROVISIONAL_PATH_FLAG_1;
+		footpath_provisional_set(gFootpathProvisionalType,
+				gFootpathProvisionalPosition.x,
+				gFootpathProvisionalPosition.y,
+				gFootpathProvisionalPosition.z,
+				gFootpathProvisionalSlope);
+	}
+}
+
 int map_element_get_banner_index(rct_map_element *mapElement)
 {
 	rct_scenery_entry* sceneryEntry;

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -407,6 +407,8 @@ rct_map_element *map_get_small_scenery_element_at(int x, int y, int z, int type,
 int map_element_height(int x, int y);
 void sub_68B089();
 int map_coord_is_connected(int x, int y, int z, uint8 faceDirection);
+void map_remove_provisional_elements();
+void map_restore_provisional_elements();
 void map_update_path_wide_flags();
 bool map_is_location_valid(int x, int y);
 bool map_is_location_owned(int x, int y, int z);


### PR DESCRIPTION
Currently provisional paths (the preview of the path builder tool) are treated almost like paths that were already built. They affect the path finding algorithm, (temporarily) remove scenery like benches and bins and staff even walks over them. Since provisional paths aren't synced in multiplayer this causes quite a lot of desync.
These bugs also cause problems in singleplayer since you can accidentally drown a employee that decided to walk over a bridge that wasn't built yet.

This PR makes peeps ignore provisional paths. This even allows peeps to sit on benches which are currently hidden by the path builder. While this looks quite odd I wouldn't consider it a bug since the bench isn't actually gone but just hidden for the sake of previewing what would happen if the path was built. Also peeps that already sit on the bench is hidden don't stand up either.