### PR TITLE
Remove duplicate ride penalty for closed rides

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride_ratings.c
+++ b/src/openrct2/ride/ride_ratings.c
@@ -643,7 +643,7 @@ static void ride_ratings_calculate_value(rct_ride *ride)
 	rct_ride *ride2;
 	sint32 i;
 	FOR_ALL_RIDES(i, ride2) {
-		if (ride2->type == ride->type)
+		if (ride2->type == ride->type && ride2->status == RIDE_STATUS_OPEN)
 			otherRidesOfSameType++;
 	}
 	if (otherRidesOfSameType > 1)


### PR DESCRIPTION
The game reduces the 'value' of a ride, which decides how much guests will pay for it, when multiple rides of the same type exists within a park. Currently, the rides' status is not taken into account.

This PR ensures a ride with status "closed" will no longer attract the penalty. Only open or broken rides will do so.

In other words, this PR removes ill-deserved punishment for players who:
- Use (partial) rides as scenery
- Build replacement rides while keeping the originals open