### PR TITLE
Fix macOS 64-bit build black screen issue

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -769,7 +769,9 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, in
 			}
 			gfx_clear(dpi2, colour);
 		}
+#ifndef NO_RCT2
 		g_ps_EE7880 = &gUnkF1A4CC;
+#endif
 		unk_140E9A8 = dpi2;
 		painter_setup();
 		viewport_paint_setup();
@@ -1398,7 +1400,9 @@ void get_map_coordinates_from_pos(int screenX, int screenY, int flags, sint16 *x
 			dpi->zoom_level = _viewportDpi1.zoom_level;
 			dpi->x = _viewportDpi1.x;
 			dpi->width = 1;
+#ifndef NO_RCT2
 			g_ps_EE7880 = &gUnkF1A4CC;
+#endif
 			unk_140E9A8 = dpi;
 			painter_setup();
 			viewport_paint_setup();

--- a/src/paint/paint.c
+++ b/src/paint/paint.c
@@ -38,10 +38,8 @@ uint32 _F1AD0C;
 uint32 _F1AD10;
 static paint_struct *_paint_structs[512];
 void *g_currently_drawn_item;
-paint_struct * g_ps_EE7880;
 sint16 gUnk9DE568;
 sint16 gUnk9DE56C;
-paint_struct gUnkF1A4CC;
 uint8 gPaintInteractionType;
 support_height gSupportSegments[9] = { 0 };
 support_height gSupport;
@@ -95,7 +93,7 @@ static paint_struct * sub_9819_c(uint32 image_id, rct_xyz16 offset, rct_xyz16 bo
 {
 	paint_struct * ps = unk_EE7888;
 
-	if (ps >= g_ps_EE7880) return NULL;
+	if (ps >= &_unkEE788C[3999]) return NULL;
 
 	ps->image_id = image_id;
 
@@ -209,7 +207,7 @@ paint_struct * sub_98196C(
 	//Not a paint struct but something similar
 	paint_struct *ps = unk_EE7888;
 
-	if (ps >= g_ps_EE7880) {
+	if (ps >= &_unkEE788C[3999]) {
 		return NULL;
 	}
 
@@ -545,7 +543,7 @@ bool paint_attach_to_previous_attach(uint32 image_id, uint16 x, uint16 y)
 
 	attached_paint_struct * ps = (attached_paint_struct *)unk_EE7888;
 
-	if ((paint_struct *)ps >= g_ps_EE7880) {
+	if ((paint_struct *)ps >= &_unkEE788C[3999]) {
         return false;
     }
 
@@ -578,7 +576,7 @@ bool paint_attach_to_previous_ps(uint32 image_id, uint16 x, uint16 y)
 {
 	attached_paint_struct * ps = (attached_paint_struct *)unk_EE7888;
 
-	if ((paint_struct *)ps >= g_ps_EE7880) {
+	if ((paint_struct *)ps >= &_unkEE788C[3999]) {
         return false;
     }
 
@@ -618,7 +616,7 @@ void sub_685EBC(money32 amount, rct_string_id string_id, sint16 y, sint16 z, sin
 {
 	paint_string_struct * ps = (paint_string_struct *)unk_EE7888;
 
-	if ((paint_struct *)ps >= g_ps_EE7880) {
+	if ((paint_struct *)ps >= &_unkEE788C[3999]) {
 		return;
 	}
 

--- a/src/paint/paint.h
+++ b/src/paint/paint.h
@@ -29,16 +29,14 @@ typedef struct paint_struct paint_struct;
 
 #ifdef NO_RCT2
 	extern void *g_currently_drawn_item;
-	extern paint_struct * g_ps_EE7880;
 	extern sint16 gUnk9DE568;
 	extern sint16 gUnk9DE56C;
-	extern paint_struct gUnkF1A4CC;
 #else
 	#define g_currently_drawn_item	RCT2_GLOBAL(0x009DE578, void*)
 	#define g_ps_EE7880				RCT2_GLOBAL(0x00EE7880, paint_struct *)
 	#define gUnk9DE568				RCT2_GLOBAL(0x009DE568, sint16)
 	#define gUnk9DE56C				RCT2_GLOBAL(0x009DE56C, sint16)
-	#define gUnkF1A4CC				RCT2_GLOBAL(0x00F1A4CC, paint_struct);
+	#define gUnkF1A4CC				RCT2_GLOBAL(0x00F1A4CC, paint_struct)
 #endif
 
 #pragma pack(push, 1)

--- a/src/windows/ride_construction.c
+++ b/src/windows/ride_construction.c
@@ -2310,7 +2310,9 @@ static void sub_6CBCE2(
 	gCurrentViewportFlags = 0;
 	trackDirection &= 3;
 
+#ifndef NO_RCT2
 	g_ps_EE7880 = &gUnkF1A4CC;
+#endif
 	painter_setup();
 
 	ride = get_ride(rideIndex);


### PR DESCRIPTION
This was caused by `gUnkF1A4CC` being used as the stopping point in `_unkEE788C`. The variables overlapped without the `NO_RCT2` macro due to the usage of `RCT2_GLOBAL`, but didn't overlap when compiled with `NO_RCT2`. It appears that the mac compiler just happened to put `gUnkF1A4CC` before `_unkEE788C` in memory, causing the black screen. I'm sure there are other issues like this still in the code, but this is the one I found.