### PR TITLE
Fix game commands being directly executed from within network_update.

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -361,6 +361,10 @@ void game_logic_update()
     gInUpdateCode = true;
     ///////////////////////////
 
+    // Separated out processing commands in network_update which could call scenario_rand where gInUpdateCode is false.
+    // All commands that are received are first queued and then executed where gInUpdateCode is set to true.
+    network_process_game_commands();
+
     gScreenAge++;
     if (gScreenAge == 0)
         gScreenAge--;

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1322,7 +1322,6 @@ void Network::ProcessGameCommandQueue()
         // run all the game commands at the current tick
         const GameCommand& gc = (*game_command_queue.begin());
 
-        // If our tick is higher than the command tick we are in trouble.
         if (mode == NETWORK_MODE_CLIENT) {
 
             if (game_command_queue.begin()->tick < gCurrentTicks) {
@@ -2032,7 +2031,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
             ticks - connection.Player->LastPlaceSceneryTime < ACTION_COOLDOWN_TIME_PLACE_SCENERY &&
             // In case platform_get_ticks() wraps after ~49 days, ignore larger logged times.
             ticks > connection.Player->LastPlaceSceneryTime
-            ) {
+        ) {
             if (!(group->CanPerformCommand(MISC_COMMAND_TOGGLE_SCENERY_CLUSTER))) {
                 Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
                 return;
@@ -2046,7 +2045,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
             ticks - connection.Player->LastDemolishRideTime < ACTION_COOLDOWN_TIME_DEMOLISH_RIDE &&
             // In case platform_get_ticks() wraps after ~49 days, ignore larger logged times.
             ticks > connection.Player->LastDemolishRideTime
-            ) {
+        ) {
             Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
             return;
         }

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -2017,7 +2017,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
 
     uint32 ticks = platform_get_ticks(); //tick count is different by time last_action_time is set, keep same value.
 
-                                         // Check if player's group permission allows command to run
+    // Check if player's group permission allows command to run
     NetworkGroup* group = GetGroupByID(connection.Player->Group);
     if (!group || (group && !group->CanPerformCommand(commandCommand))) {
         Server_Send_SHOWERROR(connection, STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
@@ -2054,7 +2054,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
     // Don't let clients send pause or quit
     else if (commandCommand == GAME_COMMAND_TOGGLE_PAUSE ||
              commandCommand == GAME_COMMAND_LOAD_OR_QUIT
-             ) {
+    ) {
         return;
     }
 

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1338,8 +1338,9 @@ void Network::ProcessGameCommandQueue()
                 continue;
             }
 
+            // exit the game command processing loop to still have a chance at finding desync.
             if (game_command_queue.begin()->tick != gCurrentTicks)
-                return;
+                break;
         }
 
         if (GetPlayerID() == gc.playerid) {

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,7 +56,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -108,6 +108,7 @@ public:
     uint32 GetServerTick();
     uint8 GetPlayerID();
     void Update();
+    void ProcessGameCommandQueue();
     std::vector<std::unique_ptr<NetworkPlayer>>::iterator GetPlayerIteratorByID(uint8 id);
     NetworkPlayer* GetPlayerByID(uint8 id);
     std::vector<std::unique_ptr<NetworkGroup>>::iterator GetGroupIteratorByID(uint8 id);
@@ -178,7 +179,6 @@ public:
 private:
     bool ProcessConnection(NetworkConnection& connection);
     void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
-    void ProcessGameCommandQueue();
     void AddClient(ITcpSocket * socket);
     void RemoveClient(std::unique_ptr<NetworkConnection>& connection);
     NetworkPlayer* AddPlayer(const utf8 *name, const std::string &keyhash);
@@ -287,6 +287,7 @@ sint32 network_begin_server(sint32 port, const char* address);
 sint32 network_get_mode();
 sint32 network_get_status();
 void network_update();
+void network_process_game_commands();
 sint32 network_get_authstatus();
 uint32 network_get_server_tick();
 uint8 network_get_current_player_id();


### PR DESCRIPTION
Refactored the network code to use the game command queue to not directly execute game commands from within network_update. This should also fix false positives when calling scenario_rand within game command callbacks.