### PR TITLE
Fix #5253: RCT1 park value conversion factor too high

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#4055] Sort rides by track type: Sorting rule is not really clear (inconsistent?)
 - Fix: [#5400] New Ride window does not focus properly on newly invented ride.
 - Fix: [#5009] Ride rating calculations can overflow
+- Fix: [#5253] RCT1 park value conversion factor too high
 - Fix: [#5489] Sprite index crash for car view on car ride.
 - Fix: [#5730] Unable to uncheck 'No money' in the Scenario Editor.
 - Fix: Non-invented vehicles can be used via track designs in select-by-track-type mode.

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -290,6 +290,8 @@ private:
     void Initialise()
     {
         _gameVersion = sawyercoding_detect_rct1_version(_s4.game_version) & FILE_VERSION_MASK;
+        // Avoid reusing the value used for last import
+        _parkValueConversionFactor = 0;
 
         Memory::Set(_rideTypeToRideEntryMap,     255, sizeof(_rideTypeToRideEntryMap));
         Memory::Set(_vehicleTypeToRideEntryMap,  255, sizeof(_vehicleTypeToRideEntryMap));

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -98,6 +98,7 @@ private:
     const utf8 * _s4Path = nullptr;
     rct1_s4      _s4 = { 0 };
     uint8        _gameVersion = 0;
+    uint8        _parkValueConversionFactor = 0;
 
     // Lists of dynamic object entries
     EntryList _rideEntries;
@@ -259,9 +260,30 @@ public:
         return result;
     }
 
-    sint32 CorrectRCT1ParkValue(sint32 oldParkValue)
+    sint32 CorrectRCT1ParkValue(money32 oldParkValue)
     {
-        return oldParkValue * 10;
+        if (oldParkValue == MONEY32_UNDEFINED)
+        {
+            return MONEY32_UNDEFINED;
+        }
+
+        if (_parkValueConversionFactor == 0)
+        {
+            if (_s4.park_value != 0)
+            {
+                // Use the ratio between the old and new park value to calcute the ratio to
+                // use for the park value history and the goal.
+                _parkValueConversionFactor = (calculate_park_value() * 10) / _s4.park_value;
+            }
+            else
+            {
+                // In new games, the park value isn't set.
+                _parkValueConversionFactor = 100;
+
+            }
+        }
+
+        return (oldParkValue * _parkValueConversionFactor) / 10;
     }
 
 private:
@@ -1621,7 +1643,7 @@ private:
         for (size_t i = 0; i < 128; i++)
         {
             gCashHistory[i] = _s4.cash_history[i];
-            gParkValueHistory[i] = _s4.park_value_history[i];
+            gParkValueHistory[i] = CorrectRCT1ParkValue(_s4.park_value_history[i]);
             gWeeklyProfitHistory[i] = _s4.weekly_profit_history[i];
         }
 


### PR DESCRIPTION
To ensure that RCT1 saves do not suddenly fail to achieve the goal when imported, calculate the ratio between the old and the new park value and adjust the other values, including the goal, accordingly.

In case there isn't an old park value, it will still use 10. Compared to dakinle's and RCTC's conversions, this seems very reasonable.