### PR TITLE
Fix #4747: Fix available land rights not being recounted when using sandbox tools

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -1933,14 +1933,20 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
  */
 void game_command_set_land_ownership(int *eax, int *ebx, int *ecx, int *edx, int *esi, int *edi, int *ebp)
 {
+	int flags = *ebx & 0xFF;
+
 	*ebx = map_set_land_ownership(
-		*ebx & 0xFF,
+		flags,
 		*eax & 0xFFFF,
 		*ecx & 0xFFFF,
 		*edi & 0xFFFF,
 		*ebp & 0xFFFF,
 		*edx & 0xFF
 		);
+
+	if (flags & GAME_COMMAND_FLAG_APPLY) {
+		map_count_remaining_land_rights();
+	}
 }
 
 


### PR DESCRIPTION
This commit fixes the game command set_land_ownership missing a land
rights recount call. This would cause problems when the user changes
land ownership with the sandbox mode tools.