### PR TITLE
Fix - Trim invalid land size when setting land ownership

### DIFF
--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -1800,10 +1800,10 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
 		return 0;
 
 	// Clamp to maximum addressable element to prevent long loop spamming the log
-	x1 = clamp(0, x1, gMapSizeUnits);
-	y1 = clamp(0, y1, gMapSizeUnits);
-	x2 = min(x2, gMapSizeUnits);
-	y2 = min(y2, gMapSizeUnits);
+	x1 = clamp(32, x1, gMapSizeUnits - 32);
+	y1 = clamp(32, y1, gMapSizeUnits - 32);
+	x2 = clamp(32, x2, gMapSizeUnits - 32);
+	y2 = clamp(32, y2, gMapSizeUnits - 32);
 	gUnk9E2E28 = 0;
 	map_buy_land_rights(x1, y1, x2, y2, 6, flags | (newOwnership << 8));
 
@@ -1811,8 +1811,8 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
 		return 0;
 	}
 
-	sint16 x = clamp(0, x1, gMapSizeUnits);
-	sint16 y = clamp(0, y1, gMapSizeUnits);
+	sint16 x = clamp(32, x1, gMapSizeUnits - 32);
+	sint16 y = clamp(32, y1, gMapSizeUnits - 32);
 
 	x += 16;
 	y += 16;


### PR DESCRIPTION
When creating a new sandbox scenario, you may naturally want to own all of the land, so you might set the land tool size to 64 and spastically brush the entire map zoomed out (or it might just be me that does this). When you do this, setting some of the sides will cancel out if it's larger than the map or overlapping the map boundaries. This fixes that by cropping the coordinates down to the actual map unit size. I discovered this problem when creating the functionality for my other PR cheat Own All Land.