### PR TITLE
Reduce memory footprint for headless instances

### DIFF
--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -34,6 +34,7 @@ int main(int argc, char * * argv)
     if (runGame == 1)
     {
         gOpenRCT2Headless = true;
+        gOpenRCT2NoGraphics = true;
 
         // Run OpenRCT2 with a plain context
         auto context = CreateContext();

--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -38,6 +38,8 @@ extern "C"
     utf8 gCustomPassword[MAX_PATH] = { 0 };
 
     bool gOpenRCT2Headless = false;
+    bool gOpenRCT2NoGraphics = false;
+
     bool gOpenRCT2ShowChangelog;
     bool gOpenRCT2SilentBreakpad;
 

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -53,6 +53,7 @@ extern "C"
     extern utf8 gCustomRCT2DataPath[MAX_PATH];
     extern utf8 gCustomPassword[MAX_PATH];
     extern bool gOpenRCT2Headless;
+    extern bool gOpenRCT2NoGraphics;
     extern bool gOpenRCT2ShowChangelog;
 
 #ifndef DISABLE_NETWORK

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -191,6 +191,7 @@ exitcode_t CommandLine::HandleCommandDefault()
     }
 
     gOpenRCT2Headless = _headless;
+    gOpenRCT2NoGraphics = _headless;
     gOpenRCT2SilentBreakpad = _silentBreakpad || _headless;
 
     if (_userDataPath != nullptr)

--- a/src/openrct2/drawing/Image.cpp
+++ b/src/openrct2/drawing/Image.cpp
@@ -19,6 +19,7 @@
 #include "../core/Console.hpp"
 #include "../core/Guard.hpp"
 #include "../core/Memory.hpp"
+#include "../OpenRCT2.h"
 
 extern "C"
 {
@@ -208,7 +209,7 @@ extern "C"
 {
     uint32 gfx_object_allocate_images(const rct_g1_element * images, uint32 count)
     {
-        if (count == 0)
+        if (count == 0 || gOpenRCT2NoGraphics)
         {
             return INVALID_IMAGE_ID;
         }

--- a/src/openrct2/drawing/drawing.c
+++ b/src/openrct2/drawing/drawing.c
@@ -20,6 +20,7 @@
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
 #include "../object.h"
+#include "../OpenRCT2.h"
 #include "../platform/platform.h"
 #include "../rct2.h"
 #include "../world/water.h"
@@ -517,6 +518,10 @@ void gfx_transpose_palette(sint32 pal, uint8 product)
  */
 void load_palette()
 {
+    if (gOpenRCT2NoGraphics) {
+        return;
+    }
+
     rct_water_type* water_type = (rct_water_type*)object_entry_groups[OBJECT_TYPE_WATER].chunks[0];
 
     uint32 palette = 0x5FC;

--- a/src/openrct2/interface/colour.c
+++ b/src/openrct2/interface/colour.c
@@ -38,6 +38,10 @@ enum
 
 void colours_init_maps()
 {
+    if (g1Elements == NULL) {
+        return;
+    }
+
     // Get colour maps from g1
     for (sint32 i = 0; i < 32; i++) {
         rct_g1_element *g1Element = &g1Elements[SPR_PALETTE_2_START + i];

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -17,6 +17,7 @@
 #include "../core/Console.hpp"
 #include "../core/IStream.hpp"
 #include "../core/Memory.hpp"
+#include "../OpenRCT2.h"
 #include "ImageTable.h"
 #include "Object.h"
 
@@ -29,6 +30,11 @@ ImageTable::~ImageTable()
 
 void ImageTable::Read(IReadObjectContext * context, IStream * stream)
 {
+    if (gOpenRCT2NoGraphics)
+    {
+        return;
+    }
+
     try
     {
         uint32 numImages = stream->ReadValue<uint32>();

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -18,6 +18,7 @@
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
 #include "../core/Util.hpp"
+#include "../OpenRCT2.h"
 #include "ObjectRepository.h"
 #include "RideObject.h"
 #include "../ride/RideGroupManager.h"
@@ -330,7 +331,9 @@ void RideObject::Load()
                     num_images *= 2;
                 }
 
-                set_vehicle_type_image_max_sizes(vehicleEntry, num_images);
+                if (!gOpenRCT2NoGraphics) {
+                    set_vehicle_type_image_max_sizes(vehicleEntry, num_images);
+                }
             }
             vehicleEntry->peep_loading_positions = _peepLoadingPositions[i];
 #ifdef NO_RCT2

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include "../core/IStream.hpp"
+#include "../OpenRCT2.h"
 #include "WaterObject.h"
 
 extern "C"

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10573,7 +10573,7 @@ static void peep_spend_money(rct_peep *peep, money16 *peep_expend_type, money32 
     if (gConfigGeneral.show_guest_purchases && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)) {
         // HACK Currently disabled for multiplayer due to limitation of all sprites
         //      needing to be synchronised
-        if (network_get_mode() == NETWORK_MODE_NONE) {
+        if (network_get_mode() == NETWORK_MODE_NONE && !gOpenRCT2Headless) {
             money_effect_create_at(amount, peep->x, peep->y, peep->z, true);
         }
     }

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -151,15 +151,18 @@ bool rct2_init()
 
     input_reset_place_obj_modifier();
 
-    if (!gfx_load_g1()) {
-        return false;
-    }
-    if (!gfx_load_g2()) {
-        return false;
-    }
-    gfx_load_csg();
+    if (!gOpenRCT2NoGraphics) {
+        if (!gfx_load_g1()) {
+            return false;
+        }
+        if (!gfx_load_g2()) {
+            return false;
+        }
+        gfx_load_csg();
 
-    font_sprite_initialise_characters();
+        font_sprite_initialise_characters();
+    }
+
     if (!gOpenRCT2Headless) {
         // platform_init();
         audio_init_ride_sounds_and_info();
@@ -169,11 +172,13 @@ bool rct2_init()
     game_init_all(150);
     if (!gOpenRCT2Headless)
         window_title_menu_open();
-    load_palette();
 
+    if (!gOpenRCT2NoGraphics) {
+        load_palette();
 #ifdef __ENABLE_LIGHTFX__
-    lightfx_init();
+        lightfx_init();
 #endif
+    }
 
     log_verbose("initialising game finished");
     return true;


### PR DESCRIPTION
Cuts the memory usage of headless instances / servers from ~100MiB to ~15MiB.

By not loading g1, g2, csg or any object graphics. The only side effect I can see is that vehicles will not have their sprite_width or height set. However I think this is only used for UI logic only and is already ignored by the sprite checksum.