### PR TITLE
Fix #5617, PLATFORM_MODIFIER defined twice for macOS correctly

### DIFF
--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -26,12 +26,6 @@ typedef struct rct2_install_info rct2_install_info;
 #define MAX_PATH 260
 #endif
 
-#ifdef __APPLE__
-#define KEYBOARD_PRIMARY_MODIFIER KMOD_GUI
-#else
-#define KEYBOARD_PRIMARY_MODIFIER KMOD_CTRL
-#endif
-
 #define INVALID_HANDLE -1
 
 #define TOUCH_DOUBLE_TIMEOUT 300

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -26,6 +26,12 @@ typedef struct rct2_install_info rct2_install_info;
 #define MAX_PATH 260
 #endif
 
+#ifdef __APPLE__
+#define KEYBOARD_PRIMARY_MODIFIER KMOD_GUI
+#else
+#define KEYBOARD_PRIMARY_MODIFIER KMOD_CTRL
+#endif
+
 #define INVALID_HANDLE -1
 
 #define TOUCH_DOUBLE_TIMEOUT 300
@@ -42,11 +48,6 @@ typedef struct rct2_install_info rct2_install_info;
 #define CTRL 0x200
 #define ALT 0x400
 #define CMD 0x800
-#ifdef __APPLE__
-    #define PLATFORM_MODIFIER CMD
-#else
-    #define PLATFORM_MODIFIER CTRL
-#endif
 
 typedef struct resolution {
     sint32 width, height;


### PR DESCRIPTION
As @AaronVanGeffen [correctly pointed out](https://github.com/OpenRCT2/OpenRCT2/commit/5f5f12a63cdfad3079aea286466797b83e008d42), I managed to remove the wrong `#define` from platform.h when fixing #5617.

This reverts my cock-up and implements the right fix.