### PR TITLE
Fix #667: Incorrect banner limit calculation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#441] Construction rights over entrance path erased (original bug)
 - Fix: [#578] Ride ghosts show up in ride list during construction (original bug)
 - Fix: [#597] 'Finish 5 roller coasters' goal not properly checked (original bug)
+- Fix: [#667] Incorrect banner limit calculation (original bug)
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug)
 - Fix: [#837] Can't move windows on title screen to where the toolbar would be (original bug)
 - Fix: [#1705] Time Twister's Medieval entrance has incorrect scrolling (original bug)

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -48,6 +48,7 @@
 #include "util/util.h"
 #include "windows/error.h"
 #include "windows/tooltip.h"
+#include "world/banner.h"
 #include "world/Climate.h"
 #include "world/entrance.h"
 #include "world/footpath.h"
@@ -1077,6 +1078,9 @@ void game_fix_save_vars() {
             }
         }
     }
+
+    // Fix banner list pointing to NULL map elements
+    banner_reset_broken_index();
 }
 
 /**

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -38,7 +38,6 @@
 #include "../util/sawyercoding.h"
 #include "../util/util.h"
 #include "../Version.h"
-#include "../world/banner.h"
 #include "../world/Climate.h"
 #include "../world/park.h"
 #include "../world/scenery.h"
@@ -1177,12 +1176,6 @@ static sint32 cc_reset_user_strings(const utf8 **argv, sint32 argc)
     return 0;
 }
 
-static sint32 cc_fix_banner_count(const utf8 **argv, sint32 argc)
-{
-    banner_reset_broken_index();
-    return 0;
-}
-
 static sint32 cc_open(const utf8 **argv, sint32 argc) {
     if (argc > 0) {
         bool title = (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) != 0;
@@ -1282,7 +1275,6 @@ console_command console_command_table[] = {
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "twitch", cc_twitch, "Twitch API" },
     { "reset_user_strings", cc_reset_user_strings, "Resets all user-defined strings, to fix incorrectly occurring 'Chosen name in use already' errors.", "reset_user_strings" },
-    { "fix_banner_count", cc_fix_banner_count, "Fixes incorrectly appearing 'Too many banners' error by marking every banner entry without a map element as null.", "fix_banner_count" },
     { "rides", cc_rides, "Ride management.", "rides <subcommand>" },
     { "staff", cc_staff, "Staff management.", "staff <subcommand>"},
 };


### PR DESCRIPTION
Fixes the banner list when loading a save.

This was previously a console command, but it's inobtrusive and therefore there is no harm running it when loading. We already fix several other variables this way.