### PR TITLE
Validate access to stru_97B5C0

### DIFF
--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -502,6 +502,8 @@ static void viewport_surface_draw_land_side_top(enum edge_t edge, uint8 height, 
 		return;
 	}
 
+	assert(terrain < countof(_terrainEdgeSpriteIds));
+
 	if (!(gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)) {
 		uint8 incline = (regs.cl - regs.al) + 1;
 


### PR DESCRIPTION
Load attached save, extracted from https://github.com/OpenRCT2/OpenRCT2/issues/3731

[invalid-map-elem.sv6.zip](https://github.com/OpenRCT2/OpenRCT2/files/572679/invalid-map-elem.sv6.zip)

The save seems somewhat broken, I get this when trying to load it from #3731:
> `ERROR[/home/janisozaur/workspace/OpenRCT2/src/game.c:774 (game_fix_save_vars)]: Null map element at x = 128 and y = 128. Fixing...`

@marijnvdwerf perhaps you would know something about it?