### PR TITLE
Drop unused RCT_CALL* wrappers

### DIFF
--- a/dockerfiles/32bit/Dockerfile
+++ b/dockerfiles/32bit/Dockerfile
@@ -12,6 +12,6 @@ RUN usermod -aG wheel travis
 RUN sed -i 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
 
 # sdl2_ttf (x86_64) is needed to satisfy compile-time dependencies, even if we don't use it
-RUN pacman -S --noconfirm lib32-curl lib32-sdl2 lib32-speex lib32-fontconfig lib32-openssl lib32-libpng sdl2_ttf lib32-libzip1 && pacman -Sc
+RUN pacman -S --noconfirm lib32-curl lib32-sdl2 lib32-speex lib32-fontconfig lib32-openssl lib32-libpng sdl2_ttf && pacman -Sc
 USER travis
-RUN yaourt -S --noconfirm lib32-jansson lib32-sdl2_ttf && rm -rf /tmp/yaourt-tmp-travis && sudo pacman -Sc
+RUN yaourt -S --noconfirm lib32-jansson lib32-sdl2_ttf lib32-libzip1 && rm -rf /tmp/yaourt-tmp-travis && sudo pacman -Sc

--- a/src/addresses.h
+++ b/src/addresses.h
@@ -628,11 +628,6 @@
  */
 int RCT2_CALLPROC_X(int address, int _eax, int _ebx, int _ecx, int _edx, int _esi, int _edi, int _ebp);
 
-static int RCT2_CALLPROC_EBPSAFE(int address)
-{
-	return RCT2_CALLPROC_X(address, 0xBBBBBBBB, 0xBBBBBBBB, 0xBBBBBBBB, 0xBBBBBBBB, 0xBBBBBBBB, 0xBBBBBBBB, 0xBBBBBBBB);
-}
-
 /**
  * Returns the flags register
  *
@@ -646,17 +641,6 @@ static int RCT2_CALLPROC_EBPSAFE(int address)
  * All other bits are undefined.
  */
 int RCT2_CALLFUNC_X(int address, int *_eax, int *_ebx, int *_ecx, int *_edx, int *_esi, int *_edi, int *_ebp);
-
-static int RCT2_CALLFUNC_Y(int address, registers *inOut)
-{
-	return RCT2_CALLFUNC_X(address, &inOut->eax, &inOut->ebx, &inOut->ecx, &inOut->edx, &inOut->esi, &inOut->edi, &inOut->ebp);
-}
-
-static int RCT2_CALLFUNC_Z(int address, const registers *in, registers *out)
-{
-	*out = *in;
-	return RCT2_CALLFUNC_Y(address, out);
-}
 
 #endif
 


### PR DESCRIPTION
These are not in use, but can cause compilation issues in tests, so just drop them.

@IntelOrca @duncanspumpkin @marijnvdwerf can you confirm these are not needed?