### PR TITLE
Add config option for the listen address of the socket

### DIFF
--- a/distribution/man/openrct2.6
+++ b/distribution/man/openrct2.6
@@ -30,6 +30,7 @@ restrictions or finance.
 .Nm
 .Ar host
 uri
+.Op Fl -address Ar address
 .Op Fl -port Ar port
 .Op Fl -password Ar password
 .Op Fl -headless
@@ -110,6 +111,9 @@ without a graphical window.
 
 .It Fl -port Ar port
 Port to use for hosting or joining a server.
+
+.It Fl -address Ar address
+Address to bind to when hosting a server.
 
 .It Fl -password Ar password
 Password needed to join the server.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -345,6 +345,11 @@ namespace OpenRCT2
                         gNetworkStartPort = gConfigNetwork.default_port;
                     }
 
+                    if (String::IsNullOrEmpty(gNetworkStartAddress))
+                    {
+                        gNetworkStartAddress = gConfigNetwork.listen_address;
+                    }
+
                     if (String::IsNullOrEmpty(gCustomPassword))
                     {
                         network_set_password(gConfigNetwork.default_password);
@@ -353,7 +358,7 @@ namespace OpenRCT2
                     {
                         network_set_password(gCustomPassword);
                     }
-                    network_begin_server(gNetworkStartPort);
+                    network_begin_server(gNetworkStartPort, gNetworkStartAddress);
                 }
 #endif // DISABLE_NETWORK
                 break;

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -67,6 +67,7 @@ extern "C"
     extern sint32 gNetworkStart;
     extern char gNetworkStartHost[128];
     extern sint32 gNetworkStartPort;
+    extern char* gNetworkStartAddress;
 #endif
 
     void openrct2_write_full_version_info(utf8 * buffer, size_t bufferSize);

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -44,8 +44,10 @@ extern "C"
 sint32  gNetworkStart = NETWORK_MODE_NONE;
 char gNetworkStartHost[128];
 sint32  gNetworkStartPort = NETWORK_DEFAULT_PORT;
+char* gNetworkStartAddress = nullptr;
 
 static uint32 _port            = 0;
+static char*  _address         = nullptr;
 #endif
 
 static bool   _help            = false;
@@ -72,6 +74,7 @@ static const CommandLineOptionDefinition StandardOptions[]
     { CMDLINE_TYPE_SWITCH,  &_headless,        NAC, "headless",          "run " OPENRCT2_NAME " headless" IMPLIES_SILENT_BREAKPAD     },
 #ifndef DISABLE_NETWORK
     { CMDLINE_TYPE_INTEGER, &_port,            NAC, "port",              "port to use for hosting or joining a server"                },
+    { CMDLINE_TYPE_STRING,  &_address,         NAC, "address",           "address to listen on when hosting a server"                 },
 #endif
     { CMDLINE_TYPE_STRING,  &_password,        NAC, "password",          "password needed to join the server"                         },
     { CMDLINE_TYPE_STRING,  &_userDataPath,    NAC, "user-data-path",    "path to the user data directory (containing config.ini)"    },
@@ -287,6 +290,8 @@ exitcode_t HandleCommandHost(CommandLineArgEnumerator * enumerator)
 
     gNetworkStart = NETWORK_MODE_SERVER;
     gNetworkStartPort = _port;
+    gNetworkStartAddress = _address;
+
     return EXITCODE_CONTINUE;
 }
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -344,9 +344,9 @@ namespace Config
             model->player_name = reader->GetCString("player_name", "Player");
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);
 
-			model->listen_address = reader->GetCString("listen_address", "");
-			if (strlen(model->listen_address) == 0)
-				model->listen_address = nullptr;
+            model->listen_address = reader->GetCString("listen_address", "");
+            if (strlen(model->listen_address) == 0)
+                model->listen_address = nullptr;
 
             model->default_password = reader->GetCString("default_password", nullptr);
             model->stay_connected = reader->GetBoolean("stay_connected", true);
@@ -370,7 +370,7 @@ namespace Config
         writer->WriteSection("network");
         writer->WriteString("player_name", model->player_name);
         writer->WriteSint32("default_port", model->default_port);
-		writer->WriteString("listen_address", model->listen_address);
+        writer->WriteString("listen_address", model->listen_address);
         writer->WriteString("default_password", model->default_password);
         writer->WriteBoolean("stay_connected", model->stay_connected);
         writer->WriteBoolean("advertise", model->advertise);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -343,11 +343,7 @@ namespace Config
             auto model = &gConfigNetwork;
             model->player_name = reader->GetCString("player_name", "Player");
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);
-
             model->listen_address = reader->GetCString("listen_address", "");
-            if (strlen(model->listen_address) == 0)
-                model->listen_address = nullptr;
-
             model->default_password = reader->GetCString("default_password", nullptr);
             model->stay_connected = reader->GetBoolean("stay_connected", true);
             model->advertise = reader->GetBoolean("advertise", true);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -343,6 +343,11 @@ namespace Config
             auto model = &gConfigNetwork;
             model->player_name = reader->GetCString("player_name", "Player");
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);
+
+			model->listen_address = reader->GetCString("listen_address", "");
+			if (strlen(model->listen_address) == 0)
+				model->listen_address = nullptr;
+
             model->default_password = reader->GetCString("default_password", nullptr);
             model->stay_connected = reader->GetBoolean("stay_connected", true);
             model->advertise = reader->GetBoolean("advertise", true);
@@ -365,6 +370,7 @@ namespace Config
         writer->WriteSection("network");
         writer->WriteString("player_name", model->player_name);
         writer->WriteSint32("default_port", model->default_port);
+		writer->WriteString("listen_address", model->listen_address);
         writer->WriteString("default_password", model->default_password);
         writer->WriteBoolean("stay_connected", model->stay_connected);
         writer->WriteBoolean("advertise", model->advertise);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -137,6 +137,7 @@ typedef struct NetworkConfiguration
 {
     utf8 *      player_name;
     sint32      default_port;
+	char *      listen_address;
     utf8 *      default_password;
     bool        stay_connected;
     bool        advertise;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -137,7 +137,7 @@ typedef struct NetworkConfiguration
 {
     utf8 *      player_name;
     sint32      default_port;
-	char *      listen_address;
+    char *      listen_address;
     utf8 *      default_password;
     bool        stay_connected;
     bool        advertise;

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -264,7 +264,7 @@ bool Network::BeginClient(const char* host, uint16 port)
 	return true;
 }
 
-bool Network::BeginServer(uint16 port)
+bool Network::BeginServer(uint16 port, const char* address)
 {
 	Close();
 	if (!Init())
@@ -280,7 +280,7 @@ bool Network::BeginServer(uint16 port)
 	listening_socket = CreateTcpSocket();
 	try
 	{
-		listening_socket->Listen(gConfigNetwork.listen_address, port);
+		listening_socket->Listen(address, port);
 	}
 	catch (const Exception &ex)
 	{
@@ -2136,7 +2136,11 @@ sint32 network_begin_client(const char *host, sint32 port)
 
 sint32 network_begin_server(sint32 port)
 {
-	return gNetwork.BeginServer(port);
+	char *address = nullptr;
+	if (strlen(gConfigNetwork.listen_address) > 0)
+		address = gConfigNetwork.listen_address;
+
+	return gNetwork.BeginServer(port, address);
 }
 
 void network_update()

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -264,7 +264,7 @@ bool Network::BeginClient(const char* host, uint16 port)
 	return true;
 }
 
-bool Network::BeginServer(uint16 port, const char* address)
+bool Network::BeginServer(uint16 port)
 {
 	Close();
 	if (!Init())
@@ -280,7 +280,7 @@ bool Network::BeginServer(uint16 port, const char* address)
 	listening_socket = CreateTcpSocket();
 	try
 	{
-		listening_socket->Listen(address, port);
+		listening_socket->Listen(gConfigNetwork.listen_address, port);
 	}
 	catch (const Exception &ex)
 	{

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -274,6 +274,9 @@ bool Network::BeginServer(uint16 port, const char* address)
 
 	_userManager.Load();
 
+	if (strlen(address) == 0)
+		address = nullptr;
+
 	log_verbose("Begin listening for clients");
 
 	assert(listening_socket == nullptr);
@@ -2134,12 +2137,8 @@ sint32 network_begin_client(const char *host, sint32 port)
 	return gNetwork.BeginClient(host, port);
 }
 
-sint32 network_begin_server(sint32 port)
+sint32 network_begin_server(sint32 port, const char* address)
 {
-	char *address = nullptr;
-	if (strlen(gConfigNetwork.listen_address) > 0)
-		address = gConfigNetwork.listen_address;
-
 	return gNetwork.BeginServer(port, address);
 }
 
@@ -2674,7 +2673,7 @@ void network_send_gamecmd(uint32 eax, uint32 ebx, uint32 ecx, uint32 edx, uint32
 void network_send_map() {}
 void network_update() {}
 sint32 network_begin_client(const char *host, sint32 port) { return 1; }
-sint32 network_begin_server(sint32 port) { return 1; }
+sint32 network_begin_server(sint32 port, const char * address) { return 1; }
 sint32 network_get_num_players() { return 1; }
 const char* network_get_player_name(uint32 index) { return "local (OpenRCT2 compiled without MP)"; }
 uint32 network_get_player_flags(uint32 index) { return 0; }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -95,7 +95,7 @@ public:
 	bool Init();
 	void Close();
 	bool BeginClient(const char* host, uint16 port);
-	bool BeginServer(uint16 port);
+	bool BeginServer(uint16 port, const char* address);
 	sint32 GetMode();
 	sint32 GetStatus();
 	sint32 GetAuthStatus();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -95,7 +95,7 @@ public:
 	bool Init();
 	void Close();
 	bool BeginClient(const char* host, uint16 port);
-	bool BeginServer(uint16 port, const char* address = NULL);
+	bool BeginServer(uint16 port);
 	sint32 GetMode();
 	sint32 GetStatus();
 	sint32 GetAuthStatus();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -264,7 +264,7 @@ sint32 network_init();
 void network_close();
 void network_shutdown_client();
 sint32 network_begin_client(const char *host, sint32 port);
-sint32 network_begin_server(sint32 port);
+sint32 network_begin_server(sint32 port, const char* address);
 
 sint32 network_get_mode();
 sint32 network_get_status();

--- a/src/openrct2/windows/server_start.c
+++ b/src/openrct2/windows/server_start.c
@@ -166,7 +166,7 @@ static void window_server_start_scenarioselect_callback(const utf8 *path)
 {
 	network_set_password(_password);
 	if (scenario_load_and_play_from_path(path)) {
-		network_begin_server(gConfigNetwork.default_port);
+		network_begin_server(gConfigNetwork.default_port, gConfigNetwork.listen_address);
 	} else {
 		title_load();
 	}
@@ -175,7 +175,7 @@ static void window_server_start_scenarioselect_callback(const utf8 *path)
 static void window_server_start_loadsave_callback(sint32 result, const utf8 * path)
 {
 	if (result == MODAL_RESULT_OK && game_load_save_or_scenario(path)) {
-		network_begin_server(gConfigNetwork.default_port);
+		network_begin_server(gConfigNetwork.default_port, gConfigNetwork.listen_address);
 	}
 }
 


### PR DESCRIPTION
This adds a new config option `listen-address`, which sets the address to listen on for the socket.

This will fix #5430, because setting a dedicated IPv6 address in the config seems to be a good workaround. It is also useful when you own multiple IPs on a dedicated server, because you can specify which one to use.