### PR TITLE
Prevent Emma Garrell easter egg from activating during ride entry/exit (#5357)

### DIFF
--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -11124,7 +11124,7 @@ static bool peep_has_valid_xy(rct_peep *peep)
 
 static void peep_give_passing_peeps_purple_clothes(rct_peep *peep)
 {
-	if (peep_has_valid_xy(peep)) {
+	if (peep_has_valid_xy(peep) && peep->state != PEEP_STATE_ENTERING_RIDE && peep->state != PEEP_STATE_LEAVING_RIDE) {
 		rct_peep *otherPeep;
 		uint16 spriteIndex = sprite_get_first_in_quadrant(peep->x, peep->y);
 		for (; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = otherPeep->next_in_quadrant) {


### PR DESCRIPTION
Fixes #5357.

The `peep_give_passing_peeps_purple_clothes` function seemed to be doing strange things to `vehicleEntry`/ies during entry and exit of tracked flat rides - this adds a condition preventing it from acting during these phases.