### PR TITLE
Headless server saves default user.json (#5140)

### DIFF
--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -307,6 +307,14 @@ bool Network::BeginServer(uint16 port, const char* address)
 	player->Group = 0;
 	player_id = player->Id;
 
+	if (network_get_mode() == NETWORK_MODE_SERVER) {
+		// Add SERVER to users.json and save.
+		NetworkUser *networkUser = _userManager.GetOrAddUser(player->KeyHash);
+		networkUser->GroupId = player->Group;
+		networkUser->Name = player->Name;
+		_userManager.Save();
+	}
+
 	printf("Ready for clients...\n");
 	network_chat_show_connected_message();
 	network_chat_show_server_greeting();


### PR DESCRIPTION
This causes the headless server to initialise the users.json at the time the server starts before announcing it's waiting for clients. As mentioned in #5140 