### PR TITLE
Define native file dialog strings when loading heightmap, to avoid crashes

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4363,6 +4363,7 @@ STR_6051    :The width and height need to match
 STR_6052    :The heightmap is too big, and will be cut off
 STR_6053    :The heightmap cannot be normalised
 STR_6054    :Only 24-bit bitmaps are supported
+STR_6055    :OpenRCT2 Heightmap File
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3713,6 +3713,7 @@ enum {
 	STR_ERROR_HEIHGT_MAP_TOO_BIG = 6052,
 	STR_ERROR_CANNOT_NORMALIZE = 6053,
 	STR_ERROR_24_BIT_BITMAP = 6054,
+	STR_OPENRCT2_HEIGHTMAP_FILE = 6055,
 
 	// Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
 	STR_COUNT = 32768

--- a/src/openrct2/windows/loadsave.c
+++ b/src/openrct2/windows/loadsave.c
@@ -281,6 +281,11 @@ static bool browse(bool isSave, char *path, size_t pathSize)
 		desc.filters[0].name = language_get_string(STR_OPENRCT2_TRACK_DESIGN_FILE);
 		desc.filters[0].pattern = isSave ? "*.td6" : "*.td6;*.td4";
 		break;
+	case LOADSAVETYPE_IMAGE:
+		title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
+		desc.filters[0].name = language_get_string(STR_OPENRCT2_HEIGHTMAP_FILE);
+		desc.filters[0].pattern = "*.jpg;*.png";
+		break;
 	}
 
 	desc.title = language_get_string(title);


### PR DESCRIPTION
Thanks to @wolfreak99 for the fix.