### PR TITLE
Add enhancement to show money effect when peeps make purchases

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4368,6 +4368,8 @@ STR_6056    :{SMALLFONT}{BLACK}Mute
 STR_6057    :{SMALLFONT}{BLACK}Show a separate button for the Mute Option in the toolbar
 STR_6058    :Mute
 STR_6059    :{RIGHTGUILLEMET}
+STR_6060    :Show guest purchases as animation
+STR_6061    :{SMALLFONT}{BLACK}Show animated money effect{NEWLINE}when guests make purchases.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4370,6 +4370,8 @@ STR_6058    :Mute
 STR_6059    :{RIGHTGUILLEMET}
 STR_6060    :Show guest purchases as animation
 STR_6061    :{SMALLFONT}{BLACK}Show animated money effect{NEWLINE}when guests make purchases.
+STR_6062    :{OUTLINE}{GREEN}+ {CURRENCY2DP}
+STR_6063    :{OUTLINE}{RED}- {CURRENCY2DP}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.0.8 (in development)
 ------------------------------------------------------------------------
+- Feature: [#5133] Add option to display guest expenditure (as seen in RCTC).
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#3178, #5456] Paths with non-ASCII characters not handled properly on macOS.

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -202,6 +202,7 @@ namespace Config
             model->zoom_to_cursor = reader->GetBoolean("zoom_to_cursor", true);
             model->render_weather_effects = reader->GetBoolean("render_weather_effects", true);
             model->render_weather_gloom = reader->GetBoolean("render_weather_gloom", true);
+            model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
         }
     }
 
@@ -270,6 +271,7 @@ namespace Config
         writer->WriteBoolean("zoom_to_cursor", model->zoom_to_cursor);
         writer->WriteBoolean("render_weather_effects", model->render_weather_effects);
         writer->WriteBoolean("render_weather_gloom", model->render_weather_gloom);
+        writer->WriteBoolean("show_guest_purchases", model->show_guest_purchases);
     }
 
     static void ReadInterface(IIniReader * reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -49,6 +49,7 @@ typedef struct GeneralConfiguration
     bool        render_weather_effects;
     bool        render_weather_gloom;
     bool        disable_lightning_effect;
+    bool        show_guest_purchases;
 
     // Localisation
     sint32      language;

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3723,6 +3723,8 @@ enum {
 
 	STR_SHOW_GUEST_PURCHASES = 6060,
 	STR_SHOW_GUEST_PURCHASES_TIP = 6061,
+	STR_MONEY_EFFECT_RECEIVE_HIGHP = 6062,
+	STR_MONEY_EFFECT_SPEND_HIGHP = 6063,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3721,6 +3721,9 @@ enum {
 
 	STR_RIGHTGUILLEMET = 6059,
 
+	STR_SHOW_GUEST_PURCHASES = 6060,
+	STR_SHOW_GUEST_PURCHASES_TIP = 6061,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };

--- a/src/openrct2/paint/sprite/misc.c
+++ b/src/openrct2/paint/sprite/misc.c
@@ -55,15 +55,9 @@ void misc_paint(rct_sprite *misc, sint32 imageDirection)
 				return;
 			}
 
-			rct_money_effect moneyEffect = misc->money_effect;
-			money32 amount = moneyEffect.value;
-			rct_string_id stringId = STR_MONEY_EFFECT_RECEIVE;
-			if (amount < 0) {
-				amount = -amount;
-				stringId = STR_MONEY_EFFECT_SPEND;
-			}
-
-			sub_685EBC(amount, stringId, moneyEffect.y, moneyEffect.z, (sint8 *) &money_wave[moneyEffect.wiggle % 22], moneyEffect.offset_x, get_current_rotation());
+			rct_money_effect * moneyEffect = &misc->money_effect;
+			rct_string_id stringId = money_effect_get_string_id(moneyEffect);
+			sub_685EBC(moneyEffect->value, stringId, moneyEffect->y, moneyEffect->z, (sint8 *) &money_wave[moneyEffect->wiggle % 22], moneyEffect->offset_x, get_current_rotation());
 			break;
 		}
 

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10565,6 +10565,9 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
 	gUnk141F568 = gUnk13CA740;
 	finance_payment(-amount, gCommandExpenditureType);
 
+	if (gConfigGeneral.show_guest_purchases)
+		money_effect_create_at(amount, peep->x, peep->y, peep->z, true);
+
 	audio_play_sound_at_location(SOUND_PURCHASE, peep->x, peep->y, peep->z);
 }
 

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10565,8 +10565,13 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
 	gUnk141F568 = gUnk13CA740;
 	finance_payment(-amount, gCommandExpenditureType);
 
-	if (gConfigGeneral.show_guest_purchases)
-		money_effect_create_at(amount, peep->x, peep->y, peep->z, true);
+	if (gConfigGeneral.show_guest_purchases) {
+		// HACK Currently disabled for multiplayer due to limitation of all sprites
+		//      needing to be synchronised
+		if (network_get_mode() == NETWORK_MODE_NONE) {
+			money_effect_create_at(amount, peep->x, peep->y, peep->z, true);
+		}
+	}
 
 	audio_play_sound_at_location(SOUND_PURCHASE, peep->x, peep->y, peep->z);
 }

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -104,6 +104,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_UPPER_CASE_BANNERS_CHECKBOX,
 	WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
 	WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
+	WIDX_SHOW_GUEST_PURCHASES_CHECKBOX,
 
 	// Culture / Units
 	WIDX_LANGUAGE = WIDX_PAGE_START,
@@ -243,7 +244,7 @@ static rct_widget window_options_display_widgets[] = {
 static rct_widget window_options_rendering_widgets[] = {
 	MAIN_OPTIONS_WIDGETS,
 #define FRAME_RENDERING_START 53
-	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,		FRAME_RENDERING_START + 136,	STR_RENDERING_GROUP,			STR_NONE },								// Rendering group
+	{ WWT_GROUPBOX,			1,	5,      304,	FRAME_RENDERING_START + 0,		FRAME_RENDERING_START + 151,	STR_RENDERING_GROUP,			STR_NONE },								// Rendering group
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 15,		FRAME_RENDERING_START + 26,		STR_TILE_SMOOTHING, 			STR_TILE_SMOOTHING_TIP },				// Landscape smoothing
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 30,		FRAME_RENDERING_START + 41,		STR_GRIDLINES,					STR_GRIDLINES_TIP },					// Gridlines
 	{ WWT_DROPDOWN,			1,	155,	299,	FRAME_RENDERING_START + 45,		FRAME_RENDERING_START + 55,		STR_NONE,						STR_NONE },								// Construction marker
@@ -253,6 +254,7 @@ static rct_widget window_options_rendering_widgets[] = {
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 90,		FRAME_RENDERING_START + 101,	STR_UPPERCASE_BANNERS,			STR_UPPERCASE_BANNERS_TIP },			// Uppercase banners
 	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 105,	FRAME_RENDERING_START + 116,	STR_RENDER_WEATHER_EFFECTS,		STR_RENDER_WEATHER_EFFECTS_TIP },		// Render weather effects
 	{ WWT_CHECKBOX,			1,	31,		290,	FRAME_RENDERING_START + 120,	FRAME_RENDERING_START + 131,	STR_DISABLE_LIGHTNING_EFFECT,	STR_DISABLE_LIGHTNING_EFFECT_TIP },		// Disable lightning effect
+	{ WWT_CHECKBOX,			1,	10,		290,	FRAME_RENDERING_START + 135,	FRAME_RENDERING_START + 146,	STR_SHOW_GUEST_PURCHASES, STR_SHOW_GUEST_PURCHASES_TIP },
 #undef FRAME_RENDERING_START
 	{ WIDGETS_END },
 };
@@ -489,7 +491,8 @@ static uint64 window_options_page_enabled_widgets[] = {
 	(1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX) |
 	(1 << WIDX_UPPER_CASE_BANNERS_CHECKBOX) |
 	(1 << WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX) |
-	(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX),
+	(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX) |
+	(1 << WIDX_SHOW_GUEST_PURCHASES_CHECKBOX),
 
 	MAIN_OPTIONS_ENABLED_WIDGETS |
 	(1 << WIDX_LANGUAGE) |
@@ -697,6 +700,11 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
 			config_save_default();
 			window_invalidate(w);
 			gfx_invalidate_screen();
+			break;
+		case WIDX_SHOW_GUEST_PURCHASES_CHECKBOX:
+			gConfigGeneral.show_guest_purchases ^= 1;
+			config_save_default();
+			window_invalidate(w);
 			break;
 		}
 		break;
@@ -1578,6 +1586,7 @@ static void window_options_invalidate(rct_window *w)
 			w->enabled_widgets |= (1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
 			w->disabled_widgets &= ~(1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
 		}
+		widget_set_checkbox_value(w, WIDX_SHOW_GUEST_PURCHASES_CHECKBOX, gConfigGeneral.show_guest_purchases);
 		// construction marker: white/translucent
 		static const rct_string_id construction_marker_colours[] = {
 			STR_CONSTRUCTION_MARKER_COLOUR_WHITE,
@@ -1594,6 +1603,7 @@ static void window_options_invalidate(rct_window *w)
 		window_options_rendering_widgets[WIDX_UPPER_CASE_BANNERS_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_rendering_widgets[WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_rendering_widgets[WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX].type = WWT_CHECKBOX;
+		window_options_rendering_widgets[WIDX_SHOW_GUEST_PURCHASES_CHECKBOX].type = WWT_CHECKBOX;
 		break;
 
 	case WINDOW_OPTIONS_PAGE_CULTURE:

--- a/src/openrct2/world/money_effect.c
+++ b/src/openrct2/world/money_effect.c
@@ -30,7 +30,7 @@ static const rct_xy16 _moneyEffectMoveOffset[] = {
  *
  *  rct2: 0x0067351F
  */
-static void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z)
+void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool vertical)
 {
 	rct_money_effect *moneyEffect;
 	rct_string_id stringId;
@@ -41,6 +41,7 @@ static void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z)
 		return;
 
 	moneyEffect->value = value;
+	moneyEffect->vertical = vertical;
 	moneyEffect->var_14 = 64;
 	moneyEffect->var_09 = 20;
 	moneyEffect->var_15 = 30;
@@ -92,7 +93,7 @@ void money_effect_create(money32 value)
 		mapPosition.z = map_element_height(mapPosition.x, mapPosition.y) & 0xFFFF;
 	}
 	mapPosition.z += 10;
-	money_effect_create_at(-value, mapPosition.x, mapPosition.y, mapPosition.z);
+	money_effect_create_at(-value, mapPosition.x, mapPosition.y, mapPosition.z, false);
 }
 
 /**
@@ -110,10 +111,17 @@ void money_effect_update(rct_money_effect *moneyEffect)
 	if (moneyEffect->move_delay < 2)
 		return;
 
-	moneyEffect->move_delay = 0;
-	sint32 x = moneyEffect->x + _moneyEffectMoveOffset[get_current_rotation()].x;
-	sint32 y = moneyEffect->y + _moneyEffectMoveOffset[get_current_rotation()].y;
+	sint32 x = moneyEffect->x;
+	sint32 y = moneyEffect->y;
 	sint32 z = moneyEffect->z;
+	moneyEffect->move_delay = 0;
+
+	if (moneyEffect->vertical) {
+		z += 1;
+	}
+	y += _moneyEffectMoveOffset[get_current_rotation()].y;
+	x += _moneyEffectMoveOffset[get_current_rotation()].x;
+
 	sprite_move(x, y, z, (rct_sprite*)moneyEffect);
 
 	moneyEffect->num_movements++;

--- a/src/openrct2/world/money_effect.c
+++ b/src/openrct2/world/money_effect.c
@@ -32,16 +32,12 @@ static const rct_xy16 _moneyEffectMoveOffset[] = {
  */
 void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool vertical)
 {
-	rct_money_effect *moneyEffect;
-	rct_string_id stringId;
-	char buffer[128];
-
-	moneyEffect = (rct_money_effect*)create_sprite(2);
+	rct_money_effect * moneyEffect = (rct_money_effect *)create_sprite(2);
 	if (moneyEffect == NULL)
 		return;
 
 	moneyEffect->value = value;
-	moneyEffect->vertical = vertical;
+	moneyEffect->vertical = (vertical ? 1 : 0);
 	moneyEffect->var_14 = 64;
 	moneyEffect->var_09 = 20;
 	moneyEffect->var_15 = 30;
@@ -51,12 +47,11 @@ void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool ve
 	moneyEffect->num_movements = 0;
 	moneyEffect->move_delay = 0;
 
-	stringId = 1388;
-	if (value < 0) {
-		value *= -1;
-		stringId = 1399;
-	}
+	// Construct string to display
+	rct_string_id stringId = money_effect_get_string_id(moneyEffect);
+	char buffer[128];
 	format_string(buffer, 128, stringId, &value);
+
 	gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 	moneyEffect->offset_x = -(gfx_get_string_width(buffer) / 2);
 	moneyEffect->wiggle = 0;
@@ -129,4 +124,18 @@ void money_effect_update(rct_money_effect *moneyEffect)
 		return;
 
 	sprite_remove((rct_sprite*)moneyEffect);
+}
+
+rct_string_id money_effect_get_string_id(const rct_money_effect * sprite)
+{
+	bool vertical = (sprite->vertical != 0);
+	rct_string_id spentStringId = vertical ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
+	rct_string_id receiveStringId = vertical ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
+	rct_string_id stringId = receiveStringId;
+	money32 value = sprite->value;
+	if (value < 0) {
+		value *= -1;
+		stringId = spentStringId;
+	}
+	return stringId;
 }

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -229,7 +229,8 @@ typedef struct rct_money_effect {
 	uint8 var_15;
 	uint8 pad_16[0xE];
 	uint16 move_delay;				// 0x24
-	uint16 num_movements;			// 0x26
+	uint8 num_movements;			// 0x26
+	uint8 vertical;
 	money32 value;					// 0x28
 	uint8 pad_2C[0x18];
 	sint16 offset_x;				// 0x44
@@ -460,6 +461,7 @@ uint32 duck_get_frame_image(const rct_duck * duck, sint32 direction);
 // Money effect
 ///////////////////////////////////////////////////////////////
 void money_effect_create(money32 value);
+void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool vertical);
 void money_effect_update(rct_money_effect *moneyEffect);
 
 ///////////////////////////////////////////////////////////////

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -463,6 +463,7 @@ uint32 duck_get_frame_image(const rct_duck * duck, sint32 direction);
 void money_effect_create(money32 value);
 void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool vertical);
 void money_effect_update(rct_money_effect *moneyEffect);
+rct_string_id money_effect_get_string_id(const rct_money_effect * sprite);
 
 ///////////////////////////////////////////////////////////////
 // Crash particles


### PR DESCRIPTION
I got the idea to implement this after playing the recently-release mobile version "Roller Coaster Tycoon Classic." Basically a monetary effect is played whenever a peep makes a purchase, similar to the green `+$x` animation that is played when you delete a path, for example.

I also added a way to enable/disable the feature in the options menu, disabled by default.

P.S. the code base is super easy to read (and thus to contribute to) -- cheers