### PR TITLE
Extended compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ option(DISABLE_RCT2 "Build a standalone version, without using code and data seg
 option(USE_MMAP "Use mmap to try loading rct2's data segment into memory.")
 option(LAUNCHPAD_BUILD "Sets some build system options on launchpad.net")
 
-set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Warray-bounds -Waddress -Wchar-subscripts -Wenum-compare")
+set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wno-unknown-pragmas -Wno-unused-function -Wno-missing-braces -Wno-comment")
 
 # On mingw all code is already PIC, this will avoid compiler error on redefining this option
 if(NOT MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,9 @@ if (NOT DISABLE_OPENGL)
 	if (WIN32)
 		# Curl depends on openssl and ws2 in mingw builds, but is not wired up in pkg-config
 		set(GLLIBS opengl32)
+		# mingw complains about "%zu" not being a valid format specifier for printf, unless we
+		# tell it that it is
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_MINGW_ANSI_STDIO=1")
 	elseif (APPLE)
 		# GL doesn't work nicely with macOS, while find_package doesn't work with multiarch on Ubuntu.
 		find_package(OpenGL REQUIRED)

--- a/src/common.h
+++ b/src/common.h
@@ -142,4 +142,6 @@ typedef struct registers {
 assert_struct_size(registers, 7 * 4);
 #pragma pack(pop)
 
+#define UNUSED(x) ((void)(x))
+
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -814,7 +814,7 @@ static void config_read_properties(config_section_definition **currentSection, c
 	} else {
 		if (*currentSection != NULL) {
 			utf8 *propertyName, *value;
-			int propertyNameSize, valueSize;
+			int propertyNameSize = 0, valueSize;
 			if (config_get_property_name_value(ch, &propertyName, &propertyNameSize, &value, &valueSize)) {
 				config_property_definition *property;
 				property = config_get_property_def(*currentSection, propertyName, propertyNameSize);

--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -672,7 +672,7 @@ static void format_comma_separated_fixed_1dp(char **dest, size_t *size, long lon
 	char tmp;
 	const char *commaMark = language_get_string(STR_LOCALE_THOUSANDS_SEPARATOR);
 	const char *decimalMark = language_get_string(STR_LOCALE_DECIMAL_POINT);
-	const char *ch;
+	const char *ch = NULL;
 	int zeroNeeded = 1;
 	
 	if ((*size) == 0) return;

--- a/src/network/http.cpp
+++ b/src/network/http.cpp
@@ -118,7 +118,7 @@ http_json_response *http_request_json(const http_json_request *request)
 	CURL *curl;
 	CURLcode curlResult;
 	http_json_response *response;
-	read_buffer readBuffer;
+	read_buffer readBuffer = { 0 };
 	write_buffer writeBuffer;
 
 	curl = curl_easy_init();

--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -509,6 +509,9 @@ bool openrct2_setup_rct2_segment()
 	// necessary. Windows does not need to do this as OpenRCT2 runs as a DLL loaded from the Windows PE.
 	int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
 	int err = 0;
+	// in some configurations err and len may be unused
+	UNUSED(err);
+	UNUSED(len);
 #if defined(USE_MMAP) && (defined(__unix__) || defined(__MACOSX__)) && !defined(NO_RCT2)
 	#define RDATA_OFFSET 0x004A4000
 	#define DATASEG_OFFSET 0x005E2000

--- a/src/paint/map_element/surface.c
+++ b/src/paint/map_element/surface.c
@@ -336,9 +336,9 @@ static void viewport_surface_smoothen_edge(enum edge edge, struct tile_descripto
 		return;
 	}
 
-	uint32 maskImageBase;
-	uint8 neighbourCorners[2];
-	uint8 ownCorners[2];
+	uint32 maskImageBase = 0;
+	uint8 neighbourCorners[2] = { 0 };
+	uint8 ownCorners[2] = { 0 };
 
 	switch (edge) {
 		case EDGE_BOTTOMLEFT:
@@ -376,7 +376,7 @@ static void viewport_surface_smoothen_edge(enum edge edge, struct tile_descripto
 		return;
 	}
 
-	uint8 dh, cl;
+	uint8 dh = 0, cl = 0;
 	switch(edge) {
 		case EDGE_BOTTOMLEFT:
 			dh = byte_97B524[byte_97B444[self.slope]];

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -730,7 +730,7 @@ utf8 *platform_open_directory_browser(utf8 *title)
 
 	utf8 *outPath = NULL;
 
-	if (pidl = SHBrowseForFolderW(&bi)) {
+	if ((pidl = SHBrowseForFolderW(&bi))) {
 		// Copy the path directory to the buffer
 		if (SHGetPathFromIDListW(pidl, pszBuffer)) {
 			// Store pszBuffer (and the path) in the outPath
@@ -766,10 +766,10 @@ int windows_get_registry_install_info(rct2_install_info *installInfo, char *sour
 
 
 	size = 260;
-	RegQueryValueExA(hKey, "Title", 0, &type, installInfo->title, &size);
+	RegQueryValueExA(hKey, "Title", 0, &type, (LPBYTE)installInfo->title, &size);
 
 	size = 260;
-	RegQueryValueExA(hKey, "Path", 0, &type, installInfo->path, &size);
+	RegQueryValueExA(hKey, "Path", 0, &type, (LPBYTE)installInfo->path, &size);
 
 	installInfo->var_20C = 235960;
 
@@ -778,7 +778,7 @@ int windows_get_registry_install_info(rct2_install_info *installInfo, char *sour
 	for (int i = 0; i <= 15; i++) {
 		snprintf(keyName, 100, "AddonPack%d", i);
 		size = sizeof(installInfo->expansionPackNames[i]);
-		if (RegQueryValueExA(hKey, keyName, 0, &type, installInfo->expansionPackNames[i], &size) == ERROR_SUCCESS)
+		if (RegQueryValueExA(hKey, keyName, 0, &type, (LPBYTE)installInfo->expansionPackNames[i], &size) == ERROR_SUCCESS)
 			installInfo->activeExpansionPacks |= (1 << i);
 	}
 

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -619,11 +619,10 @@ static int track_design_place_scenery(rct_td6_scenery_element *scenery_start, ui
 					uint8 bh = rotation | (quadrant << 6) | MAP_ELEMENT_TYPE_SCENERY;
 
 					rct_scenery_entry* small_scenery = get_small_scenery_entry(entry_index);
-					if (!(small_scenery->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE) &&
-						(small_scenery->small_scenery.flags & SMALL_SCENERY_FLAG9)){
-						bh = bh;
-					}
-					else if (small_scenery->small_scenery.flags & (SMALL_SCENERY_FLAG9 | SMALL_SCENERY_FLAG24 | SMALL_SCENERY_FLAG25)){
+					if (!(!(small_scenery->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE) &&
+						(small_scenery->small_scenery.flags & SMALL_SCENERY_FLAG9)) &&
+						(small_scenery->small_scenery.flags & (SMALL_SCENERY_FLAG9 | SMALL_SCENERY_FLAG24 | SMALL_SCENERY_FLAG25)))
+					{
 						bh &= 0x3F;
 					}
 

--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -465,7 +465,7 @@ static size_t encode_chunk_repeat(const uint8 *src_buffer, uint8 *dst_buffer, si
 {
 	size_t i, j, outLength;
 	size_t searchIndex, searchEnd, maxRepeatCount;
-	size_t bestRepeatIndex, bestRepeatCount, repeatIndex, repeatCount;
+	size_t bestRepeatIndex = 0, bestRepeatCount = 0, repeatIndex, repeatCount;
 
 	if (length == 0)
 		return 0;

--- a/src/windows/text_input.c
+++ b/src/windows/text_input.c
@@ -278,7 +278,7 @@ static void window_text_input_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	size_t char_count = 0;
 	uint8 cur_drawn = 0;
 
-	int cursorX, cursorY;
+	int cursorX = 0, cursorY = 0;
 	for (int line = 0; line <= no_lines; line++) {
 		gfx_draw_string(dpi, wrap_pointer, w->colours[1], w->x + 12, y);
 


### PR DESCRIPTION
This should cover large chunk of https://github.com/OpenRCT2/OpenRCT2/issues/4401

CMake builds will no use `-Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wno-unknown-pragmas -Wno-unused-function -Wno-missing-braces -Wno-comment`

There's one last error in clang builds which I'm not sure how to solve (the simplest way of removing it may not be the best one):
```
/home/travis/build/janisozaur/OpenRCT2/src/ride/track_design.c:624:10: error: 
      explicitly assigning value of variable of type 'uint8'
      (aka 'unsigned char') to itself [-Werror,-Wself-assign]
                                                bh = bh;
                                                ~~ ^ ~~
```
see https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/ride/track_design.c#L624