### PR TITLE
Timestamp messages for client in chat view

### DIFF
--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -574,13 +574,9 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     char* lineCh = formatted;
     formatted[0] = 0;
     if (fromplayer) {
-        time_t timer;
-        time(&timer);
-        auto tmInfo = localtime(&timer);
         lineCh = utf8_write_codepoint(lineCh, FORMAT_OUTLINE);
         lineCh = utf8_write_codepoint(lineCh, FORMAT_BABYBLUE);
-        lineCh += strftime(lineCh, sizeof(formatted) - (lineCh - formatted), "[%H:%M] ", tmInfo);
-        safe_strcat(lineCh, (const char *) fromplayer->Name.c_str(), sizeof(formatted) - (lineCh - formatted));
+        safe_strcpy(lineCh, (const char *) fromplayer->Name.c_str(), sizeof(formatted) - (lineCh - formatted));
         safe_strcat(lineCh, ": ", sizeof(formatted) - (lineCh - formatted));
         lineCh = strchr(lineCh, '\0');
     }
@@ -588,7 +584,6 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     lineCh = utf8_write_codepoint(lineCh, FORMAT_WHITE);
     char* ptrtext = lineCh;
     safe_strcpy(lineCh, text, 800);
-
     utf8_remove_format_codes((utf8*)ptrtext, true);
     return formatted;
 }

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -574,9 +574,13 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     char* lineCh = formatted;
     formatted[0] = 0;
     if (fromplayer) {
+        time_t timer;
+        time(&timer);
+        auto tmInfo = localtime(&timer);
         lineCh = utf8_write_codepoint(lineCh, FORMAT_OUTLINE);
         lineCh = utf8_write_codepoint(lineCh, FORMAT_BABYBLUE);
-        safe_strcpy(lineCh, (const char *) fromplayer->Name.c_str(), sizeof(formatted) - (lineCh - formatted));
+        lineCh += strftime(lineCh, sizeof(formatted) - (lineCh - formatted), "[%H:%M] ", tmInfo);
+        safe_strcat(lineCh, (const char *) fromplayer->Name.c_str(), sizeof(formatted) - (lineCh - formatted));
         safe_strcat(lineCh, ": ", sizeof(formatted) - (lineCh - formatted));
         lineCh = strchr(lineCh, '\0');
     }
@@ -584,6 +588,7 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     lineCh = utf8_write_codepoint(lineCh, FORMAT_WHITE);
     char* ptrtext = lineCh;
     safe_strcpy(lineCh, text, 800);
+
     utf8_remove_format_codes((utf8*)ptrtext, true);
     return formatted;
 }

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <time.h>
 #include "../common.h"
 #include "../core/Guard.hpp"
 #include "../localisation/localisation.h"
@@ -531,3 +532,17 @@ money32 add_clamp_money32(money32 value, money32 value_to_add)
 }
 
 #undef add_clamp_body
+
+/**
+ * strftime wrapper which appends to an existing string.
+ */
+size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const struct tm * tp)
+{
+    size_t stringLen = strnlen(buffer, bufferSize);
+    if (stringLen < bufferSize) {
+        char * dst = buffer + stringLen;
+        size_t dstMaxSize = bufferSize - stringLen;
+        return strftime(dst, dstMaxSize, format, tp);
+    }
+    return 0;
+}

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -17,6 +17,7 @@
 #ifndef _UTIL_H_
 #define _UTIL_H_
 
+#include <time.h>
 #include "../common.h"
 
 sint32 squaredmetres_to_squaredfeet(sint32 squaredMetres);
@@ -61,5 +62,7 @@ sint8 add_clamp_sint8(sint8 value, sint8 value_to_add);
 sint16 add_clamp_sint16(sint16 value, sint16 value_to_add);
 sint32 add_clamp_sint32(sint32 value, sint32 value_to_add);
 money32 add_clamp_money32(money32 value, money32 value_to_add);
+
+size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const struct tm * tp);
 
 #endif


### PR DESCRIPTION
For https://github.com/OpenRCT2/OpenRCT2/issues/5231,
shows a [HH:MM] timestamp next to chat messages in the clientside.
Defaults to off, and can be toggled with config parameter `timestamp_chat`