### PR TITLE
natural loudness scale on the music and sound volume settings

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -441,6 +441,13 @@ Mixer::Mixer()
 {
 	effectbuffer = 0;
 	volume = 1;
+	adjust_sound_vol = 0.f;
+	adjust_music_vol = 0.f;
+
+	// invalidate initial memorized volume setting
+	setting_sound_vol = 0xff;
+	setting_music_vol = 0xff;
+
 	for (size_t i = 0; i < Util::CountOf(css1sources); i++) {
 		css1sources[i] = 0;
 	}
@@ -581,6 +588,16 @@ void SDLCALL Mixer::Callback(void* arg, uint8* stream, int length)
 
 void Mixer::MixChannel(Channel& channel, uint8* data, int length)
 {
+	// Did the volume level get changed? Recalculate level in this case.
+	if (setting_sound_vol != gConfigSound.sound_volume) {
+		setting_sound_vol = gConfigSound.sound_volume;
+		adjust_sound_vol = powf(setting_sound_vol / 100.f, 10.f / 6.f);
+	}
+	if (setting_music_vol != gConfigSound.ride_music_volume) {
+		setting_music_vol = gConfigSound.ride_music_volume;
+		adjust_music_vol = powf(setting_music_vol / 100.f, 10.f / 6.f);
+	}
+
 	// Do not mix channel if channel is a sound and sound is disabled
 	if (channel.group == MIXER_GROUP_SOUND && !gConfigSound.sound_enabled) {
 		return;
@@ -678,7 +695,7 @@ void Mixer::MixChannel(Channel& channel, uint8* data, int length)
 				volumeadjust *= (gConfigSound.master_volume / 100.0f);
 				switch (channel.group) {
 				case MIXER_GROUP_SOUND:
-					volumeadjust *= (gConfigSound.sound_volume / 100.0f);
+					volumeadjust *= adjust_sound_vol;
 
 					// Cap sound volume on title screen so music is more audible
 					if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) {
@@ -686,7 +703,7 @@ void Mixer::MixChannel(Channel& channel, uint8* data, int length)
 					}
 					break;
 				case MIXER_GROUP_RIDE_MUSIC:
-					volumeadjust *= (gConfigSound.ride_music_volume / 100.0f);
+					volumeadjust *= adjust_music_vol;
 					break;
 				}
 				int startvolume = (int)(channel.oldvolume * volumeadjust);

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -184,6 +184,8 @@ private:
 	std::list<Channel*> channels;
 	Source_Null source_null;
 	float volume;
+	float adjust_sound_vol, adjust_music_vol;
+	uint8 setting_sound_vol, setting_music_vol;
 };
 
 extern "C"


### PR DESCRIPTION
I've been talking about this neat thing on the OpenRCT gitter yesterday:

So this commit changes the volume settings for sounds and ride music to be of linear loudness instead of linear amplitude. The idea is that you don't have to move the slider at the very few pixels on the left when changing the volume at quieter levels. I tried to compensate this with a curve that is supposed to create a linear loudness scale (which still isn't natural) but works pretty well.
On the gitter I was told that using floats is okay as long as it's audio stuff and doesn't cause a decrease in performance. I changed it the way that the powf() call (which creates the loudness curve) only get's called if the settings are changed.