### PR TITLE
Disable MSVC 2017 RC on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.0.6.{build}
 image:
   - Visual Studio 2015
-  - Visual Studio 2017 RC
+#  - Visual Studio 2017 RC
 cache:
 - C:\ProgramData\chocolatey\bin -> scripts\ps\appveyor_install.ps1
 - C:\ProgramData\chocolatey\lib -> scripts\ps\appveyor_install.ps1


### PR DESCRIPTION
I don't recall a build that would fail on MSVC15, but not on MSVC14.
Testing with both of them provides little benefit, while causing huge
delays in builds on AppVeyor.

In due time this can be re-enabled or AppVeyor setup can be moved fully
to MSVC15 when it becomes released.