### PR TITLE
Create "misc_commands" enum

### DIFF
--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -96,12 +96,6 @@ enum GAME_COMMAND {
 	GAME_COMMAND_COUNT
 };
 
-enum MISC_COMMAND {
-	MISC_COMMAND_CHAT = -1,
-	MISC_COMMAND_TOGGLE_SCENERY_CLUSTER = -2,
-	MISC_COMMAND_PASSWORDLESS_LOGIN = -3,
-};
-
 enum {
 	GAME_COMMAND_FLAG_APPLY = (1 << 0), // If this flag is set, the command is applied, otherwise only the cost is retrieved
 	GAME_COMMAND_FLAG_2 = (1 << 2),

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -96,6 +96,12 @@ enum GAME_COMMAND {
 	GAME_COMMAND_COUNT
 };
 
+enum MISC_COMMAND {
+	MISC_COMMAND_CHAT = -1,
+	MISC_COMMAND_TOGGLE_SCENERY_CLUSTER = -2,
+	MISC_COMMAND_PASSWORDLESS_LOGIN = -3,
+};
+
 enum {
 	GAME_COMMAND_FLAG_APPLY = (1 << 0), // If this flag is set, the command is applied, otherwise only the cost is retrieved
 	GAME_COMMAND_FLAG_2 = (1 << 2),

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -67,7 +67,7 @@ const std::vector<NetworkAction> NetworkActions::Actions =
     {
         STR_ACTION_CHAT, "PERMISSION_CHAT",
         {
-            -1
+            MISC_COMMAND_CHAT
         }
     }, {
         STR_ACTION_TERRAFORM, "PERMISSION_TERRAFORM",
@@ -214,12 +214,12 @@ const std::vector<NetworkAction> NetworkActions::Actions =
     }, {
         STR_ACTION_TOGGLE_SCENERY_CLUSTER, "PERMISSION_TOGGLE_SCENERY_CLUSTER",
         {
-            -2
+            MISC_COMMAND_TOGGLE_SCENERY_CLUSTER
         }
     }, {
         STR_ACTION_PASSWORDLESS_LOGIN, "PERMISSION_PASSWORDLESS_LOGIN",
         {
-            -3
+            MISC_COMMAND_PASSWORDLESS_LOGIN
         }
     },
 };

--- a/src/openrct2/network/NetworkAction.h
+++ b/src/openrct2/network/NetworkAction.h
@@ -20,6 +20,13 @@
 #include <string>
 #include "../common.h"
 
+enum MISC_COMMAND
+{
+    MISC_COMMAND_CHAT = -1,
+    MISC_COMMAND_TOGGLE_SCENERY_CLUSTER = -2,
+    MISC_COMMAND_PASSWORDLESS_LOGIN = -3,
+};
+
 class NetworkAction final
 {
 public:

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1570,7 +1570,7 @@ void Network::Server_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
 		bool passwordless = false;
 		if (connection.AuthStatus == NETWORK_AUTH_VERIFIED) {
 			const NetworkGroup * group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
-			size_t actionIndex = NetworkActions::FindCommandByPermissionName("PERMISSION_PASSWORDLESS_LOGIN");
+			size_t actionIndex = NetworkActions::FindCommand(MISC_COMMAND_PASSWORDLESS_LOGIN);
 			passwordless = group->CanPerformAction(actionIndex);
 		}
 		if (!gameversion || strcmp(gameversion, NETWORK_STREAM_ID) != 0) {
@@ -1680,7 +1680,7 @@ void Network::Server_Handle_CHAT(NetworkConnection& connection, NetworkPacket& p
 {
 	if (connection.Player) {
 		NetworkGroup* group = GetGroupByID(connection.Player->Group);
-		if (!group || (group && !group->CanPerformCommand(-1))) {
+		if (!group || (group && !group->CanPerformCommand(MISC_COMMAND_CHAT))) {
 			return;
 		}
 	}
@@ -1734,7 +1734,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	// cluster mode is a for loop that runs the place_scenery code multiple times.
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
 		if ((ticks - connection.Player->LastActionTime) < 20) {
-			if (!(group->CanPerformCommand(-2))) {
+			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
 				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_CANT_DO_THIS);
 				return;
 			}

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1570,8 +1570,7 @@ void Network::Server_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
 		bool passwordless = false;
 		if (connection.AuthStatus == NETWORK_AUTH_VERIFIED) {
 			const NetworkGroup * group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
-			size_t actionIndex = NetworkActions::FindCommand(MISC_COMMAND_PASSWORDLESS_LOGIN);
-			passwordless = group->CanPerformAction(actionIndex);
+			passwordless = group->CanPerformCommand(MISC_COMMAND_PASSWORDLESS_LOGIN);
 		}
 		if (!gameversion || strcmp(gameversion, NETWORK_STREAM_ID) != 0) {
 			connection.AuthStatus = NETWORK_AUTH_BADVERSION;


### PR DESCRIPTION
I have replaced the sections that used magic numbers with a "misc_command" enum, which can be used for commands that aren't really gamestate specific. this will help with banishing magic numbers and also banish the need to rely on looking commands up by a string variable, which is vulnerable to typos etc