### PR TITLE
Create confirmation prompt for enabling "Quick Demolish"

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4430,7 +4430,11 @@ STR_6118    :A gentle roller coaster for people who haven't yet got the courage 
 STR_6119    :A cheap and easy to build roller coaster, but with a limited height
 STR_6120    :{BABYBLUE}New vehicle now available for {STRINGID}:{NEWLINE}{STRINGID}
 STR_6121    :{SMALLFONT}{BLACK}Extends the park's land rights all the way to the edges of the map
-
+STR_6122    :Enable quick demolish mode?
+STR_6123    :{WINDOW_COLOUR_1}This mode allows demolishing rides by pressing their name in the ride list. Are you sure you wish to enable this?{NEWLINE}{NEWLINE}Once a ride is demolished, it cannot be undone.
+STR_6124    :Confirm
+STR_6125    :Cancel
+STR_6126    :Quick demolish prompt
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4433,8 +4433,7 @@ STR_6121    :{SMALLFONT}{BLACK}Extends the park's land rights all the way to the
 STR_6122    :Enable quick demolish mode?
 STR_6123    :{WINDOW_COLOUR_1}This mode allows demolishing rides by pressing their name in the ride list. Are you sure you wish to enable this?{NEWLINE}{NEWLINE}Once a ride is demolished, it cannot be undone.
 STR_6124    :Confirm
-STR_6125    :Cancel
-STR_6126    :Quick demolish prompt
+STR_6125    :Quick demolish prompt
 
 #############
 # Scenarios #

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -175,6 +175,7 @@ WindowThemeDesc WindowThemeDescriptors[] =
     { THEME_WC(WC_NETWORK_STATUS),                 STR_THEMES_WINDOW_NETWORK_STATUS,                 COLOURS_1(COLOUR_LIGHT_BLUE                                                                                                    ) },
     { THEME_WC(WC_SERVER_LIST),                    STR_SERVER_LIST,                                  COLOURS_2(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_CHAT),                           STR_CHAT,                                         COLOURS_1(TRANSLUCENT(COLOUR_GREY)                                                                                             ) },
+    { THEME_WC(WC_QUICKDEMOLISH_PROMPT),           STR_THEMES_WINDOW_QUICK_DEMOLISH_PROMPT,          COLOURS_1(TRANSLUCENT(COLOUR_BORDEAUX_RED)) },
 };
 
 #pragma endregion

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -175,7 +175,6 @@ WindowThemeDesc WindowThemeDescriptors[] =
     { THEME_WC(WC_NETWORK_STATUS),                 STR_THEMES_WINDOW_NETWORK_STATUS,                 COLOURS_1(COLOUR_LIGHT_BLUE                                                                                                    ) },
     { THEME_WC(WC_SERVER_LIST),                    STR_SERVER_LIST,                                  COLOURS_2(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_CHAT),                           STR_CHAT,                                         COLOURS_1(TRANSLUCENT(COLOUR_GREY)                                                                                             ) },
-    { THEME_WC(WC_QUICKDEMOLISH_PROMPT),           STR_THEMES_WINDOW_QUICK_DEMOLISH_PROMPT,          COLOURS_1(TRANSLUCENT(COLOUR_BORDEAUX_RED)) },
 };
 
 #pragma endregion

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -477,6 +477,7 @@ enum {
     WC_CUSTOM_CURRENCY_CONFIG = 129,
     WC_DEBUG_PAINT = 130,
     WC_VIEW_CLIPPING = 131,
+    WC_QUICKDEMOLISH_PROMPT = 132,
 
     // Only used for colour schemes
     WC_STAFF = 220,

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3789,6 +3789,12 @@ enum {
     
     STR_CHEAT_OWN_ALL_LAND_TIP = 6121,
 
+    STR_QUICK_DEMOLISH_PROMPT_TITLE = 6122,
+    STR_QUICK_DEMOLISH_PROMPT_DESCRIPTION = 6123,
+    STR_QUICK_DEMOLISH_PROMPT_CONFIRM = 6124,
+    STR_QUICK_DEMOLISH_PROMPT_CANCEL = 6125,
+    STR_THEMES_WINDOW_QUICK_DEMOLISH_PROMPT = 6126,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3792,8 +3792,7 @@ enum {
     STR_QUICK_DEMOLISH_PROMPT_TITLE = 6122,
     STR_QUICK_DEMOLISH_PROMPT_DESCRIPTION = 6123,
     STR_QUICK_DEMOLISH_PROMPT_CONFIRM = 6124,
-    STR_QUICK_DEMOLISH_PROMPT_CANCEL = 6125,
-    STR_THEMES_WINDOW_QUICK_DEMOLISH_PROMPT = 6126,
+    STR_THEMES_WINDOW_QUICK_DEMOLISH_PROMPT = 6125,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -1019,6 +1019,7 @@ static void window_quickdemolish_prompt_open()
     w = window_create_centred(QUICKDEMOLISH_WW, QUICKDEMOLISH_WH, &window_quickdemolish_prompt_events, WC_QUICKDEMOLISH_PROMPT, WF_TRANSPARENT);
     w->widgets = window_quickdemolish_prompt_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_QUICKDEMOLISH_CANCEL) | (1 << WIDX_QUICKDEMOLISH_ENABLE);
+    w->colours[0] = TRANSLUCENT(COLOUR_BORDEAUX_RED);
     window_init_scroll_widgets(w);
 }
 


### PR DESCRIPTION
It can be very easy to click the toggle for quick demolish mode by accident, and with this mode having the risk of losing custom rides, i felt there should be a confirmation window to warn the user what they're about to do, and to remind them that damages from the mode cannot be undone. 