### PR TITLE
Add code to inspect any file and classify its format

### DIFF
--- a/openrct2.vcxproj
+++ b/openrct2.vcxproj
@@ -88,6 +88,7 @@
     <None Include="openrct2.exe" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\FileClassifier.cpp" />
     <ClCompile Include="src\rct2\addresses.c" />
     <ClCompile Include="src\audio\audio.c" />
     <ClCompile Include="src\audio\mixer.cpp" />
@@ -422,6 +423,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resources\resource.h" />
+    <ClInclude Include="src\FileClassifier.h" />
     <ClInclude Include="src\rct2\addresses.h" />
     <ClInclude Include="src\audio\audio.h" />
     <ClInclude Include="src\audio\mixer.h" />

--- a/src/FileClassifier.cpp
+++ b/src/FileClassifier.cpp
@@ -1,0 +1,175 @@
+#pragma region Copyright (c) 2014-2016 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#include "core/FileStream.hpp"
+#include "FileClassifier.h"
+
+extern "C"
+{
+    #include "scenario/scenario.h"
+    #include "util/sawyercoding.h"
+}
+
+static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result);
+static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result);
+static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFile * result);
+static bool sawyercoding_try_read_chunk(void * dst, size_t expectedSize, IStream * stream);
+
+bool TryClassifyFile(const std::string &path, ClassifiedFile * result)
+{
+    try
+    {
+        auto fs = FileStream(path, FILE_MODE_OPEN);
+        return TryClassifyFile(&fs, result);
+    }
+    catch (Exception)
+    {
+        return false;
+    }
+}
+
+bool TryClassifyFile(IStream * stream, ClassifiedFile * result)
+{
+    // TODO Currently track designs get classified as SC4s because they use the
+    //      same checksum algorithm. The only way after to tell the difference
+    //      between them is to decode it. Decoding however is currently not protected
+    //      against invalid compression data for that decoding algorithm and will crash.
+
+    // S6 detection
+    if (TryClassifyAsS6(stream, result))
+    {
+        return true;
+    }
+
+    // S4 detection
+    if (TryClassifyAsS4(stream, result))
+    {
+        return true;
+    }
+
+    // TD6 detection
+    if (TryClassifyAsTD4_TD6(stream, result))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result)
+{
+    rct_s6_header s6Header;
+    if (sawyercoding_try_read_chunk(&s6Header, sizeof(rct_s6_header), stream))
+    {
+        if (s6Header.type == S6_TYPE_SAVEDGAME)
+        {
+            result->Type = FILE_TYPE::SAVED_GAME;
+        }
+        else if (s6Header.type == S6_TYPE_SCENARIO)
+        {
+            result->Type = FILE_TYPE::SCENARIO;
+        }
+        result->Version = s6Header.version;
+        return true;
+    }
+
+    return false;
+}
+
+static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result)
+{
+    uint64 originalPosition = stream->GetPosition();
+    size_t dataLength = (size_t)stream->GetLength();
+    uint8 * data = stream->ReadArray<uint8>(dataLength);
+    stream->SetPosition(originalPosition);
+    int fileTypeVersion = sawyercoding_detect_file_type(data, dataLength);
+    Memory::Free(data);
+
+    int type = fileTypeVersion & FILE_TYPE_MASK;
+    int version = fileTypeVersion & FILE_VERSION_MASK;
+
+    if (type == FILE_TYPE_SV4)
+    {
+        result->Type = FILE_TYPE::SAVED_GAME;
+        result->Version = version;
+        return true;
+    }
+    else if (type == FILE_TYPE_SC4)
+    {
+        result->Type = FILE_TYPE::SCENARIO;
+        result->Version = version;
+        return true;
+    }
+    
+    return false;
+}
+
+static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFile * result)
+{
+    bool success = false;
+    uint64 originalPosition = stream->GetPosition();
+    size_t dataLength = (size_t)stream->GetLength();
+    uint8 * data = stream->ReadArray<uint8>(dataLength);
+    stream->SetPosition(originalPosition);
+
+    if (sawyercoding_validate_track_checksum(data, dataLength))
+    {
+        uint8 * td6data = Memory::Allocate<uint8>(0x10000);
+        size_t td6len = sawyercoding_decode_td6(data, td6data, dataLength);
+        if (td6data != nullptr && td6len >= 8)
+        {
+            uint8 version = (td6data[7] >> 2) & 3;
+            if (version <= 2)
+            {
+                result->Type = FILE_TYPE::TRACK_DESIGN;
+                result->Version = version;
+                success = true;
+            }
+        }
+        Memory::Free(td6data);
+    }
+    Memory::Free(data);
+
+    return success;
+}
+
+static bool sawyercoding_try_read_chunk(void * dst, size_t expectedSize, IStream * stream)
+{
+    uint64 originalPosition = stream->GetPosition();
+
+    bool success = false;
+    auto header = stream->ReadValue<sawyercoding_chunk_header>();
+    switch (header.encoding) {
+    case CHUNK_ENCODING_NONE:
+    case CHUNK_ENCODING_RLE:
+    case CHUNK_ENCODING_RLECOMPRESSED:
+    case CHUNK_ENCODING_ROTATE:
+        uint8 * compressedData = Memory::Allocate<uint8>(header.length);
+        if (stream->TryRead(compressedData, header.length) == header.length)
+        {
+            size_t uncompressedLength = sawyercoding_read_chunk_buffer((uint8 *)dst, compressedData, header, expectedSize);
+            if (uncompressedLength == expectedSize)
+            {
+                success = true;
+            }
+        }
+        Memory::Free(compressedData);
+        break;
+    }
+
+    stream->SetPosition(originalPosition);
+    return success;
+}

--- a/src/FileClassifier.h
+++ b/src/FileClassifier.h
@@ -1,0 +1,40 @@
+#pragma region Copyright (c) 2014-2016 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#pragma once
+
+#include <string>
+#include "common.h"
+
+interface IStream;
+
+enum class FILE_TYPE
+{
+    UNDEFINED,
+    OBJECT,
+    SAVED_GAME,
+    SCENARIO,
+    TRACK_DESIGN,
+};
+
+struct ClassifiedFile
+{
+    FILE_TYPE Type;
+    uint32    Version;
+};
+
+bool TryClassifyFile(const std::string &path, ClassifiedFile * result);
+bool TryClassifyFile(IStream * stream, ClassifiedFile * result);


### PR DESCRIPTION
This is needed for #4662 where we want to know whether a file is a scenario or saved game and RCT1 and RCT2 without knowing its file extension.

The code isn't great because of the issue where track designs use the same checksum algorithm as SC4. I can't see a way around that until all our sawyercoding code is robust and can work against any data given to it without crashing. For example I tried to decode an SC4 file using RLE and it crashed due to it going out the bounds of the destination buffer. We have a version that protects against this, but it calls `assert` rather than giving out a graceful error return code.