### PR TITLE
Allow Construction rights to be placed on park entrance

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#5576] Add a persistent 'display real names of guests' setting.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Feature: [#5611] Add support for Android
+- Improved: Construction rights can now be placed on park entrances.
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#259] Money making glitch involving swamps (original bug)
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug)

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -947,17 +947,17 @@ static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, 
             return MONEY32_UNDEFINED;
         }
 
+        uint8 newOwnership = (flags & 0xFF00) >> 4;
+        if (newOwnership == (surfaceElement->properties.surface.ownership & 0xF0)) {
+            return 0;
+        }
+
         rct_map_element* mapElement = map_get_first_element_at(x / 32, y / 32);
         do {
             if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_ENTRANCE){
                 return 0;
             }
         } while (!map_element_is_last_for_tile(mapElement++));
-
-        uint8 newOwnership = (flags & 0xFF00) >> 4;
-        if (newOwnership == (surfaceElement->properties.surface.ownership & 0xF0)) {
-            return 0;
-        }
 
         if (!(flags & GAME_COMMAND_FLAG_APPLY)) {
             return gLandPrice;

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -954,8 +954,17 @@ static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, 
 
         rct_map_element* mapElement = map_get_first_element_at(x / 32, y / 32);
         do {
-            if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_ENTRANCE){
-                return 0;
+            if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_ENTRANCE) {
+                // Do not allow ownership of park entrance.
+                if (newOwnership == OWNERSHIP_OWNED || newOwnership == OWNERSHIP_AVAILABLE)
+                    return 0;
+                // Allow construction rights available / for sale on park entrances on surface.
+                // There is no need to check the height if newOwnership is 0 (unowned and no rights available).
+                if ((newOwnership == OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED ||
+                     newOwnership == OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) &&
+                    (mapElement->base_height - 3 > surfaceElement->base_height ||
+                     mapElement->base_height < surfaceElement->base_height))
+                    return 0;
             }
         } while (!map_element_is_last_for_tile(mapElement++));
 


### PR DESCRIPTION
This is to keep it in line with how the cheats > own all land works. Guests can still enter park just fine if the park entrance has construction rights and is not too far up from the ground or below the ground.