### PR TITLE
Guard access to _numAvailableObjectsForType

### DIFF
--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -652,6 +652,7 @@ static int sub_6AB211()
 	const ObjectRepositoryItem * items = object_repository_get_items();
 	for (int i = 0; i < numObjects; i++) {
 		uint8 objectType = items[i].ObjectEntry.flags & 0xF;
+		assert(objectType < countof(_numAvailableObjectsForType));
 		_numAvailableObjectsForType[objectType]++;
 	}
 


### PR DESCRIPTION

[1001NIGH.DAT.zip](https://github.com/OpenRCT2/OpenRCT2/files/491029/1001NIGH.DAT.zip)

```
>>> p items[i]
$1 = {
  Id = 0, 
  ObjectEntry = {
    flags = 1413698158, 
    name = "\000\213\030\n1001", 
    checksum = 1212631374
  }, 
  Path = 0xf3e270e0 "\373T\347E/home/janisozaur/games/Rollercoaster Tycoon 2/ObjData/1001NIGH.DAT", 
  Name = 0xe685c5b0 "1001 Nights", 
  LoadedObject = 0x0, 
  {
    {
      RideFlags = 0 '\000', 
      RideCategory = "\000", 
      RideType = "\000\000"
    }, 
    {
      NumThemeObjects = 0, 
      ThemeObjects = 0x0
    }
  }
}
```