### PR TITLE
Add security to help prevent mass demolishing

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4325,6 +4325,7 @@ STR_6013    :{SMALLFONT}{BLACK}Guests will only pay the ticket to enter the park
 STR_6014    :{SMALLFONT}{BLACK}Guests will only pay entrance tickets for rides and services.{NEWLINE}They won't pay anything to enter the park.
 STR_6015    :Sloped
 STR_6016    :Modify Tile
+STR_6017    :Please slow down
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3668,6 +3668,7 @@ enum {
 	STR_ADMISSION_PRICE_PAY_PER_RIDE_TIP = 6014,
 	STR_TILE_INSPECTOR_PATH_SLOPED = 6015,
 	STR_ACTION_MODIFY_TILE = 6016,
+	STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE = 6017,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -31,20 +31,21 @@ class NetworkPacket;
 class NetworkPlayer final
 {
 public:
-    uint8       Id                  = 0;
+    uint8       Id                      = 0;
     std::string Name;
-    uint16      Ping                = 0;
-    uint8       Flags               = 0;
-    uint8       Group               = 0;
-    money32     MoneySpent          = MONEY(0, 0);
-    uint32      CommandsRan         = 0;
-	sint32      LastAction          = -999;
-    uint32      LastActionTime      = 0;
-    rct_xyz16   LastActionCoord     = { 0 };
-    rct_peep*   PickupPeep          = 0;
-	sint32      PickupPeepOldX      = SPRITE_LOCATION_NULL;
+    uint16      Ping                    = 0;
+    uint8       Flags                   = 0;
+    uint8       Group                   = 0;
+    money32     MoneySpent              = MONEY(0, 0);
+    uint32      CommandsRan             = 0;
+    sint32      LastAction              = -999;
+    uint32      LastActionTime          = 0;
+    rct_xyz16   LastActionCoord         = { 0 };
+    rct_peep*   PickupPeep              = 0;
+    sint32      PickupPeepOldX          = SPRITE_LOCATION_NULL;
     std::string KeyHash;
-    uint32      LastDemolishTime    = 0;
+    uint32      LastDemolishRideTime    = 0;
+    uint32      LastPlaceSceneryTime    = 0;
 
     NetworkPlayer() = default;
 

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -44,6 +44,7 @@ public:
     rct_peep*   PickupPeep          = 0;
 	sint32      PickupPeepOldX      = SPRITE_LOCATION_NULL;
     std::string KeyHash;
+    uint32      LastDemolishTime    = 0;
 
     NetworkPlayer() = default;
 

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1863,6 +1863,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 		Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
 		return;
 	}
+
 	// In case someone modifies the code / memory to enable cluster build,
 	// require a small delay in between placing scenery to provide some security, as
 	// cluster mode is a for loop that runs the place_scenery code multiple times.
@@ -1875,9 +1876,9 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 		}
 	}
 	// This is to prevent abuse of demolishing rides. Anyone that is not the server
-	// host will have to wait 1 second in between deleting rides.
+	// host will have to wait a specified amount of ticks in between deleting rides.
 	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
-		if ((ticks - connection.Player->LastActionTime) < 1000) {
+		if ((ticks - connection.Player->LastDemolishTime) < 1000) {
 			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 			return;
 		}
@@ -1900,6 +1901,11 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	connection.Player->LastAction = NetworkActions::FindCommand(commandCommand);
 	connection.Player->LastActionTime = SDL_GetTicks();
 	connection.Player->AddMoneySpent(cost);
+
+	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
+		connection.Player->LastDemolishTime = connection.Player->LastActionTime;
+	}
+
 	Server_Send_GAMECMD(args[0], args[1], args[2], args[3], args[4], args[5], args[6], playerid, callback);
 }
 

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1873,6 +1873,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
 		if (
 			ticks - connection.Player->LastPlaceSceneryTime < ACTION_COOLDOWN_TIME_PLACE_SCENERY &&
+			// Incase SDL_GetTicks() wraps after ~49 days, ignore larger logged times.
 			ticks > connection.Player->LastPlaceSceneryTime
 		) {
 			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
@@ -1886,6 +1887,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	else if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
 		if (
 			ticks - connection.Player->LastDemolishRideTime < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE &&
+			// Incase SDL_GetTicks() wraps after ~49 days, ignore larger logged times.
 			ticks > connection.Player->LastDemolishRideTime
 		) {
 			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -26,6 +26,9 @@ extern "C" {
 
 #include "network.h"
 
+#define ACTION_COOLDOWN_TIME_PLACE_SCENERY	20
+#define ACTION_COOLDOWN_TIME_DEMOLISH_RIDE	1000
+
 rct_peep* _pickup_peep = 0;
 sint32 _pickup_peep_old_x = SPRITE_LOCATION_NULL;
 
@@ -1868,7 +1871,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	// require a small delay in between placing scenery to provide some security, as
 	// cluster mode is a for loop that runs the place_scenery code multiple times.
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
-		if ((ticks - connection.Player->LastActionTime) < 20) {
+		if ((ticks - connection.Player->LastActionTime) < ACTION_COOLDOWN_TIME_PLACE_SCENERY) {
 			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
 				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 				return;
@@ -1876,9 +1879,9 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 		}
 	}
 	// This is to prevent abuse of demolishing rides. Anyone that is not the server
-	// host will have to wait a specified amount of ticks in between deleting rides.
+	// host will have to wait a small amount of time in between deleting rides.
 	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
-		if ((ticks - connection.Player->LastDemolishTime) < 1000) {
+		if ((ticks - connection.Player->LastDemolishTime) < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE) {
 			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 			return;
 		}

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1858,7 +1858,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 
 	sint32 commandCommand = args[4];
 
-	sint32 ticks = SDL_GetTicks(); //tick count is different by time last_action_time is set, keep same value.
+	uint32 ticks = SDL_GetTicks(); //tick count is different by time last_action_time is set, keep same value.
 
 	// Check if player's group permission allows command to run
 	NetworkGroup* group = GetGroupByID(connection.Player->Group);

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1871,7 +1871,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	// require a small delay in between placing scenery to provide some security, as
 	// cluster mode is a for loop that runs the place_scenery code multiple times.
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
-		if ((ticks - connection.Player->LastActionTime) < ACTION_COOLDOWN_TIME_PLACE_SCENERY) {
+		if ((ticks - connection.Player->LastPlaceSceneryTime) < ACTION_COOLDOWN_TIME_PLACE_SCENERY) {
 			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
 				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 				return;
@@ -1880,14 +1880,14 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	}
 	// This is to prevent abuse of demolishing rides. Anyone that is not the server
 	// host will have to wait a small amount of time in between deleting rides.
-	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
-		if ((ticks - connection.Player->LastDemolishTime) < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE) {
+	else if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
+		if ((ticks - connection.Player->LastDemolishRideTime) < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE) {
 			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 			return;
 		}
 	}
 	// Don't let clients send pause or quit
-	if (commandCommand == GAME_COMMAND_TOGGLE_PAUSE ||
+	else if (commandCommand == GAME_COMMAND_TOGGLE_PAUSE ||
 		commandCommand == GAME_COMMAND_LOAD_OR_QUIT
 	) {
 		return;
@@ -1905,8 +1905,11 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	connection.Player->LastActionTime = SDL_GetTicks();
 	connection.Player->AddMoneySpent(cost);
 
-	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
-		connection.Player->LastDemolishTime = connection.Player->LastActionTime;
+	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
+		connection.Player->LastPlaceSceneryTime = connection.Player->LastActionTime;
+	}
+	else if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
+		connection.Player->LastDemolishRideTime = connection.Player->LastActionTime;
 	}
 
 	Server_Send_GAMECMD(args[0], args[1], args[2], args[3], args[4], args[5], args[6], playerid, callback);

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1869,9 +1869,17 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
 		if ((ticks - connection.Player->LastActionTime) < 20) {
 			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
-				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_CANT_DO_THIS);
+				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 				return;
 			}
+		}
+	}
+	// This is to prevent abuse of demolishing rides. Anyone that is not the server
+	// host will have to wait 1 second in between deleting rides.
+	if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
+		if ((ticks - connection.Player->LastActionTime) < 1000) {
+			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
+			return;
 		}
 	}
 	// Don't let clients send pause or quit

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1871,7 +1871,10 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	// require a small delay in between placing scenery to provide some security, as
 	// cluster mode is a for loop that runs the place_scenery code multiple times.
 	if (commandCommand == GAME_COMMAND_PLACE_SCENERY) {
-		if ((ticks - connection.Player->LastPlaceSceneryTime) < ACTION_COOLDOWN_TIME_PLACE_SCENERY) {
+		if (
+			ticks - connection.Player->LastPlaceSceneryTime < ACTION_COOLDOWN_TIME_PLACE_SCENERY &&
+			ticks > connection.Player->LastPlaceSceneryTime
+		) {
 			if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
 				Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 				return;
@@ -1881,7 +1884,10 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 	// This is to prevent abuse of demolishing rides. Anyone that is not the server
 	// host will have to wait a small amount of time in between deleting rides.
 	else if (commandCommand == GAME_COMMAND_DEMOLISH_RIDE) {
-		if ((ticks - connection.Player->LastDemolishRideTime) < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE) {
+		if (
+			ticks - connection.Player->LastDemolishRideTime < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE &&
+			ticks > connection.Player->LastDemolishRideTime
+		) {
 			Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
 			return;
 		}

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
Because #5055  is up and there is no code in the current game and that pull request may take a bit to get pushed, this is more of a security PR to prevent anyone from downloading that PR and modifying the code to abuse in multiplayer mode. I have a feeling I have seen a couple of instances where someone was using that PR to delete alot of rides very quickly before getting kicked.