### PR TITLE
Fixed getting the temperature format in windows.

### DIFF
--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -953,23 +953,23 @@ uint8 platform_get_locale_measurement_format()
 
 uint8 platform_get_locale_temperature_format()
 {
-	// There does not seem to be a function to obtain this, just check the countries
-	UINT country;
+	UINT fahrenheit;
+
+	// GetLocaleInfo will set fahrenheit to 1 if the locale on this computer
+	// uses the United States measurement system or 0 otherwise.
 	if (GetLocaleInfo(LOCALE_USER_DEFAULT,
 		LOCALE_IMEASURE | LOCALE_RETURN_NUMBER,
-		(LPSTR)&country,
-		sizeof(country)) == 0
+		(LPSTR)&fahrenheit,
+		sizeof(fahrenheit)) == 0
 	) {
+		// Assume celsius by default if function call fails
 		return TEMPERATURE_FORMAT_C;
 	}
 
-	switch (country) {
-	case CTRY_UNITED_STATES:
-	case CTRY_BELIZE:
+	if(fahrenheit)
 		return TEMPERATURE_FORMAT_F;
-	default:
+	else
 		return TEMPERATURE_FORMAT_C;
-	}
 }
 
 bool platform_check_steam_overlay_attached()


### PR DESCRIPTION
The current method worked by a funny coincidence.

Passing LOCALE_IMEASURE to GetLocaleInfo makes it return 1 on the third argument if the United States measurement system [Fahrenheit] is used, or 0 if the metric system is used.

CTRY_UNITED_STATES is 1. Thus, the switch that was implemented will make this function return TEMPERATURE_FORMAT_F if GetLocateInfo returns 1, and TEMPERATURE_FORMAT_C otherwise, which is the intended behaviour.

It's clearly not supposed to be implemented like this: the country code of my country (CTRY_PORTUGAL) is 351, but 'country' is not set to 351 after the function call, but 0 instead.

References:
[https://msdn.microsoft.com/en-us/library/windows/desktop/dd318101(v=vs.85).aspx](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318101(v=vs.85).aspx)
[https://msdn.microsoft.com/en-us/library/windows/desktop/dd373786(v=vs.85).aspx](https://msdn.microsoft.com/en-us/library/windows/desktop/dd373786(v=vs.85).aspx)
