### PR TITLE
Refactor track design repository to use std::string

### DIFF
--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -26,22 +26,22 @@ extern "C"
 
 namespace File
 {
-    bool Copy(const utf8 * srcPath, const utf8 * dstPath, bool overwrite)
+    bool Copy(const std::string &srcPath, const std::string &dstPath, bool overwrite)
     {
-        return platform_file_copy(srcPath, dstPath, overwrite);
+        return platform_file_copy(srcPath.c_str(), dstPath.c_str(), overwrite);
     }
 
-    bool Delete(const utf8 * path)
+    bool Delete(const std::string &path)
     {
-        return platform_file_delete(path);
+        return platform_file_delete(path.c_str());
     }
 
-    bool Move(const utf8 * srcPath, const utf8 * dstPath)
+    bool Move(const std::string &srcPath, const std::string &dstPath)
     {
-        return platform_file_move(srcPath, dstPath);
+        return platform_file_move(srcPath.c_str(), dstPath.c_str());
     }
 
-    void * ReadAllBytes(const utf8 * path, size_t * length)
+    void * ReadAllBytes(const std::string &path, size_t * length)
     {
         void * result = nullptr;
 

--- a/src/openrct2/core/File.h
+++ b/src/openrct2/core/File.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include <string>
 #include "../common.h"
 
 namespace File
 {
-    bool Copy(const utf8 * srcPath, const utf8 * dstPath, bool overwrite);
-    bool Delete(const utf8 * path);
-    bool Move(const utf8 * srcPath, const utf8 * dstPath);
-    void * ReadAllBytes(const utf8 * path, size_t * length);
+    bool Copy(const std::string &srcPath, const std::string &dstPath, bool overwrite);
+    bool Delete(const std::string &path);
+    bool Move(const std::string &srcPath, const std::string &dstPath);
+    void * ReadAllBytes(const std::string &path, size_t * length);
 }

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -377,7 +377,7 @@ private:
 
 IFileScanner * Path::ScanDirectory(const std::string &pattern, bool recurse)
 {
-    return Path::ScanDirectory(pattern.c_str(), recurse);
+    return ScanDirectory(pattern.c_str(), recurse);
 }
 
 IFileScanner * Path::ScanDirectory(const utf8 * pattern, bool recurse)
@@ -387,6 +387,11 @@ IFileScanner * Path::ScanDirectory(const utf8 * pattern, bool recurse)
 #elif defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     return new FileScannerUnix(pattern, recurse);
 #endif
+}
+
+void Path::QueryDirectory(QueryDirectoryResult * result, const std::string &pattern)
+{
+    return QueryDirectory(result, pattern.c_str());
 }
 
 void Path::QueryDirectory(QueryDirectoryResult * result, const utf8 * pattern)

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -375,6 +375,11 @@ private:
 
 #endif // defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 
+IFileScanner * Path::ScanDirectory(const std::string &pattern, bool recurse)
+{
+    return Path::ScanDirectory(pattern.c_str(), recurse);
+}
+
 IFileScanner * Path::ScanDirectory(const utf8 * pattern, bool recurse)
 {
 #ifdef __WINDOWS__

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <stack>
+#include <string>
 #include <vector>
 #include "FileScanner.h"
 #include "Memory.hpp"
@@ -45,10 +46,10 @@ extern "C"
     #include "../platform/platform.h"
 }
 
-enum DIRECTORY_CHILD_TYPE
+enum class DIRECTORY_CHILD_TYPE
 {
-    DCT_DIRECTORY,
-    DCT_FILE,
+    DIRECTORY,
+    FILE,
 };
 
 struct DirectoryChild
@@ -75,10 +76,9 @@ private:
     };
 
     // Options
-    utf8 *      _rootPath;
-    utf8 * *    _patterns;
-    size_t      _numPatterns;
-    bool        _recurse;
+    std::string                 _rootPath;
+    std::vector<std::string>    _patterns;
+    bool                        _recurse;
 
     // State
     bool                        _started;
@@ -89,12 +89,11 @@ private:
     utf8        * _currentPath;
 
 public:
-    FileScannerBase(const utf8 * pattern, bool recurse)
+    FileScannerBase(const std::string &pattern, bool recurse)
     {
-        _rootPath = Memory::Allocate<utf8>(MAX_PATH);
-        Path::GetDirectory(_rootPath, MAX_PATH, pattern);
+        _rootPath = Path::GetDirectory(pattern);
         _recurse = recurse;
-        _numPatterns = GetPatterns(&_patterns, Path::GetFileName(pattern));
+        _patterns = GetPatterns(Path::GetFileName(pattern));
 
         _currentPath = Memory::Allocate<utf8>(MAX_PATH);
         _currentFileInfo = Memory::Allocate<FileInfo>();
@@ -104,12 +103,6 @@ public:
 
     ~FileScannerBase() override
     {
-        Memory::Free(_rootPath);
-        for (size_t i = 0; i < _numPatterns; i++)
-        {
-            Memory::Free(_patterns[i]);
-        }
-        Memory::Free(_patterns);
         Memory::Free(_currentPath);
         Memory::Free(_currentFileInfo);
     }
@@ -127,7 +120,7 @@ public:
     const utf8 * GetPathRelative() const override
     {
         // +1 to remove the path separator
-        return _currentPath + String::SizeOf(_rootPath) + 1;
+        return _currentPath + _rootPath.size() + 1;
     }
 
     void Reset() override
@@ -156,7 +149,7 @@ public:
             else
             {
                 const DirectoryChild * child = &state->Listing[state->Index];
-                if (child->Type == DCT_DIRECTORY)
+                if (child->Type == DIRECTORY_CHILD_TYPE::DIRECTORY)
                 {
                     utf8 childPath[MAX_PATH];
                     String::Set(childPath, sizeof(childPath), state->Path.c_str());
@@ -164,7 +157,7 @@ public:
 
                     PushState(childPath);
                 }
-                else if (PatternMatch(child->Name.c_str()))
+                else if (PatternMatch(child->Name))
                 {
                     String::Set(_currentPath, MAX_PATH, state->Path.c_str());
                     Path::Append(_currentPath, MAX_PATH, child->Name.c_str());
@@ -180,20 +173,20 @@ public:
     }
 
 private:
-    void PushState(const utf8 * directory)
+    void PushState(const std::string &directory)
     {
         DirectoryState newState;
-        newState.Path = std::string(directory);
+        newState.Path = directory;
         newState.Index = -1;
         GetDirectoryChildren(newState.Listing, directory);
         _directoryStack.push(newState);
     }
 
-    bool PatternMatch(const utf8 * fileName)
+    bool PatternMatch(const std::string &fileName)
     {
-        for (size_t i = 0; i < _numPatterns; i++)
+        for (const auto &pattern : _patterns)
         {
-            if (MatchWildcard(fileName, _patterns[i]))
+            if (MatchWildcard(fileName.c_str(), pattern.c_str()))
             {
                 return true;
             }
@@ -201,11 +194,11 @@ private:
         return false;
     }
 
-    static size_t GetPatterns(utf8 * * * outPatterns, const utf8 * delimitedPatterns)
+    static std::vector<std::string> GetPatterns(const std::string &delimitedPatterns)
     {
-        std::vector<utf8 *> patterns;
+        std::vector<std::string> patterns;
 
-        const utf8 * start = delimitedPatterns;
+        const utf8 * start = delimitedPatterns.c_str();
         const utf8 * ch = start;
         utf8 c;
         do
@@ -216,9 +209,7 @@ private:
                 size_t length = (size_t)(ch - start);
                 if (length > 0)
                 {
-                    utf8 * newPattern = Memory::Allocate<utf8>(length + 1);
-                    Memory::Copy(newPattern, start, length);
-                    newPattern[length] = '\0';
+                    std::string newPattern = std::string(start, length);
                     patterns.push_back(newPattern);
                 }
                 start = ch + 1;
@@ -227,12 +218,12 @@ private:
         }
         while (c != '\0');
 
-        *outPatterns = Memory::DuplicateArray(patterns.data(), patterns.size());
-        return patterns.size();
+        patterns.shrink_to_fit();
+        return patterns;
     }
 
 protected:
-    virtual void GetDirectoryChildren(std::vector<DirectoryChild> &children, const utf8 * path) abstract;
+    virtual void GetDirectoryChildren(std::vector<DirectoryChild> &children, const std::string &path) abstract;
 
 };
 
@@ -241,21 +232,16 @@ protected:
 class FileScannerWindows final : public FileScannerBase
 {
 public:
-    FileScannerWindows(const utf8 * pattern, bool recurse)
+    FileScannerWindows(const std::string &pattern, bool recurse)
         : FileScannerBase(pattern, recurse)
     {
     }
 
 protected:
-    void GetDirectoryChildren(std::vector<DirectoryChild> &children, const utf8 * path) override
+    void GetDirectoryChildren(std::vector<DirectoryChild> &children, const std::string &path) override
     {
-        size_t pathLength = String::SizeOf(path);
-        utf8 * pattern = Memory::Duplicate(path, pathLength + 3);
-        pattern[pathLength + 0] = '\\';
-        pattern[pathLength + 1] = '*';
-        pattern[pathLength + 2] = '\0';
-
-        wchar_t * wPattern = utf8_to_widechar(pattern);
+        std::string pattern = path + "\\*";
+        wchar_t * wPattern = utf8_to_widechar(pattern.c_str());
 
         WIN32_FIND_DATAW findData;
         HANDLE hFile = FindFirstFileW(wPattern, &findData);
@@ -274,7 +260,6 @@ protected:
             FindClose(hFile);
         }
 
-        Memory::Free(pattern);
         Memory::Free(wPattern);
     }
 
@@ -289,11 +274,11 @@ private:
 
         if (child->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
-            result.Type = DCT_DIRECTORY;
+            result.Type = DIRECTORY_CHILD_TYPE::DIRECTORY;
         }
         else
         {
-            result.Type = DCT_FILE;
+            result.Type = DIRECTORY_CHILD_TYPE::FILE;
             result.Size = ((uint64)child->nFileSizeHigh << 32ULL) | (uint64)child->nFileSizeLow;
             result.LastModified = ((uint64)child->ftLastWriteTime.dwHighDateTime << 32ULL) | (uint64)child->ftLastWriteTime.dwLowDateTime;
         }
@@ -308,16 +293,16 @@ private:
 class FileScannerUnix final : public FileScannerBase
 {
 public:
-    FileScannerUnix(const utf8 * pattern, bool recurse)
+    FileScannerUnix(const std::string &pattern, bool recurse)
         : FileScannerBase(pattern, recurse)
     {
     }
 
 protected:
-    void GetDirectoryChildren(std::vector<DirectoryChild> &children, const utf8 * path) override
+    void GetDirectoryChildren(std::vector<DirectoryChild> &children, const std::string &path) override
     {
         struct dirent * * namelist;
-        int count = scandir(path, &namelist, FilterFunc, alphasort);
+        int count = scandir(path.c_str(), &namelist, FilterFunc, alphasort);
         if (count > 0)
         {
             for (int i = 0; i < count; i++)
@@ -326,7 +311,7 @@ protected:
                 if (!String::Equals(node->d_name, ".") &&
                     !String::Equals(node->d_name, ".."))
                 {
-                    DirectoryChild child = CreateChild(path, node);
+                    DirectoryChild child = CreateChild(path.c_str(), node);
                     children.push_back(child);
                 }
                 free(namelist[i]);
@@ -347,11 +332,11 @@ private:
         result.Name = std::string(node->d_name);
         if (node->d_type & DT_DIR)
         {
-            result.Type = DCT_DIRECTORY;
+            result.Type = DIRECTORY_CHILD_TYPE::DIRECTORY;
         }
         else
         {
-            result.Type = DCT_FILE;
+            result.Type = DIRECTORY_CHILD_TYPE::FILE;
 
             // Get the full path of the file
             size_t pathSize = String::SizeOf(directory) + 1 + String::SizeOf(node->d_name) + 1;
@@ -377,11 +362,6 @@ private:
 
 IFileScanner * Path::ScanDirectory(const std::string &pattern, bool recurse)
 {
-    return ScanDirectory(pattern.c_str(), recurse);
-}
-
-IFileScanner * Path::ScanDirectory(const utf8 * pattern, bool recurse)
-{
 #ifdef __WINDOWS__
     return new FileScannerWindows(pattern, recurse);
 #elif defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
@@ -390,11 +370,6 @@ IFileScanner * Path::ScanDirectory(const utf8 * pattern, bool recurse)
 }
 
 void Path::QueryDirectory(QueryDirectoryResult * result, const std::string &pattern)
-{
-    return QueryDirectory(result, pattern.c_str());
-}
-
-void Path::QueryDirectory(QueryDirectoryResult * result, const utf8 * pattern)
 {
     IFileScanner * scanner = Path::ScanDirectory(pattern, true);
     while (scanner->Next())

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -71,5 +71,13 @@ namespace Path
      * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
      * @returns An aggregated result of all scanned files.
      */
+    void QueryDirectory(QueryDirectoryResult * result, const std::string &pattern);
+
+    /**
+     * Scans a directory and all sub directories
+     * @param result The query result to modify.
+     * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
+     * @returns An aggregated result of all scanned files.
+     */
     void QueryDirectory(QueryDirectoryResult * result, const utf8 * pattern);
 }

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <string>
 #include "../common.h"
 
 struct FileInfo
@@ -57,27 +58,10 @@ namespace Path
     IFileScanner * ScanDirectory(const std::string &pattern, bool recurse);
 
     /**
-     * Scans a directory and optionally sub directories for files that matches the
-     * given pattern and returns an enumerator.
-     * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
-     * @param recurse Whether to scan sub directories or not.
-     * @returns A new FileScanner, this must be deleted when no longer needed.
-     */
-    IFileScanner * ScanDirectory(const utf8 * pattern, bool recurse);
-
-    /**
      * Scans a directory and all sub directories
      * @param result The query result to modify.
      * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
      * @returns An aggregated result of all scanned files.
      */
     void QueryDirectory(QueryDirectoryResult * result, const std::string &pattern);
-
-    /**
-     * Scans a directory and all sub directories
-     * @param result The query result to modify.
-     * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
-     * @returns An aggregated result of all scanned files.
-     */
-    void QueryDirectory(QueryDirectoryResult * result, const utf8 * pattern);
 }

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -54,6 +54,15 @@ namespace Path
      * @param recurse Whether to scan sub directories or not.
      * @returns A new FileScanner, this must be deleted when no longer needed.
      */
+    IFileScanner * ScanDirectory(const std::string &pattern, bool recurse);
+
+    /**
+     * Scans a directory and optionally sub directories for files that matches the
+     * given pattern and returns an enumerator.
+     * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
+     * @param recurse Whether to scan sub directories or not.
+     * @returns A new FileScanner, this must be deleted when no longer needed.
+     */
     IFileScanner * ScanDirectory(const utf8 * pattern, bool recurse);
 
     /**

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -29,7 +29,12 @@ extern "C"
 
 namespace Path
 {
-    std::string Append(const std::string &a, const std::string &b)
+    utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src)
+    {
+        return safe_strcat_path(buffer, src, bufferSize);
+    }
+
+    std::string Combine(const std::string &a, const std::string &b)
     {
         utf8 buffer[MAX_PATH];
         String::Set(buffer, sizeof(buffer), a.c_str());
@@ -37,9 +42,9 @@ namespace Path
         return std::string(buffer);
     }
 
-    utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src)
+    std::string GetDirectory(const std::string &path)
     {
-        return safe_strcat_path(buffer, src, bufferSize);
+        return GetDirectory(path.c_str());
     }
 
     utf8 * GetDirectory(const utf8 * path)
@@ -64,6 +69,11 @@ namespace Path
         Memory::Copy(buffer, path, copyLength);
         buffer[copyLength] = '\0';
         return buffer;
+    }
+
+    std::string GetFileName(const std::string &path)
+    {
+        return GetFileName(path.c_str());
     }
 
     const utf8 * GetFileName(const utf8 * path)
@@ -132,6 +142,11 @@ namespace Path
         return buffer;
     }
 
+    const std::string GetExtension(const std::string &path)
+    {
+        return GetExtension(path.c_str());
+    }
+
     const utf8 * GetExtension(const utf8 * path)
     {
         const utf8 * lastDot = nullptr;
@@ -185,6 +200,11 @@ namespace Path
             return buffer;
         }
 #endif
+    }
+
+    bool Equals(const std::string &a, const std::string &b)
+    {
+        return String::Equals(a.c_str(), b.c_str());
     }
 
     bool Equals(const utf8 * a, const utf8 * b)

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -29,6 +29,14 @@ extern "C"
 
 namespace Path
 {
+    std::string Append(const std::string &a, const std::string &b)
+    {
+        utf8 buffer[MAX_PATH];
+        String::Set(buffer, sizeof(buffer), a.c_str());
+        Path::Append(buffer, sizeof(buffer), b.c_str());
+        return std::string(buffer);
+    }
+
     utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src)
     {
         return safe_strcat_path(buffer, src, bufferSize);
@@ -79,6 +87,14 @@ namespace Path
         return lastPathSeperator == nullptr ?
             path :
             lastPathSeperator + 1;
+    }
+
+    std::string GetFileNameWithoutExtension(const std::string &path)
+    {
+        utf8 * cstr = GetFileNameWithoutExtension(path.c_str());
+        std::string result = String::ToStd(cstr);
+        Memory::Free(cstr);
+        return result;
     }
 
     utf8 * GetFileNameWithoutExtension(const utf8 * path)

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -23,10 +23,12 @@ extern "C"
 
 namespace Path
 {
+    std::string Append(const std::string &a, const std::string &b);
     utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src);
     utf8 * GetDirectory(const utf8 * path);
     utf8 * GetDirectory(utf8 * buffer, size_t bufferSize, const utf8 * path);
     const utf8 * GetFileName(const utf8 * path);
+    std::string GetFileNameWithoutExtension(const std::string &path);
     utf8 * GetFileNameWithoutExtension(const utf8 * path);
     utf8 * GetFileNameWithoutExtension(utf8 * buffer, size_t bufferSize, const utf8 * path);
     const utf8 * GetExtension(const utf8 * path);

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -16,22 +16,24 @@
 
 #pragma once
 
-extern "C"
-{
-    #include "../common.h"
-}
+#include <string>
+#include "../common.h"
 
 namespace Path
 {
-    std::string Append(const std::string &a, const std::string &b);
     utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src);
+    std::string Combine(const std::string &a, const std::string &b);
+    std::string GetDirectory(const std::string &path);
     utf8 * GetDirectory(const utf8 * path);
     utf8 * GetDirectory(utf8 * buffer, size_t bufferSize, const utf8 * path);
+    std::string GetFileName(const std::string &path);
     const utf8 * GetFileName(const utf8 * path);
     std::string GetFileNameWithoutExtension(const std::string &path);
     utf8 * GetFileNameWithoutExtension(const utf8 * path);
     utf8 * GetFileNameWithoutExtension(utf8 * buffer, size_t bufferSize, const utf8 * path);
+    const std::string GetExtension(const std::string &path);
     const utf8 * GetExtension(const utf8 * path);
     utf8 * GetAbsolute(utf8 * buffer, size_t bufferSize, const utf8 * relativePath);
+    bool Equals(const std::string &a, const std::string &b);
     bool Equals(const utf8 * a, const utf8 * b);
 }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -50,12 +50,12 @@ namespace String
         return str == nullptr || str[0] == '\0';
     }
 
-    sint32 Compare(const std::string &a, const std::string &b, bool ignoreCase = false)
+    sint32 Compare(const std::string &a, const std::string &b, bool ignoreCase)
     {
         return Compare(a.c_str(), b.c_str(), ignoreCase);
     }
 
-    sint32 Compare(const utf8 * a, const utf8 * b, bool ignoreCase = false)
+    sint32 Compare(const utf8 * a, const utf8 * b, bool ignoreCase)
     {
         if (a == b) return true;
         if (a == nullptr || b == nullptr) return false;
@@ -68,6 +68,11 @@ namespace String
         {
             return strcmp(a, b);
         }
+    }
+
+    bool Equals(const std::string &a, const std::string &b, bool ignoreCase)
+    {
+        return Equals(a.c_str(), b.c_str(), ignoreCase);
     }
 
     bool Equals(const utf8 * a, const utf8 * b, bool ignoreCase)

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -50,6 +50,26 @@ namespace String
         return str == nullptr || str[0] == '\0';
     }
 
+    sint32 Compare(const std::string &a, const std::string &b, bool ignoreCase = false)
+    {
+        return Compare(a.c_str(), b.c_str(), ignoreCase);
+    }
+
+    sint32 Compare(const utf8 * a, const utf8 * b, bool ignoreCase = false)
+    {
+        if (a == b) return true;
+        if (a == nullptr || b == nullptr) return false;
+
+        if (ignoreCase)
+        {
+            return _stricmp(a, b);
+        }
+        else
+        {
+            return strcmp(a, b);
+        }
+    }
+
     bool Equals(const utf8 * a, const utf8 * b, bool ignoreCase)
     {
         if (a == b) return true;
@@ -245,6 +265,11 @@ namespace String
         }
 
         return buffer;
+    }
+
+    utf8 * Duplicate(const std::string &src)
+    {
+        return String::Duplicate(src.c_str());
     }
 
     utf8 * Duplicate(const utf8 * src)

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -27,6 +27,8 @@ namespace String
     std::string StdFormat(const utf8 * format, ...);
 
     bool   IsNullOrEmpty(const utf8 * str);
+    sint32 Compare(const std::string &a, const std::string &b, bool ignoreCase = false);
+    sint32 Compare(const utf8 * a, const utf8 * b, bool ignoreCase = false);
     bool   Equals(const utf8 * a, const utf8 * b, bool ignoreCase = false);
     bool   StartsWith(const utf8 * str, const utf8 * match, bool ignoreCase = false);
     size_t LastIndexOf(const utf8 * str, utf8 match);
@@ -48,6 +50,7 @@ namespace String
     utf8 * Format(const utf8 * format, ...);
     utf8 * Format_VA(const utf8 * format, va_list args);
     utf8 * AppendFormat(utf8 * buffer, size_t bufferSize, const utf8 * format, ...);
+    utf8 * Duplicate(const std::string &src);
     utf8 * Duplicate(const utf8 * src);
 
     /**

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -29,6 +29,7 @@ namespace String
     bool   IsNullOrEmpty(const utf8 * str);
     sint32 Compare(const std::string &a, const std::string &b, bool ignoreCase = false);
     sint32 Compare(const utf8 * a, const utf8 * b, bool ignoreCase = false);
+    bool Equals(const std::string &a, const std::string &b, bool ignoreCase = false);
     bool   Equals(const utf8 * a, const utf8 * b, bool ignoreCase = false);
     bool   StartsWith(const utf8 * str, const utf8 * match, bool ignoreCase = false);
     size_t LastIndexOf(const utf8 * str, utf8 match);

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -374,13 +374,13 @@ extern "C"
     size_t track_repository_get_count_for_ride(uint8 rideType, const utf8 * entry)
     {
         ITrackDesignRepository * repo = GetTrackDesignRepository();
-        return repo->GetCountForObjectEntry(rideType, entry);
+        return repo->GetCountForObjectEntry(rideType, String::ToStd(entry));
     }
 
     size_t track_repository_get_items_for_ride(track_design_file_ref * * outRefs, uint8 rideType, const utf8 * entry)
     {
         ITrackDesignRepository * repo = GetTrackDesignRepository();
-        return repo->GetItemsForObjectEntry(outRefs, rideType, entry);
+        return repo->GetItemsForObjectEntry(outRefs, rideType, String::ToStd(entry));
     }
 
     bool track_repository_delete(const utf8 * path)

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -151,7 +151,7 @@ public:
             const TrackRepositoryItem * item = &_items[index];
             if (!(item->Flags & TRIF_READ_ONLY))
             {
-                if (File::Delete(path.c_str()))
+                if (File::Delete(path))
                 {
                     _items.erase(_items.begin() + index);
                     result = true;
@@ -172,7 +172,7 @@ public:
             {
                 std::string directory = Path::GetDirectory(path);
                 std::string newPath = Path::Combine(directory, newName + Path::GetExtension(path));
-                if (File::Move(path.c_str(), newPath.c_str()))
+                if (File::Move(path, newPath))
                 {
                     item->Name = newName;
                     item->Path = newPath;
@@ -191,7 +191,7 @@ public:
         std::string installDir = _env->GetDirectoryPath(DIRBASE::USER, DIRID::TRACK);
 
         std::string newPath = Path::Combine(installDir, fileName);
-        if (File::Copy(path.c_str(), newPath.c_str(), false))
+        if (File::Copy(path, newPath, false))
         {
             AddTrack(path);
             SortItems();

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -110,8 +110,8 @@ public:
                 (entry == nullptr || String::Equals(item.ObjectEntry.c_str(), entry, true)))
             {
                 track_design_file_ref ref;
-                ref.name = GetNameFromTrackPath(item.Path.c_str());
-                ref.path = String::Duplicate(item.Path.c_str());
+                ref.name = String::Duplicate(GetNameFromTrackPath(item.Path));
+                ref.path = String::Duplicate(item.Path);
                 refs.push_back(ref);
             }
         }
@@ -228,10 +228,7 @@ private:
 
     void Scan(const std::string &directory, uint32 flags = 0)
     {
-        utf8 pattern[MAX_PATH];
-        String::Set(pattern, sizeof(pattern), directory.c_str());
-        Path::Append(pattern, sizeof(pattern), "*.td4;*.td6");
-
+        std::string pattern = Path::Append(directory, "*.td4;*.td6");
         IFileScanner * scanner = Path::ScanDirectory(pattern, true);
         while (scanner->Next())
         {
@@ -241,14 +238,14 @@ private:
         delete scanner;
     }
 
-    void AddTrack(const utf8 * path, uint32 flags = 0)
+    void AddTrack(const std::string path, uint32 flags = 0)
     {
-        rct_track_td6 * td6 = track_design_open(path);
+        rct_track_td6 * td6 = track_design_open(path.c_str());
         if (td6 != nullptr)
         {
             TrackRepositoryItem item;
-            item.Name = std::string(GetNameFromTrackPath(path));
-            item.Path = std::string(path);
+            item.Name = GetNameFromTrackPath(path);
+            item.Path = path;
             item.RideType = td6->type;
             item.ObjectEntry = std::string(td6->vehicle_object.name, 8);
             item.Flags = flags;
@@ -266,10 +263,7 @@ private:
                 {
                     return a.RideType < b.RideType;
                 }
-
-                const utf8 * nameA = a.Name.c_str();
-                const utf8 * nameB = b.Name.c_str();
-                return _stricmp(nameA, nameB) < 0;
+                return String::Compare(a.Name, b.Name) < 0;
             });
     }
 
@@ -369,12 +363,9 @@ private:
     }
 
 public:
-    static utf8 * GetNameFromTrackPath(const utf8 * path)
+    static std::string GetNameFromTrackPath(const std::string &path)
     {
-        utf8 * name = Memory::Allocate<utf8>(MAX_PATH);
-        Path::GetFileNameWithoutExtension(name, MAX_PATH, path);
-        name = Memory::ReallocateArray(name, String::SizeOf(name) + 1);
-        return name;
+        return Path::GetFileNameWithoutExtension(path);
     }
 };
 
@@ -431,6 +422,6 @@ extern "C"
 
     utf8 * track_repository_get_name_from_path(const utf8 * path)
     {
-        return TrackDesignRepository::GetNameFromTrackPath(path);
+        return String::Duplicate(TrackDesignRepository::GetNameFromTrackPath(path));
     }
 }

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -26,6 +26,8 @@ typedef struct track_design_file_ref
 
 #ifdef __cplusplus
 
+#include <string>
+
 interface IPlatformEnvironment;
 
 interface ITrackDesignRepository
@@ -33,15 +35,15 @@ interface ITrackDesignRepository
     virtual ~ITrackDesignRepository() = default;
 
     virtual size_t GetCount() const abstract;
-    virtual size_t GetCountForObjectEntry(uint8 rideType, const utf8 * entry) const abstract;
+    virtual size_t GetCountForObjectEntry(uint8 rideType, const std::string &entry) const abstract;
     virtual size_t GetItemsForObjectEntry(track_design_file_ref * * outRefs,
                                           uint8 rideType,
-                                          const utf8 * entry) const abstract;
+                                          const std::string &entry) const abstract;
 
     virtual void Scan() abstract;
-    virtual bool Delete(const utf8 * path) abstract;
-    virtual const utf8 * Rename(const utf8 * path, const utf8 * newName) abstract;
-    virtual const utf8 * Install(const utf8 * path) abstract;
+    virtual bool Delete(const std::string &path) abstract;
+    virtual std::string Rename(const std::string &path, const std::string &newName) abstract;
+    virtual std::string Install(const std::string &path) abstract;
 };
 
 ITrackDesignRepository * CreateTrackDesignRepository(IPlatformEnvironment * env);
@@ -53,13 +55,13 @@ ITrackDesignRepository * GetTrackDesignRepository();
 extern "C"
 {
 #endif
-    void         track_repository_scan();
-    size_t       track_repository_get_count_for_ride(uint8 rideType, const utf8 * entry);
-    size_t       track_repository_get_items_for_ride(track_design_file_ref * * outRefs, uint8 rideType, const utf8 * entry);
-    utf8 *       track_repository_get_name_from_path(const utf8 *path);
-    bool         track_repository_delete(const utf8 *path);
-    const utf8 * track_repository_rename(const utf8 *path, const utf8 *newName);
-    const utf8 * track_repository_install(const utf8 *srcPath);
+    void    track_repository_scan();
+    size_t  track_repository_get_count_for_ride(uint8 rideType, const utf8 * entry);
+    size_t  track_repository_get_items_for_ride(track_design_file_ref * * outRefs, uint8 rideType, const utf8 * entry);
+    utf8 *  track_repository_get_name_from_path(const utf8 *path);
+    bool    track_repository_delete(const utf8 *path);
+    bool    track_repository_rename(const utf8 *path, const utf8 *newName);
+    bool    track_repository_install(const utf8 *srcPath);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Changing a lot of `utf8 *` to `std::string`, it produces much simpler code with less likelihood of memory bugs.