### PR TITLE
Fix #4777. Check for enough free elements before placement

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -8183,7 +8183,7 @@ static money32 place_ride_entrance_or_exit(sint16 x, sint16 y, sint16 z, uint8 d
 	gCommandPosition.x = x;
 	gCommandPosition.y = y;
 
-	if (!sub_68B044()) {
+	if (!map_check_free_elements_and_reorganise(1)) {
 		return MONEY32_UNDEFINED;
 	}
 

--- a/src/ride/track.c
+++ b/src/ride/track.c
@@ -946,9 +946,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 		gGameCommandErrorText = STR_NOT_ALLOWED_TO_MODIFY_STATION;
 		return MONEY32_UNDEFINED;
 	}
-	if (!sub_68B044()) {
-		return MONEY32_UNDEFINED;
-	}
+
 	if (!(flags & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED)) {
 		if (game_is_paused() && !gCheatsBuildInPauseMode) {
 			gGameCommandErrorText = STR_CONSTRUCTION_NOT_POSSIBLE_WHILE_GAME_IS_PAUSED;
@@ -983,7 +981,7 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 
 	money32 cost = 0;
 	const rct_preview_track *trackBlock = get_track_def_from_ride(ride, type);
-
+	uint32 num_elements = 0;
 	// First check if any of the track pieces are outside the park
 	for (; trackBlock->index != 0xFF; trackBlock++) {
 		int x, y, z, offsetX, offsetY;
@@ -1015,8 +1013,12 @@ static money32 track_place(int rideIndex, int type, int originX, int originY, in
 			gGameCommandErrorText = STR_LAND_NOT_OWNED_BY_PARK;
 			return MONEY32_UNDEFINED;
 		}
+		num_elements++;
 	}
 
+	if (!map_check_free_elements_and_reorganise(num_elements)) {
+		return MONEY32_UNDEFINED;
+	}
 	const uint16 *trackFlags = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ?
 		FlatTrackFlags :
 		TrackFlags;
@@ -1757,7 +1759,7 @@ static money32 set_maze_track(uint16 x, uint8 flags, uint8 direction, uint16 y, 
 
 	money32 cost = 0;
 
-	if (!sub_68B044()) {
+	if (!map_check_free_elements_and_reorganise(1)) {
 		return MONEY32_UNDEFINED;
 	}
 

--- a/src/ride/track_design.c
+++ b/src/ride/track_design.c
@@ -1558,7 +1558,7 @@ static money32 place_maze_design(uint8 flags, uint8 rideIndex, uint16 mazeEntry,
 	gCommandPosition.x = x + 8;
 	gCommandPosition.y = y + 8;
 	gCommandPosition.z = z;
-	if (!sub_68B044()) {
+	if (!map_check_free_elements_and_reorganise(1)) {
 		return MONEY32_UNDEFINED;
 	}
 

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -182,7 +182,7 @@ static money32 footpath_element_insert(int type, int x, int y, int z, int slope,
 	rct_map_element *mapElement;
 	int bl, zHigh;
 
-	if (!sub_68B044())
+	if (!map_check_free_elements_and_reorganise(1))
 		return MONEY32_UNDEFINED;
 
 	if ((flags & GAME_COMMAND_FLAG_APPLY) && !(flags & (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST)))

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -428,7 +428,7 @@ void map_remove_all_rides();
 void map_invalidate_map_selection_tiles();
 void map_invalidate_selection_rect();
 void map_reorganise_elements();
-int sub_68B044();
+bool map_check_free_elements_and_reorganise(int num_elements);
 rct_map_element *map_element_insert(int x, int y, int z, int flags);
 
 typedef int (CLEAR_FUNC)(rct_map_element** map_element, int x, int y, uint8 flags, money32* price);


### PR DESCRIPTION
Fix #4777. Check for enough free elements before placement of multi tiled elements

Previously multi tiled placements would only check for one free element before placing. This would cause a crash when it failed to allocate the next element on maps that were close to reaching their full capacity. Renamed sub_68B044 to map_check_free_elements_and_organise and gave it an argument value to check for enough free elements.