### PR TITLE
Memory handling fixes

### DIFF
--- a/src/core/FileScanner.cpp
+++ b/src/core/FileScanner.cpp
@@ -311,7 +311,9 @@ protected:
                     DirectoryChild child = CreateChild(path, node);
                     children.push_back(child);
                 }
+                free(namelist[i]);
             }
+            free(namelist);
         }
     }
 

--- a/src/core/FileScanner.cpp
+++ b/src/core/FileScanner.cpp
@@ -101,7 +101,11 @@ public:
     ~FileScannerBase() override
     {
         Memory::Free(_rootPath);
-        Memory::FreeArray(_patterns, _numPatterns);
+        for (size_t i = 0; i < _numPatterns; i++)
+        {
+            Memory::Free(_patterns[i]);
+        }
+        Memory::Free(_patterns);
         Memory::Free(_currentPath);
         Memory::Free(_currentFileInfo);
     }

--- a/src/core/IStream.cpp
+++ b/src/core/IStream.cpp
@@ -35,6 +35,21 @@ utf8 * IStream::ReadString()
     return resultString;
 }
 
+std::string IStream::ReadStdString()
+{
+    std::vector<utf8> result;
+
+    uint8 ch;
+    while ((ch = ReadValue<uint8>()) != 0)
+    {
+        result.push_back(ch);
+    }
+    result.push_back(0);
+
+    std::string resultString(result.data(), result.data() + result.size());
+    return resultString;
+}
+
 void IStream::WriteString(const utf8 * str)
 {
     if (str == nullptr)

--- a/src/core/IStream.hpp
+++ b/src/core/IStream.hpp
@@ -107,6 +107,7 @@ interface IStream
     }
 
     utf8 * ReadString();
+    std::string ReadStdString();
     void WriteString(const utf8 * str);
     void WriteString(const std::string &string);
 };

--- a/src/ride/TrackDesignRepository.cpp
+++ b/src/ride/TrackDesignRepository.cpp
@@ -284,10 +284,10 @@ private:
                 for (uint32 i = 0; i < header.NumItems; i++)
                 {
                     TrackRepositoryItem item;
-                    item.Name = fs.ReadString();
-                    item.Path = fs.ReadString();
+                    item.Name = fs.ReadStdString();
+                    item.Path = fs.ReadStdString();
                     item.RideType = fs.ReadValue<uint8>();
-                    item.ObjectEntry = fs.ReadString();
+                    item.ObjectEntry = fs.ReadStdString();
                     item.Flags = fs.ReadValue<uint32>();
                     _items.push_back(item);
                 }

--- a/src/windows/tooltip.c
+++ b/src/windows/tooltip.c
@@ -64,7 +64,7 @@ static rct_window_event_list window_tooltip_events = {
 	NULL
 };
 
-static utf8 _tooltipText[512];
+static utf8 _tooltipText[sizeof(gCommonStringFormatBuffer)];
 static sint16 _tooltipNumLines;
 
 void window_tooltip_reset(int x, int y)


### PR DESCRIPTION
@IntelOrca please see last commit in this PR. Either change `ReadString` to do proper strings or bear with this kludge of code.

Also, I don't like how you have `ReadString` allocate memory with `Memory::AllocateArray`, which should be matched by `FreeArray`, so it needs to do `strlen`.