### PR TITLE
Check value of DEBUG_LEVEL_X macro, not just definition

### DIFF
--- a/src/drawing/sprite.c
+++ b/src/drawing/sprite.c
@@ -314,7 +314,7 @@ uint8* FASTCALL gfx_draw_sprite_get_palette(int image_id, uint32 tertiary_colour
 
 		if (!(image_type & IMAGE_TYPE_REMAP)) {
 			palette_pointer = gOtherPalette;
-#ifdef DEBUG_LEVEL_2
+#if defined(DEBUG_LEVEL_2) && DEBUG_LEVEL_2
 			assert(tertiary_colour < PALETTE_TO_G1_OFFSET_COUNT);
 #endif // DEBUG_LEVEL_2
 			uint32 tertiary_offset = palette_to_g1_offset[tertiary_colour];

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1604,7 +1604,7 @@ uint8 get_current_rotation()
 {
 	uint8 rotation = gCurrentRotation;
 	uint8 rotation_masked = rotation & 3;
-#ifdef DEBUG_LEVEL_1
+#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 	if (rotation != rotation_masked) {
 		log_error("Found wrong rotation %d! Will return %d instead.", (uint32)rotation, (uint32)rotation_masked);
 	}


### PR DESCRIPTION
DEBUG_LEVEL_X macros are always defined to 0 or 1, this could prevent
some optimisations from compilers, especially inlining
`get_current_rotation()`.