### PR TITLE
Add --console switch for Windows

### DIFF
--- a/src/openrct2.c
+++ b/src/openrct2.c
@@ -661,17 +661,3 @@ static void openrct2_setup_rct2_hooks()
 {
 	// None for now
 }
-
-#if defined(_MSC_VER) && (_MSC_VER >= 1900)
-/**
- * Temporary fix for libraries not compiled with VS2015
- */
-FILE **__iob_func()
-{
-	static FILE* streams[3];
-	streams[0] = stdin;
-	streams[1] = stdout;
-	streams[2] = stderr;
-	return streams;
-}
-#endif

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -203,6 +203,7 @@ datetime64 platform_get_datetime_now_utc();
 	#include <windows.h>
 	#undef GetMessage
 
+	void platform_windows_open_console();
 	int windows_get_registry_install_info(rct2_install_info *installInfo, char *source, char *font, uint8 charset);
 	HWND windows_get_window_handle();
 	void platform_setup_file_associations();

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -143,6 +143,17 @@ __declspec(dllexport) int StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInsta
 
 #endif // NO_RCT2
 
+void platform_windows_open_console()
+{
+	if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
+		AllocConsole();
+	}
+
+	freopen("CONIN$", "r", stdin);
+	freopen("CONOUT$", "w", stdout);
+	freopen("CONOUT$", "w", stderr);
+}
+
 utf8 **windows_get_command_line_args(int *outNumArgs)
 {
 	int argc;


### PR DESCRIPTION
Windows subsystem does not work like console subsystem which makes it almost impossible to obtain stdout until the application has finished. This adds a `--console` switch to make the game either attach to an existing console or show a new one and redirect the C streams to it.