### PR TITLE
Don't flash the white frame around network status windows

### DIFF
--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -1168,7 +1168,7 @@ rct_window *window_bring_to_front(rct_window *w)
 	return w;
 }
 
-rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16_t flags)
+rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16 flags)
 {
 	rct_window* w;
 

--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -1168,18 +1168,23 @@ rct_window *window_bring_to_front(rct_window *w)
 	return w;
 }
 
-rct_window *window_bring_to_front_by_class(rct_windowclass cls)
+rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16_t flags)
 {
 	rct_window* w;
 
 	w = window_find_by_class(cls);
 	if (w != NULL) {
-		w->flags |= WF_WHITE_BORDER_MASK;
+		w->flags |= flags;
 		window_invalidate(w);
 		w = window_bring_to_front(w);
 	}
 
 	return w;
+}
+
+rct_window *window_bring_to_front_by_class(rct_windowclass cls)
+{
+	return window_bring_to_front_by_class_with_flags(cls, WF_WHITE_BORDER_MASK);
 }
 
 /**

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -633,6 +633,7 @@ sint32 window_get_scroll_data_index(rct_window *w, rct_widgetindex widget_index)
 
 rct_window *window_bring_to_front(rct_window *w);
 rct_window *window_bring_to_front_by_class(rct_windowclass cls);
+rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16_t flags);
 rct_window *window_bring_to_front_by_number(rct_windowclass cls, rct_windownumber number);
 
 void window_push_others_right(rct_window *w);

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -633,7 +633,7 @@ sint32 window_get_scroll_data_index(rct_window *w, rct_widgetindex widget_index)
 
 rct_window *window_bring_to_front(rct_window *w);
 rct_window *window_bring_to_front_by_class(rct_windowclass cls);
-rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16_t flags);
+rct_window *window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16 flags);
 rct_window *window_bring_to_front_by_number(rct_windowclass cls, rct_windownumber number);
 
 void window_push_others_right(rct_window *w);

--- a/src/openrct2/windows/network_status.c
+++ b/src/openrct2/windows/network_status.c
@@ -84,7 +84,7 @@ void window_network_status_open(const char* text, close_callback onClose)
 	safe_strcpy(window_network_status_text, text, sizeof(window_network_status_text));
 
 	// Check if window is already open
-	rct_window *window = window_bring_to_front_by_class(WC_NETWORK_STATUS);
+	rct_window *window = window_bring_to_front_by_class_with_flags(WC_NETWORK_STATUS, 0);
 	if (window != NULL)
 		return;
 


### PR DESCRIPTION
This commit turns off the white border for all network status windows. This is
mostly evident when downloading a map from the server before starting a
multiplayer game, as the window is repeatedly brought to the front with a white
border. This results in needlessly flashing the border, since
window_network_status_open is called for every chunk of data received from the
network socket.