### PR TITLE
Colour currently selected file in load/save window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4367,6 +4367,7 @@ STR_6055    :OpenRCT2 Heightmap File
 STR_6056    :{SMALLFONT}{BLACK}Mute
 STR_6057    :{SMALLFONT}{BLACK}Show a separate button for the Mute Option in the toolbar
 STR_6058    :Mute
+STR_6059    :{RIGHTGUILLEMET}
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3719,6 +3719,8 @@ enum {
 	STR_MUTE_BUTTON_ON_TOOLBAR_TIP = 6057,
 	STR_MUTE_BUTTON_ON_TOOLBAR = 6058,
 
+	STR_RIGHTGUILLEMET = 6059,
+
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768
 };


### PR DESCRIPTION
This will add a coloring palette similar to the tile inspector for the load/save window, showing you both the hovered item and the save file that is currently loaded.