### PR TITLE
en-GB: "harbor" -> "harbour"

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4507,8 +4507,8 @@ STR_PARK    :Funtopia
 STR_DTLS    :Covering land both sides of a highway, this park has several rides already operating
 
 <Haunted Harbor>
-STR_SCNR    :Haunted Harbor
-STR_PARK    :Haunted Harbor
+STR_SCNR    :Haunted Harbour
+STR_PARK    :Haunted Harbour
 STR_DTLS    :The local authority has agreed to sell nearby land cheaply to this small seaside park, on the condition that certain rides are preserved
 
 <Fun Fortress>


### PR DESCRIPTION
A minor change. Just found that "harbor" is used rather than "harbour" in the scenario "Haunted Harbor", which if I learned correctly, harbour is the british spelling of harbor. Please close it if harbor is the correct usage of this scenario, thank you very much!

references:
http://dictionary.cambridge.org/dictionary/english/harbour
http://dictionary.cambridge.org/dictionary/english/harbor