### PR TITLE
Fixes #4771. Start title music again after audio device changes

### DIFF
--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -1330,6 +1330,7 @@ static void window_options_dropdown(rct_window *w, int widgetIndex, int dropdown
 					gConfigSound.device = strndup(devicename, AUDIO_DEVICE_NAME_SIZE);
 				}
 				config_save_default();
+				audio_start_title_music();
 			}
 			window_invalidate(w);
 			break;


### PR DESCRIPTION
Fixes #4771. When audio_init_ride_sounds is called, it calls audio_stop_title_music, but never calls audio_start_title_music. if you do an assert for gTitleMusicChannel it shows it is null. this fixes that. i will say though this is most defintely a bandaid fix, because if run audio_start_title_music in the audio_init_ride_sounds, it still doesn't play outloud. at least on my setup it doesn't.