### PR TITLE
Fix #4725: Filled bins incorrectly displayed

### DIFF
--- a/src/paint/map_element/path.c
+++ b/src/paint/map_element/path.c
@@ -152,7 +152,9 @@ static void path_bit_bins_paint(rct_scenery_entry* pathBitEntry, rct_map_element
 		if (!(mapElement->flags & MAP_ELEMENT_FLAG_BROKEN)) {
 			imageId -= 4;
 			
-			if (!(mapElement->properties.path.addition_status & (0x3 << get_current_rotation())))
+			// Edges have been rotated around the rotation to check addition status 
+			// this will also need to be rotated.
+			if (!(mapElement->properties.path.addition_status & ror8(0x3,(2 * get_current_rotation()))))
 				imageId += 8;
 		}
 		
@@ -167,7 +169,9 @@ static void path_bit_bins_paint(rct_scenery_entry* pathBitEntry, rct_map_element
 		if (!(mapElement->flags & MAP_ELEMENT_FLAG_BROKEN)) {
 			imageId -= 4;
 
-			if (!(mapElement->properties.path.addition_status & rol8(0xC, get_current_rotation())))
+			// Edges have been rotated around the rotation to check addition status 
+			// this will also need to be rotated.
+			if (!(mapElement->properties.path.addition_status & ror8(0xC, (2 * get_current_rotation()))))
 				imageId += 8;
 		}
 		
@@ -182,8 +186,10 @@ static void path_bit_bins_paint(rct_scenery_entry* pathBitEntry, rct_map_element
 
 		if (!(mapElement->flags & MAP_ELEMENT_FLAG_BROKEN)) {
 			imageId -= 4;
-
-			if (!(mapElement->properties.path.addition_status & rol8(0x30, get_current_rotation())))
+			
+			// Edges have been rotated around the rotation to check addition status 
+			// this will also need to be rotated.
+			if (!(mapElement->properties.path.addition_status & ror8(0x30, (2 * get_current_rotation()))))
 				imageId += 8;
 		}
 		
@@ -199,7 +205,9 @@ static void path_bit_bins_paint(rct_scenery_entry* pathBitEntry, rct_map_element
 		if (!(mapElement->flags & MAP_ELEMENT_FLAG_BROKEN)) {
 			imageId -= 4;
 
-			if (!(mapElement->properties.path.addition_status & rol8(0xC0, get_current_rotation())))
+			// Edges have been rotated around the rotation to check addition status 
+			// this will also need to be rotated.
+			if (!(mapElement->properties.path.addition_status & ror8(0xC0, (2 * get_current_rotation()))))
 				imageId += 8;
 		}
 		


### PR DESCRIPTION

Fix #4725: Filled bins incorrectly displayed
The bins were incorrectly displaying their filled status on some rotations. This was caused by two mistakes. The first mistake was only rotating the status by 1 place when it was 2 bit the second was due to rotating it the wrong direction. This was likely caused by the implementer (https://github.com/OpenRCT2/OpenRCT2/commit/9f467739616956e3e365b89e483cbbb0dfe4954d me)  not realising that there were two `rol` commands but due to the inverted nature of this it would end up being two `ror`s.