### PR TITLE
Add cheat to disable ride value ageing

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4180,7 +4180,7 @@ STR_5868    :{WINDOW_COLOUR_2}Provider E-mail: {BLACK}{STRING}
 STR_5869    :{WINDOW_COLOUR_2}Provider Website: {BLACK}{STRING}
 STR_5870    :{SMALLFONT}{BLACK}Show server information
 STR_5871    :Plants don't age
-STR_5872    :{SMALLFONT}{BLACK}Disable plant aging such that they don't wilt.
+STR_5872    :{SMALLFONT}{BLACK}Disable plant ageing such that they don't wilt.
 STR_5873    :Allow chain lifts on all track pieces
 STR_5874    :{SMALLFONT}{BLACK}Allows any piece of track to be made into a chain lift
 STR_5875    :Drawing Engine:
@@ -4409,6 +4409,8 @@ STR_6097    :{STRING} placed a track of ride '{STRING}'.
 STR_6098    :{STRING} removed a track of ride.
 STR_6099    :You connected to the server.
 STR_6100    :You disconnected from the server.
+STR_6101    :Rides don't decrease in value over time
+STR_6102    :{SMALLFONT}{BLACK}The value of a ride won't decrease over time, so guests will not suddenly think that a ride is too expensive.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#5056] Add cheat to own all land.
 - Feature: [#5133] Add option to display guest expenditure (as seen in RCTC).
+- Feature: [#5196] Add cheat to disable ride ageing.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#3178, #5456] Paths with non-ASCII characters not handled properly on macOS.
@@ -110,7 +111,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Assymmetric-key-based authorisation and assignment storage.
 - Feature: Add Norwegian translation.
 - Feature: Add cheat to disable littering.
-- Feature: Add Cheat to disable plant aging.
+- Feature: Add Cheat to disable plant ageing.
 - Feature: Add Cheat that allows any track piece to use a chain lift.
 - Feature: Add Console command to set vehicle friction.
 - Feature: Add console command to set scenario initial cash.

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -49,6 +49,7 @@ bool gCheatsDisableTrainLengthLimit = false;
 bool gCheatsDisablePlantAging = false;
 bool gCheatsEnableChainLiftOnAllTrack = false;
 bool gCheatsAllowArbitraryRideTypeChanges = false;
+bool gCheatsDisableRideValueAging = false;
 
 sint32 park_rating_spinner_value;
 
@@ -539,6 +540,7 @@ void game_command_cheat(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint
             case CHEAT_RESETDATE: date_reset(); window_invalidate_by_class(WC_BOTTOM_TOOLBAR); break;
             case CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES: gCheatsAllowArbitraryRideTypeChanges = *edx != 0; window_invalidate_by_class(WC_RIDE); break;
             case CHEAT_OWNALLLAND: cheat_own_all_land(); break;
+            case CHEAT_DISABLERIDEVALUEAGING: gCheatsDisableRideValueAging = *edx != 0; break;
         }
         if (network_get_mode() == NETWORK_MODE_NONE) {
             config_save_default();

--- a/src/openrct2/cheats.h
+++ b/src/openrct2/cheats.h
@@ -36,6 +36,7 @@ extern bool gCheatsNeverendingMarketing;
 extern bool gCheatsFreezeClimate;
 extern bool gCheatsDisableTrainLengthLimit;
 extern bool gCheatsDisablePlantAging;
+extern bool gCheatsDisableRideValueAging;
 extern bool gCheatsEnableChainLiftOnAllTrack;
 extern bool gCheatsAllowArbitraryRideTypeChanges;
 
@@ -86,6 +87,7 @@ enum {
     CHEAT_RESETDATE,
     CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,
     CHEAT_OWNALLLAND,
+    CHEAT_DISABLERIDEVALUEAGING,
 };
 
 enum {

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3764,6 +3764,8 @@ enum {
     STR_LOG_REMOVE_TRACK = 6098,
     STR_LOG_CLIENT_STARTED = 6099,
     STR_LOG_CLIENT_STOPPED = 6100,
+    STR_CHEAT_DISABLE_RIDE_VALUE_AGING = 6101,
+    STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP = 6102,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1833,6 +1833,7 @@ bool Network::LoadMap(IStream * stream)
         gCheatsFreezeClimate = stream->ReadValue<uint8>() != 0;
         gCheatsDisablePlantAging = stream->ReadValue<uint8>() != 0;
         gCheatsAllowArbitraryRideTypeChanges = stream->ReadValue<uint8>() != 0;
+        gCheatsDisableRideValueAging = stream->ReadValue<uint8>() != 0;
 
         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
         result = true;
@@ -1878,6 +1879,7 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
         stream->WriteValue<uint8>(gCheatsFreezeClimate);
         stream->WriteValue<uint8>(gCheatsDisablePlantAging);
         stream->WriteValue<uint8>(gCheatsAllowArbitraryRideTypeChanges);
+        stream->WriteValue<uint8>(gCheatsDisableRideValueAging);
 
         result = true;
     }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride_ratings.c
+++ b/src/openrct2/ride/ride_ratings.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../cheats.h"
 #include "../interface/window.h"
 #include "../localisation/date.h"
 #include "../rct2.h"
@@ -680,7 +681,10 @@ static void ride_ratings_calculate_value(rct_ride *ride)
         (((ride->intensity  * RideRatings[ride->type].intensity) * 32) >> 15) +
         (((ride->nausea     * RideRatings[ride->type].nausea) * 32) >> 15);
 
-    sint32 monthsOld = gDateMonthsElapsed - ride->build_date;
+    sint32 monthsOld = 0;
+    if (!gCheatsDisableRideValueAging) {
+        monthsOld = gDateMonthsElapsed - ride->build_date;
+    }
 
     const row *age_table = age_table_new;
     sint32 table_size = countof(age_table_new);

--- a/src/openrct2/windows/cheats.c
+++ b/src/openrct2/windows/cheats.c
@@ -147,6 +147,7 @@ enum WINDOW_CHEATS_WIDGET_IDX {
     WIDX_DISABLE_TRAIN_LENGTH_LIMITS,
     WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,
     WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES,
+    WIDX_DISABLE_RIDE_VALUE_AGING,
 };
 
 #pragma region MEASUREMENTS
@@ -283,6 +284,7 @@ static rct_widget window_cheats_rides_widgets[] = {
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(12),        OHPL(12),       STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,   STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP }, // Disable train length limits
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(13),        OHPL(13),       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,   STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP }, // Enable chain lift on all track
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(14),        OHPL(14),       STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,    STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES_TIP },  // Allow arbitrary ride type changes
+    { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(15),        OHPL(15),       STR_CHEAT_DISABLE_RIDE_VALUE_AGING, STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP }, // Disable ride ageing
     { WIDGETS_END },
 };
 
@@ -460,7 +462,7 @@ static uint64 window_cheats_page_enabled_widgets[] = {
         (1ULL << WIDX_MAKE_DESTRUCTIBLE) | (1ULL << WIDX_FIX_ALL) | (1ULL << WIDX_FAST_LIFT_HILL) | (1ULL << WIDX_DISABLE_BRAKES_FAILURE) |
         (1ULL << WIDX_DISABLE_ALL_BREAKDOWNS) | (1ULL << WIDX_BUILD_IN_PAUSE_MODE) | (1ULL << WIDX_RESET_CRASH_STATUS) | (1ULL << WIDX_10_MINUTE_INSPECTIONS) |
         (1ULL << WIDX_SHOW_ALL_OPERATING_MODES) | (1ULL << WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES) | (1ULL << WIDX_DISABLE_TRAIN_LENGTH_LIMITS) |
-        (1ULL << WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK) | (1ULL << WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES)
+        (1ULL << WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK) | (1ULL << WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES) | (1ULL << WIDX_DISABLE_RIDE_VALUE_AGING)
 };
 
 static uint64 window_cheats_page_hold_down_widgets[] = {
@@ -830,6 +832,9 @@ static void window_cheats_rides_mouseup(rct_window *w, rct_widgetindex widgetInd
             window_error_open(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
         }
         break;
+    case WIDX_DISABLE_RIDE_VALUE_AGING:
+        game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLERIDEVALUEAGING, !gCheatsDisableRideValueAging, GAME_COMMAND_CHEAT, 0, 0);
+        break;
     }
 }
 
@@ -912,6 +917,7 @@ static void window_cheats_invalidate(rct_window *w)
         widget_set_checkbox_value(w, WIDX_DISABLE_TRAIN_LENGTH_LIMITS, gCheatsDisableTrainLengthLimit);
         widget_set_checkbox_value(w, WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK, gCheatsEnableChainLiftOnAllTrack);
         widget_set_checkbox_value(w, WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES, gCheatsAllowArbitraryRideTypeChanges);
+        widget_set_checkbox_value(w, WIDX_DISABLE_RIDE_VALUE_AGING, gCheatsDisableRideValueAging);
         break;
     }
 


### PR DESCRIPTION
This pull request adds a cheat which disables the ride aging mechanic for ride the ride "value" only. Rides will still become more unreliable over time.

It's something I always wished was not in the game, but I realise that it was an intentional game mechanic, so I implemented this as a cheat.

I've tested it on mac as far as compilation and running. I'm not sure of the best way to actually test that it is working at runtime. Any suggestions ? Is there a way to read the actual value of the ride somewhere?

Related to:
https://github.com/OpenRCT2/OpenRCT2/issues/3812
https://github.com/OpenRCT2/OpenRCT2/pull/3473
https://openrct2.org/forums/topic/1074-guest-eventually-stop-riding/
