### PR TITLE
Giving the cheat "Own all land" a tool-tip

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4429,6 +4429,7 @@ STR_6117    :Sitting in comfortable trains with only simple lap restraints rider
 STR_6118    :A gentle roller coaster for people who haven't yet got the courage to face the larger rides
 STR_6119    :A cheap and easy to build roller coaster, but with a limited height
 STR_6120    :{BABYBLUE}New vehicle now available for {STRINGID}:{NEWLINE}{STRINGID}
+STR_6121    :{SMALLFONT}{BLACK}Extends the park's land rights all the way to the edges of the map
 
 
 #############

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3786,6 +3786,8 @@ enum {
     STR_MIDI_COASTER_GROUP_DESC = 6119,
 
     STR_NEWS_ITEM_RESEARCH_NEW_VEHICLE_AVAILABLE = 6120,
+    
+    STR_CHEAT_OWN_ALL_LAND_TIP = 6121,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/windows/cheats.c
+++ b/src/openrct2/windows/cheats.c
@@ -244,7 +244,7 @@ static rct_widget window_cheats_misc_widgets[] = {
     { WWT_CLOSEBOX,         1,      XPL(1),                 WPL(1),                 YPL(1),         HPL(1),         STR_CHEAT_PARK_PARAMETERS,          STR_CHEAT_PARK_PARAMETERS_TIP },        // Park parameters
     { WWT_CLOSEBOX,         1,      XPL(0),                 WPL(0),                 YPL(2),         HPL(2),         STR_CHEAT_SANDBOX_MODE,             STR_CHEAT_SANDBOX_MODE_TIP },           // Sandbox mode (edit land ownership in-game)
     { WWT_CLOSEBOX,         1,      XPL(1),                 WPL(1),                 YPL(2),         HPL(2),         STR_CHEAT_RESET_DATE,               STR_NONE },                             // Reset date
-    { WWT_CLOSEBOX,         1,      XPL(0),                 WPL(0),                 YPL(3),         HPL(3),         STR_CHEAT_OWN_ALL_LAND,         STR_NONE },                             // Own all land
+    { WWT_CLOSEBOX,         1,      XPL(0),                 WPL(0),                 YPL(3),         HPL(3),         STR_CHEAT_OWN_ALL_LAND,             STR_CHEAT_OWN_ALL_LAND_TIP },           // Own all land
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(4),         OHPL(4),        STR_CHEAT_UNLOCK_PRICES,            STR_CHEAT_UNLOCK_PRICES_TIP },          // Unlock all prices
     { WWT_CHECKBOX,         1,      XPL(0),                 WPL(0),                 YPL(5),         HPL(5),         STR_FORCE_PARK_RATING,              STR_NONE },                             // Force park rating
     { WWT_SPINNER,          1,      XPL(1),                 WPL(1) - 10,            YPL(5) + 2,     HPL(5) - 3,     STR_NONE,                           STR_NONE },                             // park rating


### PR DESCRIPTION
Helps out a bit for translators as the space is limited in the textbox, most cheats have a tool-tip & gives the cheat "more off a meaning"