### PR TITLE
Prevent erroneous values in peep pathfinding

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -54,7 +54,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "31"
+#define NETWORK_STREAM_VERSION "32"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9052,6 +9052,10 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 
 		if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) continue;
 
+		if (test_edge == -1) {
+			continue;
+		}
+
 		uint8 rideIndex = 0xFF;
 		switch (map_element_get_type(mapElement)) {
 		case MAP_ELEMENT_TYPE_TRACK:


### PR DESCRIPTION
This can possibly cause unexpected results due to l-shift of negative
values (seen near line 9275) and lead to a desync.