### PR TITLE
Implement persistent 'real names of guests' setting

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4411,6 +4411,7 @@ STR_6099    :You connected to the server.
 STR_6100    :You disconnected from the server.
 STR_6101    :Rides don't decrease in value over time
 STR_6102    :{SMALLFONT}{BLACK}The value of a ride won't decrease over time, so guests will not suddenly think that a ride is too expensive.
+STR_6103    :{SMALLFONT}{BLACK}This option is disabled during network play.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#5056] Add cheat to own all land.
 - Feature: [#5133] Add option to display guest expenditure (as seen in RCTC).
 - Feature: [#5196] Add cheat to disable ride ageing.
+- Feature: [#5576] Add a persistent 'display real names of guests' setting.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#3178, #5456] Paths with non-ASCII characters not handled properly on macOS.

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -203,7 +203,7 @@ namespace Config
             model->render_weather_effects = reader->GetBoolean("render_weather_effects", true);
             model->render_weather_gloom = reader->GetBoolean("render_weather_gloom", true);
             model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
-			model->show_real_names_of_guests = reader->GetBoolean("show_real_names_of_guests", true);
+            model->show_real_names_of_guests = reader->GetBoolean("show_real_names_of_guests", true);
         }
     }
 
@@ -273,7 +273,7 @@ namespace Config
         writer->WriteBoolean("render_weather_effects", model->render_weather_effects);
         writer->WriteBoolean("render_weather_gloom", model->render_weather_gloom);
         writer->WriteBoolean("show_guest_purchases", model->show_guest_purchases);
-		writer->WriteBoolean("show_real_names_of_guests", model->show_real_names_of_guests);
+        writer->WriteBoolean("show_real_names_of_guests", model->show_real_names_of_guests);
     }
 
     static void ReadInterface(IIniReader * reader)

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -203,6 +203,7 @@ namespace Config
             model->render_weather_effects = reader->GetBoolean("render_weather_effects", true);
             model->render_weather_gloom = reader->GetBoolean("render_weather_gloom", true);
             model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
+			model->show_real_names_of_guests = reader->GetBoolean("show_real_names_of_guests", true);
         }
     }
 
@@ -272,6 +273,7 @@ namespace Config
         writer->WriteBoolean("render_weather_effects", model->render_weather_effects);
         writer->WriteBoolean("render_weather_gloom", model->render_weather_gloom);
         writer->WriteBoolean("show_guest_purchases", model->show_guest_purchases);
+		writer->WriteBoolean("show_real_names_of_guests", model->show_real_names_of_guests);
     }
 
     static void ReadInterface(IIniReader * reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -86,6 +86,7 @@ typedef struct GeneralConfiguration
     bool        scenario_unlocking_enabled;
     bool        scenario_hide_mega_park;
     bool        steam_overlay_pause;
+	bool		show_real_names_of_guests;
 
     bool        confirmation_prompt;
     sint32      load_save_sort;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -86,7 +86,7 @@ typedef struct GeneralConfiguration
     bool        scenario_unlocking_enabled;
     bool        scenario_hide_mega_park;
     bool        steam_overlay_pause;
-	bool		show_real_names_of_guests;
+    bool        show_real_names_of_guests;
 
     bool        confirmation_prompt;
     sint32      load_save_sort;

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1109,6 +1109,9 @@ bool game_load_save(const utf8 *path)
         if (network_get_mode() == NETWORK_MODE_SERVER) {
             network_send_map();
         }
+
+		peep_update_names(gConfigGeneral.show_real_names_of_guests);
+
         return true;
     } else {
         // If loading the SV6 or SV4 failed, the current park state will be corrupted

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1110,6 +1110,8 @@ bool game_load_save(const utf8 *path)
             network_send_map();
         }
 
+		// This ensures that the newly loaded save reflects the user's
+		// 'show real names of guests' option, now that it's a global setting
 		peep_update_names(gConfigGeneral.show_real_names_of_guests);
 
         return true;

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1110,9 +1110,9 @@ bool game_load_save(const utf8 *path)
             network_send_map();
         }
 
-		// This ensures that the newly loaded save reflects the user's
-		// 'show real names of guests' option, now that it's a global setting
-		peep_update_names(gConfigGeneral.show_real_names_of_guests);
+        // This ensures that the newly loaded save reflects the user's
+        // 'show real names of guests' option, now that it's a global setting
+        peep_update_names(gConfigGeneral.show_real_names_of_guests);
 
         return true;
     } else {

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3766,6 +3766,7 @@ enum {
     STR_LOG_CLIENT_STOPPED = 6100,
     STR_CHEAT_DISABLE_RIDE_VALUE_AGING = 6101,
     STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP = 6102,
+    STR_OPTION_DISABLED_DURING_NETWORK_PLAY = 6103,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1851,6 +1851,7 @@ bool Network::LoadMap(IStream * stream)
         gCheatsDisablePlantAging = stream->ReadValue<uint8>() != 0;
         gCheatsAllowArbitraryRideTypeChanges = stream->ReadValue<uint8>() != 0;
         gCheatsDisableRideValueAging = stream->ReadValue<uint8>() != 0;
+        gConfigGeneral.show_real_names_of_guests = stream->ReadValue<uint8>() != 0;
 
         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
         result = true;
@@ -1897,6 +1898,7 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
         stream->WriteValue<uint8>(gCheatsDisablePlantAging);
         stream->WriteValue<uint8>(gCheatsAllowArbitraryRideTypeChanges);
         stream->WriteValue<uint8>(gCheatsDisableRideValueAging);
+        stream->WriteValue<uint8>(gConfigGeneral.show_real_names_of_guests);
 
         result = true;
     }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -1141,21 +1141,21 @@ enum {
 };
 
 enum {
-    RCT1_PARK_FLAGS_PARK_OPEN =                     (1 << 0),
-    RCT1_PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT =  (1 << 1),
-    RCT1_PARK_FLAGS_FORBID_LANDSCAPE_CHANGES =      (1 << 2),
-    RCT1_PARK_FLAGS_FORBID_TREE_REMOVAL =           (1 << 3),
-    RCT1_PARK_FLAGS_SHOW_REAL_GUEST_NAMES =         (1 << 4),
-    RCT1_PARK_FLAGS_FORBID_HIGH_CONSTRUCTION =      (1 << 5),   // Below tree height
-    RCT1_PARK_FLAGS_PREF_LESS_INTENSE_RIDES =       (1 << 6),
-    RCT1_PARK_FLAGS_FORBID_MARKETING_CAMPAIGN =     (1 << 7),
-    RCT1_PARK_FLAGS_ANTI_CHEAT_DEPRECATED =         (1 << 8),   // Not used anymore, used for cheat detection
-    RCT1_PARK_FLAGS_PREF_MORE_INTENSE_RIDES =       (1 << 9),
-    RCT1_PARK_FLAGS_NO_MONEY =                      (1 << 11),  // Used for both scenarios and saved games, unlike RCT2
-    RCT1_PARK_FLAGS_DIFFICULT_GUEST_GENERATION =    (1 << 12),
-    RCT1_PARK_FLAGS_PARK_ENTRY_LOCKED_AT_FREE =     (1 << 13),  // Off: rides and park entry chargeable. On: only rides chargeable.
-    RCT1_PARK_FLAGS_DIFFICULT_PARK_RATING =         (1 << 14),
-    RCT1_PARK_FLAGS_LOCK_REAL_NAMES_OPTION =        (1 << 15),
+    RCT1_PARK_FLAGS_PARK_OPEN =                         (1 << 0),
+    RCT1_PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT =      (1 << 1),
+    RCT1_PARK_FLAGS_FORBID_LANDSCAPE_CHANGES =          (1 << 2),
+    RCT1_PARK_FLAGS_FORBID_TREE_REMOVAL =               (1 << 3),
+    RCT1_PARK_FLAGS_SHOW_REAL_GUEST_NAMES =             (1 << 4),
+    RCT1_PARK_FLAGS_FORBID_HIGH_CONSTRUCTION =          (1 << 5),   // Below tree height
+    RCT1_PARK_FLAGS_PREF_LESS_INTENSE_RIDES =           (1 << 6),
+    RCT1_PARK_FLAGS_FORBID_MARKETING_CAMPAIGN =         (1 << 7),
+    RCT1_PARK_FLAGS_ANTI_CHEAT_DEPRECATED =             (1 << 8),   // Not used anymore, used for cheat detection
+    RCT1_PARK_FLAGS_PREF_MORE_INTENSE_RIDES =           (1 << 9),
+    RCT1_PARK_FLAGS_NO_MONEY =                          (1 << 11),  // Used for both scenarios and saved games, unlike RCT2
+    RCT1_PARK_FLAGS_DIFFICULT_GUEST_GENERATION =        (1 << 12),
+    RCT1_PARK_FLAGS_PARK_ENTRY_LOCKED_AT_FREE =         (1 << 13),  // Off: rides and park entry chargeable. On: only rides chargeable.
+    RCT1_PARK_FLAGS_DIFFICULT_PARK_RATING =             (1 << 14),
+    RCT1_PARK_FLAGS_LOCK_REAL_NAMES_OPTION_DEPRECATED = (1 << 15),  // Deprecated now we use a persistent 'real names' setting
 };
 
 enum {

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -128,9 +128,9 @@ sint32 scenario_load_and_play_from_path(const char *path)
         network_close();
     }
 
-	// This ensures that the newly loaded scenario reflects the user's
-	// 'show real names of guests' option, now that it's a global setting
-	peep_update_names(gConfigGeneral.show_real_names_of_guests);
+    // This ensures that the newly loaded scenario reflects the user's
+    // 'show real names of guests' option, now that it's a global setting
+    peep_update_names(gConfigGeneral.show_real_names_of_guests);
 
     return 1;
 }

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -128,6 +128,10 @@ sint32 scenario_load_and_play_from_path(const char *path)
         network_close();
     }
 
+	// This ensures that the newly loaded scenario reflects the user's
+	// 'show real names of guests' option, now that it's a global setting
+	peep_update_names(gConfigGeneral.show_real_names_of_guests);
+
     return 1;
 }
 

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -1713,6 +1713,7 @@ static void window_options_invalidate(rct_window *w)
         // and the server cannot change the setting during gameplay to prevent desyncs
         if (network_get_mode() != NETWORK_MODE_NONE) {
             w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
+            window_options_misc_widgets[WIDX_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
         }
 
         w->hold_down_widgets |= (1 << WIDX_WINDOW_LIMIT_UP) | (1 << WIDX_WINDOW_LIMIT_DOWN);

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -1708,10 +1708,6 @@ static void window_options_invalidate(rct_window *w)
         break;
 
     case WINDOW_OPTIONS_PAGE_MISC:
-        // unknown park flag can disable real name checkbox
-        if (gParkFlags & PARK_FLAGS_LOCK_REAL_NAMES_OPTION)
-            w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
-
         w->hold_down_widgets |= (1 << WIDX_WINDOW_LIMIT_UP) | (1 << WIDX_WINDOW_LIMIT_DOWN);
 
         // save plugin data checkbox: visible or not

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -1710,7 +1710,8 @@ static void window_options_invalidate(rct_window *w)
 
     case WINDOW_OPTIONS_PAGE_MISC:
         // The real name setting of clients is fixed to that of the server
-        if (network_get_mode() == NETWORK_MODE_CLIENT) {
+        // and the server cannot change the setting during gameplay to prevent desyncs
+        if (network_get_mode() != NETWORK_MODE_NONE) {
             w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
         }
 

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -823,9 +823,10 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             window_invalidate(w);
             break;
         case WIDX_REAL_NAME_CHECKBOX:
-            peep_update_names(
-                !(gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
-            );
+			gConfigGeneral.show_real_names_of_guests ^= 1;
+			config_save_default();
+			window_invalidate(w);
+			peep_update_names(gConfigGeneral.show_real_names_of_guests);
             break;
         case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
             gConfigGeneral.save_plugin_data ^= 1;
@@ -1716,7 +1717,7 @@ static void window_options_invalidate(rct_window *w)
         // save plugin data checkbox: visible or not
         window_options_misc_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 
-        widget_set_checkbox_value(w, WIDX_REAL_NAME_CHECKBOX, gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES);
+        widget_set_checkbox_value(w, WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_guests);
         widget_set_checkbox_value(w, WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
         widget_set_checkbox_value(w, WIDX_TEST_UNFINISHED_TRACKS, gConfigGeneral.test_unfinished_tracks);
         widget_set_checkbox_value(w, WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.auto_staff_placement);

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -36,6 +36,7 @@
 #include "../localisation/date.h"
 #include "../localisation/language.h"
 #include "../localisation/localisation.h"
+#include "../network/network.h"
 #include "../platform/platform.h"
 #include "../rct2.h"
 #include "../sprites.h"
@@ -1708,6 +1709,11 @@ static void window_options_invalidate(rct_window *w)
         break;
 
     case WINDOW_OPTIONS_PAGE_MISC:
+        // The real name setting of clients is fixed to that of the server
+        if (network_get_mode() == NETWORK_MODE_CLIENT) {
+            w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
+        }
+
         w->hold_down_widgets |= (1 << WIDX_WINDOW_LIMIT_UP) | (1 << WIDX_WINDOW_LIMIT_DOWN);
 
         // save plugin data checkbox: visible or not

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -823,10 +823,10 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             window_invalidate(w);
             break;
         case WIDX_REAL_NAME_CHECKBOX:
-			gConfigGeneral.show_real_names_of_guests ^= 1;
-			config_save_default();
-			window_invalidate(w);
-			peep_update_names(gConfigGeneral.show_real_names_of_guests);
+            gConfigGeneral.show_real_names_of_guests ^= 1;
+            config_save_default();
+            window_invalidate(w);
+            peep_update_names(gConfigGeneral.show_real_names_of_guests);
             break;
         case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
             gConfigGeneral.save_plugin_data ^= 1;

--- a/src/openrct2/world/park.h
+++ b/src/openrct2/world/park.h
@@ -39,7 +39,7 @@ enum {
     PARK_FLAGS_DIFFICULT_GUEST_GENERATION = (1 << 12),
     PARK_FLAGS_PARK_FREE_ENTRY = (1 << 13),
     PARK_FLAGS_DIFFICULT_PARK_RATING = (1 << 14),
-    PARK_FLAGS_LOCK_REAL_NAMES_OPTION = (1 << 15),
+    PARK_FLAGS_LOCK_REAL_NAMES_OPTION_DEPRECATED = (1 << 15), // Deprecated now we use a persistent 'real names' setting
     PARK_FLAGS_NO_MONEY_SCENARIO = (1 << 17),  // equivalent to PARK_FLAGS_NO_MONEY, but used in scenario editor
     PARK_FLAGS_SPRITES_INITIALISED = (1 << 18), // After a scenario is loaded this prevents edits in the scenario editor
     PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19) // Not used anymore


### PR DESCRIPTION
This PR resolves #5576 and #3187 by implementing a persistent 'show real names of guests' setting. The setting in the save is now ignored and overriden by the user's global choice.

This also deprecates the `PARK_FLAGS_LOCK_REAL_NAMES_OPTION` flag, as it doesn't make sense to keep this in use as the setting is now persistent.