### PR TITLE
Removed reference to deprecated NSWarningAlertStyle.

### DIFF
--- a/src/platform/macos.m
+++ b/src/platform/macos.m
@@ -104,7 +104,6 @@ void platform_show_messagebox(char *message)
 		NSAlert *alert = [[[NSAlert alloc] init] autorelease];
 		[alert addButtonWithTitle:@"OK"];
 		alert.messageText = [NSString stringWithUTF8String:message];
-		alert.alertStyle = NSWarningAlertStyle;
 		[alert runModal];
 	}
 }


### PR DESCRIPTION
macOS 10.12 deprecates the use of NSWarningAlertStyle. As there is "[no visual difference between informational and warning alerts](https://developer.apple.com/reference/appkit/nsalertstyle)", it suffices to just remove the reference.