### PR TITLE
Prevent overflow of cheats_add_money, finance_payment, ride->average_speed

### DIFF
--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -246,7 +246,8 @@ static void cheat_set_money(money32 amount)
 static void cheat_add_money(money32 amount)
 {
 	money32 currentMoney = DECRYPT_MONEY(gCashEncrypted);
-	add_clamp(currentMoney, amount, INT_MIN, INT_MAX);
+	currentMoney = add_clamp_money32(currentMoney, amount, INT_MIN, INT_MAX);
+	
 	gCashEncrypted = ENCRYPT_MONEY(currentMoney);
 
 	window_invalidate_by_class(WC_FINANCES);

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -246,7 +246,7 @@ static void cheat_set_money(money32 amount)
 static void cheat_add_money(money32 amount)
 {
 	money32 currentMoney = DECRYPT_MONEY(gCashEncrypted);
-	currentMoney = add_clamp_money32(currentMoney, amount, INT_MIN, INT_MAX);
+	currentMoney = add_clamp_money32(currentMoney, amount);
 
 	gCashEncrypted = ENCRYPT_MONEY(currentMoney);
 

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -247,7 +247,7 @@ static void cheat_add_money(money32 amount)
 {
 	money32 currentMoney = DECRYPT_MONEY(gCashEncrypted);
 	currentMoney = add_clamp_money32(currentMoney, amount, INT_MIN, INT_MAX);
-	
+
 	gCashEncrypted = ENCRYPT_MONEY(currentMoney);
 
 	window_invalidate_by_class(WC_FINANCES);

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -21,6 +21,7 @@
 #include "localisation/date.h"
 #include "management/finance.h"
 #include "network/network.h"
+#include "util/util.h"
 #include "world/climate.h"
 #include "world/footpath.h"
 #include "world/scenery.h"
@@ -245,20 +246,7 @@ static void cheat_set_money(money32 amount)
 static void cheat_add_money(money32 amount)
 {
 	money32 currentMoney = DECRYPT_MONEY(gCashEncrypted);
-	if (amount >= 0) {
-		if (currentMoney < INT_MAX - amount)
-			currentMoney += amount;
-		else
-			currentMoney = INT_MAX;
-	}
-	else {
-		money32 absAmount = amount * -1;
-		if (currentMoney > INT_MIN + absAmount)
-			currentMoney -= absAmount;
-		else
-			currentMoney = INT_MIN;
-	}
-
+	add_clamp(currentMoney, amount, INT_MIN, INT_MAX);
 	gCashEncrypted = ENCRYPT_MONEY(currentMoney);
 
 	window_invalidate_by_class(WC_FINANCES);

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -220,16 +220,7 @@ typedef uint16 rct_string_id;
 	#define RESTRICT
 #endif
 
-#ifdef __cplusplus
 #define assert_struct_size(x, y) static_assert(sizeof(x) == (y), "Improper struct size")
-#else
-	// Visual Studio does not know _Static_assert
-	#if !defined(_MSC_VER)
-		#define assert_struct_size(x, y) _Static_assert(sizeof(x) == (y), "Improper struct size")
-	#else
-		#define assert_struct_size(x, y)
-	#endif // !defined(_MSC_VER)
-#endif
 
 #ifdef PLATFORM_X86
 	#ifndef FASTCALL

--- a/src/openrct2/management/finance.c
+++ b/src/openrct2/management/finance.c
@@ -76,7 +76,7 @@ void finance_payment(money32 amount, rct_expenditure_type type)
 	money32 new_money;
 
 	//overflow check
-	new_money = add_clamp_money32(cur_money, -amount, INT_MIN, INT_MAX);
+	new_money = add_clamp_money32(cur_money, -amount);
 
 	gCashEncrypted = ENCRYPT_MONEY(new_money);
 	gExpenditureTable[type] -= amount;

--- a/src/openrct2/management/finance.c
+++ b/src/openrct2/management/finance.c
@@ -73,10 +73,10 @@ uint8 gCommandExpenditureType;
 void finance_payment(money32 amount, rct_expenditure_type type)
 {
 	money32 cur_money = DECRYPT_MONEY(gCashEncrypted);
-	money32 new_money = cur_money;
+	money32 new_money;
 
 	//overflow check
-	add_clamp(new_money, -amount, INT_MIN, INT_MAX);
+	new_money = add_clamp_money32(cur_money, -amount, INT_MIN, INT_MAX);
 
 	gCashEncrypted = ENCRYPT_MONEY(new_money);
 	gExpenditureTable[type] -= amount;

--- a/src/openrct2/management/finance.c
+++ b/src/openrct2/management/finance.c
@@ -73,15 +73,10 @@ uint8 gCommandExpenditureType;
 void finance_payment(money32 amount, rct_expenditure_type type)
 {
 	money32 cur_money = DECRYPT_MONEY(gCashEncrypted);
-	money32 new_money;
+	money32 new_money = cur_money;
 
 	//overflow check
-	if (amount < 0 && cur_money >= INT_MAX + amount)
-		new_money = INT_MAX;
-	else if (amount >= 0 && cur_money < INT_MIN + amount)
-		new_money = INT_MIN;
-	else
-		new_money = cur_money - amount;
+	add_clamp(new_money, -amount, INT_MIN, INT_MAX);
 
 	gCashEncrypted = ENCRYPT_MONEY(new_money);
 	gExpenditureTable[type] -= amount;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -28,6 +28,7 @@
 #include "../world/map_animation.h"
 #include "../world/scenery.h"
 #include "../world/sprite.h"
+#include "../util/util.h"
 #include "cable_lift.h"
 #include "ride.h"
 #include "ride_data.h"

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -1244,7 +1244,7 @@ static void vehicle_update_measurements(rct_vehicle *vehicle)
 		}
 
 		if (ride->average_speed_test_timeout == 0 && velocity > 0x8000){
-			ride->average_speed += velocity;
+			add_clamp(ride->average_speed, velocity, INT32_MIN, INT32_MAX);
 			ride->time[test_segment]++;
 		}
 

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -1245,7 +1245,7 @@ static void vehicle_update_measurements(rct_vehicle *vehicle)
 		}
 
 		if (ride->average_speed_test_timeout == 0 && velocity > 0x8000){
-			ride->average_speed = add_clamp_sint32(ride->average_speed, velocity, INT32_MIN, INT32_MAX);
+			ride->average_speed = add_clamp_sint32(ride->average_speed, velocity);
 			ride->time[test_segment]++;
 		}
 

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -1244,7 +1244,7 @@ static void vehicle_update_measurements(rct_vehicle *vehicle)
 		}
 
 		if (ride->average_speed_test_timeout == 0 && velocity > 0x8000){
-			add_clamp(ride->average_speed, velocity, INT32_MIN, INT32_MAX);
+			ride->average_speed = add_clamp_sint32(ride->average_speed, velocity, INT32_MIN, INT32_MAX);
 			ride->time[test_segment]++;
 		}
 

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -17,6 +17,7 @@
 // Include common.h before SDL, otherwise M_PI gets redefined
 #include "../common.h"
 
+#include <assert.h>
 #include <SDL.h>
 #include "../core/Guard.hpp"
 #include "../localisation/localisation.h"
@@ -551,8 +552,9 @@ sint32 add_clamp_sint32(sint32 value, sint32 value_to_add)
 
 money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
-	// This function is intended only for clarity, but money32 is the technically 
-	// the same as sint32
+	// This function is intended only for clarity, but money32
+	// is technically the same as sint32
+	static_assert(sizeof(money32) == sizeof(sint32), "money32 is not the same as sint32");
 	return add_clamp_sint32(value, value_to_add);
 }
 

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -554,7 +554,7 @@ money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
 	// This function is intended only for clarity, but money32
 	// is technically the same as sint32
-	static_assert(sizeof(money32) == sizeof(sint32), "money32 is not the same as sint32");
+	_STATIC_ASSERT(sizeof(money32) == sizeof(sint32));
 	return add_clamp_sint32(value, value_to_add);
 }
 

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -531,27 +531,27 @@ uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_ou
        value += value_to_add; \
     }
 
-sint8 add_clamp_sint8(sint8 value, sint8 value_to_add, sint8 min_cap, sint8 max_cap)
+sint8 add_clamp_sint8(sint8 value, sint8 value_to_add)
 {
-	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	add_clamp_body(value, value_to_add, INT8_MIN, INT8_MAX);
 	return value;
 }
 
-sint16 add_clamp_sint16(sint16 value, sint16 value_to_add, sint16 min_cap, sint16 max_cap)
+sint16 add_clamp_sint16(sint16 value, sint16 value_to_add)
 {
-	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	add_clamp_body(value, value_to_add, INT16_MIN, INT16_MAX);
 	return value;
 }
 
-sint32 add_clamp_sint32(sint32 value, sint32 value_to_add, sint32 min_cap, sint32 max_cap)
+sint32 add_clamp_sint32(sint32 value, sint32 value_to_add)
 {
-	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	add_clamp_body(value, value_to_add, INT32_MIN, INT32_MAX);
 	return value;
 }
 
-money32 add_clamp_money32(money32 value, money32 value_to_add, money32 min_cap, money32 max_cap)
+money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
-	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	add_clamp_body(value, value_to_add, INT_MIN, INT_MAX);
 	return value;
 }
 

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -518,3 +518,41 @@ uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_ou
 	buffer = realloc(buffer, *data_out_size);
 	return buffer;
 }
+
+// Type-independant code left as macro to reduce duplicate code.
+#define add_clamp_body(value, value_to_add, min_cap, max_cap) \
+    if ((value_to_add > 0) && (value > (max_cap - value_to_add))) { \
+        value = max_cap; \
+    } \
+    else if ((value_to_add < 0) && (value < (min_cap - value_to_add))) { \
+        value = min_cap; \
+    } \
+    else { \
+       value += value_to_add; \
+    }
+
+sint8 add_clamp_sint8(sint8 value, sint8 value_to_add, sint8 min_cap, sint8 max_cap)
+{
+	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	return value;
+}
+
+sint16 add_clamp_sint16(sint16 value, sint16 value_to_add, sint16 min_cap, sint16 max_cap)
+{
+	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	return value;
+}
+
+sint32 add_clamp_sint32(sint32 value, sint32 value_to_add, sint32 min_cap, sint32 max_cap)
+{
+	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	return value;
+}
+
+money32 add_clamp_money32(money32 value, money32 value_to_add, money32 min_cap, money32 max_cap)
+{
+	add_clamp_body(value, value_to_add, min_cap, max_cap);
+	return value;
+}
+
+#undef add_clamp_body

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -551,8 +551,9 @@ sint32 add_clamp_sint32(sint32 value, sint32 value_to_add)
 
 money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
-	add_clamp_body(value, value_to_add, INT_MIN, INT_MAX);
-	return value;
+	// This function is intended only for clarity, but money32 is the technically 
+	// the same as sint32
+	return add_clamp_sint32(value, value_to_add);
 }
 
 #undef add_clamp_body

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -17,7 +17,6 @@
 // Include common.h before SDL, otherwise M_PI gets redefined
 #include "../common.h"
 
-#include <assert.h>
 #include <SDL.h>
 #include "../core/Guard.hpp"
 #include "../localisation/localisation.h"
@@ -552,9 +551,9 @@ sint32 add_clamp_sint32(sint32 value, sint32 value_to_add)
 
 money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
-	// This function is intended only for clarity, but money32
+	// This function is intended only for clarity, as money32
 	// is technically the same as sint32
-	_STATIC_ASSERT(sizeof(money32) == sizeof(sint32));
+	assert_struct_size(money32, sizeof(sint32));
 	return add_clamp_sint32(value, value_to_add);
 }
 

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -56,9 +56,9 @@ uint32 util_rand();
 uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_out_size);
 uint8 *util_zlib_inflate(uint8 *data, size_t data_in_size, size_t *data_out_size);
 
-sint8 add_clamp_sint8(sint8 value, sint8 value_to_add, sint8 min_cap, sint8 max_cap);
-sint16 add_clamp_sint16(sint16 value, sint16 value_to_add, sint16 min_cap, sint16 max_cap);
-sint32 add_clamp_sint32(sint32 value, sint32 value_to_add, sint32 min_cap, sint32 max_cap);
-money32 add_clamp_money32(money32 value, money32 value_to_add, money32 min_cap, money32 max_cap);
+sint8 add_clamp_sint8(sint8 value, sint8 value_to_add);
+sint16 add_clamp_sint16(sint16 value, sint16 value_to_add);
+sint32 add_clamp_sint32(sint32 value, sint32 value_to_add);
+money32 add_clamp_money32(money32 value, money32 value_to_add);
 
 #endif

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -56,4 +56,12 @@ uint32 util_rand();
 uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_out_size);
 uint8 *util_zlib_inflate(uint8 *data, size_t data_in_size, size_t *data_out_size);
 
+#define add_clamp(value, value_to_add, min_cap, max_cap) \
+	if ((max_cap - abs(value_to_add)) < abs(value) && (value < 0) == (value_to_add < 0)) { \
+		value = (value < 0) ? min_cap : max_cap; \
+	} \
+	else { \
+		value += value_to_add; \
+	}
+
 #endif

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -56,15 +56,9 @@ uint32 util_rand();
 uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_out_size);
 uint8 *util_zlib_inflate(uint8 *data, size_t data_in_size, size_t *data_out_size);
 
-#define add_clamp(value, value_to_add, min_cap, max_cap) \
-    if ((value_to_add > 0) && (value > (max_cap - value_to_add))) { \
-        value = max_cap; \
-    } \
-    else if ((value_to_add < 0) && (value < (min_cap - value_to_add))) { \
-        value = min_cap; \
-    } \
-    else { \
-       value += value_to_add; \
-    }
+sint8 add_clamp_sint8(sint8 value, sint8 value_to_add, sint8 min_cap, sint8 max_cap);
+sint16 add_clamp_sint16(sint16 value, sint16 value_to_add, sint16 min_cap, sint16 max_cap);
+sint32 add_clamp_sint32(sint32 value, sint32 value_to_add, sint32 min_cap, sint32 max_cap);
+money32 add_clamp_money32(money32 value, money32 value_to_add, money32 min_cap, money32 max_cap);
 
 #endif

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -57,11 +57,14 @@ uint8 *util_zlib_deflate(const uint8 *data, size_t data_in_size, size_t *data_ou
 uint8 *util_zlib_inflate(uint8 *data, size_t data_in_size, size_t *data_out_size);
 
 #define add_clamp(value, value_to_add, min_cap, max_cap) \
-	if ((max_cap - abs(value_to_add)) < abs(value) && (value < 0) == (value_to_add < 0)) { \
-		value = (value < 0) ? min_cap : max_cap; \
-	} \
-	else { \
-		value += value_to_add; \
-	}
+    if ((value_to_add > 0) && (value > (max_cap - value_to_add))) { \
+        value = max_cap; \
+    } \
+    else if ((value_to_add < 0) && (value < (min_cap - value_to_add))) { \
+        value = min_cap; \
+    } \
+    else { \
+       value += value_to_add; \
+    }
 
 #endif

--- a/src/openrct2/windows/cheats.c
+++ b/src/openrct2/windows/cheats.c
@@ -495,11 +495,11 @@ static void window_cheats_money_mousedown(sint32 widgetIndex, rct_window *w, rct
 {
 	switch (widgetIndex) {
 	case WIDX_MONEY_SPINNER_INCREMENT:
-		_moneySpinnerValue = min(INT_MAX, MONEY_INCREMENT_DIV * (_moneySpinnerValue / MONEY_INCREMENT_DIV + 1));
+		_moneySpinnerValue = add_clamp_money32(MONEY_INCREMENT_DIV * (_moneySpinnerValue / MONEY_INCREMENT_DIV), MONEY_INCREMENT_DIV);
 		widget_invalidate_by_class(WC_CHEATS, WIDX_MONEY_SPINNER);
 		break;
 	case WIDX_MONEY_SPINNER_DECREMENT:
-		_moneySpinnerValue = max(INT_MIN, MONEY_INCREMENT_DIV * (_moneySpinnerValue / MONEY_INCREMENT_DIV - 1));
+		_moneySpinnerValue = add_clamp_money32(MONEY_INCREMENT_DIV * (_moneySpinnerValue / MONEY_INCREMENT_DIV), -MONEY_INCREMENT_DIV);
 		widget_invalidate_by_class(WC_CHEATS, WIDX_MONEY_SPINNER);
 		break;
 	case WIDX_ADD_MONEY:


### PR DESCRIPTION
This makes use of #4960 's overflow clamp and puts it into a generic function (allowing custom min and max values) that can be used for almost any overflow clamp..

I feel at least 5 total clamps should be added before this is merged. This will prevent the network version from being updated more than needed.. If this is not preferred, however, then this can be tested, reviewed, and merged.

**Overflows clamped**
1) cheats_add_money
2) finance_payment
3) ride->average_speed

**EDIT:** Within the following comments, it was discussed that the 3 above is an alright number for merging, as with the add_clamp, it will be easy to clamp further numbers when necessary.