### PR TITLE
Remove SDL2 and speex dependencies from libopenrct2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
+include(FindPkgConfig)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 

--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -11,9 +11,6 @@ endif ()
 # CMake dependencies
 include(FindPkgConfig)
 
-# Third party libraries (which we want to eventually remove from openrct2-cli)
-PKG_CHECK_MODULES(SDL2 REQUIRED sdl2)
-
 # Sources
 file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/*.c"
@@ -29,8 +26,7 @@ add_executable(${PROJECT} EXCLUDE_FROM_ALL ${OPENRCT2_CLI_SOURCES})
 target_link_libraries(${PROJECT} "libopenrct2")
 
 # Includes
-target_include_directories(${PROJECT} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/.."
-                                              ${SDL2_INCLUDE_DIRS})
+target_include_directories(${PROJECT} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
 
 # Compiler flags
 if (FORCE32)

--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -8,9 +8,6 @@ if (PORTABLE)
     set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif ()
 
-# CMake dependencies
-include(FindPkgConfig)
-
 # Sources
 file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/*.c"

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMAKE project for openrct2-cli (UI build of OpenRCT2)
+# CMAKE project for openrct2-ui (UI build of OpenRCT2)
 cmake_minimum_required(VERSION 2.6)
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
@@ -10,9 +10,6 @@ option(DISABLE_OPENGL "Disable OpenGL support.")
 if (PORTABLE)
     set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif ()
-
-# CMake dependencies
-include(FindPkgConfig)
 
 # Third party libraries
 PKG_CHECK_MODULES(SDL2 REQUIRED sdl2)

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -56,7 +56,6 @@ if (NOT DISABLE_NETWORK)
 endif ()
 
 # Third party libraries (which we want to eventually remove from libopenrct2)
-PKG_CHECK_MODULES(SDL2 REQUIRED sdl2)
 PKG_CHECK_MODULES(SPEEX REQUIRED speexdsp)
 if (NOT DISABLE_TTF)
     if (UNIX AND NOT APPLE)
@@ -150,15 +149,13 @@ endif ()
 
 # Libraries
 if (STATIC)
-    target_link_libraries(${PROJECT} ${SDL2_STATIC_LIBRARIES}
-                                     ${JANSSON_STATIC_LIBRARIES}
+    target_link_libraries(${PROJECT} ${JANSSON_STATIC_LIBRARIES}
                                      ${SPEEX_STATIC_LIBRARIES}
                                      ${PNG_STATIC_LIBRARIES}
                                      ${ZLIB_STATIC_LIBRARIES}
                                      ${LIBZIP_STATIC_LIBRARIES})
 else ()
-    target_link_libraries(${PROJECT} ${SDL2_LIBRARIES}
-                                     ${JANSSON_LIBRARIES}
+    target_link_libraries(${PROJECT} ${JANSSON_LIBRARIES}
                                      ${SPEEX_LIBRARIES}
                                      ${PNG_LIBRARIES}
                                      ${ZLIB_LIBRARIES}
@@ -204,8 +201,7 @@ endif()
 
 # Includes
 target_include_directories(${PROJECT} SYSTEM PRIVATE ${LIBZIP_INCLUDE_DIRS})
-target_include_directories(${PROJECT} PRIVATE ${SDL2_INCLUDE_DIRS}
-                                              ${FREETYPE_INCLUDE_DIRS}
+target_include_directories(${PROJECT} PRIVATE ${FREETYPE_INCLUDE_DIRS}
                                               ${JANSSON_INCLUDE_DIRS}
                                               ${SPEEX_INCLUDE_DIRS}
                                               ${PNG_INCLUDE_DIRS}

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -55,8 +55,6 @@ if (NOT DISABLE_NETWORK)
     find_package(OpenSSL 1.0.0 REQUIRED)
 endif ()
 
-# Third party libraries (which we want to eventually remove from libopenrct2)
-PKG_CHECK_MODULES(SPEEX REQUIRED speexdsp)
 if (NOT DISABLE_TTF)
     if (UNIX AND NOT APPLE)
         PKG_CHECK_MODULES(FONTCONFIG REQUIRED fontconfig)
@@ -150,13 +148,11 @@ endif ()
 # Libraries
 if (STATIC)
     target_link_libraries(${PROJECT} ${JANSSON_STATIC_LIBRARIES}
-                                     ${SPEEX_STATIC_LIBRARIES}
                                      ${PNG_STATIC_LIBRARIES}
                                      ${ZLIB_STATIC_LIBRARIES}
                                      ${LIBZIP_STATIC_LIBRARIES})
 else ()
     target_link_libraries(${PROJECT} ${JANSSON_LIBRARIES}
-                                     ${SPEEX_LIBRARIES}
                                      ${PNG_LIBRARIES}
                                      ${ZLIB_LIBRARIES}
                                      ${LIBZIP_LIBRARIES})
@@ -201,9 +197,7 @@ endif()
 
 # Includes
 target_include_directories(${PROJECT} SYSTEM PRIVATE ${LIBZIP_INCLUDE_DIRS})
-target_include_directories(${PROJECT} PRIVATE ${FREETYPE_INCLUDE_DIRS}
-                                              ${JANSSON_INCLUDE_DIRS}
-                                              ${SPEEX_INCLUDE_DIRS}
+target_include_directories(${PROJECT} PRIVATE ${JANSSON_INCLUDE_DIRS}
                                               ${PNG_INCLUDE_DIRS}
                                               ${ZLIB_INCLUDE_DIRS})
 if (NOT DISABLE_HTTP_TWITCH OR NOT DISABLE_NETWORK)
@@ -212,8 +206,11 @@ endif ()
 if (NOT DISABLE_NETWORK)
     target_include_directories(${PROJECT} PUBLIC ${OPENSSL_INCLUDE_DIR})
 endif ()
-if (NOT DISABLE_TTF AND UNIX AND NOT APPLE)
-    target_include_directories(${PROJECT} PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
+if (NOT DISABLE_TTF)
+    target_include_directories(${PROJECT} PRIVATE ${FREETYPE_INCLUDE_DIRS})
+    if (UNIX AND NOT APPLE)
+        target_include_directories(${PROJECT} PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
+    endif ()
 endif ()
 
 if(APPLE)

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -4,9 +4,6 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif ()
 
-# CMake dependencies
-include(FindPkgConfig)
-
 # Options
 option(STATIC "Create a static build.")
 option(USE_MMAP "Use mmap to try loading rct2's data segment into memory.")


### PR DESCRIPTION
Remaining change needed to remove SDL2 from `libopenrct2`.