### PR TITLE
Fix #5603: Game fails on startup

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -170,6 +170,12 @@ namespace OpenRCT2
                 config_save_default();
             }
 
+            if (!rct2_init_directories() || !rct2_startup_checks())
+            {
+                return false;
+            }
+            _env->SetBasePath(DIRBASE::RCT2, gRCT2AddressAppPath);
+
             if (!gOpenRCT2Headless)
             {
                 GetContext()->GetUiContext()->CreateWindow();

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -85,6 +85,11 @@ public:
         return std::string(path);
     }
 
+    void SetBasePath(DIRBASE base, const std::string &path) override
+    {
+        _basePath[(size_t)base] = path;
+    }
+
 private:
     static const char * DirectoryNamesRCT2[];
     static const char * DirectoryNamesOpenRCT2[];
@@ -113,25 +118,7 @@ IPlatformEnvironment * OpenRCT2::CreatePlatformEnvironment()
     config_set_defaults();
     if (!config_open_default())
     {
-        if (!config_find_or_browse_install_directory())
-        {
-            gConfigGeneral.last_run_version = String::Duplicate(OPENRCT2_VERSION);
-            config_save_default();
-            utf8 path[MAX_PATH];
-            config_get_default_path(path, sizeof(path));
-            Console::Error::WriteLine("An RCT2 install directory must be specified! Please edit \"game_path\" in %s.", path);
-            return nullptr;
-        }
         config_save_default();
-    }
-
-    if (!rct2_init_directories())
-    {
-        return nullptr;
-    }
-    if (!rct2_startup_checks())
-    {
-        return nullptr;
     }
 
     utf8 path[260];

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -73,6 +73,7 @@ namespace OpenRCT2
         virtual std::string GetDirectoryPath(DIRBASE base) const abstract;
         virtual std::string GetDirectoryPath(DIRBASE base, DIRID did) const abstract;
         virtual std::string GetFilePath(PATHID pathid) const abstract;
+        virtual void SetBasePath(DIRBASE base, const std::string &path) abstract;
     };
 
     IPlatformEnvironment * CreatePlatformEnvironment(DIRBASE_VALUES basePaths);

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -195,7 +195,7 @@ sint32 rct2_init_directories()
             if (!config_find_or_browse_install_directory()) {
                 utf8 path[MAX_PATH];
                 config_get_default_path(path, sizeof(path));
-                log_fatal("Invalid RCT2 installation path. Please correct \"game_path\" in %s.", path);
+                fprintf(stderr, "An RCT2 install directory must be specified! Please edit \"game_path\" in %s.\n", path);
                 return 0;
             }
         }


### PR DESCRIPTION
The game tries to use a ui context while setting up a platform environment. Let the platform environment be created before looking for the RCT2 directory. This is a bit hacky at the moment, but a necessary fix until it can be cleaned up.