### PR TITLE
Fix sending of new map to clients.

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -927,11 +927,18 @@ void Network::Server_Send_MAP(NetworkConnection* connection)
 	SDL_RWops* rw = SDL_RWFromFP(temp, SDL_TRUE);
 	size_t out_size;
 	unsigned char *header;
-	header = save_for_network(rw, out_size, connection->RequestedObjects);
+	if (connection) {
+		header = save_for_network(rw, out_size, connection->RequestedObjects);
+	} else {
+		std::vector<const ObjectRepositoryItem *> requestedObjects;
+		header = save_for_network(rw, out_size, requestedObjects);
+	}
 	SDL_RWclose(rw);
 	if (header == nullptr) {
-		connection->SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
-		connection->Socket->Disconnect();
+		if (connection) {
+			connection->SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
+			connection->Socket->Disconnect();
+		}
 		return;
 	}
 	size_t chunksize = 65000;


### PR DESCRIPTION
This fixes a bug* introduced by #4615 in which the connection was not checked if it was null or not before retrieving requestedobjects. The connection is null when a new map is loaded, as network_send_map() is called, which then calls the Network_Send_MAP with a null connection value. 

* = The code may not be accurate and feel kinda "hacked together", or feel as more of a workaround, but loading maps now work on multiplayer with this.