### PR TITLE
Fix #5456: Paths with non-ASCII characters mishandled on macOS

### DIFF
--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -133,6 +133,15 @@ utf8 *platform_open_directory_browser(const utf8 *title)
 	}
 }
 
+utf8* macos_str_decomp_to_precomp(utf8 *input)
+{
+	@autoreleasepool
+	{
+		NSString *inputDecomp = [NSString stringWithUTF8String:input];
+		return strdup([inputDecomp.precomposedStringWithCanonicalMapping cStringUsingEncoding:NSUTF8StringEncoding]);
+	}
+}
+
 bool platform_open_common_file_dialog(utf8 *outFilename, file_dialog_desc *desc, size_t outSize) {
 	@autoreleasepool
 	{

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -240,6 +240,7 @@ void core_init();
 
 #ifdef __MACOSX__
 	void macos_disallow_automatic_window_tabbing();
+	utf8* macos_str_decomp_to_precomp();
 #endif
 
 // On macOS the resizing behaviour effectively resizes the window in the same

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -117,7 +117,7 @@ void platform_get_time_local(rct2_time *out_time)
 static size_t platform_utf8_to_multibyte(const utf8 *path, char *buffer, size_t buffer_size)
 {
 	wchar_t *wpath = utf8_to_widechar(path);
-	setlocale(LC_CTYPE, "");
+	setlocale(LC_CTYPE, "UTF-8");
 	size_t len = wcstombs(NULL, wpath, 0);
 	bool truncated = false;
 	if (len > buffer_size - 1) {

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -1966,7 +1966,11 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 			w->x + window_options_misc_widgets[WIDX_WINDOW_LIMIT].left + 1,
 			w->y + window_options_misc_widgets[WIDX_WINDOW_LIMIT].top
 		);
-		set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
+		#ifdef __MACOSX__
+			set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));
+		#else
+			set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
+		#endif
 		gfx_draw_string_left_clipped(
 			dpi,
 			STR_STRING,


### PR DESCRIPTION
(#5456)

This ensures that UTF-8 strings are properly handled as such in `platform_utf8_to_multibyte()`, and also introduces a new function - `macos_str_decomp_to_precomp()` in `platform/macos.m` to ensure such strings are properly displayed in the UI (macOS generally uses decomposed Unicode strings in contrast to Windows/Linux, which uses precomposed strings).