### PR TITLE
Count spawn point collision as leaving park [Not vanilla compatible]

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,4 +1,4 @@
-0.0.7 (in development)
+﻿0.0.7 (in development)
 ------------------------------------------------------------------------
 - Improved: [#5137]: Removing all guests no longer closes the rides and removes the vehicles.
 - Fix: [#5150] --openrct-data-path sets user data path instead of OpenRCT2 data path.
@@ -11,6 +11,7 @@
 - Feature: [#4916] FreeBSD support.
 - Feature: [#4963] Add boosters (from RCT1 and RCTC).
 - Feature: [#5113] Entertainers are now hired with a random costume.
+- Improved: Peeps can now leave map at spawn points.
 - Improved: [#4847] Guest / staff pathfinding.
 - Improved: [#4938] Checksum calculations speeded up.
 - Improved: [#5007] Vehicles and functioning rides are now imported when loading SC4 / SV4 parks.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -54,7 +54,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10364,7 +10364,7 @@ static sint32 sub_693C9E(rct_peep *peep)
 			if (
 				peep->direction % 4 == gPeepSpawns[i].direction % 4 &&
 				x > gPeepSpawns[i].x - 4 && x < gPeepSpawns[i].x + 4 &&
-				y > gPeepSpawns[i].y - 4 && y < gPeepSpawns[i].y - 4
+				y > gPeepSpawns[i].y - 4 && y < gPeepSpawns[i].y + 4
 			) {
 				_unk_F1EE18 |= F1EE18_OUTSIDE_PARK;
 				return peep_return_to_center_of_tile(peep);

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10363,8 +10363,8 @@ static sint32 sub_693C9E(rct_peep *peep)
 			if (gPeepSpawns[i].x == PEEP_SPAWN_UNDEFINED) continue;
 			if (
 				peep->direction % 4 == gPeepSpawns[i].direction % 4 &&
-				x > gPeepSpawns[i].x - 4 && x < gPeepSpawns[i].x + 4 &&
-				y > gPeepSpawns[i].y - 4 && y < gPeepSpawns[i].y + 4
+				x > gPeepSpawns[i].x - 8 && x < gPeepSpawns[i].x + 8 &&
+				y > gPeepSpawns[i].y - 8 && y < gPeepSpawns[i].y + 8
 			) {
 				_unk_F1EE18 |= F1EE18_OUTSIDE_PARK;
 				return peep_return_to_center_of_tile(peep);

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10357,6 +10357,20 @@ static sint32 sub_693C9E(rct_peep *peep)
 		}
 		return peep_return_to_center_of_tile(peep);
 	}
+	
+	if (peep->outside_of_park == 1) {
+		for (sint32 i = 0; i < MAX_PEEP_SPAWNS; i++) {
+			if (gPeepSpawns[i].x == PEEP_SPAWN_UNDEFINED) continue;
+			if (
+				peep->direction % 4 == gPeepSpawns[i].direction % 4 &&
+				x > gPeepSpawns[i].x - 4 && x < gPeepSpawns[i].x + 4 &&
+				y > gPeepSpawns[i].y - 4 && y < gPeepSpawns[i].y - 4
+			) {
+				_unk_F1EE18 |= F1EE18_OUTSIDE_PARK;
+				return peep_return_to_center_of_tile(peep);
+			}
+		}
+	}
 
 	rct_map_element* mapElement = map_get_first_element_at(x / 32, y / 32);
 	sint16 base_z = max(0, (peep->z / 8) - 2);


### PR DESCRIPTION
This allows using spawn points as a mean of guests leaving the map, along with map edges. This will allow more fancier park entrances such as small tunnels, or park entrances that are in the middle of a park. The guest must be facing the opposite direction of where the arrows point on spawn points. The path that is under the peep spawn must also have the edge connection visible like the preview picture below shows. 

http://i.imgur.com/og96hlz.gifv

An important note, this will break vanilla compatibility to a degree. Paths that are connected to the map edge will still be alright, but any paths such as the above will cause peeps to not be able to leave the map in vanilla RCT.