### PR TITLE
Improve booster construction

### DIFF
--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -1547,7 +1547,7 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_end;
 			slope = FlatRideTrackDefinitions[trackType].vangle_end;
 		} else {
-			if(ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
+			if (ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
 				curve = 0x100 | TRACK_ELEM_BOOSTER;
 			} else {
 				curve = gTrackCurveChain[trackType].next;
@@ -1602,7 +1602,7 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_start;
 			slope = FlatRideTrackDefinitions[trackType].vangle_start;
 		} else {
-			if(ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
+			if (ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
 				curve = 0x100 | TRACK_ELEM_BOOSTER;
 			} else {
 				curve = gTrackCurveChain[trackType].previous;

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -1547,7 +1547,7 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_end;
 			slope = FlatRideTrackDefinitions[trackType].vangle_end;
 		} else {
-			curve = gTrackCurveChain[trackType].next;
+			curve = (ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER)?356:gTrackCurveChain[trackType].next;
 			bank = TrackDefinitions[trackType].bank_end;
 			slope = TrackDefinitions[trackType].vangle_end;
 		}
@@ -1598,7 +1598,7 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_start;
 			slope = FlatRideTrackDefinitions[trackType].vangle_start;
 		} else {
-			curve = gTrackCurveChain[trackType].previous;
+			curve = (ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER)?356:gTrackCurveChain[trackType].previous;
 			bank = TrackDefinitions[trackType].bank_start;
 			slope = TrackDefinitions[trackType].vangle_start;
 		}

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -1547,7 +1547,11 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_end;
 			slope = FlatRideTrackDefinitions[trackType].vangle_end;
 		} else {
-			curve = (ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER)?356:gTrackCurveChain[trackType].next;
+			if(ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER) {
+				curve = 0x100 | TRACK_ELEM_BOOSTER;
+			} else {
+				curve=gTrackCurveChain[trackType].next;
+			}
 			bank = TrackDefinitions[trackType].bank_end;
 			slope = TrackDefinitions[trackType].vangle_end;
 		}
@@ -1598,7 +1602,11 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_start;
 			slope = FlatRideTrackDefinitions[trackType].vangle_start;
 		} else {
-			curve = (ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER)?356:gTrackCurveChain[trackType].previous;
+			if(ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER) {
+				curve = 0x100 | TRACK_ELEM_BOOSTER;
+			} else {
+				curve=gTrackCurveChain[trackType].previous;
+			}
 			bank = TrackDefinitions[trackType].bank_start;
 			slope = TrackDefinitions[trackType].vangle_start;
 		}

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -1547,10 +1547,10 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_end;
 			slope = FlatRideTrackDefinitions[trackType].vangle_end;
 		} else {
-			if(ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER) {
+			if(ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
 				curve = 0x100 | TRACK_ELEM_BOOSTER;
 			} else {
-				curve=gTrackCurveChain[trackType].next;
+				curve = gTrackCurveChain[trackType].next;
 			}
 			bank = TrackDefinitions[trackType].bank_end;
 			slope = TrackDefinitions[trackType].vangle_end;
@@ -1602,10 +1602,10 @@ void ride_construction_set_default_next_piece()
 			bank = FlatRideTrackDefinitions[trackType].bank_start;
 			slope = FlatRideTrackDefinitions[trackType].vangle_start;
 		} else {
-			if(ride->type!=RIDE_TYPE_WILD_MOUSE&&trackType==TRACK_ELEM_BOOSTER) {
+			if(ride->type != RIDE_TYPE_WILD_MOUSE && trackType == TRACK_ELEM_BOOSTER) {
 				curve = 0x100 | TRACK_ELEM_BOOSTER;
 			} else {
-				curve=gTrackCurveChain[trackType].previous;
+				curve = gTrackCurveChain[trackType].previous;
 			}
 			bank = TrackDefinitions[trackType].bank_start;
 			slope = TrackDefinitions[trackType].vangle_start;


### PR DESCRIPTION
This is a very minor change - it prevents boosters from being deselected automatically when building, so you can build a launch run quickly, as described in #4975
 
It is a bit awkward - ideally, this would involve modifying gTrackCurveChain, but because the boosters have the same ID as the spinning control toggle, that piece would be affected as well. So I've added a conditional at the locations where that data is referenced instead.