### PR TITLE
Don't use tabs in the Xcode project, fixes #5565

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -1639,7 +1639,7 @@
 				D497D0791C20FD52002BF46A /* Products */,
 			);
 			sourceTree = "<group>";
-			usesTabs = 1;
+			usesTabs = 0;
 		};
 		D497D0791C20FD52002BF46A /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
I initially addressed this in the Ride Groups PR, but that has ballooned and this change doesn't really belong in that PR either. So for the sake of getting this annoyance out of the way and making the ride groups PR less of a mess, I created this one.