### PR TITLE
Fix #4819. Prevent peep queue loops when next_in_queue broken.

### DIFF
--- a/src/network/network.h
+++ b/src/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -4889,7 +4889,20 @@ static void peep_update_queuing(rct_peep* peep){
 	}
 
 	if (peep->sub_state != 10){
-		if (peep->next_in_queue == 0xFFFF){
+		bool is_front = true;
+		if (peep->next_in_queue != 0xFFFF) {
+			// Fix #4819: Occasionally the peep->next_in_queue is incorrectly set
+			// to prevent this from causing the peeps to enter a loop
+			// first check if the next in queue is actually nearby
+			// if they are not then its safe to assume that this is
+			// the front of the queue.
+			rct_peep* next_peep = GET_PEEP(peep->next_in_queue);
+			if (abs(next_peep->x - peep->x) < 32 &&
+				abs(next_peep->y - peep->y) < 32) {
+				is_front = false;
+			}
+		}
+		if (is_front){
 			//Happens every time peep goes onto ride.
 			peep->destination_tolerence = 0;
 			peep_decrement_num_riders(peep);


### PR DESCRIPTION
Fix #4819. Prevent peep queue loops when next_in_queue broken.

Not sure how next_in_queue is becoming incorrect but this check will ensure that an incorrect next_in_queue does not force the peeps to rewalk the entire queue path when it gets set incorrectly. After one peep queues correctly the issue will be resolved as next_in_queue will be set correctly