### PR TITLE
Migrate Ubuntu jobs to containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,31 @@ before_install:
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/install.sh; fi
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo gem install xcpretty-travis-formatter; fi
 
-sudo: required
+sudo: false
 dist: trusty
 env:
     global:
         - OPENRCT2_VERSION="0.0.5.0"
 
+
 matrix:
     include:
         - os: linux
+          addons:
+              apt:
+                  packages:
+                      - cmake
+                      - libsdl2-dev
+                      - libsdl2-ttf-dev
+                      - libjansson-dev
+                      - libcurl4-openssl-dev
+                      - libcrypto++-dev
+                      - libfontconfig1-dev
+                      - libfreetype6-dev
+                      - libpng-dev
+                      - libssl-dev
+                      - gcc-4.8
+                      - g++-4.8
           env:
             - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=OpenRCT2" OPENRCT2_MAKE_OPTS="-j2" TARGET=linux64
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
@@ -27,6 +43,7 @@ matrix:
               else curl --progress-bar --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-x86_64.tar.gz -o link && cat link;
               fi
         - os: linux
+          sudo: required
           env:
             - OPENRCT2_CMAKE_OPTS="-DFORCE32=ON -DDISABLE_RCT2=OFF -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=linux
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
@@ -41,9 +58,24 @@ matrix:
               else curl --progress-bar --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-i686.tar.gz -o link && cat link;
               fi
         - os: linux
+          addons:
+              apt:
+                  packages:
+                      - cmake
+                      - libsdl2-dev
+                      - libsdl2-ttf-dev
+                      - libjansson-dev
+                      - libcurl4-openssl-dev
+                      - libcrypto++-dev
+                      - libfontconfig1-dev
+                      - libfreetype6-dev
+                      - libpng-dev
+                      - libssl-dev
+                      - clang-3.5
           env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" TARGET=linux64
         - os: linux
           env: OPENRCT2_CMAKE_OPTS="-DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DFORCE32=on" TARGET=windows
+          sudo: required
         - os: linux
           env: TARGET=docker64
           services:


### PR DESCRIPTION
I have submitted the packages we need for inclusion to Travis' Trusty containers and had most of them enabled, with one exception, speex, which required fixing a minor bug in Travis.

Depends on not-yet-resolved https://github.com/travis-ci/apt-package-whitelist/issues/3528

I expect this to be resolved in nearest future.

Container-based jobs offer more cores (2 vs 1.5), more RAM (4GB vs 3GB), CPU time is guaranteed and builds start faster.

In our case, the first job takes around 1 minute less than previously.

Over time, when more packages become available, I'll try migrating some other jobs to containers as well.