### PR TITLE
Replace malloc(0) with explicit NULL

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1115,7 +1115,7 @@ void title_sequences_set_default()
 	platform_get_user_directory(path, "title sequences", sizeof(path));
 	platform_ensure_directory_exists(path);
 
-	gConfigTitleSequences.presets = malloc(0);
+	gConfigTitleSequences.presets = NULL;
 	gConfigTitleSequences.num_presets = 0;
 
 	platform_get_openrct_data_path(dataPath, sizeof(dataPath));
@@ -1236,8 +1236,8 @@ static void title_sequence_open(const char *path, const char *customName)
 			safe_strcpy(gConfigTitleSequences.presets[preset].path, path, MAX_PATH);
 		}
 
-		gConfigTitleSequences.presets[preset].saves = malloc(0);
-		gConfigTitleSequences.presets[preset].commands = malloc(0);
+		gConfigTitleSequences.presets[preset].saves = NULL;
+		gConfigTitleSequences.presets[preset].commands = NULL;
 		gConfigTitleSequences.presets[preset].num_saves = 0;
 		gConfigTitleSequences.presets[preset].num_commands = 0;
 	}

--- a/src/interface/title_sequences.c
+++ b/src/interface/title_sequences.c
@@ -95,8 +95,8 @@ void title_sequence_create_preset(const char *name)
 		safe_strcpy(gConfigTitleSequences.presets[preset].name, name, TITLE_SEQUENCE_NAME_SIZE);
 		gConfigTitleSequences.presets[preset].path[0] = 0;
 
-		gConfigTitleSequences.presets[preset].saves = malloc(0);
-		gConfigTitleSequences.presets[preset].commands = malloc(0);
+		gConfigTitleSequences.presets[preset].saves = NULL;
+		gConfigTitleSequences.presets[preset].commands = NULL;
 		gConfigTitleSequences.presets[preset].num_saves = 0;
 		gConfigTitleSequences.presets[preset].num_commands = 0;
 


### PR DESCRIPTION
From documentation on `void* malloc( size_t size );`:
> If size is zero, the behavior is implementation defined (null pointer
may be returned, or some non-null pointer may be returned that may not
be used to access storage).

Both `free()` and `realloc()` understand `NULL`, so use that to avoid
implementation-defined behaviour