### PR TITLE
Refactor sawyercoding

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -28,6 +28,7 @@
 extern "C" {
 #include "../openrct2.h"
 #include "../platform/platform.h"
+#include "../util/sawyercoding.h"
 }
 
 #include "network.h"

--- a/src/util/sawyercoding.h
+++ b/src/util/sawyercoding.h
@@ -28,6 +28,8 @@ typedef struct sawyercoding_chunk_header {
 assert_struct_size(sawyercoding_chunk_header, 5);
 #pragma pack(pop)
 
+extern bool gUseRLE;
+
 enum {
 	CHUNK_ENCODING_NONE,
 	CHUNK_ENCODING_RLE,
@@ -52,7 +54,8 @@ uint32 sawyercoding_calculate_checksum(const uint8* buffer, size_t length);
 bool sawyercoding_read_chunk_safe(SDL_RWops *rw, void *dst, size_t dstLength);
 bool sawyercoding_skip_chunk(SDL_RWops *rw);
 size_t sawyercoding_read_chunk_with_size(SDL_RWops* rw, uint8 *buffer, const size_t buffer_size);
-size_t sawyercoding_write_chunk_buffer(uint8 *dst_file, uint8* buffer, sawyercoding_chunk_header chunkHeader);
+size_t sawyercoding_read_chunk_buffer(uint8 *dst_buffer, const uint8 *src_buffer, sawyercoding_chunk_header chunkHeader, size_t dst_buffer_size);
+size_t sawyercoding_write_chunk_buffer(uint8 *dst_file, const uint8 *src_buffer, sawyercoding_chunk_header chunkHeader);
 size_t sawyercoding_decode_sv4(const uint8 *src, uint8 *dst, size_t length, size_t bufferLength);
 size_t sawyercoding_decode_sc4(const uint8 *src, uint8 *dst, size_t length, size_t bufferLength);
 size_t sawyercoding_encode_sv4(const uint8 *src, uint8 *dst, size_t length);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -24,8 +24,6 @@
 #include "util.h"
 #include "zlib.h"
 
-bool gUseRLE = true;
-
 int squaredmetres_to_squaredfeet(int squaredMetres)
 {
 	// 1 metre squared = 10.7639104 feet squared

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -19,8 +19,6 @@
 
 #include "../common.h"
 
-extern bool gUseRLE;
-
 int squaredmetres_to_squaredfeet(int squaredMetres);
 int metres_to_feet(int metres);
 int mph_to_kmph(int mph);


### PR DESCRIPTION
This introduces `sawyercoding_read_chunk_buffer` for parity with `sawyercoding_write_chunk_buffer`, makes source arguments `const`.

`gUseRLE` is also move to a better place.