### PR TITLE
Ignore wide flags on patrol zone edges in path finding heuristic.

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9105,9 +9105,32 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 			z = mapElement->base_height;
 
 			if (footpath_element_is_wide(mapElement)) {
-				searchResult = PATH_SEARCH_WIDE;
-				found = true;
-				break;
+				if (peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_MECHANIC) {
+					// Check whether the tile is not on the
+					// edge of the mechanic patrol zone.
+					bool onZoneEdge = false;
+					int neighbourDir = 0;
+					while (!onZoneEdge && neighbourDir <= 3) {
+						int neighbourX = x + TileDirectionDelta[neighbourDir].x;
+						int neighbourY = y + TileDirectionDelta[neighbourDir].y;
+						onZoneEdge = !staff_is_location_in_patrol(peep, neighbourX, neighbourY);
+						neighbourDir++;
+					}
+					// Wide paths not on the edge of the
+					// mechanic patrol zone are observed.
+					if (!onZoneEdge) {
+						searchResult = PATH_SEARCH_WIDE;
+						found = true;
+						break;
+					}
+					// Wide path flag for path tiles on the
+					// edge of the mechanic patrol zone are
+					// ignored.
+				} else {
+					searchResult = PATH_SEARCH_WIDE;
+					found = true;
+					break;
+				}
 			}
 
 			searchResult = PATH_SEARCH_THIN;


### PR DESCRIPTION
Wide path flags in patrol zones can divide the paths with an uncrossable boundary.
Rather than changing the general path finding heuristic related to the wide flag (which would result in worse path finding overall) add a special case for mechanics with respect to their patrol zones:
Ignore wide flags on the patrol zone edges to provide doorways for mechanics through these boundaries without otherwise affecting the path finding heuristic.

Fixes #5414.

Requires new network version.