### PR TITLE
Fix game crashing/freezing when kicking players in MP. (#5666)

### DIFF
--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -2696,6 +2696,11 @@ void game_command_kick_player(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx
 {
     uint8 playerid = (uint8)*eax;
     NetworkPlayer* player = gNetwork.GetPlayerByID(playerid);
+    if (player == nullptr) {
+        // Player might be already removed by the PLAYERLIST command, need to refactor non-game commands executing too early.
+        return;
+    }
+
     if (player && player->Flags & NETWORK_PLAYER_FLAG_ISSERVER) {
         gGameCommandErrorTitle = STR_CANT_KICK_THE_HOST;
         gGameCommandErrorText = STR_NONE;


### PR DESCRIPTION
Currently not all network packets are bound to the server tick, so when a client is kicked it sends the player list to everyone which they all execute without waiting for the server tick, 
kick command is bound to the tick and executed later. The player list command already removes the player causing the kick handler to dereference null by non existant player id.

To fix this properly this needs some major refacotring, for now this will do.