### PR TITLE
Fix #3178: Precompose file name strings on macOS to prevent mojibake when displayed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.0.8 (in development)
 ------------------------------------------------------------------------
+- Fix: [#3178, #5456] Paths with non-ASCII characters not handled properly on macOS.
 - Fix: [#3681] Steel Twister rollercoaster always shows all track designs
 - Fix: Track components added by OpenRCT2 are now usable in older scenarios.
 

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -392,9 +392,9 @@ sint32 platform_enumerate_files_begin(const utf8 *pattern)
 				safe_strcat_path(paths[idx], d->d_name, path_len);
 				log_verbose("paths[%d] = %s", idx, paths[idx]);
 
-				// macOS uses decomposed Unicode strings (e.g. an 'e' and a combining accent) in filenames
-				// This causes problems with the sprite font, as the font only contains precomposed characters
-				// The block below converts all filename strings to their precomposed form, preventing mojibake
+// macOS uses decomposed Unicode strings (e.g. an 'e' and a combining accent) in filenames
+// This causes problems with the sprite font, as the font only contains precomposed characters
+// The block below converts all filename strings to their precomposed form, preventing mojibake
 #ifdef __MACOSX__
 				utf8* precomp_path = macos_str_decomp_to_precomp(paths[idx]);
 				size_t precomp_len = sizeof(utf8) * min(MAX_PATH, strnlen(precomp_path, MAX_PATH) + 2);

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -393,7 +393,11 @@ sint32 platform_enumerate_files_begin(const utf8 *pattern)
 				log_verbose("paths[%d] = %s", idx, paths[idx]);
 
 				#ifdef __MACOSX__
-					paths[idx] = macos_str_decomp_to_precomp(paths[idx]);
+					utf8* precomp_path = macos_str_decomp_to_precomp(paths[idx]);
+					size_t precomp_len = sizeof(utf8) * min(MAX_PATH, strnlen(precomp_path, MAX_PATH) + 2);
+					paths[idx] = malloc(precomp_len);
+					safe_strcpy(paths[idx], precomp_path, precomp_len);
+					log_verbose("macOS decomp-to-precomp fix - paths[%d] = %s", idx, paths[idx]);
 				#endif
 			}
 			enumFileInfo->handle = 0;

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -392,6 +392,9 @@ sint32 platform_enumerate_files_begin(const utf8 *pattern)
 				safe_strcat_path(paths[idx], d->d_name, path_len);
 				log_verbose("paths[%d] = %s", idx, paths[idx]);
 
+				// macOS uses decomposed Unicode strings (e.g. an 'e' and a combining accent) in filenames
+				// This causes problems with the sprite font, as the font only contains precomposed characters
+				// The block below converts all filename strings to their precomposed form, preventing mojibake
 				#ifdef __MACOSX__
 					utf8* precomp_path = macos_str_decomp_to_precomp(paths[idx]);
 					size_t precomp_len = sizeof(utf8) * min(MAX_PATH, strnlen(precomp_path, MAX_PATH) + 2);

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -391,6 +391,10 @@ sint32 platform_enumerate_files_begin(const utf8 *pattern)
 				safe_strcpy(paths[idx], dir_name, path_len);
 				safe_strcat_path(paths[idx], d->d_name, path_len);
 				log_verbose("paths[%d] = %s", idx, paths[idx]);
+
+				#ifdef __MACOSX__
+					paths[idx] = macos_str_decomp_to_precomp(paths[idx]);
+				#endif
 			}
 			enumFileInfo->handle = 0;
 			enumFileInfo->active = 1;

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -395,13 +395,13 @@ sint32 platform_enumerate_files_begin(const utf8 *pattern)
 				// macOS uses decomposed Unicode strings (e.g. an 'e' and a combining accent) in filenames
 				// This causes problems with the sprite font, as the font only contains precomposed characters
 				// The block below converts all filename strings to their precomposed form, preventing mojibake
-				#ifdef __MACOSX__
-					utf8* precomp_path = macos_str_decomp_to_precomp(paths[idx]);
-					size_t precomp_len = sizeof(utf8) * min(MAX_PATH, strnlen(precomp_path, MAX_PATH) + 2);
-					paths[idx] = malloc(precomp_len);
-					safe_strcpy(paths[idx], precomp_path, precomp_len);
-					log_verbose("macOS decomp-to-precomp fix - paths[%d] = %s", idx, paths[idx]);
-				#endif
+#ifdef __MACOSX__
+				utf8* precomp_path = macos_str_decomp_to_precomp(paths[idx]);
+				size_t precomp_len = sizeof(utf8) * min(MAX_PATH, strnlen(precomp_path, MAX_PATH) + 2);
+				paths[idx] = malloc(precomp_len);
+				safe_strcpy(paths[idx], precomp_path, precomp_len);
+				log_verbose("macOS decomp-to-precomp fix - paths[%d] = %s", idx, paths[idx]);
+#endif
 			}
 			enumFileInfo->handle = 0;
 			enumFileInfo->active = 1;
@@ -809,12 +809,12 @@ time_t platform_file_get_modified_time(const utf8* path){
 }
 
 uint8 platform_get_locale_temperature_format(){
-	// LC_MEASUREMENT is GNU specific.
-	#ifdef LC_MEASUREMENT
+// LC_MEASUREMENT is GNU specific.
+#ifdef LC_MEASUREMENT
 	const char *langstring = setlocale(LC_MEASUREMENT, "");
-	#else
+#else
 	const char *langstring = setlocale(LC_ALL, "");
-	#endif
+#endif
 
 	if(langstring != NULL){
 		if (!fnmatch("*_US*", langstring, 0) ||


### PR DESCRIPTION
Fixes #3178.