### PR TITLE
Fix quarter-scenery cluster selection

### DIFF
--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -2310,7 +2310,7 @@ static void top_toolbar_tool_update_scenery(sint16 x, sint16 y){
 		scenery = get_small_scenery_entry(selected_scenery);
 
 		gMapSelectType = MAP_SELECT_TYPE_FULL;
-		if (!(scenery->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE)){
+		if (!(scenery->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE) && !gWindowSceneryClusterEnabled){
 			gMapSelectType = MAP_SELECT_TYPE_QUARTER_0 + ((parameter2 & 0xFF) ^ 2);
 		}
 


### PR DESCRIPTION
This PR fixes an issue with quadrant scenery that I overlooked when making #4632.