### PR TITLE
Only create OpenGL window when necessary

### DIFF
--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -29,6 +29,7 @@ extern "C"
 extern rct_string_id DrawingEngineStringIds[3];
 
 sint32 drawing_engine_get_type();
+bool drawing_engine_requires_restart(sint32 srcEngine, sint32 dstEngine);
 void drawing_engine_init();
 void drawing_engine_resize();
 void drawing_engine_set_palette(SDL_Color * colours);

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -581,8 +581,6 @@ void platform_init()
 
 static void platform_create_window()
 {
-	sint32 width, height;
-
 	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 		log_fatal("SDL_Init %s", SDL_GetError());
 		exit(-1);
@@ -597,16 +595,18 @@ static void platform_create_window()
 	sub_68371D();
 
 	// Get window size
-	width = gConfigGeneral.window_width;
-	height = gConfigGeneral.window_height;
+	sint32 width = gConfigGeneral.window_width;
+	sint32 height = gConfigGeneral.window_height;
 	if (width == -1) width = 640;
 	if (height == -1) height = 480;
 
 	// Create window in window first rather than fullscreen so we have the display the window is on first
-	gWindow = SDL_CreateWindow(
-		"OpenRCT2", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL
-	);
+	uint32 flags = SDL_WINDOW_RESIZABLE;
+	if (gConfigGeneral.drawing_engine == DRAWING_ENGINE_OPENGL) {
+		flags |= SDL_WINDOW_OPENGL;
+	}
 
+	gWindow = SDL_CreateWindow(OPENRCT2_NAME, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags);
 	if (!gWindow) {
 		log_fatal("SDL_CreateWindow failed %s", SDL_GetError());
 		exit(-1);

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -1222,16 +1222,15 @@ static void window_options_dropdown(rct_window *w, sint32 widgetIndex, sint32 dr
 			break;
 		case WIDX_DRAWING_ENGINE_DROPDOWN:
 			if (dropdownIndex != gConfigGeneral.drawing_engine) {
-				gConfigGeneral.drawing_engine = (uint8)dropdownIndex;
-#ifdef __WINDOWS__
-				// Windows is apparently able to switch to hardware rendering on the fly although
-				// using the same window in an unaccelerated and accelerated context is unsupported by SDL2
-				platform_refresh_video();
-#else
-				// Linux requires a restart. This could be improved in the future by recreating the window,
-				// https://github.com/OpenRCT2/OpenRCT2/issues/2015
-				window_error_open(STR_RESTART_REQUIRED, STR_NONE);
-#endif
+				sint32 srcEngine = drawing_engine_get_type();
+				sint32 dstEngine = dropdownIndex;
+
+				gConfigGeneral.drawing_engine = (uint8)dstEngine;
+				if (drawing_engine_requires_restart(srcEngine, dstEngine)) {
+					window_error_open(STR_RESTART_REQUIRED, STR_NONE);
+				} else {
+					platform_refresh_video();
+				}
 				config_save_default();
 				window_invalidate(w);
 			}


### PR DESCRIPTION
Currently the game window is always created with an OpenGL context which then means that opengl32.dll and other modules are loaded. The OpenGL window flag will now only be used if the config drawing engine is set to OpenGL. This means that a restart of the game is required when switching to the OpenGL drawing engine for Windows.