### PR TITLE
macOS GUI resize should update the model values as a normal resize

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -74,6 +74,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Daniel Trujillo Viedma (gDanix)
 * Jonathan Haas (HaasJona)
 * Jake Breen (Haekb)
+* Marco Benzi Tobar (Lisergishnu)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -569,4 +569,9 @@ bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size)
 }
 #endif // NO_TTF
 
+sint32 platform_get_non_window_flags()
+{
+	return SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
 #endif

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -279,4 +279,9 @@ uint8 platform_get_locale_measurement_format()
 	}
 }
 
+sint32 platform_get_non_window_flags()
+{
+	return SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
 #endif

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -239,4 +239,9 @@ void core_init();
 	void macos_disallow_automatic_window_tabbing();
 #endif
 
+// On macOS the resizing behaviour effectively resizes the window in the same
+// way a normal drag would do, given constraints in the user desktop (e.g. the dock
+// positioning). So it follows that the finished window size should be saved.
+sint32 platform_get_non_window_flags();
+
 #endif

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -831,4 +831,11 @@ void platform_init_window_icon()
 	// SDL_SetWindowIcon(gWindow, iconSurface)
 }
 
+#if !defined(__MACOSX__)
+sint32 platform_get_non_window_flags()
+{
+	return SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+#endif
+
 #endif

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -831,11 +831,4 @@ void platform_init_window_icon()
 	// SDL_SetWindowIcon(gWindow, iconSurface)
 }
 
-#if !defined(__MACOSX__)
-sint32 platform_get_non_window_flags()
-{
-	return SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
-}
-#endif
-
 #endif

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -194,18 +194,7 @@ static void platform_resize(sint32 width, sint32 height)
 
 	// Check if the window has been resized in windowed mode and update the config file accordingly
 	// This is called in rct2_update and is only called after resizing a window has finished
-	// On macOS the resizing behaviour effectively resizes the window in the same
-	// way a normal drag would do, given constraints in the user desktop (e.g. the dock
-	// positioning). So it follows that the finished window size should be saved.
-#if defined(__MACOSX__)
-	const sint32 nonWindowFlags =
-	SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
-#else
-	const sint32 nonWindowFlags =
-	SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
-#endif
-	
-	if (!(flags & nonWindowFlags)) {
+	if (!(flags & platform_get_non_window_flags())) {
 		if (width != gConfigGeneral.window_width || height != gConfigGeneral.window_height) {
 			gConfigGeneral.window_width = width;
 			gConfigGeneral.window_height = height;

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -194,8 +194,17 @@ static void platform_resize(sint32 width, sint32 height)
 
 	// Check if the window has been resized in windowed mode and update the config file accordingly
 	// This is called in rct2_update and is only called after resizing a window has finished
+	// On macOS the resizing behaviour effectively resizes the window in the same
+	// way a normal drag would do, given constraints in the user desktop (e.g. the dock
+	// positioning). So it follows that the finished window size should be saved.
+#if defined(__APPLE__)
 	const sint32 nonWindowFlags =
-		SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+	SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+#else
+	const sint32 nonWindowFlags =
+	SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+#endif
+	
 	if (!(flags & nonWindowFlags)) {
 		if (width != gConfigGeneral.window_width || height != gConfigGeneral.window_height) {
 			gConfigGeneral.window_width = width;

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -197,7 +197,7 @@ static void platform_resize(sint32 width, sint32 height)
 	// On macOS the resizing behaviour effectively resizes the window in the same
 	// way a normal drag would do, given constraints in the user desktop (e.g. the dock
 	// positioning). So it follows that the finished window size should be saved.
-#if defined(__APPLE__)
+#if defined(__MACOSX__)
 	const sint32 nonWindowFlags =
 	SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
 #else

--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -1237,4 +1237,9 @@ bool platform_setup_uri_protocol()
 
 ///////////////////////////////////////////////////////////////////////////////
 
+sint32 platform_get_non_window_flags()
+{
+	return SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
 #endif


### PR DESCRIPTION
This small patch solves an specific issue with macOS, in which, after resizing a window with the green (+) resize button, the game will not save the new window dimensions to the default config file.

Since this uses the same code in platform_resize(...) it still updates the game model window dimensions. 