### PR TITLE
Prevents double allocations of string allocated config values

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -598,13 +598,13 @@ extern "C"
 
     void config_set_defaults()
     {
-	config_release();
+        config_release();
         Config::SetDefaults();
     }
 
     bool config_open(const utf8 * path)
     {
-	config_release();
+        config_release();
         return Config::ReadFile(path);
     }
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -128,6 +128,8 @@ namespace Config
     {
         if (reader->ReadSection("general"))
         {
+            config_release();
+
             auto model = &gConfigGeneral;
             model->always_show_gridlines = reader->GetBoolean("always_show_gridlines", false);
             model->autosave_frequency = reader->GetSint32("autosave", AUTOSAVE_EVERY_5MINUTES);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -128,8 +128,6 @@ namespace Config
     {
         if (reader->ReadSection("general"))
         {
-            config_release();
-
             auto model = &gConfigGeneral;
             model->always_show_gridlines = reader->GetBoolean("always_show_gridlines", false);
             model->autosave_frequency = reader->GetSint32("autosave", AUTOSAVE_EVERY_5MINUTES);
@@ -600,11 +598,13 @@ extern "C"
 
     void config_set_defaults()
     {
+	config_release();
         Config::SetDefaults();
     }
 
     bool config_open(const utf8 * path)
     {
+	config_release();
         return Config::ReadFile(path);
     }
 


### PR DESCRIPTION
since they can be set by default and then by reading the config file.
safe enough to free them before.