### PR TITLE
Check for file existence before releasing config in config_open()

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -622,6 +622,11 @@ extern "C"
 
     bool config_open(const utf8 * path)
     {
+        if (!platform_file_exists(path))
+        {
+            return false;
+        }
+
         config_release();
         return Config::ReadFile(path);
     }

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -18,6 +18,7 @@
 #include "../Context.h"
 #include "../core/Console.hpp"
 #include "../core/Exception.hpp"
+#include "../core/File.h"
 #include "../core/FileStream.hpp"
 #include "../core/Memory.hpp"
 #include "../core/Path.hpp"
@@ -622,7 +623,7 @@ extern "C"
 
     bool config_open(const utf8 * path)
     {
-        if (!platform_file_exists(path))
+        if (!File::Exists(path))
         {
             return false;
         }


### PR DESCRIPTION
This change makes `config_open()` check that the target file actually exists before releasing the existing config.

Without this guard, the game would crash on opening the server list window on first start, as config would be cleared and not set back to defaults, leading to `gConfigNetwork.player_name` being `NULL`. This `NULL` was used in a `strcpy()` thus... boom.