### PR TITLE
Fix invalid desync checks

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -213,6 +213,7 @@ private:
 	uint8 default_group = 0;
 	SDL_RWops *_chatLogStream = nullptr;
 	std::string _chatLogPath;
+	uint32 game_commands_processed_this_tick = 0;
 
 	void UpdateServer();
 	void UpdateClient();


### PR DESCRIPTION
I talked to @janisozaur about this a while back but haven't got around to fix it.

This should fix a lot of fake desync detected messages, and doesn't require the network version to be changed.