### PR TITLE
Fix #5750: OpenRCT2 locking up consistently, no reports

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "23"
+#define NETWORK_STREAM_VERSION "24"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -518,6 +518,15 @@ static const rct_xy16 SpiralSlideWalkingPath[64] = {
     {   0,  32 },
 };
 
+rct_peep * try_get_guest(uint16 spriteIndex)
+{
+    rct_sprite * sprite = try_get_sprite(spriteIndex);
+    if (sprite == NULL) return NULL;
+    if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_PEEP) return NULL;
+    if (sprite->peep.type != PEEP_TYPE_GUEST) return NULL;
+    return &sprite->peep;
+}
+
 sint32 peep_get_staff_count()
 {
     uint16 spriteIndex;
@@ -2921,7 +2930,8 @@ static void peep_update_ride_sub_state_2_enter_ride(rct_peep* peep, rct_ride* ri
  *
  *  rct2: 0x00691FD4
  */
-static void peep_update_ride_sub_state_2_rejoin_queue(rct_peep* peep, rct_ride* ride){
+static void peep_update_ride_sub_state_2_rejoin_queue(rct_peep* peep, rct_ride* ride)
+{
     sint16 x, y, z;
     x = ride->entrances[peep->current_ride_station] & 0xFF;
     y = ride->entrances[peep->current_ride_station] >> 8;
@@ -2945,23 +2955,9 @@ static void peep_update_ride_sub_state_2_rejoin_queue(rct_peep* peep, rct_ride* 
     peep->sub_state = 0;
     peep_window_state_update(peep);
 
-    peep->next_in_queue = SPRITE_INDEX_NULL;
-
-    ride->queue_length[peep->current_ride_station]++;
-
-    uint16 current_last = ride->last_peep_in_queue[peep->current_ride_station];
-    if (current_last == SPRITE_INDEX_NULL) {
-        ride->last_peep_in_queue[peep->current_ride_station] = peep->sprite_index;
-        return;
-    }
-
-    rct_peep* queue_peep;
-    for (queue_peep = GET_PEEP(current_last);
-        queue_peep->next_in_queue != SPRITE_INDEX_NULL;
-        queue_peep = GET_PEEP(queue_peep->next_in_queue));
-
-    queue_peep->next_in_queue = peep->sprite_index;
+    ride_queue_insert_guest_at_front(ride, peep->current_ride_station, peep);
 }
+
 /**
  *
  *  rct2: 0x00691E42

--- a/src/openrct2/peep/peep.h
+++ b/src/openrct2/peep/peep.h
@@ -713,6 +713,7 @@ extern rct_xyz16 gPeepPathFindGoalPosition;
 extern bool gPeepPathFindIgnoreForeignQueues;
 extern uint8 gPeepPathFindQueueRideIndex;
 
+rct_peep * try_get_guest(uint16 spriteIndex);
 sint32 peep_get_staff_count();
 sint32 peep_can_be_picked_up(rct_peep* peep);
 void peep_update_all();

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -1029,6 +1029,8 @@ extern uint8 gLastEntranceStyle;
 sint32 ride_get_count();
 sint32 ride_get_total_queue_length(rct_ride *ride);
 sint32 ride_get_max_queue_time(rct_ride *ride);
+rct_peep * ride_get_queue_head_guest(rct_ride * ride, sint32 stationIndex);
+void ride_queue_insert_guest_at_front(rct_ride * ride, sint32 stationIndex, rct_peep * peep);
 void ride_init_all();
 void reset_all_ride_build_dates();
 void ride_update_favourited_stat();


### PR DESCRIPTION
Prevent freezing on corrupted ride queues by ignoring sprites that are not guests when a guest re-joins the front of the queue.