### PR TITLE
Fix call to `realpath` in `posix.c`

### DIFF
--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -699,9 +699,16 @@ void platform_get_openrct_data_path(utf8 *outPath, size_t outSize)
 void platform_resolve_openrct_data_path()
 {
 	if (gCustomOpenrctDataPath[0] != 0) {
-		if (realpath(gCustomOpenrctDataPath, _openrctDataDirectoryPath) == NULL) {
+		// NOTE: second argument to `realpath` is meant to either be NULL or `PATH_MAX`-sized buffer,
+		// since our `MAX_PATH` macro is set to some other value, pass NULL to have `realpath` return
+		// a `malloc`ed buffer.
+		char *resolved_path = realpath(gCustomOpenrctDataPath, NULL);
+		if (resolved_path == NULL) {
 			log_error("Could not resolve path \"%s\", errno = %d", gCustomOpenrctDataPath, errno);
 			return;
+		} else {
+			safe_strcpy(_openrctDataDirectoryPath, resolved_path, MAX_PATH);
+			free(resolved_path);
 		}
 
 		path_end_with_separator(_openrctDataDirectoryPath, MAX_PATH);


### PR DESCRIPTION
Uncovered in #4837:
```
In file included from /usr/include/stdlib.h:959:0,
                 from /home/travis/build/OpenRCT2/OpenRCT2/src/platform/../rct2.h:36,
                 from /home/travis/build/OpenRCT2/OpenRCT2/src/platform/../common.h:21,
                 from /home/travis/build/OpenRCT2/OpenRCT2/src/platform/../config.h:20,
                 from /home/travis/build/OpenRCT2/OpenRCT2/src/platform/posix.c:19:
In function ‘realpath’,
    inlined from ‘platform_resolve_openrct_data_path’ at /home/travis/build/OpenRCT2/OpenRCT2/src/platform/posix.c:749:21:
/usr/include/x86_64-linux-gnu/bits/stdlib.h:43:2: error: call to ‘__realpath_chk_warn’ declared with attribute warning: second argument of realpath must be either NULL or at least PATH_MAX bytes long buffer [-Werror]
  return __realpath_chk_warn (__name, __resolved, __bos (__resolved));
  ^
```