### PR TITLE
Fix #5489: Sprite index crash when viewing cars on Car Ride

### DIFF
--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1834,7 +1834,9 @@ static void window_ride_init_viewport(rct_window *w)
 		rct_ride_entry* ride_entry = get_ride_entry_by_ride(ride);
 		if (ride_entry && ride_entry->tab_vehicle != 0){
 			rct_vehicle* vehicle = GET_VEHICLE(focus.sprite.sprite_id);
-			focus.sprite.sprite_id = vehicle->next_vehicle_on_train;
+			if (vehicle->next_vehicle_on_train < countof(ride_entry->vehicles)) {
+				focus.sprite.sprite_id = vehicle->next_vehicle_on_train;
+			}
 		}
 		focus.sprite.type |= 0xC0;
 	}


### PR DESCRIPTION
This PR adds a guard in `window_ride_init_viewport()` to prevent the `sprite_id` being set to `vehicle->next_vehicle_on_train` when that value is larger than the number of vehicles available.

There may be a bug in the SC4 importer which leads to this, might be worth @Gymnasiast taking a quick look?