### PR TITLE
Update VS prerequisites and force Windows 10 SDK

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- Allow any version of VS and Windows SDK -->
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <TargetPlatformVersion>$(UCRTVersion)</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
 
     <CharacterSet>MultiByte</CharacterSet>
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,9 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 
 ### Windows:
 - 7 / 8 / 10
-- Visual Studio 2015 Update 3 or 2017 RC (Enterprise / Professional / [Community (Free)](https://www.visualstudio.com/products/visual-studio-community-vs))
+- Visual Studio 2017 (Enterprise / Professional / [Community (Free)](https://www.visualstudio.com/vs/community/))
+  - Desktop development with C++
+  - Windows 10 SDK (10.0.14393.0)
 - [7-Zip](http://www.7-zip.org/) (for deployment only)
 - [NSIS](http://nsis.sourceforge.net/) (for deployment only)
 
@@ -83,7 +85,7 @@ The program can also be built as a command line program using CMake. This type o
 ## 3.2 Compiling and running
 ### Windows:
 1. Check out the repository. This can be done using [GitHub Desktop](https://desktop.github.com) or [other tools](https://help.github.com/articles/which-remote-url-should-i-use).
-2. Open a new Developer Command Prompt for VS2015, then navigate to the repository (e.g. `cd C:\GitHub\OpenRCT2`).
+2. Open a new Developer Command Prompt for VS 2017, then navigate to the repository (e.g. `cd C:\GitHub\OpenRCT2`).
 3. Run `msbuild openrct2.proj /t:build /p:platform=x64`.
 4. Run the game, `bin\openrct2`
 


### PR DESCRIPTION
Sorting out Windows building to work smoothly for VS2017.