### PR TITLE
Allow mechanics to walk over wide tiles on the edge of the patrol zone

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "22"
+#define NETWORK_STREAM_VERSION "23"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9000,6 +9000,9 @@ static bool path_is_thin_junction(rct_map_element *path, sint16 x, sint16 y, uin
 static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep *peep, rct_map_element *currentMapElement, bool inPatrolArea, uint8 counter, uint16 *endScore, sint32 test_edge, uint8 *endJunctions, rct_xyz8 junctionList[16], uint8 directionList[16], rct_xyz8 *endXYZ, uint8 *endSteps) {
     uint8 searchResult = PATH_SEARCH_FAILED;
 
+    bool currentElementIsWide = (footpath_element_is_wide(currentMapElement) &&
+                !staff_can_ignore_wide_flag(peep, x, y, z, currentMapElement));
+
     x += TileDirectionDelta[test_edge].x;
     y += TileDirectionDelta[test_edge].y;
 
@@ -9221,7 +9224,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
         /* If this is a wide path the search ends here. */
         if (searchResult == PATH_SEARCH_WIDE) {
             /* Ignore Wide paths as continuing paths UNLESS
-             * the current path is also Wide.
+             * the current path is also Wide (and, for staff, not ignored).
              * This permits a peep currently on a wide path to
              * cross other wide paths to reach a thin path.
              *
@@ -9230,7 +9233,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
              * If the search result is better than the best so far
              * (in the parameters), then update the parameters with
              * this search before continuing to the next map element. */
-            if (footpath_element_is_wide(currentMapElement) &&
+            if (currentElementIsWide &&
                 (new_score < *endScore || (new_score == *endScore && counter < *endSteps ))) {
                 // Update the search results
                 *endScore = new_score;

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9121,32 +9121,9 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
             z = mapElement->base_height;
 
             if (footpath_element_is_wide(mapElement)) {
-                if (peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_MECHANIC) {
-                    // Check whether the tile is not on the
-                    // edge of the mechanic patrol zone.
-                    bool onZoneEdge = false;
-                    int neighbourDir = 0;
-                    while (!onZoneEdge && neighbourDir <= 7) {
-                        int neighbourX = x + TileDirectionDelta[neighbourDir].x;
-                        int neighbourY = y + TileDirectionDelta[neighbourDir].y;
-                        onZoneEdge = !staff_is_location_in_patrol(peep, neighbourX, neighbourY);
-                        neighbourDir++;
-                    }
-                    // Wide paths not on the edge of the
-                    // mechanic patrol zone are observed.
-                    if (!onZoneEdge) {
-                        searchResult = PATH_SEARCH_WIDE;
-                        found = true;
-                        break;
-                    }
-                    // Wide path flag for path tiles on the
-                    // edge of the mechanic patrol zone are
-                    // ignored.
-                } else {
-                    searchResult = PATH_SEARCH_WIDE;
-                    found = true;
-                    break;
-                }
+                searchResult = PATH_SEARCH_WIDE;
+                found = true;
+                break;
             }
 
             searchResult = PATH_SEARCH_THIN;

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -9225,14 +9225,32 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 
         /* If this is a wide path the search ends here. */
         if (searchResult == PATH_SEARCH_WIDE) {
-            /* Ignore Wide paths as continuing paths UNLESS the current path is also Wide.
-             * i.e. search across wide paths from a wide path to get onto a thin path,
-             * thereafter stay on thin paths. */
-            /* So, if the current path is also wide the goal could still
-             * be reachable from here.
-             * If the search result is better than the best so far (in the parameters),
-             * then update the parameters with this search before continuing to the next map element. */
-            if (footpath_element_is_wide(currentMapElement) &&
+            /* Ignore Wide paths as continuing paths UNLESS:
+             * 1. the current path is also Wide, OR
+             * 2. peep is a mechanic and the wide path is on the
+             *   edge of their patrol zone.
+             *
+             * Case 1 permits a peep currently on a wide path to
+             * cross other wide paths to reach a thin path.
+             * Case 2 permits mechanics with a patrol zone to
+             * cross wide paths at the zone edge - wide paths could
+             * otherwise fence a mechanic into one part of their
+             * patrol zone.
+             *
+             * So, if the current path is also wide or on the edge
+             * of a mechanic's patrol zone the goal could still be
+             * reachable from here.
+             * If the search result is better than the best so far
+             * (in the parameters), then update the parameters with
+             * this search before continuing to the next map element. */
+            if ((
+                // Case 1 as described above.
+                footpath_element_is_wide(currentMapElement) ||
+                ( // Case 2 as described above.
+                    peep->type == PEEP_TYPE_STAFF &&
+                    peep->staff_type == STAFF_TYPE_MECHANIC &&
+                    staff_is_location_on_patrol_edge(peep, x, y))
+                ) &&
                 (new_score < *endScore || (new_score == *endScore && counter < *endSteps ))) {
                 // Update the search results
                 *endScore = new_score;

--- a/src/openrct2/peep/peep.h
+++ b/src/openrct2/peep/peep.h
@@ -766,6 +766,8 @@ void game_command_set_guest_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *
 sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep *peep);
 void peep_reset_pathfind_goal(rct_peep *peep);
 
+bool is_valid_path_z_and_direction(rct_map_element *mapElement, sint32 currentZ, sint32 currentDirection);
+
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 #define PATHFIND_DEBUG 0 // Set to 0 to disable pathfinding debugging;
              // Set to 1 to enable pathfinding debugging.

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -628,10 +628,10 @@ sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
 	// Check whether the location x,y is inside and on the edge of the
 	// patrol zone for mechanic.
 	sint32 onZoneEdge = 0;
-	uint32 neighbourDir = 0;
+	sint32 neighbourDir = 0;
 	while (!onZoneEdge && neighbourDir <= 7) {
-		uint32 neighbourX = x + TileDirectionDelta[neighbourDir].x;
-		uint32 neighbourY = y + TileDirectionDelta[neighbourDir].y;
+		sint32 neighbourX = x + TileDirectionDelta[neighbourDir].x;
+		sint32 neighbourY = y + TileDirectionDelta[neighbourDir].y;
 		onZoneEdge = !staff_is_location_in_patrol(mechanic, neighbourX, neighbourY);
 		neighbourDir++;
 	}

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -628,10 +628,10 @@ sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
 	// Check whether the location x,y is inside and on the edge of the
 	// patrol zone for mechanic.
 	sint32 onZoneEdge = 0;
-	int neighbourDir = 0;
+	uint32 neighbourDir = 0;
 	while (!onZoneEdge && neighbourDir <= 7) {
-		int neighbourX = x + TileDirectionDelta[neighbourDir].x;
-		int neighbourY = y + TileDirectionDelta[neighbourDir].y;
+		uint32 neighbourX = x + TileDirectionDelta[neighbourDir].x;
+		uint32 neighbourY = y + TileDirectionDelta[neighbourDir].y;
 		onZoneEdge = !staff_is_location_in_patrol(mechanic, neighbourX, neighbourY);
 		neighbourDir++;
 	}

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -625,17 +625,136 @@ sint32 staff_is_location_in_patrol(rct_peep *staff, sint32 x, sint32 y)
 
 sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
 {
-	// Check whether the location x,y is inside and on the edge of the
-	// patrol zone for mechanic.
-	sint32 onZoneEdge = 0;
-	sint32 neighbourDir = 0;
-	while (!onZoneEdge && neighbourDir <= 7) {
-		sint32 neighbourX = x + TileDirectionDelta[neighbourDir].x;
-		sint32 neighbourY = y + TileDirectionDelta[neighbourDir].y;
-		onZoneEdge = !staff_is_location_in_patrol(mechanic, neighbourX, neighbourY);
-		neighbourDir++;
-	}
-	return onZoneEdge;
+    // Check whether the location x,y is inside and on the edge of the
+    // patrol zone for mechanic.
+    sint32 onZoneEdge = 0;
+    sint32 neighbourDir = 0;
+    while (!onZoneEdge && neighbourDir <= 7) {
+        sint32 neighbourX = x + TileDirectionDelta[neighbourDir].x;
+        sint32 neighbourY = y + TileDirectionDelta[neighbourDir].y;
+        onZoneEdge = !staff_is_location_in_patrol(mechanic, neighbourX, neighbourY);
+        neighbourDir++;
+    }
+    return onZoneEdge;
+}
+
+
+sint32 staff_can_ignore_wide_flag(rct_peep *staff, sint32 x, sint32 y, uint8 z, rct_map_element *path)
+{
+    /* Wide flags can potentially wall off parts of a staff patrol zone
+     * for the heuristic search.
+     * This function provide doors through such "walls" by defining
+     * the conditions under which staff can ignore the wide path flag. */
+    /* Staff can ignore the wide flag on a path on the edge of the patrol
+     * zone based on its adjacent tiles that are also in the patrol zone
+     * but not on the patrol zone edge:
+     * Basic points of interest are:
+     * - how many such tiles there are;
+     * - whether there are connected paths on those tiles;
+     * - whether the conected paths have the wide flag set.
+     * If there are no such tiles, the path is a concave corner of
+     * the patrol zone and the wide flag can be ignored.
+     * If there is one such tile, the path is on a straight side of the
+     * patrol zone. If this one tile is either a connected wide path or
+     * not a connected path, the wide flag can be ignored.
+     * If there are two such tiles, the path is a convex corner of the
+     * patrol zone. If at most one of these tiles is a connected path or
+     * both of these tiles are connected wide paths, the wide flag can be
+     * ignored. */
+
+    if (staff->type != PEEP_TYPE_STAFF)
+        return 0;
+
+    if (!staff_is_location_on_patrol_edge(staff, x, y))
+    {
+        return 0;
+    }
+
+    /* Check the connected adjacent paths that are also inside the patrol
+     * zone but are not on the patrol zone edge have the wide flag set. */
+    uint8 total = 0;
+    uint8 pathcount = 0;
+    uint8 widecount = 0;
+    for (sint32 adjac_dir = 0; adjac_dir <= 3; adjac_dir++)
+    {
+        sint32 adjac_x = x + TileDirectionDelta[adjac_dir].x;
+        sint32 adjac_y = y + TileDirectionDelta[adjac_dir].y;
+        uint8 adjac_z = z;
+
+        /* Ignore adjacent tiles outside the patrol zone. */
+        if (!staff_is_location_in_patrol(staff, adjac_x, adjac_y))
+            continue;
+
+        /* Ignore adjacent tiles on the patrol zone edge. */
+        if (staff_is_location_on_patrol_edge(staff, adjac_x, adjac_y))
+            continue;
+
+        /* Adjacent tile is inside the patrol zone but not on the
+         * patrol zone edge. */
+        total++;
+
+        /* Check if path has an edge in adjac_dir */
+        if (!(path->properties.path.edges & (1u << adjac_dir)))
+        {
+            continue;
+        }
+
+        if (footpath_element_is_sloped(path)) {
+            if (footpath_element_get_slope_direction(path) == adjac_dir) {
+                adjac_z = z + 2;
+            }
+        }
+
+        /* Search through all adjacent map elements */
+        rct_map_element *test_element = map_get_first_element_at(adjac_x / 32, adjac_y / 32);
+        bool pathfound = false;
+        bool widefound = false;
+        do {
+            if (map_element_get_type(test_element) != MAP_ELEMENT_TYPE_PATH)
+            {
+                continue;
+            }
+
+            /* test_element is a path */
+            if (!is_valid_path_z_and_direction(test_element, adjac_z, adjac_dir)) continue;
+
+            /* test_element is a connected path */
+            if (!pathfound)
+            {
+                pathfound = true;
+                pathcount++;
+            }
+
+            if (footpath_element_is_wide(test_element))
+            {
+                if (!widefound)
+                {
+                    widefound = true;
+                    widecount++;
+                }
+            }
+        } while (!map_element_is_last_for_tile(test_element++));
+    }
+
+    switch (total)
+    {
+        case 0: /* Concave corner */
+            return 1;
+            break;
+        case 1: /* Straight side */
+        case 2: /* Convex corner */
+            if (pathcount <= total - 1 || widecount == total)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
+            }
+            break;
+        default:
+            return 0;
+    }
 }
 
 /**

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -623,7 +623,6 @@ sint32 staff_is_location_in_patrol(rct_peep *staff, sint32 x, sint32 y)
     return staff_is_location_in_patrol_area(staff, x, y);
 }
 
-
 sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
 {
 	// Check whether the location x,y is inside and on the edge of the
@@ -638,6 +637,7 @@ sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
 	}
 	return onZoneEdge;
 }
+
 /**
  *
  *  rct2: 0x006C095B

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -623,6 +623,21 @@ sint32 staff_is_location_in_patrol(rct_peep *staff, sint32 x, sint32 y)
     return staff_is_location_in_patrol_area(staff, x, y);
 }
 
+
+sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y)
+{
+	// Check whether the location x,y is inside and on the edge of the
+	// patrol zone for mechanic.
+	sint32 onZoneEdge = 0;
+	int neighbourDir = 0;
+	while (!onZoneEdge && neighbourDir <= 7) {
+		int neighbourX = x + TileDirectionDelta[neighbourDir].x;
+		int neighbourY = y + TileDirectionDelta[neighbourDir].y;
+		onZoneEdge = !staff_is_location_in_patrol(mechanic, neighbourX, neighbourY);
+		neighbourDir++;
+	}
+	return onZoneEdge;
+}
 /**
  *
  *  rct2: 0x006C095B

--- a/src/openrct2/peep/staff.h
+++ b/src/openrct2/peep/staff.h
@@ -85,6 +85,7 @@ uint16 hire_new_staff_member(uint8 staffType);
 void staff_update_greyed_patrol_areas();
 sint32 staff_is_location_in_patrol(rct_peep *mechanic, sint32 x, sint32 y);
 sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y);
+sint32 staff_can_ignore_wide_flag(rct_peep *mechanic, sint32 x, sint32 y, uint8 z, rct_map_element *path);
 sint32 staff_path_finding(rct_peep* peep);
 void staff_reset_stats();
 bool staff_is_patrol_area_set(sint32 staffIndex, sint32 x, sint32 y);

--- a/src/openrct2/peep/staff.h
+++ b/src/openrct2/peep/staff.h
@@ -84,6 +84,7 @@ void update_staff_colour(uint8 staffType, uint16 colour);
 uint16 hire_new_staff_member(uint8 staffType);
 void staff_update_greyed_patrol_areas();
 sint32 staff_is_location_in_patrol(rct_peep *mechanic, sint32 x, sint32 y);
+sint32 staff_is_location_on_patrol_edge(rct_peep *mechanic, sint32 x, sint32 y);
 sint32 staff_path_finding(rct_peep* peep);
 void staff_reset_stats();
 bool staff_is_patrol_area_set(sint32 staffIndex, sint32 x, sint32 y);

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -1454,9 +1454,9 @@ void footpath_chain_ride_queue(sint32 rideIndex, sint32 entranceIndex, sint32 x,
 
     if (rideIndex != 255 && lastPathElement != NULL) {
         if (footpath_element_is_queue(lastPathElement)) {
-            lastPathElement->properties.path.type |= (1 << 3);
-            lastPathElement->type &= 0x3F;
-            lastPathElement->type |= lastPathDirection << 6;
+            lastPathElement->properties.path.type |= (1 << 3); // Set the ride sign flag
+            lastPathElement->type &= 0x3F; // Clear the ride sign direction
+            lastPathElement->type |= lastPathDirection << 6; // set the ride sign direction
 
             map_animation_create(
                 MAP_ANIMATION_TYPE_QUEUE_BANNER,


### PR DESCRIPTION
This is a better alternative to #5424 and #5429.
With this fix, the heuristic allow mechanics to walk onto tiles on the patrol edge with the wide flag set, but does not otherwise change the wide flag for the rest of the heuristic which was causing serious problems in some cases in #5424 and #5429.

Reverts #5424 and #5429; re-Fixes #5414 and fixes the remaining issues discussed in #5429.

Mechanics could still get stuck with some path layouts due to wide flags interacting badly with their patrol zone.

Requires new network version.