### PR TITLE
Add include categories to .clang-format for sorting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,14 @@ AllowShortFunctionsOnASingleLine: Empty
 BreakBeforeBraces: Allman
 ColumnLimit: '128'
 Cpp11BracedListStyle: 'false'
+IncludeCategories:
+  - Regex:           '^"(\./)*common\.h"$'
+    Priority:        -1
+  - Regex:           '^<.*>$'
+    Priority:        1
+  - Regex:           '^".*"$'
+    Priority:        2
+IncludeIsMainRegex: 'false'
 IndentWidth: '4'
 PointerAlignment: Middle
 SortIncludes: 'true'


### PR DESCRIPTION
This adds 3 rules that clang-format uses when ordering include files:
 - common.h is assigned priority -1
 - Incudes using <> is given priority 1
 - Includes using "" is given priority 2
It also disables putting the "main" file first (the .h/.hpp with the same name as the .c/.cpp"

Example (`windows/banner.c` with `common.h` added):
```
#include "../game.h"
#include "../config.h"
#include "../localisation/localisation.h"
#include "../interface/viewport.h"
#include "../interface/widget.h"
#include "../interface/window.h"
#include "../world/map.h"
#include "../world/banner.h"
#include "../world/scenery.h"
#include "error.h"
#include "dropdown.h"
#include "../drawing/drawing.h"
#include "../interface/themes.h"
#include "../sprites.h"
#include "../common.h"
```
Becomes:
```
#include "../common.h"
#include "../config.h"
#include "../drawing/drawing.h"
#include "../game.h"
#include "../interface/themes.h"
#include "../interface/viewport.h"
#include "../interface/widget.h"
#include "../interface/window.h"
#include "../localisation/localisation.h"
#include "../sprites.h"
#include "../world/banner.h"
#include "../world/map.h"
#include "../world/scenery.h"
#include "dropdown.h"
#include "error.h"
```