### PR TITLE
Don't zoom to cursor for keyboard or toolbar inputs

### DIFF
--- a/src/openrct2/interface/keyboard_shortcut.c
+++ b/src/openrct2/interface/keyboard_shortcut.c
@@ -174,34 +174,12 @@ static void shortcut_pause_game()
 
 static void shortcut_zoom_view_out()
 {
-	if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
-		return;
-
-	if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gS6Info.editor_step == EDITOR_STEP_LANDSCAPE_EDITOR) {
-		if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
-			rct_window *window = window_find_by_class(WC_TOP_TOOLBAR);
-			if (window != NULL) {
-				window_invalidate(window);
-				window_event_mouse_up_call(window, 2);
-			}
-		}
-	}
+	main_window_zoom(false, false);
 }
 
 static void shortcut_zoom_view_in()
 {
-	if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
-		return;
-
-	if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gS6Info.editor_step == EDITOR_STEP_LANDSCAPE_EDITOR) {
-		if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
-			rct_window *window = window_find_by_class(WC_TOP_TOOLBAR);
-			if (window != NULL) {
-				window_invalidate(window);
-				window_event_mouse_up_call(window, 3);
-			}
-		}
-	}
+	main_window_zoom(true, false);
 }
 
 static void shortcut_rotate_view_clockwise()

--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -244,9 +244,9 @@ static void window_viewport_wheel_input(rct_window *w, int wheel)
 		return;
 
 	if (wheel < 0)
-		window_zoom_in(w);
+		window_zoom_in(w, true);
 	else if (wheel > 0)
-		window_zoom_out(w);
+		window_zoom_out(w, true);
 }
 
 static bool window_other_wheel_input(rct_window *w, int widgetIndex, int wheel)
@@ -1490,7 +1490,7 @@ void window_viewport_centre_tile_around_cursor(rct_window *w, sint16 map_x, sint
 	w->saved_view_y = dest_y + rebased_y + (offset_y / (1 << w->viewport->zoom));
 }
 
-void window_zoom_set(rct_window *w, int zoomLevel)
+void window_zoom_set(rct_window *w, int zoomLevel, bool atCursor)
 {
 	rct_viewport* v = w->viewport;
 
@@ -1500,7 +1500,7 @@ void window_zoom_set(rct_window *w, int zoomLevel)
 
 	// Zooming to cursor? Remember where we're pointing at the moment.
 	sint16 saved_map_x, saved_map_y, offset_x, offset_y;
-	if (gConfigGeneral.zoom_to_cursor) {
+	if (gConfigGeneral.zoom_to_cursor && atCursor) {
 		window_viewport_get_map_coords_by_cursor(w, &saved_map_x, &saved_map_y, &offset_x, &offset_y);
 	}
 
@@ -1523,7 +1523,7 @@ void window_zoom_set(rct_window *w, int zoomLevel)
 	}
 
 	// Zooming to cursor? Centre around the tile we were hovering over just now.
-	if (gConfigGeneral.zoom_to_cursor) {
+	if (gConfigGeneral.zoom_to_cursor && atCursor) {
 		window_viewport_centre_tile_around_cursor(w, saved_map_x, saved_map_y, offset_x, offset_y);
 	}
 
@@ -1537,18 +1537,30 @@ void window_zoom_set(rct_window *w, int zoomLevel)
  *
  *  rct2: 0x006887A6
  */
-void window_zoom_in(rct_window *w)
+void window_zoom_in(rct_window *w, bool atCursor)
 {
-	window_zoom_set(w, w->viewport->zoom - 1);
+	window_zoom_set(w, w->viewport->zoom - 1, atCursor);
 }
 
 /**
  *
  *  rct2: 0x006887E0
  */
-void window_zoom_out(rct_window *w)
+void window_zoom_out(rct_window *w, bool atCursor)
 {
-	window_zoom_set(w, w->viewport->zoom + 1);
+	window_zoom_set(w, w->viewport->zoom + 1, atCursor);
+}
+
+void main_window_zoom(bool zoomIn, bool atCursor) {
+	if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
+		return;
+	if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gS6Info.editor_step == EDITOR_STEP_LANDSCAPE_EDITOR) {
+		if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
+			rct_window *mainWindow = window_get_main();
+			if (mainWindow != NULL)
+				window_zoom_set(mainWindow, mainWindow->viewport->zoom + (zoomIn ? -1 : 1), atCursor);
+		}
+	}
 }
 
 /**

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -600,9 +600,10 @@ void window_scroll_to_location(rct_window *w, int x, int y, int z);
 void window_rotate_camera(rct_window *w, int direction);
 void window_viewport_get_map_coords_by_cursor(rct_window *w, sint16 *map_x, sint16 *map_y, sint16 *offset_x, sint16 *offset_y);
 void window_viewport_centre_tile_around_cursor(rct_window *w, sint16 map_x, sint16 map_y, sint16 offset_x, sint16 offset_y);
-void window_zoom_set(rct_window *w, int zoomLevel);
-void window_zoom_in(rct_window *w);
-void window_zoom_out(rct_window *w);
+void window_zoom_set(rct_window *w, int zoomLevel, bool atCursor);
+void window_zoom_in(rct_window *w, bool atCursor);
+void window_zoom_out(rct_window *w, bool atCursor);
+void main_window_zoom(bool zoomIn, bool atCursor);
 
 void window_show_textinput(rct_window *w, int widgetIndex, uint16 title, uint16 text, int value);
 void window_text_input_key(rct_window* w, int key);

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -19,6 +19,7 @@
 #include "../config.h"
 #include "../drawing/drawing.h"
 #include "../drawing/lightfx.h"
+#include "../editor.h"
 #include "../game.h"
 #include "../input.h"
 #include "../interface/console.h"
@@ -507,12 +508,9 @@ void platform_process_messages()
 				// Zoom gesture
 				const int tolerance = 128;
 				int gesturePixels = (int)(_gestureRadius * gScreenWidth);
-				if (gesturePixels > tolerance) {
+				if (abs(gesturePixels) > tolerance) {
 					_gestureRadius = 0;
-					keyboard_shortcut_handle_command(SHORTCUT_ZOOM_VIEW_IN);
-				} else if (gesturePixels < -tolerance) {
-					_gestureRadius = 0;
-					keyboard_shortcut_handle_command(SHORTCUT_ZOOM_VIEW_OUT);
+					main_window_zoom(gesturePixels > 0, true);
 				}
 			}
 			break;

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -314,7 +314,7 @@ private:
         rct_window * w = window_get_main();
         if (w != nullptr && w->viewport != nullptr)
         {
-            window_zoom_set(w, zoom);
+            window_zoom_set(w, zoom, false);
         }
     }
 

--- a/src/openrct2/windows/top_toolbar.c
+++ b/src/openrct2/windows/top_toolbar.c
@@ -308,11 +308,11 @@ static void window_top_toolbar_mouseup(rct_window *w, int widgetIndex)
 		break;
 	case WIDX_ZOOM_OUT:
 		if ((mainWindow = window_get_main()) != NULL)
-			window_zoom_out(mainWindow);
+			window_zoom_out(mainWindow, false);
 		break;
 	case WIDX_ZOOM_IN:
 		if ((mainWindow = window_get_main()) != NULL)
-			window_zoom_in(mainWindow);
+			window_zoom_in(mainWindow, false);
 		break;
 	case WIDX_CLEAR_SCENERY:
 		toggle_clear_scenery_window(w, WIDX_CLEAR_SCENERY);


### PR DESCRIPTION
This is an update to the feature added in #4146. I noticed that, while the feature works in a reasonable way for the scroll wheel or pinch-to-zoom methods, when I tried to zoom with the top toolbar buttons, it acted in an unintuitive way. This PR changes it so that it only takes the cursor position into account if both the setting is active and the zoom was triggered by a mouse/trackpad/touchscreen driven method (so scrolling or pinch-to-zoom). For the keyboard shortcuts (Page-Up and Page-Down by default) and top toolbar buttons, it always uses the original behavior.

This PR is completely functional, but the code is poorly organized. I think the code added/copied to `platform_process_messages` should be broken out to its own function, but I wasn't sure where to put it. I'd like some feedback on that.