### PR TITLE
remove excess generate_new_guest, make park_generate_new_guest public

### DIFF
--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -278,10 +278,8 @@ static void cheat_clear_loan()
 
 static void cheat_generate_guests(sint32 count)
 {
-	sint32 i;
-
-	for (i = 0; i < count; i++)
-		generate_new_guest();
+	for (sint32 i = 0; i < count; i++)
+		park_generate_new_guest();
 
 	window_invalidate_by_class(WC_BOTTOM_TOOLBAR);
 }

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -487,7 +487,7 @@ static void get_random_peep_spawn(rct2_peep_spawn *spawn)
 	}
 }
 
-static rct_peep *park_generate_new_guest()
+rct_peep *park_generate_new_guest()
 {
 	rct_peep *peep = NULL;
 	rct2_peep_spawn spawn;
@@ -512,12 +512,6 @@ static rct_peep *park_generate_new_guest()
 	}
 
 	return peep;
-}
-
-//This is called via the cheat window.
-void generate_new_guest()
-{
-	park_generate_new_guest();
 }
 
 static rct_peep *park_generate_new_guest_due_to_campaign(sint32 campaign)

--- a/src/openrct2/world/park.h
+++ b/src/openrct2/world/park.h
@@ -89,7 +89,7 @@ sint32 calculate_park_rating();
 money32 calculate_park_value();
 money32 calculate_company_value();
 void reset_park_entrances();
-void generate_new_guest();
+rct_peep * park_generate_new_guest();
 
 void park_update();
 void park_update_histories();


### PR DESCRIPTION
I noticed there is an extra generate_new_guest which calls park_generate_new_guest. This can be removed in favor of just making park_generate_new_guest public. 

This also allows potential in the future for customized trams, such as a group of angry people arriving to trash the park or something like that.