### PR TITLE
Add OpenBSD support.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -57,6 +57,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Hielke Morsink (Broxzier) - Tile inspector, heightmap loader, misc.
 * Joël Troch (JoelTroch) - Keyboard shortcuts for ride construction.
 * Thomas Delebo (delebota) - Misc.
+* Brian Callahan (ibara) - OpenBSD port.
 
 ## Bug fixes
 * (halfbro)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#5576] Add a persistent 'display real names of guests' setting.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Feature: [#5611] Add support for Android
+- Feature: [#5706] Add support for OpenBSD
 - Improved: Construction rights can now be placed on park entrances.
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#259] Money making glitch involving swamps (original bug)

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -14,7 +14,7 @@
 *****************************************************************************/
 #pragma endregion
 
-#if defined(__linux__) && !defined(__ANDROID__)
+#if (defined(__linux__) || defined(__OpenBSD__)) && !defined(__ANDROID__)
 
 #include <dlfcn.h>
 #include <sstream>
@@ -50,6 +50,7 @@ namespace OpenRCT2 { namespace Ui
 
         bool IsSteamOverlayAttached() override
         {
+#ifdef __linux__
             // See http://syprog.blogspot.ru/2011/12/listing-loaded-shared-objects-in-linux.html
             struct lmap
             {
@@ -84,6 +85,9 @@ namespace OpenRCT2 { namespace Ui
                 dlclose(processHandle);
             }
             return result;
+#else
+            return false; // Needed for OpenBSD, likely all other Unixes.
+#endif
         }
 
         void ShowMessageBox(SDL_Window * window, const std::string &message) override
@@ -351,4 +355,4 @@ namespace OpenRCT2 { namespace Ui
     }
 } }
 
-#endif // __linux__
+#endif // __linux__ || __OpenBSD__

--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -61,6 +61,9 @@
 #ifdef __ANDROID__
     #define OPENRCT2_PLATFORM       "Android"
 #endif
+#ifdef __OpenBSD__
+    #define OPENRCT2_PLATFORM       "OpenBSD"
+#endif
 #ifndef OPENRCT2_PLATFORM
     #error Unknown platform!
 #endif

--- a/src/openrct2/core/FileStream.hpp
+++ b/src/openrct2/core/FileStream.hpp
@@ -116,7 +116,7 @@ public:
     {
 #if defined(_MSC_VER)
         return _ftelli64(_file);
-#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID__)
+#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID__) || defined(__OpenBSD__)
         return ftello(_file);
 #else
         return ftello64(_file);
@@ -142,7 +142,7 @@ public:
             _fseeki64(_file, offset, SEEK_END);
             break;
         }
-#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID__)
+#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID__) || defined(__OpenBSD__)
         switch (origin) {
         case STREAM_SEEK_BEGIN:
             fseeko(_file, offset, SEEK_SET);

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <stdarg.h>
 #include <string>
 #include <vector>
 #include "../common.h"

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <string>
 #include <vector>
 #include "../common.h"

--- a/src/openrct2/localisation/localisation.c
+++ b/src/openrct2/localisation/localisation.c
@@ -1372,7 +1372,7 @@ sint32 win1252_to_utf8(utf8string dst, const char *src, size_t srcLength, size_t
     //log_warning("converting %s of size %d", src, srcLength);
     char *buffer_conv = strndup(src, srcLength);
     char *buffer_orig = buffer_conv;
-    const char *to_charset = "UTF8";
+    const char *to_charset = "UTF-8";
     const char *from_charset = "CP1252";
     iconv_t cd = iconv_open(to_charset, from_charset);
     if ((iconv_t)-1 == cd)

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -18,7 +18,7 @@
 
 // Despite the name, this file contains support for more OSs besides Linux, provided the necessary ifdefs remain small.
 // Otherwise, they should be spun off into their own files.
-#if (defined(__linux__) || defined(__FREEBSD__)) && !defined(__ANDROID__)
+#if (defined(__linux__) || defined(__FREEBSD__) || defined(__OpenBSD__)) && !defined(__ANDROID__)
 
 #ifdef __FREEBSD__
 #include <sys/sysctl.h>
@@ -56,6 +56,8 @@ void platform_get_exe_path(utf8 *outPath, size_t outSize)
         log_fatal("failed to get process path");
 
     }
+#elif defined(__OpenBSD__)
+    strlcpy(exePath, "/usr/local/bin/", sizeof(exePath));
 #else
 #error "Platform does not support full path exe retrieval"
 #endif

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -57,6 +57,8 @@ void platform_get_exe_path(utf8 *outPath, size_t outSize)
 
     }
 #elif defined(__OpenBSD__)
+    // There is no way to get the path name of a running executable.
+    // If you are not using the port or package, you must change this line!
     strlcpy(exePath, "/usr/local/bin/", sizeof(exePath));
 #else
 #error "Platform does not support full path exe retrieval"

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -104,7 +104,11 @@ set(LANGUAGEPACK_TEST_SOURCES
         "${ROOT_DIR}/src/openrct2/localisation/LanguagePack.cpp"
         )
 add_executable(test_languagepack ${LANGUAGEPACK_TEST_SOURCES})
-target_link_libraries(test_languagepack ${GTEST_LIBRARIES} test-common dl z SDL2)
+if (UNIX AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+    # Include libdl for dlopen
+    set(LDL dl)
+endif ()
+target_link_libraries(test_languagepack ${GTEST_LIBRARIES} test-common ${LDL} z SDL2)
 add_test(NAME languagepack COMMAND test_languagepack)
 
 # INI test
@@ -117,7 +121,7 @@ set(INI_TEST_SOURCES
         "${ROOT_DIR}/src/openrct2/core/MemoryStream.cpp"
         )
 add_executable(test_ini ${INI_TEST_SOURCES})
-target_link_libraries(test_ini ${GTEST_LIBRARIES} test-common dl z)
+target_link_libraries(test_ini ${GTEST_LIBRARIES} test-common ${LDL} z)
 add_test(NAME ini COMMAND test_ini)
 
 # String test
@@ -125,7 +129,7 @@ set(STRING_TEST_SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/StringTest.cpp"
         )
 add_executable(test_string ${STRING_TEST_SOURCES})
-target_link_libraries(test_string ${GTEST_LIBRARIES} test-common dl z)
+target_link_libraries(test_string ${GTEST_LIBRARIES} test-common ${LDL} z)
 add_test(NAME string COMMAND test_string)
 
 if (NOT DISABLE_RCT2_TESTS)
@@ -133,13 +137,13 @@ if (NOT DISABLE_RCT2_TESTS)
     set(RIDE_RATINGS_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/RideRatings.cpp"
                                   "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
     add_executable(test_ride_ratings ${RIDE_RATINGS_TEST_SOURCES})
-    target_link_libraries(test_ride_ratings ${GTEST_LIBRARIES} libopenrct2 dl z)
+    target_link_libraries(test_ride_ratings ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
     add_test(NAME ride_ratings COMMAND test_ride_ratings)
 
     # Multi-launch test
     set(MULTILAUNCH_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/MultiLaunch.cpp"
                                  "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
     add_executable(test_multilaunch ${MULTILAUNCH_TEST_SOURCES})
-    target_link_libraries(test_multilaunch ${GTEST_LIBRARIES} libopenrct2 dl z)
+    target_link_libraries(test_multilaunch ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
     add_test(NAME multilaunch COMMAND test_multilaunch)
 endif ()


### PR DESCRIPTION
Hello --

This patch allows OpenRCT2 to successfully build and run on OpenBSD.
I'll briefly walk through the patch:

`src/openrct2-ui/UiContext.Linux.cpp`: Add a defined(__OpenBSD__) at the top. Additionally, in `IsSteamOverlayAttached()`, since there is no Steam on OpenBSD, simply return false. Perhaps this can be reframed to be `#ifdef __linux__` ... code ... `#else` return false; `#endif` so other platforms can benefit but I will leave that to you to decide.

`src/openrct2/Version.h`: Add OpenBSD OPENRCT2_PLATFORM.

`src/openrct2/core/FileStream.cpp`: The BSDs are like Mac OS X and Android in regards to fseeko and ftello functions (which makes sense, since Mac OS X is based on FreeBSD and Android libc is OpenBSD libc).

`src/openrct2/core/String.hpp`: Need `#include <stdarg.h>` to get va_args, at least on OpenBSD.

`src/openrct2/localisation/localisation.c`: The iconv charset name is UTF-8, not UTF8, at least on OpenBSD.

`src/openrct2/platform/linux.c`: Add defined(__OpenBSD__). Also, we know the exePath for the openrct2 binary will always be `/usr/local/bin/` on OpenBSD so don't bother doing anything fancy for discovering exePath.

I intend to add OpenRCT2 to OpenBSD's official package repository once this is committed, and I will make sure that OpenRCT2 continues to build and run on OpenBSD.

Thanks!