### PR TITLE
Configure MinGW to consume Vista+ APIs

### DIFF
--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -18,6 +18,12 @@
 
 #ifdef __WINDOWS__
 
+#ifdef __MINGW32__
+// 0x0600 == vista
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#endif // __MINGW32__
+
 #include <windows.h>
 #include <lmcons.h>
 #include <psapi.h>
@@ -1037,7 +1043,6 @@ utf8* platform_get_username() {
 	return username;
 }
 
-#ifndef __MINGW32__
 ///////////////////////////////////////////////////////////////////////////////
 // File association setup
 ///////////////////////////////////////////////////////////////////////////////
@@ -1183,5 +1188,4 @@ void platform_remove_file_associations()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-#endif
 #endif

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -14,15 +14,15 @@
  *****************************************************************************/
 #pragma endregion
 
-#include "../common.h"
-
-#ifdef __WINDOWS__
-
 #ifdef __MINGW32__
 // 0x0600 == vista
 #define WINVER 0x0600
 #define _WIN32_WINNT 0x0600
 #endif // __MINGW32__
+
+#include "../common.h"
+
+#ifdef __WINDOWS__
 
 #include <windows.h>
 #include <lmcons.h>


### PR DESCRIPTION
This is proof of concept and may require some discussion. This effectively drops XP support we've sort-of had until now, even though we claimed we don't have it.