### PR TITLE
Fix chat sounds

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -350,6 +350,11 @@ namespace OpenRCT2 { namespace Audio
             {
                 sint32 srcSamples = (sint32)(bufferLen / byteRate);
                 sint32 dstSamples = numSamples;
+                if (bytesRead != readLength)
+               {
+                    srcSamples = _format.freq;
+                    dstSamples = _format.freq * (1 / rate);
+                }
                 bufferLen = ApplyResample(channel, buffer, srcSamples, dstSamples);
                 buffer = _effectBuffer.GetData();
             }

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -212,7 +212,7 @@ void chat_history_add(const char * src)
 
     free(buffer);
 
-    Mixer_Play_Effect(SOUND_NEWS_ITEM, 0, MIXER_VOLUME_MAX, 0, 1.5f, true);
+    Mixer_Play_Effect(SOUND_NEWS_ITEM, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
 }
 
 void chat_input(CHAT_INPUT input)


### PR DESCRIPTION
There were some weird glitch sounds being played after chat messages for a while now since the refactor, this was caused by some incorrect resampler usage.