### PR TITLE
Fix sprite commands

### DIFF
--- a/src/openrct2/cmdline/SpriteCommands.cpp
+++ b/src/openrct2/cmdline/SpriteCommands.cpp
@@ -40,9 +40,11 @@ static exitcode_t HandleSprite(CommandLineArgEnumerator *argEnumerator);
 const CommandLineCommand CommandLine::SpriteCommands[]
 {
     // Main commands
+    DefineCommand("append",    "<spritefile> <input>",                SpriteOptions, HandleSprite),
+    DefineCommand("build",     "<spritefile> <resourcedir> [silent]", SpriteOptions, HandleSprite),
+    DefineCommand("create",    "<spritefile>",                        SpriteOptions, HandleSprite),
     DefineCommand("details",   "<spritefile> [idx]",                  SpriteOptions, HandleSprite),
     DefineCommand("export",    "<spritefile> <idx> <output>",         SpriteOptions, HandleSprite),
-    DefineCommand("build",     "<spritefile> <resourcedir> [silent]", SpriteOptions, HandleSprite),
     DefineCommand("exportall", "<spritefile> <outputdir>",            SpriteOptions, HandleSprite),
     CommandTableEnd
 };

--- a/src/openrct2/cmdline/SpriteCommands.cpp
+++ b/src/openrct2/cmdline/SpriteCommands.cpp
@@ -40,9 +40,10 @@ static exitcode_t HandleSprite(CommandLineArgEnumerator *argEnumerator);
 const CommandLineCommand CommandLine::SpriteCommands[]
 {
     // Main commands
-    DefineCommand("details", "<spritefile> [idx]",                  SpriteOptions, HandleSprite),
-    DefineCommand("export",  "<spritefile> <idx> <output>",         SpriteOptions, HandleSprite),
-    DefineCommand("build",   "<spritefile> <resourcedir> [silent]", SpriteOptions, HandleSprite),
+    DefineCommand("details",   "<spritefile> [idx]",                  SpriteOptions, HandleSprite),
+    DefineCommand("export",    "<spritefile> <idx> <output>",         SpriteOptions, HandleSprite),
+    DefineCommand("build",     "<spritefile> <resourcedir> [silent]", SpriteOptions, HandleSprite),
+    DefineCommand("exportall", "<spritefile> <outputdir>",            SpriteOptions, HandleSprite),
     CommandTableEnd
 };
 

--- a/src/openrct2/cmdline_sprite.c
+++ b/src/openrct2/cmdline_sprite.c
@@ -527,16 +527,16 @@ sint32 cmdline_for_sprite(const char **argv, sint32 argc)
 			return -1;
 		}
 
-		if (!platform_ensure_directory_exists(argv[2])){
+		safe_strcpy(outputPath, argv[2], MAX_PATH);
+		path_end_with_separator(outputPath, MAX_PATH);
+
+		if (!platform_ensure_directory_exists(outputPath)){
 			fprintf(stderr, "Unable to create directory.\n");
 			return -1;
 		}
 
-
 		sint32 maxIndex = (sint32)spriteFileHeader.num_entries;
 		sint32 numbers = (sint32)floor(log(maxIndex));
-
-		safe_strcpy(outputPath, argv[2], MAX_PATH);
 		size_t pathLen = strlen(outputPath);
 
 		if (pathLen >= (size_t)(MAX_PATH - numbers - 5)) {


### PR DESCRIPTION
Some console commands caused a null reference exception to occur. With this PR it should be possible to once again export, append, and create sprites using the command line.

This also fixes an issue for the `exportall` command where a path that does not end with a separator would result in the files being exported one level up, with the folder name in their filename. (e.g. calling `sprite exportall g2.dat export` would create files called `export0001.png`).

Only tested on Windows.