### PR TITLE
Improve ignoring wide flags on patrol zone edges

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "21"
+#define NETWORK_STREAM_VERSION "22"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9110,7 +9110,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 					// edge of the mechanic patrol zone.
 					bool onZoneEdge = false;
 					int neighbourDir = 0;
-					while (!onZoneEdge && neighbourDir <= 3) {
+					while (!onZoneEdge && neighbourDir <= 7) {
 						int neighbourX = x + TileDirectionDelta[neighbourDir].x;
 						int neighbourY = y + TileDirectionDelta[neighbourDir].y;
 						onZoneEdge = !staff_is_location_in_patrol(peep, neighbourX, neighbourY);


### PR DESCRIPTION
This is a small improvement to #5424.

The patrol zone edge detection is expanded to also check the diagonal neighbouring tiles so that the fix in #5424 also works for tiles on an internal corner of a patrol zone.

The following screenshot (courtesy of @Gymnasiast) illustrates such a case that now works with this improvement.  A mechanic approaching the circled tile from the indicated sides was previously blocked from reaching the Ferris wheel when that tile has the wide flag set.
![widepathinternalcornerofzone](https://cloud.githubusercontent.com/assets/20344978/25634095/aa2ddcbe-2f79-11e7-9112-3f26f727c43f.png)

Requires a new network version.