### PR TITLE
Fix #4959: Compiler warning: tmpnam

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -226,9 +226,8 @@ if (NOT DISABLE_TTF AND UNIX AND NOT APPLE)
     target_include_directories(${PROJECT} PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
 endif ()
 
-# macOS builds fail on the use of tmpnam otherwise (#4959)
 if(APPLE)
-    set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -Wno-error=deprecated-declarations -Wno-error=objc-method-access")
+    set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -Wno-error=objc-method-access")
 endif()
 
 # Compiler flags

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -71,6 +71,8 @@ bool TryClassifyFile(IStream * stream, ClassifiedFile * result)
 
 static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result)
 {
+    bool success = false;
+    uint64 originalPosition = stream->GetPosition();
     try
     {
         auto chunkReader = SawyerChunkReader(stream);
@@ -84,12 +86,13 @@ static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result)
             result->Type = FILE_TYPE::SCENARIO;
         }
         result->Version = s6Header.version;
-        return true;
+        success = true;
     }
     catch (Exception)
     {
     }
-    return false;
+    stream->SetPosition(originalPosition);
+    return success;
 }
 
 static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result)

--- a/src/openrct2/network/http.h
+++ b/src/openrct2/network/http.h
@@ -60,8 +60,14 @@ void http_request_dispose(http_response_t *response);
 
 const char *http_get_extension_from_url(const char *url, const char *fallback);
 
-// Padding for extension that is appended to temporary file name
-bool http_download_park(const char *url, char tmpPath[L_tmpnam + 10]);
+/**
+ * Download a park via HTTP/S from the given URL into a memory buffer. This is
+ * a blocking operation.
+ * @param url The URL to download the park from.
+ * @param outData The data returned.
+ * @returns The size of the data or 0 if the download failed.
+ */
+size_t http_download_park(const char * url, void * * outData);
 #endif // DISABLE_HTTP
 
 // These callbacks are defined anyway, but are dummy if HTTP is disabled


### PR DESCRIPTION
Load download parks directly from memory without writing to a temporary file.