### PR TITLE
Fix #578: Ride ghosts show up in ride list during construction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#259] Money making glitch involving swamps (original bug)
 - Fix: [#441] Construction rights over entrance path erased (original bug)
+- Fix: [#578] Ride ghosts show up in ride list during construction
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug)
 - Fix: [#837] Can't move windows on title screen to where the toolbar would be (original bug)
 - Fix: [#1705] Time Twister's Medieval entrance has incorrect scrolling (original bug)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,7 +12,7 @@
 - Improved: Mouse can now be dragged to select scenery when saving track designs
 - Fix: [#259] Money making glitch involving swamps (original bug)
 - Fix: [#441] Construction rights over entrance path erased (original bug)
-- Fix: [#578] Ride ghosts show up in ride list during construction
+- Fix: [#578] Ride ghosts show up in ride list during construction (original bug)
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug)
 - Fix: [#837] Can't move windows on title screen to where the toolbar would be (original bug)
 - Fix: [#1705] Time Twister's Medieval entrance has incorrect scrolling (original bug)

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -513,7 +513,7 @@ static void window_ride_list_invalidate(rct_window *w)
         sint32 i;
         rct_ride *ride;
         FOR_ALL_RIDES(i, ride) {
-            if (w->page != gRideClassifications[ride->type])
+            if (w->page != gRideClassifications[ride->type] || !ride_has_any_track_elements(i))
                 continue;
             if (ride->status == RIDE_STATUS_OPEN) {
                 if (allOpen == -1) allOpen = true;
@@ -737,7 +737,7 @@ static void window_ride_list_refresh_list(rct_window *w)
 
     countA = countB = 0;
     FOR_ALL_RIDES(i, ride) {
-        if (w->page != gRideClassifications[ride->type])
+        if (w->page != gRideClassifications[ride->type] || !ride_has_any_track_elements(i))
             continue;
 
         countA++;
@@ -756,7 +756,7 @@ static void window_ride_list_refresh_list(rct_window *w)
     w->no_list_items = countA;
     sint32 list_index = 0;
     FOR_ALL_RIDES(i, ride) {
-        if (w->page != gRideClassifications[ride->type])
+        if (w->page != gRideClassifications[ride->type] || !ride_has_any_track_elements(i))
             continue;
 
         w->list_item_positions[list_index] = i;
@@ -914,7 +914,7 @@ static void window_ride_list_close_all(rct_window *w)
     rct_ride *ride;
 
     FOR_ALL_RIDES(i, ride) {
-        if (w->page != gRideClassifications[ride->type])
+        if (w->page != gRideClassifications[ride->type] || !ride_has_any_track_elements(i))
             continue;
         if (ride->status == RIDE_STATUS_CLOSED)
             continue;
@@ -933,7 +933,7 @@ static void window_ride_list_open_all(rct_window *w)
     rct_ride *ride;
 
     FOR_ALL_RIDES(i, ride) {
-        if (w->page != gRideClassifications[ride->type])
+        if (w->page != gRideClassifications[ride->type] || !ride_has_any_track_elements(i))
             continue;
         if (ride->status == RIDE_STATUS_OPEN)
             continue;


### PR DESCRIPTION
This PR introduces a check when iterating through rides for the ride list window - if they don't have any non-ghost track elements, they are skipped. This prevents the issue in #578.