### PR TITLE
Fix #5658: Assertion failed errors in peep.c

### DIFF
--- a/src/openrct2/ride/station.c
+++ b/src/openrct2/ride/station.c
@@ -322,3 +322,15 @@ rct_map_element *ride_get_station_exit_element(rct_ride *ride, sint32 x, sint32 
 
     return NULL;
 }
+
+sint32 ride_get_first_valid_station_exit(rct_ride * ride)
+{
+    for (sint32 i = 0; i < MAX_STATIONS; i++)
+    {
+        if (ride->exits[i] != 0xFFFF)
+        {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/src/openrct2/ride/station.h
+++ b/src/openrct2/ride/station.h
@@ -24,5 +24,6 @@
 #define MAX_STATIONS 4
 
 void ride_update_station(rct_ride *ride, sint32 stationIndex);
+sint32 ride_get_first_valid_station_exit(rct_ride * ride);
 
 #endif


### PR DESCRIPTION
Protect edge cases that occur in various hacked parks:
* Current station <-> ride exits
* Current seat <-> peep load positions