### PR TITLE
Guard against null pointer in macos_str_decomp_to_precomp()

### DIFF
--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -137,6 +137,10 @@ utf8* macos_str_decomp_to_precomp(utf8 *input)
 {
 	@autoreleasepool
 	{
+		if (input == NULL) {
+			return NULL;
+		}
+
 		NSString *inputDecomp = [NSString stringWithUTF8String:input];
 		return strdup([inputDecomp.precomposedStringWithCanonicalMapping cStringUsingEncoding:NSUTF8StringEncoding]);
 	}


### PR DESCRIPTION
If a user on macOS doesn't have an RCT1 path set (e.g. setting up a new instance of the game - as I just was!), `macos_str_decomp_to_precomp()` gets fed a null pointer and blows up. This guards against that.

I'll also fix this on the no-SDL branch.