### PR TITLE
Guard against null pointers in banner_paint() (fixes #5377)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -76,6 +76,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Jonathan Haas (HaasJona)
 * Jake Breen (Haekb)
 * Marco Benzi Tobar (Lisergishnu)
+* Richard Jenkins (rwjuk)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -48,6 +48,10 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
 	rct_scenery_entry* banner_scenery = get_banner_entry(gBanners[map_element->properties.banner.index].type);
 
+	if ((banner_scenery == nullptr) || (banner_scenery == (rct_scenery_entry *)-1)) {
+		return;
+	}
+
 	direction += map_element->properties.banner.position;
 	direction &= 3;
 

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -48,7 +48,7 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
 	rct_scenery_entry* banner_scenery = get_banner_entry(gBanners[map_element->properties.banner.index].type);
 
-	if ((banner_scenery == (rct_scenery_entry *)-1) || (banner_scenery == null)) {
+	if ((banner_scenery == (rct_scenery_entry *)-1) || (banner_scenery == NULL)) {
 		return;
 	}
 

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -48,7 +48,7 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
 	rct_scenery_entry* banner_scenery = get_banner_entry(gBanners[map_element->properties.banner.index].type);
 
-	if ((banner_scenery == (rct_scenery_entry *)-1) || (!banner_scenery)) {
+	if ((banner_scenery == (rct_scenery_entry *)-1) || (banner_scenery == null)) {
 		return;
 	}
 

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -48,7 +48,7 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
 	rct_scenery_entry* banner_scenery = get_banner_entry(gBanners[map_element->properties.banner.index].type);
 
-	if ((banner_scenery == nullptr) || (banner_scenery == (rct_scenery_entry *)-1)) {
+	if ((banner_scenery == (rct_scenery_entry *)-1) || (!banner_scenery)) {
 		return;
 	}
 


### PR DESCRIPTION
Adds a null pointer check to `banner_paint()` to prevent crashes, particularly with hacked saves. Fixes #5377.