### PR TITLE
Use boost

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -41,7 +41,7 @@
              C4245: 'conversion_type': conversion from 'type1' to 'type2', signed/unsigned mismatch
       -->
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;CURL_STATICLIB;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;ZIP_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;CURL_STATICLIB;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;ZIP_STATIC;BOOST_ALL_NO_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -45,6 +45,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <AdditionalOptions>/utf-8 /std:c++latest</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -64,8 +64,8 @@
   <!-- 3rd party libraries / dependencies -->
   <PropertyGroup>
     <DependenciesCheckFile>$(RootDir).dependencies</DependenciesCheckFile>
-    <LibsUrl>https://github.com/OpenRCT2/Dependencies/releases/download/v$(TargetLibsVersion)/openrct2-libs-vs2015.zip</LibsUrl>
-    <LibsSha1>f088adcd12450c2672f78679ea5d1fbffc28fd22</LibsSha1>
+    <LibsUrl>https://ci.appveyor.com/api/buildjobs/xkecerc9au7jjeop/artifacts/artifacts%2Fopenrct2-libs-vs2015.zip</LibsUrl>
+    <LibsSha1>c9d64809537c7ec79cdaea92375631bff56d6d19</LibsSha1>
     <GtestVersion>1.8.0</GtestVersion>
     <GtestUrl>https://github.com/google/googletest/archive/release-1.8.0.zip</GtestUrl>
     <GtestSha1>667f873ab7a4d246062565fad32fb6d8e203ee73</GtestSha1>

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <boost/filesystem.hpp>
 #include "Console.hpp"
 #include "File.h"
 #include "FileStream.hpp"
@@ -29,7 +30,7 @@ namespace File
 {
     bool Exists(const std::string &path)
     {
-        return platform_file_exists(path.c_str());
+        return boost::filesystem::exists(path);
     }
 
     bool Copy(const std::string &srcPath, const std::string &dstPath, bool overwrite)


### PR DESCRIPTION
To reduce the amount of platform code and utility we have to maintain / write.

Related: https://github.com/OpenRCT2/Dependencies/pull/16