### PR TITLE
Improve Retina Display Support on macOS

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -24,5 +24,7 @@
 	<string>OpenRCT2 is licensed under the GNU General Public License version 3</string>
 	<key>CFBundleAllowMixedLocalizations</key>
 	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
So this is something I've been meaning to do for a while now. There's a flag that must be set in the Info.plist file to tell the OS that the app can properly handle High-DPI displays. This was so that apps that weren't made to handle Retina displays didn't end up displaying their content incorrectly.

SDL2 can handle the High-DPI context just fine. If you use the `SDL_WINDOW_ALLOW_HIGHDPI` argument when creating the window, it will give the app a rendering context for the actual resolution. When that argument isn't passed (as is the case for OpenRCT2), then SDL will handle the scaling properly so that everything displays correctly.

What this change does is allow for the macOS-controlled elements of the game to be rendered at retina quality. This includes the title bar at the top of the window (when playing in windowed mode) and the information menu (which includes the version number (as of #4532) and license information). I have tested this in all rendering modes (Software, Hardware Display, and OpenGL), and they all work the same with this flag added.