### PR TITLE
Use custom 1 & custom 2 as title musics

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4232,6 +4232,9 @@ STR_5920    :Render weather effects
 STR_5921    :{SMALLFONT}{BLACK}If enabled, rain and gloomy colours will be rendered during storms.
 STR_5922    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{SMALLFONT}{BLACK}Max {STRINGID}
 STR_5923    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{SMALLFONT}{BLACK}Max {COMMA16} {STRINGID} per train
+STR_5924    :CUSTOM1.WAV not found
+STR_5925    :CUSTOM2.WAV not found
+STR_5926    :Read the 'CUSTOM' instructions in the RCT2 directory
 
 #############
 # Scenarios #

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -283,6 +283,12 @@ void audio_start_title_music()
 		else
 			pathId = PATH_ID_CSS17;
 		break;
+	case 4:
+		pathId = PATH_ID_CUSTOM1;
+		break;
+	case 5:
+		pathId = PATH_ID_CUSTOM2;
+		break;
 	default:
 		return;
 	}

--- a/src/localisation/string_ids.h
+++ b/src/localisation/string_ids.h
@@ -3574,6 +3574,9 @@ enum {
 	STR_RENDER_WEATHER_EFFECTS_TIP = 5921,
 	STR_MAX_VEHICLES_TIP = 5922,
 	STR_MAX_CARS_PER_TRAIN_TIP = 5923,
+	STR_OPTIONS_MUSIC_ERR_CUSTOM1_NOT_FOUND = 5924,
+	STR_OPTIONS_MUSIC_ERR_CUSTOM2_NOT_FOUND = 5925,
+	STR_OPTIONS_MUSIC_ERR_CUSTOM_NOT_FOUND_HINT = 5926,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768


### PR DESCRIPTION
This will enable the ability to use Custom 1 & Custom 2 as a title music + adding a checkbox to disable the title music (mostly to make the list more populated by removing 'None')

ps. WIP

TODO:
* None is still in the dropdown list
* The checkbox doesn't disable the dropdown widex
* It doesn't go back to the original song 'Rct2' like before