### PR TITLE
Fix TD4 loading / memory violation

### DIFF
--- a/src/rct1.h
+++ b/src/rct1.h
@@ -346,51 +346,59 @@ typedef struct rct1_s4 {
 } rct1_s4;
 assert_struct_size(rct1_s4, 0x1F850C);
 
+/**
+ * Track design structure.
+ * size: 0x2006
+ */
 typedef struct rct_track_td4 {
 	uint8 type;										// 0x00
-	uint8 vehicle_type;								// 0x01
-	uint32 special_track_flags;						// 0x02
-	uint8 operating_mode;							// 0x06
-	uint8 vehicle_colour_version;					// 0x07 Vehicle colour type in first two bits, Version in bits 3,4
-	colour_t body_trim_colour[24];					// 0x08
-	colour_t track_spine_colour_rct1;				// 0x20
-	colour_t track_rail_colour_rct1;				// 0x21
-	colour_t track_support_colour_rct1;				// 0x22
-	uint8 departure_control_flags;					// 0x23
+	uint8 vehicle_type;
+	uint32 flags;									// 0x02
+	uint8 mode;										// 0x06
+	uint8 version_and_colour_scheme;				// 0x07 0b0000_VVCC
+	rct_vehicle_colour vehicle_colours[12];			// 0x08
+	uint8 track_spine_colour_v0;					// 0x20
+	uint8 track_rail_colour_v0;						// 0x21
+	uint8 track_support_colour_v0;					// 0x22
+	uint8 depart_flags;								// 0x23
 	uint8 number_of_trains;							// 0x24
-	uint8 cars_per_train;							// 0x25
-	uint8 min_wait_time;							// 0x26
-	uint8 max_wait_time;							// 0x27
-	uint8 speed;									// 0x28
-	uint8 max_speed;								// 0x29
-	uint8 average_speed;							// 0x2A
+	uint8 number_of_cars_per_train;					// 0x25
+	uint8 min_waiting_time;							// 0x26
+	uint8 max_waiting_time;							// 0x27
+	union {
+		uint8 operation_setting;
+		uint8 launch_speed;
+		uint8 num_laps;
+		uint8 max_people;
+	};
+	sint8 max_speed;								// 0x29
+	sint8 average_speed;							// 0x2A
 	uint16 ride_length;								// 0x2B
 	uint8 max_positive_vertical_g;					// 0x2D
-	uint8 max_negitive_vertical_g;					// 0x2E
+	sint8 max_negative_vertical_g;					// 0x2C
 	uint8 max_lateral_g;							// 0x2F
 	union {
-		uint8 inversions;							// 0x30
-		uint8 holes;								// 0x30
+		uint8 num_inversions;						// 0x30
+		uint8 num_holes;							// 0x30
 	};
-	uint8 drops;									// 0x31
+	uint8 num_drops;								// 0x31
 	uint8 highest_drop_height;						// 0x32
 	uint8 excitement;								// 0x33
 	uint8 intensity;								// 0x34
 	uint8 nausea;									// 0x35
-	uint8 pad_36[2];
-	union{
-		uint16 start_track_data_original;			// 0x38
-		colour_t track_spine_colour[4];				// 0x38
-	};
-	colour_t track_rail_colour[4];					// 0x3C
-	union{
-		colour_t track_support_colour[4];			// 0x40
-		uint8 wall_type[4];							// 0x40
-	};
-	uint8 pad_41[0x83];
-	uint16 start_track_data_AA_CF;					// 0xC4
-} rct_track_td4; // Information based off RCTTechDepot
-assert_struct_size(rct_track_td4, 0xC9);
+	money16 upkeep_cost;							// 0x36
+
+	// Added Attractions / Loopy Landscapes only
+	uint8 track_spine_colour[4];					// 0x38
+	uint8 track_rail_colour[4];						// 0x3C
+	uint8 track_support_colour[4];					// 0x40
+	uint8 flags2;									// 0x44
+
+	uint8 var_45[0x7F];								// 0x45
+
+	void *elements;									// 0xC4 (data starts here in file, 38 for original RCT1)
+	size_t elementsSize;
+} rct_track_td4;
 #pragma pack(pop)
 
 enum {

--- a/src/rct1/Tables.h
+++ b/src/rct1/Tables.h
@@ -50,6 +50,7 @@ namespace RCT1
 extern "C" {
 #endif
 
+    uint8 rct1_get_ride_type(uint8 rideType);
     const char * rct1_get_ride_type_object(uint8 rideType);
     const char * rct1_get_vehicle_object(uint8 vehicleType);
 

--- a/src/rct1/tables.cpp
+++ b/src/rct1/tables.cpp
@@ -1113,6 +1113,11 @@ namespace RCT1
 
 extern "C"
 {
+    uint8 rct1_get_ride_type(uint8 rideType)
+    {
+        return RCT1::GetRideType(rideType);
+    }
+
     const char * rct1_get_ride_type_object(uint8 rideType)
     {
         return RCT1::GetRideTypeObject(rideType);

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -882,6 +882,13 @@ enum {
 	RIDE_SETTING_RIDE_TYPE,
 };
 
+enum {
+	MAZE_WALL_TYPE_BRICK,
+	MAZE_WALL_TYPE_HEDGE,
+	MAZE_WALL_TYPE_ICE,
+	MAZE_WALL_TYPE_WOOD,
+};
+
 typedef struct rct_ride_properties {
 	uint32 flags;
 	uint8 min_value;

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -158,16 +158,10 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 		return NULL;
 	}
 	
-	// Convert RCT1 ride type to RCT2 ride type
-	if (td4->type == RCT1_RIDE_TYPE_WOODEN_ROLLER_COASTER) {
-		td6->type = RIDE_TYPE_WOODEN_ROLLER_COASTER;
-		td6->ride_mode = td4->mode;
-	} else {
-		td6->type = td4->type;
-		td6->ride_mode = td4->mode;
-	}
+	td6->type = rct1_get_ride_type(td4->type);
 
 	// All TD4s that use powered launch use the type that doesn't pass the station.
+	td6->ride_mode = td4->mode;
 	if (td4->mode == RCT1_RIDE_MODE_POWERED_LAUNCH) {
 		td6->ride_mode = RIDE_MODE_POWERED_LAUNCH;
 	}

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -208,6 +208,11 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 			td6->track_spine_colour[i] = rct1_get_colour(td4->track_spine_colour_v0);
 			td6->track_rail_colour[i] = rct1_get_colour(td4->track_rail_colour_v0);
 			td6->track_support_colour[i] = rct1_get_colour(td4->track_support_colour_v0);
+
+			// Mazes were only hedges
+			if (td4->type == RCT1_RIDE_TYPE_HEDGE_MAZE) {
+				td6->track_support_colour[i] = MAZE_WALL_TYPE_HEDGE;
+			}
 		}
 	} else {
 		for (int i = 0; i < 4; i++) {

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -124,7 +124,7 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 		return NULL;
 	}
 
-	uint8 version = (src[7] >> 2) & 2;
+	uint8 version = (src[7] >> 2) & 3;
 	if (version == 0) {
 		memcpy(td4, src, 0x38);
 		td4->elementsSize = srcLength - 0x38;
@@ -272,7 +272,7 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 
 static rct_track_td6 *track_design_open_from_buffer(uint8 * src, size_t srcLength)
 {
-	uint8 version = (src[7] >> 2) & 2;
+	uint8 version = (src[7] >> 2) & 3;
 	if (version == 0 || version == 1) {
 		return track_design_open_from_td4(src, srcLength);
 	} else if (version != 2) {

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -175,11 +175,11 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 	// Convert RCT1 vehicle type to RCT2 vehicle type
 	rct_object_entry vehicleObject = { 0x80, { "        " }, 0 };
 	if (td4->type == RIDE_TYPE_MAZE) {
-		const char * name = rct1_get_ride_type_object(td6->type);
+		const char * name = rct1_get_ride_type_object(td4->type);
 		assert(name != NULL);
 		memcpy(vehicleObject.name, name, min(strlen(name), 8));
 	} else {
-		const char * name = rct1_get_vehicle_object(td6->vehicle_type);
+		const char * name = rct1_get_vehicle_object(td4->vehicle_type);
 		assert(name != NULL);
 		memcpy(vehicleObject.name, name, min(strlen(name), 8));
 	}

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -1389,19 +1389,12 @@ static bool sub_6D2189(rct_track_td6 *td6, money32 *cost, uint8 *rideId, uint8 *
 		user_string_free(old_name);
 	}
 
-	uint8 version = td6->version_and_colour_scheme >> 2;
-	if (version == 2) {
-		ride->entrance_style = td6->entrance_style;
-	}
+	ride->entrance_style = td6->entrance_style;
 
-	if (version != 0) {
-		memcpy(&ride->track_colour_main, &td6->track_spine_colour, 4);
-		memcpy(&ride->track_colour_additional, &td6->track_rail_colour, 4);
-		memcpy(&ride->track_colour_supports, &td6->track_support_colour, 4);
-	} else {
-		memset(&ride->track_colour_main, td6->track_spine_colour_rct1, 4);
-		memset(&ride->track_colour_additional, td6->track_rail_colour_rct1, 4);
-		memset(&ride->track_colour_supports, td6->track_support_colour_rct1, 4);
+	for (int i = 0; i < 4; i++) {
+		ride->track_colour_main[i] = td6->track_spine_colour[i];
+		ride->track_colour_additional[i] = td6->track_rail_colour[i];
+		ride->track_colour_supports[i] = td6->track_support_colour[i];
 	}
 
 	byte_9D8150 |= 1;

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -159,16 +159,9 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 	}
 	
 	// Convert RCT1 ride type to RCT2 ride type
-	uint8 rct1RideType = td4->type;
 	if (td4->type == RCT1_RIDE_TYPE_WOODEN_ROLLER_COASTER) {
 		td6->type = RIDE_TYPE_WOODEN_ROLLER_COASTER;
 		td6->ride_mode = td4->mode;
-	} else if (td4->type == RCT1_RIDE_TYPE_STEEL_CORKSCREW_ROLLER_COASTER) {
-		if (td4->vehicle_type == RCT1_VEHICLE_TYPE_HYPERCOASTER_TRAIN &&
-			td4->mode == RCT1_RIDE_MODE_REVERSE_INCLINE_LAUNCHED_SHUTTLE
-		) {
-			td6->ride_mode = RIDE_MODE_CONTINUOUS_CIRCUIT;
-		}
 	} else {
 		td6->type = td4->type;
 		td6->ride_mode = td4->mode;
@@ -224,9 +217,9 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 		}
 	} else {
 		for (int i = 0; i < 4; i++) {
-			td6->track_spine_colour[i] = rct1_get_colour(td6->track_spine_colour[i]);
-			td6->track_rail_colour[i] = rct1_get_colour(td6->track_rail_colour[i]);
-			td6->track_support_colour[i] = rct1_get_colour(td6->track_support_colour[i]);
+			td6->track_spine_colour[i] = rct1_get_colour(td4->track_spine_colour[i]);
+			td6->track_rail_colour[i] = rct1_get_colour(td4->track_rail_colour[i]);
+			td6->track_support_colour[i] = rct1_get_colour(td4->track_support_colour[i]);
 		}
 	}
 

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -1530,23 +1530,12 @@ static money32 place_track_design(sint16 x, sint16 y, sint16 z, uint8 flags, uin
 	ride->lifecycle_flags |= RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN;
 	ride->colour_scheme_type = td6->version_and_colour_scheme & 3;
 
-	uint8 version = td6->version_and_colour_scheme >> 2;
-	if (version >= 2) {
-		ride->entrance_style = td6->entrance_style;
-	}
+	ride->entrance_style = td6->entrance_style;
 
-	if (version >= 1) {
-		for (int i = 0; i < 4; i++) {
-			ride->track_colour_main[i] = td6->track_spine_colour[i];
-			ride->track_colour_additional[i] = td6->track_rail_colour[i];
-			ride->track_colour_supports[i] = td6->track_support_colour[i];
-		}
-	} else {
-		for (int i = 0; i < 4; i++) {
-			ride->track_colour_main[i] = td6->track_spine_colour_rct1;
-			ride->track_colour_additional[i] = td6->track_rail_colour_rct1;
-			ride->track_colour_supports[i] = td6->track_support_colour_rct1;
-		}
+	for (int i = 0; i < 4; i++) {
+		ride->track_colour_main[i] = td6->track_spine_colour[i];
+		ride->track_colour_additional[i] = td6->track_rail_colour[i];
+		ride->track_colour_supports[i] = td6->track_support_colour[i];
 	}
 
 	for (int i = 0; i < 32; i++) {

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -210,8 +210,14 @@ static rct_track_td6 * track_design_open_from_td4(uint8 *src, size_t srcLength)
 			td6->track_support_colour[i] = rct1_get_colour(td4->track_support_colour_v0);
 
 			// Mazes were only hedges
-			if (td4->type == RCT1_RIDE_TYPE_HEDGE_MAZE) {
+			switch (td4->type) {
+			case RCT1_RIDE_TYPE_HEDGE_MAZE:
 				td6->track_support_colour[i] = MAZE_WALL_TYPE_HEDGE;
+				break;
+			case RCT1_RIDE_TYPE_RIVER_RAPIDS:
+				td6->track_spine_colour[i] = COLOUR_WHITE;
+				td6->track_rail_colour[i] = COLOUR_WHITE;
+				break;
 			}
 		}
 	} else {

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -315,15 +315,13 @@ static void td6_reset_trailing_elements(rct_track_td6 * td6)
 		while (mazeElement->all != 0) {
 			mazeElement++;
 		}
-		mazeElement++;
-		lastElement = mazeElement;
+		lastElement = (void *)((uintptr_t)mazeElement + 1);
 	} else {
 		rct_td6_track_element * trackElement = (rct_td6_track_element *)td6->elements;
 		while (trackElement->type != 0xFF) {
 			trackElement++;
 		}
-		trackElement++;
-		lastElement = trackElement;
+		lastElement = (void *)((uintptr_t)trackElement + 1);
 	}
 	size_t trailingSize = td6->elementsSize - (size_t)((uintptr_t)lastElement - (uintptr_t)td6->elements);
 	memset(lastElement, 0xFF, trailingSize);

--- a/src/ride/track_design.h
+++ b/src/ride/track_design.h
@@ -110,7 +110,7 @@ typedef struct rct_track_td6 {
 	uint8 number_of_cars_per_train;					// 0x4D
 	uint8 min_waiting_time;							// 0x4E
 	uint8 max_waiting_time;							// 0x4F
-	uint8 var_50;
+	uint8 operation_setting;
 	sint8 max_speed;								// 0x51
 	sint8 average_speed;							// 0x52
 	uint16 ride_length;								// 0x53

--- a/src/ride/track_design_save.c
+++ b/src/ride/track_design_save.c
@@ -744,7 +744,7 @@ static rct_track_td6 *track_design_save_to_td6(uint8 rideIndex)
 	td6->number_of_cars_per_train = ride->num_cars_per_train;
 	td6->min_waiting_time = ride->min_waiting_time;
 	td6->max_waiting_time = ride->max_waiting_time;
-	td6->var_50 = ride->operation_option;
+	td6->operation_setting = ride->operation_option;
 	td6->lift_hill_speed_num_circuits =
 		ride->lift_hill_speed |
 		(ride->num_circuits << 5);


### PR DESCRIPTION
This fixes issues I was having and possibly others when TD4s were being scanned.

Instead of doing these hacks to load bits of TD4 into a TD6, load TD4 data directly into its own struct and then copy field by field to TD6. Simplify TD6 loading.

@Gymnasiast would you be able to test this to make sure TD4s are still correctly imported?