### PR TITLE
Add OpenBSD to the list of pre-built packages. [ci skip]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,9 @@ Some Linux distributions offer native packages already. These packages are usual
 * Ubuntu PPA: [`master` branch](https://launchpad.net/~openrct2/+archive/ubuntu/master) and [`develop` branch](https://launchpad.net/~openrct2/+archive/ubuntu/nightly) (`develop` branch builds are temporarily on hold due to [missing functionality in bzr](https://bugs.launchpad.net/ubuntu/+source/bzr-git/+bug/1084403))
 * openSUSE OBS: [games/openrct2](https://software.opensuse.org/download.html?project=games&package=openrct2)
 
+Some \*BSD operating systems offer native packages. These packages are usually third-party, but we're trying to resolve issues they are facing.
+* OpenBSD: [games/openrct2](http://openports.se/games/openrct2)
+
 # 3 Building the game
 
 ## 3.1 Building prerequisites


### PR DESCRIPTION
I have imported OpenRCT2 to the OpenBSD ports tree:
http://marc.info/?l=openbsd-ports-cvs&m=149866823330371&w=2

Packages will start being built now for our users.
The openports.se link might not work just yet but it will populate in the next few hours.