### PR TITLE
get_ride_queue_end() fails for some ride queues

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9267,7 +9267,7 @@ static void get_ride_queue_end(sint16 *x, sint16 *y, sint16 *z){
 				if (!footpath_element_is_sloped(mapElement))
 					break;
 
-				if (footpath_element_get_slope_direction(mapElement) != direction)
+				if (footpath_element_get_slope_direction(mapElement) != (direction ^ 2))
 					break;
 
 				baseZ -= 2;


### PR DESCRIPTION
get_ride_queue_end() fails if any tile in the queue goes up towards the station entry.

In this situation the pathfinding goal is set to the station entry location rather than the queue end location.

This fixes #3541.