### PR TITLE
correctly save with one extension

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -417,6 +417,13 @@ char *safe_strtrimleft(char *destination, const char *source, size_t size)
 	return safe_strcpy(destination, source, size);
 }
 
+char *substr(char *start, int length) {
+	char *result = malloc(length + 1);
+	memcpy(result, start, length);
+	result[length] = 0;
+	return result;
+}
+
 bool utf8_is_bom(const char *str)
 {
 	return str[0] == (char)0xEF && str[1] == (char)0xBB && str[2] == (char)0xBF;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -48,6 +48,7 @@ char *safe_strcpy(char * destination, const char * source, size_t num);
 char *safe_strcat(char *destination, const char *source, size_t size);
 char *safe_strcat_path(char *destination, const char *source, size_t size);
 char *safe_strtrimleft(char *destination, const char *source, size_t size);
+char *substr(char *start, int length);
 
 bool utf8_is_bom(const char *str);
 bool str_is_null_or_empty(const char *str);

--- a/src/windows/loadsave.c
+++ b/src/windows/loadsave.c
@@ -187,14 +187,14 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 	case LOADSAVETYPE_GAME:
 		w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
 		if (window_loadsave_get_dir(gConfigGeneral.last_save_game_directory, path, "save", sizeof(path))) {
-			window_loadsave_populate_list(w, isSave, path, isSave ? ".sv6" : ".sv6;.sc6;.sv4;.sc4");
+			window_loadsave_populate_list(w, isSave, path, ".sv6;.sc6;.sv4;.sc4");
 			success = true;
 		}
 		break;
 	case LOADSAVETYPE_LANDSCAPE:
 		w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
 		if (window_loadsave_get_dir(gConfigGeneral.last_save_landscape_directory, path, "landscape", sizeof(path))) {
-			window_loadsave_populate_list(w, isSave, path, isSave ? ".sc6" : ".sc6;.sv6;.sc4;.sv4");
+			window_loadsave_populate_list(w, isSave, path, ".sc6;.sv6;.sc4;.sv4");
 			success = true;
 		}
 		break;
@@ -208,7 +208,7 @@ rct_window *window_loadsave_open(int type, char *defaultName)
 	case LOADSAVETYPE_TRACK:
 		w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
 		if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "track", sizeof(path))) {
-			window_loadsave_populate_list(w, isSave, path, isSave ? ".td6" : ".td6;.td4");
+			window_loadsave_populate_list(w, isSave, path, ".td6;.td4");
 			success = true;
 		}
 		break;
@@ -442,7 +442,10 @@ static void window_loadsave_textinput(rct_window *w, int widgetIndex, char *text
 
 			safe_strcpy(path, _directory, sizeof(path));
 			safe_strcat_path(path, text, sizeof(path));
-			path_append_extension(path, _extension, sizeof(path));
+			int sepIndex = strchr(_extension, ';') - _extension;
+			char *firstExt = substr(_extension, sepIndex);
+			path_append_extension(path, firstExt, sizeof(path));
+			
 
 			overwrite = 0;
 			for (i = 0; i < _listItemsCount; i++) {


### PR DESCRIPTION
@Gymnasiast Your fixup made it still only show one format when saving, this will correct that by showing it as it did before, but add on only the first extension to the save file path.