### PR TITLE
Fix #5449: Underflow of gNumGuestsHeadingForPark in SC4 import

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1419,9 +1419,11 @@ private:
 
         if (dst->type == PEEP_TYPE_GUEST)
         {
-            if (dst->outside_of_park && !(dst->state == PEEP_STATE_LEAVING_PARK)) {
+            if (dst->outside_of_park && !(dst->state == PEEP_STATE_LEAVING_PARK))
+            {
                 gNumGuestsHeadingForPark++;
-            } else {
+            } else
+            {
                 gNumGuestsInPark++;
             }
         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1419,7 +1419,7 @@ private:
 
         if (dst->type == PEEP_TYPE_GUEST)
         {
-            if (dst->outside_of_park && !(dst->state == PEEP_STATE_LEAVING_PARK))
+            if (dst->outside_of_park && dst->state != PEEP_STATE_LEAVING_PARK)
             {
                 gNumGuestsHeadingForPark++;
             }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1417,9 +1417,13 @@ private:
 
         peep_update_name_sort(dst);
 
-        if (!dst->outside_of_park && dst->type == PEEP_TYPE_GUEST)
+        if (dst->type == PEEP_TYPE_GUEST)
         {
-            gNumGuestsInPark++;
+            if (dst->outside_of_park && !(dst->state == PEEP_STATE_LEAVING_PARK)) {
+                gNumGuestsHeadingForPark++;
+            } else {
+                gNumGuestsInPark++;
+            }
         }
     }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1422,7 +1422,8 @@ private:
             if (dst->outside_of_park && !(dst->state == PEEP_STATE_LEAVING_PARK))
             {
                 gNumGuestsHeadingForPark++;
-            } else
+            }
+            else
             {
                 gNumGuestsInPark++;
             }


### PR DESCRIPTION
gNumGuestsHeadingForPark wasn't being set during SC4 import. Therefore, when the game decremented the value when guests entered the park, it underflowed, causing major issues with guest generation.

(I'm assuming this doesn't need a network version increment as the only change is at import time?)