### PR TITLE
Display and load sc6 files in "load game" browser

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Improved: Performance and reliability of loading objects.
 - Improved: Screenshots are now saved with the name of the park and the current date and time.
 - Improved: More accurate frame rate calculation
+- Improved: In-game file dialog now shows more formats (sv6, sc6, sv4, etc.)
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
 - Fix: [#1038] Guest List is out of order.

--- a/src/editor.c
+++ b/src/editor.c
@@ -258,17 +258,18 @@ bool editor_load_landscape(const utf8 *path)
 {
 	window_close_construction_windows();
 
-	char *extension = strrchr(path, '.');
-	if (extension != NULL) {
-		if (_stricmp(extension, ".sv4") == 0) {
-			return editor_load_landscape_from_sv4(path);
-		} else if (_stricmp(extension, ".sc4") == 0) {
+	uint32 extension = get_file_extension_type(path);
+	switch (extension) {
+		case FILE_EXTENSION_SC6:
+		case FILE_EXTENSION_SV6:
+			return editor_read_s6(path);
+		case FILE_EXTENSION_SC4:
 			return editor_load_landscape_from_sc4(path);
-		}
+		case FILE_EXTENSION_SV4:
+			return editor_load_landscape_from_sv4(path);
+		default:
+			return 0;
 	}
-
-	// Load SC6 / SV6
-	return editor_read_s6(path);
 }
 
 /**

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -45,6 +45,7 @@
 #include "world/scenery.h"
 #include "world/sprite.h"
 #include "world/water.h"
+#include "rct1.h"
 
 const rct_string_id ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT] = {
 	STR_BEGINNER_PARKS,
@@ -129,8 +130,18 @@ int scenario_load_and_play_from_path(const char *path)
 {
 	window_close_construction_windows();
 
-	if (!scenario_load(path))
+	uint32 extension = get_file_extension_type(path);
+	if (extension == FILE_EXTENSION_SC6) {
+		if (!scenario_load(path))
+			return 0;
+	}
+	else if (extension == FILE_EXTENSION_SC4) {
+		if (!rct1_load_scenario(path))
+			return 0;
+	}
+	else {
 		return 0;
+	}
 
 	reset_sprite_spatial_index();
 	reset_all_sprite_quadrant_placements();

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -207,7 +207,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 	case LOADSAVETYPE_TRACK:
 		w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
 		if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "track", sizeof(path))) {
-			window_loadsave_populate_list(w, isSave, path, ".td?");
+			window_loadsave_populate_list(w, isSave, path, ".td6;.td4");
 			success = true;
 		}
 		break;
@@ -266,7 +266,7 @@ static bool browse(bool isSave, char *path, size_t pathSize)
 	case LOADSAVETYPE_TRACK:
 		title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
 		desc.filters[0].name = language_get_string(STR_OPENRCT2_TRACK_DESIGN_FILE);
-		desc.filters[0].pattern = isSave ? "*.td6" : "*.td4;*.td6";
+		desc.filters[0].pattern = isSave ? "*.td6" : "*.td6;*.td4";
 		break;
 	}
 

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -193,7 +193,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 	case LOADSAVETYPE_LANDSCAPE:
 		w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
 		if (window_loadsave_get_dir(gConfigGeneral.last_save_landscape_directory, path, "landscape", sizeof(path))) {
-			window_loadsave_populate_list(w, isSave, path, ".sc6");
+			window_loadsave_populate_list(w, isSave, path, ".sc6;.sv6;.sc4;.sv4");
 			success = true;
 		}
 		break;
@@ -256,7 +256,7 @@ static bool browse(bool isSave, char *path, size_t pathSize)
 	case LOADSAVETYPE_LANDSCAPE:
 		title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
 		desc.filters[0].name = language_get_string(STR_OPENRCT2_LANDSCAPE_FILE);
-		desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc4;*.sv4;*.sc6;*.sv6";
+		desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4";
 		break;
 	case LOADSAVETYPE_SCENARIO:
 		title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;


### PR DESCRIPTION
This makes use of string tokens and the "scenario_load_and_play_from_file" that is used in the scenario select window to extend the files shown in the load game browser. Because sv6 and sc6 files are seperate things, I chose to show extensions for the sc6 extension. this may also allow for showing sv4 and sc4 files in the browser as well, but i am unsure if those will load properly as is. I'm also not sure if loading a scenario this way will work when running servers, now that i think of the callback function in the scenarioselect window.... I'm about to test that.

EDIT: This will not work when running a server. I'm looking to fix this.
EDIT2: Turns out it not working while running a server wasn't because of this, as attempting to load a game on network in vanilla OpenRCT2 also triggers the crash. It is something to do with comparing a vector somewhere, I am still looking to find the issue and to fix it.
EDIT3: I have found the underlying issue with the bug mentioned above and have posted a seperate PR to address that (#4780). This can now be reviewed and merged more comfortably.