### PR TITLE
Fix scrolling when game speed was increased.

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -65,6 +65,7 @@ uint8 gGamePaused = 0;
 sint32 gGameSpeed = 1;
 float gDayNightCycle = 0;
 bool gInUpdateCode = false;
+bool gInMapInitCode = false;
 sint32 gGameCommandNestLevel;
 bool gGameCommandIsNetworked;
 
@@ -279,6 +280,8 @@ void update_palette_effects()
 
 void game_update()
 {
+    gInUpdateCode = true;
+
     sint32 i, numUpdates;
 
     // 0x006E3AEC // screen_game_process_mouse_input();
@@ -307,8 +310,37 @@ void game_update()
         map_animation_invalidate_all();
 
         // Special case because we set numUpdates to 0, otherwise in game_logic_update.
-        game_handle_input();
         network_update();
+    }
+
+    if (!gOpenRCT2Headless)
+    {
+        input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
+
+        // the flickering frequency is reduced by 4, compared to the original
+        // it was done due to inability to reproduce original frequency
+        // and decision that the original one looks too fast
+        if (gCurrentTicks % 4 == 0)
+            gWindowMapFlashingFlags ^= (1 << 15);
+
+        // Handle guest map flashing
+        gWindowMapFlashingFlags &= ~(1 << 1);
+        if (gWindowMapFlashingFlags & (1 << 0))
+            gWindowMapFlashingFlags |= (1 << 1);
+        gWindowMapFlashingFlags &= ~(1 << 0);
+
+        // Handle staff map flashing
+        gWindowMapFlashingFlags &= ~(1 << 3);
+        if (gWindowMapFlashingFlags & (1 << 2))
+            gWindowMapFlashingFlags |= (1 << 3);
+        gWindowMapFlashingFlags &= ~(1 << 2);
+
+        window_map_tooltip_update_visibility();
+
+        // Input
+        gUnk141F568 = gUnk13CA740;
+
+        game_handle_input();
     }
 
     // Update the game one or more times
@@ -341,6 +373,7 @@ void game_update()
     window_dispatch_update_all();
 
     gGameCommandNestLevel = 0;
+    gInUpdateCode = false;
 }
 
 void game_logic_update()
@@ -355,44 +388,9 @@ void game_logic_update()
         }
     }
 
-    ///////////////////////////
-    // network_update() when downloaded a map will call game_init_all(), which
-    // leaves gInUpdateCode false. Don't call network_update() when in update code.
-    gInUpdateCode = true;
-    ///////////////////////////
-
     gScreenAge++;
     if (gScreenAge == 0)
         gScreenAge--;
-
-    if (!gOpenRCT2Headless)
-    {
-        input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
-
-        // the flickering frequency is reduced by 4, compared to the original
-        // it was done due to inability to reproduce original frequency
-        // and decision that the original one looks too fast
-        if (gCurrentTicks % 4 == 0)
-            gWindowMapFlashingFlags ^= (1 << 15);
-
-        // Handle guest map flashing
-        gWindowMapFlashingFlags &= ~(1 << 1);
-        if (gWindowMapFlashingFlags & (1 << 0))
-            gWindowMapFlashingFlags |= (1 << 1);
-        gWindowMapFlashingFlags &= ~(1 << 0);
-
-        // Handle staff map flashing
-        gWindowMapFlashingFlags &= ~(1 << 3);
-        if (gWindowMapFlashingFlags & (1 << 2))
-            gWindowMapFlashingFlags |= (1 << 3);
-        gWindowMapFlashingFlags &= ~(1 << 2);
-
-        window_map_tooltip_update_visibility();
-
-        // Input
-        gUnk141F568 = gUnk13CA740;
-        game_handle_input();
-    }
 
     sub_68B089();
     scenario_update();
@@ -411,10 +409,6 @@ void game_logic_update()
     ride_ratings_update_all();
     ride_measurements_update();
     news_item_update_current();
-
-    ///////////////////////////
-    gInUpdateCode = false;
-    ///////////////////////////
 
     map_animation_invalidate_all();
     vehicle_sounds_update();
@@ -1416,7 +1410,7 @@ void game_load_or_quit_no_save_prompt()
  */
 void game_init_all(sint32 mapSize)
 {
-    gInUpdateCode = true;
+    gInMapInitCode = true;
 
     map_init(mapSize);
     park_init();
@@ -1431,7 +1425,7 @@ void game_init_all(sint32 mapSize)
     news_item_init_queue();
     user_string_clear_all();
 
-    gInUpdateCode = false;
+    gInMapInitCode = false;
 
     window_new_ride_init_vars();
     window_guest_list_init_vars_a();

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -148,6 +148,7 @@ extern uint8 gGamePaused;
 extern sint32 gGameSpeed;
 extern float gDayNightCycle;
 extern bool gInUpdateCode;
+extern bool gInMapInitCode;
 extern sint32 gGameCommandNestLevel;
 extern bool gGameCommandIsNetworked;
 

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -388,7 +388,6 @@ uint8 Network::GetPlayerID()
 void Network::Update()
 {
     _closeLock = true;
-    assert(gInUpdateCode == false);
 
     switch (GetMode()) {
     case NETWORK_MODE_SERVER:

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -604,7 +604,7 @@ uint32 dbg_scenario_rand(const char *file, const char *function, const uint32 li
     {
         fprintf(fp, "Tick: %d, Rand: %08X - REF: %s:%u %s (%p)\n", gCurrentTicks, gScenarioSrand1, file, line, function, data);
     }
-    if (!gInUpdateCode) {
+    if (!gInUpdateCode && !gInMapInitCode) {
         log_warning("scenario_rand called from outside game update");
         assert(false);
     }

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -168,6 +168,8 @@ extern "C"
 
     void title_update()
     {
+        gInUpdateCode = true;
+
         screenshot_check();
         title_handle_keyboard_input();
 
@@ -196,6 +198,8 @@ extern "C"
         gSavedAge++;
 
         game_handle_input();
+
+        gInUpdateCode = false;
     }
 
     void DrawOpenRCT2(rct_drawpixelinfo * dpi, sint32 x, sint32 y)

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -197,6 +197,8 @@ public:
         }
 
         // Keep updating until we reach target position
+        gInUpdateCode = true;
+
         while (_position < targetPosition)
         {
             if (Update())
@@ -208,6 +210,8 @@ public:
                 break;
             }
         }
+
+        gInUpdateCode = false;
 
         _waitCounter = 0;
     }


### PR DESCRIPTION
One of my recent changes moved the input handling into game_update_logic which is ran per tick, input should be managed per frame instead.

Also introduced a new global variable that will prevent the scenario_rand to assert because gInUpdateCode is not set at that time.

I've also added to set gInUpdateCode at few missing places that would cause it to assert while it shouldn't.