### PR TITLE
Add Importing of RollerCoaster Tycoon Classic scenarios

### DIFF
--- a/src/rct2/S6Exporter.cpp
+++ b/src/rct2/S6Exporter.cpp
@@ -92,6 +92,7 @@ void S6Exporter::SaveScenario(SDL_RWops *rw)
 void S6Exporter::Save(SDL_RWops * rw, bool isScenario)
 {
     _s6.header.type = isScenario ? S6_TYPE_SCENARIO : S6_TYPE_SAVEDGAME;
+    _s6.header.classic_flag = 0;
     _s6.header.num_packed_objects = uint16(ExportObjectsList.size());
     _s6.header.version = S6_RCT2_VERSION;
     _s6.header.magic_number = S6_MAGIC_NUMBER;

--- a/src/rct2/S6Importer.cpp
+++ b/src/rct2/S6Importer.cpp
@@ -112,6 +112,7 @@ void S6Importer::LoadSavedGame(SDL_RWops *rw)
     {
         throw Exception("Data is not a saved game.");
     }
+    log_verbose("saved game classic_flag = 0x%02x\n", _s6.header.classic_flag);
 
     // Read packed objects
     // TODO try to contain this more and not store objects until later
@@ -133,6 +134,7 @@ void S6Importer::LoadScenario(SDL_RWops *rw)
     {
         throw Exception("Data is not a scenario.");
     }
+    log_verbose("scenario classic_flag = 0x%02x\n", _s6.header.classic_flag);
 
     sawyercoding_read_chunk_safe(rw, &_s6.info, sizeof(_s6.info));
 

--- a/src/scenario/scenario.h
+++ b/src/scenario/scenario.h
@@ -38,7 +38,8 @@
  * size: 0x20
  */
 typedef struct rct_s6_header {
-	uint16 type;				// 0x00
+	uint8 type;					// 0x00
+	uint8 classic_flag;			// 0x01
 	uint16 num_packed_objects;	// 0x02
 	uint32 version;				// 0x04
 	uint32 magic_number;		// 0x08


### PR DESCRIPTION
This adds support for loading the scenario files generated by the Toolkit DLC for RollerCoaster Tycoon Classic. It is likely that this PR is incomplete, but I based it off of an example scenario provided by /u/Jamak2001 on Reddit. [Here is that park in a .zip file](https://github.com/OpenRCT2/OpenRCT2/files/669662/_u_Jamak2001.test.park.sc6.zip).

A quick technical overview, it appears to export regular .SC6 files, but with a minor change. The header value for "Type" (usually 0 for save game and 1 for scenario) has had 0x300 added to it. Allowing for the game to account for that value allowed it to load properly in my testing.