### PR TITLE
Fix #5470: Available construction rights only displays once

### DIFF
--- a/src/openrct2/windows/land_rights.c
+++ b/src/openrct2/windows/land_rights.c
@@ -122,7 +122,9 @@ void window_land_rights_open()
 
 static void window_land_rights_close(rct_window *w)
 {
-	hide_construction_rights();
+	if (gLandRemainingConstructionSales == 0) {
+		hide_construction_rights();
+	}
 	
 	// If the tool wasn't changed, turn tool off
 	if (land_rights_tool_is_active())


### PR DESCRIPTION
Somehow managed to forget to add a condition around `hide_construction_rights();` in `window_land_rights_close()` when fixing #4748.