### PR TITLE
Fix various currently loaded map marker issues

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -71,6 +71,7 @@ bool gInUpdateCode = false;
 bool gInMapInitCode = false;
 sint32 gGameCommandNestLevel;
 bool gGameCommandIsNetworked;
+char gCurrentLoadedPath[MAX_PATH];
 
 uint8 gUnk13CA740;
 uint8 gUnk141F568;
@@ -1206,6 +1207,7 @@ void save_game()
         log_verbose("Saving to %s", gScenarioSavePath);
         if (scenario_save(gScenarioSavePath, 0x80000000 | (gConfigGeneral.save_plugin_data ? 1 : 0))) {
             log_verbose("Saved to %s", gScenarioSavePath);
+            safe_strcpy(gCurrentLoadedPath, gScenarioSavePath, MAX_PATH);
 
             // Setting screen age to zero, so no prompt will pop up when closing the
             // game shortly after saving.

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -150,6 +150,7 @@ extern bool gInUpdateCode;
 extern bool gInMapInitCode;
 extern sint32 gGameCommandNestLevel;
 extern bool gGameCommandIsNetworked;
+extern char gCurrentLoadedPath[260];
 
 extern uint8 gUnk13CA740;
 extern uint8 gUnk141F568;

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -87,6 +87,7 @@ void TitleScreen::Load()
 
     gScreenFlags = SCREEN_FLAGS_TITLE_DEMO;
     gScreenAge = 0;
+    gCurrentLoadedPath[0] = '\0';
 
     network_close();
     audio_stop_all_music_and_sounds();

--- a/src/openrct2/windows/LoadSave.cpp
+++ b/src/openrct2/windows/LoadSave.cpp
@@ -789,6 +789,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
     case (LOADSAVETYPE_LOAD | LOADSAVETYPE_LANDSCAPE) :
         save_path(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
         if (editor_load_landscape(pathBuffer)) {
+            safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             gfx_invalidate_screen();
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         } else {
@@ -801,6 +802,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
         save_path(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
         safe_strcpy(gScenarioFileName, pathBuffer, sizeof(gScenarioFileName));
         if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 3 : 2)) {
+            safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             window_close_by_class(WC_LOADSAVE);
             gfx_invalidate_screen();
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);

--- a/src/openrct2/windows/LoadSave.cpp
+++ b/src/openrct2/windows/LoadSave.cpp
@@ -705,7 +705,7 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
                 listItem->type = TYPE_FILE;
                 listItem->date_modified = platform_file_get_modified_time(listItem->path);
                 // Mark if file is the currently loaded game
-                listItem->loaded = strcmp(listItem->path, gScenarioSavePath) == 0;
+                listItem->loaded = strcmp(listItem->path, gCurrentLoadedPath) == 0;
 
                 // Remove the extension (but only the first extension token)
                 safe_strcpy(listItem->name, fileInfo.path, sizeof(listItem->name));
@@ -765,6 +765,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
     case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME) :
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
+        safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         window_close_by_class(WC_LOADSAVE);
         gfx_invalidate_screen();
@@ -773,6 +774,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 1 : 0)) {
             safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
+            safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             gFirstTimeSaving = false;
 
             window_close_by_class(WC_LOADSAVE);


### PR DESCRIPTION
The original implementation used gScenarioSavePath, which was used for storing the path to save to when using "save". There have been a few issues with this, such as not being able to mark scenario files when loaded and it not being reset when quitting the game (leading to the marker still showing it as being loaded, as also mentioned in #5584 ). This fixes those issues by using a variable that's seperate from gScenarioSavePath.

EDIT: 
There has been a bit of confusion on what this PR specifically fixes, so I've placed a few before and after videos showing bugs in the current code vs this pr

- Incorrect save games being marked when loading scenarios: 
- - [Before](http://i.imgur.com/wL2EhEi.gifv) | [After](http://i.imgur.com/3cyLeSG.gifv)
- Loaded games are still marked on title screen: 
- - [Before](http://i.imgur.com/YNzLcZW.gifv) | [After](http://i.imgur.com/0LLwt39.gifv)
- Loading scenarios from load game dialog not marked: 
- - [Before](http://i.imgur.com/VH5kOGp.gifv) | [After](http://i.imgur.com/c9Qo8ty.gifv)