### PR TITLE
Use POPCNT, if available, to count the number of set bits

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -196,6 +196,9 @@ bool platform_check_steam_overlay_attached();
 
 datetime64 platform_get_datetime_now_utc();
 
+// Called very early in the program before parsing commandline arguments.
+void core_init();
+
 // Windows specific definitions
 #ifdef __WINDOWS__
 	#ifndef WIN32_LEAN_AND_MEAN

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -51,6 +51,8 @@ utf8 _openrctDataDirectoryPath[MAX_PATH] = { 0 };
  */
 int main(int argc, const char **argv)
 {
+	core_init();
+	
 	int run_game = cmdline_run(argv, argc);
 	if (run_game == 1)
 	{

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -782,3 +782,8 @@ uint8 platform_get_currency_value(const char *currCode) {
 	
 	return CURRENCY_POUNDS;
 }
+
+void core_init()
+{
+	bitcount_init();
+}

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -61,6 +61,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 {
 	_dllModule = hInstance;
 
+	core_init();
+
 	int argc;
 	char ** argv = (char**)windows_get_command_line_args(&argc);
 	int runGame = cmdline_run((const char **)argv, argc);
@@ -85,6 +87,8 @@ int main(int argc, char *argv[])
 {
 	HINSTANCE hInstance = GetModuleHandle(NULL);
 	_dllModule = hInstance;
+
+	core_init();
 
 	int runGame = cmdline_run((const char **)argv, argc);
 	if (runGame == 1) {
@@ -123,6 +127,8 @@ __declspec(dllexport) int StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInsta
 	if (_dllModule == NULL) {
 		_dllModule = GetModuleHandleA(OPENRCT2_DLL_MODULE_NAME);
 	}
+
+	core_init();
 
 	// argv = CommandLineToArgvA(lpCmdLine, &argc);
 	argv = (char**)windows_get_command_line_args(&argc);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -203,7 +203,7 @@ int bitscanforward(int source)
 	#define OpenRCT2_POPCNT_MSVC
 #endif
 
-static int bitcount_popcnt_available()
+static bool bitcount_popcnt_available()
 {
 	// POPCNT support is declared as the 23rd bit of ECX with CPUID(EAX = 1).
 	#if defined(OpenRCT2_POPCNT_GNUC)
@@ -217,7 +217,7 @@ static int bitcount_popcnt_available()
 		__cpuid(regs, 1);
 		return (regs[2] & (1 << 23));
 	#else
-		return 0;
+		return false;
 	#endif
 }
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -199,7 +199,7 @@ int bitscanforward(int source)
 	#include <cpuid.h>
 	#define OpenRCT2_POPCNT_GNUC
 #elif defined(_MSC_VER) && (_MSC_VER >= 1500) && (defined(_M_X64) || defined(_M_IX86)) // VS2008
-	#include <intrin.h>
+	#include <nmmintrin.h>
 	#define OpenRCT2_POPCNT_MSVC
 #endif
 
@@ -221,7 +221,7 @@ static bool bitcount_popcnt_available()
 	#endif
 }
 
-static int bitcount_popcnt(int source)
+static int bitcount_popcnt(uint32 source)
 {
 	#if defined(OpenRCT2_POPCNT_GNUC)
 		// use asm directly in order to actually emit the instruction : using
@@ -230,14 +230,14 @@ static int bitcount_popcnt(int source)
 		asm volatile ("popcnt %1,%0" : "=r"(rv) : "rm"(source) : "cc");
 		return rv;
 	#elif defined(OpenRCT2_POPCNT_MSVC)
-		return __popcnt(source);
+		return _mm_popcnt_u32(source);
 	#else
-		assert(false && "bitcount_popcnt() called, without support compiled in");
+		openrct2_assert(false, "bitcount_popcnt() called, without support compiled in");
 		return INT_MAX;
 	#endif
 }
 
-static int bitcount_lut(int source)
+static int bitcount_lut(uint32 source)
 {
 	// https://graphics.stanford.edu/~seander/bithacks.html
 	static const unsigned char BitsSetTable256[256] = 
@@ -253,14 +253,14 @@ static int bitcount_lut(int source)
 		BitsSetTable256[source >> 24];
 }
 
-static int(*bitcount_fn)(int);
+static int(*bitcount_fn)(uint32);
 
 void bitcount_init()
 {
 	bitcount_fn = bitcount_popcnt_available() ? bitcount_popcnt : bitcount_lut;
 }
 
-int bitcount(int source)
+int bitcount(uint32 source)
 {
 	return bitcount_fn(source);
 }

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -253,13 +253,15 @@ static int bitcount_lut(int source)
 		BitsSetTable256[source >> 24];
 }
 
+static int(*bitcount_fn)(int);
+
+void bitcount_init(void)
+{
+	bitcount_fn = bitcount_available() ? bitcount_popcnt : bitcount_lut;
+}
+
 int bitcount(int source)
 {
-	static int(*bitcount_fn)(int);
-	if(bitcount_fn == 0)
-	{
-		bitcount_fn = bitcount_available() ? bitcount_popcnt : bitcount_lut;
-	}
 	return bitcount_fn(source);
 }
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -203,7 +203,7 @@ int bitscanforward(int source)
 	#define OpenRCT2_POPCNT_MSVC
 #endif
 
-static int bitcount_available(void)
+static int bitcount_popcnt_available()
 {
 	// POPCNT support is declared as the 23rd bit of ECX with CPUID(EAX = 1).
 	#if defined(OpenRCT2_POPCNT_GNUC)
@@ -255,9 +255,9 @@ static int bitcount_lut(int source)
 
 static int(*bitcount_fn)(int);
 
-void bitcount_init(void)
+void bitcount_init()
 {
-	bitcount_fn = bitcount_available() ? bitcount_popcnt : bitcount_lut;
+	bitcount_fn = bitcount_popcnt_available() ? bitcount_popcnt : bitcount_lut;
 }
 
 int bitcount(int source)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -38,7 +38,7 @@ void path_end_with_separator(utf8 *path, size_t size);
 bool readentirefile(const utf8 *path, void **outBuffer, size_t *outLength);
 
 int bitscanforward(int source);
-void bitcount_init(void);
+void bitcount_init();
 int bitcount(int source);
 bool strequals(const char *a, const char *b, int length, bool caseInsensitive);
 int strcicmp(char const *a, char const *b);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -39,7 +39,7 @@ bool readentirefile(const utf8 *path, void **outBuffer, size_t *outLength);
 
 int bitscanforward(int source);
 void bitcount_init();
-int bitcount(int source);
+int bitcount(uint32 source);
 bool strequals(const char *a, const char *b, int length, bool caseInsensitive);
 int strcicmp(char const *a, char const *b);
 int strlogicalcmp(char const *a, char const *b);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -38,6 +38,7 @@ void path_end_with_separator(utf8 *path, size_t size);
 bool readentirefile(const utf8 *path, void **outBuffer, size_t *outLength);
 
 int bitscanforward(int source);
+void bitcount_init(void);
 int bitcount(int source);
 bool strequals(const char *a, const char *b, int length, bool caseInsensitive);
 int strcicmp(char const *a, char const *b);


### PR DESCRIPTION
Replace the current implementation of bitcount() with a one that uses the
POPCNT instruction available in most newer CPUs. Also, replace the basic
implementation with a one based on a lookup table, which has much better
performance than the old one.

I measured the performance by loading a park with ~1000 guests and 15 rides, and running it for about 5 seconds. The application-wide cost of all calls to bitcount(), according to Callgrind :
- current implementation - 24842196
- LUT - 1864492
- POPCNT - 230876
