### PR TITLE
Alter cost of mountain tool to be more in line with regular landscaping costs (#2127)

### DIFF
--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -2334,6 +2334,7 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
 	sint32 x = mapLeft;
 	sint32 y = mapTop;
 	sint32 size = ((mapRight - mapLeft) >> 5) + 1;
+	sint32 toolSize = size;  // Required later for correcting the cost
 	sint32 initialMinZ = -2;
 
 	// Then do the smoothing
@@ -2500,7 +2501,10 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
 	gCommandPosition.x = centreX;
 	gCommandPosition.y = centreY;
 	gCommandPosition.z = centreZ;
-	return totalCost * 4;
+
+	sint32 correction = 80*(toolSize + 1);
+
+	return totalCost + MONEY(correction,00);
 }
 
 /**

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -2334,7 +2334,7 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
 	sint32 x = mapLeft;
 	sint32 y = mapTop;
 	sint32 size = ((mapRight - mapLeft) >> 5) + 1;
-	sint32 toolSize = size;  // Required later for correcting the cost
+	sint32 costCorrection = 80*(size + 1);
 	sint32 initialMinZ = -2;
 
 	// Then do the smoothing
@@ -2502,9 +2502,7 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
 	gCommandPosition.y = centreY;
 	gCommandPosition.z = centreZ;
 
-	sint32 correction = 80*(toolSize + 1);
-
-	return totalCost + MONEY(correction,00);
+	return totalCost + MONEY(costCorrection,00);
 }
 
 /**


### PR DESCRIPTION
As described in #2127, the cost of the mountain tool does not line up well with that of regular landscaping - it is too cheap for small operations, and wildly expensive for large ones.

This PR fixes that by applying a 'correction' term when calculating the cost, rather than effectively multiplying the single-tile price by the size of the selection.

EDIT: This doesn't address the second issue in #2127 - namely that raising a mountain multiple levels doesn't affect the cost, despite the change in number of tiles affected. If that is something that we want to address, then a different approach will be needed.