### PR TITLE
Clean up switch statement for map window

### DIFF
--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -367,6 +367,9 @@ static void window_map_mouseup(rct_window *w, sint32 widgetIndex)
 	case WIDX_MAP_SIZE_SPINNER:
 		window_map_inputsize_map(w);
 		break;
+	case WIDX_MAP_GENERATOR:
+		window_mapgen_open();
+		break;
 	default:
 		if (widgetIndex >= WIDX_PEOPLE_TAB && widgetIndex <= WIDX_RIDES_TAB) {
 			widgetIndex -= WIDX_PEOPLE_TAB;
@@ -375,14 +378,7 @@ static void window_map_mouseup(rct_window *w, sint32 widgetIndex)
 
  			w->selected_tab = widgetIndex;
  			w->list_information_type = 0;
-			break;
-
-	case WIDX_MAP_GENERATOR:
-			window_mapgen_open();
-			break;
  		}
-
- 		break;
  	}
  }
 


### PR DESCRIPTION
This PR cleans up the `default` case for the switch statement in `window_map_mouseup`. It also removes a few unnecessary `break` statements.

Presumably the code was in this state due to a rebase gone wrong. Interestingly, it doesn't seem to have caused any bugs.