### PR TITLE
Allow automatic positioning of new staff in multiplayer

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -153,7 +153,7 @@ static inline void staff_autoposition_new_staff_member(rct_peep *newPeep)
 	invalidate_sprite_2((rct_sprite *)newPeep);
 }
 
-static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16 command_x, sint16 command_y, sint16 command_z, int *newPeep_sprite_index)
+static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16 command_x, sint16 command_y, sint16 command_z, int autoposition, int *newPeep_sprite_index)
 {
 	gCommandExpenditureType = RCT_EXPENDITURE_TYPE_WAGES;
 	gCommandPosition.x = command_x;
@@ -274,8 +274,7 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
 		newPeep->sprite_height_negative = spriteBounds->sprite_height_negative;
 		newPeep->sprite_height_positive = spriteBounds->sprite_height_positive;
 
-		// gConfigGeneral.auto_staff_placement is client specific so we need to force this
-		if (network_get_mode() == NETWORK_MODE_NONE && gConfigGeneral.auto_staff_placement != ((SDL_GetModState() & KMOD_SHIFT) != 0)) {
+		if (autoposition) {
 			staff_autoposition_new_staff_member(newPeep);
 		} else {
 			newPeep->state = PEEP_STATE_PICKED;
@@ -331,6 +330,7 @@ void game_command_hire_new_staff_member(int* eax, int* ebx, int* ecx, int* edx, 
 									   *eax & 0xFFFF,
 									   *ecx & 0xFFFF,
 									   *edx & 0xFFFF,
+									   (*ebx & 0xFF0000) >> 16,
 									   edi);
 }
 
@@ -510,18 +510,20 @@ uint16 hire_new_staff_member(uint8 staffType)
 {
 	gGameCommandErrorTitle = STR_CANT_HIRE_NEW_STAFF;
 
-	int eax, ebx, ecx, edx, esi, edi, ebp;
-	ecx = edx = esi = edi = ebp = 0;
-	eax = 0x8000;
-	ebx = staffType << 8 | GAME_COMMAND_FLAG_APPLY;
+	int command_x, ebx, command_y, command_z, esi, new_sprite_index, ebp;
+	command_y = command_z = esi = new_sprite_index = ebp = 0;
+	command_x = 0x8000;
+
+	int autoposition = gConfigGeneral.auto_staff_placement == ((SDL_GetModState() & KMOD_SHIFT) == 0);
+	ebx = autoposition << 16 | staffType << 8 | GAME_COMMAND_FLAG_APPLY;
 
 	game_command_callback = game_command_callback_hire_new_staff_member;
-	int result = game_do_command_p(GAME_COMMAND_HIRE_NEW_STAFF_MEMBER, &eax, &ebx, &ecx, &edx, &esi, &edi, &ebp);
+	int result = game_do_command_p(GAME_COMMAND_HIRE_NEW_STAFF_MEMBER, &command_x, &ebx, &command_y, &command_z, &esi, &new_sprite_index, &ebp);
 
 	if (result == MONEY32_UNDEFINED)
 		return 0xFFFF;
 
-	return edi;
+	return new_sprite_index;
 }
 
 /**


### PR DESCRIPTION
Currently automatic placement of newly hired staff is disabled in multiplayer because it depends on `gConfigGeneral.auto_staff_placement` and whether the shift key is pressed - both depend on the local state of the machine.

This PR moves the check for those parameters out of the game command and performs it on the client. The game command is extended by a parameter which indicates whether the employee is positioned automatically or manually.

Since this PR changes the protocol it also increases the network version.