### PR TITLE
Allow ride names to duplicate existing user strings (fixes #5211)

### DIFF
--- a/src/openrct2/localisation/localisation.h
+++ b/src/openrct2/localisation/localisation.h
@@ -59,6 +59,12 @@ wchar_t encoding_convert_big5_to_unicode(wchar_t big5);
 #define MAX_USER_STRINGS 1024
 #define USER_STRING_MAX_LENGTH 32
 
+// Constants used by user_string_allocate
+enum {
+	USER_STRING_HIGH_ID_NUMBER = 1 << 2,
+	USER_STRING_DUPLICATION_PERMITTED = 1 << 7
+};
+
 // Real name data
 extern const char real_name_initials[16];
 extern const char *real_names[1024];

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/network/twitch.cpp
+++ b/src/openrct2/network/twitch.cpp
@@ -491,7 +491,7 @@ namespace Twitch
                 if (!is_user_string_id(peep->name_string_idx) && !(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK))
                 {
                     // Rename peep and add flags
-                    rct_string_id newStringId = user_string_allocate(4, member->Name);
+                    rct_string_id newStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, member->Name);
                     if (newStringId != 0)
                     {
                         peep->name_string_idx = newStringId;

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -12562,7 +12562,7 @@ money32 set_peep_name(sint32 flags, sint32 state, uint16 sprite_index, uint8* te
 		return MONEY32_UNDEFINED;
 	}
 
-	rct_string_id newId = user_string_allocate(4, newName);
+	rct_string_id newId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, newName);
 	if (newId == 0) {
 		return MONEY32_UNDEFINED;
 	}

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -675,7 +675,7 @@ private:
             std::string rideName = GetUserString(src->name);
             if (!rideName.empty())
             {
-                rct_string_id rideNameStringId = user_string_allocate(4, rideName.c_str());
+                rct_string_id rideNameStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, rideName.c_str());
                 if (rideNameStringId != 0)
                 {
                     dst->name = rideNameStringId;
@@ -1286,7 +1286,7 @@ private:
             std::string peepName = GetUserString(src->name_string_idx);
             if (!peepName.empty())
             {
-                rct_string_id peepNameStringId = user_string_allocate(4, peepName.c_str());
+                rct_string_id peepNameStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, peepName.c_str());
                 if (peepNameStringId != 0)
                 {
                     dst->name_string_idx = peepNameStringId;
@@ -1887,7 +1887,7 @@ private:
             }
         }
 
-        rct_string_id stringId = user_string_allocate(4, parkName.c_str());
+        rct_string_id stringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, parkName.c_str());
         if (stringId != 0)
         {
             gParkName = stringId;
@@ -2338,7 +2338,7 @@ private:
             std::string bannerText = GetUserString(src->string_idx);
             if (!bannerText.empty())
             {
-                rct_string_id bannerTextStringId = user_string_allocate(128, bannerText.c_str());
+                rct_string_id bannerTextStringId = user_string_allocate(USER_STRING_DUPLICATION_PERMITTED, bannerText.c_str());
                 if (bannerTextStringId != 0)
                 {
                     dst->string_idx = bannerTextStringId;

--- a/src/openrct2/ride/track_design.c
+++ b/src/openrct2/ride/track_design.c
@@ -1339,7 +1339,7 @@ static bool sub_6D2189(rct_track_td6 *td6, money32 *cost, uint8 *rideId, uint8 *
 	}
 
 	rct_ride *ride = get_ride(rideIndex);
-	rct_string_id new_ride_name = user_string_allocate(132, "");
+	rct_string_id new_ride_name = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, "");
 	if (new_ride_name != 0) {
 		rct_string_id old_name = ride->name;
 		ride->name = new_ride_name;

--- a/src/openrct2/world/banner.cpp
+++ b/src/openrct2/world/banner.cpp
@@ -325,7 +325,7 @@ static money32 BannerSetName(uint8 bannerIndex,
     dst = utf8_write_codepoint(dst, FORMAT_COLOUR_CODE_START + banner->text_colour);
     String::Set(dst, 256, newName, 32);
 
-    rct_string_id stringId = user_string_allocate(128, buffer);
+    rct_string_id stringId = user_string_allocate(USER_STRING_DUPLICATION_PERMITTED, buffer);
     if (stringId != 0)
     {
         rct_string_id prevStringId = banner->string_idx;
@@ -392,7 +392,7 @@ static money32 BannerSetStyle(uint8 bannerIndex, uint8 colour, uint8 textColour,
         utf8_insert_codepoint(buffer, colourCodepoint);
     }
 
-    rct_string_id stringId = user_string_allocate(128, buffer);
+    rct_string_id stringId = user_string_allocate(USER_STRING_DUPLICATION_PERMITTED, buffer);
     if (stringId != 0)
     {
         rct_string_id prevStringId = banner->string_idx;

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -4393,7 +4393,7 @@ void game_command_set_sign_name(sint32* eax, sint32* ebx, sint32* ecx, sint32* e
 	}
 
 	if (newName[0] != 0) {
-		rct_string_id string_id = user_string_allocate(128, newName);
+		rct_string_id string_id = user_string_allocate(USER_STRING_DUPLICATION_PERMITTED, newName);
 		if (string_id != 0) {
 			rct_string_id prev_string_id = banner->string_idx;
 			banner->string_idx = string_id;

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -825,7 +825,7 @@ void game_command_set_park_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 		return;
 	}
 
-	newUserStringId = user_string_allocate(4, newName);
+	newUserStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, newName);
 	if (newUserStringId == 0) {
 		gGameCommandErrorText = STR_INVALID_NAME_FOR_PARK;
 		*ebx = MONEY32_UNDEFINED;


### PR DESCRIPTION
(#5211)

This pull request allows rides to have names that duplicate existing user strings (used for signs, rides, peeps and the park name). Currently, ride names must be unique user strings, which leads to the un-intuitive behaviour in #5211, namely that if you change a sign name, you can't change the ride name to the same thing.

This will also allow you to name a ride the same as a peep or the park name - not sure why you'd want to, but I doubt this would cause problems in of itself.

This will need testing to ensure that it doesn't break other things!

(Previously under pull request  #5323, that one was closed owing to my monumental stupidity in making these changes on my 'develop' branch rather than the 'fix' one...)