### PR TITLE
remove unused gRCT2AddressSavedGamesPath2

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1075,8 +1075,6 @@ bool game_load_save(const utf8 *path)
 {
     log_verbose("loading saved game, %s", path);
 
-    safe_strcpy((char*)gRCT2AddressSavedGamesPath2, path, MAX_PATH);
-
     safe_strcpy(gScenarioSavePath, path, MAX_PATH);
 
     uint32 extension_type = get_file_extension_type(path);

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -118,7 +118,6 @@ uint8 gSavePromptMode;
 
 char gRCT2AddressAppPath[MAX_PATH];
 char gRCT2AddressSavedGamesPath[MAX_PATH];
-char gRCT2AddressSavedGamesPath2[MAX_PATH];
 char gRCT2AddressScenariosPath[MAX_PATH];
 char gRCT2AddressLandscapesPath[MAX_PATH];
 char gRCT2AddressObjectDataPath[MAX_PATH];
@@ -228,8 +227,6 @@ sint32 rct2_init_directories()
     safe_strcpy(gRCT2AddressTracksPath, gRCT2AddressAppPath, sizeof(gRCT2AddressTracksPath));
     safe_strcat_path(gRCT2AddressTracksPath, "Tracks", sizeof(gRCT2AddressTracksPath));
     safe_strcat_path(gRCT2AddressTracksPath, "*.TD?", sizeof(gRCT2AddressTracksPath));
-
-    safe_strcpy(gRCT2AddressSavedGamesPath2, gRCT2AddressSavedGamesPath, sizeof(gRCT2AddressSavedGamesPath2));
     return 1;
 }
 
@@ -335,7 +332,6 @@ bool rct2_open_file(const char *path)
     extension++;
 
     if (_stricmp(extension, "sv6") == 0) {
-        safe_strcpy((char*)gRCT2AddressSavedGamesPath2, path, sizeof(gRCT2AddressSavedGamesPath2));
         if (game_load_save(path)) {
             gFirstTimeSave = 0;
             return true;

--- a/src/openrct2/rct2.h
+++ b/src/openrct2/rct2.h
@@ -164,7 +164,6 @@ extern uint8 gSavePromptMode;
 
 extern char gRCT2AddressAppPath[];
 extern char gRCT2AddressSavedGamesPath[];
-extern char gRCT2AddressSavedGamesPath2[];
 extern char gRCT2AddressScenariosPath[];
 extern char gRCT2AddressLandscapesPath[];
 extern char gRCT2AddressObjectDataPath[];

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -233,10 +233,6 @@ void scenario_begin()
     safe_strcat_path(gScenarioSavePath, parkName, sizeof(gScenarioSavePath));
     path_append_extension(gScenarioSavePath, ".sv6", sizeof(gScenarioSavePath));
 
-    safe_strcpy(gRCT2AddressSavedGamesPath2, gRCT2AddressSavedGamesPath, MAX_PATH);
-    safe_strcat_path(gRCT2AddressSavedGamesPath2, gScenarioSavePath, MAX_PATH);
-    path_append_extension(gRCT2AddressSavedGamesPath2, ".SV6", MAX_PATH);
-
     gCurrentExpenditure = 0;
     gCurrentProfit = 0;
     gWeeklyProfitAverageDividend = 0;


### PR DESCRIPTION
gRCT2AddressSavedGamesPath2 does not seem to be used at this time. The lines removed are the only calls to gRCT2AddressSavedGamesPath2, and they are all write-only.