### PR TITLE
Add heightmap file browser support for bmp

### DIFF
--- a/src/openrct2/windows/loadsave.c
+++ b/src/openrct2/windows/loadsave.c
@@ -284,7 +284,7 @@ static bool browse(bool isSave, char *path, size_t pathSize)
 	case LOADSAVETYPE_IMAGE:
 		title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
 		desc.filters[0].name = language_get_string(STR_OPENRCT2_HEIGHTMAP_FILE);
-		desc.filters[0].pattern = "*.jpg;*.png";
+		desc.filters[0].pattern = "*.jpg;*.png;*.bmp";
 		break;
 	}
 


### PR DESCRIPTION
Upon playing with the heightmap tool, i realized that the feature actually supports bmp files as well, and they are even listed in the in-game load/save dialog, but they are not shown when using a native file browser. This fixes that.