### PR TITLE
Remove known_issues.txt

### DIFF
--- a/distribution/known_issues.txt
+++ b/distribution/known_issues.txt
@@ -1,7 +1,0 @@
-Release version: 0.0.6
-------------------------------------------------------------------------
-* Scenario editor object selection window will show object names in the selected language at the time of building the object cache. (Deleting plugin.dat in Documents/OpenRCT2 will fix this)
-* Guest AI is slightly worse than the original game.
-* Multiplayer is very experimental and is likely to desynchronise often.
-
-Some bugs or limitations present in the original game have not yet been fixed or lifted.

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -137,9 +137,6 @@ Section "!OpenRCT2" Section1
     File ..\changelog.txt
     Push "$INSTDIR\changelog.txt"
     Call unix2dos
-    File ..\known_issues.txt
-    Push "$INSTDIR\known_issues.txt"
-    Call unix2dos
     File ..\..\licence.txt
     Push "$INSTDIR\licence.txt"
     Call unix2dos
@@ -215,7 +212,6 @@ Section "Uninstall"
 
     ; Clean up OpenRCT2 dir
     Delete "$INSTDIR\changelog.txt"
-    Delete "$INSTDIR\known_issues.txt"
     Delete "$INSTDIR\licence.txt"
     Delete "$INSTDIR\readme.txt"
     Delete "$INSTDIR\contributors.md"

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -94,7 +94,6 @@
     <PublishItems Include="$(OutputDll)" />
     <PublishItems Include="$(TargetDir)data" />
     <PublishItems Include="$(DistDir)changelog.txt" />
-    <PublishItems Include="$(DistDir)known_issues.txt" />
     <PublishItems Include="$(DistDir)readme.txt" />
     <PublishItems Include="$(RootDir)contributors.md" />
     <PublishItems Include="$(RootDir)licence.txt" />


### PR DESCRIPTION
This file is out of date and adds extra maintenance to releasing. Instead users should check the project's issue tracker on GitHub.

Have I missed any references to this?
@janisozaur @LRFLEW 