### PR TITLE
Disable console key when text input is active (fixes #3062)

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1431,7 +1431,7 @@ void title_handle_keyboard_input()
 
 		// Reserve backtick for console
 		if (key == SDL_SCANCODE_GRAVE) {
-			if (gConfigGeneral.debugging_tools || gConsoleOpen) {
+			if ((gConfigGeneral.debugging_tools && !platform_is_input_active()) || gConsoleOpen) {
 				window_cancel_textbox();
 				console_toggle();
 			}
@@ -1502,7 +1502,7 @@ void game_handle_keyboard_input()
 
 		// Reserve backtick for console
 		if (key == SDL_SCANCODE_GRAVE) {
-			if (gConfigGeneral.debugging_tools || gConsoleOpen) {
+			if ((gConfigGeneral.debugging_tools && !platform_is_input_active()) || gConsoleOpen) {
 				window_cancel_textbox();
 				console_toggle();
 			}

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -141,6 +141,7 @@ void platform_process_messages();
 int platform_scancode_to_rct_keycode(int sdl_key);
 void platform_start_text_input(utf8 *buffer, int max_length);
 void platform_stop_text_input();
+bool platform_is_input_active();
 void platform_get_date_utc(rct2_date *out_date);
 void platform_get_time_utc(rct2_time *out_time);
 void platform_get_date_local(rct2_date *out_date);

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -652,6 +652,11 @@ void platform_start_text_input(utf8* buffer, int max_length)
 	textinputbuffer_init(&gTextInput, buffer, max_length);
 }
 
+bool platform_is_input_active()
+{
+	return SDL_IsTextInputActive() && gTextInput.buffer != NULL;
+}
+
 void platform_stop_text_input()
 {
 	SDL_StopTextInput();


### PR DESCRIPTION
For some reason `SDL_IsTextInputActive()` returns `SDL_TRUE` before any call to `SDL_StartTextInput()`. This may be an SDL bug, but I've worked around it for this feature by also checking if there is a valid `gTextInput.buffer`. I've made an exception for the console itself, where the backtick should probably continue to close it.