### PR TITLE
Implement #5370: add ability to change ride operating mode from console

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#1730] Keyboard shortcuts for track construction.
 - Feature: [#5110] The tile inspector can now be used in multiplayer.
 - Feature: [#5305] Add scenery eye dropper tool.
+- Feature: [#5370] Ride operating mode can be set from the console.
 - Improved: [#5254] Scenario option changes are now synchronised over multiplayer.
 - Improved: [#3288] Added server description and greeting textboxes to the start server menu.
 - Improved: [#3502] Track previews display at higher zoom level for large layouts.

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -484,7 +484,7 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 				}
 			}
 			else if (strcmp(argv[1], "mode") == 0) {
-				bool int_valid[3] = { 0 };
+				bool int_valid[2] = { 0 };
 				sint32 ride_index = console_parse_int(argv[2], &int_valid[0]);
 				sint32 mode = console_parse_int(argv[3], &int_valid[1]);
 				if (!int_valid[0] || !int_valid[1]) {
@@ -493,10 +493,10 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 					console_printf("Ride index must not be negative");
 				} else {
 					rct_ride *ride = get_ride(ride_index);
-					if (mode <= 0) {
-						console_printf("Ride mode must be strictly positive");
+					if (mode <= 0 || mode > RIDE_MODE_COUNT) {
+						console_printf("Invalid ride mode.");
 					}
-					else if (ride->type == RIDE_TYPE_NULL) {
+					else if (ride == NULL || ride->type == RIDE_TYPE_NULL) {
 						console_printf("No ride found with index %d", ride_index);
 					}
 					else {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -454,11 +454,12 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 			FOR_ALL_RIDES(i, ride) {
 				char name[128];
 				format_string(name, 128, ride->name, &ride->name_arguments);
-				console_printf("rides %03d type: %02u subtype %03u name %s", i, ride->type, ride->subtype, name);
+				console_printf("ride: %03d type: %02u subtype %03u operating mode: %02u name: %s", i, ride->type, ride->subtype, ride->mode, name);
 			}
 		} else if (strcmp(argv[0], "set") == 0) {
 			if (argc < 4) {
 				console_printf("rides set type <ride id> <ride type>");
+				console_printf("rides set mode <ride id> <operating mode>");
 				console_printf("rides set friction <ride id> <friction value>");
 				console_printf("rides set excitement <ride id> <excitement value>");
 				console_printf("rides set intensity <ride id> <intensity value>");
@@ -478,6 +479,27 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 					sint32 res = game_do_command(0, (type << 8) | 1, 0, (RIDE_SETTING_RIDE_TYPE << 8) | ride_index, GAME_COMMAND_SET_RIDE_SETTING, 0, 0);
 					if (res == MONEY32_UNDEFINED) {
 						console_printf("That didn't work");
+					}
+				}
+			}
+			else if (strcmp(argv[1], "mode") == 0) {
+				bool int_valid[3] = { 0 };
+				sint32 ride_index = console_parse_int(argv[2], &int_valid[0]);
+				sint32 mode = console_parse_int(argv[3], &int_valid[1]);
+				if (!int_valid[0] || !int_valid[1]) {
+					console_printf("This command expects integer arguments");
+				} else if (ride_index < 0) {
+					console_printf("Ride index must not be negative");
+				} else {
+					rct_ride *ride = get_ride(ride_index);
+					if (mode <= 0) {
+						console_printf("Ride mode must be strictly positive");
+					}
+					else if (ride->type == RIDE_TYPE_NULL) {
+						console_printf("No ride found with index %d", ride_index);
+					}
+					else {
+						ride->mode = mode;
 					}
 				}
 			}

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -33,6 +33,7 @@
 #include "../peep/staff.h"
 #include "../platform/platform.h"
 #include "../rct2.h"
+#include "../ride/ride.h"
 #include "../util/sawyercoding.h"
 #include "../util/util.h"
 #include "../Version.h"
@@ -500,6 +501,7 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 					}
 					else {
 						ride->mode = mode;
+						invalidate_test_results(ride_index);
 					}
 				}
 			}

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -468,7 +468,7 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 				return 0;
 			}
 			if (strcmp(argv[1], "type") == 0) {
-				bool int_valid[3] = { 0 };
+				bool int_valid[2] = { 0 };
 				sint32 ride_index = console_parse_int(argv[2], &int_valid[0]);
 				sint32 type = console_parse_int(argv[3], &int_valid[1]);
 				if (!int_valid[0] || !int_valid[1]) {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -461,8 +461,8 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 				console_printf("rides set type <ride id> <ride type>");
 				console_printf("rides set friction <ride id> <friction value>");
 				console_printf("rides set excitement <ride id> <excitement value>");
-				console_printf("rides set intensity <ride id> <excitement value>");
-				console_printf("rides set nausea <ride id> <excitement value>");
+				console_printf("rides set intensity <ride id> <intensity value>");
+				console_printf("rides set nausea <ride id> <nausea value>");
 				return 0;
 			}
 			if (strcmp(argv[1], "type") == 0) {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -460,44 +460,14 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 		} else if (strcmp(argv[0], "set") == 0) {
 			if (argc < 4) {
 				if (argc > 1 && strcmp(argv[1], "mode") == 0){
-					console_printf("Ride modes are specified using integer IDs, as listed below:");
-					console_printf("00 - Normal mode");
-					console_printf("01 - Continuous circuit mode");
-					console_printf("02 - Reverse-incline launched shuttle mode");
-					console_printf("03 - Powered launch (passing station) mode");
-					console_printf("04 - Shuttle mode");
-					console_printf("05 - Boat hire mode");
-					console_printf("06 - Upward launch mode");
-					console_printf("07 - Rotating lift mode");
-					console_printf("08 - Station to station mode");
-					console_printf("09 - Single ride per admission");
-					console_printf("10 - Unlimited rides per admission");
-					console_printf("11 - Maze mode");
-					console_printf("12 - Race mode");
-					console_printf("13 - Bumper car mode");
-					console_printf("14 - Swing mode");
-					console_printf("15 - Shop/stall mode");
-					console_printf("16 - Rotation mode");
-					console_printf("17 - Forward rotation mode");
-					console_printf("18 - Backward rotation mode");
-					console_printf("19 - Film: 'Avenging Aviators'");
-					console_printf("20 - 3D Film: 'Mouse Tails'");
-					console_printf("21 - Space Rings mode");
-					console_printf("22 - Beginner mode");
-					console_printf("23 - LIM-powered launch mode");
-					console_printf("24 - Film: 'Thrill Riders'");
-					console_printf("25 - 3D Film: 'Storm Chasers'");
-					console_printf("26 - 3D Film: 'Space Raiders'");
-					console_printf("27 - Intense mode");
-					console_printf("28 - Berserk mode");
-					console_printf("29 - Haunted House mode");
-					console_printf("30 - Circus show mode");
-					console_printf("31 - Downward launch mode");
-					console_printf("32 - Crooked House mode");
-					console_printf("33 - Freefall drop mode");
-					console_printf("34 - Continuous circuit block sectioned mode");
-					console_printf("35 - Powered launch mode");
-					console_printf("36 - Powered launch block sectioned mode");
+					console_printf("Ride modes are specified using integer IDs as given below:");
+					for (sint32 i = 0; i < RIDE_MODE_COUNT; i++) {
+						char mode_name[128] = { 0 };
+						rct_string_id mode_string_id = STR_RIDE_MODE_NORMAL + i;
+						format_string(mode_name, 128, mode_string_id, 0);
+						console_printf("%02d - %s", i, mode_name);
+					}
+					
 				} else {
 					console_printf("rides set type <ride id> <ride type>");
 					console_printf("rides set mode [<ride id> <operating mode>]");
@@ -534,7 +504,7 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 					console_printf("Ride index must not be negative");
 				} else {
 					rct_ride *ride = get_ride(ride_index);
-					if (mode <= 0 || mode > RIDE_MODE_COUNT) {
+					if (mode <= 0 || mode > (RIDE_MODE_COUNT - 1)) {
 						console_printf("Invalid ride mode.");
 					}
 					else if (ride == NULL || ride->type == RIDE_TYPE_NULL) {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -459,12 +459,53 @@ static sint32 cc_rides(const utf8 **argv, sint32 argc)
 			}
 		} else if (strcmp(argv[0], "set") == 0) {
 			if (argc < 4) {
-				console_printf("rides set type <ride id> <ride type>");
-				console_printf("rides set mode <ride id> <operating mode>");
-				console_printf("rides set friction <ride id> <friction value>");
-				console_printf("rides set excitement <ride id> <excitement value>");
-				console_printf("rides set intensity <ride id> <intensity value>");
-				console_printf("rides set nausea <ride id> <nausea value>");
+				if (argc > 1 && strcmp(argv[1], "mode") == 0){
+					console_printf("Ride modes are specified using integer IDs, as listed below:");
+					console_printf("00 - Normal mode");
+					console_printf("01 - Continuous circuit mode");
+					console_printf("02 - Reverse-incline launched shuttle mode");
+					console_printf("03 - Powered launch (passing station) mode");
+					console_printf("04 - Shuttle mode");
+					console_printf("05 - Boat hire mode");
+					console_printf("06 - Upward launch mode");
+					console_printf("07 - Rotating lift mode");
+					console_printf("08 - Station to station mode");
+					console_printf("09 - Single ride per admission");
+					console_printf("10 - Unlimited rides per admission");
+					console_printf("11 - Maze mode");
+					console_printf("12 - Race mode");
+					console_printf("13 - Bumper car mode");
+					console_printf("14 - Swing mode");
+					console_printf("15 - Shop/stall mode");
+					console_printf("16 - Rotation mode");
+					console_printf("17 - Forward rotation mode");
+					console_printf("18 - Backward rotation mode");
+					console_printf("19 - Film: 'Avenging Aviators'");
+					console_printf("20 - 3D Film: 'Mouse Tails'");
+					console_printf("21 - Space Rings mode");
+					console_printf("22 - Beginner mode");
+					console_printf("23 - LIM-powered launch mode");
+					console_printf("24 - Film: 'Thrill Riders'");
+					console_printf("25 - 3D Film: 'Storm Chasers'");
+					console_printf("26 - 3D Film: 'Space Raiders'");
+					console_printf("27 - Intense mode");
+					console_printf("28 - Berserk mode");
+					console_printf("29 - Haunted House mode");
+					console_printf("30 - Circus show mode");
+					console_printf("31 - Downward launch mode");
+					console_printf("32 - Crooked House mode");
+					console_printf("33 - Freefall drop mode");
+					console_printf("34 - Continuous circuit block sectioned mode");
+					console_printf("35 - Powered launch mode");
+					console_printf("36 - Powered launch block sectioned mode");
+				} else {
+					console_printf("rides set type <ride id> <ride type>");
+					console_printf("rides set mode [<ride id> <operating mode>]");
+					console_printf("rides set friction <ride id> <friction value>");
+					console_printf("rides set excitement <ride id> <excitement value>");
+					console_printf("rides set intensity <ride id> <intensity value>");
+					console_printf("rides set nausea <ride id> <nausea value>");
+				}
 				return 0;
 			}
 			if (strcmp(argv[1], "type") == 0) {

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -902,6 +902,8 @@ extern const rct_ride_properties RideProperties[RIDE_TYPE_COUNT];
 
 #define MAX_RIDES 255
 
+#define RIDE_MODE_COUNT 36
+
 #define MAX_RIDE_MEASUREMENTS 8
 #define RIDE_VALUE_UNDEFINED 0xFFFF
 #define RIDE_INITIAL_RELIABILITY ((100 << 8) - 1)

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -902,7 +902,7 @@ extern const rct_ride_properties RideProperties[RIDE_TYPE_COUNT];
 
 #define MAX_RIDES 255
 
-#define RIDE_MODE_COUNT 36
+#define RIDE_MODE_COUNT 37
 
 #define MAX_RIDE_MEASUREMENTS 8
 #define RIDE_VALUE_UNDEFINED 0xFFFF


### PR DESCRIPTION
This PR adds a `rides set mode` command to the console. It behaves in much the same way as the `rides set type` command, except that it eschews `game_do_command()` and goes straight to the ride object - otherwise we'd run into problems such as having to close the ride first, which would negate the object of having the command!

It doesn't invalidate the test results after making the change, I'm not sure whether this is something we should do or not.

I also added the operating mode to the `rides list` command.