### PR TITLE
Fix #5010 windows builds not pushed

### DIFF
--- a/scripts/ps/appveyor_deploy.ps1
+++ b/scripts/ps/appveyor_deploy.ps1
@@ -2,10 +2,10 @@
 # Script to deploy OpenRCT2 from AppVeyor #
 ###########################################
 
-$testing = (${env:Configuration} -like "*tests")
+$nottesting = (${env:Configuration} -notlike "*tests")
 # Only deploy from VS2015 for now.
-$vs2015 = (${env:APPVEYOR_JOB_NAME} -like "*2015*")
-if (-not $testing -and $vs2015)
+$notvs2017 = (${env:APPVEYOR_JOB_NAME} -notlike "*2017*")
+if ($nottesting -and $notvs2017)
 {
     # Check if OpenRCT2.org API security token is available
     if (${env:OPENRCT2_ORG_TOKEN})


### PR DESCRIPTION
windows builds not pushed to openrct2.org due to invalid condition. since there're only one image configured at build, appveyor did not include image name at job name, causing deploy script think that build is not coming from VS2015.

This PR removes VS2015 condition so builds without `*2015*` could be pushed.