### PR TITLE
Fix #2042: Underflow in entertainer code when subtracting 200 from time_in_queue.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -70,6 +70,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * (marcovmun)
 * Sven Slootweg (joepie91)
 * Daniel Trujillo Viedma (gDanix)
+* Jonathan Haas (HaasJona)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
 - Fix: [#1038] Guest List is out of order.
+- Fix: [#2042] Guests entering queues are immediately annoyed when many entertainers are around (original bug).
 - Fix: [#2081] Game hangs when track has infinite loop.
 - Fix: [#2754] Dragging scrollview fails when scaled.
 - Fix: [#3210] Scenery window scrolls too far.

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -1240,7 +1240,12 @@ static void staff_entertainer_update_nearby_peeps(rct_peep* peep) {
 			peep->happiness_growth_rate = min(peep->happiness_growth_rate + 4, 255);
 		}
 		else if (peep->state == PEEP_STATE_QUEUING) {
-			peep->time_in_queue -= 200;
+			if(peep->time_in_queue > 200) {
+				peep->time_in_queue -= 200;
+			}
+			else {
+				peep->time_in_queue = 0;
+			}
 			peep->happiness_growth_rate = min(peep->happiness_growth_rate + 3, 255);
 		}
 	}


### PR DESCRIPTION
Fix #2042: Underflow in entertainer code when subtracting 200 from time_in_queue.

Adding myself to contributors + changelog.