### PR TITLE
Fix RCT1 research import

### DIFF
--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -27,11 +27,12 @@
 #include "world/map.h"
 #include "world/sprite.h"
 
-#define RCT1_MAX_MAP_ELEMENTS       0xC000
-#define RCT1_MAX_SPRITES            5000
-#define RCT1_MAX_TRAINS_PER_RIDE    12
-#define RCT1_MAX_MAP_SIZE           128
-#define RCT1_MAX_RIDES_IN_PARK      128
+#define RCT1_MAX_MAP_ELEMENTS         0xC000
+#define RCT1_MAX_SPRITES              5000
+#define RCT1_MAX_TRAINS_PER_RIDE      12
+#define RCT1_MAX_MAP_SIZE             128
+#define RCT1_MAX_RIDES_IN_PARK        128
+#define RCT1_RESEARCH_FLAGS_SEPARATOR 0xFF
 
 #pragma pack(push, 1)
 typedef struct rct1_entrance {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -324,14 +324,17 @@ private:
         for (size_t i = 0; i < researchListCount; i++)
         {
             const rct1_research_item * researchItem = &researchList[i];
-            if (researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE ||
-                researchItem->item == RCT1_RESEARCH_END)
+
+            if (researchItem->flags == 0xFF)
             {
-                break;
-            }
-            if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE)
-            {
-                continue;
+                if (researchItem->item == RCT1_RESEARCH_END)
+                {
+                    break;
+                }
+                if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE || researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE)
+                {
+                    continue;
+                }
             }
 
             switch (researchItem->category) {
@@ -347,10 +350,17 @@ private:
                 for (size_t j = 0; j < researchListCount; j++)
                 {
                     const rct1_research_item *researchItem2 = &researchList[j];
-                    if (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
-                        researchItem2->item == RCT1_RESEARCH_END_AVAILABLE)
+                    if (researchItem2->flags == 0xFF)
                     {
-                        break;
+                        if (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
+                            researchItem2->item == RCT1_RESEARCH_END_AVAILABLE)
+                        {
+                            continue;
+                        }
+                        else if (researchItem2->item == RCT1_RESEARCH_END)
+                        {
+                            break;
+                        }
                     }
 
                     if (researchItem2->category == RCT1_RESEARCH_CATEGORY_VEHICLE &&
@@ -1709,14 +1719,21 @@ private:
         for (size_t i = 0; i < researchListCount; i++)
         {
             const rct1_research_item * researchItem = &researchList[i];
-            if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE)
+            if (researchItem->flags == 0xFF)
             {
-                researched = false;
-            }
-            else if (researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE ||
-                     researchItem->item == RCT1_RESEARCH_END)
-            {
-                break;
+                if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE)
+                {
+                    researched = false;
+                    continue;
+                }
+                else if (researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE)
+                {
+                    continue;
+                }
+                else if (researchItem->item == RCT1_RESEARCH_END)
+                {
+                    break;
+                }
             }
 
             switch (researchItem->category) {
@@ -1734,16 +1751,18 @@ private:
             case RCT1_RESEARCH_CATEGORY_RIDE:
             {
                 uint8 rct1RideType = researchItem->item;
+                _researchRideTypeUsed[rct1RideType] = true;
 
                 // Add all vehicles for this ride type that are researched or before this research item
                 uint32 numVehicles = 0;
                 for (size_t j = 0; j < researchListCount; j++)
                 {
                     const rct1_research_item *researchItem2 = &researchList[j];
-                    if (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
+                    if (researchItem2->flags == 0xFF &&
+                        (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
                         researchItem2->item == RCT1_RESEARCH_END_AVAILABLE)
-                    {
-                        break;
+                    ) {
+                        continue;
                     }
 
                     if (researchItem2->category == RCT1_RESEARCH_CATEGORY_VEHICLE &&
@@ -1764,13 +1783,14 @@ private:
                     // No vehicles found so just add the default for this ride
                     uint8 rideEntryIndex = _rideTypeToRideEntryMap[rct1RideType];
                     Guard::Assert(rideEntryIndex != 255, "rideEntryIndex was 255");
-
                     if (!_researchRideEntryUsed[rideEntryIndex])
                     {
                         _researchRideEntryUsed[rideEntryIndex] = true;
                         research_insert_ride_entry(rideEntryIndex, researched);
                     }
+
                 }
+
                 break;
             }
             case RCT1_RESEARCH_CATEGORY_VEHICLE:
@@ -1780,6 +1800,7 @@ private:
                 {
                     InsertResearchVehicle(researchItem, researched);
                 }
+
                 break;
             case RCT1_RESEARCH_CATEGORY_SPECIAL:
                 // Not supported
@@ -1788,8 +1809,6 @@ private:
         }
 
         research_remove_non_separate_vehicle_types();
-        // Fixes availability of rides
-        sub_684AC3();
 
         // Research funding / priority
         uint8 activeResearchTypes = 0;
@@ -1831,6 +1850,7 @@ private:
     {
         uint8 vehicle = researchItem->item;
         uint8 rideEntryIndex = _vehicleTypeToRideEntryMap[vehicle];
+
         if (!_researchRideEntryUsed[rideEntryIndex])
         {
             _researchRideEntryUsed[rideEntryIndex] = true;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -325,7 +325,7 @@ private:
         {
             const rct1_research_item * researchItem = &researchList[i];
 
-            if (researchItem->flags == 0xFF)
+            if (researchItem->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
             {
                 if (researchItem->item == RCT1_RESEARCH_END)
                 {
@@ -350,7 +350,7 @@ private:
                 for (size_t j = 0; j < researchListCount; j++)
                 {
                     const rct1_research_item *researchItem2 = &researchList[j];
-                    if (researchItem2->flags == 0xFF)
+                    if (researchItem2->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
                     {
                         if (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
                             researchItem2->item == RCT1_RESEARCH_END_AVAILABLE)
@@ -1719,7 +1719,7 @@ private:
         for (size_t i = 0; i < researchListCount; i++)
         {
             const rct1_research_item * researchItem = &researchList[i];
-            if (researchItem->flags == 0xFF)
+            if (researchItem->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
             {
                 if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE)
                 {
@@ -1758,10 +1758,10 @@ private:
                 for (size_t j = 0; j < researchListCount; j++)
                 {
                     const rct1_research_item *researchItem2 = &researchList[j];
-                    if (researchItem2->flags == 0xFF &&
+                    if (researchItem2->flags == RCT1_RESEARCH_FLAGS_SEPARATOR &&
                         (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE ||
-                        researchItem2->item == RCT1_RESEARCH_END_AVAILABLE)
-                    ) {
+                        researchItem2->item == RCT1_RESEARCH_END_AVAILABLE))
+                    {
                         continue;
                     }
 

--- a/src/openrct2/util/sawyercoding.c
+++ b/src/openrct2/util/sawyercoding.c
@@ -561,6 +561,9 @@ sint32 sawyercoding_detect_rct1_version(sint32 gameVersion)
 		return (FILE_VERSION_RCT1_AA | fileType);
 	else if (gameVersion >= 120000 && gameVersion < 130000)
 		return (FILE_VERSION_RCT1_LL | fileType);
+	// RCTOA Acres sets this, and possibly some other user-created scenarios as well
+	else if (gameVersion == 0)
+		return (FILE_VERSION_RCT1_LL | fileType);
 
 	return -1;
 }


### PR DESCRIPTION
This fixes the availability of many rides in imported SV4 files.
Some of the issues:
- It wouldn't look in the section of randomly inserted rides, making them unavailable.
- _researchRideTypeUsed was never set, so any vehicle that had a higher index than the corresponding ride was unavailable.