### PR TITLE
macOS Sierra (10.12): Disallow Automatic Window Tabbing

### DIFF
--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -27,8 +27,8 @@
 void macos_disallow_automatic_window_tabbing()
 {
 	@autoreleasepool {
-		if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
-			NSWindow.allowsAutomaticWindowTabbing = NO;
+		if ([NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:)]) {
+			[NSWindow setAllowsAutomaticWindowTabbing:NO];
 		}
 	}
 }

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -24,6 +24,15 @@
 #include "../localisation/language.h"
 #include "../config/Config.h"
 
+void macos_disallow_automatic_window_tabbing()
+{
+	@autoreleasepool {
+		if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)]) {
+			NSWindow.allowsAutomaticWindowTabbing = NO;
+		}
+	}
+}
+
 bool platform_check_steam_overlay_attached() {
 	STUB();
 	return false;

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -234,4 +234,8 @@ void core_init();
 	void platform_posix_sub_resolve_openrct_data_path(utf8 *out, size_t size);
 #endif
 
+#ifdef __MACOSX__
+	void macos_disallow_automatic_window_tabbing();
+#endif
+
 #endif

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -617,6 +617,9 @@ static void platform_create_window()
 	SDL_SetWindowGrab(gWindow, gConfigGeneral.trap_cursor ? SDL_TRUE : SDL_FALSE);
 	SDL_SetWindowMinimumSize(gWindow, 720, 480);
 	platform_init_window_icon();
+#ifdef __MACOSX__
+	macos_disallow_automatic_window_tabbing();
+#endif
 
 	// Initialise the surface, palette and draw buffer
 	platform_resize(width, height);


### PR DESCRIPTION
Before:
<img width="418" alt="screen shot 2017-03-08 at 12 41 39 am" src="https://cloud.githubusercontent.com/assets/5363/23696789/07e7ca9c-039a-11e7-901a-03b79b04af97.png">
After:
<img width="434" alt="screen shot 2017-03-08 at 12 36 03 am" src="https://cloud.githubusercontent.com/assets/5363/23696800/12f440dc-039a-11e7-9e6d-549ea9327247.png">

Automatic Window Tabbing in macOS Sierra causes a menu item called "Show
Tab Bar" to appear under the Window menu in the menu bar. Selecting this
option causes a double-title bar effect as there is no option in OpenRCT2
to make new tabbed "documents". This double-title bar can be untoggled
by selecting "Hide Tab Bar".

<img width="1552" alt="screen shot 2017-03-08 at 12 41 46 am" src="https://cloud.githubusercontent.com/assets/5363/23696805/1be6d63c-039a-11e7-8277-04bca783f091.png">


I don't think OpenRCT2 is going to become a tabbed document-oriented
themepark simulator anytime soon. Thanks, but no thanks Sierra.

References:
* https://codereview.chromium.org/2325313002/
* https://hg.mozilla.org/releases/mozilla-aurora/rev/385b9ea08ff7