### PR TITLE
Fixes #4808: Add land rights recalculation for loading save games

### DIFF
--- a/src/rct1/S4Importer.cpp
+++ b/src/rct1/S4Importer.cpp
@@ -157,6 +157,7 @@ public:
         ImportSavedView();
 
         game_convert_strings_to_utf8();
+        map_count_remaining_land_rights();
     }
 
 private:

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -352,6 +352,7 @@ void S6Importer::Import()
     }
     map_update_tile_pointers();
     game_convert_strings_to_utf8();
+    map_count_remaining_land_rights();
     if (FixIssues)
     {
         game_fix_save_vars();


### PR DESCRIPTION
The feature of disabling the land rights buying buttons depends on the
land rights being accounted for, but the function that calculates these
was not called when loading saved games. Therefore it would often make
it impossible to buy land after loading a saved game.