### PR TITLE
Remove x64 suffix from 64-bit Windows builds

### DIFF
--- a/openrct2.proj
+++ b/openrct2.proj
@@ -39,8 +39,7 @@
 
     <NsisScript>$(DistDir)windows\install.nsi</NsisScript>
 
-    <OutputExe Condition="'$(Platform)'=='Win32'">$(TargetDir)openrct2.exe</OutputExe>
-    <OutputExe Condition="'$(Platform)'=='x64'">$(TargetDir)openrct2_x64.exe</OutputExe>
+    <OutputExe>$(TargetDir)openrct2.exe</OutputExe>
     <g2Output>$(TargetDir)data\g2.dat</g2Output>
 
     <SignCertificate Condition="'$(SignCertificate)'==''">$(DistDir)windows\code-sign-key-openrct2.org.pfx</SignCertificate>

--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -589,14 +589,12 @@
     <OutDir>$(SolutionDir)bin\</OutDir>
     <IntDir>$(SolutionDir)obj\$(ProjectName)\$(Configuration)_$(Platform)\</IntDir>
     <LinkIncremental />
-    <TargetName>$(ProjectName)_x64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(SolutionDir)lib\include;$(SolutionDir)lib\include\breakpad;$(SolutionDir)lib\include\libspeex;$(SolutionDir)lib\include\sdl;$(SolutionDir)lib\include\jansson;$(SolutionDir)lib\include\sdl_ttf;$(SolutionDir)lib\include\libpng;$(SolutionDir)lib\include\zlib;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)bin\</OutDir>
     <IntDir>$(SolutionDir)obj\$(ProjectName)\$(Configuration)_$(Platform)\</IntDir>
-    <TargetName>$(ProjectName)_x64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Breakpad)'=='true'">
     <ClCompile>


### PR DESCRIPTION
This changes the names of the 64-bit Windows builds from `openrct2_x64.exe` to just `openrct2.exe`. This is both because the 64-bit builds are now recommended, so a suffix doesn't make much sense there, and because this change makes the Launcher a lot easier to implement.

@IntelOrca can you verify that I didn't break anything with this change?