### PR TITLE
Fix openrct2-cli build

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -434,6 +434,8 @@
 		F76C88921EC539A300FA49E2 /* libopenrct2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F76C809A1EC4D9FA00FA49E2 /* libopenrct2.a */; };
 		F775F5341EE35A6B001F00E7 /* DummyUiContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */; };
 		F775F5351EE35A89001F00E7 /* DummyUiContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */; };
+		F775F5371EE3724F001F00E7 /* DummyAudioContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5361EE3724F001F00E7 /* DummyAudioContext.cpp */; };
+		F775F5381EE3725C001F00E7 /* DummyAudioContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5361EE3724F001F00E7 /* DummyAudioContext.cpp */; };
 		F7D7747B1EC5EB6D00BE6EBC /* lay_down_roller_coaster.c in Sources */ = {isa = PBXBuildFile; fileRef = F76C84951EC4E7CC00FA49E2 /* lay_down_roller_coaster.c */; };
 		F7D7747F1EC61E5100BE6EBC /* UiContext.macOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7D7747E1EC61E5100BE6EBC /* UiContext.macOS.mm */; };
 		F7D7748D1EC66F8600BE6EBC /* libopenrct2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F76C809A1EC4D9FA00FA49E2 /* libopenrct2.a */; };
@@ -1323,6 +1325,7 @@
 		F76C85AF1EC4E82600FA49E2 /* UiContext.Win32.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UiContext.Win32.cpp; sourceTree = "<group>"; };
 		F775F5321EE35A48001F00E7 /* Ui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ui.h; sourceTree = "<group>"; };
 		F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DummyUiContext.cpp; sourceTree = "<group>"; };
+		F775F5361EE3724F001F00E7 /* DummyAudioContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DummyAudioContext.cpp; sourceTree = "<group>"; };
 		F7D7747E1EC61E5100BE6EBC /* UiContext.macOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UiContext.macOS.mm; sourceTree = "<group>"; usesTabs = 0; };
 		F7D774841EC66CD700BE6EBC /* OpenRCT2-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "OpenRCT2-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1768,6 +1771,7 @@
 		F76C83561EC4E7CC00FA49E2 /* audio */ = {
 			isa = PBXGroup;
 			children = (
+				F775F5361EE3724F001F00E7 /* DummyAudioContext.cpp */,
 				F76C83571EC4E7CC00FA49E2 /* audio.cpp */,
 				F76C83581EC4E7CC00FA49E2 /* audio.h */,
 				F76C83591EC4E7CC00FA49E2 /* AudioChannel.h */,
@@ -2924,6 +2928,7 @@
 				F775F5341EE35A6B001F00E7 /* DummyUiContext.cpp in Sources */,
 				F76C887F1EC5324E00FA49E2 /* CopyFramebufferShader.cpp in Sources */,
 				F76C88801EC5324E00FA49E2 /* DrawImageShader.cpp in Sources */,
+				F775F5371EE3724F001F00E7 /* DummyAudioContext.cpp in Sources */,
 				F76C88811EC5324E00FA49E2 /* DrawLineShader.cpp in Sources */,
 				F76C88821EC5324E00FA49E2 /* FillRectShader.cpp in Sources */,
 				F76C88831EC5324E00FA49E2 /* OpenGLAPI.cpp in Sources */,
@@ -2945,6 +2950,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F775F5381EE3725C001F00E7 /* DummyAudioContext.cpp in Sources */,
 				F775F5351EE35A89001F00E7 /* DummyUiContext.cpp in Sources */,
 				F7D7747B1EC5EB6D00BE6EBC /* lay_down_roller_coaster.c in Sources */,
 				F76C85B01EC4E88300FA49E2 /* audio.cpp in Sources */,

--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <openrct2/Context.h>
+#include <openrct2/OpenRCT2.h>
 
 using namespace OpenRCT2;
 
@@ -23,8 +24,16 @@ using namespace OpenRCT2;
 */
 int main(int argc, char * * argv)
 {
-    IContext * context = CreateContext();
-    int exitCode = context->RunOpenRCT2(argc, argv);
-    delete context;
-    return exitCode;
+    core_init();
+    int runGame = cmdline_run((const char * *)argv, argc);
+    if (runGame == 1)
+    {
+        gOpenRCT2Headless = true;
+
+        // Run OpenRCT2 with a plain context
+        auto context = CreateContext();
+        context->RunOpenRCT2(argc, argv);
+        delete context;
+    }
+    return gExitCode;
 }

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -39,16 +39,26 @@ int main(int argc, char * * argv)
     int runGame = cmdline_run((const char * *)argv, argc);
     if (runGame == 1)
     {
-        // Run OpenRCT2 with a UI context
-        IAudioContext * audioContext = CreateAudioContext();
-        IUiContext * uiContext = gOpenRCT2Headless ? CreateDummyUiContext() : CreateUiContext();
-        IContext * context = CreateContext(audioContext, uiContext);
+        if (gOpenRCT2Headless)
+        {
+            // Run OpenRCT2 with a plain context
+            auto context = CreateContext();
+            context->RunOpenRCT2(argc, argv);
+            delete context;
+        }
+        else
+        {
+            // Run OpenRCT2 with a UI context
+            auto audioContext = CreateAudioContext();
+            auto uiContext = CreateUiContext();
+            auto context = CreateContext(audioContext, uiContext);
 
-        context->RunOpenRCT2(argc, argv);
+            context->RunOpenRCT2(argc, argv);
 
-        delete context;
-        delete uiContext;
-        delete audioContext;
+            delete context;
+            delete uiContext;
+            delete audioContext;
+        }
     }
     return gExitCode;
 }

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -80,6 +80,8 @@ namespace OpenRCT2
         virtual Ui::IUiContext *        GetUiContext() abstract;
 
         virtual sint32 RunOpenRCT2(int argc, char * * argv) abstract;
+
+        virtual bool Initialise() abstract;
         virtual void Finish() abstract;
     };
 

--- a/src/openrct2/audio/AudioContext.h
+++ b/src/openrct2/audio/AudioContext.h
@@ -60,5 +60,7 @@ namespace OpenRCT2
             virtual void StopTitleMusic() abstract;
             virtual void StopVehicleSounds() abstract;
         };
+
+        IAudioContext * CreateDummyAudioContext();
     }
 }

--- a/src/openrct2/audio/AudioMixer.cpp
+++ b/src/openrct2/audio/AudioMixer.cpp
@@ -59,16 +59,19 @@ void * Mixer_Play_Effect(size_t id, sint32 loop, sint32 volume, float pan, doubl
         else
         {
             IAudioMixer * mixer = GetMixer();
-            mixer->Lock();
-            IAudioSource * source = mixer->GetSoundSource((sint32)id);
-            channel = mixer->Play(source, loop, deleteondone != 0, false);
-            if (channel != nullptr)
+            if (mixer != nullptr)
             {
-                channel->SetVolume(volume);
-                channel->SetPan(pan);
-                channel->SetRate(rate);
+                mixer->Lock();
+                IAudioSource * source = mixer->GetSoundSource((sint32)id);
+                channel = mixer->Play(source, loop, deleteondone != 0, false);
+                if (channel != nullptr)
+                {
+                    channel->SetVolume(volume);
+                    channel->SetPan(pan);
+                    channel->SetRate(rate);
+                }
+                mixer->Unlock();
             }
-            mixer->Unlock();
         }
     }
     return channel;

--- a/src/openrct2/audio/DummyAudioContext.cpp
+++ b/src/openrct2/audio/DummyAudioContext.cpp
@@ -1,0 +1,52 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+*
+* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+* For more information, visit https://github.com/OpenRCT2/OpenRCT2
+*
+* OpenRCT2 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* A full copy of the GNU General Public License can be found in licence.txt
+*****************************************************************************/
+#pragma endregion
+
+#include "AudioContext.h"
+
+namespace OpenRCT2 { namespace Audio
+{
+    class DummyAudioContext final : public IAudioContext
+    {
+        IAudioMixer * GetMixer() override { return nullptr; }
+
+        std::vector<std::string> GetOutputDevices() override { return std::vector<std::string>(); }
+        void SetOutputDevice(const std::string &deviceName) override { }
+
+        IAudioSource * CreateStreamFromWAV(const std::string &path) override { return nullptr; }
+
+        void StartTitleMusic() override { }
+
+        IAudioChannel * PlaySound(sint32 soundId, sint32 volume, sint32 pan) override { return nullptr; }
+        IAudioChannel * PlaySoundAtLocation(sint32 soundId, sint16 x, sint16 y, sint16 z) override { return nullptr; }
+        IAudioChannel * PlaySoundPanned(sint32 soundId, sint32 pan, sint16 x, sint16 y, sint16 z) override { return nullptr; }
+
+        void ToggleAllSounds() override { }
+        void PauseSounds() override { }
+        void UnpauseSounds() override { }
+
+        void StopAll() override { }
+        void StopCrowdSound() override { }
+        void StopRainSound() override { }
+        void StopRideMusic() override { }
+        void StopTitleMusic() override { }
+        void StopVehicleSounds() override { }
+    };
+
+    IAudioContext * CreateDummyAudioContext()
+    {
+        return new DummyAudioContext();
+    }
+} }

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -210,13 +210,19 @@ uint8 platform_get_currency_value(const char *currCode) {
 
 void core_init()
 {
-	bitcount_init();
-	
+	static bool initialised = false;
+	if (!initialised)
+	{
+		initialised = true;
+
+		bitcount_init();
+
 #if defined(__APPLE__) && (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200)
-	kern_return_t ret = mach_timebase_info(&_mach_base_info);
-	if (ret != 0) {
-		log_fatal("Unable to get mach_timebase_info.");
-		exit(-1);
-	}
+		kern_return_t ret = mach_timebase_info(&_mach_base_info);
+		if (ret != 0) {
+			log_fatal("Unable to get mach_timebase_info.");
+			exit(-1);
+		}
 #endif
+	}
 }


### PR DESCRIPTION
By using a dummy audio context, we can now make openrct2-cli start a headless instance without any SDL2 calls. SDL2 is still a dependency until we remove out the input code to openrct2-ui.