### PR TITLE
Don't apply peep_make_passing_peeps_sick() to peeps in a queue (fixes #1992)

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -11185,12 +11185,14 @@ static void peep_make_passing_peeps_sick(rct_peep *peep)
 				sint32 zDiff = abs(otherPeep->z - peep->z);
 				if (zDiff <= 32) {
 					if (peep != otherPeep) {
-						if (otherPeep->action == PEEP_ACTION_NONE_1 || otherPeep->action == PEEP_ACTION_NONE_2) {
-							otherPeep->action = PEEP_ACTION_THROW_UP;
-							otherPeep->action_frame = 0;
-							otherPeep->action_sprite_image_offset = 0;
-							sub_693B58(otherPeep);
-							invalidate_sprite_2((rct_sprite*)otherPeep);
+						if (otherPeep->state != PEEP_STATE_QUEUING) {
+							if (otherPeep->action == PEEP_ACTION_NONE_1 || otherPeep->action == PEEP_ACTION_NONE_2) {
+								otherPeep->action = PEEP_ACTION_THROW_UP;
+								otherPeep->action_frame = 0;
+								otherPeep->action_sprite_image_offset = 0;
+								sub_693B58(otherPeep);
+								invalidate_sprite_2((rct_sprite*)otherPeep);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Checks target peeps' state and doesn't trigger vomiting if peeps are queuing.

This prevents a 'Felicity Anderson' Easter egg from holding up a queue by trapping peeps in a vomit-loop (and potentially crashing the game as a side-effect!), as in #1992.