### PR TITLE
Add pathfinding loop detection based on peep->pathfind_history

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
The heuristic search currently only inludes detection of loops in the current search path - i.e. from where the peep is now.

The peep->pathfind_history includes (limited) junctions that the peep has already passed through for the current search goal to get to their current location. Consider search paths through these junctions as loops as well.

This will prevent peeps getting stuck in some path layouts where looping back through a junction they already walked through and then proceeding via an alternative path (such that there is no loop in the current search path) hits the search limits on a continuing path that is closer to the goal than simply continuing on along the path which then turns (temporarily) away from the goal.

This prevents _some_ cases of alternate, longer routes to nearer tiles being returned as a better result than a route that goes through that same tile (with less steps) and then continues on to end overall further from the goal though closer to getting to the goal (as was previously documented in PR #4527).

The network version is incremented in this PR.

Fixes #4668 - the peeps stuck heading for the exit.
