### PR TITLE
Fix #5077 - Giga Coaster design name display wrong

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -73,6 +73,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Daniel Trujillo Viedma (gDanix)
 * Jonathan Haas (HaasJona)
 * Jake Breen (Haekb)
+* Luis Rodriguez (luisfrdr)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/contributors.md
+++ b/contributors.md
@@ -73,7 +73,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Daniel Trujillo Viedma (gDanix)
 * Jonathan Haas (HaasJona)
 * Jake Breen (Haekb)
-* Luis Rodriguez (luisfrdr)
+* Marco Benzi Tobar (Lisergishnu)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -134,8 +134,10 @@ void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
 	char *lastDot = strrchr(path_get_filename(path), '.');
-	if (lastDot != NULL)
+	if (lastDot != NULL){
 		*lastDot = '\0';
+        while((lastDot = strrchr(path_get_filename(path), '.')) != NULL) *lastDot = '\0';
+    }
 	else
 		log_warning("No extension found. (path = %s)", path);
 }

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -134,10 +134,8 @@ void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
 	char *lastDot = strrchr(path_get_filename(path), '.');
-	if (lastDot != NULL){
+	if (lastDot != NULL)
 		*lastDot = '\0';
-        while((lastDot = strrchr(path_get_filename(path), '.')) != NULL) *lastDot = '\0';
-    }
 	else
 		log_warning("No extension found. (path = %s)", path);
 }

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -134,8 +134,15 @@ void path_remove_extension(utf8 *path)
 {
 	// Find last dot in filename, and replace it with a null-terminator
 	char *lastDot = strrchr(path_get_filename(path), '.');
-	if (lastDot != NULL)
+	if (lastDot != NULL){
 		*lastDot = '\0';
+        //Check if the file extension was either ".TD4" or ".TD6"; if so, keep checking if there are more dots before the file extension
+        if((*(lastDot + 1) == 't' || *(lastDot + 1) == 'T') &&
+           (*(lastDot + 2) == 'd' || *(lastDot + 2) == 'D') &&
+           (*(lastDot + 3) == '4' || *(lastDot + 3) == '6'))
+           while((lastDot = strrchr(path_get_filename(path), '.')) != NULL) *lastDot = '\0';
+    } 
+    
 	else
 		log_warning("No extension found. (path = %s)", path);
 }


### PR DESCRIPTION
I followed the conversation on issue [#5077](https://github.com/OpenRCT2/OpenRCT2/issues/5077) where [Gymnasiast](https://github.com/Gymnasiast) mentioned how RCT2 ignores everything after the first period and the same behavior should be replicated.

Assuming the intention was to maintain the addition to the warning log that no extension was found, I added a while-loop inside the original if-statement that kept checking for the last '.' character in the string until it couldn't find any more, and for every '.' found, the character on the original string is replaced by a null character to effectively remove it from the string passed in.

Tested it on another machine and it worked as expected.