### PR TITLE
Check for invalid colours

### DIFF
--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -469,6 +469,7 @@ static void colour_char_window(uint8 colour, uint16* current_font_flags,uint8* p
 
 	int eax;
 
+	assert(colour < countof(ColourMapB));
 	eax = ColourMapB[colour].b;
 	if (*current_font_flags & 2) {
 		eax |= 0x0A0A00;


### PR DESCRIPTION
Select RCT1 theme, then demolish any ride.

Caused by https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/interface/Theme.cpp#L123:
`{ THEME_WC(WC_DEMOLISH_RIDE_PROMPT), STR_THEMES_WINDOW_DEMOLISH_RIDE_PROMPT, COLOURS_1(TRANSLUCENT(COLOUR_BORDEAUX_RED) ) },`

`COLOUR_BORDEAUX_RED` = 26
`TRANSLUCENT(COLOUR_BORDEAUX_RED)` = 154

while `ColourMapB` only has 32 entries.