### PR TITLE
Giga Coaster design name display wrong (fixes #5077)

### DIFF
--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -346,7 +346,10 @@ private:
 public:
     static std::string GetNameFromTrackPath(const std::string &path)
     {
-        return Path::GetFileNameWithoutExtension(path);
+        std::string name = Path::GetFileNameWithoutExtension(path);
+        //The track name should be the file name until the first instance of a dot
+        name = name.substr(0, name.find_first_of("."));
+        return name;
     }
 };
 


### PR DESCRIPTION
In this pull request we are addressing the "Goliath.1" issue #5077 that is in OpenRCT2. This fix addresses better than the solution proposed in #5337, because ours is more specific. We only change the displayed name of the track "Goliath.1" to "Goliath" by an if-statement. Therefore our solution is more specific to the issue.