### PR TITLE
Set 'Show all files' on by default

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -16,6 +16,7 @@
     <OutDir>$(SolutionDir)bin\</OutDir>
     <IntDir>$(SolutionDir)obj\$(ProjectName)\$(Configuration)_$(Platform)\</IntDir>
     <TargetName>$(ProjectName)</TargetName>
+    <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
This way when someone new opens the solution for the first time, they will see the folder structure in the solution explorer, instead of one long list. The .vcxproj.user file will still overrides this setting.