### PR TITLE
Move utf-related functions to utf8.c

### DIFF
--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -423,21 +423,6 @@ const char *format_get_token(uint32 code)
 	return 0;
 }
 
-bool utf8_is_format_code(int codepoint)
-{
-	if (codepoint < 32) return true;
-	if (codepoint >= FORMAT_ARGUMENT_CODE_START && codepoint <= FORMAT_ARGUMENT_CODE_END) return true;
-	if (codepoint >= FORMAT_COLOUR_CODE_START && codepoint <= FORMAT_COLOUR_CODE_END) return true;
-	if (codepoint == FORMAT_COMMA1DP16) return true;
-	return false;
-}
-
-bool utf8_is_colour_code(int codepoint)
-{
-	if (codepoint >= FORMAT_COLOUR_CODE_START && codepoint <= FORMAT_COLOUR_CODE_END) return true;
-	return false;
-}
-
 bool utf8_should_use_sprite_for_codepoint(int codepoint)
 {
 	switch (codepoint) {
@@ -456,39 +441,6 @@ bool utf8_should_use_sprite_for_codepoint(int codepoint)
 		return true;
 	default:
 		return false;
-	}
-}
-
-int utf8_get_format_code_arg_length(int codepoint)
-{
-	switch (codepoint) {
-	case FORMAT_MOVE_X:
-	case FORMAT_ADJUST_PALETTE:
-	case 3:
-	case 4:
-		return 1;
-	case FORMAT_NEWLINE_X_Y:
-		return 2;
-	case FORMAT_INLINE_SPRITE:
-		return 4;
-	default:
-		return 0;
-	}
-}
-
-void utf8_remove_formatting(utf8* string, bool allowColours) {
-	utf8* readPtr = string;
-	utf8* writePtr = string;
-
-	while (true) {
-		uint32 code = utf8_get_next(readPtr, (const utf8**)&readPtr);
-
-		if (code == 0) {
-			*writePtr = 0;
-			break;
-		} else if (!utf8_is_format_code(code) || (allowColours && utf8_is_colour_code(code))) {
-			writePtr = utf8_write_codepoint(writePtr, code);
-		}
 	}
 }
 
@@ -1382,48 +1334,6 @@ void format_string_to_upper(utf8 *dest, size_t size, rct_string_id format, void 
 		*ch = toupper(*ch);
 		ch++;
 	}
-}
-
-/**
- * Returns a pointer to the null terminator of the given UTF-8 string.
- */
-utf8 *get_string_end(const utf8 *text)
-{
-	int codepoint;
-	const utf8 *ch = text;
-
-	while ((codepoint = utf8_get_next(ch, &ch)) != 0) {
-		int argLength = utf8_get_format_code_arg_length(codepoint);
-		ch += argLength;
-	}
-	return (utf8*)(ch - 1);
-}
-
-/**
- * Return the number of bytes (including the null terminator) in the given UTF-8 string.
- */
-size_t get_string_size(const utf8 *text)
-{
-	return get_string_end(text) - text + 1;
-}
-
-/**
- * Return the number of visible characters (excludes format codes) in the given UTF-8 string.
- */
-int get_string_length(const utf8 *text)
-{
-	int codepoint;
-	const utf8 *ch = text;
-
-	int count = 0;
-	while ((codepoint = utf8_get_next(ch, &ch)) != 0) {
-		if (utf8_is_format_code(codepoint)) {
-			ch += utf8_get_format_code_arg_length(codepoint);
-		} else {
-			count++;
-		}
-	}
-	return count;
 }
 
 utf8 *win1252_to_utf8_alloc(const char *src)


### PR DESCRIPTION
This makes utf8.c standalone (not requiring any external symbols)