### PR TITLE
Update ride_find_closest_mechanic() to search using the station exit …

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -2590,7 +2590,7 @@ static void ride_call_closest_mechanic(sint32 rideIndex)
 
 rct_peep *ride_find_closest_mechanic(rct_ride *ride, sint32 forInspection)
 {
-	sint32 x, y, z, stationIndex, direction;
+	sint32 x, y, z, stationIndex;
 	uint16 xy;
 	rct_map_element *mapElement;
 
@@ -2613,9 +2613,8 @@ rct_peep *ride_find_closest_mechanic(rct_ride *ride, sint32 forInspection)
 
 	x *= 32;
 	y *= 32;
-	direction = mapElement->type & 3;
-	x -= TileDirectionDelta[direction].x;
-	y -= TileDirectionDelta[direction].y;
+
+	// Set x,y to centre of the station exit for the mechanic search.
 	x += 16;
 	y += 16;
 


### PR DESCRIPTION
…location

This is for consistency with PR#4576 (in which the mechanic called to fix/inspect a ride pathfinds to the station exit itself, rather than pathfinding to the path connecting to the station exit) and prevents ride from calling mechanics whose patrol zone covers the path connecting to the station exit but does **not** cover the station exit itself.

Fixes #5284

This PR needs the network version to be incremented.