### PR TITLE
Fix #5471: Ride name issues at ride construction time

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5773,14 +5773,12 @@ static bool ride_name_exists(char *name)
 	char buffer[256];
 	rct_ride *ride;
 	sint32 i;
-
 	FOR_ALL_RIDES(i, ride) {
 		format_string(buffer, 256, ride->name, &ride->name_arguments);
-		if (strcmp(buffer, name) == 0) {
+		if ((strcmp(buffer, name) == 0) && ride_has_any_track_elements(i)) {
 			return true;
 		}
 	}
-
 	return false;
 }
 
@@ -6000,7 +5998,7 @@ foundRideEntry:
 		ride->name = 1;
 		ride->name_arguments_type_name = rideEntry->name;
 		rct_string_id rideNameStringId = 0;
-		name_args.type_name = 2 + ride->type;
+		name_args.type_name = rideEntry->name;
 		name_args.number = 0;
 
 		do {


### PR DESCRIPTION
This PR ensures that in-construction rides with no extant track do not 'claim' ride names, and fixes a regression that led to track names being used rather than ride names.(#5471 points 2 and 3)