### PR TITLE
Fix #4704, #4708: Crash when painting money effect

### DIFF
--- a/src/paint/paint.c
+++ b/src/paint/paint.c
@@ -21,6 +21,7 @@
 #include "../interface/viewport.h"
 #include "map_element/map_element.h"
 #include "sprite/sprite.h"
+#include "supports.h"
 
 const uint32 construction_markers[] = {
 	COLOUR_DARK_GREEN << 19 | COLOUR_GREY << 24 | IMAGE_TYPE_REMAP, // White
@@ -94,6 +95,7 @@ void paint_init(rct_drawpixelinfo * dpi)
 	_paintQuadrantFrontIndex = 0;
 	gPaintPSStringHead = NULL;
 	_paintLastPSString = NULL;
+	gWoodenSupportsPrependTo = NULL;
 }
 
 static void paint_add_ps_to_quadrant(paint_struct * ps, sint32 positionHash)


### PR DESCRIPTION
Root cause of this crash was due to line 474 in supports.c
```
paint_struct* edi = gWoodenSupportsPrependTo;
edi->var_20 = ps;
```
gWoodenSupportsPrependTo is never reset and could be pointing to anything else.  paint_struct is in a union shared with paint_string_struct, which has a y_offsets pointer at 0x1A (0x1E in x64).  The 64 bit version has 8 byte pointers so setting var_20 would override the last 2 bytes of y_offsets pointer, causing invalid pointer exception if that happened to be a paint_string_struct.