### PR TITLE
Allow 3 cars per train on the Rocket cars

### DIFF
--- a/src/object/RideObject.cpp
+++ b/src/object/RideObject.cpp
@@ -16,6 +16,7 @@
 
 #include "../core/IStream.hpp"
 #include "../core/Memory.hpp"
+#include "../core/String.hpp"
 #include "../core/Util.hpp"
 #include "ObjectRepository.h"
 #include "RideObject.h"
@@ -74,7 +75,7 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_NAME);
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_DESCRIPTION);
 
-    if (strcmp(this->GetIdentifier(), "RCKC    ") == 0) {
+    if (String::Equals(this->GetIdentifier(), "RCKC    ")) {
         // The rocket cars could take 3 cars per train in RCT1. Restore this.
         _legacyType.max_cars_in_train = 3 + _legacyType.zero_cars;
     }

--- a/src/object/RideObject.cpp
+++ b/src/object/RideObject.cpp
@@ -74,6 +74,11 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_NAME);
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_DESCRIPTION);
 
+    if (strcmp(this->GetIdentifier(), "RCKC    ") == 0) {
+        // The rocket cars could take 3 cars per train in RCT1. Restore this.
+        _legacyType.max_cars_in_train = 3 + _legacyType.zero_cars;
+    }
+
     // TODO: Move to its own function when ride construction window is merged.
     if (gConfigInterface.select_by_track_type) {
         _legacyType.enabledTrackPieces = 0xFFFFFFFFFFFFFFFF;

--- a/src/object/RideObject.cpp
+++ b/src/object/RideObject.cpp
@@ -75,11 +75,6 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_NAME);
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_DESCRIPTION);
 
-    if (String::Equals(this->GetIdentifier(), "RCKC    ")) {
-        // The rocket cars could take 3 cars per train in RCT1. Restore this.
-        _legacyType.max_cars_in_train = 3 + _legacyType.zero_cars;
-    }
-
     // TODO: Move to its own function when ride construction window is merged.
     if (gConfigInterface.select_by_track_type) {
         _legacyType.enabledTrackPieces = 0xFFFFFFFFFFFFFFFF;
@@ -129,6 +124,8 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     {
         context->LogError(OBJECT_ERROR_INVALID_PROPERTY, "Nausea multiplier too high.");
     }
+
+    this->PerformRCT1CompatibilityFixes();
 }
 
 void RideObject::Load()
@@ -443,4 +440,12 @@ void RideObject::ReadLegacyVehicle(IReadObjectContext * context, IStream * strea
     vehicle->draw_order = stream->ReadValue<uint8>();
     vehicle->special_frames = stream->ReadValue<uint8>();
     stream->Seek(4, STREAM_SEEK_CURRENT);
+}
+
+void RideObject::PerformRCT1CompatibilityFixes()
+{
+    if (String::Equals(this->GetIdentifier(), "RCKC    ")) {
+        // The rocket cars could take 3 cars per train in RCT1. Restore this.
+        _legacyType.max_cars_in_train = 3 + _legacyType.zero_cars;
+    }
 }

--- a/src/object/RideObject.cpp
+++ b/src/object/RideObject.cpp
@@ -125,7 +125,7 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
         context->LogError(OBJECT_ERROR_INVALID_PROPERTY, "Nausea multiplier too high.");
     }
 
-    this->PerformRCT1CompatibilityFixes();
+    PerformRCT1CompatibilityFixes();
 }
 
 void RideObject::Load()
@@ -444,7 +444,7 @@ void RideObject::ReadLegacyVehicle(IReadObjectContext * context, IStream * strea
 
 void RideObject::PerformRCT1CompatibilityFixes()
 {
-    if (String::Equals(this->GetIdentifier(), "RCKC    ")) {
+    if (String::Equals(GetIdentifier(), "RCKC    ")) {
         // The rocket cars could take 3 cars per train in RCT1. Restore this.
         _legacyType.max_cars_in_train = 3 + _legacyType.zero_cars;
     }

--- a/src/object/RideObject.h
+++ b/src/object/RideObject.h
@@ -49,4 +49,5 @@ public:
 
 private:
     void ReadLegacyVehicle(IReadObjectContext * context, IStream * stream, rct_ride_entry_vehicle * vehicle);
+    void PerformRCT1CompatibilityFixes();
 };


### PR DESCRIPTION
Allow 3 cars per train on the Rocket cars, for feature parity with RCT1.