### PR TITLE
Scenery size fix

### DIFF
--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -1100,13 +1100,13 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 	while ((currentSceneryGlobalId = window_scenery_tab_entries[tabIndex][sceneryTabItemIndex]) != -1) {
 		uint16 tabSelectedSceneryId = gWindowSceneryTabSelections[tabIndex];
 
-		if (gWindowSceneryPaintEnabled == 1)
-		{
+		if (gWindowSceneryPaintEnabled == 1) {
 			if (w->scenery.selected_scenery_id == currentSceneryGlobalId) {
 				gfx_fill_rect_inset(dpi, left, top, left + SCENERY_BUTTON_WIDTH - 1,
 					top + SCENERY_BUTTON_HEIGHT - 1, w->colours[1], INSET_RECT_FLAG_FILL_MID_LIGHT);
 			}
-		} else {
+		} 
+		else {
 			if (tabSelectedSceneryId == currentSceneryGlobalId) {
 				gfx_fill_rect_inset(dpi, left, top, left + SCENERY_BUTTON_WIDTH - 1,
 					top + SCENERY_BUTTON_HEIGHT - 1, w->colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_MID_LIGHT));
@@ -1125,19 +1125,22 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 
 			gfx_draw_sprite(dpi, imageId, left + 0x21, top + 0x28, w->colours[1]);
 			gfx_draw_sprite(dpi, imageId + 1, left + 0x21, top + 0x28, w->colours[1]);
-		} else if (currentSceneryGlobalId >= 0x300) {
+		}
+		else if (currentSceneryGlobalId >= 0x300) {
 			sceneryEntry = get_large_scenery_entry(currentSceneryGlobalId - 0x300);
 			uint32 imageId = sceneryEntry->image + gWindowSceneryRotation;
 			imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
 			imageId |= (gWindowScenerySecondaryColour << 24) | 0x80000000;
 
 			gfx_draw_sprite(dpi, imageId, left + 0x21, top, w->colours[1]);
-		} else if (currentSceneryGlobalId >= 0x200) {
+		}
+		else if (currentSceneryGlobalId >= 0x200) {
 			sceneryEntry = get_wall_entry(currentSceneryGlobalId - 0x200);
 			rct_drawpixelinfo clipdpi;
-			if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, 64, 78)) {
+			if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
 				uint32 imageId = sceneryEntry->image;
 				uint8 tertiaryColour = w->colours[1];
+				uint16 spriteTop = (sceneryEntry->wall.height * 2) + 0x32;
 
 				if (sceneryEntry->wall.flags & WALL_SCENERY_FLAG2) {
 					imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
@@ -1145,12 +1148,10 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 					if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR) {
 						imageId |= (gWindowScenerySecondaryColour << 24) | 0x80000000;
 					}
-					gfx_draw_sprite(&clipdpi, imageId, 0x2F, (sceneryEntry->wall.height * 2) + 0x32,
-						tertiaryColour);
+					gfx_draw_sprite(&clipdpi, imageId, 0x2F, spriteTop, tertiaryColour);
 
 					imageId = (sceneryEntry->image + 0x40000006) | (GlassPaletteIds[gWindowSceneryPrimaryColour] << 19);
-					gfx_draw_sprite(&clipdpi, imageId, 0x2F, (sceneryEntry->wall.height * 2) + 0x32,
-						tertiaryColour);
+					gfx_draw_sprite(&clipdpi, imageId, 0x2F, spriteTop, tertiaryColour);
 				}
 				else {
 					imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
@@ -1162,23 +1163,22 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 							imageId &= 0xDFFFFFFF;
 							tertiaryColour = gWindowSceneryTertiaryColour;
 						}
-
 					}
-					gfx_draw_sprite(&clipdpi, imageId, 0x2F, (sceneryEntry->wall.height * 2) + 0x32,
-					tertiaryColour);
+					gfx_draw_sprite(&clipdpi, imageId, 0x2F, spriteTop, tertiaryColour);
 
-					if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOOR){
-						gfx_draw_sprite(&clipdpi, imageId + 1, 0x2F, (sceneryEntry->wall.height * 2) + 0x32,
-							tertiaryColour);
+					if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOOR) {
+						gfx_draw_sprite(&clipdpi, imageId + 1, 0x2F, spriteTop, tertiaryColour);
 					}
 				}
 			}
-		} else if (currentSceneryGlobalId >= 0x100) {
+		}
+		else if (currentSceneryGlobalId >= 0x100) {
 			sceneryEntry = get_footpath_item_entry(currentSceneryGlobalId - 0x100);
 			uint32 imageId = sceneryEntry->image;
 
 			gfx_draw_sprite(dpi, imageId, left + 0x0B, top + 0x10, w->colours[1]);
-		} else {
+		}
+		else {
 			sceneryEntry = get_small_scenery_entry(currentSceneryGlobalId);
 			rct_drawpixelinfo clipdpi;
 			if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
@@ -1195,7 +1195,7 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 				uint16 spriteTop = (sceneryEntry->small_scenery.height / 4) + 0x2B;
 
 				if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE &&
-					sceneryEntry->small_scenery.flags &  SMALL_SCENERY_FLAG_VOFFSET_CENTRE) {
+					sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_VOFFSET_CENTRE) {
 					spriteTop -= 0x0C;
 				}
 

--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -1118,26 +1118,26 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 		}
 
 		rct_scenery_entry* sceneryEntry;
-		if (currentSceneryGlobalId >= 0x400) {
-			sceneryEntry = get_banner_entry(currentSceneryGlobalId - 0x400);
-			uint32 imageId = sceneryEntry->image + gWindowSceneryRotation * 2;
-			imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
+		rct_drawpixelinfo clipdpi;
+		if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
+			if (currentSceneryGlobalId >= 0x400) {
+				sceneryEntry = get_banner_entry(currentSceneryGlobalId - 0x400);
+				uint32 imageId = sceneryEntry->image + gWindowSceneryRotation * 2;
+				imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
 
-			gfx_draw_sprite(dpi, imageId, left + 0x21, top + 0x28, w->colours[1]);
-			gfx_draw_sprite(dpi, imageId + 1, left + 0x21, top + 0x28, w->colours[1]);
-		}
-		else if (currentSceneryGlobalId >= 0x300) {
-			sceneryEntry = get_large_scenery_entry(currentSceneryGlobalId - 0x300);
-			uint32 imageId = sceneryEntry->image + gWindowSceneryRotation;
-			imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
-			imageId |= (gWindowScenerySecondaryColour << 24) | 0x80000000;
+				gfx_draw_sprite(&clipdpi, imageId, 0x21, 0x28, w->colours[1]);
+				gfx_draw_sprite(&clipdpi, imageId + 1, 0x21, 0x28, w->colours[1]);
+			}
+			else if (currentSceneryGlobalId >= 0x300) {
+				sceneryEntry = get_large_scenery_entry(currentSceneryGlobalId - 0x300);
+				uint32 imageId = sceneryEntry->image + gWindowSceneryRotation;
+				imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
+				imageId |= (gWindowScenerySecondaryColour << 24) | 0x80000000;
 
-			gfx_draw_sprite(dpi, imageId, left + 0x21, top, w->colours[1]);
-		}
-		else if (currentSceneryGlobalId >= 0x200) {
-			sceneryEntry = get_wall_entry(currentSceneryGlobalId - 0x200);
-			rct_drawpixelinfo clipdpi;
-			if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
+				gfx_draw_sprite(&clipdpi, imageId, 0x21, 0, w->colours[1]);
+			}
+			else if (currentSceneryGlobalId >= 0x200) {
+				sceneryEntry = get_wall_entry(currentSceneryGlobalId - 0x200);
 				uint32 imageId = sceneryEntry->image;
 				uint8 tertiaryColour = w->colours[1];
 				uint16 spriteTop = (sceneryEntry->wall.height * 2) + 0x32;
@@ -1171,17 +1171,14 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int scrol
 					}
 				}
 			}
-		}
-		else if (currentSceneryGlobalId >= 0x100) {
-			sceneryEntry = get_footpath_item_entry(currentSceneryGlobalId - 0x100);
-			uint32 imageId = sceneryEntry->image;
+			else if (currentSceneryGlobalId >= 0x100) {
+				sceneryEntry = get_footpath_item_entry(currentSceneryGlobalId - 0x100);
+				uint32 imageId = sceneryEntry->image;
 
-			gfx_draw_sprite(dpi, imageId, left + 0x0B, top + 0x10, w->colours[1]);
-		}
-		else {
-			sceneryEntry = get_small_scenery_entry(currentSceneryGlobalId);
-			rct_drawpixelinfo clipdpi;
-			if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
+				gfx_draw_sprite(&clipdpi, imageId, 0x0B, 0x10, w->colours[1]);
+			}
+			else {
+				sceneryEntry = get_small_scenery_entry(currentSceneryGlobalId);
 				uint32 imageId = sceneryEntry->image + gWindowSceneryRotation;
 
 				if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR) {


### PR DESCRIPTION
This fixes custom objects overlapping other objects in the scenery window. Instead of only certain objects having a clipped dpi, all items are now drawn into a clipped dpi in the scenario window. It doesn't fix the obscene image sizes, but it's a halfway-there point.

Before:
[http://i.imgur.com/vImvKI7.png](http://i.imgur.com/vImvKI7.png)

After:
[http://i.imgur.com/vImvKI7.png](http://i.imgur.com/xAHcq0p.png)