### PR TITLE
Fix client not resuming when server toggles pause. (Issue #5686)

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -311,6 +311,8 @@ void game_update()
 
         // Special case because we set numUpdates to 0, otherwise in game_logic_update.
         network_update();
+
+        network_process_game_commands();
     }
 
     if (!gOpenRCT2Headless)


### PR DESCRIPTION
Fixes game commands being no longer processed once the client entered pause state.