### PR TITLE
Fix for window map not updating on map generation resize

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -72,6 +72,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Sven Slootweg (joepie91)
 * Daniel Trujillo Viedma (gDanix)
 * Jonathan Haas (HaasJona)
+* Jake Breen (Haekb)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -740,6 +740,7 @@ void window_align_tabs( rct_window *w, uint8 start_tab_id, uint8 end_tab_id );
 void window_new_ride_init_vars();
 void window_new_ride_focus(ride_list_item rideItem);
 
+void window_map_reset();
 void window_map_tooltip_update_visibility();
 
 void window_staff_list_init_vars();

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -252,6 +252,20 @@ void window_map_open()
 	gLandToolSize = 1;
 }
 
+void window_map_reset()
+{
+	rct_window *w;
+
+	// Check if window is even opened
+	w = window_bring_to_front_by_class(WC_MAP);
+	if (w == NULL) {
+		return;
+	}
+
+	window_map_init_map();
+	window_map_center_on_view_point();
+}
+
 /**
 *
 *  rct2: 0x0068D0F1

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -398,6 +398,8 @@ void map_init(sint32 size)
 	gMapBaseZ = 7;
 	map_update_tile_pointers();
 	map_remove_out_of_range_elements();
+
+	window_map_reset();
 }
 
 /**


### PR DESCRIPTION
Proposed Fix for issue #4972. 

Not 100% sure if there's a better way to notify a window to do something, so world/map_init calls it, and then window/map handles the rest.