### PR TITLE
Replace free+null with SafeFree, allow freeing NULL

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -58,8 +58,7 @@ namespace OpenRCT2 { namespace Audio
 
         void Free()
         {
-            Memory::Free(_data);
-            _data = nullptr;
+            SafeFree(_data);
             _capacity = 0;
         }
 

--- a/src/openrct2/audio/audio.cpp
+++ b/src/openrct2/audio/audio.cpp
@@ -158,11 +158,7 @@ void audio_init()
 
 void audio_populate_devices()
 {
-    if (gAudioDevices != nullptr)
-    {
-        Memory::Free(gAudioDevices);
-        gAudioDevices = nullptr;
-    }
+    SafeFree(gAudioDevices);
 
     IAudioContext * audioContext = OpenRCT2::GetContext()->GetAudioContext();
     std::vector<std::string> devices = audioContext->GetOutputDevices();

--- a/src/openrct2/core/StringBuilder.hpp
+++ b/src/openrct2/core/StringBuilder.hpp
@@ -107,11 +107,7 @@ public:
     {
         _length = 0;
         _capacity = 0;
-        if (_buffer != nullptr)
-        {
-            Memory::Free(_buffer);
-            _buffer = nullptr;
-        }
+        SafeFree(_buffer);
     }
 
     /**

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -89,8 +89,7 @@ public:
                 uint64 readBytes = zip_fread(zipFile, data, dataSize);
                 if (readBytes != dataSize)
                 {
-                    Memory::Free(data);
-                    data = nullptr;
+                    SafeFree(data);
                     dataSize = 0;
                 }
                 zip_fclose(zipFile);

--- a/src/openrct2/windows/loadsave.c
+++ b/src/openrct2/windows/loadsave.c
@@ -720,8 +720,7 @@ static void window_loadsave_invoke_callback(sint32 result, const utf8 * path)
 
 static void save_path(utf8 **config_str, const char *path)
 {
-    if (*config_str != NULL)
-        free(*config_str);
+    free(*config_str);
     *config_str = path_get_directory(path);
     config_save_default();
 }

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -2039,8 +2039,7 @@ static void window_options_text_input(rct_window *w, rct_widgetindex widgetIndex
         return;
 
     if (widgetIndex == WIDX_CHANNEL_BUTTON) {
-        if (gConfigTwitch.channel != NULL)
-            free(gConfigTwitch.channel);
+        free(gConfigTwitch.channel);
         gConfigTwitch.channel = _strdup(text);
         config_save_default();
     }

--- a/src/openrct2/windows/server_list.cpp
+++ b/src/openrct2/windows/server_list.cpp
@@ -530,8 +530,7 @@ static void dispose_server_entry_list()
         for (sint32 i = 0; i < _numServerEntries; i++) {
             dispose_server_entry(&_serverEntries[i]);
         }
-        free(_serverEntries);
-        _serverEntries = NULL;
+        SafeFree(_serverEntries);
     }
     _numServerEntries = 0;
 }

--- a/src/openrct2/windows/title_editor.c
+++ b/src/openrct2/windows/title_editor.c
@@ -291,8 +291,7 @@ static void window_title_editor_close(rct_window *w)
     _isSequencePlaying = false;
     _sequenceName = NULL;
 
-    free(_renameSavePath);
-    _renameSavePath = NULL;
+    SafeFree(_renameSavePath);
 }
 
 static void window_title_editor_mouseup(rct_window *w, rct_widgetindex widgetIndex)


### PR DESCRIPTION
Replaced `free(x); x = NULL;` with `SafeFree(x);`.
Removed `if (x != NULL)` checks before `free(x);`, since `free()` handles NULL fine.