### PR TITLE
Further pathfinding fixes

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9297,7 +9297,17 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 					if (peep->pathfind_history[i].x == x >> 5 &&
 						peep->pathfind_history[i].y == y >> 5 &&
 						peep->pathfind_history[i].z == z) {
-						pathLoop = true;
+						if (peep->pathfind_history[i].direction == 0) {
+							/* If all directions have already been tried while
+							 * heading to this goal, this is a loop. */
+							pathLoop = true;
+						}
+						else {
+							/* The peep remembers walking through this junction
+							 * before, but has not yet tried all directions.
+							 * Limit the edges to search to those not yet tried. */
+							edges &= peep->pathfind_history[i].direction;
+						}
 						break;
 					}
 				}

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9529,7 +9529,17 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 			if (peep->pathfind_history[i].x == x / 32 &&
 					peep->pathfind_history[i].y == y / 32 &&
 					peep->pathfind_history[i].z == z) {
-				edges = peep->pathfind_history[i].direction & 0xF;
+
+				/* Fix broken pathfind_history[i].direction
+				 * which have untried directions that are not
+				 * currently possible - could be due to pathing
+				 * changes or in earlier code .directions was
+				 * initialised to 0xF rather than the permitted
+				 * edges. */
+				peep->pathfind_history[i].direction &= permitted_edges;
+
+				edges = peep->pathfind_history[i].direction;
+
 				#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 				if (gPathFindDebug) {
 					log_verbose("Getting untried edges from pf_history for %d,%d,%d:  %s,%s,%s,%s", x >> 5, y >> 5, z, (edges & 1) ? "0" : "-", (edges & 2) ? "1" : "-", (edges & 4) ? "2" : "-", (edges & 8) ? "3" : "-");
@@ -9540,8 +9550,6 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		}
 	}
 
-	// Remove any edges that are not permitted
-	edges &= path_get_permitted_edges(dest_map_element);
 
 	// Peep has tried all edges.
 	if (edges == 0) return -1;

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -143,7 +143,7 @@ static void peep_ride_is_too_intense(rct_peep *peep, int rideIndex, bool peepAtR
 static void peep_chose_not_to_go_on_ride(rct_peep *peep, int rideIndex, bool peepAtRide, bool updateLastRide);
 static void peep_tried_to_enter_full_queue(rct_peep *peep, int rideIndex);
 static bool peep_should_go_to_shop(rct_peep *peep, int rideIndex, bool peepAtShop);
-static void peep_reset_pathfind_goal(rct_peep *peep);
+void peep_reset_pathfind_goal(rct_peep *peep);
 static bool peep_find_ride_to_look_at(rct_peep *peep, uint8 edge, uint8 *rideToView, uint8 *rideSeatToView);
 static void peep_easter_egg_peep_interactions(rct_peep *peep);
 static int peep_get_height_on_slope(rct_peep *peep, int x, int y);
@@ -10248,6 +10248,14 @@ static int guest_path_finding(rct_peep* peep)
 	#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 	if (direction == -1){
+		/* Heuristic search failed for all directions.
+		 * Reset the pathfind_goal - this means that the pathfind_history
+		 * will be reset in the next call to peep_pathfind_choose_direction().
+		 * This lets the heuristic search "try again" in case the player has
+		 * edited the path layout or the mechanic was already stuck in the
+		 * save game (e.g. with a worse version of the pathfinding). */
+		peep_reset_pathfind_goal(peep);
+
 		return guest_path_find_aimless(peep, edges);
 	}
 	return peep_move_one_tile(direction, peep);
@@ -11005,7 +11013,7 @@ static bool peep_should_use_cash_machine(rct_peep *peep, int rideIndex)
  *
  *  rct2: 0x0069A98C
  */
-static void peep_reset_pathfind_goal(rct_peep *peep)
+void peep_reset_pathfind_goal(rct_peep *peep)
 {
 	peep->pathfind_goal.x = 0xFF;
 	peep->pathfind_goal.y = 0xFF;

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9545,6 +9545,25 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 					log_verbose("Getting untried edges from pf_history for %d,%d,%d:  %s,%s,%s,%s", x >> 5, y >> 5, z, (edges & 1) ? "0" : "-", (edges & 2) ? "1" : "-", (edges & 4) ? "2" : "-", (edges & 8) ? "3" : "-");
 				}
 				#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+
+				if (edges == 0) {
+					/* If peep has tried all edges, reset to
+					 * all edges are untried.
+					 * This permits the pathfinding to try
+					 * again, which is good for getting
+					 * unstuck when the player has edited
+					 * the paths or the pathfinding itself
+					 * has changed (been fixed) since
+					 * the game was saved. */
+					peep->pathfind_history[i].direction = permitted_edges;
+					edges = peep->pathfind_history[i].direction;
+
+					#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+					if (gPathFindDebug) {
+						log_verbose("All edges tried for %d,%d,%d - resetting to all untried", x >> 5, y >> 5, z);
+					}
+					#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+				}
 				break;
 			}
 		}

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9715,7 +9715,7 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		peep->pathfind_history[i].x = x >> 5;
 		peep->pathfind_history[i].y = y >> 5;
 		peep->pathfind_history[i].z = z;
-		peep->pathfind_history[i].direction = 0xF;
+		peep->pathfind_history[i].direction = permitted_edges;
 		peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 		if (gPathFindDebug) {

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -9550,6 +9550,26 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		}
 	}
 
+	/* If this is a new goal for the peep. Store it and reset the peep's
+	 * pathfind_history. */
+	if (peep->pathfind_goal.direction > 3 ||
+		peep->pathfind_goal.x != goal.x ||
+		peep->pathfind_goal.y != goal.y ||
+		peep->pathfind_goal.z != goal.z
+	) {
+		peep->pathfind_goal.x = goal.x;
+		peep->pathfind_goal.y = goal.y;
+		peep->pathfind_goal.z = goal.z;
+		peep->pathfind_goal.direction = 0;
+
+		// Clear pathfinding history
+		memset(peep->pathfind_history, 0xFF, sizeof(peep->pathfind_history));
+		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+		if (gPathFindDebug) {
+			log_verbose("New goal; clearing pf_history.");
+		}
+		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+	}
 
 	// Peep has tried all edges.
 	if (edges == 0) return -1;
@@ -9673,27 +9693,6 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 				log_verbose("Junction#%d %d,%d,%d Direction %d", listIdx + 1, bestJunctionList[listIdx].x, bestJunctionList[listIdx].y, bestJunctionList[listIdx].z, bestDirectionList[listIdx]);
 			}
 			log_verbose("End at %d,%d,%d", bestXYZ.x, bestXYZ.y, bestXYZ.z);
-		}
-		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-	}
-
-	/* If this is a new goal for the peep. Store it and reset the peep's
-	 * pathfind_history. */
-	if (peep->pathfind_goal.direction > 3 ||
-		peep->pathfind_goal.x != goal.x ||
-		peep->pathfind_goal.y != goal.y ||
-		peep->pathfind_goal.z != goal.z
-	) {
-		peep->pathfind_goal.x = goal.x;
-		peep->pathfind_goal.y = goal.y;
-		peep->pathfind_goal.z = goal.z;
-		peep->pathfind_goal.direction = 0;
-
-		// Clear pathfinding history
-		memset(peep->pathfind_history, 0xFF, sizeof(peep->pathfind_history));
-		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-		if (gPathFindDebug) {
-			log_verbose("New goal; clearing pf_history.");
 		}
 		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 	}

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -685,5 +685,6 @@ money32 set_peep_name(int flags, int state, uint16 sprite_index, uint8* text_1, 
 void game_command_set_guest_name(int *eax, int *ebx, int *ecx, int *edx, int *esi, int *edi, int *ebp);
 
 int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep);
+void peep_reset_pathfind_goal(rct_peep *peep);
 
 #endif

--- a/src/peep/peep.h
+++ b/src/peep/peep.h
@@ -20,12 +20,6 @@
 #include "../common.h"
 #include "../world/map.h"
 
-#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-// Some variables used for the path finding debugging.
-extern bool gPathFindDebug;
-extern utf8 gPathFindDebugPeepName[256];
-#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-
 #define PEEP_MAX_THOUGHTS 5
 
 #define PEEP_HUNGER_WARNING_THRESHOLD 25
@@ -686,5 +680,18 @@ void game_command_set_guest_name(int *eax, int *ebx, int *ecx, int *edx, int *es
 
 int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep);
 void peep_reset_pathfind_goal(rct_peep *peep);
+
+#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+#define PATHFIND_DEBUG 0 // Set to 0 to disable pathfinding debugging;
+			 // Set to 1 to enable pathfinding debugging.
+// Some variables used for the path finding debugging.
+extern bool gPathFindDebug; // Use to guard calls to log messages
+extern utf8 gPathFindDebugPeepName[256]; // Use to put the peep name in the log message
+
+// The following calls set the above two variables for a peep.
+// ... when PATHFIND_DEBUG is 1 (non zero) 
+void pathfind_logging_enable(rct_peep* peep);
+void pathfind_logging_disable();
+#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 #endif

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -1073,7 +1073,7 @@ static uint8 staff_mechanic_direction_path(rct_peep* peep, uint8 validDirections
 		gPeepPathFindGoalPosition.z = z;
 
 		/* Find location of the exit for the target ride station
-		 * or if the ride has no exit, the entrance */
+		 * or if the ride has no exit, the entrance. */
 		uint16 location = ride->exits[peep->current_ride_station];
 		if (location == 0xFFFF) {
 			location = ride->entrances[peep->current_ride_station];
@@ -1113,19 +1113,13 @@ static uint8 staff_mechanic_direction_path(rct_peep* peep, uint8 validDirections
 		gPeepPathFindQueueRideIndex = 255;
 
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-		/* Determine if the pathfinding debugging is wanted for this peep. */
-		/* For staff, there is no tracking button (any other similar
-		 * suitable existing mechanism?), so fall back to a crude
-		 * string comparison with a compile time hardcoded name. */
-		format_string(gPathFindDebugPeepName, sizeof(gPathFindDebugPeepName), peep->name_string_idx, &(peep->id));
-
-		gPathFindDebug = strcmp(gPathFindDebugPeepName, "Mechanic Debug") == 0;
+		pathfind_logging_enable(peep);
 		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 		int pathfindDirection = peep_pathfind_choose_direction(peep->next_x, peep->next_y, peep->next_z, peep);
 
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-		gPathFindDebug = false;
+		pathfind_logging_disable();
 		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 		if (pathfindDirection == -1) {

--- a/src/peep/staff.c
+++ b/src/peep/staff.c
@@ -1129,6 +1129,13 @@ static uint8 staff_mechanic_direction_path(rct_peep* peep, uint8 validDirections
 		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 		if (pathfindDirection == -1) {
+			/* Heuristic search failed for all directions.
+			 * Reset the pathfind_goal - this means that the pathfind_history
+			 * will be reset in the next call to peep_pathfind_choose_direction().
+			 * This lets the heuristic search "try again" in case the player has
+			 * edited the path layout or the mechanic was already stuck in the
+			 * save game (e.g. with a worse version of the pathfinding). */
+			peep_reset_pathfind_goal(peep);
 			return staff_mechanic_direction_path_rand(peep, pathDirections);
 		}
 


### PR DESCRIPTION
Includes the following small fixes to the peep pathfinding:
1. Make path finding aware of all path elements when choosing a direction.  Importantly the heuristic search is similarly aware of this already and this inconsistency could cause pathfinding glitches.
2. Fix initialisation of junctions added to pathfind_history. Specifically set .direction to the permitted edges rather than all edges.
3. Repair pathfind_history[i].direction when choosing peep direction. Specifically remove non-permitted edges.
4. After pathfind_goal is reset do the pathfind_history reset *before* calling the heuristic search, since it uses the pathfind_history for some loop detection.
5. Reset pathfind_history[i].direction after all directions have been tried. This makes the pathfinding try again.  Good for recovering e.g. when pathing is edited or the savegame is bad due to earlier pathfinding bugs.
6. Fix loop detection based on the pathfind_history in the heuristic search. A loop is now only detected when revisiting a path in the pathfind_history for which all edges have been tried. Previously the edges were not considered, which meant backtracking and trying a different direction at a remembered junction was not possible.
7. Reset the pathfind_goal (causing pathfind_history to be reset) when choosing a direction completely fails. This makes the pathfinding try again.  Good for recovering e.g. when pathing is edited or the savegame is bad due to earlier pathfinding bugs.
8. Various changes to improve pathfinding debugging.
9. Increment the network version.

Fixes #4842 (excluding the patrol zone issues that are recorded in #4699).
Fixes #4668 (improves on the fixes made in #4688).