### PR TITLE
[WIP] Remove the use of a temporary file for loading saves via http

### DIFF
--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -228,14 +228,27 @@ extern "C"
                 {
 #ifndef DISABLE_HTTP
                     // Download park and open it using its temporary filename
-                    char tmpPath[MAX_PATH];
-                    if (!http_download_park(gOpenRCT2StartupActionPath, tmpPath))
+                    http_response_t *response = http_download_park(gOpenRCT2StartupActionPath);
+                    if (response == NULL)
                     {
                         title_load();
                         break;
                     }
 
-                    parkLoaded = OpenRCT2::OpenParkAutoDetectFormat(tmpPath);
+					SDL_RWops *rw = SDL_RWFromConstMem(response->body, response->size - 1);
+					if (rw == NULL) {
+						title_load();
+                        break;
+					}
+					
+					if (game_load_sv6(rw)) {
+						game_load_init();
+						parkLoaded = true;
+						gFirstTimeSave = 1;
+					}
+					
+					SDL_RWclose(rw);
+					http_request_dispose(response);
 #endif
                 }
                 else

--- a/src/openrct2/network/http.cpp
+++ b/src/openrct2/network/http.cpp
@@ -265,7 +265,7 @@ const char *http_get_extension_from_url(const char *url, const char *fallback)
     }
 }
 
-bool http_download_park(const char *url, char tmpPath[L_tmpnam + 10])
+http_response_t *http_download_park(const char *url)
 {
 	// Download park to buffer in memory
 	http_request_t request;
@@ -280,35 +280,10 @@ bool http_download_park(const char *url, char tmpPath[L_tmpnam + 10])
 		if (response != NULL) {
 			http_request_dispose(response);
 		}
-		return false;
+		return NULL;
 	}
 
-	// Generate temporary filename that includes the original extension
-	if (tmpnam(tmpPath) == NULL) {
-		Console::Error::WriteLine("Failed to generate temporary filename for downloaded park '%s'", request.url);
-		http_request_dispose(response);
-		return false;
-	}
-	size_t remainingBytes = L_tmpnam + 10 - strlen(tmpPath);
-
-	const char *ext = http_get_extension_from_url(request.url, ".sv6");
-	strncat(tmpPath, ext, remainingBytes);
-
-	// Store park in temporary file and load it (discard ending NUL in response body)
-	FILE* tmpFile = fopen(tmpPath, "wb");
-
-	if (tmpFile == NULL) {
-		Console::Error::WriteLine("Failed to write downloaded park '%s' to temporary file", request.url);
-		http_request_dispose(response);
-		return false;
-	}
-
-	fwrite(response->body, 1, response->size - 1, tmpFile);
-	fclose(tmpFile);
-
-	http_request_dispose(response);
-
-	return true;
+	return response;
 }
 
 #endif

--- a/src/openrct2/network/http.h
+++ b/src/openrct2/network/http.h
@@ -62,7 +62,7 @@ void http_request_dispose(http_response_t *response);
 const char *http_get_extension_from_url(const char *url, const char *fallback);
 
 // Padding for extension that is appended to temporary file name
-bool http_download_park(const char *url, char tmpPath[L_tmpnam + 10]);
+http_response_t *http_download_park(const char *url);
 #endif // DISABLE_HTTP
 
 // These callbacks are defined anyway, but are dummy if HTTP is disabled


### PR DESCRIPTION
This is to fix #4959 (in a different way from #4969). The temporary file feels like a cheat in the way it's being used, and this PR hopes to get rid of the concept as a whole. In the current version, the data is downloaded into RAM, written to a temp-file, and then immediately read into RAM via the load functions. This cuts out the writing and reading of the temp-file by using the `SDL_RWFromConstMem` function to get an `SDL_RWops` pointer for the pointer (and size). This should allow all the same file loading as before without requiring the temp file, and therefore avoids the "unsafe" temp-file functions.

This is still a Work In Progress. Right now, it just assumes the downloaded file is a `.SV6` and doesn't perform the file-intrinsics that it previously did. That needs to be reworked to support `SDL_RWops`, which I'll work on. It also should get some code reorganization once the intrinsics are fixed to stop passing a `http_response_t` pointer as a returned value.