### PR TITLE
Stop infinite title sequence loading

### DIFF
--- a/src/title/TitleSequenceManager.cpp
+++ b/src/title/TitleSequenceManager.cpp
@@ -67,9 +67,7 @@ namespace TitleSequenceManager
 
     const TitleSequenceManagerItem * GetItem(size_t i)
     {
-        TitleSequenceManagerItem * item = &_items[i];
-        assert(item != nullptr);
-        return item;
+        return &_items[i];
     }
 
     static size_t FindItemIndexByPath(const utf8 * path)
@@ -84,6 +82,11 @@ namespace TitleSequenceManager
     void DeleteItem(size_t i)
     {
         auto item = GetItem(i);
+        if (item == nullptr)
+        {
+            log_error("Delete title sequence failed: %d does not exist.", i);
+            return;
+        }
         const utf8 * path = item->Path.c_str();
         if (item->IsZip)
         {
@@ -99,6 +102,11 @@ namespace TitleSequenceManager
     size_t RenameItem(size_t i, const utf8 * newName)
     {
         auto item = &_items[i];
+        if (item == nullptr)
+        {
+            log_error("Rename title sequence failed: %d does not exist.", i);
+            return -1;
+        }
         const utf8 * oldPath = item->Path.c_str();
 
         utf8 newPath[MAX_PATH];
@@ -125,6 +133,11 @@ namespace TitleSequenceManager
     size_t DuplicateItem(size_t i, const utf8 * name)
     {
         auto item = &_items[i];
+        if (item == nullptr)
+        {
+            log_error("Delete title sequence failed: %d does not exist.", i);
+            return -1;
+        }
         const utf8 * srcPath = item->Path.c_str();
 
         std::string dstPath = GetNewTitleSequencePath(std::string(name), item->IsZip);
@@ -298,6 +311,8 @@ extern "C"
     const utf8 * title_sequence_manager_get_name(size_t index)
     {
         auto item = TitleSequenceManager::GetItem(index);
+        if (item == nullptr) { item = TitleSequenceManager::GetItem(0); }
+        if (item == nullptr) { return "<null>"; }
         const utf8 * name = item->Name.c_str();
         return name;
     }
@@ -327,6 +342,7 @@ extern "C"
     uint16 title_sequence_manager_get_predefined_index(size_t index)
     {
         auto item = TitleSequenceManager::GetItem(index);
+        assert(item != nullptr);
         uint16 predefinedIndex = item->PredefinedIndex;
         return predefinedIndex;
     }
@@ -337,7 +353,7 @@ extern "C"
         for (size_t i = 0; i < count; i++)
         {
             const utf8 * cid = title_sequence_manager_get_config_id(i);
-            if (String::Equals(cid, configId))
+            if (cid != nullptr && String::Equals(cid, configId))
             {
                 return i;
             }

--- a/src/title/TitleSequenceManager.cpp
+++ b/src/title/TitleSequenceManager.cpp
@@ -67,7 +67,9 @@ namespace TitleSequenceManager
 
     const TitleSequenceManagerItem * GetItem(size_t i)
     {
-        return &_items[i];
+        TitleSequenceManagerItem * item = &_items[i];
+        assert(item != nullptr);
+        return item;
     }
 
     static size_t FindItemIndexByPath(const utf8 * path)

--- a/src/title/TitleSequencePlayer.cpp
+++ b/src/title/TitleSequencePlayer.cpp
@@ -147,7 +147,6 @@ public:
     {
         _position = 0;
         _waitCounter = 0;
-        _lastLoadedSaveIndex = -1;
         Update();
     }
 
@@ -246,6 +245,7 @@ private:
             gGameSpeed = Math::Clamp<uint8>(1, command->Speed, 4);
             break;
         case TITLE_SCRIPT_RESTART:
+            _lastLoadedSaveIndex = -1;
             Reset();
             break;
         case TITLE_SCRIPT_LOAD:

--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -904,8 +904,11 @@ void window_scenery_invalidate(rct_window *w)
 
 	uint16 tabIndex = gWindowSceneryActiveTabIndex;
 	uint32 titleStringId = STR_MISCELLANEOUS;
-	if (tabIndex < 19)
-		titleStringId = get_scenery_group_entry(tabIndex)->name;
+	if (tabIndex < 19) {
+		if (get_scenery_group_entry(tabIndex) != NULL) {
+			titleStringId = get_scenery_group_entry(tabIndex)->name;
+		}
+	}
 
 	window_scenery_widgets[WIDX_SCENERY_TITLE].text = titleStringId;
 
@@ -927,7 +930,7 @@ void window_scenery_invalidate(rct_window *w)
 				window_scenery_widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = WWT_FLATBTN;
 
 			rct_scenery_entry* sceneryEntry = get_small_scenery_entry(tabSelectedSceneryId);
-			if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG4) {
+			if (sceneryEntry != NULL && sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG4) {
 				window_scenery_widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WWT_FLATBTN;
 			}
 		}
@@ -958,7 +961,7 @@ void window_scenery_invalidate(rct_window *w)
 		if (tabSelectedSceneryId >= 0x400) {
 			sceneryEntry = get_banner_entry(tabSelectedSceneryId - 0x400);
 
-			if (sceneryEntry->banner.flags & 1)
+			if (sceneryEntry != NULL && sceneryEntry->banner.flags & 1)
 				window_scenery_widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WWT_COLOURBTN;
 		} else if (tabSelectedSceneryId >= 0x300) {
 			sceneryEntry = get_large_scenery_entry(tabSelectedSceneryId - 0x300);
@@ -969,7 +972,7 @@ void window_scenery_invalidate(rct_window *w)
 				window_scenery_widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WWT_COLOURBTN;
 		} else if (tabSelectedSceneryId >= 0x200) {
 			sceneryEntry = get_wall_entry(tabSelectedSceneryId - 0x200);
-			if (sceneryEntry->wall.flags & (WALL_SCENERY_FLAG1 | WALL_SCENERY_FLAG2)) {
+			if (sceneryEntry != NULL && sceneryEntry->wall.flags & (WALL_SCENERY_FLAG1 | WALL_SCENERY_FLAG2)) {
 				window_scenery_widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WWT_COLOURBTN;
 
 				if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR) {
@@ -984,7 +987,7 @@ void window_scenery_invalidate(rct_window *w)
 		} else if (tabSelectedSceneryId < 0x100) {
 			sceneryEntry = get_small_scenery_entry(tabSelectedSceneryId);
 
-			if (sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR | SMALL_SCENERY_FLAG_HAS_GLASS)) {
+			if (sceneryEntry != NULL && sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR | SMALL_SCENERY_FLAG_HAS_GLASS)) {
 				window_scenery_widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WWT_COLOURBTN;
 
 				if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR)

--- a/src/windows/title_editor.c
+++ b/src/windows/title_editor.c
@@ -314,7 +314,9 @@ static void window_title_editor_mouseup(rct_window *w, int widgetIndex)
 		break;
 	case WIDX_TITLE_EDITOR_DUPLICATE_BUTTON:
 		if (!commandEditorOpen) {
-			window_text_input_open(w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING, (uintptr_t)_editingTitleSequence->Name, 64);
+			if (_editingTitleSequence != NULL) {
+				window_text_input_open(w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING, (uintptr_t)_editingTitleSequence->Name, 64);
+			}
 		}
 		break;
 	case WIDX_TITLE_EDITOR_DELETE_BUTTON:
@@ -325,7 +327,9 @@ static void window_title_editor_mouseup(rct_window *w, int widgetIndex)
 		break;
 	case WIDX_TITLE_EDITOR_RENAME_SAVE_BUTTON:
 		if (window_title_editor_check_can_edit()) {
-			window_text_input_open(w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING, (uintptr_t)_editingTitleSequence->Name, 64);
+			if (_editingTitleSequence != NULL) {
+				window_text_input_open(w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING, (uintptr_t)_editingTitleSequence->Name, 64);
+			}
 		}
 		break;
 


### PR DESCRIPTION
In the event that someone runs a title sequence that only has a load park command, the game will hang in an attempt to continuously load and unload that park. this attempts to address any hangs by checking to see if it's about to load a save file that's already loaded. if it's the same file, and there has been no "wait" commands anywhere, it ends the title sequence. this also fixes an issue of the end command not ending the while true loop.

This still allows someone to have a title sequence with the same park loaded every 5 seconds for any scenarios such as someone wanting to show a crashing ride over and over, for whatever reason. 