### PR TITLE
Refactor / use scenario repository as dependency

### DIFF
--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -152,7 +152,7 @@ extern "C"
 
         IObjectRepository * objRepo = CreateObjectRepository(OpenRCT2::_env);
         ITrackDesignRepository * tdRepo = CreateTrackDesignRepository(OpenRCT2::_env);
-        CreateScenarioRepository(OpenRCT2::_env);
+        IScenarioRepository * scenarioRepo = CreateScenarioRepository(OpenRCT2::_env);
 
         if (!language_open(gConfigGeneral.language))
         {
@@ -174,6 +174,7 @@ extern "C"
         //      as its not required until the player wants to place a new ride.
         tdRepo->Scan();
 
+        scenarioRepo->Scan();
         TitleSequenceManager::Scan();
 
         if (!gOpenRCT2Headless)

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -17,6 +17,7 @@
 #include "../core/Console.hpp"
 #include "../network/network.h"
 #include "../OpenRCT2.h"
+#include "../scenario/ScenarioRepository.h"
 #include "TitleScreen.h"
 #include "TitleSequence.h"
 #include "TitleSequenceManager.h"
@@ -59,7 +60,8 @@ static void TitleInitialise()
 {
     if (_sequencePlayer == nullptr)
     {
-        _sequencePlayer = CreateTitleSequencePlayer();
+        IScenarioRepository * scenarioRepository = GetScenarioRepository();
+        _sequencePlayer = CreateTitleSequencePlayer(scenarioRepository);
     }
     size_t seqId = title_sequence_manager_get_index_for_config_id(gConfigInterface.current_title_sequence_preset);
     if (seqId == SIZE_MAX)

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -39,6 +39,8 @@ extern "C"
 class TitleSequencePlayer final : public ITitleSequencePlayer
 {
 private:
+    static constexpr const char * SFMM_FILENAME = "Six Flags Magic Mountain.SC6";
+
     uint32          _sequenceId = 0;
     TitleSequence * _sequence = nullptr;
     sint32          _position = 0;
@@ -231,7 +233,15 @@ private:
             break;
         case TITLE_SCRIPT_LOADMM:
         {
-            const utf8 * path = get_file_path(PATH_ID_SIXFLAGS_MAGICMOUNTAIN);
+            IScenarioRepository * scenarioRepo = GetScenarioRepository();
+            const scenario_index_entry * entry = scenarioRepo->GetByFilename(SFMM_FILENAME);
+            if (entry == nullptr)
+            {
+                Console::Error::WriteLine("%s not found.", SFMM_FILENAME);
+                return false;
+            }
+
+            const utf8 * path = entry->path;
             if (!LoadParkFromFile(path))
             {
                 Console::Error::WriteLine("Failed to load: \"%s\" for the title sequence.", path);

--- a/src/openrct2/title/TitleSequencePlayer.h
+++ b/src/openrct2/title/TitleSequencePlayer.h
@@ -20,6 +20,8 @@
 
 #ifdef __cplusplus
 
+interface IScenarioRepository;
+
 interface ITitleSequencePlayer
 {
     virtual ~ITitleSequencePlayer() = default;
@@ -33,7 +35,7 @@ interface ITitleSequencePlayer
     virtual void Eject() abstract;
 };
 
-ITitleSequencePlayer * CreateTitleSequencePlayer();
+ITitleSequencePlayer * CreateTitleSequencePlayer(IScenarioRepository * scenarioRepository);
 
 #else
 


### PR DESCRIPTION
Small cleanup to TitleSequencePlayer to

* Accept IScenarioRepository as a dependency.
* Load SFMM from the repository - removing one more use of `get_file_path`