### PR TITLE
Clean up boosters, ride type indices and scenery IDs

### DIFF
--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1129,7 +1129,7 @@ static sint32 cc_load_object(const utf8 **argv, sint32 argc) {
 
             for (sint32 j = 0; j < MAX_RIDE_TYPES_PER_RIDE_ENTRY; j++) {
                 rideType = rideEntry->ride_type[j];
-                if (rideType != 255)
+                if (rideType != RIDE_TYPE_NULL)
                     research_insert(true, 0x10000 | (rideType << 8) | groupIndex, rideEntry->category[0]);
             }
 

--- a/src/openrct2/management/research.c
+++ b/src/openrct2/management/research.c
@@ -551,7 +551,7 @@ void research_populate_list_random()
         sint32 researched = (scenario_rand() & 0xFF) > 128;
         for (sint32 j = 0; j < MAX_RIDE_TYPES_PER_RIDE_ENTRY; j++) {
             sint32 rideType = rideEntry->ride_type[j];
-            if (rideType != 255)
+            if (rideType != RIDE_TYPE_NULL)
                 research_insert(researched, 0x10000 | (rideType << 8) | i, rideEntry->category[0]);
         }
     }
@@ -577,7 +577,7 @@ void research_populate_list_researched()
 
         for (sint32 j = 0; j < MAX_RIDE_TYPES_PER_RIDE_ENTRY; j++) {
             sint32 rideType = rideEntry->ride_type[j];
-            if (rideType != 255)
+            if (rideType != RIDE_TYPE_NULL)
                 research_insert(true, 0x10000 | (rideType << 8) | i, rideEntry->category[0]);
         }
     }
@@ -639,7 +639,7 @@ void research_insert_ride_entry(uint8 entryIndex, bool researched)
     uint8 category = rideEntry->category[0];
     for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++) {
         uint8 rideType = rideEntry->ride_type[i];
-        if (rideType != 255) {
+        if (rideType != RIDE_TYPE_NULL) {
             research_insert(researched, 0x10000 | (rideType << 8) | entryIndex, category);
         }
     }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -498,7 +498,7 @@ private:
             {
                 stream->WriteValue<uint8>(item.RideCategory[i]);
             }
-            for (sint32 i = 0; i < 3; i++)
+            for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++)
             {
                 stream->WriteValue<uint8>(item.RideType[i]);
             }

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -79,16 +79,10 @@ void RideObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_DESCRIPTION);
 
     // Add boosters if the track type is eligible
-    for (sint32 i = 0; i < 3; i++)
+    for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++)
     {
-        if (
-            _legacyType.ride_type[i] == RIDE_TYPE_LOOPING_ROLLER_COASTER ||
-            _legacyType.ride_type[i] == RIDE_TYPE_CORKSCREW_ROLLER_COASTER ||
-            _legacyType.ride_type[i] == RIDE_TYPE_TWISTER_ROLLER_COASTER ||
-            _legacyType.ride_type[i] == RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER ||
-            _legacyType.ride_type[i] == RIDE_TYPE_GIGA_COASTER ||
-            _legacyType.ride_type[i] == RIDE_TYPE_JUNIOR_ROLLER_COASTER
-        ) {
+        if (ride_type_supports_boosters(_legacyType.ride_type[i]))
+        {
             _legacyType.enabledTrackPieces |= (1ULL << TRACK_BOOSTER);
         }
     }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8580,3 +8580,17 @@ uint8 ride_entry_get_first_non_null_ride_type(rct_ride_entry * rideEntry)
     }
    return RIDE_TYPE_NULL;
 }
+
+bool ride_type_supports_boosters(uint8 rideType)
+{
+    if (rideType == RIDE_TYPE_LOOPING_ROLLER_COASTER ||
+        rideType == RIDE_TYPE_CORKSCREW_ROLLER_COASTER ||
+        rideType == RIDE_TYPE_TWISTER_ROLLER_COASTER ||
+        rideType == RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER ||
+        rideType == RIDE_TYPE_GIGA_COASTER ||
+        rideType == RIDE_TYPE_JUNIOR_ROLLER_COASTER)
+    {
+        return true;
+    }
+    return false;
+}

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -1186,5 +1186,6 @@ bool ride_has_ratings(const rct_ride * ride);
 const char * ride_type_get_enum_name(sint32 rideType);
 
 uint8 ride_entry_get_first_non_null_ride_type(rct_ride_entry * rideEntry);
+bool ride_type_supports_boosters(uint8 rideType);
 
 #endif

--- a/src/openrct2/windows/editor_object_selection.c
+++ b/src/openrct2/windows/editor_object_selection.c
@@ -504,9 +504,9 @@ static void setup_track_manager_objects()
         if (object_type == OBJECT_TYPE_RIDE) {
             *selectionFlags |= OBJECT_SELECTION_FLAG_6;
 
-            for (uint8 j = 0; j < 3; j++) {
+            for (uint8 j = 0; j < MAX_RIDE_TYPES_PER_RIDE_ENTRY; j++) {
                 uint8 rideType = item->RideType[j];
-                if (rideType != 0xFF && ride_type_has_flag(rideType, RIDE_TYPE_FLAG_HAS_TRACK)) {
+                if (rideType != RIDE_TYPE_NULL && ride_type_has_flag(rideType, RIDE_TYPE_FLAG_HAS_TRACK)) {
                     *selectionFlags &= ~OBJECT_SELECTION_FLAG_6;
                     break;
                 }
@@ -530,9 +530,9 @@ static void setup_track_designer_objects()
         if (objectType == OBJECT_TYPE_RIDE){
             *selectionFlags |= OBJECT_SELECTION_FLAG_6;
 
-            for (uint8 j = 0; j < 3; j++) {
+            for (uint8 j = 0; j < MAX_RIDE_TYPES_PER_RIDE_ENTRY; j++) {
                 uint8 rideType = item->RideType[j];
-                if (rideType != 0xFF) {
+                if (rideType != RIDE_TYPE_NULL) {
                     if (RideData4[rideType].flags & RIDE_TYPE_FLAG4_SHOW_IN_TRACK_DESIGNER) {
                         *selectionFlags &= ~OBJECT_SELECTION_FLAG_6;
                         break;
@@ -1853,8 +1853,8 @@ static bool filter_chunks(const ObjectRepositoryItem * item)
         }
         else {
             uint8 rideType = 0;
-            for (sint32 i = 0; i < 3; i++) {
-                if (item->RideType[i] != 255) {
+            for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++) {
+                if (item->RideType[i] != RIDE_TYPE_NULL) {
                     rideType = item->RideType[i];
                     break;
                 }
@@ -1895,9 +1895,9 @@ static void filter_update_counts()
 static rct_string_id get_ride_type_string_id(const ObjectRepositoryItem * item)
 {
     rct_string_id result = STR_NONE;
-    for (sint32 i = 0; i < 3; i++) {
+    for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++) {
         uint8 rideType = item->RideType[i];
-        if (rideType != 255) {
+        if (rideType != RIDE_TYPE_NULL) {
             result = RideNaming[rideType].name;
             break;
         }

--- a/src/openrct2/windows/new_campaign.c
+++ b/src/openrct2/windows/new_campaign.c
@@ -208,8 +208,12 @@ static void window_new_campaign_get_shop_items()
     //
     numItems = 0;
     for (i = 0; i < 64; i++)
+    {
         if (items & (1LL << i))
+        {
             window_new_campaign_shop_items[numItems++] = i;
+        }
+    }
     window_new_campaign_shop_items[numItems] = 255;
 }
 

--- a/src/openrct2/windows/new_ride.c
+++ b/src/openrct2/windows/new_ride.c
@@ -426,7 +426,7 @@ static void window_new_ride_scroll_to_focused_ride(rct_window *w)
     sint32 focusRideType = _windowNewRideHighlightedItem[_windowNewRideCurrentTab].ride_type_and_entry;
     sint32 count = 0, row = 0;
     ride_list_item *listItem = _windowNewRideListItems;
-    while (listItem->type != 255 || listItem->entry_index != 255) {
+    while (listItem->type != RIDE_TYPE_NULL || listItem->entry_index != 255) {
         if (listItem->type == focusRideType) {
             row = count / 5;
             break;
@@ -730,7 +730,7 @@ static void window_new_ride_scrollgetsize(rct_window *w, sint32 scrollIndex, sin
     ride_list_item *listItem = _windowNewRideListItems;
 
     sint32 count = 0;
-    while (listItem->type != 255 || listItem->entry_index != 255) {
+    while (listItem->type != RIDE_TYPE_NULL || listItem->entry_index != 255) {
         count++;
         listItem++;
     }
@@ -746,7 +746,7 @@ static void window_new_ride_scrollmousedown(rct_window *w, sint32 scrollIndex, s
     ride_list_item item;
 
     item = window_new_ride_scroll_get_ride_list_item_at(w, x, y);
-    if (item.type == 255 && item.entry_index == 255)
+    if (item.type == RIDE_TYPE_NULL && item.entry_index == 255)
         return;
 
     _windowNewRideHighlightedItem[_windowNewRideCurrentTab] = item;
@@ -821,7 +821,7 @@ static void window_new_ride_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     if (_windowNewRideCurrentTab != WINDOW_NEW_RIDE_PAGE_RESEARCH) {
         ride_list_item item = { .ride_type_and_entry = w->new_ride.highlighted_ride_id };
-        if (item.type != 255 || item.entry_index != 255)
+        if (item.type != RIDE_TYPE_NULL || item.entry_index != 255)
             window_new_ride_paint_ride_information(w, dpi, item, w->x + 3, w->y + w->height - 52, w->width - 6);
     } else {
         window_research_development_page_paint(w, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
@@ -842,7 +842,7 @@ static void window_new_ride_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, s
     sint32 x = 1;
     sint32 y = 1;
     ride_list_item *listItem = _windowNewRideListItems;
-    while (listItem->type != 255 || listItem->entry_index != 255) {
+    while (listItem->type != RIDE_TYPE_NULL || listItem->entry_index != 255) {
         rct_ride_entry *rideEntry;
         // Draw flat button rectangle
         sint32 flags = 0;
@@ -894,7 +894,7 @@ static ride_list_item window_new_ride_scroll_get_ride_list_item_at(rct_window *w
     sint32 index = column + (row * 5);
 
     ride_list_item *listItem = _windowNewRideListItems;
-    while (listItem->type != 255 || listItem->entry_index != 255) {
+    while (listItem->type != RIDE_TYPE_NULL || listItem->entry_index != 255) {
         if (index-- == 0)
             return *listItem;
         listItem++;
@@ -995,7 +995,7 @@ static void window_new_ride_paint_ride_information(rct_window *w, rct_drawpixeli
 static void window_new_ride_select(rct_window *w)
 {
     ride_list_item item = { .ride_type_and_entry = w->new_ride.selected_ride_id };
-    if (item.type == 255)
+    if (item.type == RIDE_TYPE_NULL)
         return;
 
     window_close(w);

--- a/src/openrct2/windows/scenery.c
+++ b/src/openrct2/windows/scenery.c
@@ -259,7 +259,7 @@ void init_scenery()
     }
 
     // small scenery
-    for (uint16 sceneryId = 0; sceneryId < 0xFC; sceneryId++) {
+    for (uint16 sceneryId = SCENERY_SMALL_SCENERY_ID_MIN; sceneryId < SCENERY_SMALL_SCENERY_ID_MAX; sceneryId++) {
         if (get_small_scenery_entry(sceneryId) == (rct_scenery_entry *)-1)
             continue;
 
@@ -268,8 +268,8 @@ void init_scenery()
     }
 
     // large scenery
-    for (sint32 sceneryId = 0x300; sceneryId < 0x380; sceneryId++) {
-        sint32 largeSceneryIndex = sceneryId - 0x300;
+    for (sint32 sceneryId = SCENERY_LARGE_SCENERY_ID_MIN; sceneryId < SCENERY_LARGE_SCENERY_ID_MAX; sceneryId++) {
+        sint32 largeSceneryIndex = sceneryId - SCENERY_LARGE_SCENERY_ID_MIN;
 
         if (get_large_scenery_entry(largeSceneryIndex) == (rct_scenery_entry *)-1)
             continue;
@@ -279,8 +279,8 @@ void init_scenery()
     }
 
     // walls
-    for (sint32 sceneryId = 0x200; sceneryId < 0x280; sceneryId++) {
-        sint32 wallSceneryIndex = sceneryId - 0x200;
+    for (sint32 sceneryId = SCENERY_WALLS_ID_MIN; sceneryId < SCENERY_WALLS_ID_MAX; sceneryId++) {
+        sint32 wallSceneryIndex = sceneryId - SCENERY_WALLS_ID_MIN;
 
         if (get_wall_entry(wallSceneryIndex) == (rct_scenery_entry *)-1)
             continue;
@@ -290,8 +290,8 @@ void init_scenery()
     }
 
     // banners
-    for (sint32 sceneryId = 0x400; sceneryId < 0x420; sceneryId++) {
-        sint32 bannerIndex = sceneryId - 0x400;
+    for (sint32 sceneryId = SCENERY_BANNERS_ID_MIN; sceneryId < SCENERY_BANNERS_ID_MAX; sceneryId++) {
+        sint32 bannerIndex = sceneryId - SCENERY_BANNERS_ID_MIN;
 
         if (get_banner_entry(bannerIndex) == (rct_scenery_entry *)-1)
             continue;
@@ -301,8 +301,8 @@ void init_scenery()
     }
 
     // path bits
-    for (sint32 sceneryId = 0x100; sceneryId < 0x10F; sceneryId++) {
-        sint32 pathBitIndex = sceneryId - 0x100;
+    for (sint32 sceneryId = SCENERY_PATH_SCENERY_ID_MIN; sceneryId < SCENERY_PATH_SCENERY_ID_MAX; sceneryId++) {
+        sint32 pathBitIndex = sceneryId - SCENERY_PATH_SCENERY_ID_MIN;
 
         if (get_footpath_item_entry(pathBitIndex) == (rct_scenery_entry *)-1)
             continue;
@@ -1134,24 +1134,24 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 sc
         rct_scenery_entry* sceneryEntry;
         rct_drawpixelinfo clipdpi;
         if (clip_drawpixelinfo(&clipdpi, dpi, left + 1, top + 1, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2)) {
-            if (currentSceneryGlobalId >= 0x400) {
-                sceneryEntry = get_banner_entry(currentSceneryGlobalId - 0x400);
+            if (currentSceneryGlobalId >= SCENERY_BANNERS_ID_MIN) {
+                sceneryEntry = get_banner_entry(currentSceneryGlobalId - SCENERY_BANNERS_ID_MIN);
                 uint32 imageId = sceneryEntry->image + gWindowSceneryRotation * 2;
                 imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
 
                 gfx_draw_sprite(&clipdpi, imageId, 0x21, 0x28, w->colours[1]);
                 gfx_draw_sprite(&clipdpi, imageId + 1, 0x21, 0x28, w->colours[1]);
             }
-            else if (currentSceneryGlobalId >= 0x300) {
-                sceneryEntry = get_large_scenery_entry(currentSceneryGlobalId - 0x300);
+            else if (currentSceneryGlobalId >= SCENERY_LARGE_SCENERY_ID_MIN) {
+                sceneryEntry = get_large_scenery_entry(currentSceneryGlobalId - SCENERY_LARGE_SCENERY_ID_MIN);
                 uint32 imageId = sceneryEntry->image + gWindowSceneryRotation;
                 imageId |= (gWindowSceneryPrimaryColour << 19) | 0x20000000;
                 imageId |= (gWindowScenerySecondaryColour << 24) | 0x80000000;
 
                 gfx_draw_sprite(&clipdpi, imageId, 0x21, 0, w->colours[1]);
             }
-            else if (currentSceneryGlobalId >= 0x200) {
-                sceneryEntry = get_wall_entry(currentSceneryGlobalId - 0x200);
+            else if (currentSceneryGlobalId >= SCENERY_WALLS_ID_MIN) {
+                sceneryEntry = get_wall_entry(currentSceneryGlobalId - SCENERY_WALLS_ID_MIN);
                 uint32 imageId = sceneryEntry->image;
                 uint8 tertiaryColour = w->colours[1];
                 uint16 spriteTop = (sceneryEntry->wall.height * 2) + 0x32;
@@ -1185,8 +1185,8 @@ void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 sc
                     }
                 }
             }
-            else if (currentSceneryGlobalId >= 0x100) {
-                sceneryEntry = get_footpath_item_entry(currentSceneryGlobalId - 0x100);
+            else if (currentSceneryGlobalId >= SCENERY_PATH_SCENERY_ID_MIN) {
+                sceneryEntry = get_footpath_item_entry(currentSceneryGlobalId - SCENERY_PATH_SCENERY_ID_MIN);
                 uint32 imageId = sceneryEntry->image;
 
                 gfx_draw_sprite(&clipdpi, imageId, 0x0B, 0x10, w->colours[1]);

--- a/src/openrct2/world/scenery.c
+++ b/src/openrct2/world/scenery.c
@@ -292,11 +292,11 @@ rct_scenery_set_entry *get_scenery_group_entry(sint32 entryIndex)
 sint32 get_scenery_id_from_entry_index(uint8 objectType, sint32 entryIndex)
 {
     switch (objectType) {
-    case OBJECT_TYPE_SMALL_SCENERY: return entryIndex;
-    case OBJECT_TYPE_PATH_BITS:     return entryIndex + 0x100;
-    case OBJECT_TYPE_WALLS:         return entryIndex + 0x200;
-    case OBJECT_TYPE_LARGE_SCENERY: return entryIndex + 0x300;
-    case OBJECT_TYPE_BANNERS:       return entryIndex + 0x400;
+    case OBJECT_TYPE_SMALL_SCENERY: return entryIndex + SCENERY_SMALL_SCENERY_ID_MIN;
+    case OBJECT_TYPE_PATH_BITS:     return entryIndex + SCENERY_PATH_SCENERY_ID_MIN;
+    case OBJECT_TYPE_WALLS:         return entryIndex + SCENERY_WALLS_ID_MIN;
+    case OBJECT_TYPE_LARGE_SCENERY: return entryIndex + SCENERY_LARGE_SCENERY_ID_MIN;
+    case OBJECT_TYPE_BANNERS:       return entryIndex + SCENERY_BANNERS_ID_MIN;
     default:                        return -1;
     }
 }

--- a/src/openrct2/world/scenery.h
+++ b/src/openrct2/world/scenery.h
@@ -21,6 +21,17 @@
 #include "../object.h"
 #include "../world/map.h"
 
+#define SCENERY_SMALL_SCENERY_ID_MIN 0x0
+#define SCENERY_SMALL_SCENERY_ID_MAX 0xFC
+#define SCENERY_LARGE_SCENERY_ID_MIN 0x300
+#define SCENERY_LARGE_SCENERY_ID_MAX 0x380
+#define SCENERY_WALLS_ID_MIN         0x200
+#define SCENERY_WALLS_ID_MAX         0x280
+#define SCENERY_BANNERS_ID_MIN       0x400
+#define SCENERY_BANNERS_ID_MAX       0x420
+#define SCENERY_PATH_SCENERY_ID_MIN  0x100
+#define SCENERY_PATH_SCENERY_ID_MAX  0x10F
+
 #pragma pack(push, 1)
 typedef struct rct_small_scenery_entry {
     uint32 flags;           // 0x06

--- a/test/testpaint/main.cpp
+++ b/test/testpaint/main.cpp
@@ -466,7 +466,7 @@ int main(int argc, char *argv[]) {
     }
 
     for (uint8 rideType = 0; rideType < RIDE_TYPE_COUNT; rideType++) {
-        if (specificRideType != 0xFF && rideType != specificRideType) {
+        if (specificRideType != RIDE_TYPE_NULL && rideType != specificRideType) {
             continue;
         }
 


### PR DESCRIPTION
Fixes #5613.

I have taken the scenery ID bits from https://github.com/OpenRCT2/OpenRCT2/pull/4986 and properly attributed those to @ccoors. Please make sure not to squash when merging this PR, but to rebase and merge.