### PR TITLE
Select previous element after removing in tile inspector

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
I would like if @Broxzier looked at this and decide if it's how he would prefer to approach this, but the idea is that the tile inspector would select the item that is in the list after removing, rather than how the current effect is, where when you remove an item it no longer has anything selected. this would help with deleting multiple stuff in a single tile.