### PR TITLE
Fix #5571: Crash when deleting text at end of line

### DIFF
--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -288,7 +288,9 @@ void TextComposition::Delete()
     utf8 * buffer = _session.Buffer;
     utf8 * targetShiftPtr = buffer + _session.SelectionStart;
     utf8 * sourceShiftPtr = targetShiftPtr + _session.SelectionSize;
-    size_t shiftSize = _session.Size - (_session.SelectionStart - _session.SelectionSize + 1);
+
+    // std::min() is used to ensure that shiftSize doesn't underflow; it should be between 0 and _session.Size
+    size_t shiftSize = _session.Size - std::min(_session.Size, (_session.SelectionStart - _session.SelectionSize + 1));
     memmove(targetShiftPtr, sourceShiftPtr, shiftSize);
     _session.SelectionSize = 0;
     RecalculateLength();


### PR DESCRIPTION
Interestingly the overflow that caused this bug happens on all platforms, but only caused a crash on Windows.