### PR TITLE
Modify Readme to be more clear about Gitter Channels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 
 ---
 
-![OpenRCT2.org Group Park 5](https://i.imgur.com/6eMxD0m.png)
+![OpenRCT2.org Group Park 5](https://i.imgur.com/e7CK5Sc.png)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,3 @@
-![logo](https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/resources/logo/icon_x256.png)
-
----
-
 # OpenRCT2
 An open-source re-implementation of RollerCoaster Tycoon 2. A construction and management simulation video game that simulates amusement park management.
 
@@ -20,9 +16,11 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 ---
 
 ### Chat
+You only need a GitHub or Twitter account to access these channels.
+
 If you want to help *make* the game, join the developer channel.
 
-If you need help, or want to talk to the developers, or just want to stay up to date, join the non-developer channel for your language.
+If you need help, want to talk to the developers, or just want to stay up to date then join the non-developer channel for your language.
 
 If you want to help translate the game to your language, please stop by the Localisation channel.
 

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,23 @@
+![logo](https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/resources/logo/icon_x256.png)![text](http://imgh.us/openrct2logo.svg)
+
+---
+
 # OpenRCT2
 An open-source re-implementation of RollerCoaster Tycoon 2. A construction and management simulation video game that simulates amusement park management.
+
+---
+
+![screenshot](https://i.imgur.com/e2mOsmW.png)
+
+---
 
 ### Build Status
 |             | Windows | Linux / Mac | Download |
 |-------------|---------|-------------|----------|
 | **master**  | [![AppVeyor](https://ci.appveyor.com/api/projects/status/7efnemxhon6i5n34/branch/master?svg=true)](https://ci.appveyor.com/project/IntelOrca/openrct2-ject9) | [![Travis CI](https://travis-ci.org/OpenRCT2/OpenRCT2.svg?branch=master)](https://travis-ci.org/OpenRCT2/OpenRCT2) | [![OpenRCT2.org](https://img.shields.io/badge/master-v0.0.7-green.svg)](https://openrct2.org/downloads/master/latest) |
 | **develop** | [![AppVeyor](https://ci.appveyor.com/api/projects/status/7efnemxhon6i5n34/branch/develop?svg=true)](https://ci.appveyor.com/project/IntelOrca/openrct2-ject9) | [![Travis CI](https://travis-ci.org/OpenRCT2/OpenRCT2.svg?branch=develop)](https://travis-ci.org/OpenRCT2/OpenRCT2) | [![OpenRCT2.org](https://img.shields.io/badge/develop-v0.0.8-blue.svg)](https://openrct2.org/downloads/develop/latest) |
+
+---
 
 ### Chat
 If you want to help *make* the game, join the developer channel.
@@ -19,6 +31,7 @@ If you want to help translate the game to your language, please stop by the Loca
 | English | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev) | [![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2) | [![Gitter](https://img.shields.io/badge/gitter-localisation-green.svg)](https://gitter.im/OpenRCT2/Localisation) |
 | Nederlands | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands) | | |
 
+---
 
 # Contents
 - 1 - [Introduction](#1-introduction)
@@ -65,6 +78,8 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
   - Windows 10 SDK (10.0.14393.0)
 - [7-Zip](http://www.7-zip.org/) (for deployment only)
 - [NSIS](http://nsis.sourceforge.net/) (for deployment only)
+
+---
 
 ### macOS:
 - Xcode 8
@@ -138,6 +153,8 @@ make
 ```
 Detailed instructions can be found on our [wiki](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux).
 
+---
+
 # 4 Contributing
 OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.
 
@@ -152,8 +169,12 @@ Please talk to the OpenRCT2 team first before starting to develop a new feature.
 ## 4.3 Translation
 You can translate the game into other languages by editing the language files in ```data/language``` directory. Please join discussions and submit pull requests to [OpenRCT2/Localisation](https://github.com/OpenRCT2/Localisation).
 
+---
+
 # 5 Licence
 **OpenRCT2** is licensed under the GNU General Public License version 3.
+
+---
 
 # 6 More information
 - [GitHub](https://github.com/OpenRCT2/OpenRCT2)

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,9 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 
 ### Chat
 English:<br />
+Go to this one for Help with the game (Or to just talk to us in a relaxed setting):  
 [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev)<br />
+Go to this one if you are a Developer and want to help make the game:  
 [![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2)<br />
 Nederlands:<br />
 [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands)
@@ -43,9 +45,6 @@ Some Linux distributions offer native packages already. These packages are usual
 * ArchLinux AUR: [openrct2-git](https://aur.archlinux.org/packages/openrct2-git) and [openrct2](https://aur.archlinux.org/packages/openrct2)
 * Ubuntu PPA: [`master` branch](https://launchpad.net/~openrct2/+archive/ubuntu/master) and [`develop` branch](https://launchpad.net/~openrct2/+archive/ubuntu/nightly) (`develop` branch builds are temporarily on hold due to [missing functionality in bzr](https://bugs.launchpad.net/ubuntu/+source/bzr-git/+bug/1084403))
 * openSUSE OBS: [games/openrct2](https://software.opensuse.org/download.html?project=games&package=openrct2)
-
-Some \*BSD operating systems offer native packages. These packages are usually third-party, but we're trying to resolve issues they are facing.
-* OpenBSD: [games/openrct2](http://openports.se/games/openrct2)
 
 # 3 Building the game
 

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,15 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 | **develop** | [![AppVeyor](https://ci.appveyor.com/api/projects/status/7efnemxhon6i5n34/branch/develop?svg=true)](https://ci.appveyor.com/project/IntelOrca/openrct2-ject9) | [![Travis CI](https://travis-ci.org/OpenRCT2/OpenRCT2.svg?branch=develop)](https://travis-ci.org/OpenRCT2/OpenRCT2) | [![OpenRCT2.org](https://img.shields.io/badge/develop-v0.0.8-blue.svg)](https://openrct2.org/downloads/develop/latest) |
 
 ### Chat
-English:<br />
-Go to this one for Help with the game (Or to just talk to us in a relaxed setting):  
-[![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev)<br />
-Go to this one if you are a Developer and want to help make the game:  
-[![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2)<br />
-Nederlands:<br />
-[![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands)
+If you want to help *make* the game, join the Developer Channel for your Language.
+
+If you need help, or want to talk to the developers, or just want to stay up to date, join the Non Developer channels.
+
+| Language | Non Developer | Developer |
+|----------|---------------|-----------|
+| English | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev) | [![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2) |
+| Nederlands | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands) | |
+
 
 # Contents
 - 1 - [Introduction](#1-introduction)
@@ -46,6 +48,8 @@ Some Linux distributions offer native packages already. These packages are usual
 * Ubuntu PPA: [`master` branch](https://launchpad.net/~openrct2/+archive/ubuntu/master) and [`develop` branch](https://launchpad.net/~openrct2/+archive/ubuntu/nightly) (`develop` branch builds are temporarily on hold due to [missing functionality in bzr](https://bugs.launchpad.net/ubuntu/+source/bzr-git/+bug/1084403))
 * openSUSE OBS: [games/openrct2](https://software.opensuse.org/download.html?project=games&package=openrct2)
 
+* Some \*BSD operating systems offer native packages. These packages are usually third-party, but we're trying to resolve issues they are facing.
+* OpenBSD: [games/openrct2](http://openports.se/games/openrct2)
 # 3 Building the game
 
 ## 3.1 Building prerequisites

--- a/readme.md
+++ b/readme.md
@@ -12,10 +12,12 @@ If you want to help *make* the game, join the developer channel.
 
 If you need help, or want to talk to the developers, or just want to stay up to date, join the non-developer channel for your language.
 
-| Language | Non Developer | Developer |
-|----------|---------------|-----------|
-| English | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev) | [![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2) |
-| Nederlands | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands) | |
+If you want to help translate the game to your language, please stop by the Localisation channel.
+
+| Language | Non Developer | Developer | Localisation |
+|----------|---------------|-----------|--------------|
+| English | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/non-dev) | [![Gitter](https://img.shields.io/badge/gitter-development-yellowgreen.svg)](https://gitter.im/OpenRCT2/OpenRCT2) | [![Gitter](https://img.shields.io/badge/gitter-localisation-green.svg)](https://gitter.im/OpenRCT2/Localisation) |
+| Nederlands | [![Gitter](https://img.shields.io/badge/gitter-general-blue.svg)](https://gitter.im/OpenRCT2/OpenRCT2/Nederlands) | | |
 
 
 # Contents

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 
 ---
 
-![screenshot](https://i.imgur.com/e2mOsmW.png)
+![OpenRCT2.org Group Park 5](https://i.imgur.com/6eMxD0m.png)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![logo](https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/resources/logo/icon_x256.png)![text](http://imgh.us/openrct2logo.svg)
+![logo](https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/resources/logo/icon_x256.png)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,9 @@ An open-source re-implementation of RollerCoaster Tycoon 2. A construction and m
 | **develop** | [![AppVeyor](https://ci.appveyor.com/api/projects/status/7efnemxhon6i5n34/branch/develop?svg=true)](https://ci.appveyor.com/project/IntelOrca/openrct2-ject9) | [![Travis CI](https://travis-ci.org/OpenRCT2/OpenRCT2.svg?branch=develop)](https://travis-ci.org/OpenRCT2/OpenRCT2) | [![OpenRCT2.org](https://img.shields.io/badge/develop-v0.0.8-blue.svg)](https://openrct2.org/downloads/develop/latest) |
 
 ### Chat
-If you want to help *make* the game, join the Developer Channel for your Language.
+If you want to help *make* the game, join the developer channel.
 
-If you need help, or want to talk to the developers, or just want to stay up to date, join the Non Developer channels.
+If you need help, or want to talk to the developers, or just want to stay up to date, join the non-developer channel for your language.
 
 | Language | Non Developer | Developer |
 |----------|---------------|-----------|
@@ -48,7 +48,7 @@ Some Linux distributions offer native packages already. These packages are usual
 * Ubuntu PPA: [`master` branch](https://launchpad.net/~openrct2/+archive/ubuntu/master) and [`develop` branch](https://launchpad.net/~openrct2/+archive/ubuntu/nightly) (`develop` branch builds are temporarily on hold due to [missing functionality in bzr](https://bugs.launchpad.net/ubuntu/+source/bzr-git/+bug/1084403))
 * openSUSE OBS: [games/openrct2](https://software.opensuse.org/download.html?project=games&package=openrct2)
 
-* Some \*BSD operating systems offer native packages. These packages are usually third-party, but we're trying to resolve issues they are facing.
+Some \*BSD operating systems offer native packages. These packages are usually third-party, but we're trying to resolve issues they are facing.
 * OpenBSD: [games/openrct2](http://openports.se/games/openrct2)
 # 3 Building the game
 


### PR DESCRIPTION
Makes it clear which gitter channel to go to for help. I've noticed a lot of people looking for help end up in the wrong channel, so this should help prevent that.