### PR TITLE
Fix players last action never showing up on player list.

### DIFF
--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1363,7 +1363,7 @@ void Network::ProcessGameCommandQueue()
                 return;
 
             player->LastAction = NetworkActions::FindCommand(command);
-            player->LastActionTime = gc.tick;
+            player->LastActionTime = platform_get_ticks();
             player->AddMoneySpent(cost);
 
             if (mode == NETWORK_MODE_SERVER) {


### PR DESCRIPTION
It accidentally slipped under from one of my PRs, I was mistaken by thinking LastActionTime is the tick where the command executed, sorry.