### PR TITLE
Fix #5507: RCT1 path check is case-sensitive on Linux

### DIFF
--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -43,4 +43,12 @@ namespace Path
     utf8 * GetAbsolute(utf8 * buffer, size_t bufferSize, const utf8 * relativePath);
     bool Equals(const std::string &a, const std::string &b);
     bool Equals(const utf8 * a, const utf8 * b);
+
+    /**
+     * Checks if the given path is a file. If not, checks to see if
+     * there are any files with different casing and selects the first
+     * one found based on a straight forward character sort.
+     * Note: This will not resolve the case for Windows.
+     */
+    std::string ResolveCasing(const std::string &path);
 }

--- a/src/openrct2/drawing/sprite.cpp
+++ b/src/openrct2/drawing/sprite.cpp
@@ -195,7 +195,11 @@ extern "C"
         safe_strcpy(path, gConfigGeneral.rct1_path, sizeof(path));
         safe_strcat_path(path, "Data", sizeof(path));
         safe_strcat_path(path, "csg1i.dat", sizeof(path));
-        return String::Duplicate(Path::ResolveCasing(path));
+
+        auto fixedPath = Path::ResolveCasing(path);
+        utf8 * fixedPathC = new utf8[fixedPath.size() + 1];
+        Memory::Copy(fixedPathC, fixedPath.data(), fixedPath.size() + 1);
+        return fixedPathC;
     }
 
     static utf8 * gfx_get_csg_data_path()
@@ -217,7 +221,10 @@ extern "C"
             safe_strcat_path(path, "csg1.dat", sizeof(path));
             fixedPath = Path::ResolveCasing(path);
         }
-        return String::Duplicate(fixedPath);
+
+        utf8 * fixedPathC = new utf8[fixedPath.size() + 1];
+        Memory::Copy(fixedPathC, fixedPath.data(), fixedPath.size() + 1);
+        return fixedPathC;
     }
 
     bool gfx_load_csg()
@@ -230,8 +237,8 @@ extern "C"
             return false;
         }
 
-        auto pathHeaderPath = std::unique_ptr<utf8>(gfx_get_csg_header_path());
-        auto pathDataPath = std::unique_ptr<utf8>(gfx_get_csg_data_path());
+        auto pathHeaderPath = std::unique_ptr<utf8[]>(gfx_get_csg_header_path());
+        auto pathDataPath = std::unique_ptr<utf8[]>(gfx_get_csg_data_path());
         try
         {
             auto fileHeader = FileStream(pathHeaderPath.get(), FILE_MODE_OPEN);


### PR DESCRIPTION
If the csg path does not exist, find the first file in the directory that matches (case insensitive).

**Note:** this does not fix the casing of the `Data` directory.