### PR TITLE
Copy "Quick fire" to "Quick demolish"

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4347,6 +4347,7 @@ STR_6035    :Please select your RCT1 directory
 STR_6036    :{SMALLFONT}{BLACK}Clear
 STR_6037    :Please select a valid RCT1 directory
 STR_6038    :{SMALLFONT}{BLACK}If you have RCT1 installed, set this option to its directory to load scenarios, music, etc.
+STR_6039    :{SMALLFONT}{BLACK}Quick demolish ride
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3694,6 +3694,8 @@ enum {
 	STR_PATH_TO_RCT1_WRONG_ERROR = 6037,
 	STR_PATH_TO_RCT1_TIP = 6038,
 
+	STR_QUICK_DEMOLISH_RIDE = 6039,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -72,7 +72,7 @@ static rct_widget window_ride_list_widgets[] = {
 	{ WIDGETS_END },
 };
 
-bool _quick_demolish_mode = false;
+static bool _quickDemolishMode = false;
 
 static void window_ride_list_mouseup(rct_window *w, sint32 widgetIndex);
 static void window_ride_list_resize(rct_window *w);
@@ -231,7 +231,7 @@ void window_ride_list_open()
 	}
 	_window_ride_list_information_type = INFORMATION_TYPE_STATUS;
 	window->list_information_type = 0;
-	_quick_demolish_mode = false;
+	_quickDemolishMode = false;
 }
 
 /**
@@ -271,10 +271,10 @@ static void window_ride_list_mouseup(rct_window *w, sint32 widgetIndex)
 		break;
 	case WIDX_QUICK_DEMOLISH:
 		if (network_get_mode() != NETWORK_MODE_CLIENT) {
-			_quick_demolish_mode = !_quick_demolish_mode;
+			_quickDemolishMode = !_quickDemolishMode;
 		}
 		else {
-			_quick_demolish_mode = false;
+			_quickDemolishMode = false;
 		}
 		window_invalidate(w);
 		break;
@@ -431,7 +431,7 @@ static void window_ride_list_scrollmousedown(rct_window *w, sint32 scrollIndex, 
 
 	// Open ride window
 	uint8 rideIndex = w->list_item_positions[index];
-	if (_quick_demolish_mode && network_get_mode() != NETWORK_MODE_CLIENT) {
+	if (_quickDemolishMode && network_get_mode() != NETWORK_MODE_CLIENT) {
 		gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
 		game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, rideIndex, GAME_COMMAND_DEMOLISH_RIDE, 0, 0);
 	}
@@ -483,7 +483,7 @@ static void window_ride_list_invalidate(rct_window *w)
 
 	window_ride_list_widgets[WIDX_TITLE].text = page_names[w->page];
 
-	if (_quick_demolish_mode)
+	if (_quickDemolishMode)
 		w->pressed_widgets |= (1ULL << WIDX_QUICK_DEMOLISH);
 	else
 		w->pressed_widgets &= ~(1ULL << WIDX_QUICK_DEMOLISH);
@@ -568,12 +568,12 @@ static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, 
 
 	y = 0;
 	for (i = 0; i < w->no_list_items; i++) {
-		format = (_quick_demolish_mode ? STR_RED_STRINGID : STR_BLACK_STRING);
+		format = (_quickDemolishMode ? STR_RED_STRINGID : STR_BLACK_STRING);
 
 		// Background highlight
 		if (i == w->selected_list_item) {
 			gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
-			format = (_quick_demolish_mode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
+			format = (_quickDemolishMode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
 		}
 
 		// Get ride

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -26,6 +26,7 @@
 #include "../interface/themes.h"
 #include "../interface/themes.h"
 #include "../localisation/date.h"
+#include "../network/network.h"
 
 enum {
 	PAGE_RIDES,
@@ -67,7 +68,7 @@ static rct_widget window_ride_list_widgets[] = {
 	{ WWT_SCROLL,			1,	3,		336,	60,		236,	SCROLL_VERTICAL,							STR_NONE },									// list
 	{ WWT_IMGBTN,			1,	320,	333,	62,		75,		SPR_G2_RCT1_CLOSE_BUTTON_0,	STR_NONE },
 	{ WWT_IMGBTN,			1,	320,	333,	76,		89,		SPR_G2_RCT1_OPEN_BUTTON_0,	STR_NONE },
-	{ WWT_IMGBTN,			1,	315,	338,	90,		113,	SPR_DEMOLISH,				STR_QUICK_DEMOLISH_RIDE },
+	{ WWT_FLATBTN,			1,	315,	338,	90,		113,	SPR_DEMOLISH,				STR_QUICK_DEMOLISH_RIDE },
 	{ WIDGETS_END },
 };
 
@@ -214,8 +215,10 @@ void window_ride_list_open()
 			(1 << WIDX_TAB_2) |
 			(1 << WIDX_TAB_3) |
 			(1 << WIDX_CLOSE_LIGHT) |
-			(1 << WIDX_OPEN_LIGHT) |
-			(1 << WIDX_QUICK_DEMOLISH);
+			(1 << WIDX_OPEN_LIGHT);
+		if (network_get_mode() != NETWORK_MODE_CLIENT) {
+			window->enabled_widgets |= (1 << WIDX_QUICK_DEMOLISH);
+		}
 		window_init_scroll_widgets(window);
 		window->page = PAGE_RIDES;
 		window->no_list_items = 0;
@@ -267,7 +270,12 @@ static void window_ride_list_mouseup(rct_window *w, sint32 widgetIndex)
 		window_ride_list_open_all(w);
 		break;
 	case WIDX_QUICK_DEMOLISH:
-		_quick_demolish_mode ^= 1;
+		if (network_get_mode() != NETWORK_MODE_CLIENT) {
+			_quick_demolish_mode = !_quick_demolish_mode;
+		}
+		else {
+			_quick_demolish_mode = false;
+		}
 		window_invalidate(w);
 		break;
 	}
@@ -422,12 +430,13 @@ static void window_ride_list_scrollmousedown(rct_window *w, sint32 scrollIndex, 
 		return;
 
 	// Open ride window
-	if (_quick_demolish_mode) {
+	uint8 rideIndex = w->list_item_positions[index];
+	if (_quick_demolish_mode && network_get_mode() != NETWORK_MODE_CLIENT) {
 		gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
-		game_do_command(0, 1, 0, w->list_item_positions[index], GAME_COMMAND_DEMOLISH_RIDE, 0, 0);
+		game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, rideIndex, GAME_COMMAND_DEMOLISH_RIDE, 0, 0);
 	}
 	else {
-		window_ride_main_open(w->list_item_positions[index]);
+		window_ride_main_open(rideIndex);
 	}
 }
 
@@ -496,7 +505,7 @@ static void window_ride_list_invalidate(rct_window *w)
 	w->widgets[WIDX_OPEN_LIGHT].left = w->width - 20;
 	w->widgets[WIDX_QUICK_DEMOLISH].right = w->width - 2;
 	w->widgets[WIDX_QUICK_DEMOLISH].left = w->width - 25;
-
+	
 	if (theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_RIDE) {
 		w->widgets[WIDX_OPEN_CLOSE_ALL].type = WWT_EMPTY;
 		w->widgets[WIDX_CLOSE_LIGHT].type = WWT_IMGBTN;
@@ -520,12 +529,16 @@ static void window_ride_list_invalidate(rct_window *w)
 		}
 		w->widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + (allClosed == 1) * 2 + widget_is_pressed(w, WIDX_CLOSE_LIGHT);
 		w->widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + (allOpen == 1) * 2 + widget_is_pressed(w, WIDX_OPEN_LIGHT);
+		w->widgets[WIDX_QUICK_DEMOLISH].top = w->widgets[WIDX_OPEN_LIGHT].bottom + 3;
 	}
 	else {
 		w->widgets[WIDX_OPEN_CLOSE_ALL].type = WWT_FLATBTN;
 		w->widgets[WIDX_CLOSE_LIGHT].type = WWT_EMPTY;
 		w->widgets[WIDX_OPEN_LIGHT].type = WWT_EMPTY;
+		w->widgets[WIDX_QUICK_DEMOLISH].top = w->widgets[WIDX_OPEN_CLOSE_ALL].bottom + 3;
 	}
+	w->widgets[WIDX_QUICK_DEMOLISH].bottom = w->widgets[WIDX_QUICK_DEMOLISH].top + 23;
+	w->widgets[WIDX_QUICK_DEMOLISH].type = network_get_mode() != NETWORK_MODE_CLIENT ? WWT_FLATBTN : WWT_EMPTY;
 }
 
 /**

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -48,7 +48,8 @@ enum WINDOW_RIDE_LIST_WIDGET_IDX {
 	WIDX_TAB_3,
 	WIDX_LIST,
 	WIDX_CLOSE_LIGHT,
-	WIDX_OPEN_LIGHT
+	WIDX_OPEN_LIGHT,
+	WIDX_QUICK_DEMOLISH,
 };
 
 static rct_widget window_ride_list_widgets[] = {
@@ -66,8 +67,11 @@ static rct_widget window_ride_list_widgets[] = {
 	{ WWT_SCROLL,			1,	3,		336,	60,		236,	SCROLL_VERTICAL,							STR_NONE },									// list
 	{ WWT_IMGBTN,			1,	320,	333,	62,		75,		SPR_G2_RCT1_CLOSE_BUTTON_0,	STR_NONE },
 	{ WWT_IMGBTN,			1,	320,	333,	76,		89,		SPR_G2_RCT1_OPEN_BUTTON_0,	STR_NONE },
+	{ WWT_IMGBTN,			1,	315,	338,	90,		113,	SPR_DEMOLISH,				STR_QUICK_DEMOLISH_RIDE },
 	{ WIDGETS_END },
 };
+
+bool _quick_demolish_mode = false;
 
 static void window_ride_list_mouseup(rct_window *w, sint32 widgetIndex);
 static void window_ride_list_resize(rct_window *w);
@@ -210,7 +214,8 @@ void window_ride_list_open()
 			(1 << WIDX_TAB_2) |
 			(1 << WIDX_TAB_3) |
 			(1 << WIDX_CLOSE_LIGHT) |
-			(1 << WIDX_OPEN_LIGHT);
+			(1 << WIDX_OPEN_LIGHT) |
+			(1 << WIDX_QUICK_DEMOLISH);
 		window_init_scroll_widgets(window);
 		window->page = PAGE_RIDES;
 		window->no_list_items = 0;
@@ -223,6 +228,7 @@ void window_ride_list_open()
 	}
 	_window_ride_list_information_type = INFORMATION_TYPE_STATUS;
 	window->list_information_type = 0;
+	_quick_demolish_mode = false;
 }
 
 /**
@@ -259,6 +265,10 @@ static void window_ride_list_mouseup(rct_window *w, sint32 widgetIndex)
 		break;
 	case WIDX_OPEN_LIGHT:
 		window_ride_list_open_all(w);
+		break;
+	case WIDX_QUICK_DEMOLISH:
+		_quick_demolish_mode ^= 1;
+		window_invalidate(w);
 		break;
 	}
 }
@@ -412,7 +422,13 @@ static void window_ride_list_scrollmousedown(rct_window *w, sint32 scrollIndex, 
 		return;
 
 	// Open ride window
-	window_ride_main_open(w->list_item_positions[index]);
+	if (_quick_demolish_mode) {
+		gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
+		game_do_command(0, 1, 0, w->list_item_positions[index], GAME_COMMAND_DEMOLISH_RIDE, 0, 0);
+	}
+	else {
+		window_ride_main_open(w->list_item_positions[index]);
+	}
 }
 
 /**
@@ -458,6 +474,11 @@ static void window_ride_list_invalidate(rct_window *w)
 
 	window_ride_list_widgets[WIDX_TITLE].text = page_names[w->page];
 
+	if (_quick_demolish_mode)
+		w->pressed_widgets |= (1ULL << WIDX_QUICK_DEMOLISH);
+	else
+		w->pressed_widgets &= ~(1ULL << WIDX_QUICK_DEMOLISH);
+
 	w->widgets[WIDX_BACKGROUND].right = w->width - 1;
 	w->widgets[WIDX_BACKGROUND].bottom = w->height - 1;
 	w->widgets[WIDX_PAGE_BACKGROUND].right = w->width - 1;
@@ -473,6 +494,8 @@ static void window_ride_list_invalidate(rct_window *w)
 	w->widgets[WIDX_CLOSE_LIGHT].left = w->width - 20;
 	w->widgets[WIDX_OPEN_LIGHT].right = w->width - 7;
 	w->widgets[WIDX_OPEN_LIGHT].left = w->width - 20;
+	w->widgets[WIDX_QUICK_DEMOLISH].right = w->width - 2;
+	w->widgets[WIDX_QUICK_DEMOLISH].left = w->width - 25;
 
 	if (theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_RIDE) {
 		w->widgets[WIDX_OPEN_CLOSE_ALL].type = WWT_EMPTY;
@@ -532,12 +555,12 @@ static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, 
 
 	y = 0;
 	for (i = 0; i < w->no_list_items; i++) {
-		format = STR_BLACK_STRING;
+		format = (_quick_demolish_mode ? STR_RED_STRINGID : STR_BLACK_STRING);
 
 		// Background highlight
 		if (i == w->selected_list_item) {
 			gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
-			format = STR_WINDOW_COLOUR_2_STRINGID;
+			format = (_quick_demolish_mode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
 		}
 
 		// Get ride


### PR DESCRIPTION
**EDIT:** I have moved all above security implementation to #5202 to allow merging and testing of that first before merging this.. The only security that is in this is the button being hidden in multiplayer mode. this is to reduce the need for updating the network version. Before this is merged, i highly urge #5202 to be merged first.

--------

This copies the quick fire button from the staff list over to the ride list. Along with this, i have implemented a 3 second demolish rule for multiplayer to prevent some abuse of it (or, at least give an admin/moderator a chance to catch who ever is deleting the rides).

There are some potentials to this. Some off the top of my head are:
- create scenarios similar to the "build your own six flags ___" parks
- demolish any blank rides
- demolish a food court area more quicker

Some questions or considerations:
- I'm unsure if 3 seconds is a bit too long, and should be 2 seconds instead.
- Considering staff are more easily replacable than rides, should i still include a demolish ride prompt?

While there are potentials to this, the chance of this needing to be used (aside from multiplayer abuse) seems slim, so I'm unsure if this is really a necessary feature. I'd like some discussion before this is merged.