### PR TITLE
Pre-emptively reset sprites on export for higher compression ratios

### DIFF
--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -52,6 +52,7 @@ extern "C"
     #include "../world/Climate.h"
     #include "../world/map_animation.h"
     #include "../world/park.h"
+    #include "../world/sprite.h"
 }
 
 S6Exporter::S6Exporter()
@@ -178,6 +179,20 @@ void S6Exporter::Export()
     memcpy(_s6.map_elements, gMapElements, sizeof(_s6.map_elements));
 
     _s6.next_free_map_element_pointer_index = gNextFreeMapElementPointerIndex;
+    // Sprites needs to be reset before they get used.
+    // Might as well reset them in here to zero out the space and improve
+    // compression ratios. Especially useful for multiplayer servers that
+    // use zlib on the sent stream.
+    {
+        uint16 spriteIndex;
+        spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
+        while (spriteIndex != SPRITE_INDEX_NULL)
+        {
+            rct_unk_sprite *sprite = &(get_sprite(spriteIndex))->unknown;
+            spriteIndex = sprite->next;
+            sprite_reset(sprite);
+        }
+    }
     for (sint32 i = 0; i < MAX_SPRITES; i++)
     {
         memcpy(&_s6.sprites[i], get_sprite(i), sizeof(rct_sprite));

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -184,14 +184,7 @@ void S6Exporter::Export()
     // compression ratios. Especially useful for multiplayer servers that
     // use zlib on the sent stream.
     {
-        uint16 spriteIndex;
-        spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
-        while (spriteIndex != SPRITE_INDEX_NULL)
-        {
-            rct_unk_sprite *sprite = &(get_sprite(spriteIndex))->unknown;
-            spriteIndex = sprite->next;
-            sprite_reset(sprite);
-        }
+        reset_empty_sprites();
     }
     for (sint32 i = 0; i < MAX_SPRITES; i++)
     {

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -272,7 +272,7 @@ void sprite_clear_all_unused()
     }
 }
 
-static void sprite_reset(rct_unk_sprite *sprite)
+void sprite_reset(rct_unk_sprite *sprite)
 {
     // Need to retain how the sprite is linked in lists
     uint8 llto = sprite->linked_list_type_offset;

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -272,7 +272,7 @@ void sprite_clear_all_unused()
     }
 }
 
-void sprite_reset(rct_unk_sprite *sprite)
+static void sprite_reset(rct_unk_sprite *sprite)
 {
     // Need to retain how the sprite is linked in lists
     uint8 llto = sprite->linked_list_type_offset;
@@ -287,6 +287,22 @@ void sprite_reset(rct_unk_sprite *sprite)
     sprite->next = next;
     sprite->previous = prev;
     sprite->sprite_index = sprite_index;
+}
+
+// Resets all sprites in SPRITE_LIST_NULL list
+void reset_empty_sprites()
+{
+    uint16 spriteIndex;
+    spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
+    while (spriteIndex != SPRITE_INDEX_NULL)
+    {
+        rct_unk_sprite *sprite = &(get_sprite(spriteIndex))->unknown;
+        spriteIndex = sprite->next;
+        if (sprite->sprite_identifier == SPRITE_IDENTIFIER_NULL)
+        {
+            sprite_reset(sprite);
+        }
+    }
 }
 
 /*

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -419,6 +419,7 @@ extern uint16 *gSpriteListCount;
 extern uint16 gSpriteSpatialIndex[0x10001];
 
 rct_sprite *create_sprite(uint8 bl);
+void sprite_reset(rct_unk_sprite *sprite);
 void reset_sprite_list();
 void reset_sprite_spatial_index();
 void sprite_clear_all_unused();

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -419,7 +419,7 @@ extern uint16 *gSpriteListCount;
 extern uint16 gSpriteSpatialIndex[0x10001];
 
 rct_sprite *create_sprite(uint8 bl);
-void sprite_reset(rct_unk_sprite *sprite);
+void reset_empty_sprites();
 void reset_sprite_list();
 void reset_sprite_spatial_index();
 void sprite_clear_all_unused();


### PR DESCRIPTION
The sprites need to be reset anyway before they get used, so resest them
on every export just so they can be compressed better