### PR TITLE
Fix some ghost consideration in peep AI

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -54,7 +54,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "29"
+#define NETWORK_STREAM_VERSION "30"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -5399,7 +5399,7 @@ static sint32 peep_update_walking_find_bench(rct_peep* peep){
 	rct_map_element* map_element = map_get_first_element_at(peep->next_x / 32, peep->next_y / 32);
 
 	for (;; map_element++){
-		if (!(map_element->flags & MAP_ELEMENT_FLAG_GHOST) && (map_element_get_type(map_element) == MAP_ELEMENT_TYPE_PATH)) {
+		if (map_element_get_type(map_element) == MAP_ELEMENT_TYPE_PATH) {
 			if (peep->next_z == map_element->base_height)break;
 		}
 		if (map_element_is_last_for_tile(map_element)){
@@ -10109,7 +10109,7 @@ static sint32 guest_path_finding(rct_peep* peep)
 	z = peep->next_z;
 
 	rct_map_element *mapElement = map_get_path_element_at(x / 32, y / 32, z);
-	if (mapElement == NULL || (mapElement->flags & MAP_ELEMENT_FLAG_GHOST)) {
+	if (mapElement == NULL) {
 		return 1;
 	}
 
@@ -10420,7 +10420,7 @@ static sint32 sub_693C9E(rct_peep *peep)
 			continue;
 		if (top_z < mapElement->base_height)
 			continue;
-		if ((mapElement->flags & MAP_ELEMENT_FLAG_GHOST))
+		if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST)
 			continue;
 
 		if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_PATH){

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -5399,7 +5399,7 @@ static sint32 peep_update_walking_find_bench(rct_peep* peep){
 	rct_map_element* map_element = map_get_first_element_at(peep->next_x / 32, peep->next_y / 32);
 
 	for (;; map_element++){
-		if (map_element_get_type(map_element) == MAP_ELEMENT_TYPE_PATH){
+		if (!(map_element->flags & MAP_ELEMENT_FLAG_GHOST) && (map_element_get_type(map_element) == MAP_ELEMENT_TYPE_PATH)) {
 			if (peep->next_z == map_element->base_height)break;
 		}
 		if (map_element_is_last_for_tile(map_element)){
@@ -8699,6 +8699,7 @@ static uint8 footpath_element_next_in_direction(sint16 x, sint16 y, sint16 z, rc
 	y += TileDirectionDelta[chosenDirection].y;
 	nextMapElement = map_get_first_element_at(x / 32, y / 32);
 	do {
+		if (nextMapElement->flags & MAP_ELEMENT_FLAG_GHOST) continue;
 		if (map_element_get_type(nextMapElement) != MAP_ELEMENT_TYPE_PATH) continue;
 		if (!is_valid_path_z_and_direction(nextMapElement, z, chosenDirection)) continue;
 		if (footpath_element_is_wide(nextMapElement)) return PATH_SEARCH_WIDE;
@@ -10108,7 +10109,7 @@ static sint32 guest_path_finding(rct_peep* peep)
 	z = peep->next_z;
 
 	rct_map_element *mapElement = map_get_path_element_at(x / 32, y / 32, z);
-	if (mapElement == NULL) {
+	if (mapElement == NULL || (mapElement->flags & MAP_ELEMENT_FLAG_GHOST)) {
 		return 1;
 	}
 
@@ -10419,10 +10420,10 @@ static sint32 sub_693C9E(rct_peep *peep)
 			continue;
 		if (top_z < mapElement->base_height)
 			continue;
+		if ((mapElement->flags & MAP_ELEMENT_FLAG_GHOST))
+			continue;
 
 		if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_PATH){
-			if ((mapElement->flags & MAP_ELEMENT_FLAG_GHOST))
-				continue;
 			if (peep_interact_with_path(peep, x, y, mapElement))
 				return 1;
 		}

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -330,6 +330,8 @@ rct_map_element* map_get_path_element_at(sint32 x, sint32 y, sint32 z){
 
 	// Find the path element at known z
 	do {
+		if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST)
+			continue;
 		if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_PATH)
 			continue;
 		if (mapElement->base_height != z)


### PR DESCRIPTION
This is a continuation of https://github.com/OpenRCT2/OpenRCT2/pull/5094.

While the previous PR cured some desyncs, the real issue remained –
logic of the game considers ghost elements. This change fixes it, to
some extent.

The problem here is we already remove ghosts when interacting over
network (e.g. `footpath_provisional_remove` in `footpath_place_real`),
but this happens only when such a game command is executed in OpenRCT2.
Whenever SV6 gets imported, path map elements already have had edges
calculated for them, neighbours being ghost or not, and we don't update
it. OpenRCT2/OpenRCT2#5094 is one, naïve, way to solve, the other option
would be to recalculate all the paths whenever we load SV6.