### PR TITLE
Replace spinlock in main game loop

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -458,12 +458,11 @@ static void openrct2_loop()
 			currentTick = SDL_GetTicks();
 			ticksElapsed = currentTick - lastTick;
 			if (ticksElapsed < 25) {
-				if (ticksElapsed < 15)
-					SDL_Delay(15 - ticksElapsed);
-				continue;
+				SDL_Delay(25 - ticksElapsed);
+				lastTick += 25;
+			} else {
+				lastTick = currentTick;
 			}
-
-			lastTick = currentTick;
 
 			platform_process_messages();
 


### PR DESCRIPTION
Ok, so this change is a bit weird. This change only affects the game when the uncapped FPS option is off.

First off, the sleep/delay function (in our code, we use `SDL_Delay`) doesn't guarantee that the thread wakes up after exactly the specified amount of time, only after at least that much time. This means that just using the sleep function can cause the framerate to drop a few FPS just due to the unexpected extra delay between frames.

The current solution is to sleep up until a few milliseconds before the frame is expected (right now, it's 10ms before, but that is longer than necessary) and then run a spin lock until it's time to run the frame. This causes a (relatively small) additional CPU load, but is the only way to get frames to render at the exact right time.

My change takes a different approach to the problem. My solution doesn't care if a frame comes a little later than expected. With how long a frame takes to simulate/render (and the amount of variance in it), it doesn't make a huge difference if the frame starts rendering a few ms later. Instead, my code will account for the extra delay added by taking it from the delay until the next frame.

For example, let's say the first frame takes 20ms to simulate/render. To hit a target FPS of 40fps, the game will (request to) sleep for 5ms. Let's say that `SDL_Delay` takes 7ms to wake the thread up (so +2ms) (this is generally a lot higher than `SDL_Delay`'s margin of error). After the next frame simulates/renders for 20ms, the game will sleep for 5ms - 2ms = 3ms. This means that while frames may start a little later than expected, their total error doesn't exceed the error of `SDL_Delay`.

The only special case to consider is when a frame takes longer than 25ms. In that case, the error being accounted for is considered to be 0ms, as `SDL_Delay` isn't run. If we didn't consider this case, significant delays can cause the game to not cap the framerate as the game catches up.