### PR TITLE
Set correct base height for newly inserted corrupt elements

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/tile_inspector.c
+++ b/src/openrct2/world/tile_inspector.c
@@ -83,7 +83,7 @@ sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex,
 		corruptElement->type = MAP_ELEMENT_TYPE_CORRUPT;
 
 		// Set the base height to be the same as the selected element
-		rct_map_element *const selectedElement = map_get_nth_element_at(x, y, elementIndex);
+		rct_map_element *const selectedElement = map_get_nth_element_at(x, y, elementIndex + 1);
 		if (!selectedElement) {
 			return MONEY32_UNDEFINED;
 		}


### PR DESCRIPTION
When inserting a corrupt element, its base height was not set to the next element's. As a result when building something above the corrupt element and below the hidden element, the hidden one would be revealed, and the newly build element would be hidden instead. This PR prevents that behaviour by clamping the corrupt element to the element that is going to be hidden.