### PR TITLE
Update readme.md: fix 'gitflow workflow' link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ make
 Detailed instructions can be found on our [wiki](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux).
 
 # 4 Contributing
-OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.
+OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.
 
 Please read our [contributing guidelines](https://github.com/OpenRCT2/OpenRCT2/blob/develop/CONTRIBUTING.md) for information.
 


### PR DESCRIPTION
Current:
https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow
lands on:
https://www.atlassian.com/git/tutorials/comparing-workflows
Replace it with:
https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow
to point to specific workflow.