### PR TITLE
Addition of Timestamps to Log Output

### DIFF
--- a/src/openrct2/diagnostic.c
+++ b/src/openrct2/diagnostic.c
@@ -17,8 +17,8 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <time.h>
 #include "diagnostic.h"
+#include "platform/platform.h"
 
 static bool _log_location_enabled = true;
 bool _log_levels[DIAGNOSTIC_LEVEL_COUNT] = { true, true, true, false, true };
@@ -31,15 +31,6 @@ const char * _level_strings[] = {
 	"INFO"
 };
 
-// returns the current system time in a printable format                                                                                                                                                    
-char* getTime() {
-        time_t rawTime;
-        time(&rawTime);
-        static char curTime[128];
-        strftime(curTime, sizeof(curTime), "[%FT%T]", localtime(&rawTime));
-        return curTime;
-}
-
 void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
 {
 	FILE *stream;
@@ -50,8 +41,8 @@ void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
 
 	stream = stderr;
 
-	// timestamp                                                                                                                                                                                        
-        fprintf(stream, "%s: ", getTime());
+	// timestamp
+	printLocalDateTime(stream);
 	
 	// Level
 	fprintf(stream, "%s: ", _level_strings[diagnosticLevel]);
@@ -74,10 +65,10 @@ void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *f
 		return;
 
 	stream = stderr;
-	
-	// timestamp                                                                                                                                                                                        
-        fprintf(stream, "%s: ", getTime());
 
+	// timestamp                                                                                                                                                                                        
+	printLocalDateTime(stream);
+	
 	// Level and source code information
 	if (_log_location_enabled)
 		fprintf(stream, "%s[%s:%d (%s)]: ", _level_strings[diagnosticLevel], file, line, function);

--- a/src/openrct2/diagnostic.c
+++ b/src/openrct2/diagnostic.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <time.h>
 #include "diagnostic.h"
 
 static bool _log_location_enabled = true;
@@ -30,6 +31,15 @@ const char * _level_strings[] = {
 	"INFO"
 };
 
+// returns the current system time in a printable format                                                                                                                                                    
+char* getTime() {
+        time_t rawTime;
+        time(&rawTime);
+        static char curTime[128];
+        strftime(curTime, sizeof(curTime), "[%FT%T]", localtime(&rawTime));
+        return curTime;
+}
+
 void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
 {
 	FILE *stream;
@@ -40,6 +50,9 @@ void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
 
 	stream = stderr;
 
+	// timestamp                                                                                                                                                                                        
+        fprintf(stream, "%s: ", getTime());
+	
 	// Level
 	fprintf(stream, "%s: ", _level_strings[diagnosticLevel]);
 
@@ -61,6 +74,9 @@ void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *f
 		return;
 
 	stream = stderr;
+	
+	// timestamp                                                                                                                                                                                        
+        fprintf(stream, "%s: ", getTime());
 
 	// Level and source code information
 	if (_log_location_enabled)

--- a/src/openrct2/diagnostic.h
+++ b/src/openrct2/diagnostic.h
@@ -81,6 +81,7 @@ extern bool _log_levels[DIAGNOSTIC_LEVEL_COUNT];
 extern "C" {
 #endif // __cplusplus
 
+char* getTime();
 void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...);
 void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
 

--- a/src/openrct2/diagnostic.h
+++ b/src/openrct2/diagnostic.h
@@ -81,7 +81,6 @@ extern bool _log_levels[DIAGNOSTIC_LEVEL_COUNT];
 extern "C" {
 #endif // __cplusplus
 
-char* getTime();
 void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...);
 void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
 

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -158,6 +158,7 @@ void platform_get_date_utc(rct2_date *out_date);
 void platform_get_time_utc(rct2_time *out_time);
 void platform_get_date_local(rct2_date *out_date);
 void platform_get_time_local(rct2_time *out_time);
+void printLocalDateTime(FILE *stream);
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath, size_t outSize);

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -782,3 +782,13 @@ void core_init()
 {
 	bitcount_init();
 }
+
+// prints the current system time in a printable format to the passed stream
+void printLocalDateTime (FILE *stream) {
+	rct2_date outDate;
+	platform_get_date_local(&outDate);
+	rct2_time outTime;
+	platform_get_time_local(&outTime);
+	fprintf(stream, "[%hd-%hhu-%hhuT", outDate.year, outDate.month, outDate.day);
+	fprintf(stream, "%hhu:%hhu:%hhu]", outTime.hour, outTime.minute, outTime.second);
+}


### PR DESCRIPTION
A request was made (https://github.com/OpenRCT2/OpenRCT2/issues/4816) to add timestamps
to the log output. A function has been added to 'diagnostic.c' that returns a string of the system
time in ISO-8601 format. That string is then printed before any regular log output. The definition for
the function was also added to 'diagnostic.h'.