### PR TITLE
Fix footpath_remove ignoring the ghost flag removing the wrong path. (Issue #5694)

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "21"
+#define NETWORK_STREAM_VERSION "22"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/track.c
+++ b/src/openrct2/ride/track.c
@@ -1397,7 +1397,7 @@ static money32 track_place(sint32 rideIndex, sint32 type, sint32 originX, sint32
             mapElement = surfaceElement;
         }
 
-        if (!gCheatsDisableClearanceChecks || !(flags & (1 << 6))) {
+        if (!gCheatsDisableClearanceChecks || !(flags & GAME_COMMAND_FLAG_GHOST)) {
             footpath_connect_edges(x, y, mapElement, flags);
         }
         map_invalidate_tile_full(x, y);

--- a/src/openrct2/ride/track_design.c
+++ b/src/openrct2/ride/track_design.c
@@ -635,6 +635,11 @@ static sint32 track_design_place_scenery(rct_td6_scenery_element *scenery_start,
                     }
                 }
                 sint32 z;
+                const uint32 flags = GAME_COMMAND_FLAG_APPLY |
+                    GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED |
+                    GAME_COMMAND_FLAG_5 |
+                    GAME_COMMAND_FLAG_GHOST;
+
                 switch (entry_type) {
                 case OBJECT_TYPE_SMALL_SCENERY:
                     //bl
@@ -654,11 +659,10 @@ static sint32 track_design_place_scenery(rct_td6_scenery_element *scenery_start,
                     {
                         bh &= 0x3F;
                     }
-
                     z = (scenery->z * 8 + originZ) / 8;
                     game_do_command(
                         mapCoord.x,
-                        0x69 | bh << 8,
+                        flags | bh << 8,
                         mapCoord.y,
                         (entry_index << 8) | z,
                         GAME_COMMAND_REMOVE_SCENERY,
@@ -669,7 +673,7 @@ static sint32 track_design_place_scenery(rct_td6_scenery_element *scenery_start,
                     z = (scenery->z * 8 + originZ) / 8;
                     game_do_command(
                         mapCoord.x,
-                        0x69 | (((rotation + scenery->flags) & 0x3) << 8),
+                        flags | (((rotation + scenery->flags) & 0x3) << 8),
                         mapCoord.y,
                         z,
                         GAME_COMMAND_REMOVE_LARGE_SCENERY,
@@ -680,7 +684,7 @@ static sint32 track_design_place_scenery(rct_td6_scenery_element *scenery_start,
                     z = (scenery->z * 8 + originZ) / 8;
                     game_do_command(
                         mapCoord.x,
-                        0x69,
+                        flags,
                         mapCoord.y,
                         (z << 8) | ((rotation + scenery->flags) & 0x3),
                         GAME_COMMAND_REMOVE_WALL,
@@ -689,7 +693,11 @@ static sint32 track_design_place_scenery(rct_td6_scenery_element *scenery_start,
                     break;
                 case OBJECT_TYPE_PATHS:
                     z = (scenery->z * 8 + originZ) / 8;
-                    footpath_remove(mapCoord.x, mapCoord.y, z, 0x69);
+                    footpath_remove(
+                        mapCoord.x,
+                        mapCoord.y,
+                        z,
+                        flags);
                     break;
                 }
             }


### PR DESCRIPTION
When the ghost flag is applied it should only remove ghosts and nothing else, also replaced some constants with the known flags where I was sure they are correct. This issue only happened when "Disable clearance check" was active.