### PR TITLE
fix FreeBSD build by conditionalizing APPLE check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,9 @@ else (DISABLE_NETWORK)
 	endif (WIN32)
 	# If you are on macOS, CMake might try using system-provided OpenSSL.
 	# This is too old and will not work.
-	PKG_CHECK_MODULES(SSL REQUIRED openssl>=1.0.0)
+	if (APPLE)
+		PKG_CHECK_MODULES(SSL REQUIRED openssl>=1.0.0)
+	endif (APPLE)
 endif (DISABLE_NETWORK)
 
 if (DISABLE_RCT2)


### PR DESCRIPTION
All supported FreeBSD releases ship OpenSSL 1.0.0+ but don't
always have pkgconfig file for it. Since this is APPLE-specific
check, mark it as such.