### PR TITLE
Initialise fields of MemoryStream in header

### DIFF
--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -18,17 +18,6 @@
 #include "Memory.hpp"
 #include "MemoryStream.h"
 
-MemoryStream::MemoryStream()
-{
-    _access = MEMORY_ACCESS_READ |
-              MEMORY_ACCESS_WRITE |
-              MEMORY_ACCESS_OWNER;
-    _dataCapacity = 0;
-    _dataSize = 0;
-    _data = nullptr;
-    _position = nullptr;
-}
-
 MemoryStream::MemoryStream(const MemoryStream &copy)
 {
     _access = copy._access;
@@ -44,11 +33,7 @@ MemoryStream::MemoryStream(const MemoryStream &copy)
 
 MemoryStream::MemoryStream(size_t capacity)
 {
-    _access = MEMORY_ACCESS_READ |
-              MEMORY_ACCESS_WRITE |
-              MEMORY_ACCESS_OWNER;
     _dataCapacity = capacity;
-    _dataSize = 0;
     _data = Memory::Allocate<void>(capacity);
     _position = _data;
 }

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -32,15 +32,15 @@ enum MEMORY_ACCESS
 class MemoryStream final : public IStream
 {
 private:
-    uint16  _access;
-    size_t  _dataCapacity;
-    size_t  _dataSize;
-    void *  _data;
-    void *  _position;
+    uint16 _access       = MEMORY_ACCESS_READ | MEMORY_ACCESS_WRITE | MEMORY_ACCESS_OWNER;
+    size_t _dataCapacity = 0;
+    size_t _dataSize     = 0;
+    void * _data         = nullptr;
+    void * _position     = nullptr;
 
 public:
     MemoryStream();
-    MemoryStream(const MemoryStream &copy);
+    MemoryStream(const MemoryStream & copy);
     explicit MemoryStream(size_t capacity);
     MemoryStream(void * data, size_t dataSize, uint32 access = MEMORY_ACCESS_READ);
     MemoryStream(const void * data, size_t dataSize);


### PR DESCRIPTION
This makes all the constructors use these defaulted values