### PR TITLE
Fix out-of-bounds access in convert_multibyte_charset

### DIFF
--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -292,7 +292,7 @@ static utf8 *convert_multibyte_charset(const char *src, int languageId)
 		if (*ch == 0xFF) {
 			ch++;
 			uint8 a = *ch++;
-			uint8 b = *ch++;
+			uint8 b = (*ch != 0) ? *ch++ : 0;
 			uint16 codepoint = (a << 8) | b;
 
 			codepoint = convert_specific_language_character_to_unicode(languageId, codepoint);


### PR DESCRIPTION
convert_multibyte_charset unconditionally assumes that a 0xFF is always
followed by two more bytes. This is not the case with BATFL.DAT, whose
string at offset 0x2D6 (languageId = 0xA) ends with bytes 0xFF, 0xC2,
0x00. Therefore, it seems like 0x00 is used as both the string terminator
and the second byte of a multicharacter sequence in this case.

This commit does not change the original behaviour at all, and prevents
the code from looking for a 0x00 after the string actually ends.
