### PR TITLE
Fix #5511: Backspace behaves inconsistently in track manager

### DIFF
--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -811,8 +811,6 @@ rct_window *window_find_by_number(rct_windowclass cls, rct_windownumber number)
 void window_close_top()
 {
 	rct_window* w;
-	bool window_is_track_list;
-
 	window_close_by_class(WC_DROPDOWN);
 
 	if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
@@ -821,17 +819,7 @@ void window_close_top()
 
 	for (w = RCT2_NEW_WINDOW - 1; w >= g_window_list; w--) {
 		if (!(w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))) {
-			window_is_track_list = (w->classification == WC_TRACK_DESIGN_LIST);
 			window_close(w);
-
-			if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) {
-				if (window_is_track_list) {
-					window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
-					window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
-					trackmanager_load();
-				}
-			}
-
 			return;
 		}
 	}

--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -811,6 +811,7 @@ rct_window *window_find_by_number(rct_windowclass cls, rct_windownumber number)
 void window_close_top()
 {
 	rct_window* w;
+	bool window_is_track_list;
 
 	window_close_by_class(WC_DROPDOWN);
 
@@ -820,7 +821,17 @@ void window_close_top()
 
 	for (w = RCT2_NEW_WINDOW - 1; w >= g_window_list; w--) {
 		if (!(w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))) {
+			window_is_track_list = (w->classification == WC_TRACK_DESIGN_LIST);
 			window_close(w);
+
+			if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) {
+				if (window_is_track_list) {
+					window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
+					window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
+					trackmanager_load();
+				}
+			}
+
 			return;
 		}
 	}

--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -811,6 +811,7 @@ rct_window *window_find_by_number(rct_windowclass cls, rct_windownumber number)
 void window_close_top()
 {
 	rct_window* w;
+
 	window_close_by_class(WC_DROPDOWN);
 
 	if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)

--- a/src/openrct2/windows/track_list.c
+++ b/src/openrct2/windows/track_list.c
@@ -265,7 +265,7 @@ static void window_track_list_mouseup(rct_window *w, rct_widgetindex widgetIndex
 		break;
 	case WIDX_BACK:
 		window_close(w);
-		if (gScreenFlags | SCREEN_FLAGS_TRACK_MANAGER) {
+		if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
 			window_new_ride_open();
 		}
 		break;

--- a/src/openrct2/windows/track_list.c
+++ b/src/openrct2/windows/track_list.c
@@ -174,6 +174,17 @@ static void window_track_list_close(rct_window *w)
 	}
 	SafeFree(_trackDesigns);
 	_trackDesignsCount = 0;
+
+	// If gScreenAge is zero, we're already in the process
+	// of loading the track manager, so we shouldn't try
+	// to do it again. Otherwise, this window will get
+	// another close signal from the track manager load function,
+	// try to load the track manager again, and an infinite loop will result.
+	if (gScreenAge != 0){
+		window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
+		window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
+		trackmanager_load();
+	}
 }
 
 /**
@@ -241,11 +252,6 @@ static void window_track_list_mouseup(rct_window *w, rct_widgetindex widgetIndex
 	switch (widgetIndex) {
 	case WIDX_CLOSE:
 		window_close(w);
-		if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) {
-			window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
-			window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
-			trackmanager_load();
-		}
 		break;
 	case WIDX_ROTATE:
 		_currentTrackPieceDirection++;
@@ -259,11 +265,7 @@ static void window_track_list_mouseup(rct_window *w, rct_widgetindex widgetIndex
 		break;
 	case WIDX_BACK:
 		window_close(w);
-		if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) {
-			window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
-			window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
-			trackmanager_load();
-		} else {
+		if (gScreenFlags | SCREEN_FLAGS_TRACK_MANAGER) {
 			window_new_ride_open();
 		}
 		break;

--- a/src/openrct2/windows/track_list.c
+++ b/src/openrct2/windows/track_list.c
@@ -180,7 +180,7 @@ static void window_track_list_close(rct_window *w)
 	// to do it again. Otherwise, this window will get
 	// another close signal from the track manager load function,
 	// try to load the track manager again, and an infinite loop will result.
-	if (gScreenAge != 0){
+	if ((gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && gScreenAge != 0){
 		window_close_by_number(WC_MANAGE_TRACK_DESIGN, w->number);
 		window_close_by_number(WC_TRACK_DELETE_PROMPT, w->number);
 		trackmanager_load();


### PR DESCRIPTION
This does the same check as in `window_track_list_mouseup()` when closing a track list window, to ensure that the main track manager window is loaded if the user is in track manager mode.

I don't like the idea of copy-paste code in multiple areas - I did try to include the relevant check in a function, but couldn't make it work. Open to suggestions!