### PR TITLE
Extract openrct2_assert to guard.h

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../core/Guard.hpp"
 extern "C" {
 	#include "../config.h"
 	#include "../platform/platform.h"

--- a/src/cmdline/CommandLine.cpp
+++ b/src/cmdline/CommandLine.cpp
@@ -14,6 +14,8 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../core/Guard.hpp"
+
 extern "C"
 {
     #include "../platform/platform.h"

--- a/src/cmdline/ConvertCommand.cpp
+++ b/src/cmdline/ConvertCommand.cpp
@@ -17,6 +17,7 @@
 #include "../common.h"
 #include "../core/Console.hpp"
 #include "../core/Exception.hpp"
+#include "../core/Guard.hpp"
 #include "../core/Path.hpp"
 #include "../rct1/S4Importer.h"
 #include "CommandLine.hpp"

--- a/src/cmdline/RootCommands.cpp
+++ b/src/cmdline/RootCommands.cpp
@@ -16,6 +16,8 @@
 
 #include <time.h>
 
+#include "../core/Guard.hpp"
+
 extern "C"
 {
     #include "../config.h"

--- a/src/core/Guard.hpp
+++ b/src/core/Guard.hpp
@@ -16,6 +16,15 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void openrct2_assert(bool expression, const char * message, ...);
+
+#ifdef __cplusplus
+}
+
 #include <stdarg.h>
 
 /**
@@ -48,3 +57,5 @@ namespace Guard
 };
 
 #define GUARD_LINE "Location: %s:%d", __func__, __LINE__
+
+#endif // __cplusplus

--- a/src/core/guard.h
+++ b/src/core/guard.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_H
+#define GUARD_H
+
+void openrct2_assert(bool expression, const char * message, ...);
+
+#endif // GUARD_H

--- a/src/core/guard.h
+++ b/src/core/guard.h
@@ -1,6 +1,0 @@
-#ifndef GUARD_H
-#define GUARD_H
-
-void openrct2_assert(bool expression, const char * message, ...);
-
-#endif // GUARD_H

--- a/src/localisation/language.cpp
+++ b/src/localisation/language.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <stack>
+#include "../core/Guard.hpp"
 #include "../core/String.hpp"
 #include "../object/ObjectManager.h"
 #include "LanguagePack.h"

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -23,6 +23,8 @@
 	#include <arpa/inet.h>
 #endif
 
+#include "../core/Guard.hpp"
+
 extern "C" {
 #include "../openrct2.h"
 #include "../platform/platform.h"

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -18,7 +18,7 @@
 #define _OPENRCT2_H_
 
 #include "common.h"
-#include "core/guard.h"
+#include "core/Guard.hpp"
 #include "platform/platform.h"
 
 #ifndef DISABLE_NETWORK

--- a/src/openrct2.h
+++ b/src/openrct2.h
@@ -18,6 +18,7 @@
 #define _OPENRCT2_H_
 
 #include "common.h"
+#include "core/guard.h"
 #include "platform/platform.h"
 
 #ifndef DISABLE_NETWORK
@@ -61,7 +62,6 @@ void openrct2_dispose();
 void openrct2_finish();
 void openrct2_reset_object_tween_locations();
 bool openrct2_setup_rct2_segment();
-void openrct2_assert(bool expression, const char * message, ...);
 
 int cmdline_run(const char **argv, int argc);
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -18,7 +18,7 @@
 #include "../common.h"
 
 #include <SDL.h>
-#include "../core/guard.h"
+#include "../core/Guard.hpp"
 #include "../localisation/localisation.h"
 #include "../platform/platform.h"
 #include "util.h"

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -18,6 +18,7 @@
 #include "../common.h"
 
 #include <SDL.h>
+#include "../core/guard.h"
 #include "../localisation/localisation.h"
 #include "../platform/platform.h"
 #include "util.h"


### PR DESCRIPTION
`openrct2_assert` is not defined in util.c and including all of
openrct2.h is unnecessary.