### PR TITLE
Fix data path commandline on windows

### DIFF
--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -510,17 +510,17 @@ void platform_resolve_openrct_data_path()
 	wchar_t wOutPath[MAX_PATH];
 
 	if (gCustomOpenrctDataPath[0] != 0) {
-		wchar_t *customUserDataPathW = utf8_to_widechar(gCustomOpenrctDataPath);
-		if (GetFullPathNameW(customUserDataPathW, countof(wOutPath), wOutPath, NULL) == 0) {
+		wchar_t *customOpenrctDataPathW = utf8_to_widechar(gCustomOpenrctDataPath);
+		if (GetFullPathNameW(customOpenrctDataPathW, countof(wOutPath), wOutPath, NULL) == 0) {
 			log_fatal("Unable to resolve path '%s'.", gCustomOpenrctDataPath);
 			exit(-1);
 		}
 		utf8 *outPathTemp = widechar_to_utf8(wOutPath);
-		safe_strcpy(_userDataDirectoryPath, outPathTemp, sizeof(_userDataDirectoryPath));
+		safe_strcpy(_openrctDataDirectoryPath, outPathTemp, sizeof(_openrctDataDirectoryPath));
 		free(outPathTemp);
-		free(customUserDataPathW);
+		free(customOpenrctDataPathW);
 
-		path_end_with_separator(_userDataDirectoryPath, sizeof(_userDataDirectoryPath));
+		path_end_with_separator(_openrctDataDirectoryPath, sizeof(_openrctDataDirectoryPath));
 		return;
 	}
 	char buffer[MAX_PATH];


### PR DESCRIPTION
The commandline command to override the data path never worked on windows, changing the user data path instead, probably due to copypaste. The important changes are on line 519/523, but I renamed the variable too for good measure.