### PR TITLE
Rename gUnk9E2E28 to gMapLandRightsUpdateSuccess

### DIFF
--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -127,7 +127,7 @@ uint16 gLandRemainingConstructionSales;
 
 rct_xyz16 gCommandPosition;
 
-uint8 gMapLandRightsUpdateSuccess;
+bool gMapLandRightsUpdateSuccess;
 
 static void map_update_grass_length(sint32 x, sint32 y, rct_map_element *mapElement);
 static void map_set_grass_length(sint32 x, sint32 y, rct_map_element *mapElement, sint32 length);
@@ -1805,12 +1805,11 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
     y1 = clamp(32, y1, gMapSizeUnits - 32);
     x2 = clamp(32, x2, gMapSizeUnits - 32);
     y2 = clamp(32, y2, gMapSizeUnits - 32);
-	gMapLandRightsUpdateSuccess = 0;
+    gMapLandRightsUpdateSuccess = false;
     map_buy_land_rights(x1, y1, x2, y2, 6, flags | (newOwnership << 8));
 
-    if (!(gMapLandRightsUpdateSuccess & 1)) {
+    if (!gMapLandRightsUpdateSuccess)
         return 0;
-    }
 
     sint16 x = clamp(32, x1, gMapSizeUnits - 32);
     sint16 y = clamp(32, y1, gMapSizeUnits - 32);

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -127,7 +127,7 @@ uint16 gLandRemainingConstructionSales;
 
 rct_xyz16 gCommandPosition;
 
-uint8 gUnk9E2E28;
+uint8 gMapLandRightsUpdateSuccess;
 
 static void map_update_grass_length(sint32 x, sint32 y, rct_map_element *mapElement);
 static void map_set_grass_length(sint32 x, sint32 y, rct_map_element *mapElement, sint32 length);
@@ -1805,10 +1805,10 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
     y1 = clamp(32, y1, gMapSizeUnits - 32);
     x2 = clamp(32, x2, gMapSizeUnits - 32);
     y2 = clamp(32, y2, gMapSizeUnits - 32);
-    gUnk9E2E28 = 0;
+	gMapLandRightsUpdateSuccess = 0;
     map_buy_land_rights(x1, y1, x2, y2, 6, flags | (newOwnership << 8));
 
-    if (!(gUnk9E2E28 & 1)) {
+    if (!(gMapLandRightsUpdateSuccess & 1)) {
         return 0;
     }
 

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -410,7 +410,7 @@ extern uint16 gLandRemainingConstructionSales;
 
 extern rct_xyz16 gCommandPosition;
 
-extern uint8 gUnk9E2E28;
+extern uint8 gMapLandRightsUpdateSuccess;
 
 void map_init(sint32 size);
 void map_count_remaining_land_rights();

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -410,7 +410,7 @@ extern uint16 gLandRemainingConstructionSales;
 
 extern rct_xyz16 gCommandPosition;
 
-extern uint8 gMapLandRightsUpdateSuccess;
+extern bool gMapLandRightsUpdateSuccess;
 
 void map_init(sint32 size);
 void map_count_remaining_land_rights();

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -977,7 +977,7 @@ static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, 
         surfaceElement->properties.surface.ownership &= 0x0F;
         surfaceElement->properties.surface.ownership |= newOwnership;
         update_park_fences_around_tile(x, y);
-		gMapLandRightsUpdateSuccess |= 1;
+        gMapLandRightsUpdateSuccess = true;
         return 0;
     }
 }

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -977,7 +977,7 @@ static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, 
         surfaceElement->properties.surface.ownership &= 0x0F;
         surfaceElement->properties.surface.ownership |= newOwnership;
         update_park_fences_around_tile(x, y);
-        gUnk9E2E28 |= 1;
+		gMapLandRightsUpdateSuccess |= 1;
         return 0;
     }
 }


### PR DESCRIPTION
Checking the code this function seems to be set to 0 before map_buy_land_rights is called, and set to 1 if it succeeds. I'm not sure if the name is appropriate enough, but it's one less unknown variable. If anyone has a better name suggestion, i'm all for it.