### PR TITLE
Fix Crash on Optimixed macOS Build

### DIFF
--- a/src/title.c
+++ b/src/title.c
@@ -367,7 +367,7 @@ static void title_do_next_script_opcode()
 	case TITLE_SCRIPT_LOAD:
 		{
 			char *ch, filename[32], path[MAX_PATH];
-			char separator = platform_get_path_separator();
+			char separator[2] = {platform_get_path_separator(), '\0'};
 
 			// Get filename
 			ch = filename;
@@ -382,7 +382,7 @@ static void title_do_next_script_opcode()
 			else {
 				platform_get_user_directory(path, "title sequences");
 				strcat(path, gConfigTitleSequences.presets[_scriptCurrentPreset].name);
-				strncat(path, &separator, 1);
+				strcat(path, separator);
 			}
 
 			strcat(path, filename);


### PR DESCRIPTION
I noticed an odd crash on macOS that only appeared when compiled with optimizations. Apparently, the optimizer does something that upsets the runtime checks when calling strncat. This removes that unexpected behavior of the optimizer, and prevents the crash.