### PR TITLE
Fix #5635, overflow when calculating loan interest

### DIFF
--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -158,11 +158,13 @@ typedef sint16 fixed16_1dp;
 typedef sint16 fixed16_2dp;
 typedef sint32 fixed32_1dp;
 typedef sint32 fixed32_2dp;
+typedef sint64 fixed64_1dp;
 
 // Money is stored as a multiple of 0.10.
 typedef fixed8_1dp money8;
 typedef fixed16_1dp money16;
 typedef fixed32_1dp money32;
+typedef fixed64_1dp money64;
 
 // Construct a fixed point number. For example, to create the value 3.65 you
 // would write FIXED_2DP(3,65)

--- a/src/openrct2/management/finance.c
+++ b/src/openrct2/management/finance.c
@@ -126,8 +126,11 @@ void finance_pay_research()
 void finance_pay_interest()
 {
     money32 current_loan = gBankLoan;
-    sint16 current_interest = gBankLoanInterestRate;
-    money32 tempcost = (current_loan * 5 * current_interest) >> 14; // (5 * interest) / 2^14 is pretty close to
+    uint8 current_interest = gBankLoanInterestRate;
+
+    // This variable uses the 64-bit type as the line below can involve multiplying very large numbers
+    // that will overflow money32 (e.g. in the Alton Towers RCT1 scenario)
+    money64 tempcost = (current_loan * 5 * current_interest) >> 14; // (5 * interest) / 2^14 is pretty close to
 
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
         return;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
To do this I had to introduce a 64-bit money type, as the calculations involved can overflow `sint32`.

I also changed the type of `current_interest` within the same function, as treating a `uint8` as a `sint16` doesn't make a lot of sense.

(P.S. Please ignore the name of the branch used for this PR - it's a typo!)