### PR TITLE
Do not set fullscreen mode on startup, fixes #4022

### DIFF
--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -622,9 +622,6 @@ static void platform_create_window()
 	// Initialise the surface, palette and draw buffer
 	platform_resize(width, height);
 
-	platform_update_fullscreen_resolutions();
-	platform_set_fullscreen_mode(gConfigGeneral.fullscreen_mode);
-
 	// Check if steam overlay renderer is loaded into the process
 	gSteamOverlayActive = platform_check_steam_overlay_attached();
 	platform_trigger_resize();


### PR DESCRIPTION
Apparently, when the game is created, and as a consequence the main window of the game is created, the code sets the main window to fullscreen resolution. This is definitely wrong since the window is always initialized in windowed mode. As a consequence of this bug, the mouse cursor in the game appears to be off of where it should, making it almost impossible for the user to click in any dialog box option inside the game.

**SOLUTION:** Since the game always start in windowed mode, there's no point in setting the resolution of the screen to fullscreen, so to fix the bug, we had to delete the lines related to setting the screen resolution to fullscreen.