### PR TITLE
Fix #5318 - clearing ghost paths with bulldozer yields unlimited free money

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -449,7 +449,7 @@ money32 footpath_remove_real(sint32 x, sint32 y, sint32 z, sint32 flags)
 		sub_6A759F();
 	}
 
-	return (flags & (1 << 5)) || (gParkFlags & PARK_FLAGS_NO_MONEY) ? 0 : -MONEY(10,00);
+	return (flags & (1 << 5)) || (gParkFlags & PARK_FLAGS_NO_MONEY) || map_element_is_ghost(mapElement) ? 0 : -MONEY(10,00);
 }
 
 /**

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -449,7 +449,17 @@ money32 footpath_remove_real(sint32 x, sint32 y, sint32 z, sint32 flags)
 		sub_6A759F();
 	}
 
-	return (flags & (1 << 5)) || (gParkFlags & PARK_FLAGS_NO_MONEY) || map_element_is_ghost(mapElement) ? 0 : -MONEY(10,00);
+	if (
+		(flags & (1 << 5)) || 
+		(gParkFlags & PARK_FLAGS_NO_MONEY) || 
+		map_element_is_ghost(mapElement)
+	) {
+		return 0;
+	}
+	else
+	{
+		return -MONEY(10,00);
+	}
 }
 
 /**

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -449,18 +449,18 @@ money32 footpath_remove_real(sint32 x, sint32 y, sint32 z, sint32 flags)
 		sub_6A759F();
 	}
 
-	if (
-		(flags & (1 << 5)) || 
-		(gParkFlags & PARK_FLAGS_NO_MONEY) || 
-		map_element_is_ghost(mapElement)
-	) {
-		return 0;
+	money32 cost = -MONEY(10,00);
+
+	bool isNotOwnedByPark = (flags & (1 << 5));
+	bool moneyDisabled = (gParkFlags & PARK_FLAGS_NO_MONEY);
+	bool isGhost = map_element_is_ghost(mapElement);
+
+	if (isNotOwnedByPark || moneyDisabled || isGhost) {
+		cost = 0;
 	}
-	else
-	{
-		return -MONEY(10,00);
+
+	return cost;
 	}
-}
 
 /**
  *

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -460,7 +460,7 @@ money32 footpath_remove_real(sint32 x, sint32 y, sint32 z, sint32 flags)
 	}
 
 	return cost;
-	}
+}
 
 /**
  *


### PR DESCRIPTION
Currently ghost footpaths are treated as regular paths when handling removal; this results in a refund when clearing these ghosts with the bulldozer tool as detailed in #5318. This pull request fixes that by returning a refund of zero for ghost paths.