### PR TITLE
Shaking screen (fixes #2875)

### DIFF
--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1627,14 +1627,26 @@ void game_handle_edge_scroll()
 	else if (gCursorState.y >= gScreenHeight - 1)
 		scrollY = 1;
 
+	//get the x and y for the viewport, with the "scroll distance" already added to it
+	sint16 x = mainWindow->viewport->view_width / 2 + mainWindow->saved_view_x+ scrollX * (12 << mainWindow->viewport->zoom);
+	sint16 y = mainWindow->viewport->view_height / 2 + mainWindow->saved_view_y+ scrollY * (12 << mainWindow->viewport->zoom);
+	sint16 z;
+	sub_689174(&x, &y, &z);
+	
 	// Scroll viewport
 	if (scrollX != 0) {
-		mainWindow->saved_view_x += scrollX * (12 << mainWindow->viewport->zoom);
-		_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		//check to see if the "x + scroll distance" is inside the boundary, if so, we move the viewport
+		if (x >= MAP_MINIMUM_X_Y && x <= gMapSizeMinus2) {
+			mainWindow->saved_view_x += scrollX * (12 << mainWindow->viewport->zoom);
+			_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		}
 	}
 	if (scrollY != 0) {
-		mainWindow->saved_view_y += scrollY * (12 << mainWindow->viewport->zoom);
-		_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		//check to see if the "y + scroll distance" is inside the boundary, if so, we move the viewport
+		if (y >= MAP_MINIMUM_X_Y && y <= gMapSizeMinus2) {
+			mainWindow->saved_view_y += scrollY * (12 << mainWindow->viewport->zoom);
+			_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		}
 	}
 }
 
@@ -1698,14 +1710,26 @@ void game_handle_key_scroll()
 		}
 	}
 
+	//get the x and y for the viewport, with the "scroll distance" already added to it
+	sint16 x = mainWindow->viewport->view_width / 2 + mainWindow->saved_view_x+ scrollX * (12 << mainWindow->viewport->zoom);
+	sint16 y = mainWindow->viewport->view_height / 2 + mainWindow->saved_view_y+ scrollY * (12 << mainWindow->viewport->zoom);
+	sint16 z;
+	sub_689174(&x, &y, &z);
+	
 	// Scroll viewport
 	if (scrollX != 0) {
-		mainWindow->saved_view_x += scrollX * (12 << mainWindow->viewport->zoom);
-		_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		//check to see if the "x + scroll distance" is inside the boundary, if so, we move the viewport
+		if (x >= MAP_MINIMUM_X_Y && x <= gMapSizeMinus2) {
+			mainWindow->saved_view_x += scrollX * (12 << mainWindow->viewport->zoom);
+			_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		}
 	}
 	if (scrollY != 0) {
-		mainWindow->saved_view_y += scrollY * (12 << mainWindow->viewport->zoom);
-		_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		//check to see if the "y + scroll distance" is inside the boundary, if so, we move the viewport
+		if (y >= MAP_MINIMUM_X_Y && y <= gMapSizeMinus2) {
+			mainWindow->saved_view_y += scrollY * (12 << mainWindow->viewport->zoom);
+			_inputFlags |= INPUT_FLAG_VIEWPORT_SCROLLING;
+		}
 	}
 }
 


### PR DESCRIPTION
This solution fixes the bug when a user put their mouse cursor on the side of the map, the map begins to shake when it reaches its limit.
**CAUSE:** The problem was caused because the game first moves the map to where the mouse cursor is pointing, and then checks if the map is outside of the predefined boundaries. If the map is outside of the boundaries, then the game moves the map back inside the boundary, causing a shaking artifact for the user.
**OUR FIX:** Our solution first detects if the map-move will surpass its boundaries. If so, then the map is not moved. If the map-move doesn't surpass the boundaries, then the map is moved; and thus the final map position will for sure be inside the boundary.