### PR TITLE
Fix #4748: No way to see owned rights after #4701

### DIFF
--- a/src/openrct2/windows/land_rights.c
+++ b/src/openrct2/windows/land_rights.c
@@ -114,10 +114,16 @@ void window_land_rights_open()
 	gWaterToolLowerCost = MONEY32_UNDEFINED;
 
 	show_land_rights();
+	
+	if (gLandRemainingConstructionSales == 0) {
+		show_construction_rights();
+	}
 }
 
 static void window_land_rights_close(rct_window *w)
 {
+	hide_construction_rights();
+	
 	// If the tool wasn't changed, turn tool off
 	if (land_rights_tool_is_active())
 		tool_cancel();

--- a/src/openrct2/windows/park.c
+++ b/src/openrct2/windows/park.c
@@ -1035,15 +1035,6 @@ static void window_park_entrance_invalidate(rct_window *w)
 		window_park_entrance_widgets[i].bottom = height + 23;
 		height += 24;
 	}
-
-	// Disable land rights button if there's no more construction/ownership for sale
-	if (gLandRemainingOwnershipSales == 0 && gLandRemainingConstructionSales == 0) {
-		w->disabled_widgets |= (1 << WIDX_BUY_LAND_RIGHTS);
-		window_park_entrance_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_NO_LAND_OR_CONSTRUCTION_RIGHTS_FOR_SALE_TIP;
-	} else {
-		w->disabled_widgets &= ~(1 << WIDX_BUY_LAND_RIGHTS);
-		window_park_entrance_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_BUY_LAND_AND_CONSTRUCTION_RIGHTS_TIP;
-	}
 }
 
 /**


### PR DESCRIPTION
This partially reverts #4701 - the land rights button in the park window will always be visible, and if no construction rights are available to buy, all owned rights will be displayed.