### PR TITLE
Fix crashes in ride with more than 12 cars per train

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -2272,7 +2272,7 @@ static void peep_update_ride_sub_state_0(rct_peep* peep){
 	}
 
 	uint8 car_array_size = 0xFF;
-	uint8 car_array[12];
+	uint8 car_array[255];
 
 	if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_13)){
 		if (ride->num_riders >= ride->operation_option)


### PR DESCRIPTION
This seems to have been broken by 7cecdeba3f0a2f0bd1990f579f7f9d8e3fce7e7e. It could very well be it silently wrote to adjacent memory before integration.