### PR TITLE
Restrict backtracking during peep pathfinding

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "26"
+#define NETWORK_STREAM_VERSION "27"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9800,7 +9800,7 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 				peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 				#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 				if (gPathFindDebug) {
-					log_verbose("Removing edge %d from existing pf_history for %d,%d,%d.", chosen_edge, x >> 5, y >> 5, z);
+					log_verbose("Updating existing pf_history (in index: %d) for %d,%d,%d without entry edge %d & exit edge %d.", i, x >> 5, y >> 5, z, peep->direction ^ 2, chosen_edge);
 				}
 				#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 				return chosen_edge;
@@ -9815,13 +9815,14 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		peep->pathfind_history[i].y = y >> 5;
 		peep->pathfind_history[i].z = z;
 		peep->pathfind_history[i].direction = permitted_edges;
+		/* Remove the chosen_edge from those left to try. */
 		peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
 		/* Also remove the edge through which the peep
 		 * entered the junction from those left to try. */
 		peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 		if (gPathFindDebug) {
-			log_verbose("Storing new pf_history (in index: %d) for %d,%d,%d without edge %d.", i, x >> 5, y >> 5, z, chosen_edge);
+			log_verbose("Storing new pf_history (in index: %d) for %d,%d,%d without entry edge %d & exit edge %d.", i, x >> 5, y >> 5, z, peep->direction ^ 2, chosen_edge);
 		}
 		#endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 	}

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9795,8 +9795,8 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 				/* Peep remembers this junction, so remove the
 				 * chosen_edge from those left to try. */
 				peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
-				/* Also remove the edge the peep came from from
-				 * those left to try. */
+				/* Also remove the edge through which the peep
+				 * entered the junction from those left to try. */
 				peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 				#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 				if (gPathFindDebug) {
@@ -9816,8 +9816,8 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		peep->pathfind_history[i].z = z;
 		peep->pathfind_history[i].direction = permitted_edges;
 		peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
-		/* Also remove the edge the peep came from from
-		 * those left to try. */
+		/* Also remove the edge through which the peep
+		 * entered the junction from those left to try. */
 		peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 		if (gPathFindDebug) {

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9795,6 +9795,9 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 				/* Peep remembers this junction, so remove the
 				 * chosen_edge from those left to try. */
 				peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
+				/* Also remove the edge the peep came from from
+				 * those left to try. */
+				peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 				#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 				if (gPathFindDebug) {
 					log_verbose("Removing edge %d from existing pf_history for %d,%d,%d.", chosen_edge, x >> 5, y >> 5, z);
@@ -9813,6 +9816,9 @@ int peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep)
 		peep->pathfind_history[i].z = z;
 		peep->pathfind_history[i].direction = permitted_edges;
 		peep->pathfind_history[i].direction &= ~(1 << chosen_edge);
+		/* Also remove the edge the peep came from from
+		 * those left to try. */
+		peep->pathfind_history[i].direction &= ~(1 << (peep->direction ^ 2));
 		#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 		if (gPathFindDebug) {
 			log_verbose("Storing new pf_history (in index: %d) for %d,%d,%d without edge %d.", i, x >> 5, y >> 5, z, chosen_edge);


### PR DESCRIPTION
Dependent on the path layout it is possible for peeps to get stuck in backtracking cycles between two or more path tiles - peeps turn around and backtrack because from those tiles, the reachable tile on the search boundary that is closest to the peep destination is in the direction the peep came from.

In choose_direction when storing/updating the pathfind_history, in addition to removing the chosen direction **also** remove the direction the peep came from from the directions left to try to prevent such backtracking.

Network version is also incremented.

@Broxzier spotted peeps stuck like this in "The OpenRCT2 Group Park 4.58.sv6" and asked if I could take a look.  This PR resolves the issue in that case.