### PR TITLE
Fix #5537: SDL_Init(SDL_INIT_VIDEO) is called even when using --headless

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -432,6 +432,8 @@
 		F76C888D1EC5324E00FA49E2 /* UiContext.Linux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C85AE1EC4E82600FA49E2 /* UiContext.Linux.cpp */; };
 		F76C888E1EC5324E00FA49E2 /* UiContext.Win32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C85AF1EC4E82600FA49E2 /* UiContext.Win32.cpp */; };
 		F76C88921EC539A300FA49E2 /* libopenrct2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F76C809A1EC4D9FA00FA49E2 /* libopenrct2.a */; };
+		F775F5341EE35A6B001F00E7 /* DummyUiContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */; };
+		F775F5351EE35A89001F00E7 /* DummyUiContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */; };
 		F7D7747B1EC5EB6D00BE6EBC /* lay_down_roller_coaster.c in Sources */ = {isa = PBXBuildFile; fileRef = F76C84951EC4E7CC00FA49E2 /* lay_down_roller_coaster.c */; };
 		F7D7747F1EC61E5100BE6EBC /* UiContext.macOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7D7747E1EC61E5100BE6EBC /* UiContext.macOS.mm */; };
 		F7D7748D1EC66F8600BE6EBC /* libopenrct2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F76C809A1EC4D9FA00FA49E2 /* libopenrct2.a */; };
@@ -1319,6 +1321,8 @@
 		F76C85AD1EC4E82600FA49E2 /* UiContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UiContext.h; sourceTree = "<group>"; };
 		F76C85AE1EC4E82600FA49E2 /* UiContext.Linux.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UiContext.Linux.cpp; sourceTree = "<group>"; };
 		F76C85AF1EC4E82600FA49E2 /* UiContext.Win32.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UiContext.Win32.cpp; sourceTree = "<group>"; };
+		F775F5321EE35A48001F00E7 /* Ui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ui.h; sourceTree = "<group>"; };
+		F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DummyUiContext.cpp; sourceTree = "<group>"; };
 		F7D7747E1EC61E5100BE6EBC /* UiContext.macOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UiContext.macOS.mm; sourceTree = "<group>"; usesTabs = 0; };
 		F7D774841EC66CD700BE6EBC /* OpenRCT2-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "OpenRCT2-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -2325,6 +2329,7 @@
 		F76C85041EC4E7CD00FA49E2 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */,
 				F76C85051EC4E7CD00FA49E2 /* UiContext.h */,
 			);
 			path = ui;
@@ -2476,6 +2481,7 @@
 		F76C85801EC4E82600FA49E2 /* openrct2-ui */ = {
 			isa = PBXGroup;
 			children = (
+				F775F5321EE35A48001F00E7 /* Ui.h */,
 				F76C85811EC4E82600FA49E2 /* audio */,
 				F76C858D1EC4E82600FA49E2 /* drawing */,
 				F76C858A1EC4E82600FA49E2 /* CursorData.cpp */,
@@ -2915,6 +2921,7 @@
 				F76C887D1EC5324E00FA49E2 /* CursorData.cpp in Sources */,
 				F7D7747F1EC61E5100BE6EBC /* UiContext.macOS.mm in Sources */,
 				F76C887E1EC5324E00FA49E2 /* CursorRepository.cpp in Sources */,
+				F775F5341EE35A6B001F00E7 /* DummyUiContext.cpp in Sources */,
 				F76C887F1EC5324E00FA49E2 /* CopyFramebufferShader.cpp in Sources */,
 				F76C88801EC5324E00FA49E2 /* DrawImageShader.cpp in Sources */,
 				F76C88811EC5324E00FA49E2 /* DrawLineShader.cpp in Sources */,
@@ -2938,6 +2945,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F775F5351EE35A89001F00E7 /* DummyUiContext.cpp in Sources */,
 				F7D7747B1EC5EB6D00BE6EBC /* lay_down_roller_coaster.c in Sources */,
 				F76C85B01EC4E88300FA49E2 /* audio.cpp in Sources */,
 				F76C85B41EC4E88300FA49E2 /* AudioMixer.cpp in Sources */,

--- a/src/openrct2-dll/openrct2-dll.cpp
+++ b/src/openrct2-dll/openrct2-dll.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2-ui/audio/AudioContext.h>
+#include <openrct2-ui/Ui.h>
 #include <openrct2-ui/UiContext.h>
 
 using namespace OpenRCT2;
@@ -36,25 +37,6 @@ using namespace OpenRCT2::Ui;
 static char * * GetCommandLineArgs(int argc, wchar_t * * argvW);
 static void FreeCommandLineArgs(int argc, char * * argv);
 static char * ConvertUTF16toUTF8(const wchar_t * src);
-
-static int NormalisedMain(int argc, char * * argv)
-{
-    core_init();
-    int runGame = cmdline_run((const char * *)argv, argc);
-    if (runGame == 1)
-    {
-        IAudioContext * audioContext = CreateAudioContext();
-        IUiContext * uiContext = CreateUiContext();
-        IContext * context = CreateContext(audioContext, uiContext);
-
-        context->RunOpenRCT2(argc, argv);
-
-        delete context;
-        delete uiContext;
-        delete audioContext;
-    }
-    return gExitCode;
-}
 
 DLLEXPORT int LaunchOpenRCT2(int argc, wchar_t * * argvW)
 {

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -14,13 +14,12 @@
 *****************************************************************************/
 #pragma endregion
 
-#ifndef _MSC_VER
-
 #include <openrct2/audio/AudioContext.h>
 #include <openrct2/Context.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ui/UiContext.h>
 #include "audio/AudioContext.h"
+#include "Ui.h"
 #include "UiContext.h"
 
 using namespace OpenRCT2;
@@ -30,7 +29,11 @@ using namespace OpenRCT2::Ui;
 /**
  * Main entry point for non-Windows sytems. Windows instead uses its own DLL proxy.
  */
+#ifdef _MSC_VER
+int NormalisedMain(int argc, char * * argv)
+#else
 int main(int argc, char * * argv)
+#endif
 {
     core_init();
     int runGame = cmdline_run((const char * *)argv, argc);
@@ -38,7 +41,7 @@ int main(int argc, char * * argv)
     {
         // Run OpenRCT2 with a UI context
         IAudioContext * audioContext = CreateAudioContext();
-        IUiContext * uiContext = CreateUiContext();
+        IUiContext * uiContext = gOpenRCT2Headless ? CreateDummyUiContext() : CreateUiContext();
         IContext * context = CreateContext(audioContext, uiContext);
 
         context->RunOpenRCT2(argc, argv);
@@ -49,5 +52,3 @@ int main(int argc, char * * argv)
     }
     return gExitCode;
 }
-
-#endif

--- a/src/openrct2-ui/Ui.h
+++ b/src/openrct2-ui/Ui.h
@@ -1,0 +1,19 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+*
+* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+* For more information, visit https://github.com/OpenRCT2/OpenRCT2
+*
+* OpenRCT2 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* A full copy of the GNU General Public License can be found in licence.txt
+*****************************************************************************/
+#pragma endregion
+
+#ifdef _MSC_VER
+    int NormalisedMain(int argc, char * * argv);
+#endif

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -64,6 +64,7 @@
     <ClInclude Include="drawing\engines\opengl\TextureCache.h" />
     <ClInclude Include="SDLException.h" />
     <ClInclude Include="TextComposition.h" />
+    <ClInclude Include="Ui.h" />
     <ClInclude Include="UiContext.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -338,31 +338,34 @@ void game_update()
 
 	gGameCommandNestLevel = 0;
 
-	input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
+	if (!gOpenRCT2Headless)
+	{
+		input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
 
-	// the flickering frequency is reduced by 4, compared to the original
-	// it was done due to inability to reproduce original frequency
-	// and decision that the original one looks too fast
-	if (gCurrentTicks % 4 == 0)
-		gWindowMapFlashingFlags ^= (1 << 15);
+		// the flickering frequency is reduced by 4, compared to the original
+		// it was done due to inability to reproduce original frequency
+		// and decision that the original one looks too fast
+		if (gCurrentTicks % 4 == 0)
+			gWindowMapFlashingFlags ^= (1 << 15);
 
-	// Handle guest map flashing
-	gWindowMapFlashingFlags &= ~(1 << 1);
-	if (gWindowMapFlashingFlags & (1 << 0))
-		gWindowMapFlashingFlags |= (1 << 1);
-	gWindowMapFlashingFlags &= ~(1 << 0);
+		// Handle guest map flashing
+		gWindowMapFlashingFlags &= ~(1 << 1);
+		if (gWindowMapFlashingFlags & (1 << 0))
+			gWindowMapFlashingFlags |= (1 << 1);
+		gWindowMapFlashingFlags &= ~(1 << 0);
 
-	// Handle staff map flashing
-	gWindowMapFlashingFlags &= ~(1 << 3);
-	if (gWindowMapFlashingFlags & (1 << 2))
-		gWindowMapFlashingFlags |= (1 << 3);
-	gWindowMapFlashingFlags &= ~(1 << 2);
+		// Handle staff map flashing
+		gWindowMapFlashingFlags &= ~(1 << 3);
+		if (gWindowMapFlashingFlags & (1 << 2))
+			gWindowMapFlashingFlags |= (1 << 3);
+		gWindowMapFlashingFlags &= ~(1 << 2);
 
-	window_map_tooltip_update_visibility();
+		window_map_tooltip_update_visibility();
 
-	// Input
-	gUnk141F568 = gUnk13CA740;
-	game_handle_input();
+		// Input
+		gUnk141F568 = gUnk13CA740;
+		game_handle_input();
+	}
 }
 
 void game_logic_update()
@@ -915,8 +918,11 @@ void game_load_init()
 
 	load_palette();
 	gfx_invalidate_screen();
-	window_tile_inspector_clear_clipboard();
-	window_update_all();
+
+	if (!gOpenRCT2Headless) {
+		window_tile_inspector_clear_clipboard();
+		window_update_all();
+	}
 
 	gGameSpeed = 1;
 }

--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1470,6 +1470,10 @@ void game_handle_keyboard_input()
 	rct_window *w;
 	sint32 key;
 
+	if (gOpenRCT2Headless) {
+		return;
+	}
+
 	if (!gConsoleOpen) {
 		// Handle mouse scrolling
 		if (_inputState == INPUT_STATE_NORMAL && gConfigGeneral.edge_scrolling) {

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -1,0 +1,68 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+*
+* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+* For more information, visit https://github.com/OpenRCT2/OpenRCT2
+*
+* OpenRCT2 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* A full copy of the GNU General Public License can be found in licence.txt
+*****************************************************************************/
+#pragma endregion
+
+#include "UiContext.h"
+
+namespace OpenRCT2 { namespace Ui
+{
+    /**
+    * Represents the window or screen that OpenRCT2 is presented on.
+    */
+    class DummyUiContext final : public IUiContext
+    {
+        void CreateWindow() override { }
+        void CloseWindow() override { }
+        SDL_Window * GetWindow() override { return nullptr; }
+        sint32 GetWidth() override { return 0; }
+        sint32 GetHeight() override { return 0; }
+        void SetFullscreenMode(FULLSCREEN_MODE mode) override { }
+        std::vector<Resolution> GetFullscreenResolutions() override { return std::vector<Resolution>(); }
+        bool HasFocus() override { return false; }
+        bool IsMinimised() override { return false; }
+        bool IsSteamOverlayActive() override { return false; }
+        void ProcessMessages() override { }
+        void TriggerResize() override { }
+
+        virtual void ShowMessageBox(const std::string &message) override { }
+        virtual std::string ShowFileDialog(const FileDialogDesc &desc) override { return std::string(); }
+        virtual std::string ShowDirectoryDialog(const std::string &title) override { return std::string(); }
+
+        // Input
+        virtual const CursorState * GetCursorState() override { return nullptr; }
+        virtual CURSOR_ID GetCursor() override { return CURSOR_ARROW; }
+        virtual void SetCursor(CURSOR_ID cursor) override { }
+        virtual void SetCursorVisible(bool value) override { }
+        virtual void GetCursorPosition(sint32 * x, sint32 * y) override { }
+        virtual void SetCursorPosition(sint32 x, sint32 y) override { }
+        virtual void SetCursorTrap(bool value) override { }
+        virtual const uint8 * GetKeysState() override { return nullptr; }
+        virtual const uint8 * GetKeysPressed() override { return nullptr; }
+        virtual void SetKeysPressed(uint32 keysym, uint8 scancode) override { }
+
+        // Drawing
+        virtual Drawing::IDrawingEngine * CreateDrawingEngine(Drawing::DRAWING_ENGINE_TYPE type) override { return nullptr; }
+
+        // Text input
+        virtual bool IsTextInputActive() override { return false; }
+        virtual TextInputSession * StartTextInput(utf8 * buffer, size_t bufferSize) override { return nullptr; }
+        virtual void StopTextInput() override { }
+    };
+
+    IUiContext * CreateDummyUiContext()
+    {
+        return new DummyUiContext();
+    }
+} }

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -129,5 +129,7 @@ namespace OpenRCT2
             virtual TextInputSession *  StartTextInput(utf8 * buffer, size_t bufferSize) abstract;
             virtual void                StopTextInput() abstract;
         };
+
+        IUiContext * CreateDummyUiContext();
     }
 }


### PR DESCRIPTION
Create a dummy UI context and use that if headless is enabled. Some extra guards added to deal with the return values from the dummy class. It may be temporary until the window and input code is moved to openrct2ui.