### PR TITLE
Fix #5316 - banners now correctly pick up primary colour

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "8"
+#define NETWORK_STREAM_VERSION "9"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/windows/top_toolbar.c
+++ b/src/openrct2/windows/top_toolbar.c
@@ -1638,7 +1638,7 @@ static void window_top_toolbar_scenery_tool_down(sint16 x, sint16 y, rct_window 
 
 		gGameCommandErrorTitle = STR_CANT_POSITION_THIS_HERE;
 		game_command_callback = game_command_callback_place_banner;
-		game_do_command(gridX, flags, gridY, parameter_2, GAME_COMMAND_PLACE_BANNER, parameter_3, 0);
+		game_do_command(gridX, flags, gridY, parameter_2, GAME_COMMAND_PLACE_BANNER, parameter_3, gWindowSceneryPrimaryColour);
 		break;
 	}
 	}


### PR DESCRIPTION
(#5316)

gWindowSceneryPrimaryColour wasn't being passed to game_do_command when placing banners - the final (ebp) parameter was zero, resulting in all newly placed banners being black.

This pull request fixes that by passing gWindowSceneryPrimaryColour as the final param to game_do_command.