### PR TITLE
Store IP address in TcpClient

### DIFF
--- a/src/network/TcpSocket.cpp
+++ b/src/network/TcpSocket.cpp
@@ -216,7 +216,8 @@ public:
                     NI_NUMERICHOST | NI_NUMERICSERV); 
                 SetTCPNoDelay(socket, true);
                 tcpSocket = new TcpSocket(socket);
-                if (rc == 0) {
+                if (rc == 0)
+                {
                     _hostName = std::string(hostName);
                 }
             }

--- a/src/network/TcpSocket.cpp
+++ b/src/network/TcpSocket.cpp
@@ -87,7 +87,7 @@ private:
     uint16          _listeningPort  = 0;
     SOCKET          _socket         = INVALID_SOCKET;
 
-    std::string     _hostStr;
+    std::string     _hostName;
 
     SDL_mutex *     _connectMutex   = nullptr;
     std::string     _error;
@@ -205,12 +205,20 @@ public:
             }
             else
             {
-                char hoststr[NI_MAXHOST];
-                int rc = getnameinfo((struct sockaddr *)&client_addr, client_len, hoststr, sizeof(hoststr), nullptr, 0, NI_NUMERICHOST | NI_NUMERICSERV);
+                char hostName[NI_MAXHOST];
+                int rc = getnameinfo(
+                    (struct sockaddr *)&client_addr,
+                    client_len,
+                    hostName,
+                    sizeof(hostName),
+                    nullptr,
+                    0,
+                    NI_NUMERICHOST | NI_NUMERICSERV); 
                 SetTCPNoDelay(socket, true);
                 tcpSocket = new TcpSocket(socket);
-                if (rc == 0)
-                    tcpSocket->SetHostStr(hoststr);
+                if (rc == 0) {
+                    _hostName = std::string(hostName);
+                }
             }
         }
         return tcpSocket;
@@ -411,14 +419,9 @@ public:
         SDL_UnlockMutex(_connectMutex);
     }
 
-    const char * GetHostStr() override 
+    const char * GetHostName() const override 
     {
-        return _hostStr.empty() ? nullptr : _hostStr.c_str();
-    }
-
-    void SetHostStr(const char * hostStr) override
-    {
-        _hostStr = std::string(hostStr);
+        return _hostName.empty() ? nullptr : _hostName.c_str();
     }
 
 private:

--- a/src/network/TcpSocket.h
+++ b/src/network/TcpSocket.h
@@ -58,6 +58,9 @@ public:
 
     virtual void Disconnect() abstract;
     virtual void Close() abstract;
+
+    virtual const char * GetHostStr() abstract;
+    virtual void SetHostStr(const char * hostStr) abstract;
 };
 
 ITcpSocket * CreateTcpSocket();

--- a/src/network/TcpSocket.h
+++ b/src/network/TcpSocket.h
@@ -59,8 +59,7 @@ public:
     virtual void Disconnect() abstract;
     virtual void Close() abstract;
 
-    virtual const char * GetHostStr() abstract;
-    virtual void SetHostStr(const char * hostStr) abstract;
+    virtual const char * GetHostName() const abstract;
 };
 
 ITcpSocket * CreateTcpSocket();

--- a/src/network/TcpSocket.h
+++ b/src/network/TcpSocket.h
@@ -45,6 +45,7 @@ public:
 
     virtual SOCKET_STATUS   GetStatus() abstract;
     virtual const char *    GetError() abstract;
+    virtual const char *    GetHostName() const abstract;
 
     virtual void         Listen(uint16 port)                       abstract;
     virtual void         Listen(const char * address, uint16 port) abstract;
@@ -58,8 +59,6 @@ public:
 
     virtual void Disconnect() abstract;
     virtual void Close() abstract;
-
-    virtual const char * GetHostName() const abstract;
 };
 
 ITcpSocket * CreateTcpSocket();

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1408,10 +1408,6 @@ void Network::Server_Client_Joined(const char* name, const std::string &keyhash,
 	if (player) {
 		char text[256];
 		const char * player_name = (const char *) player->name.c_str();
-		//Relay connection information to console
-		auto hostStr = connection.Socket->GetHostStr();
-		log_info("%s has joined from host: %s", player_name, hostStr);
-		//Show join message in chat
 		format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
 		chat_history_add(text);
 		Server_Send_MAP(&connection);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1408,6 +1408,10 @@ void Network::Server_Client_Joined(const char* name, const std::string &keyhash,
 	if (player) {
 		char text[256];
 		const char * player_name = (const char *) player->name.c_str();
+		//Relay connection information to console
+		auto hostStr = connection.Socket->GetHostStr();
+		log_info("%s has joined from host: %s", player_name, hostStr);
+		//Show join message in chat
 		format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
 		chat_history_add(text);
 		Server_Send_MAP(&connection);


### PR DESCRIPTION
This helps address the need for logging ip addresses that join onto servers by logging it into the external console via the server side. This will not show ip addresses for non-host users. In the event that #4273 has confusion with retrieving ip addresses, this will save him the stress and struggles i did back when i needed to figure out how to retrieve ips (as in, googling for about 3 or 4 weeks).