### PR TITLE
Fix tall ride consideration

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -54,7 +54,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "28"
+#define NETWORK_STREAM_VERSION "29"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -11988,10 +11988,10 @@ static void peep_pick_ride_to_go_on(rct_peep *peep)
 			}
 		}
 
-		// Always take the big rides into consideration (realistic as you can usually see them from anywhere in the park)
+		// Always take the tall rides into consideration (realistic as you can usually see them from anywhere in the park)
 		int i;
 		FOR_ALL_RIDES(i, ride) {
-			if (ride->lifecycle_flags == RIDE_LIFECYCLE_TESTED) continue;
+			if (ride->status != RIDE_STATUS_OPEN) continue;
 			if (!ride_has_ratings(ride)) continue;
 			if (ride->highest_drop_height <= 66 && ride->excitement < RIDE_RATING(8,00)) continue;
 


### PR DESCRIPTION
The consideration of tall rides was probably not working properly as it was doing a straight comparrison of a flags variable.

This instead removes it as it already checks if the ride has ratings anyway. I've also added a status check so that guests do not attempt to walk to a ride far away that isn't open.

This isn't just tall rides, rides that have >= 8 excitement get this treatment too.