### PR TITLE
Clean up windows using land tools

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4C8B42701EEB1ABD00F015CA /* X8DrawingEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C8B426E1EEB1ABD00F015CA /* X8DrawingEngine.cpp */; };
 		4C8B42721EEB1AE400F015CA /* HardwareDisplayDrawingEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C8B42711EEB1AE400F015CA /* HardwareDisplayDrawingEngine.cpp */; };
 		4C8B42741EEB1B6F00F015CA /* Screenshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C8B42731EEB1B6F00F015CA /* Screenshot.cpp */; };
+		4CB832A71EFBDCCE00B88761 /* land_tool.c in Sources */ = {isa = PBXBuildFile; fileRef = 4CB832A51EFBDCCE00B88761 /* land_tool.c */; };
 		C606CCBE1DB4054000FE4015 /* compat.c in Sources */ = {isa = PBXBuildFile; fileRef = C606CCAB1DB4054000FE4015 /* compat.c */; };
 		C606CCBF1DB4054000FE4015 /* data.c in Sources */ = {isa = PBXBuildFile; fileRef = C606CCAC1DB4054000FE4015 /* data.c */; };
 		C606CCC01DB4054000FE4015 /* FunctionCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C606CCAE1DB4054000FE4015 /* FunctionCall.cpp */; };
@@ -570,6 +571,8 @@
 		4C8B426F1EEB1ABD00F015CA /* X8DrawingEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = X8DrawingEngine.h; sourceTree = "<group>"; };
 		4C8B42711EEB1AE400F015CA /* HardwareDisplayDrawingEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HardwareDisplayDrawingEngine.cpp; sourceTree = "<group>"; };
 		4C8B42731EEB1B6F00F015CA /* Screenshot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Screenshot.cpp; sourceTree = "<group>"; };
+		4CB832A51EFBDCCE00B88761 /* land_tool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = land_tool.c; sourceTree = "<group>"; };
+		4CB832A61EFBDCCE00B88761 /* land_tool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = land_tool.h; sourceTree = "<group>"; };
 		C606CCAB1DB4054000FE4015 /* compat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; lineEnding = 0; path = compat.c; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.c; };
 		C606CCAC1DB4054000FE4015 /* data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; lineEnding = 0; path = data.c; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.c; };
 		C606CCAD1DB4054000FE4015 /* data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = data.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -1917,6 +1920,8 @@
 				F76C83C41EC4E7CC00FA49E2 /* Fonts.h */,
 				F76C83C51EC4E7CC00FA49E2 /* graph.c */,
 				F76C83C61EC4E7CC00FA49E2 /* graph.h */,
+				4CB832A51EFBDCCE00B88761 /* land_tool.c */,
+				4CB832A61EFBDCCE00B88761 /* land_tool.h */,
 				F76C83CA1EC4E7CC00FA49E2 /* screenshot.h */,
 				F76C83CB1EC4E7CC00FA49E2 /* Theme.cpp */,
 				F76C83CC1EC4E7CC00FA49E2 /* themes.h */,
@@ -2975,6 +2980,7 @@
 				F7CB864D1EEDA1A80030C877 /* DummyWindowManager.cpp in Sources */,
 				F76C887C1EC5324E00FA49E2 /* MemoryAudioSource.cpp in Sources */,
 				F76C887D1EC5324E00FA49E2 /* CursorData.cpp in Sources */,
+				4CB832A71EFBDCCE00B88761 /* land_tool.c in Sources */,
 				F7D7747F1EC61E5100BE6EBC /* UiContext.macOS.mm in Sources */,
 				F76C887E1EC5324E00FA49E2 /* CursorRepository.cpp in Sources */,
 				F775F5341EE35A6B001F00E7 /* DummyUiContext.cpp in Sources */,

--- a/src/openrct2/interface/land_tool.c
+++ b/src/openrct2/interface/land_tool.c
@@ -1,0 +1,118 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#include "../windows/dropdown.h"
+#include "../world/map.h"
+#include "land_tool.h"
+#include "widget.h"
+#include "window.h"
+
+static uint16 toolSizeSpriteIndices[] =
+{
+    SPR_LAND_TOOL_SIZE_0,
+    SPR_LAND_TOOL_SIZE_1,
+    SPR_LAND_TOOL_SIZE_2,
+    SPR_LAND_TOOL_SIZE_3,
+    SPR_LAND_TOOL_SIZE_4,
+    SPR_LAND_TOOL_SIZE_5,
+    SPR_LAND_TOOL_SIZE_6,
+    SPR_LAND_TOOL_SIZE_7,
+};
+
+static char FloorTextureOrder[] =
+{
+    TERRAIN_SAND_DARK, TERRAIN_SAND_LIGHT,  TERRAIN_DIRT,      TERRAIN_GRASS_CLUMPS, TERRAIN_GRASS,
+    TERRAIN_ROCK,      TERRAIN_SAND,        TERRAIN_MARTIAN,   TERRAIN_CHECKERBOARD, TERRAIN_ICE,
+    TERRAIN_GRID_RED,  TERRAIN_GRID_YELLOW, TERRAIN_GRID_BLUE, TERRAIN_GRID_GREEN
+};
+
+static char WallTextureOrder[] =
+{
+    TERRAIN_EDGE_ROCK,       TERRAIN_EDGE_WOOD_RED,
+    TERRAIN_EDGE_WOOD_BLACK, TERRAIN_EDGE_ICE,
+    0, 0
+};
+
+uint16 gLandToolSize;
+money32 gLandToolRaiseCost;
+money32 gLandToolLowerCost;
+uint8 gLandToolTerrainSurface;
+uint8 gLandToolTerrainEdge;
+money32 gWaterToolRaiseCost;
+money32 gWaterToolLowerCost;
+
+uint32 land_tool_size_to_sprite_index(uint16 size)
+{
+    if (size <= MAX_TOOL_SIZE_WITH_SPRITE)
+    {
+        return toolSizeSpriteIndices[size];
+    }
+    else
+    {
+        return 0xFFFFFFFF;
+    }
+}
+
+void land_tool_show_surface_style_dropdown(rct_window * w, rct_widget * widget, uint8 currentSurfaceType)
+{
+    uint8 defaultIndex = 0;
+
+    for (uint8 i = 0; i < TERRAIN_COUNT_REGULAR; i++)
+    {
+        gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
+        gDropdownItemsArgs[i] = SPR_FLOOR_TEXTURE_GRASS + FloorTextureOrder[i];
+        if (FloorTextureOrder[i] == currentSurfaceType)
+        {
+            defaultIndex = i;
+        }
+    }
+
+    window_dropdown_show_image(
+       w->x + widget->left, w->y + widget->top,
+       widget->bottom - widget->top,
+       w->colours[2],
+       0,
+       TERRAIN_COUNT_REGULAR,
+       47, 36,
+       gAppropriateImageDropdownItemsPerRow[TERRAIN_COUNT_REGULAR]
+    );
+
+    gDropdownDefaultIndex = defaultIndex;
+}
+
+void land_tool_show_edge_style_dropdown(rct_window * w, rct_widget * widget, uint8 currentEdgeType)
+{
+    uint8 defaultIndex = 0;
+
+    for (uint8 i = 0; i < TERRAIN_EDGE_COUNT; i++) {
+        gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
+        gDropdownItemsArgs[i] = SPR_WALL_TEXTURE_ROCK + WallTextureOrder[i];
+        if (WallTextureOrder[i] == currentEdgeType)
+            defaultIndex = i;
+    }
+
+    window_dropdown_show_image(
+       w->x + widget->left, w->y + widget->top,
+       widget->bottom - widget->top,
+       w->colours[2],
+       0,
+       TERRAIN_EDGE_COUNT,
+       47, 36,
+       gAppropriateImageDropdownItemsPerRow[TERRAIN_EDGE_COUNT]
+    );
+
+    gDropdownDefaultIndex = defaultIndex;
+}

--- a/src/openrct2/interface/land_tool.h
+++ b/src/openrct2/interface/land_tool.h
@@ -1,0 +1,37 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#pragma once
+
+#include "../common.h"
+#include "../sprites.h"
+
+#define MINIMUM_TOOL_SIZE         1
+#define MAXIMUM_TOOL_SIZE         64
+// The highest tool size to have a sprite. Bigger tool sizes simply display a number.
+#define MAX_TOOL_SIZE_WITH_SPRITE 7
+
+extern uint16 gLandToolSize;
+extern money32 gLandToolRaiseCost;
+extern money32 gLandToolLowerCost;
+extern uint8 gLandToolTerrainSurface;
+extern uint8 gLandToolTerrainEdge;
+extern money32 gWaterToolRaiseCost;
+extern money32 gWaterToolLowerCost;
+
+uint32 land_tool_size_to_sprite_index(uint16 size);
+void land_tool_show_surface_style_dropdown(rct_window * w, rct_widget * widget, uint8 currentSurfaceType);
+void land_tool_show_edge_style_dropdown(rct_window * w, rct_widget * widget, uint8 currentEdgeType);

--- a/src/openrct2/windows/clear_scenery.c
+++ b/src/openrct2/windows/clear_scenery.c
@@ -16,6 +16,7 @@
 
 #include "../Context.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
@@ -23,9 +24,6 @@
 #include "../sprites.h"
 #include "../world/map.h"
 #include "../world/scenery.h"
-
-#define MINIMUM_TOOL_SIZE 1
-#define MAXIMUM_TOOL_SIZE 64
 
 enum WINDOW_CLEAR_SCENERY_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -112,6 +110,7 @@ void window_clear_scenery_open()
     window_init_scroll_widgets(window);
     window_push_others_below(window);
 
+    gLandToolSize = 2;
     gClearSceneryCost = MONEY32_UNDEFINED;
 
     gClearSmallScenery = true;
@@ -220,8 +219,7 @@ static void window_clear_scenery_invalidate(rct_window *w)
         (gClearFootpath     ? (1 << WIDX_FOOTPATH)      : 0);
 
     // Update the preview image (for tool sizes up to 7)
-    window_clear_scenery_widgets[WIDX_PREVIEW].image = gLandToolSize <= 7 ?
-        SPR_LAND_TOOL_SIZE_0 + gLandToolSize : 0xFFFFFFFF;
+    window_clear_scenery_widgets[WIDX_PREVIEW].image = land_tool_size_to_sprite_index(gLandToolSize);
 }
 
 /**
@@ -237,7 +235,7 @@ static void window_clear_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi)
     // Draw number for tool sizes bigger than 7
     x = w->x + (window_clear_scenery_widgets[WIDX_PREVIEW].left + window_clear_scenery_widgets[WIDX_PREVIEW].right) / 2;
     y = w->y + (window_clear_scenery_widgets[WIDX_PREVIEW].top + window_clear_scenery_widgets[WIDX_PREVIEW].bottom) / 2;
-    if (gLandToolSize > 7) {
+    if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE) {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
     }
 

--- a/src/openrct2/windows/land.c
+++ b/src/openrct2/windows/land.c
@@ -16,6 +16,7 @@
 
 #include "../Context.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
@@ -24,8 +25,7 @@
 #include "../world/map.h"
 #include "dropdown.h"
 
-#define MINIMUM_TOOL_SIZE 1
-#define MAXIMUM_TOOL_SIZE 64
+
 
 enum WINDOW_LAND_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -100,18 +100,6 @@ static rct_window_event_list window_land_events = {
     NULL
 };
 
-static char FloorTextureOrder[] = {
-    TERRAIN_SAND_DARK, TERRAIN_SAND_LIGHT,  TERRAIN_DIRT,      TERRAIN_GRASS_CLUMPS, TERRAIN_GRASS,
-    TERRAIN_ROCK,      TERRAIN_SAND,        TERRAIN_MARTIAN,   TERRAIN_CHECKERBOARD, TERRAIN_ICE,
-    TERRAIN_GRID_RED,  TERRAIN_GRID_YELLOW, TERRAIN_GRID_BLUE, TERRAIN_GRID_GREEN
-};
-
-static char WallTextureOrder[] = {
-    TERRAIN_EDGE_ROCK,       TERRAIN_EDGE_WOOD_RED,
-    TERRAIN_EDGE_WOOD_BLACK, TERRAIN_EDGE_ICE,
-    0, 0
-};
-
 sint32 _selectedFloorTexture;
 sint32 _selectedWallTexture;
 
@@ -141,6 +129,7 @@ void window_land_open()
     window_init_scroll_widgets(window);
     window_push_others_below(window);
 
+    gLandToolSize = 1;
     gLandToolTerrainSurface = 255;
     gLandToolTerrainEdge = 255;
     gLandMountainMode = false;
@@ -212,40 +201,10 @@ static void window_land_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct
     sint32 defaultIndex = -1;
     switch (widgetIndex) {
     case WIDX_FLOOR:
-        for (i = 0; i < TERRAIN_COUNT_REGULAR; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_FLOOR_TEXTURE_GRASS + FloorTextureOrder[i];
-            if (FloorTextureOrder[i] == _selectedFloorTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_COUNT_REGULAR,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_COUNT_REGULAR]
-        );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_surface_style_dropdown(w, widget, _selectedFloorTexture);
         break;
     case WIDX_WALL:
-        for (i = 0; i < TERRAIN_EDGE_COUNT; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_WALL_TEXTURE_ROCK + WallTextureOrder[i];
-            if (WallTextureOrder[i] == _selectedWallTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_EDGE_COUNT,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_EDGE_COUNT]
-        );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_edge_style_dropdown(w, widget, _selectedWallTexture);
         break;
     case WIDX_PREVIEW:
         window_land_inputsize(w);
@@ -351,9 +310,7 @@ static void window_land_invalidate(rct_window *w)
     window_land_widgets[WIDX_FLOOR].image = SPR_FLOOR_TEXTURE_GRASS + _selectedFloorTexture;
     window_land_widgets[WIDX_WALL].image = SPR_WALL_TEXTURE_ROCK + _selectedWallTexture;
     // Update the preview image (for tool sizes up to 7)
-    window_land_widgets[WIDX_PREVIEW].image = gLandToolSize <= 7 ?
-        SPR_LAND_TOOL_SIZE_0 + gLandToolSize :
-        0xFFFFFFFF;
+    window_land_widgets[WIDX_PREVIEW].image = land_tool_size_to_sprite_index(gLandToolSize);
 }
 
 /**
@@ -369,7 +326,7 @@ static void window_land_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_draw_widgets(w, dpi);
 
     // Draw number for tool sizes bigger than 7
-    if (gLandToolSize > 7) {
+    if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE) {
         x = w->x + (previewWidget->left + previewWidget->right) / 2;
         y = w->y + (previewWidget->top + previewWidget->bottom) / 2;
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);

--- a/src/openrct2/windows/land.c
+++ b/src/openrct2/windows/land.c
@@ -197,8 +197,6 @@ static void window_land_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  */
 static void window_land_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
 {
-    sint32 i;
-    sint32 defaultIndex = -1;
     switch (widgetIndex) {
     case WIDX_FLOOR:
         land_tool_show_surface_style_dropdown(w, widget, _selectedFloorTexture);

--- a/src/openrct2/windows/land_rights.c
+++ b/src/openrct2/windows/land_rights.c
@@ -17,6 +17,7 @@
 #include "../Context.h"
 #include "../game.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/viewport.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
@@ -24,9 +25,6 @@
 #include "../rct2.h"
 #include "../sprites.h"
 #include "../world/map.h"
-
-#define MINIMUM_TOOL_SIZE 1
-#define MAXIMUM_TOOL_SIZE 64
 
 enum WINDOW_WATER_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -110,6 +108,7 @@ void window_land_rights_open()
     LandRightsMode = true;
     window->pressed_widgets = (1 << WIDX_BUY_LAND_RIGHTS);
 
+    gLandToolSize = 1;
     gWaterToolRaiseCost = MONEY32_UNDEFINED;
     gWaterToolLowerCost = MONEY32_UNDEFINED;
 
@@ -211,10 +210,7 @@ static void window_land_rights_invalidate(rct_window *w)
     w->pressed_widgets &= ~(1 << (!LandRightsMode ? WIDX_BUY_LAND_RIGHTS : WIDX_BUY_CONSTRUCTION_RIGHTS));
 
     // Update the preview image
-    // TODO: Don't apply addition to images
-    window_land_rights_widgets[WIDX_PREVIEW].image = gLandToolSize <= 7 ?
-        SPR_LAND_TOOL_SIZE_0 + gLandToolSize :
-        0xFFFFFFFF;
+    window_land_rights_widgets[WIDX_PREVIEW].image = land_tool_size_to_sprite_index(gLandToolSize);
 
     // Disable ownership and/or construction buying functions if there are no tiles left for sale
     if (gLandRemainingOwnershipSales == 0) {
@@ -243,7 +239,7 @@ static void window_land_rights_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     window_draw_widgets(w, dpi);
     // Draw number for tool sizes bigger than 7
-    if (gLandToolSize > 7) {
+    if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE) {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
     }
 

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -18,6 +18,7 @@
 #include "../cheats.h"
 #include "../game.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/viewport.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
@@ -28,9 +29,6 @@
 #include "../world/footpath.h"
 #include "../world/scenery.h"
 #include "error.h"
-
-#define MINIMUM_TOOL_SIZE 1
-#define MAXIMUM_TOOL_SIZE 64
 
 #define MAP_COLOUR_2(colourA, colourB) ((colourA << 8) | colourB)
 #define MAP_COLOUR(colour) MAP_COLOUR_2(colour, colour)
@@ -803,9 +801,7 @@ static void window_map_invalidate(rct_window *w)
                 for (i = 0; i < 4; i++)
                     w->widgets[WIDX_LAND_OWNED_CHECKBOX + i].type = WWT_CHECKBOX;
 
-                w->widgets[WIDX_LAND_TOOL].image = gLandToolSize <= 7 ?
-                    SPR_LAND_TOOL_SIZE_0 + gLandToolSize :
-                    0xFFFFFFFF;
+                w->widgets[WIDX_LAND_TOOL].image = land_tool_size_to_sprite_index(gLandToolSize);
             }
         } else {
             // if no tool is active: show the default scenario editor buttons
@@ -827,7 +823,7 @@ static void window_map_paint(rct_window *w, rct_drawpixelinfo *dpi)
     sint32 y = w->y + (window_map_widgets[WIDX_LAND_TOOL].top + window_map_widgets[WIDX_LAND_TOOL].bottom) / 2;
 
     // Draw land tool size
-    if (widget_is_active_tool(w, WIDX_SET_LAND_RIGHTS) && gLandToolSize > 7) {
+    if (widget_is_active_tool(w, WIDX_SET_LAND_RIGHTS) && gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE) {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
     }
     y = w->y + window_map_widgets[WIDX_LAND_TOOL].bottom + 5;

--- a/src/openrct2/windows/mapgen.c
+++ b/src/openrct2/windows/mapgen.c
@@ -919,8 +919,6 @@ static void window_mapgen_simplex_mouseup(rct_window *w, rct_widgetindex widgetI
 
 static void window_mapgen_simplex_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
 {
-    sint32 i;
-    sint32 defaultIndex = -1;
     switch (widgetIndex) {
     case WIDX_SIMPLEX_LOW_UP:
         _simplex_low = min(_simplex_low + 1, 24);

--- a/src/openrct2/windows/mapgen.c
+++ b/src/openrct2/windows/mapgen.c
@@ -16,6 +16,7 @@
 
 #include "../localisation/localisation.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/widget.h"
 #include "../interface/viewport.h"
 #include "../interface/window.h"
@@ -541,18 +542,6 @@ static void window_mapgen_set_pressed_tab(rct_window *w);
 static void window_mapgen_anchor_border_widgets(rct_window *w);
 static void window_mapgen_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w);
 
-static char FloorTextureOrder[] = {
-    TERRAIN_SAND_DARK, TERRAIN_SAND_LIGHT,  TERRAIN_DIRT,      TERRAIN_GRASS_CLUMPS, TERRAIN_GRASS,
-    TERRAIN_ROCK,      TERRAIN_SAND,        TERRAIN_MARTIAN,   TERRAIN_CHECKERBOARD, TERRAIN_ICE,
-    TERRAIN_GRID_RED,  TERRAIN_GRID_YELLOW, TERRAIN_GRID_BLUE, TERRAIN_GRID_GREEN
-};
-
-static char WallTextureOrder[] = {
-    TERRAIN_EDGE_ROCK,       TERRAIN_EDGE_WOOD_RED,
-    TERRAIN_EDGE_WOOD_BLACK, TERRAIN_EDGE_ICE,
-    0, 0
-};
-
 static sint32 _mapSize = 150;
 static sint32 _baseHeight = 12;
 static sint32 _waterLevel = 6;
@@ -667,8 +656,6 @@ static void window_mapgen_base_mouseup(rct_window *w, rct_widgetindex widgetInde
 
 static void window_mapgen_base_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
 {
-    sint32 i;
-    sint32 defaultIndex = -1;
     switch (widgetIndex) {
     case WIDX_MAP_SIZE_UP:
         _mapSize = min(_mapSize + 1, MAXIMUM_MAP_SIZE_TECHNICAL);
@@ -695,40 +682,10 @@ static void window_mapgen_base_mousedown(rct_widgetindex widgetIndex, rct_window
         window_invalidate(w);
         break;
     case WIDX_FLOOR_TEXTURE:
-        for (i = 0; i < TERRAIN_COUNT_REGULAR; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_FLOOR_TEXTURE_GRASS + FloorTextureOrder[i];
-            if (FloorTextureOrder[i] == _floorTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_COUNT_REGULAR,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_COUNT_REGULAR]
-        );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_surface_style_dropdown(w, widget, _floorTexture);
         break;
     case WIDX_WALL_TEXTURE:
-        for (i = 0; i < TERRAIN_EDGE_COUNT; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_WALL_TEXTURE_ROCK + WallTextureOrder[i];
-            if (WallTextureOrder[i] == _wallTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_EDGE_COUNT,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_EDGE_COUNT]
-        );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_edge_style_dropdown(w, widget, _wallTexture);
         break;
     }
 }
@@ -1014,40 +971,10 @@ static void window_mapgen_simplex_mousedown(rct_widgetindex widgetIndex, rct_win
         window_invalidate(w);
         break;
     case WIDX_SIMPLEX_FLOOR_TEXTURE:
-        for (i = 0; i < TERRAIN_COUNT_REGULAR; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_FLOOR_TEXTURE_GRASS + FloorTextureOrder[i];
-            if (FloorTextureOrder[i] == _floorTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_COUNT_REGULAR,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_COUNT_REGULAR]
-            );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_surface_style_dropdown(w, widget, _floorTexture);
         break;
     case WIDX_SIMPLEX_WALL_TEXTURE:
-        for (i = 0; i < TERRAIN_EDGE_COUNT; i++) {
-            gDropdownItemsFormat[i] = DROPDOWN_FORMAT_LAND_PICKER;
-            gDropdownItemsArgs[i] = SPR_WALL_TEXTURE_ROCK + WallTextureOrder[i];
-            if (WallTextureOrder[i] == _wallTexture)
-                defaultIndex = i;
-        }
-        window_dropdown_show_image(
-            w->x + widget->left, w->y + widget->top,
-            widget->bottom - widget->top,
-            w->colours[2],
-            0,
-            TERRAIN_EDGE_COUNT,
-            47, 36,
-            gAppropriateImageDropdownItemsPerRow[TERRAIN_EDGE_COUNT]
-            );
-        gDropdownDefaultIndex = defaultIndex;
+        land_tool_show_edge_style_dropdown(w, widget, _wallTexture);
         break;
     }
 }

--- a/src/openrct2/windows/park.c
+++ b/src/openrct2/windows/park.c
@@ -21,6 +21,7 @@
 #include "../localisation/localisation.h"
 #include "../input.h"
 #include "../interface/graph.h"
+#include "../interface/land_tool.h"
 #include "../interface/viewport.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
@@ -1154,7 +1155,6 @@ void toggle_land_rights_window(rct_window *parkWindow, rct_widgetindex widgetInd
         show_gridlines();
         tool_set(parkWindow, widgetIndex, TOOL_UP_ARROW);
         input_set_flag(INPUT_FLAG_6, true);
-        gLandToolSize = 1;
         window_land_rights_open();
     }
 }

--- a/src/openrct2/windows/top_toolbar.c
+++ b/src/openrct2/windows/top_toolbar.c
@@ -22,6 +22,7 @@
 #include "../game.h"
 #include "../input.h"
 #include "../interface/console.h"
+#include "../interface/land_tool.h"
 #include "../interface/Screenshot.h"
 #include "../interface/viewport.h"
 #include "../interface/widget.h"
@@ -1785,10 +1786,7 @@ static void top_toolbar_tool_update_scenery_clear(sint16 x, sint16 y){
         state_changed++;
     }
 
-    sint16 tool_size = gLandToolSize;
-    if (tool_size == 0)
-        tool_size = 1;
-
+    sint16 tool_size = max(1, gLandToolSize);
     sint16 tool_length = (tool_size - 1) * 32;
 
     // Move to tool bottom left
@@ -1865,10 +1863,7 @@ static void top_toolbar_tool_update_land_paint(sint16 x, sint16 y){
         state_changed++;
     }
 
-    sint16 tool_size = gLandToolSize;
-    if (tool_size == 0)
-        tool_size = 1;
-
+    sint16 tool_size = max(1, gLandToolSize);
     sint16 tool_length = (tool_size - 1) * 32;
 
     // Move to tool bottom left
@@ -2146,10 +2141,7 @@ static void top_toolbar_tool_update_water(sint16 x, sint16 y){
         state_changed++;
     }
 
-    sint16 tool_size = gLandToolSize;
-    if (tool_size == 0)
-        tool_size = 1;
-
+    sint16 tool_size = max(1, gLandToolSize);
     sint16 tool_length = (tool_size - 1) * 32;
 
     // Move to tool bottom left
@@ -3300,7 +3292,6 @@ void toggle_land_window(rct_window *topToolbar, rct_widgetindex widgetIndex)
         show_gridlines();
         tool_set(topToolbar, widgetIndex, TOOL_DIG_DOWN);
         input_set_flag(INPUT_FLAG_6, true);
-        gLandToolSize = 1;
         window_land_open();
     }
 }
@@ -3317,7 +3308,6 @@ void toggle_clear_scenery_window(rct_window *topToolbar, rct_widgetindex widgetI
         show_gridlines();
         tool_set(topToolbar, widgetIndex, TOOL_CROSSHAIR);
         input_set_flag(INPUT_FLAG_6, true);
-        gLandToolSize = 2;
         window_clear_scenery_open();
     }
 }
@@ -3334,7 +3324,6 @@ void toggle_water_window(rct_window *topToolbar, rct_widgetindex widgetIndex)
         show_gridlines();
         tool_set(topToolbar, widgetIndex, TOOL_WATER_DOWN);
         input_set_flag(INPUT_FLAG_6, true);
-        gLandToolSize = 1;
         window_water_open();
     }
 }

--- a/src/openrct2/windows/water.c
+++ b/src/openrct2/windows/water.c
@@ -16,15 +16,13 @@
 
 #include "../Context.h"
 #include "../input.h"
+#include "../interface/land_tool.h"
 #include "../interface/widget.h"
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
 #include "../rct2.h"
 #include "../sprites.h"
 #include "../world/map.h"
-
-#define MINIMUM_TOOL_SIZE 1
-#define MAXIMUM_TOOL_SIZE 64
 
 enum WINDOW_WATER_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -112,6 +110,7 @@ void window_water_open()
     window_init_scroll_widgets(window);
     window_push_others_below(window);
 
+    gLandToolSize = 1;
     gWaterToolRaiseCost = MONEY32_UNDEFINED;
     gWaterToolLowerCost = MONEY32_UNDEFINED;
 }
@@ -203,12 +202,7 @@ static void window_water_invalidate(rct_window *w)
     w->pressed_widgets |= (1 << WIDX_PREVIEW);
 
     // Update the preview image
-    //window_water_widgets[WIDX_PREVIEW].image = SPR_LAND_TOOL_SIZE_0 + gLandToolSize;
-
-    window_water_widgets[WIDX_PREVIEW].image = gLandToolSize <= 7 ?
-        SPR_LAND_TOOL_SIZE_0 + gLandToolSize :
-        0xFFFFFFFF;
-
+    window_water_widgets[WIDX_PREVIEW].image = land_tool_size_to_sprite_index(gLandToolSize);
 }
 
 /**
@@ -224,7 +218,7 @@ static void window_water_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     window_draw_widgets(w, dpi);
     // Draw number for tool sizes bigger than 7
-    if (gLandToolSize > 7) {
+    if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE) {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
     }
 

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -113,15 +113,7 @@ bool gClearSmallScenery;
 bool gClearLargeScenery;
 bool gClearFootpath;
 
-uint16 gLandToolSize;
-money32 gLandToolRaiseCost;
-money32 gLandToolLowerCost;
-uint8 gLandToolTerrainSurface;
-uint8 gLandToolTerrainEdge;
-money32 gWaterToolRaiseCost;
-money32 gWaterToolLowerCost;
 money32 gLandRightsCost;
-
 uint16 gLandRemainingOwnershipSales;
 uint16 gLandRemainingConstructionSales;
 

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -398,15 +398,7 @@ extern bool gClearSmallScenery;
 extern bool gClearLargeScenery;
 extern bool gClearFootpath;
 
-extern uint16 gLandToolSize;
-extern money32 gLandToolRaiseCost;
-extern money32 gLandToolLowerCost;
-extern uint8 gLandToolTerrainSurface;
-extern uint8 gLandToolTerrainEdge;
-extern money32 gWaterToolRaiseCost;
-extern money32 gWaterToolLowerCost;
 extern money32 gLandRightsCost;
-
 extern uint16 gLandRemainingOwnershipSales;
 extern uint16 gLandRemainingConstructionSales;
 


### PR DESCRIPTION
This puts the shared stuff into a new file. This includes min and max tool sizes, tool size to sprite index lookup, surface and edge type dropdowns and several globals like gLandToolSize, that really have no business in `world/map.c`.