### PR TITLE
Fix #5707: Usernames aren't detected for multiplayer

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -344,8 +344,20 @@ namespace Config
     {
         if (reader->ReadSection("network"))
         {
+            // If the `player_name` setting is missing or equal to the empty string
+            // use the logged-in user's username instead
+            utf8* playerName = reader->GetCString("player_name", "");
+            if (String::Compare(playerName, "") == 0)
+            {
+                playerName = String::Duplicate(platform_get_username());
+                if (playerName == nullptr)
+                {
+                    playerName = "Player";
+                }
+            }
+
             auto model = &gConfigNetwork;
-            model->player_name = reader->GetCString("player_name", "Player");
+            model->player_name = playerName;
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);
             model->listen_address = reader->GetCString("listen_address", "");
             model->default_password = reader->GetCString("default_password", nullptr);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -352,7 +352,7 @@ namespace Config
                 playerName = String::Duplicate(platform_get_username());
                 if (playerName == nullptr)
                 {
-                    playerName = "Player";
+                    playerName = String::Duplicate("Player");
                 }
             }
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -347,7 +347,7 @@ namespace Config
             // If the `player_name` setting is missing or equal to the empty string
             // use the logged-in user's username instead
             utf8* playerName = reader->GetCString("player_name", "");
-            if (String::Compare(playerName, "") == 0)
+            if (String::IsNullOrEmpty(playerName))
             {
                 playerName = String::Duplicate(platform_get_username());
                 if (playerName == nullptr)


### PR DESCRIPTION
The reason usernames weren't being automatically detected for multiplayer is simply that `platform_get_username()` wasn't being used at all!

This fixes that, setting the player name to the username if the `player_name` field is missing from the config, or equal to empty string. If the username can't be determined, it will fall back to the current default of "Player".