### PR TITLE
Refresh loadsave on browse dialog cancel

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#6133] Construction rights not shown after selecting buy mode.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
+- Improved: Load/save window now refreshes list if native file dialog is closed/cancelled
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------

--- a/src/openrct2/windows/LoadSave.cpp
+++ b/src/openrct2/windows/LoadSave.cpp
@@ -320,10 +320,12 @@ static void window_loadsave_mouseup(rct_window *w, rct_widgetindex widgetIndex)
         window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, nullptr, 64);
         break;
     case WIDX_BROWSE:
-        if (browse(isSave, path, sizeof(path))) {
+        if (browse(isSave, path, sizeof(path)))
+        {
             window_loadsave_select(w, path);
         }
-        else {
+        else
+        {
             // If user cancels file dialog, refresh list
             safe_strcpy(path, _directory, sizeof(path));
             window_loadsave_populate_list(w, isSave, path, _extension);

--- a/src/openrct2/windows/LoadSave.cpp
+++ b/src/openrct2/windows/LoadSave.cpp
@@ -320,8 +320,16 @@ static void window_loadsave_mouseup(rct_window *w, rct_widgetindex widgetIndex)
         window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, nullptr, 64);
         break;
     case WIDX_BROWSE:
-        if (browse(isSave, path, sizeof(path)))
+        if (browse(isSave, path, sizeof(path))) {
             window_loadsave_select(w, path);
+        }
+        else {
+            // If user cancels file dialog, refresh list
+            safe_strcpy(path, _directory, sizeof(path));
+            window_loadsave_populate_list(w, isSave, path, _extension);
+            window_init_scroll_widgets(w);
+            w->no_list_items = _listItemsCount;
+        }
         break;
     case WIDX_SORT_NAME:
         if (gConfigGeneral.load_save_sort == SORT_NAME_ASCENDING){


### PR DESCRIPTION
I was cleaning up some of my saves and I used the loadsave's "open native file dialog" button and deleted a file. When I hit cancel, the list still shows the file. I feel like the list should refresh if someone cancels the window, so this does exactly that.

EDIT: Do not merge this, I was using the online compiler to test it because "tf2build.h" was not found on my computer. and there is a bug in this code i need to look into'

EDIT 2: Okay, I found the issue. This now works properly.