### PR TITLE
Replace OPENSSL_{malloc,free} with the standard C versions

### DIFF
--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -385,7 +385,7 @@ bool NetworkKey::Sign(const uint8 * md, const size_t len, char ** signature, siz
 
     uint8 * sig;
     /* Allocate memory for the signature based on size in slen */
-    if ((sig = (unsigned char*)OPENSSL_malloc((sint32)(sizeof(unsigned char) * (*out_size)))) == NULL)
+    if ((sig = (unsigned char*)malloc((sint32)(sizeof(unsigned char) * (*out_size)))) == NULL)
     {
         log_error("Failed to crypto-allocate space for signature");
         EVP_MD_CTX_destroy(mdctx);
@@ -395,12 +395,12 @@ bool NetworkKey::Sign(const uint8 * md, const size_t len, char ** signature, siz
     if (1 != EVP_DigestSignFinal(mdctx, sig, out_size)) {
         log_error("Failed to finalise signature");
         EVP_MD_CTX_destroy(mdctx);
-        OPENSSL_free(sig);
+        free(sig);
         return false;
     }
     *signature = new char[*out_size];
     memcpy(*signature, sig, *out_size);
-    OPENSSL_free(sig);
+    free(sig);
     EVP_MD_CTX_destroy(mdctx);
 
     return true;


### PR DESCRIPTION
There is no need to OPENSSL_malloc and OPENSSL_free when interfacing with OpenSSL. Like every single method up until recently, they're exposed API and projects only use them because of this, not because they're required.

These functions were added because back in the 90s, they considered the standard equivalents too slow - which even then was a bad idea. They're certainly a bad idea considering their implementation, which hides (or hid) bugs from tools like Valgrind or Coverity and also because it circumvents any hardening to the standard malloc functions (which OS's like OpenBSD have done).

For more information you could watch [Bob Beck's talk about LibreSSL and OpenSSL's memory allocator](https://www.youtube.com/watch?v=GnBbhXBDmwU) (memory is discussed from 20:00-ish).