### PR TITLE
Fix #5756: Only refresh ride list window every 64 ticks for performance

### DIFF
--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -737,33 +737,18 @@ static void window_ride_list_draw_tab_images(rct_drawpixelinfo *dpi, rct_window 
  */
 static void window_ride_list_refresh_list(rct_window *w)
 {
-    sint32 i, countA, countB;
+    sint32 i;
     rct_ride *ride, *otherRide;
     char bufferA[128], bufferB[128];
+    sint32 list_index = 0;
 
-    countA = countB = 0;
     FOR_ALL_RIDES(i, ride) {
         if (w->page != gRideClassifications[ride->type] || (ride->status == RIDE_STATUS_CLOSED && !ride_has_any_track_elements(i)))
             continue;
 
-        countA++;
         if (ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_LIST) {
             ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_LIST;
-            countB++;
         }
-    }
-
-    if (countB != 0)
-        window_invalidate(w);
-
-    if (countA == w->no_list_items)
-        return;
-
-    w->no_list_items = countA;
-    sint32 list_index = 0;
-    FOR_ALL_RIDES(i, ride) {
-        if (w->page != gRideClassifications[ride->type] || (ride->status == RIDE_STATUS_CLOSED && !ride_has_any_track_elements(i)))
-            continue;
 
         w->list_item_positions[list_index] = i;
         sint32 current_list_position = list_index;
@@ -910,6 +895,7 @@ static void window_ride_list_refresh_list(rct_window *w)
         list_index++;
     }
 
+    w->no_list_items = list_index;
     w->selected_list_item = -1;
     window_invalidate(w);
 }


### PR DESCRIPTION
This PR tweaks the ride list window so that it only refreshes its list every 64 ticks, preventing the performance issues identified in #5756. It always refreshes on window load. I also added another condition that checks that the ride is closed before calling `ride_has_any_track_elements()`.

Lastly, I removed the calls to `ride_has_any_track_elements()` in other ride list window functions (e.g. opening all rides). I previously added them in as 'belt and braces' (seeing as all-ghost rides can't be opened anyway), but given I now know how expensive the call is, we can probably do without them.