### PR TITLE
Fix #5206, #5207: Do not draw all disabled tabs.

### DIFF
--- a/src/openrct2/interface/widget.c
+++ b/src/openrct2/interface/widget.c
@@ -292,8 +292,17 @@ static void widget_tab_draw(rct_drawpixelinfo *dpi, rct_window *w, sint32 widget
 	if (widget->image == -1)
 		return;
 
-	if (widget_is_enabled(w, widgetIndex) || widget->type == WWT_TAB || widget->type != WWT_TRNBTN)
-	{
+	// Draw widgets that aren't explicitly disabled.
+	if (!widget_is_disabled(w, widgetIndex)) {
+		widget_draw_image(dpi, w, widgetIndex);
+		return;
+	}
+
+	// Do not draw hidden tabs, unless given a sprite.
+	if (widget->type == WWT_TAB && widget->image != (0x20000000 | SPR_G2_TAB_DISABLED))
+		return;
+
+	if (widget->type != WWT_TRNBTN) {
 		widget_draw_image(dpi, w, widgetIndex);
 		return;
 	}


### PR DESCRIPTION
PR #5138 had the unintended side-effect of drawing all disabled tabs, stemming from the assumption that `!widget_is_disabled` would be identical to `widget_is_enabled`.

I have reverted commit 4b91d92105b2c24ff0205162ce0a6988b0dbcae5 to follow the original logic more closely, adding an exception for disabled tabs made explicitly visible through a sprite.

The tab PR has been much more involved than I'd originally anticipated. Hopefully, a new widget system will eventually make these things easier.