### PR TITLE
Keep pointers to server log and chat log file streams in Network object.

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -71,6 +71,7 @@ extern "C" {
 #include <openssl/evp.h>
 #include "../core/Json.hpp"
 #include "../core/Nullable.hpp"
+#include "../core/FileStream.hpp"
 #include "NetworkConnection.h"
 #include "NetworkGroup.h"
 #include "NetworkKey.h"
@@ -128,7 +129,7 @@ public:
     void LoadGroups();
 
     std::string BeginLog(const std::string &directory, const std::string &filenameFormat);
-    void AppendLog(const std::string &logPath, const std::string &s);
+    void AppendLog(FileStream *fs, const std::string &s);
 
     void BeginChatLog();
     void AppendChatLog(const std::string &s);
@@ -236,6 +237,8 @@ private:
     std::string _serverLogPath;
     std::string _serverLogFilenameFormat = "-%Y%m%d-%H%M%S.txt";
     OpenRCT2::IPlatformEnvironment * _env;
+    FileStream * _chat_log_fs = nullptr;
+    FileStream * _server_log_fs = nullptr;
 
     void UpdateServer();
     void UpdateClient();


### PR DESCRIPTION
Create file stream objects only when beginning to log.
Reuse file stream objects when appending to logs.
Change signature of AppendLog to pass in pointer to file stream instead of logpath.