### PR TITLE
Fix #5211 - allow ride names to duplicate existing user strings

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5585,7 +5585,7 @@ void game_command_set_ride_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 		return;
 	}
 
-	rct_string_id newUserStringId = user_string_allocate(4, newName);
+	rct_string_id newUserStringId = user_string_allocate(132, newName);
 	if (newUserStringId == 0) {
 		*ebx = MONEY32_UNDEFINED;
 		return;
@@ -6007,7 +6007,7 @@ foundRideEntry:
 			ride->name_arguments_number++;
 			format_string(rideNameBuffer, 256, ride->name, &ride->name_arguments);
 
-			rideNameStringId = user_string_allocate(4, rideNameBuffer);
+			rideNameStringId = user_string_allocate(132, rideNameBuffer);
 			if (rideNameStringId != 0) {
 				ride->name = rideNameStringId;
 				break;


### PR DESCRIPTION
(#5211)

This pull request allows rides to have names that duplicate existing user strings (used for signs, rides, peeps and the park name). Currently, ride names must be unique user strings, which leads to the un-intuitive behaviour in #5211, namely that if you change a sign name, you can't change the ride name to the same thing.

This will also allow you to name a ride the same as a peep or the park name - not sure why you'd want to, but I doubt this would cause problems in of itself.

This will need testing to ensure that it doesn't break other things!
