### PR TITLE
Migrate Linux Travis-CI jobs to docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ env:
 matrix:
     include:
         - os: linux
+          services:
+            - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=OpenRCT2" OPENRCT2_MAKE_OPTS="-j2" TARGET=linux64
+            - OPENRCT2_CMAKE_OPTS="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=OpenRCT2" OPENRCT2_MAKE_OPTS="-j2" TARGET=ubuntu_amd64
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             - cd build
@@ -27,8 +29,10 @@ matrix:
               else curl --progress-bar --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-x86_64.tar.gz -o link && cat link;
               fi
         - os: linux
+          services:
+            - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-DFORCE32=ON -DDISABLE_RCT2=OFF -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=linux
+            - OPENRCT2_CMAKE_OPTS="-DFORCE32=ON -DDISABLE_RCT2=OFF -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=ubuntu_i686
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             - cd build
@@ -41,7 +45,7 @@ matrix:
               else curl --progress-bar --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-i686.tar.gz -o link && cat link;
               fi
         - os: linux
-          env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" TARGET=linux64
+          env: OPENRCT2_CMAKE_OPTS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" TARGET=ubuntu_amd64
         - os: linux
           env: OPENRCT2_CMAKE_OPTS="-DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DFORCE32=on" TARGET=windows
         - os: linux

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -18,8 +18,8 @@ else
 fi
 mkdir -p "$cachedir"
 
-# Sets default target to "linux", if none specified
-TARGET=${TARGET-linux}
+# Sets default target to "ubuntu_amd64", if none specified
+TARGET=${TARGET-ubuntu_amd64}
 # keep in sync with version in build.sh
 libversion=3
 libVFile="./libversion"
@@ -170,20 +170,14 @@ elif [[ $(uname) == "Linux" ]]; then
 	else
 		# prevent build.sh from re-doing all the steps again
 		case "$TARGET" in
-			"linux")
-				sudo dpkg --add-architecture i386
-				sudo apt-get update
-				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 clang libfontconfig1-dev:i386 libfreetype6-dev:i386 libpng-dev:i386
-				sudo apt-get install -f
+			"ubuntu_i686")
+				docker pull openrct2/openrct2:ubuntu_i686
 				;;
-			"linux64")
-				sudo apt-get update
-				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev libsdl2-ttf-dev gcc-4.8 pkg-config g++ gcc libjansson-dev libspeex-dev libspeexdsp-dev libcurl4-openssl-dev libcrypto++-dev libfontconfig1-dev libfreetype6-dev libpng-dev
-				sudo apt-get install -f
+			"ubuntu_amd64")
+				docker pull openrct2/openrct2:ubuntu_amd64
 				;;
 			"windows")
-				sudo apt-get update
-				sudo apt-get install -y --force-yes binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 cmake
+				docker pull openrct2/openrct2:mingw
 				;;
 			"docker32")
 				docker pull openrct2/openrct2:32bit-only

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ ExternalProject_Add(
 		DEPENDS googletest-distribution
 		DOWNLOAD_COMMAND ""
 		SOURCE_DIR "${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest"
+		CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${TARGET_M}"
 		# Disable install step
 		INSTALL_COMMAND ""
 		# Wrap download, configure and build steps in a script to log output


### PR DESCRIPTION
This moves all of our Travis Ubuntu jobs inside docker containers, so we can use Ubuntu 16.04.

This is required for work in https://github.com/OpenRCT2/OpenRCT2/pull/4792, as the version offered by Travis has too old libzip.

Some containers are still being built, so you can initially see red results on travis, but I will restart them once images become available.