### PR TITLE
Obey DESTDIR during title sequence installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,9 +396,9 @@ list(APPEND DOC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/contributors.md" "${CMAKE_CUR
 # CMake does not allow specifying a dependency chain which includes built-in
 # targets, like `install`, so we have to trick it and execute dependency ourselves.
 install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
-install(CODE "file(DOWNLOAD https://github.com/OpenRCT2/title-sequences/releases/download/v0.0.5/title-sequence-v0.0.5.zip ${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/title-sequences.zip EXPECTED_HASH_SHA1=79ffb2585d12abcbfce205d7696e3472a504b005 SHOW_PROGRESS)")
-install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir ${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/ \"${CMAKE_COMMAND}\" -E tar xvf title-sequences.zip)")
-install(CODE "file(REMOVE ${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/title-sequences.zip)")
+install(CODE "file(DOWNLOAD https://github.com/OpenRCT2/title-sequences/releases/download/v0.0.5/title-sequence-v0.0.5.zip \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/title-sequences.zip EXPECTED_HASH_SHA1=79ffb2585d12abcbfce205d7696e3472a504b005 SHOW_PROGRESS)")
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/ \"${CMAKE_COMMAND}\" -E tar xvf title-sequences.zip)")
+install(CODE "file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/${PROJECT}/title/title-sequences.zip)")
 install(TARGETS ${PROJECT} RUNTIME DESTINATION bin)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION share/${PROJECT})
 install(DIRECTORY data/ DESTINATION share/${PROJECT})


### PR DESCRIPTION
This fixes the typical `cmake`, `make`, `make DESTDIR=/path/to/buildroot install` sequence used during Linux packaging.

Previously DESTDIR was not obeyed, so the `install` target would try to download the title sequence directly to the install prefix (e.g. `/usr`). This fails as most distros don't build as root, and it tries to install it outside the DESTDIR so it wouldn't be included in the final package anyway!

The $ is escaped to delay evaluation of DESTDIR until runtime. It's typically only specified when `make install` runs - not during the cmake invocation itself.

(Speaking as the maintainer of the Arch AUR packages, downloading extra stuff inside the Makefile also feels dubious (particularly during the install stage - during the build stage would be slightly more acceptable), but I think that's really a separate issue.)