### PR TITLE
Fix chat input text color (Fixes #4304)

### DIFF
--- a/src/interface/chat.c
+++ b/src/interface/chat.c
@@ -146,13 +146,10 @@ void chat_draw(rct_drawpixelinfo * dpi)
 	
 	// Draw current chat input
 	if (gChatOpen) {
-		lineCh = utf8_write_codepoint(lineCh, FORMAT_OUTLINE);
-		lineCh = utf8_write_codepoint(lineCh, FORMAT_CELADON);
-
 		safe_strcpy(lineCh, _chatCurrentLine, sizeof(_chatCurrentLine));
 		y = _chatBottom - inputLineHeight - 5;
 
-		int inputLineHeight = gfx_draw_string_left_wrapped(dpi, (void*)&lineCh, x, y + 3, _chatWidth - 10, STR_STRING, 255);
+		int inputLineHeight = gfx_draw_string_left_wrapped(dpi, (void*)&lineCh, x, y + 3, _chatWidth - 10, STR_STRING, COLOUR_FLAG_OUTLINE + COLOUR_WHITE);
 		gfx_set_dirty_blocks(x, y, x + _chatWidth, y + inputLineHeight + 15);
 		
 		//TODO: Show caret if the input text have multiple lines


### PR DESCRIPTION
When there was a red or green chat message at the top of the chat history, the chat input text would appear that color for some reason. I did some experimenting and using the console to test numbers, i found that 34 keeps the color white and outlined (including during storms/night cycle).. Matching up various definitions, COLOUR_FLAG_OUTLINED gives 32 and COLOUR_WHITE gives 2, so put them together and 34 is no longer a magic number..

TLDR: This keeps chat input text color a steady white outlined color.