### PR TITLE
Fix peep sounds persisting when paused

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -858,7 +858,6 @@ void pause_toggle()
     window_invalidate_by_class(WC_TOP_TOOLBAR);
     if (gGamePaused & GAME_PAUSED_NORMAL) {
         audio_pause_sounds();
-        audio_unpause_sounds();
     } else {
         audio_unpause_sounds();
     }


### PR DESCRIPTION
I noticed recently that peep crowd noises were playing even when the game is paused - this fixes that.