### PR TITLE
Add sprite_exporter target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,27 @@ if (UNIX AND (NOT USE_MMAP) AND (NOT DISABLE_RCT2) AND (NOT FORCE64))
 	add_dependencies(testpaint segfiles)
 endif ()
 
+# A target that can be used just to generate g2.dat, it may be needed
+# separately from openrct2 proper
+file(GLOB_RECURSE ORCT2_PLATFORM_SOURCES "src/platform/*.c")
+file(GLOB_RECURSE ORCT2_CORE_SOURCES "src/core/*.cpp")
+set(ORCT2_SPRITE_EXPORTER_SOURCES
+    "src/cmdline_sprite.c"
+    "src/cmdline/SpriteCommands.cpp"
+    "src/cmdline/RootCommands.cpp"
+    "src/cmdline/CommandLine.cpp"
+    "src/diagnostic.c"
+    "src/drawing/drawing_fast.cpp"
+    "src/image_io.c"
+    "src/localisation/utf8.c"
+    "src/util/sawyercoding.c"
+    "src/util/util.c"
+    )
+add_executable(sprite_exporter EXCLUDE_FROM_ALL ${ORCT2_SPRITE_EXPORTER_SOURCES} ${ORCT2_PLATFORM_SOURCES} ${ORCT2_CORE_SOURCES})
+set_target_properties(sprite_exporter PROPERTIES COMPILE_FLAGS "-DSPRITE_EXPORTER_ONLY -DNO_RCT2")
+# if creating a static binary, precede libraries with -static, then name all the libs
+TARGET_LINK_LIBRARIES(sprite_exporter ${STATIC_START} ${SDL2LIBS} ${REQUIREDLIBS} ${BREAKPAD_LIBS})
+
 set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 0)
 set(CPACK_PACKAGE_VERSION_PATCH 5)

--- a/src/cmdline/RootCommands.cpp
+++ b/src/cmdline/RootCommands.cpp
@@ -82,10 +82,12 @@ static const CommandLineOptionDefinition StandardOptions[]
 
 static exitcode_t HandleNoCommand(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandEdit(CommandLineArgEnumerator * enumerator);
+#ifndef SPRITE_EXPORTER_ONLY
 static exitcode_t HandleCommandIntro(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandHost(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator * enumerator);
+#endif
 
 #if defined(__WINDOWS__) && !defined(__MINGW32__)
 
@@ -109,6 +111,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     // Main commands
     DefineCommand("",         "<uri>",                  StandardOptions, HandleNoCommand     ),
     DefineCommand("edit",     "<uri>",                  StandardOptions, HandleCommandEdit   ),
+#ifndef SPRITE_EXPORTER_ONLY
     DefineCommand("intro",    "",                       StandardOptions, HandleCommandIntro  ),
 #ifndef DISABLE_NETWORK
     DefineCommand("host",     "<uri>",                  StandardOptions, HandleCommandHost   ),
@@ -123,6 +126,7 @@ const CommandLineCommand CommandLine::RootCommands[]
 
     // Sub-commands
     DefineSubCommand("screenshot", CommandLine::ScreenshotCommands),
+#endif
     DefineSubCommand("sprite",     CommandLine::SpriteCommands    ),
 
     CommandTableEnd
@@ -172,6 +176,7 @@ exitcode_t CommandLine::HandleCommandDefault()
         result = EXITCODE_OK;
     }
 
+#ifndef SPRITE_EXPORTER_ONLY
     gOpenRCT2Headless = _headless;
     gOpenRCT2SilentBreakpad = _silentBreakpad || _headless;
 
@@ -198,6 +203,7 @@ exitcode_t CommandLine::HandleCommandDefault()
         String::Set(gCustomPassword, sizeof(gCustomPassword), _password);
         Memory::Free(_password);
     }
+#endif
 
     return result;
 }
@@ -210,12 +216,14 @@ exitcode_t HandleNoCommand(CommandLineArgEnumerator * enumerator)
         return result;
     }
 
+#ifndef SPRITE_EXPORTER_ONLY
     const char * parkUri;
     if (enumerator->TryPopString(&parkUri) && parkUri[0] != '-')
     {
         String::Set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
         gOpenRCT2StartupAction = STARTUP_ACTION_OPEN;
     }
+#endif
 
     return EXITCODE_CONTINUE; 
 }
@@ -234,12 +242,15 @@ exitcode_t HandleCommandEdit(CommandLineArgEnumerator * enumerator)
         Console::Error::WriteLine("Expected path or URL to a saved park.");
         return EXITCODE_FAIL;
     }
+#ifndef SPRITE_EXPORTER_ONLY
     String::Set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
 
     gOpenRCT2StartupAction = STARTUP_ACTION_EDIT;
+#endif
     return EXITCODE_CONTINUE;
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 exitcode_t HandleCommandIntro(CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
@@ -247,13 +258,14 @@ exitcode_t HandleCommandIntro(CommandLineArgEnumerator * enumerator)
     {
         return result;
     }
-
     gOpenRCT2StartupAction = STARTUP_ACTION_INTRO;
     return EXITCODE_CONTINUE;
 }
+#endif
 
 #ifndef DISABLE_NETWORK
 
+#ifndef SPRITE_EXPORTER_ONLY
 exitcode_t HandleCommandHost(CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
@@ -297,9 +309,11 @@ exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator)
     String::Set(gNetworkStartHost, sizeof(gNetworkStartHost), hostname);
     return EXITCODE_CONTINUE;
 }
+#endif
 
 #endif // DISABLE_NETWORK
 
+#ifndef SPRITE_EXPORTER_ONLY
 static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
@@ -388,6 +402,7 @@ static exitcode_t HandleCommandRegisterShell(CommandLineArgEnumerator * enumerat
     return EXITCODE_OK;
 }
 #endif // defined(__WINDOWS__) && !defined(__MINGW32__)
+#endif
 
 static void PrintAbout()
 {
@@ -409,7 +424,9 @@ static void PrintAbout()
 static void PrintVersion()
 {
     char buffer[256];
+#ifndef SPRITE_EXPORTER_ONLY
     openrct2_write_full_version_info(buffer, sizeof(buffer));
+#endif
     Console::WriteLine(buffer);
     Console::WriteFormat("%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);
 #ifdef NO_RCT2
@@ -424,8 +441,11 @@ static void PrintLaunchInformation()
     time_t      timer;
     struct tm * tmInfo;
 
+
+#ifndef SPRITE_EXPORTER_ONLY
     // Print name and version information
     openrct2_write_full_version_info(buffer, sizeof(buffer));
+#endif
     Console::WriteFormat("%s", buffer);
     Console::WriteLine();
     Console::WriteFormat("%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);

--- a/src/cmdline_sprite.c
+++ b/src/cmdline_sprite.c
@@ -439,7 +439,9 @@ static bool sprite_file_import(const char *path, rct_g1_element *outElement, uin
 
 int cmdline_for_sprite(const char **argv, int argc)
 {
+#ifndef SPRITE_EXPORTER_ONLY
 	gOpenRCT2Headless = true;
+#endif
 	if (argc == 0)
 		return -1;
 

--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -1174,6 +1174,7 @@ utf8 *get_string_end(const utf8 *text)
 	return (utf8*)(ch - 1);
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 /**
  * Return the number of bytes (including the null terminator) in the given UTF-8 string.
  */
@@ -1285,3 +1286,5 @@ int win1252_to_utf8(utf8string dst, const char *src, size_t maxBufferLength)
 
 	return result;
 }
+
+#endif

--- a/src/localisation/utf8.c
+++ b/src/localisation/utf8.c
@@ -68,6 +68,7 @@ utf8 *utf8_write_codepoint(utf8 *dst, uint32 codepoint)
 	}
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 /**
  * Inserts the given codepoint at the given address, shifting all characters after along.
  * @returns the size of the inserted codepoint.
@@ -80,6 +81,7 @@ int utf8_insert_codepoint(utf8 *dst, uint32 codepoint)
 	utf8_write_codepoint(dst, codepoint);
 	return shift;
 }
+#endif
 
 bool utf8_is_codepoint_start(const utf8 *text)
 {

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -48,8 +48,6 @@
 #include <unistd.h>
 #endif // defined(__unix__) || defined(__MACOSX__)
 
-int gExitCode;
-
 #if defined(__unix__) && !defined(NO_RCT2)
 	static int fdData;
 	static char * segments = (char *)(GOOD_PLACE_FOR_DATA_SEGMENT);

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -68,6 +68,7 @@ void platform_get_exe_path(utf8 *outPath)
 	safe_strcpy(outPath, exePath, exeDelimiterIndex + 1);
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 bool platform_check_steam_overlay_attached() {
 	void* processHandle = dlopen(NULL, RTLD_NOW);
 
@@ -240,6 +241,8 @@ uint8 platform_get_locale_measurement_format(){
 	return MEASUREMENT_FORMAT_METRIC;
 }
 
+#endif
+
 static void execute_cmd(char *command, int *exit_value, char *buf, size_t *buf_size) {
 	FILE *f;
 	size_t n_chars;
@@ -304,6 +307,7 @@ static dialog_type get_dialog_app(char *cmd, size_t *cmd_size) {
 	return dtype;
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 bool platform_open_common_file_dialog(utf8 *outFilename, file_dialog_desc *desc) {
 	int exit_value;
 	char executable[MAX_PATH];
@@ -551,5 +555,7 @@ bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer)
 	FcFini();
 	return found;
 }
+
+#endif
 
 #endif

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -52,12 +52,13 @@ utf8 _openrctDataDirectoryPath[MAX_PATH] = { 0 };
 int main(int argc, const char **argv)
 {
 	int run_game = cmdline_run(argv, argc);
+
+#ifndef SPRITE_EXPORTER_ONLY
 	if (run_game == 1)
 	{
 		openrct2_launch();
 	}
-
-	exit(gExitCode);
+#endif
 	return gExitCode;
 }
 
@@ -672,6 +673,7 @@ static wchar_t *regular_to_wchar(const char* src)
 	return w_buffer;
 }
 
+#ifndef SPRITE_EXPORTER_ONLY
 /**
  * Default directory fallback is:
  *   - (command line argument)
@@ -791,6 +793,7 @@ void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory)
 	free(path);
 	log_verbose("outPath + subDirectory = '%s'", buffer);
 }
+#endif
 
 time_t platform_file_get_modified_time(const utf8* path){
 	struct stat buf;

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -32,6 +32,10 @@
 #include "../world/climate.h"
 #include "platform.h"
 
+int gExitCode;
+
+#ifndef SPRITE_EXPORTER_ONLY
+
 typedef void(*update_palette_func)(const uint8*, int, int);
 
 openrct2_cursor gCursorState;
@@ -811,3 +815,5 @@ uint8 platform_get_currency_value(const char *currCode) {
 	
 	return CURRENCY_POUNDS;
 }
+
+#endif


### PR DESCRIPTION
I confused remotes and pushed to this repo instead of my own by mistake.

This adds a limited `sprite_exporter` target, which should be able to generate `g2.dat`. Its purpose would be to get used when building for foreign platforms which still require `g2.dat`, e.g. Android.