### PR TITLE
Add IDs for null sound IDs

### DIFF
--- a/src/openrct2/audio/audio.cpp
+++ b/src/openrct2/audio/audio.cpp
@@ -384,7 +384,7 @@ void audio_init_ride_sounds(sint32 device)
     for (sint32 i = 0; i < AUDIO_MAX_VEHICLE_SOUNDS; i++)
     {
         rct_vehicle_sound * vehicleSound = &gVehicleSoundList[i];
-        vehicleSound->id = 0xFFFF;
+        vehicleSound->id = SOUND_ID_NULL;
     }
 
     gAudioCurrentDevice = device;
@@ -443,14 +443,14 @@ void audio_stop_vehicle_sounds()
     for (size_t i = 0; i < Util::CountOf(gVehicleSoundList); i++)
     {
         rct_vehicle_sound * vehicleSound = &gVehicleSoundList[i];
-        if (vehicleSound->id != 0xFFFF)
+        if (vehicleSound->id != SOUND_ID_NULL)
         {
-            vehicleSound->id = 0xFFFF;
-            if (vehicleSound->sound1_id != 0xFFFF)
+            vehicleSound->id = SOUND_ID_NULL;
+            if (vehicleSound->sound1_id != SOUND_ID_NULL)
             {
                 Mixer_Stop_Channel(vehicleSound->sound1_channel);
             }
-            if (vehicleSound->sound2_id != 0xFFFF)
+            if (vehicleSound->sound2_id != SOUND_ID_NULL)
             {
                 Mixer_Stop_Channel(vehicleSound->sound2_channel);
             }

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -29,6 +29,7 @@ extern "C"
 #define NUM_DEFAULT_MUSIC_TRACKS    46
 #define AUDIO_PLAY_AT_CENTRE        0x8000
 #define AUDIO_PLAY_AT_LOCATION      0x8001
+#define SOUND_ID_NULL               0xFFFF
 
 typedef struct audio_device
 {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1083,8 +1083,8 @@ private:
         dst->var_BF = src->var_BF;
         dst->var_B6 = src->var_B6;
         dst->var_B8 = src->var_B8;
-        dst->sound1_id = 0xFF;
-        dst->sound2_id = 0xFF;
+        dst->sound1_id = RCT12_SOUND_ID_NULL;
+        dst->sound2_id = RCT12_SOUND_ID_NULL;
         dst->var_C0 = src->var_C0;
         dst->var_C4 = src->var_C4;
         dst->var_C5 = src->var_C5;

--- a/src/openrct2/rct12.h
+++ b/src/openrct2/rct12.h
@@ -26,6 +26,7 @@
 #define RCT12_MAX_PEEP_SPAWNS       2
 #define RCT12_MAX_PARK_ENTRANCES    4
 #define RCT12_NUM_COLOUR_SCHEMES    4
+#define RCT12_SOUND_ID_NULL         0xFF
 
 #pragma pack(push, 1)
 

--- a/src/openrct2/ride/cable_lift.c
+++ b/src/openrct2/ride/cable_lift.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../rct12.h"
 #include "../world/sprite.h"
 #include "cable_lift.h"
 #include "ride.h"
@@ -57,8 +58,8 @@ rct_vehicle *cable_lift_segment_create(sint32 rideIndex, sint32 x, sint32 y, sin
     current->var_BA = 0;
     current->var_B6 = 0;
     current->var_B8 = 0;
-    current->sound1_id = 0xFF;
-    current->sound2_id = 0xFF;
+    current->sound1_id = RCT12_SOUND_ID_NULL;
+    current->sound2_id = RCT12_SOUND_ID_NULL;
     current->var_C4 = 0;
     current->var_C5 = 0;
     current->var_C8 = 0;

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -4502,8 +4502,8 @@ static rct_vehicle *vehicle_create_car(
     vehicle->var_BA = 0;
     vehicle->var_B6 = 0;
     vehicle->var_B8 = 0;
-    vehicle->sound1_id = 0xFF;
-    vehicle->sound2_id = 0xFF;
+    vehicle->sound1_id = RCT12_SOUND_ID_NULL;
+    vehicle->sound2_id = RCT12_SOUND_ID_NULL;
     vehicle->next_vehicle_on_train = SPRITE_INDEX_NULL;
     vehicle->var_C4 = 0;
     vehicle->var_C5 = 0;

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -25,6 +25,7 @@
 #include "../management/news_item.h"
 #include "../OpenRCT2.h"
 #include "../platform/platform.h"
+#include "../rct12.h"
 #include "../rct2/hook.h"
 #include "../scenario/scenario.h"
 #include "../world/map_animation.h"
@@ -668,7 +669,7 @@ static void vehicle_invalidate(rct_vehicle *vehicle)
 static void vehicle_update_sound_params(rct_vehicle* vehicle)
 {
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && (!(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) || gS6Info.editor_step == EDITOR_STEP_ROLLERCOASTER_DESIGNER)) {
-        if (vehicle->sound1_id != (uint8)-1 || vehicle->sound2_id != (uint8)-1) {
+        if (vehicle->sound1_id != RCT12_SOUND_ID_NULL || vehicle->sound2_id != RCT12_SOUND_ID_NULL) {
             if (vehicle->sprite_left != (sint16)(uint16)0x8000) {
                 sint16 x = g_music_tracking_viewport->view_x;
                 sint16 y = g_music_tracking_viewport->view_y;
@@ -818,19 +819,19 @@ void vehicle_sounds_update()
             }
             for(sint32 i = 0; i < countof(gVehicleSoundList); i++){
                 rct_vehicle_sound* vehicle_sound = &gVehicleSoundList[i];
-                if (vehicle_sound->id != (uint16)-1) {
+                if (vehicle_sound->id != SOUND_ID_NULL) {
                     for (rct_vehicle_sound_params* vehicle_sound_params = &gVehicleSoundParamsList[0]; vehicle_sound_params != gVehicleSoundParamsListEnd; vehicle_sound_params++) {
                         if (vehicle_sound->id == vehicle_sound_params->id) {
                             goto label26;
                         }
                     }
-                    if (vehicle_sound->sound1_id != (uint16)-1) {
+                    if (vehicle_sound->sound1_id != SOUND_ID_NULL) {
                         Mixer_Stop_Channel(vehicle_sound->sound1_channel);
                     }
-                    if (vehicle_sound->sound2_id != (uint16)-1) {
+                    if (vehicle_sound->sound2_id != SOUND_ID_NULL) {
                         Mixer_Stop_Channel(vehicle_sound->sound2_channel);
                     }
-                    vehicle_sound->id = (uint16)-1;
+                    vehicle_sound->id = SOUND_ID_NULL;
                 }
             label26:
                 ;
@@ -900,7 +901,7 @@ void vehicle_sounds_update()
                     if (vehicle_sound >= &gVehicleSoundList[countof(gVehicleSoundList)]) {
                         vehicle_sound = &gVehicleSoundList[0];
                         sint32 i = 0;
-                        while (vehicle_sound->id != (uint16)-1) {
+                        while (vehicle_sound->id != SOUND_ID_NULL) {
                             vehicle_sound++;
                             i++;
                             if (i >= countof(gVehicleSoundList)) {
@@ -909,8 +910,8 @@ void vehicle_sounds_update()
                             }
                         }
                         vehicle_sound->id = vehicle_sound_params->id;
-                        vehicle_sound->sound1_id = (uint16)-1;
-                        vehicle_sound->sound2_id = (uint16)-1;
+                        vehicle_sound->sound1_id = SOUND_ID_NULL;
+                        vehicle_sound->sound2_id = SOUND_ID_NULL;
                         vehicle_sound->volume = 0x30;
                         break;
                     }
@@ -940,13 +941,13 @@ void vehicle_sounds_update()
                 if (volume < -10000) {
                     volume = -10000;
                 }
-                if (sprite->vehicle.sound1_id == (uint8)-1) {
-                    if (vehicle_sound->sound1_id != (uint16)-1) {
-                        vehicle_sound->sound1_id = -1;
+                if (sprite->vehicle.sound1_id == RCT12_SOUND_ID_NULL) {
+                    if (vehicle_sound->sound1_id != SOUND_ID_NULL) {
+                        vehicle_sound->sound1_id = SOUND_ID_NULL;
                         Mixer_Stop_Channel(vehicle_sound->sound1_channel);
                     }
                 } else {
-                    if (vehicle_sound->sound1_id == (uint16)-1) {
+                    if (vehicle_sound->sound1_id == SOUND_ID_NULL) {
                         goto label69;
                     }
                     if (sprite->vehicle.sound1_id != vehicle_sound->sound1_id) {
@@ -992,12 +993,12 @@ void vehicle_sounds_update()
                     volume = -10000;
                 }
                 if (sprite->vehicle.sound2_id == (uint8)-1) {
-                    if (vehicle_sound->sound2_id != (uint16)-1) {
+                    if (vehicle_sound->sound2_id != SOUND_ID_NULL) {
                         vehicle_sound->sound2_id = -1;
                         Mixer_Stop_Channel(vehicle_sound->sound2_channel);
                     }
                 } else {
-                    if (vehicle_sound->sound2_id == (uint16)-1) {
+                    if (vehicle_sound->sound2_id == SOUND_ID_NULL) {
                         goto label93;
                     }
                     if (sprite->vehicle.sound2_id != vehicle_sound->sound2_id) {
@@ -7519,7 +7520,7 @@ loc_6DAEB9:
     }
     else if (track_element_is_booster(ride->type, trackType)) {
         regs.eax = get_booster_speed(ride->type, (vehicle->brake_speed << 16));
-      
+
         if (regs.eax > _vehicleVelocityF64E08) {
             vehicle->acceleration = RideProperties[ride->type].booster_acceleration << 16; //_vehicleVelocityF64E08 * 1.2;
         }


### PR DESCRIPTION
This will need some discussion, as it appears that the rct_vehicle struct uses uint8's while our audio layer uses uint16's. If we want to keep it that way it might be better to rename SOUND_ID_UINT8_NULL to RCT12_SOUND_ID_NULL.