### PR TITLE
Merge colour maps

### DIFF
--- a/src/drawing/string.c
+++ b/src/drawing/string.c
@@ -470,7 +470,7 @@ static void colour_char_window(uint8 colour, uint16* current_font_flags,uint8* p
 	int eax;
 
 	colour = NOT_TRANSLUCENT(colour);
-	eax = ColourMapB[colour].b;
+	eax = ColourMapA[colour].colour_11;
 	if (*current_font_flags & 2) {
 		eax |= 0x0A0A00;
 	}

--- a/src/interface/colour.c
+++ b/src/interface/colour.c
@@ -16,26 +16,43 @@
 
 #include "../drawing/drawing.h"
 #include "colour.h"
+#include "../sprites.h"
 
-rct_colour_map_a ColourMapA[32] = { 0 };
-rct_colour_map_b ColourMapB[32] = { 0 };
+rct_colour_map ColourMapA[32] = { 0 };
+
+enum
+{
+	INDEX_COLOUR_0 = 243,
+	INDEX_COLOUR_1 = 245,
+	INDEX_DARKEST = 245,
+	INDEX_DARKER = 246,
+	INDEX_DARK = 247,
+	INDEX_MID_DARK = 248,
+	INDEX_MID_LIGHT = 249,
+	INDEX_LIGHT = 250,
+	INDEX_LIGHTER = 251,
+	INDEX_LIGHTEST = 252,
+	INDEX_COLOUR_10 = 253,
+	INDEX_COLOUR_11 = 254,
+};
 
 void colours_init_maps()
 {
 	// Get colour maps from g1
 	for (int i = 0; i < 32; i++) {
-		rct_g1_element *g1Element = &g1Elements[4915 + i];
+		rct_g1_element *g1Element = &g1Elements[SPR_PALETTE_2_START + i];
 
-		uint8 *dstA = (uint8*)&ColourMapA[i];
-		uint8 *dstB = (uint8*)&ColourMapB[i];
-		for (int j = 0; j < 4; j++) {
-			dstA[j] = g1Element->offset[0xF5 + j];
-		}
-		for (int j = 0; j < 4; j++) {
-			dstA[j + 4] = g1Element->offset[0xF9 + j];
-		}
-		for (int j = 0; j < 4; j++) {
-			dstB[j] = g1Element->offset[0xFD + j];
-		}
+		ColourMapA[i].colour_0 = g1Element->offset[INDEX_COLOUR_0];
+		ColourMapA[i].colour_1 = g1Element->offset[INDEX_COLOUR_1];
+		ColourMapA[i].darkest = g1Element->offset[INDEX_DARKEST];
+		ColourMapA[i].darker = g1Element->offset[INDEX_DARKER];
+		ColourMapA[i].dark = g1Element->offset[INDEX_DARK];
+		ColourMapA[i].mid_dark = g1Element->offset[INDEX_MID_DARK];
+		ColourMapA[i].mid_light = g1Element->offset[INDEX_MID_LIGHT];
+		ColourMapA[i].light = g1Element->offset[INDEX_LIGHT];
+		ColourMapA[i].lighter = g1Element->offset[INDEX_LIGHTER];
+		ColourMapA[i].lightest = g1Element->offset[INDEX_LIGHTEST];
+		ColourMapA[i].colour_10 = g1Element->offset[INDEX_COLOUR_10];
+		ColourMapA[i].colour_11 = g1Element->offset[INDEX_COLOUR_11];
 	}
 }

--- a/src/interface/colour.h
+++ b/src/interface/colour.h
@@ -73,7 +73,9 @@ enum {
 
 #define NUM_COLOURS 32
 
-typedef struct rct_colour_map_a {
+typedef struct rct_colour_map {
+	uint8 colour_0;
+	uint8 colour_1;
 	uint8 darkest;
 	uint8 darker;
 	uint8 dark;
@@ -82,21 +84,11 @@ typedef struct rct_colour_map_a {
 	uint8 light;
 	uint8 lighter;
 	uint8 lightest;
-} rct_colour_map_a;
+	uint8 colour_10;
+	uint8 colour_11;
+} rct_colour_map;
 
-typedef struct rct_colour_map_b {
-	uint8 a;
-	uint8 b;
-	uint8 c;
-	uint8 d;
-	uint8 e;
-	uint8 f;
-	uint8 g;
-	uint8 h;
-} rct_colour_map_b;
-
-extern rct_colour_map_a ColourMapA[32];
-extern rct_colour_map_b ColourMapB[32];
+extern rct_colour_map ColourMapA[32];
 
 void colours_init_maps();
 


### PR DESCRIPTION
Columns `e`-`h` of `rct_colour_map_b` were never assigned, `d` reading data outside the bounds of the g1-entry. Column `c` technically still belongs to the sprite, but is black. I've included the two indexes before `darkest` so that it matches up with the colour replacement palette.

https://output.jsbin.com/xisozofilo