### PR TITLE
Simplify version numbers

### DIFF
--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -1,31 +1,24 @@
-# Version numbers to update
-!define /ifndef APPV_MAJOR 0
-!define /ifndef APPV_MINOR 0
-!define /ifndef APPV_MAINT 7
-!define /ifndef APPV_BUILD 0
-
 !define APPNAME             "OpenRCT2"
-!define APPVERSION          "${APPV_MAJOR}.${APPV_MINOR}.${APPV_MAINT}${APPV_EXTRA}"
-!define APPVERSIONINTERNAL  "${APPV_MAJOR}.${APPV_MINOR}.${APPV_MAINT}.${APPV_BUILD}"
-
-!define /ifndef APPURLLINK "https://github.com/OpenRCT2/OpenRCT2"
-!define APPNAMEANDVERSION "${APPNAME} ${APPVERSION}"
+!define APPVERSION          "${APPV_MAIN}${APPV_EXTRA}"
+!define APPVERSIONINTERNAL  "${APPV_MAIN}.0"
+!define APPNAMEANDVERSION   "${APPNAME} ${APPVERSION}"
+!define APPURLLINK          "https://github.com/OpenRCT2/OpenRCT2"
 
 !if "${PLATFORM}" == "Win32"
-    !define OPENRCT2_EXE "openrct2.exe"
-    !define APPBITS      32
-    !define APPARCH      "win32"
+    !define OPENRCT2_EXE    "openrct2.exe"
+    !define APPBITS         32
+    !define APPARCH         "win32"
 
     InstallDir "$PROGRAMFILES32\OpenRCT2\"
 !else
-    !define OPENRCT2_EXE            "openrct2.exe"
-    !define APPBITS                 64
-    !define APPARCH                 "win64"
+    !define OPENRCT2_EXE    "openrct2.exe"
+    !define APPBITS         64
+    !define APPARCH         "win64"
 
     InstallDir "$PROGRAMFILES64\OpenRCT2\"
 !endif
 
-!define SUPPORTED_OS    "Windows Vista, 7, 8.1 and 10"
+!define SUPPORTED_OS        "Windows Vista, 7, 8.1 and 10"
 
 ; Define root variable relative to installer
 !define PATH_ROOT "..\..\"

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -19,7 +19,7 @@
     <TestConfig Condition="'$(Configuration)'=='DebugTests' OR '$(Configuration)'=='ReleaseTests'">true</TestConfig>
     <GIT_COMMIT_SHA1_SHORT Condition="'$(GIT_COMMIT_SHA1)'!=''">$(GIT_COMMIT_SHA1.Substring(0, 7))</GIT_COMMIT_SHA1_SHORT>
 
-    <Version>0.0.7.0</Version>
+    <Version>0.0.7</Version>
     <VersionExtra Condition="'$(GIT_BRANCH)'!=''">-$(GIT_BRANCH)-$(GIT_COMMIT_SHA1_SHORT)</VersionExtra>
     <VersionExtra Condition="'$(GIT_TAG)'!=''"></VersionExtra>
     <TargetLibsVersion>11</TargetLibsVersion>
@@ -264,6 +264,7 @@
     <!-- Create the installer -->
     <Message Text="Building Windows Installer (NSIS script)" Importance="high" />
     <Exec Command="makensis /DOUTFILE=$(PublishInstallerExe) ^
+         /DAPPV_MAIN=$(Version) ^
          /DAPPV_EXTRA=$(VersionExtra) ^
          /DPLATFORM=$(Platform) ^
          $(NsisScript)"


### PR DESCRIPTION
We don't need four version numbers anymore, so we should remove all occurrences of it.
This also attempts to reduce the number of places the version is kept.