### PR TITLE
Fix crash when headless server creates money fx

### DIFF
--- a/src/openrct2/drawing/sprite.cpp
+++ b/src/openrct2/drawing/sprite.cpp
@@ -649,6 +649,8 @@ extern "C"
 
     rct_g1_element * gfx_get_g1_element(sint32 image_id)
     {
+        openrct2_assert(!gOpenRCT2NoGraphics, "gfx_get_g1_element called on headless instance");
+
         if (image_id == (-1 & 0x7FFFF))
         {
             return nullptr;

--- a/src/openrct2/world/money_effect.c
+++ b/src/openrct2/world/money_effect.c
@@ -17,6 +17,7 @@
 #include "../localisation/localisation.h"
 #include "../interface/viewport.h"
 #include "../interface/window.h"
+#include "../OpenRCT2.h"
 #include "sprite.h"
 
 static const rct_xy16 _moneyEffectMoveOffset[] = {
@@ -47,13 +48,17 @@ void money_effect_create_at(money32 value, sint32 x, sint32 y, sint32 z, bool ve
     moneyEffect->num_movements = 0;
     moneyEffect->move_delay = 0;
 
-    // Construct string to display
-    rct_string_id stringId = money_effect_get_string_id(moneyEffect, &value);
-    char buffer[128];
-    format_string(buffer, 128, stringId, &value);
+    sint16 offsetX = 0;
+    if (!gOpenRCT2NoGraphics) {
+        // Construct string to display
+        rct_string_id stringId = money_effect_get_string_id(moneyEffect, &value);
+        char buffer[128];
+        format_string(buffer, 128, stringId, &value);
+        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        offsetX = -(gfx_get_string_width(buffer) / 2);
+    }
+    moneyEffect->offset_x = offsetX;
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    moneyEffect->offset_x = -(gfx_get_string_width(buffer) / 2);
     moneyEffect->wiggle = 0;
 }
 


### PR DESCRIPTION
Ensure headless instances of the game, which do not have graphics loaded, do not try to measure the string for new money effect sprites.

Not updating network version because money effect sprites are not included in checksum.