### PR TITLE
Delete ellipsis in comment.

### DIFF
--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -246,7 +246,7 @@ static void execute_cmd(char *command, int *exit_value, char *buf, size_t *buf_s
 	if (buf && buf_size) {
 		n_chars = fread(buf, 1, *buf_size, f);
 
-		// some commands may return a new-line terminated result, trim that…
+		// some commands may return a new-line terminated result, trim that
 		if (n_chars > 0 && buf[n_chars - 1] == '\n') {
 			buf[n_chars - 1] = '\0';
 		}


### PR DESCRIPTION
This character is causing compiling issue on Windows 10 system in Chinese language.