### PR TITLE
rename sint32 gFirstTimeSave to bool gFirstTimeSaving + bug fix

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1083,6 +1083,8 @@ bool game_load_save(const utf8 *path)
     bool result = false;
     if (extension_type == FILE_EXTENSION_SV6) {
         result = game_load_sv6_path(path);
+        if (result)
+            gFirstTimeSaving = false;
     } else if (extension_type == FILE_EXTENSION_SV4) {
         result = rct1_load_saved_game(path);
         if (result)
@@ -1357,8 +1359,8 @@ bool game_load_save_or_scenario(const utf8 * path)
 
 static void game_load_or_quit_no_save_prompt_callback(sint32 result, const utf8 * path)
 {
-    if (result == MODAL_RESULT_OK && game_load_save_or_scenario(path)) {
-        gFirstTimeSaving = false;
+    if (result == MODAL_RESULT_OK) {
+        game_load_save_or_scenario(path);
     }
 }
 

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1086,7 +1086,7 @@ bool game_load_save(const utf8 *path)
     } else if (extension_type == FILE_EXTENSION_SV4) {
         result = rct1_load_saved_game(path);
         if (result)
-            gFirstTimeSave = 1;
+            gFirstTimeSaving = true;
     }
 
     if (result) {
@@ -1173,7 +1173,7 @@ void reset_all_sprite_quadrant_placements()
 
 void save_game()
 {
-    if (!gFirstTimeSave) {
+    if (!gFirstTimeSaving) {
         log_verbose("Saving to %s", gScenarioSavePath);
         if (scenario_save(gScenarioSavePath, 0x80000000 | (gConfigGeneral.save_plugin_data ? 1 : 0))) {
             log_verbose("Saved to %s", gScenarioSavePath);
@@ -1358,7 +1358,7 @@ bool game_load_save_or_scenario(const utf8 * path)
 static void game_load_or_quit_no_save_prompt_callback(sint32 result, const utf8 * path)
 {
     if (result == MODAL_RESULT_OK && game_load_save_or_scenario(path)) {
-        gFirstTimeSave = 0;
+        gFirstTimeSaving = false;
     }
 }
 
@@ -1386,7 +1386,7 @@ void game_load_or_quit_no_save_prompt()
             input_set_flag(INPUT_FLAG_5, false);
         }
         gGameSpeed = 1;
-        gFirstTimeSave = 1;
+        gFirstTimeSaving = true;
         title_load();
         break;
     default:

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1777,7 +1777,7 @@ void Network::Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& pa
             server_srand0_tick = 0;
             // window_network_status_open("Loaded new map from network");
             _desynchronised = false;
-            gFirstTimeSave = 1;
+            gFirstTimeSaving = true;
 
             // Notify user he is now online and which shortcut key enables chat
             network_chat_show_connected_message();

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -337,7 +337,7 @@ bool rct2_open_file(const char *path)
     if (_stricmp(extension, "sv6") == 0) {
         safe_strcpy((char*)gRCT2AddressSavedGamesPath2, path, sizeof(gRCT2AddressSavedGamesPath2));
         if (game_load_save(path)) {
-            gFirstTimeSave = 0;
+            gFirstTimeSaving = false;
             return true;
         }
     } else if (_stricmp(extension, "sc6") == 0) {

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -66,7 +66,7 @@ char gScenarioDetails[256];
 char gScenarioCompletedBy[32];
 char gScenarioSavePath[MAX_PATH];
 char gScenarioExpansionPacks[3256];
-sint32 gFirstTimeSave = 1;
+bool gFirstTimeSaving = true;
 uint16 gSavedAge;
 uint32 gLastAutoSaveUpdate = 0;
 
@@ -117,7 +117,7 @@ sint32 scenario_load_and_play_from_path(const char *path)
     }
     _scenarioFileName = path_get_filename(_scenarioPath);
 
-    gFirstTimeSave = 1;
+    gFirstTimeSaving = true;
 
     log_verbose("starting scenario, %s", path);
     scenario_begin();

--- a/src/openrct2/scenario/scenario.h
+++ b/src/openrct2/scenario/scenario.h
@@ -383,7 +383,7 @@ extern char gScenarioDetails[256];
 extern char gScenarioCompletedBy[32];
 extern char gScenarioSavePath[260];
 extern char gScenarioExpansionPacks[3256];
-extern sint32 gFirstTimeSave;
+extern bool gFirstTimeSaving;
 extern uint16 gSavedAge;
 extern uint32 gLastAutoSaveUpdate;
 

--- a/src/openrct2/windows/loadsave.c
+++ b/src/openrct2/windows/loadsave.c
@@ -761,7 +761,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 1 : 0)) {
             safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
-            gFirstTimeSave = 0;
+            gFirstTimeSaving = false;
 
             window_close_by_class(WC_LOADSAVE);
             gfx_invalidate_screen();


### PR DESCRIPTION
Because gFirstTimeSave sounds like it could mean either the first save has been executed or the user is saving for the first time, i have renamed it to gFirstTimeSaving for the sake of clarity*. 

In addition to that, I have moved a call to gFirstTimeSaving to the game_load_save(path) functionality. The call being in the callback function caused loading scenario files or sv4 files to be marked false, when only the sv6 files should be marked false. Setting gFirstTimeSaving should in general be something that should be initially set during the loading of the files anyway, and not reside in a dialog callback. I must have missed this back when i added the ability to load scenarios / s4 files from the in game load dialog.

*although i'm not sure how everyone feels about a present-tense terminology, i'm starting to feel weary about it myself.. it sounds like it could mean the user is currently saving for the first time, should i rename it to something like gIsNewGame ?