### PR TITLE
Close load dialog

### DIFF
--- a/src/openrct2/windows/title_menu.c
+++ b/src/openrct2/windows/title_menu.c
@@ -136,21 +136,41 @@ static void window_title_menu_scenarioselect_callback(const utf8 *path)
 
 static void window_title_menu_mouseup(rct_window *w, sint32 widgetIndex)
 {
+	rct_window *windowToOpen = NULL;
+
 	switch (widgetIndex) {
 	case WIDX_START_NEW_GAME:
-		window_close_by_class(WC_LOADSAVE);
-		window_close_by_class(WC_SERVER_LIST);
-		window_scenarioselect_open(window_title_menu_scenarioselect_callback);
+		windowToOpen = window_find_by_class(WC_SCENARIO_SELECT);
+		if (windowToOpen != NULL) {
+			window_bring_to_front(windowToOpen);
+		}
+		else {
+			window_close_by_class(WC_LOADSAVE);
+			window_close_by_class(WC_SERVER_LIST);
+			window_scenarioselect_open(window_title_menu_scenarioselect_callback);
+		}
 		break;
 	case WIDX_CONTINUE_SAVED_GAME:
-		window_close_by_class(WC_SCENARIO_SELECT);
-		window_close_by_class(WC_SERVER_LIST);
-		game_do_command(0, 1, 0, 0, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);
+		windowToOpen = window_find_by_class(WC_LOADSAVE);
+		if (windowToOpen != NULL) {
+			window_bring_to_front(windowToOpen);
+		}
+		else {
+			window_close_by_class(WC_SCENARIO_SELECT);
+			window_close_by_class(WC_SERVER_LIST);
+			game_do_command(0, 1, 0, 0, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);
+		}
 		break;
 	case WIDX_MULTIPLAYER:
-		window_close_by_class(WC_SCENARIO_SELECT);
-		window_close_by_class(WC_LOADSAVE);
-		window_server_list_open();
+		windowToOpen = window_find_by_class(WC_SERVER_LIST);
+		if (windowToOpen != NULL) {
+			window_bring_to_front(windowToOpen);
+		}
+		else {
+			window_close_by_class(WC_SCENARIO_SELECT);
+			window_close_by_class(WC_LOADSAVE);
+			window_server_list_open();
+		}
 		break;
 	}
 }

--- a/src/openrct2/windows/title_menu.c
+++ b/src/openrct2/windows/title_menu.c
@@ -138,12 +138,18 @@ static void window_title_menu_mouseup(rct_window *w, sint32 widgetIndex)
 {
 	switch (widgetIndex) {
 	case WIDX_START_NEW_GAME:
+		window_close_by_class(WC_LOADSAVE);
+		window_close_by_class(WC_SERVER_LIST);
 		window_scenarioselect_open(window_title_menu_scenarioselect_callback);
 		break;
 	case WIDX_CONTINUE_SAVED_GAME:
+		window_close_by_class(WC_SCENARIO_SELECT);
+		window_close_by_class(WC_SERVER_LIST);
 		game_do_command(0, 1, 0, 0, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);
 		break;
 	case WIDX_MULTIPLAYER:
+		window_close_by_class(WC_SCENARIO_SELECT);
+		window_close_by_class(WC_LOADSAVE);
 		window_server_list_open();
 		break;
 	}


### PR DESCRIPTION
With this PR, the three buttons that open a window in the title menu will close the other two windows.

It's possible to have two windows open, when starting a new server and selecting "New game". In that case, pressing the new scenario and multiplayer button will bring the related window to front, and none of the others will be closed.

Edit: Video of how it works

![Loading...](http://i.imgur.com/OMC8DYy.gif)