### PR TITLE
Fixed a desync that would happen when having the guests list open.

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/paint/sprite/sprite.c
+++ b/src/openrct2/paint/sprite/sprite.c
@@ -36,7 +36,6 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
 
     if (gTrackDesignSaveMode) return;
 
-
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES) return;
 
     dpi = unk_140E9A8;

--- a/src/openrct2/windows/guest_list.c
+++ b/src/openrct2/windows/guest_list.c
@@ -706,14 +706,14 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
         // For each guest
         FOR_ALL_GUESTS(spriteIndex, peep) {
-            peep->flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
+            sprite_set_flashing(get_sprite(peep->sprite_index), false);
             if (peep->outside_of_park != 0)
                 continue;
             if (_window_guest_list_selected_filter != -1) {
                 if (window_guest_list_is_peep_in_filter(peep))
                     continue;
                 gWindowMapFlashingFlags |= (1 << 0);
-                peep->flags |= SPRITE_FLAGS_PEEP_FLASHING;
+                sprite_set_flashing(get_sprite(peep->sprite_index), true);
             }
             if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
                 continue;

--- a/src/openrct2/windows/guest_list.c
+++ b/src/openrct2/windows/guest_list.c
@@ -706,14 +706,14 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
         // For each guest
         FOR_ALL_GUESTS(spriteIndex, peep) {
-            sprite_set_flashing(get_sprite(peep->sprite_index), false);
+            sprite_set_flashing((rct_sprite*)peep, false);
             if (peep->outside_of_park != 0)
                 continue;
             if (_window_guest_list_selected_filter != -1) {
                 if (window_guest_list_is_peep_in_filter(peep))
                     continue;
                 gWindowMapFlashingFlags |= (1 << 0);
-                sprite_set_flashing(get_sprite(peep->sprite_index), true);
+                sprite_set_flashing((rct_sprite*)peep, true);
             }
             if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
                 continue;

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -1077,9 +1077,8 @@ static void window_map_paint_peep_overlay(rct_drawpixelinfo *dpi)
         right = left;
         bottom = top;
 
-            colour = PALETTE_INDEX_20;
+        colour = PALETTE_INDEX_20;
 
-        //if ((peep->flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
         if (sprite_get_flashing((rct_sprite*)peep)) {
             if (peep->type == PEEP_TYPE_STAFF) {
                 if ((gWindowMapFlashingFlags & (1 << 3)) != 0) {

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -1079,7 +1079,8 @@ static void window_map_paint_peep_overlay(rct_drawpixelinfo *dpi)
 
             colour = PALETTE_INDEX_20;
 
-        if ((peep->flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
+        //if ((peep->flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
+		if (sprite_get_flashing(get_sprite(peep->sprite_index))) {
             if (peep->type == PEEP_TYPE_STAFF) {
                 if ((gWindowMapFlashingFlags & (1 << 3)) != 0) {
                     colour = PALETTE_INDEX_138;

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -1080,7 +1080,7 @@ static void window_map_paint_peep_overlay(rct_drawpixelinfo *dpi)
             colour = PALETTE_INDEX_20;
 
         //if ((peep->flags & SPRITE_FLAGS_PEEP_FLASHING) != 0) {
-		if (sprite_get_flashing(get_sprite(peep->sprite_index))) {
+        if (sprite_get_flashing((rct_sprite*)peep)) {
             if (peep->type == PEEP_TYPE_STAFF) {
                 if ((gWindowMapFlashingFlags & (1 << 3)) != 0) {
                     colour = PALETTE_INDEX_138;

--- a/src/openrct2/windows/staff_list.c
+++ b/src/openrct2/windows/staff_list.c
@@ -323,10 +323,10 @@ void window_staff_list_update(rct_window *w)
             rct_peep * peep;
             gWindowMapFlashingFlags |= (1 << 2);
             FOR_ALL_STAFF(spriteIndex, peep) {
-                sprite_set_flashing(get_sprite(peep->sprite_index), false);
+                sprite_set_flashing((rct_sprite*)peep, false);
 
                 if (peep->staff_type == _windowStaffListSelectedTab) {
-                    sprite_set_flashing(get_sprite(peep->sprite_index), true);
+                    sprite_set_flashing((rct_sprite*)peep, true);
                 }
             }
         }

--- a/src/openrct2/windows/staff_list.c
+++ b/src/openrct2/windows/staff_list.c
@@ -323,12 +323,10 @@ void window_staff_list_update(rct_window *w)
             rct_peep * peep;
             gWindowMapFlashingFlags |= (1 << 2);
             FOR_ALL_STAFF(spriteIndex, peep) {
-                // TODO When possible, do not modify the peep state as it shows up as a
-                //      multiplayer desynchronisation
-                peep->flags &= ~(SPRITE_FLAGS_PEEP_FLASHING);
+                sprite_set_flashing(get_sprite(peep->sprite_index), false);
 
                 if (peep->staff_type == _windowStaffListSelectedTab) {
-                    peep->flags |= SPRITE_FLAGS_PEEP_FLASHING;
+                    sprite_set_flashing(get_sprite(peep->sprite_index), true);
                 }
             }
         }

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -30,10 +30,12 @@
 uint16 gSpriteListHead[6];
 uint16 gSpriteListCount[6];
 static rct_sprite _spriteList[MAX_SPRITES];
+static bool _spriteFlashingList[MAX_SPRITES];
 #else
 uint16 *gSpriteListHead = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_HEAD, uint16);
 uint16 *gSpriteListCount = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, uint16);
 static rct_sprite *_spriteList = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
+static bool _spriteFlashingList = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, bool);
 #endif
 
 #define SPATIAL_INDEX_LOCATION_NULL 0x10000
@@ -126,6 +128,7 @@ void reset_sprite_list()
     for (sint32 i = 0; i < NUM_SPRITE_LISTS; i++) {
         gSpriteListHead[i] = SPRITE_INDEX_NULL;
         gSpriteListCount[i] = 0;
+        _spriteFlashingList[i] = false;
     }
 
     rct_sprite* previous_spr = (rct_sprite*)SPRITE_INDEX_NULL;
@@ -145,6 +148,7 @@ void reset_sprite_list()
             spr->unknown.previous = SPRITE_INDEX_NULL;
             gSpriteListHead[SPRITE_LIST_NULL] = i;
         }
+        _spriteFlashingList[i] = false;
         previous_spr = spr;
         spr++;
     }
@@ -208,11 +212,6 @@ const char * sprite_checksum()
             rct_sprite copy = *sprite;
             copy.unknown.sprite_left = copy.unknown.sprite_right = copy.unknown.sprite_top = copy.unknown.sprite_bottom = 0;
 
-            // Fixes a desync, this is only done on the local client so ignore it.
-            if (copy.unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP) {
-                copy.unknown.flags &= ~SPRITE_FLAGS_PEEP_FLASHING; 
-            }
-
             if (EVP_DigestUpdate(gHashCTX, &copy, sizeof(rct_sprite)) <= 0)
             {
                 openrct2_assert(false, "Failed to update digest");
@@ -262,6 +261,7 @@ void sprite_clear_all_unused()
         sprite->previous = previousSpriteIndex;
         sprite->linked_list_type_offset = SPRITE_LIST_NULL * 2;
         sprite->sprite_index = spriteIndex;
+        _spriteFlashingList[spriteIndex] = false;
         spriteIndex = nextSpriteIndex;
     }
 }
@@ -273,6 +273,7 @@ static void sprite_reset(rct_unk_sprite *sprite)
     uint16 next = sprite->next;
     uint16 prev = sprite->previous;
     uint16 sprite_index = sprite->sprite_index;
+    _spriteFlashingList[sprite_index] = false;
 
     memset(sprite, 0, sizeof(rct_sprite));
 
@@ -595,6 +596,7 @@ void sprite_remove(rct_sprite *sprite)
     move_sprite_to_list(sprite, SPRITE_LIST_NULL * 2);
     user_string_free(sprite->unknown.name_string_idx);
     sprite->unknown.sprite_identifier = SPRITE_IDENTIFIER_NULL;
+    _spriteFlashingList[sprite->unknown.sprite_index] = false;
 
     size_t quadrantIndex = GetSpatialIndexOffset(sprite->unknown.x, sprite->unknown.y);
     uint16 *spriteIndex = &gSpriteSpatialIndex[quadrantIndex];
@@ -784,4 +786,16 @@ void sprite_position_tween_reset()
         _spritelocations1[i].z =
         _spritelocations2[i].z = sprite->unknown.z;
     }
+}
+
+void sprite_set_flashing(rct_sprite *sprite, bool flashing)
+{
+    assert(sprite->unknown.sprite_index < MAX_SPRITES);
+    _spriteFlashingList[sprite->unknown.sprite_index] = flashing;
+}
+
+bool sprite_get_flashing(rct_sprite *sprite)
+{
+    assert(sprite->unknown.sprite_index < MAX_SPRITES);
+    return _spriteFlashingList[sprite->unknown.sprite_index];
 }

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -30,13 +30,13 @@
 uint16 gSpriteListHead[6];
 uint16 gSpriteListCount[6];
 static rct_sprite _spriteList[MAX_SPRITES];
-static bool _spriteFlashingList[MAX_SPRITES];
 #else
 uint16 *gSpriteListHead = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_HEAD, uint16);
 uint16 *gSpriteListCount = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, uint16);
 static rct_sprite *_spriteList = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LIST, rct_sprite);
-static bool _spriteFlashingList = RCT2_ADDRESS(RCT2_ADDRESS_SPRITE_LISTS_COUNT, bool);
 #endif
+
+static bool _spriteFlashingList[MAX_SPRITES];
 
 #define SPATIAL_INDEX_LOCATION_NULL 0x10000
 

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -207,6 +207,12 @@ const char * sprite_checksum()
         {
             rct_sprite copy = *sprite;
             copy.unknown.sprite_left = copy.unknown.sprite_right = copy.unknown.sprite_top = copy.unknown.sprite_bottom = 0;
+
+            // Fixes a desync, this is only done on the local client so ignore it.
+            if (copy.unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP) {
+                copy.unknown.flags &= ~SPRITE_FLAGS_PEEP_FLASHING; 
+            }
+
             if (EVP_DigestUpdate(gHashCTX, &copy, sizeof(rct_sprite)) <= 0)
             {
                 openrct2_assert(false, "Failed to update digest");

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -387,7 +387,7 @@ enum {
 enum {
     SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE = 1 << 7,
     SPRITE_FLAGS_PEEP_VISIBLE = 1 << 8, // Peep is eligible to show in summarized guest list window (is inside park?)
-    SPRITE_FLAGS_PEEP_FLASHING = 1 << 9, // Peep belongs to highlighted group (flashes red on map)
+    SPRITE_FLAGS_PEEP_FLASHING = 1 << 9, // Deprecated: Use sprite_set_flashing/sprite_get_flashing instead.
 };
 
 enum {

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -475,5 +475,8 @@ void crash_splash_update(rct_crash_splash *splash);
 
 const char *sprite_checksum();
 
+void sprite_set_flashing(rct_sprite *sprite, bool flashing);
+bool sprite_get_flashing(rct_sprite *sprite);
+
 #endif
 


### PR DESCRIPTION
The map uses the flag SPRITE_FLAGS_PEEP_FLASHING to make peeps flash. The flashing/blinking only happens on the local client and requires no synchronization so we simply ignore it in the checksum generation.