### PR TITLE
Fix #4793: Inventions list broken

### DIFF
--- a/src/windows/editor_inventions_list.c
+++ b/src/windows/editor_inventions_list.c
@@ -419,9 +419,7 @@ static void move_research_item(rct_research_item *beforeItem)
 	rct_window *w;
 	rct_research_item *researchItem, draggedItem;
 
-	// We only really care about `_editorInventionsListDraggedItem == beforeItem - 1`,
-	// but this would cause a GCC warning due to -Warray-bounds
-	if (_editorInventionsListDraggedItem < beforeItem)
+	if (_editorInventionsListDraggedItem + 1 == beforeItem)
 		return;
 
 	// Back up the dragged item


### PR DESCRIPTION
This reverts commit 3f767ed8ff2 and replaces it with exact check that
doesn't trigger array-bounds GCC warning with `-O3`