### PR TITLE
Fix width of park rating bar in bottom toolbar

### DIFF
--- a/src/openrct2/windows/game_bottom_toolbar.c
+++ b/src/openrct2/windows/game_bottom_toolbar.c
@@ -426,8 +426,8 @@ static void window_game_bottom_toolbar_draw_park_rating(rct_drawpixelinfo *dpi, 
 {
 	sint16 bar_width;
 
-	bar_width = (factor * (90 + WIDTH_MOD)) / 256;
-	gfx_fill_rect_inset(dpi, x, y + 1, x + (93 + WIDTH_MOD), y + 9, w->colours[1], INSET_RECT_F_30);
+	bar_width = (factor * (92 + WIDTH_MOD)) / 255;
+	gfx_fill_rect_inset(dpi, x + 1, y + 1, x + (92 + WIDTH_MOD), y + 9, w->colours[1], INSET_RECT_F_30);
 	if (!(colour & 0x80000000) || game_is_paused() || (gCurrentTicks & 8)) {
 		if (bar_width > 2)
 			gfx_fill_rect_inset(dpi, x + 2, y + 2, x + bar_width - 1, y + 8, colour & 0x7FFFFFFF, 0);


### PR DESCRIPTION
Fix width of park rating bar in bottom toolbar, see https://www.reddit.com/r/openrct2/comments/5mpwhs/small_graphic_piece_that_may_be/?st=iy1w0alt&sh=4a69edb3

![after screenshot](https://cloud.githubusercontent.com/assets/4310707/22036586/526c0fc8-dcf4-11e6-9728-98ce10f6f328.png)
