### PR TITLE
Fix 'No real prototype' warnings

### DIFF
--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -715,14 +715,11 @@ void platform_set_cursor(uint8 cursor)
 
 void platform_refresh_video()
 {
-	int width = gScreenWidth;
-	int height = gScreenHeight;
-
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss ? "1" : "0");
 
 	drawing_engine_dispose();
 	drawing_engine_init();
-	drawing_engine_resize(width, height);
+	drawing_engine_resize();
 	drawing_engine_set_palette(gPalette);
 	gfx_invalidate_screen();
 }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -972,7 +972,7 @@ static rct_window *ride_create_or_find_construction_window(int rideIndex)
 	if (w == NULL || w->number != rideIndex) {
 		window_close_construction_windows();
 		_currentRideIndex = rideIndex;
-		w = window_ride_construction_open(rideIndex);
+		w = window_ride_construction_open();
 	} else {
 		sub_6C9627();
 		_currentRideIndex = rideIndex;

--- a/src/openrct2/world/mapgen.c
+++ b/src/openrct2/world/mapgen.c
@@ -79,7 +79,7 @@ static void mapgen_blob(int cx, int cy, int size, int height);
 static void mapgen_smooth_height(int iterations);
 static void mapgen_set_height();
 
-static void mapgen_simplex();
+static void mapgen_simplex(mapgen_settings *settings);
 
 static int _heightSize;
 static uint8 *_height;


### PR DESCRIPTION
Compiling for openSUSE (13.2 - 42.2) gcc reports some errors (warnings treated as errors).
It seems they does not appear when using gcc6, but 5 and 4.8 are affected.

The warnings are "call to function without a real prototype", the reason is the usage of prototypes without parameters but calling this functions with parameter.

So I fixed this prototypes or the usage of prototypes with unused parameters.