### PR TITLE
Add support to the Cut-away view for option Height Label: Units

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4320,6 +4320,7 @@ STR_6008    :{SMALLFONT}{BLACK}Click to toggle raw value<->value in measurement 
 STR_6009    :{SMALLFONT}{BLACK}Select cut height
 STR_6010    :{COMMA2DP32}m
 STR_6011    :{COMMA1DP16}ft
+STR_6012    :{COMMA1DP16}
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3663,6 +3663,7 @@ enum {
 	STR_VIEW_CLIPPING_HEIGHT_SCROLL_TIP = 6009,
 	STR_UNIT2DP_SUFFIX_METRES = 6010,
 	STR_UNIT1DP_SUFFIX_FEET = 6011,
+	STR_UNIT1DP_NO_SUFFIX = 6012,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/openrct2/windows/view_clipping.c
+++ b/src/openrct2/windows/view_clipping.c
@@ -254,6 +254,7 @@ static void window_view_clipping_paint(rct_window *w, rct_drawpixelinfo *dpi)
 	x = w->x + w->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1;
 	y = w->y + w->widgets[WIDX_CLIP_HEIGHT_VALUE].top;
 
+	fixed16_1dp clipHeightValueInUnits;
 	fixed32_2dp clipHeightValueInMeters;
 	fixed16_1dp clipHeightValueInFeet;
 	sint32 clipHeightRawValue = (sint32)gClipHeight;
@@ -264,18 +265,27 @@ static void window_view_clipping_paint(rct_window *w, rct_drawpixelinfo *dpi)
 		break;
 
 	case DISPLAY_UNITS:
-		// Print the value in the configured measurement units.
-		switch (gConfigGeneral.measurement_format) {
-		case MEASUREMENT_FORMAT_METRIC:
-		case MEASUREMENT_FORMAT_SI:
-			clipHeightValueInMeters = (fixed32_2dp)(FIXED_2DP(gClipHeight, 0) / 2 * 1.5f - FIXED_2DP(10, 50));
-			gfx_draw_string_left(dpi, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, w->colours[0], x, y);
-			break;
-		case MEASUREMENT_FORMAT_IMPERIAL:
-		default:
-			clipHeightValueInFeet = (fixed16_1dp)(FIXED_1DP(gClipHeight, 0) / 2.0f * 5 - FIXED_1DP(35, 0));
-			gfx_draw_string_left(dpi, STR_UNIT1DP_SUFFIX_FEET, &clipHeightValueInFeet, w->colours[0], x, y);
-			break;
+		// Print the value in the configured height label type:
+		if (gConfigGeneral.show_height_as_units == 1) {
+			// Height label is Units.
+			clipHeightValueInUnits = (fixed16_1dp)(FIXED_1DP(gClipHeight, 0) / 2 - FIXED_1DP(7, 0));
+			gfx_draw_string_left(dpi, STR_UNIT1DP_NO_SUFFIX, &clipHeightValueInUnits, w->colours[0], x, y); // Printing the value in Height Units.
+		}
+		else {
+			// Height label is Real Values.
+			// Print the value in the configured measurement units.
+			switch (gConfigGeneral.measurement_format) {
+			case MEASUREMENT_FORMAT_METRIC:
+			case MEASUREMENT_FORMAT_SI:
+				clipHeightValueInMeters = (fixed32_2dp)(FIXED_2DP(gClipHeight, 0) / 2 * 1.5f - FIXED_2DP(10, 50));
+				gfx_draw_string_left(dpi, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, w->colours[0], x, y);
+				break;
+			case MEASUREMENT_FORMAT_IMPERIAL:
+			default:
+				clipHeightValueInFeet = (fixed16_1dp)(FIXED_1DP(gClipHeight, 0) / 2.0f * 5 - FIXED_1DP(35, 0));
+				gfx_draw_string_left(dpi, STR_UNIT1DP_SUFFIX_FEET, &clipHeightValueInFeet, w->colours[0], x, y);
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
When Options->Height Label is set to "Units" show the Cut-away height in the same units.
When Options->Height Label is set to "Real Values" show the Cut-away height in ft/m as before.

Fixes #5112.