### PR TITLE
Show money effects when guests spend money

### DIFF
--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10491,6 +10491,7 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
 	finance_payment(-amount, gCommandExpenditureType);
 
 	audio_play_sound_at_location(SOUND_PURCHASE, peep->x, peep->y, peep->z);
+	money_effect_create_at(amount, peep->x, peep->y, peep->z);
 }
 
 static void peep_set_has_ridden(rct_peep *peep, int rideIndex)

--- a/src/openrct2/world/money_effect.c
+++ b/src/openrct2/world/money_effect.c
@@ -30,7 +30,7 @@ static const rct_xy16 _moneyEffectMoveOffset[] = {
  *
  *  rct2: 0x0067351F
  */
-static void money_effect_create_at(money32 value, int x, int y, int z)
+void money_effect_create_at(money32 value, int x, int y, int z)
 {
 	rct_money_effect *moneyEffect;
 	rct_string_id stringId;

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -455,6 +455,7 @@ void duck_remove_all();
 ///////////////////////////////////////////////////////////////
 // Money effect
 ///////////////////////////////////////////////////////////////
+void money_effect_create_at(money32 value, int x, int y, int z);
 void money_effect_create(money32 value);
 void money_effect_update(rct_money_effect *moneyEffect);
 


### PR DESCRIPTION
This is a small visual feature that Roller Coaster Tycoon Classic added. This is also found in Transport Tycoon and Locomotion.

* [x] Create money effect
* [ ] Increment network version
* [ ] Display money in decimal fashion (currently its rounded to the [pound])
* [ ] Add config option