### PR TITLE
Fix 5079 don't remove walls when building stalls and footpaths with clearance checks disabled.

### DIFF
--- a/src/openrct2/ride/track.c
+++ b/src/openrct2/ride/track.c
@@ -1118,7 +1118,7 @@ static money32 track_place(sint32 rideIndex, sint32 type, sint32 originX, sint32
 
 		//6c53dc
 
-		if ((flags & GAME_COMMAND_FLAG_APPLY) && !(flags & GAME_COMMAND_FLAG_GHOST)) {
+		if ((flags & GAME_COMMAND_FLAG_APPLY) && !(flags & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks) {
 			footpath_remove_litter(x, y, z);
 			if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_NO_WALLS) {
 				map_remove_walls_at(x, y, baseZ * 8, clearanceZ * 8);
@@ -1219,7 +1219,7 @@ static money32 track_place(sint32 rideIndex, sint32 type, sint32 originX, sint32
 		if (entranceDirections & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH) {
 			entranceDirections &= 0x0F;
 			if (entranceDirections != 0) {
-				if (!(flags & GAME_COMMAND_FLAG_APPLY) && !(flags & GAME_COMMAND_FLAG_GHOST)) {
+				if (!(flags & GAME_COMMAND_FLAG_APPLY) && !(flags & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks) {
 					uint8 _bl = entranceDirections;
 					for (sint32 dl = bitscanforward(_bl); dl != -1; dl = bitscanforward(_bl)){
 						_bl &= ~(1 << dl);

--- a/src/openrct2/windows/footpath.c
+++ b/src/openrct2/windows/footpath.c
@@ -891,7 +891,7 @@ static void window_footpath_construct()
 	gGameCommandErrorTitle = STR_CANT_BUILD_FOOTPATH_HERE;
 	money32 cost = footpath_place(type, x, y, z, slope, 0);
 
-	if (cost != MONEY32_UNDEFINED) {
+	if (cost != MONEY32_UNDEFINED && !gCheatsDisableClearanceChecks) {
 		// It is possible, let's remove walls between the old and new piece of path
 		uint8 direction = gFootpathConstructDirection;
 		map_remove_intersecting_walls(x, y, z, z + 4 + ((slope & 0xf) ? 2 : 0), direction ^ 2);


### PR DESCRIPTION
This PR fixes #5079. In the screenshots below I built a track, a footpath and a stall through a building with walls.

![the openrct group park 4 2017-01-15 14-15-44](https://cloud.githubusercontent.com/assets/9705046/21962722/3eb36de6-db2d-11e6-8f7c-005af4c0b0ac.png)
![the openrct group park 4 2017-01-15 14-15-46](https://cloud.githubusercontent.com/assets/9705046/21962723/40183176-db2d-11e6-8d8c-4a746177697e.png)

One difference this creates however, is that paths and stalls will not be connected to the footpaths behind the wall. Should that be changed?