### PR TITLE
Create new OpenRCT2 award struct

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -411,6 +411,7 @@
     <ClInclude Include="audio\AudioMixer.h" />
     <ClInclude Include="audio\AudioSource.h" />
     <ClInclude Include="FileClassifier.h" />
+    <ClInclude Include="rct12.h" />
     <ClInclude Include="rct2\addresses.h" />
     <ClInclude Include="audio\audio.h" />
     <ClInclude Include="cheats.h" />

--- a/src/openrct2/management/award.c
+++ b/src/openrct2/management/award.c
@@ -67,7 +67,7 @@ static const rct_string_id AwardNewsStrings[] = {
 	STR_NEWS_ITEM_BEST_GENTLE_RIDES,
 };
 
-rct_award gCurrentAwards[MAX_AWARDS];
+Award gCurrentAwards[MAX_AWARDS];
 
 bool award_is_positive(sint32 type)
 {
@@ -614,9 +614,10 @@ static sint32 award_is_deserved(sint32 awardType, sint32 activeAwardTypes)
 
 void award_reset()
 {
-	sint32 i;
-	for (i = 0; i < MAX_AWARDS; i++)
-		gCurrentAwards[i].time = 0;
+	for (sint32 i = 0; i < MAX_AWARDS; i++) {
+		gCurrentAwards[i].Time = 0;
+		gCurrentAwards[i].Type = 0;
+	}
 }
 
 /**
@@ -631,8 +632,8 @@ void award_update_all()
 		sint32 activeAwardTypes = 0;
 		sint32 freeAwardEntryIndex = -1;
 		for (sint32 i = 0; i < MAX_AWARDS; i++) {
-			if (gCurrentAwards[i].time != 0)
-				activeAwardTypes |= (1 << gCurrentAwards[i].type);
+			if (gCurrentAwards[i].Time != 0)
+				activeAwardTypes |= (1 << gCurrentAwards[i].Type);
 			else if (freeAwardEntryIndex == -1)
 				freeAwardEntryIndex = i;
 		}
@@ -648,8 +649,8 @@ void award_update_all()
 			// Check if award is deserved
 			if (award_is_deserved(awardType, activeAwardTypes)) {
 				// Add award
-				gCurrentAwards[freeAwardEntryIndex].type = awardType;
-				gCurrentAwards[freeAwardEntryIndex].time = 5;
+				gCurrentAwards[freeAwardEntryIndex].Type = awardType;
+				gCurrentAwards[freeAwardEntryIndex].Time = 5;
 				if (gConfigNotifications.park_award) {
 					news_item_add_to_queue(NEWS_ITEM_AWARD, AwardNewsStrings[awardType], 0);
 				}
@@ -660,7 +661,7 @@ void award_update_all()
 
 	// Decrease award times
 	for (sint32 i = 0; i < MAX_AWARDS; i++)
-		if (gCurrentAwards[i].time != 0)
-			if (--gCurrentAwards[i].time == 0)
+		if (gCurrentAwards[i].Time != 0)
+			if (--gCurrentAwards[i].Time == 0)
 				window_invalidate_by_class(WC_PARK_INFORMATION);
 }

--- a/src/openrct2/management/award.h
+++ b/src/openrct2/management/award.h
@@ -19,41 +19,47 @@
 
 #include "../common.h"
 
-#pragma pack(push, 1)
-typedef struct rct_award {
-	uint16 time;
-	uint16 type;
-} rct_award;
-assert_struct_size(rct_award, 4);
-#pragma pack(pop)
+typedef struct Award
+{
+    uint16 Time;
+    uint16 Type;
+} Award;
 
-enum {
-	PARK_AWARD_MOST_UNTIDY,
-	PARK_AWARD_MOST_TIDY,
-	PARK_AWARD_BEST_ROLLERCOASTERS,
-	PARK_AWARD_BEST_VALUE,
-	PARK_AWARD_MOST_BEAUTIFUL,
-	PARK_AWARD_WORST_VALUE,
-	PARK_AWARD_SAFEST,
-	PARK_AWARD_BEST_STAFF,
-	PARK_AWARD_BEST_FOOD,
-	PARK_AWARD_WORST_FOOD,
-	PARK_AWARD_BEST_RESTROOMS,
-	PARK_AWARD_MOST_DISAPPOINTING,
-	PARK_AWARD_BEST_WATER_RIDES,
-	PARK_AWARD_BEST_CUSTOM_DESIGNED_RIDES,
-	PARK_AWARD_MOST_DAZZLING_RIDE_COLOURS,
-	PARK_AWARD_MOST_CONFUSING_LAYOUT,
-	PARK_AWARD_BEST_GENTLE_RIDES,
-	PARK_AWARD_COUNT
+enum PARK_AWARD
+{
+    PARK_AWARD_MOST_UNTIDY,
+    PARK_AWARD_MOST_TIDY,
+    PARK_AWARD_BEST_ROLLERCOASTERS,
+    PARK_AWARD_BEST_VALUE,
+    PARK_AWARD_MOST_BEAUTIFUL,
+    PARK_AWARD_WORST_VALUE,
+    PARK_AWARD_SAFEST,
+    PARK_AWARD_BEST_STAFF,
+    PARK_AWARD_BEST_FOOD,
+    PARK_AWARD_WORST_FOOD,
+    PARK_AWARD_BEST_RESTROOMS,
+    PARK_AWARD_MOST_DISAPPOINTING,
+    PARK_AWARD_BEST_WATER_RIDES,
+    PARK_AWARD_BEST_CUSTOM_DESIGNED_RIDES,
+    PARK_AWARD_MOST_DAZZLING_RIDE_COLOURS,
+    PARK_AWARD_MOST_CONFUSING_LAYOUT,
+    PARK_AWARD_BEST_GENTLE_RIDES,
+    PARK_AWARD_COUNT
 };
 
 #define MAX_AWARDS 4
 
-extern rct_award gCurrentAwards[MAX_AWARDS];
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    extern Award gCurrentAwards[MAX_AWARDS];
 
-bool award_is_positive(sint32 type);
-void award_reset();
-void award_update_all();
+    bool award_is_positive(sint32 type);
+    void award_reset();
+    void award_update_all();
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -20,6 +20,7 @@
 #include "management/award.h"
 #include "management/news_item.h"
 #include "management/research.h"
+#include "rct12.h"
 #include "rct2.h"
 #include "ride/ride.h"
 #include "world/banner.h"
@@ -28,7 +29,6 @@
 
 #define RCT1_MAX_MAP_ELEMENTS   0xC000
 #define RCT1_MAX_SPRITES        5000
-#define RCT1_MAX_AWARDS         4
 
 #pragma pack(push, 1)
 typedef struct rct1_entrance {
@@ -426,14 +426,6 @@ typedef struct rct1_research_item {
 } rct1_research_item;
 assert_struct_size(rct1_research_item, 5);
 
-#pragma pack(push, 1)
-typedef struct rct1_award {
-	uint16 time;
-	uint16 type;
-} rct1_award;
-assert_struct_size(rct1_award, 4);
-#pragma pack(pop)
-
 /**
  * RCT1,AA,LL scenario / saved game structure.
  * size: 0x1F850C
@@ -529,7 +521,7 @@ typedef struct rct1_s4 {
 	money32 admission_total_income;
 	money32 company_value;
 	uint8 thought_timer[16];
-	rct1_award awards[RCT1_MAX_AWARDS];
+	rct12_award awards[RCT12_MAX_AWARDS];
 	money16 land_price;
 	money16 construction_rights_price;
 	uint16 unk_199BCC;

--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -28,6 +28,7 @@
 
 #define RCT1_MAX_MAP_ELEMENTS   0xC000
 #define RCT1_MAX_SPRITES        5000
+#define RCT1_MAX_AWARDS         4
 
 #pragma pack(push, 1)
 typedef struct rct1_entrance {
@@ -425,6 +426,14 @@ typedef struct rct1_research_item {
 } rct1_research_item;
 assert_struct_size(rct1_research_item, 5);
 
+#pragma pack(push, 1)
+typedef struct rct1_award {
+	uint16 time;
+	uint16 type;
+} rct1_award;
+assert_struct_size(rct1_award, 4);
+#pragma pack(pop)
+
 /**
  * RCT1,AA,LL scenario / saved game structure.
  * size: 0x1F850C
@@ -520,7 +529,7 @@ typedef struct rct1_s4 {
 	money32 admission_total_income;
 	money32 company_value;
 	uint8 thought_timer[16];
-	rct_award awards[4];
+	rct1_award awards[RCT1_MAX_AWARDS];
 	money16 land_price;
 	money16 construction_rights_price;
 	uint16 unk_199BCC;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1438,9 +1438,13 @@ private:
         }
 
         // Awards
-        for (size_t i = 0; i < MAX_AWARDS; i++)
+        award_reset();
+        for (sint32 i = 0; i < RCT1_MAX_AWARDS; i++)
         {
-            gCurrentAwards[i] = _s4.awards[i];
+            rct1_award * src = &_s4.awards[i];
+            Award * dst = &gCurrentAwards[i];
+            dst->Time = src->time;
+            dst->Type = src->type;
         }
 
         // Number of guests history

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1439,9 +1439,9 @@ private:
 
         // Awards
         award_reset();
-        for (sint32 i = 0; i < RCT1_MAX_AWARDS; i++)
+        for (sint32 i = 0; i < RCT12_MAX_AWARDS; i++)
         {
-            rct1_award * src = &_s4.awards[i];
+            rct12_award * src = &_s4.awards[i];
             Award * dst = &gCurrentAwards[i];
             dst->Time = src->time;
             dst->Type = src->type;

--- a/src/openrct2/rct12.h
+++ b/src/openrct2/rct12.h
@@ -1,0 +1,34 @@
+#pragma region Copyright (c) 2014-2016 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#pragma once
+
+// Structures shared between both RCT1 and RCT2.
+
+#include "common.h"
+
+#define RCT12_MAX_AWARDS        4
+
+#pragma pack(push, 1)
+
+typedef struct rct12_award
+{
+    uint16 time;
+    uint16 type;
+} rct12_award;
+assert_struct_size(rct12_award, 4);
+
+#pragma pack(pop)

--- a/src/openrct2/rct2.h
+++ b/src/openrct2/rct2.h
@@ -29,14 +29,6 @@ typedef struct rct2_install_info {
 	uint32 activeExpansionPacks;		//0xB10
 } rct2_install_info;
 
-#pragma pack(push, 1)
-typedef struct rct2_award {
-	uint16 time;
-	uint16 type;
-} rct2_award;
-assert_struct_size(rct2_award, 4);
-#pragma pack(pop)
-
 enum {
 	// Although this is labeled a flag it actually means when
 	// zero the screen is in playing mode.

--- a/src/openrct2/rct2.h
+++ b/src/openrct2/rct2.h
@@ -29,6 +29,14 @@ typedef struct rct2_install_info {
 	uint32 activeExpansionPacks;		//0xB10
 } rct2_install_info;
 
+#pragma pack(push, 1)
+typedef struct rct2_award {
+	uint16 time;
+	uint16 type;
+} rct2_award;
+assert_struct_size(rct2_award, 4);
+#pragma pack(pop)
+
 enum {
 	// Although this is labeled a flag it actually means when
 	// zero the screen is in playing mode.

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -17,8 +17,9 @@
 #include "../core/Exception.hpp"
 #include "../core/IStream.hpp"
 #include "../core/String.hpp"
-#include "../object/ObjectRepository.h"
+#include "../management/award.h"
 #include "../object/Object.h"
+#include "../object/ObjectRepository.h"
 #include "S6Exporter.h"
 
 extern "C"
@@ -348,7 +349,16 @@ void S6Exporter::Export()
     _s6.income_from_admissions = gTotalIncomeFromAdmissions;
     _s6.company_value = gCompanyValue;
     memcpy(_s6.peep_warning_throttle, gPeepWarningThrottle, sizeof(_s6.peep_warning_throttle));
-    memcpy(_s6.awards, gCurrentAwards, sizeof(_s6.awards));
+
+    // Awards
+    for (int i = 0; i < RCT2_MAX_AWARDS; i++)
+    {
+        Award * src = &gCurrentAwards[i];
+        rct2_award * dst = &_s6.awards[i];
+        dst->time = src->Time;
+        dst->type = src->Type;
+    }
+
     _s6.land_price = gLandPrice;
     _s6.construction_rights_price = gConstructionRightsPrice;
     // unk_01358774

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -351,10 +351,10 @@ void S6Exporter::Export()
     memcpy(_s6.peep_warning_throttle, gPeepWarningThrottle, sizeof(_s6.peep_warning_throttle));
 
     // Awards
-    for (int i = 0; i < RCT2_MAX_AWARDS; i++)
+    for (sint32 i = 0; i < RCT12_MAX_AWARDS; i++)
     {
         Award * src = &gCurrentAwards[i];
-        rct2_award * dst = &_s6.awards[i];
+        rct12_award * dst = &_s6.awards[i];
         dst->time = src->Time;
         dst->type = src->Type;
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -268,9 +268,9 @@ void S6Importer::Import()
 
     // Awards
     award_reset();
-    for (int i = 0; i < RCT2_MAX_AWARDS; i++)
+    for (sint32 i = 0; i < RCT12_MAX_AWARDS; i++)
     {
-        rct2_award * src = &_s6.awards[i];
+        rct12_award * src = &_s6.awards[i];
         Award * dst = &gCurrentAwards[i];
         dst->Time = src->time;
         dst->Type = src->type;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -16,6 +16,7 @@
 
 #include "../core/Exception.hpp"
 #include "../core/IStream.hpp"
+#include "../management/award.h"
 #include "../network/network.h"
 #include "S6Importer.h"
 
@@ -264,7 +265,17 @@ void S6Importer::Import()
     gTotalIncomeFromAdmissions = _s6.income_from_admissions;
     gCompanyValue = _s6.company_value;
     memcpy(gPeepWarningThrottle, _s6.peep_warning_throttle, sizeof(_s6.peep_warning_throttle));
-    memcpy(gCurrentAwards, _s6.awards, sizeof(_s6.awards));
+
+    // Awards
+    award_reset();
+    for (int i = 0; i < RCT2_MAX_AWARDS; i++)
+    {
+        rct2_award * src = &_s6.awards[i];
+        Award * dst = &gCurrentAwards[i];
+        dst->Time = src->time;
+        dst->Type = src->type;
+    }
+
     gLandPrice = _s6.land_price;
     gConstructionRightsPrice = _s6.construction_rights_price;
     // unk_01358774

--- a/src/openrct2/scenario/scenario.h
+++ b/src/openrct2/scenario/scenario.h
@@ -17,20 +17,22 @@
 #ifndef _SCENARIO_H_
 #define _SCENARIO_H_
 
-#include "../rct2/addresses.h"
 #include "../common.h"
-#include "../management/award.h"
 #include "../management/finance.h"
 #include "../management/news_item.h"
 #include "../management/research.h"
-#include "../ride/ride.h"
-#include "../ride/ride_ratings.h"
 #include "../object.h"
 #include "../platform/platform.h"
+#include "../rct2.h"
+#include "../rct2/addresses.h"
+#include "../ride/ride.h"
+#include "../ride/ride_ratings.h"
 #include "../world/banner.h"
 #include "../world/map.h"
 #include "../world/map_animation.h"
 #include "../world/sprite.h"
+
+#define RCT2_MAX_AWARDS			4
 
 #pragma pack(push, 1)
 /**
@@ -245,7 +247,7 @@ typedef struct rct_s6_data {
 	money32 income_from_admissions;
 	money32 company_value;
 	uint8 peep_warning_throttle[16];
-	rct_award awards[MAX_AWARDS];
+	rct2_award awards[RCT2_MAX_AWARDS];
 	money16 land_price;
 	money16 construction_rights_price;
 	uint16 word_01358774;

--- a/src/openrct2/scenario/scenario.h
+++ b/src/openrct2/scenario/scenario.h
@@ -23,6 +23,7 @@
 #include "../management/research.h"
 #include "../object.h"
 #include "../platform/platform.h"
+#include "../rct12.h"
 #include "../rct2.h"
 #include "../rct2/addresses.h"
 #include "../ride/ride.h"
@@ -31,8 +32,6 @@
 #include "../world/map.h"
 #include "../world/map_animation.h"
 #include "../world/sprite.h"
-
-#define RCT2_MAX_AWARDS			4
 
 #pragma pack(push, 1)
 /**
@@ -247,7 +246,7 @@ typedef struct rct_s6_data {
 	money32 income_from_admissions;
 	money32 company_value;
 	uint8 peep_warning_throttle[16];
-	rct2_award awards[RCT2_MAX_AWARDS];
+	rct12_award awards[RCT12_MAX_AWARDS];
 	money16 land_price;
 	money16 construction_rights_price;
 	uint16 word_01358774;

--- a/src/openrct2/windows/park.c
+++ b/src/openrct2/windows/park.c
@@ -1909,12 +1909,12 @@ static void window_park_awards_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	sint32 y = w->y + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 	sint32 count = 0;
 	for (sint32 i = 0; i < MAX_AWARDS; i++) {
-		rct_award *award = &gCurrentAwards[i];
-		if (award->time == 0)
+		Award *award = &gCurrentAwards[i];
+		if (award->Time == 0)
 			continue;
 
-		gfx_draw_sprite(dpi, ParkAwards[award->type].sprite, x, y, 0);
-		gfx_draw_string_left_wrapped(dpi, NULL, x + 34, y + 6, 180, ParkAwards[award->type].text, COLOUR_BLACK);
+		gfx_draw_sprite(dpi, ParkAwards[award->Type].sprite, x, y, 0);
+		gfx_draw_string_left_wrapped(dpi, NULL, x + 34, y + 6, 180, ParkAwards[award->Type].text, COLOUR_BLACK);
 
 		y += 32;
 		count++;

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -463,12 +463,12 @@ static sint32 park_calculate_guest_generation_probability()
 
 	// Reward or penalties for park awards
 	for (i = 0; i < MAX_AWARDS; i++) {
-		rct_award *award = &gCurrentAwards[i];
-		if (award->time == 0)
+		Award *award = &gCurrentAwards[i];
+		if (award->Time == 0)
 			continue;
 
 		// +/- 0.25% of the probability
-		if (award_is_positive(award->type))
+		if (award_is_positive(award->Type))
 			probability += probability / 4;
 		else
 			probability -= probability / 4;


### PR DESCRIPTION
So this is something we need to do for all our `rct_` structs in order to finally extend our map format. This is with award as a small example.

`rct1_award` and `rct2_award` have been created. We could unify these if we wanted to given that they are the same. The original `rct_award` has been changed to just `Award`. Notice that the struct size assert is no longer necessary because they are converted field by field for S4 and S6.

This means that you can increase `MAX_AWARDS` and it should just work! But obviously it will only save the first 4 to SV6.

Something like `rct_ride` will be a much more invasive change.

@janisozaur @Gymnasiast 