### PR TITLE
Further pathfinding improvements

### DIFF
--- a/src/core/Diagnostics.cpp
+++ b/src/core/Diagnostics.cpp
@@ -28,8 +28,8 @@ namespace Debug
 {
     void Break()
     {
-#if DEBUG
-#if __WINDOWS__
+#if defined(DEBUG)
+#if defined(__WINDOWS__)
         if (IsDebuggerPresent())
         {
             DebugBreak();

--- a/src/diagnostic.h
+++ b/src/diagnostic.h
@@ -62,6 +62,10 @@ enum {
 			#define DEBUG_LEVEL_3 0
 			#define DEBUG_LEVEL_2 0
 		#endif // DEBUG > 1
+	#else
+		#define DEBUG_LEVEL_1 0
+		#define DEBUG_LEVEL_2 0
+		#define DEBUG_LEVEL_3 0
 	#endif // DEBUG > 0
 #else
 	#define DEBUG_LEVEL_3 0

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8748,7 +8748,7 @@ static bool path_is_thin_junction(rct_map_element *path, sint16 x, sint16 y, uin
  *  rct2: 0x0069A997
  */
 static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_map_element *currentMapElement, uint8 counter, uint16 *endScore, int test_edge, uint8 *endJunctions, rct_xyz8 junctionList[16], uint8 directionList[16], rct_xyz8 *endXYZ, uint8 *endSteps) {
-	uint searchResult = PATH_SEARCH_FAILED;
+	uint8 searchResult = PATH_SEARCH_FAILED;
 
 	x += TileDirectionDelta[test_edge].x;
 	y += TileDirectionDelta[test_edge].y;

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -8878,7 +8878,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_map_
 
 	/* At this point the map element is found. */
 
-	uint height = z;
+	uint8 height = z;
 	if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_PATH) {
 		// Adjust height for goal comparison according to the path slope.
 		if (footpath_element_is_sloped(mapElement)) {

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -102,9 +102,6 @@ enum {
 	PATH_SEARCH_FAILED
 };
 
-// Some text descriptions corresponding to the above enum for understandable debug messages
-const char *gPathFindSearchText[] = {"DeadEnd", "Wide", "Thin", "Junction", "RideQueue", "RideEntrance", "RideExit", "ParkEntryExit", "ShopEntrance", "LimitReached", "PathLoop", "Other", "Failed"};
-
 enum {
 	F1EE18_DESTINATION_REACHED	= 1 << 0,
 	F1EE18_OUTSIDE_PARK			= 1 << 1,

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9251,10 +9251,8 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		uint8 best_sub = 0xFF;
 
 		uint8 bestJunctions = 0;
-		rct_xyz8 bestJunctionList[16];
-		memset(bestJunctionList, 0x0, sizeof(bestJunctionList));
-		uint8 bestDirectionList[16];
-		memset(bestDirectionList, 0x0, sizeof(bestDirectionList));
+		rct_xyz8 bestJunctionList[16] = { 0 };
+		uint8 bestDirectionList[16] = { 0 };
 		rct_xyz8 bestXYZ;
 		bestXYZ.x = 0;
 		bestXYZ.y = 0;

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -20,6 +20,12 @@
 #include "../common.h"
 #include "../world/map.h"
 
+#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+// Some variables used for the path finding debugging.
+extern bool gPathFindDebug;
+extern utf8 gPathFindDebugPeepName[256];
+#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+
 #define PEEP_MAX_THOUGHTS 5
 
 #define PEEP_HUNGER_WARNING_THRESHOLD 25

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -20,6 +20,7 @@
 #include "../interface/viewport.h"
 #include "../localisation/date.h"
 #include "../localisation/string_ids.h"
+#include "../localisation/localisation.h"
 #include "../management/finance.h"
 #include "../util/util.h"
 #include "../world/sprite.h"
@@ -1094,7 +1095,21 @@ static uint8 staff_mechanic_direction_path(rct_peep* peep, uint8 validDirections
 		gPeepPathFindIgnoreForeignQueues = false;
 		gPeepPathFindQueueRideIndex = 255;
 
+		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+		/* Determine if the pathfinding debugging is wanted for this peep. */
+		/* For staff, there is no tracking button (any other similar
+		 * suitable existing mechanism?), so fall back to a crude
+		 * string comparison with a compile time hardcoded name. */
+		format_string(gPathFindDebugPeepName, peep->name_string_idx, &(peep->id));
+
+		gPathFindDebug = strcmp(gPathFindDebugPeepName, "Mechanic Debug") == 0;
+		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+
 		int pathfindDirection = peep_pathfind_choose_direction(peep->next_x, peep->next_y, peep->next_z, peep);
+
+		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+		gPathFindDebug = false;
+		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 		if (pathfindDirection == -1) {
 			return staff_mechanic_direction_path_rand(peep, pathDirections);

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -1757,13 +1757,23 @@ void footpath_update_path_wide_flags(int x, int y)
 		return;
 
 	footpath_clear_wide(x, y);
-	x += 0x20;
-	footpath_clear_wide(x, y);
-	y += 0x20;
-	footpath_clear_wide(x, y);
-	x -= 0x20;
-	footpath_clear_wide(x, y);
-	y -= 0x20;
+	/* Rather than clearing the wide flag of the following tiles and
+	 * checking the state of them later, leave them intact and assume
+	 * they were cleared. Consequently only the wide flag for this single
+	 * tile is modified by this update.
+	 * This is important for avoiding glitches in pathfinding that occurs
+	 * between between the batches of updates to the path wide flags.
+	 * Corresponding pathList[] indexes for the following tiles
+	 * are: 2, 3, 4, 5.
+	 * Note: indexes 3, 4, 5 are reset in the current call;
+	 *       index 2 is reset in the previous call. */
+	//x += 0x20;
+	//footpath_clear_wide(x, y);
+	//y += 0x20;
+	//footpath_clear_wide(x, y);
+	//x -= 0x20;
+	//footpath_clear_wide(x, y);
+	//y -= 0x20;
 
 	rct_map_element *mapElement = map_get_first_element_at(x / 32, y / 32);
 	do {
@@ -1825,20 +1835,30 @@ void footpath_update_path_wide_flags(int x, int y)
 
 		if (mapElement->properties.path.edges & 2) {
 			F3EFA5 |= 0x8;
-			if (pathList[3] != NULL) {
-				if (footpath_element_is_wide(pathList[3])) {
-					F3EFA5 &= ~0x8;
-				}
-			}
+			/* In the following:
+			 * footpath_element_is_wide(pathList[3])
+			 * is always false due to the tile update order
+			 * in combination with reset tiles.
+			 * Commented out since it will never occur. */
+			//if (pathList[3] != NULL) {
+			//	if (footpath_element_is_wide(pathList[3])) {
+			//		F3EFA5 &= ~0x8;
+			//	}
+			//}
 		}
 
 		if (mapElement->properties.path.edges & 4) {
 			F3EFA5 |= 0x20;
-			if (pathList[5] != NULL) {
-				if (footpath_element_is_wide(pathList[5])) {
-					F3EFA5 &= ~0x20;
-				}
-			}
+			/* In the following:
+			 * footpath_element_is_wide(pathList[5])
+			 * is always false due to the tile update order
+			 * in combination with reset tiles.
+			 * Commented out since it will never occur. */
+			//if (pathList[5] != NULL) {
+			//	if (footpath_element_is_wide(pathList[5])) {
+			//		F3EFA5 &= ~0x20;
+			//	}
+			//}
 		}
 
 		if ((F3EFA5 & 0x80) && (pathList[7] != NULL) && !(footpath_element_is_wide(pathList[7]))) {
@@ -1849,27 +1869,44 @@ void footpath_update_path_wide_flags(int x, int y)
 				F3EFA5 |= 0x1;
 			}
 
+			/* In the following:
+			 * footpath_element_is_wide(pathList[5])
+			 * is always false due to the tile update order
+			 * in combination with reset tiles.
+			 * Short circuit the logic appropriately. */
 			if ((F3EFA5 & 0x20) &&
 				(pathList[6] != NULL) && (!footpath_element_is_wide(pathList[6])) &&
 				((pathList[6]->properties.path.edges & 3) == 3) && // N W
-				(pathList[5] != NULL) && (!footpath_element_is_wide(pathList[5]))) {
+				(pathList[5] != NULL) && (true || !footpath_element_is_wide(pathList[5]))) {
 				F3EFA5 |= 0x40;
 			}
 		}
 
 
-		if ((F3EFA5 & 0x8) && (pathList[3] != NULL) && !(pathList[3]->type & 2)) {
+		/* In the following:
+		  * footpath_element_is_wide(pathList[2])
+		  * footpath_element_is_wide(pathList[3])
+		 * are always false due to the tile update order
+		 * in combination with reset tiles.
+		 * Short circuit the logic appropriately. */
+		if ((F3EFA5 & 0x8) && (pathList[3] != NULL) && (true || !footpath_element_is_wide(pathList[3]))) {
 			if ((F3EFA5 & 2) &&
-				(pathList[2] != NULL) && (!footpath_element_is_wide(pathList[2])) &&
+				(pathList[2] != NULL) && (true || !footpath_element_is_wide(pathList[2])) &&
 				((pathList[2]->properties.path.edges & 0xC) == 0xC) &&
 				(pathList[1] != NULL) && (!footpath_element_is_wide(pathList[1]))) {
 				F3EFA5 |= 0x4;
 			}
 
+			/* In the following:
+			 * footpath_element_is_wide(pathList[4])
+			 * footpath_element_is_wide(pathList[5])
+			 * are always false due to the tile update order
+			 * in combination with reset tiles.
+			 * Short circuit the logic appropriately. */
 			if ((F3EFA5 & 0x20) &&
-				(pathList[4] != NULL) && (!footpath_element_is_wide(pathList[4])) &&
+				(pathList[4] != NULL) && (true || !footpath_element_is_wide(pathList[4])) &&
 				((pathList[4]->properties.path.edges & 9) == 9) &&
-				(pathList[5] != NULL) && (!footpath_element_is_wide(pathList[5]))) {
+				(pathList[5] != NULL) && (true || !footpath_element_is_wide(pathList[5]))) {
 				F3EFA5 |= 0x10;
 			}
 		}


### PR DESCRIPTION
Main changes to the pathfinding are:
1. Tiles are only considered if they have heuristic score == 0 (i.e. the goal is reached) or are a continuing path at the search limit. Otherwise tiles are ignored.  Fixes #785.
2. Wide tiles are only seen as a continuing tile from wide tiles. So wide tiles are used to path find from wide tiles to non-wide tiles; thereafter pathfinding sticks to the non-wide tiles.
3. Only store thin junctions in the vanilla peep->pathfinding_history[].
4. Search path telemetry is collected and returned for the best result, consisting of the thin junctions passed through and the corresponding directions taken, end tile reached and total number of steps taken to get there. This primarily aids with debugging the pathfinding and **could be** (but is **not** currently) used to visualise the pathfinding result if desired (see #4201).
5. Pathfinding debug logging (in debug builds) is improved - in particular guest logging is enabled only for the tracked guest(s); staff logging is enabled only for the name "Mechanic Debug".
6. Introduced some code identifying ride queues as the search is performed - this will be useful in the future for including transport rides in the heuristic search.
7. Update the path wide flag update to affect only a single tile at a time (resolving the first glitch below).

Glitches in the pathfinding still result from the following causes:
- wide flag updates occurring in the same area of the map as the pathfinding will cause glitches - the pathfinding will recover from these glitches (now resolved - see 7 above).
- the heuristic search still only tracks the single best result so far. Alternate, longer routes to nearer tiles will still be returned as a better result than a route that goes through that same tile (with less steps) and then continues on to end overall further from the goal though closer to getting to the goal. The only way to fix this is to implement a truer A* algorithm (over at least the thin junctions, that tracks the shortest number of steps to each thin junction), so that for searches that don't reach the goal only the edges of the search area are considered.
- laying multiple pieces of path at the same location with clearance checks disabled will cause trouble. At the very least, the pathfinding probably won't appear to follow the rendered path.

Tested reasonably extensively with various save games exhibiting pathfinding problems for guests and staff.