### PR TITLE
Update Readme's macOS Instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,10 +56,16 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 - [7-Zip](http://www.7-zip.org/) (for deployment only)
 - [NSIS](http://nsis.sourceforge.net/) (for deployment only)
 
-### Mac:
-- [Homebrew](http://brew.sh)
+### macOS:
+- Xcode 8
 
-### Mac / Linux:
+The program can also be built as a command line program using CMake. This type of build requires:
+
+- Xcode Command Line Tools
+- [Homebrew](http://brew.sh)
+- CMake (available through Homebrew)
+
+### Linux:
 - sdl2
 - sdl2-ttf
 - speexdsp
@@ -85,23 +91,28 @@ msbuild openrct2.proj /t:g2
 msbuild openrct2.proj /t:PublishPortable
 ```
 
-### Mac:
-We support native builds for macOS (limited to i386 only for now).
-Make sure that you have [Homebrew](http://brew.sh/) installed and than run the following commands to install all the needed libraries and build OpenRCT2.
-```
-# Install libraries
-./install.sh
+### macOS:
+#### Xcode:
+The recommended way of building OpenRCT2 for macOS is with Xcode. The Xcode build will create a self-contained application bundles which include all the necessary game files and dependencies. Open the project file OpenRCT2.xcodeproj in Xcode and build from there. Building this way will handle the dependencies for you automatically. You can also invoke an Xcode build from the command line using `xcodebuild`.
 
-# Build OpenRCT2
-./build.sh
-
-# Run the game
-./openrct2
+#### CMake:
+A command line version of OpenRCT2 can be built using CMake. This type of build requires you to provide the dependencies yourself. The supported method of doing this is with [Homebrew](http://brew.sh). Once you have Homebrew installed, you can download all the required libraries with this command:
 ```
+brew install cmake openssl jansson libpng sdl2 sdl2_ttf speex
+```
+
+Once you have the dependencies installed, you can build the project using CMake using the following commands:
+```
+mkdir build
+cd build
+cmake ..
+make
+ln -s ../data data
+```
+Then you can run the game by running `./openrct2`.
 
 ### Linux:
-We support native builds for Linux. x86 builds, by default, make use of pieces of original code, other builds are completely standalone.
-You can follow the standard CMake build procedure: install [required libraries](https://github.com/OpenRCT2/OpenRCT2#mac--linux), then:
+The standard CMake build procedure is to install the [required libraries](https://github.com/OpenRCT2/OpenRCT2#mac--linux), then:
 ```
 mkdir build
 cd build


### PR DESCRIPTION
Since I'm not the best at spelling, I'd like it if someone proof-read this. This replaces the old, very outdated instructions that were in the Readme previously. This includes both information about the Xcode project (which is the recommended way to build it) and CMake build instructions.