### PR TITLE
Reorder mousedown window event parameters to match others

### DIFF
--- a/src/openrct2/interface/window.c
+++ b/src/openrct2/interface/window.c
@@ -1932,7 +1932,7 @@ void window_event_resize_call(rct_window *w)
 void window_event_mouse_down_call(rct_window *w, rct_widgetindex widgetIndex)
 {
     if (w->event_handlers->mouse_down != NULL)
-        w->event_handlers->mouse_down(widgetIndex, w, &w->widgets[widgetIndex]);
+        w->event_handlers->mouse_down(w, widgetIndex, &w->widgets[widgetIndex]);
 }
 
 void window_event_dropdown_call(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex)

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -155,7 +155,7 @@ typedef struct rct_window_event_list {
     void (*close)(struct rct_window*);
     void (*mouse_up)(struct rct_window*, rct_widgetindex);
     void (*resize)(struct rct_window*);
-    void (*mouse_down)(rct_widgetindex, struct rct_window*, rct_widget*);
+    void (*mouse_down)(struct rct_window*, rct_widgetindex, rct_widget*);
     void (*dropdown)(struct rct_window*, rct_widgetindex, sint32);
     void (*unknown_05)(struct rct_window*);
     void (*update)(struct rct_window*);

--- a/src/openrct2/windows/banner.c
+++ b/src/openrct2/windows/banner.c
@@ -76,7 +76,7 @@ rct_widget window_banner_widgets[] = {
 };
 
 static void window_banner_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_banner_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_banner_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_banner_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_banner_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_banner_viewport_rotate(rct_window *w);
@@ -223,7 +223,7 @@ static void window_banner_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  *
  *  rct2: 0x6ba4ff
  */
-static void window_banner_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_banner_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     rct_banner* banner = &gBanners[w->number];
 

--- a/src/openrct2/windows/cheats.c
+++ b/src/openrct2/windows/cheats.c
@@ -296,8 +296,8 @@ static rct_widget *window_cheats_page_widgets[] = {
 };
 
 static void window_cheats_money_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_cheats_money_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
-static void window_cheats_misc_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
+static void window_cheats_money_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
+static void window_cheats_misc_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_cheats_misc_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_cheats_guests_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_cheats_misc_mouseup(rct_window *w, rct_widgetindex widgetIndex);
@@ -499,7 +499,7 @@ void window_cheats_open()
     park_rating_spinner_value = get_forced_park_rating() >= 0 ? get_forced_park_rating() : 999;
 }
 
-static void window_cheats_money_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_cheats_money_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_MONEY_SPINNER_INCREMENT:
@@ -516,7 +516,7 @@ static void window_cheats_money_mousedown(rct_widgetindex widgetIndex, rct_windo
     }
 }
 
-static void window_cheats_misc_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_cheats_misc_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_INCREASE_PARK_RATING:

--- a/src/openrct2/windows/custom_currency.c
+++ b/src/openrct2/windows/custom_currency.c
@@ -51,7 +51,7 @@ rct_widget window_custom_currency_widgets[] = {
 };
 
 
-static void custom_currency_window_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void custom_currency_window_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void custom_currency_window_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void custom_currency_window_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void custom_currency_window_text_input(struct rct_window *w, rct_widgetindex widgetIndex, char *text);
@@ -125,7 +125,7 @@ void custom_currency_window_open()
 
 
 
-static void custom_currency_window_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void custom_currency_window_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     widget = &w->widgets[widgetIndex - 1];
 

--- a/src/openrct2/windows/editor_object_selection.c
+++ b/src/openrct2/windows/editor_object_selection.c
@@ -189,7 +189,7 @@ static rct_widget window_editor_object_selection_widgets[] = {
 static void window_editor_object_selection_close(rct_window *w);
 static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_editor_object_selection_resize(rct_window *w);
-static void window_editor_object_selection_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_editor_object_selection_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_editor_object_selection_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_editor_object_selection_update(rct_window *w);
 static void window_editor_object_selection_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -897,7 +897,7 @@ static void window_editor_object_selection_resize(rct_window *w)
     window_set_resize(w, 600, 400, 1200, 1000);
 }
 
-void window_editor_object_selection_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+void window_editor_object_selection_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint32 num_items;
 

--- a/src/openrct2/windows/editor_objective_options.c
+++ b/src/openrct2/windows/editor_objective_options.c
@@ -130,7 +130,7 @@ static rct_widget *window_editor_objective_options_widgets[] = {
 
 static void window_editor_objective_options_main_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_editor_objective_options_main_resize(rct_window *w);
-static void window_editor_objective_options_main_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_editor_objective_options_main_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_editor_objective_options_main_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_editor_objective_options_main_update(rct_window *w);
 static void window_editor_objective_options_main_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
@@ -683,7 +683,7 @@ static void window_editor_objective_options_arg_2_decrease(rct_window *w)
  *
  *  rct2: 0x00671A0D
  */
-static void window_editor_objective_options_main_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_editor_objective_options_main_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_OBJECTIVE_DROPDOWN:

--- a/src/openrct2/windows/editor_scenario_options.c
+++ b/src/openrct2/windows/editor_scenario_options.c
@@ -183,21 +183,21 @@ static rct_widget *window_editor_scenario_options_widgets[] = {
 
 static void window_editor_scenario_options_financial_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_editor_scenario_options_financial_resize(rct_window *w);
-static void window_editor_scenario_options_financial_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_editor_scenario_options_financial_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_editor_scenario_options_financial_update(rct_window *w);
 static void window_editor_scenario_options_financial_invalidate(rct_window *w);
 static void window_editor_scenario_options_financial_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_editor_scenario_options_guests_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_editor_scenario_options_guests_resize(rct_window *w);
-static void window_editor_scenario_options_guests_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_editor_scenario_options_guests_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_editor_scenario_options_guests_update(rct_window *w);
 static void window_editor_scenario_options_guests_invalidate(rct_window *w);
 static void window_editor_scenario_options_guests_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_editor_scenario_options_park_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_editor_scenario_options_park_resize(rct_window *w);
-static void window_editor_scenario_options_park_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_editor_scenario_options_park_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_editor_scenario_options_park_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_editor_scenario_options_park_update(rct_window *w);
 static void window_editor_scenario_options_park_invalidate(rct_window *w);
@@ -551,7 +551,7 @@ static void window_editor_scenario_options_financial_resize(rct_window *w)
  *
  *  rct2: 0x006704C8
  */
-static void window_editor_scenario_options_financial_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_editor_scenario_options_financial_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_INITIAL_CASH_INCREASE:
@@ -884,7 +884,7 @@ static void window_editor_scenario_options_guests_resize(rct_window *w)
  *
  *  rct2: 0x00670A89
  */
-static void window_editor_scenario_options_guests_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_editor_scenario_options_guests_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_CASH_PER_GUEST_INCREASE:
@@ -1226,7 +1226,7 @@ static void window_editor_scenario_options_park_resize(rct_window *w)
  *
  *  rct2: 0x00671019
  */
-static void window_editor_scenario_options_park_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_editor_scenario_options_park_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_widget *dropdownWidget;
 

--- a/src/openrct2/windows/finances.c
+++ b/src/openrct2/windows/finances.c
@@ -198,7 +198,7 @@ static rct_widget *window_finances_page_widgets[] = {
 #pragma region Events
 
 static void window_finances_summary_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_finances_summary_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_finances_summary_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_finances_summary_update(rct_window *w);
 static void window_finances_summary_invalidate(rct_window *w);
 static void window_finances_summary_paint(rct_window *w, rct_drawpixelinfo *dpi);
@@ -224,7 +224,7 @@ static void window_finances_marketing_invalidate(rct_window *w);
 static void window_finances_marketing_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_finances_research_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_finances_research_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_finances_research_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_finances_research_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_finances_research_update(rct_window *w);
 static void window_finances_research_invalidate(rct_window *w);
@@ -605,7 +605,7 @@ static void window_finances_summary_mouseup(rct_window *w, rct_widgetindex widge
  *
  *  rct2: 0x0069CAB0
  */
-static void window_finances_summary_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_finances_summary_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     money32 newLoan;
 
@@ -1268,7 +1268,7 @@ static void window_finances_research_mouseup(rct_window *w, rct_widgetindex widg
  *
  *  rct2: 0x0069DB66
  */
-static void window_finances_research_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_finances_research_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     rct_widget *dropdownWidget;
     sint32 i;

--- a/src/openrct2/windows/footpath.c
+++ b/src/openrct2/windows/footpath.c
@@ -97,7 +97,7 @@ static rct_widget window_footpath_widgets[] = {
 
 static void window_footpath_close(rct_window *w);
 static void window_footpath_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_footpath_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_footpath_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_footpath_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_footpath_update(rct_window *w);
 static void window_footpath_toolupdate(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -336,7 +336,7 @@ static void window_footpath_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  *
  *  rct2: 0x006A7EC5
  */
-static void window_footpath_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_footpath_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_FOOTPATH_TYPE:

--- a/src/openrct2/windows/guest_list.c
+++ b/src/openrct2/windows/guest_list.c
@@ -90,7 +90,7 @@ static rct_widget window_guest_list_widgets[] = {
 
 static void window_guest_list_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_guest_list_resize(rct_window *w);
-static void window_guest_list_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_guest_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_guest_list_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_guest_list_update(rct_window *w);
 static void window_guest_list_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -347,7 +347,7 @@ static void window_guest_list_resize(rct_window *w)
  *
  *  rct2: 0x00699AC4
  */
-static void window_guest_list_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_guest_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint32 i;
     switch (widgetIndex) {

--- a/src/openrct2/windows/land.c
+++ b/src/openrct2/windows/land.c
@@ -61,7 +61,7 @@ static rct_widget window_land_widgets[] = {
 
 static void window_land_close(rct_window *w);
 static void window_land_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_land_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_land_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_land_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_land_update(rct_window *w);
 static void window_land_invalidate(rct_window *w);
@@ -195,7 +195,7 @@ static void window_land_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  *
  *  rct2: 0x0066407B
  */
-static void window_land_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_land_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_FLOOR:

--- a/src/openrct2/windows/map.c
+++ b/src/openrct2/windows/map.c
@@ -119,7 +119,7 @@ static const uint16 RideKeyColours[] = {
 static void window_map_close(rct_window *w);
 static void window_map_resize(rct_window *w);
 static void window_map_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_map_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_map_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_map_update(rct_window *w);
 static void window_map_toolupdate(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void window_map_tooldown(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -410,7 +410,7 @@ static void window_map_resize(rct_window *w)
  *
  *  rct2: 0x0068D040
  */
-static void window_map_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_map_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_MAP_SIZE_SPINNER_UP:

--- a/src/openrct2/windows/mapgen.c
+++ b/src/openrct2/windows/mapgen.c
@@ -231,7 +231,7 @@ static void window_mapgen_shared_close(rct_window *w);
 static void window_mapgen_shared_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 
 static void window_mapgen_base_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_mapgen_base_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
+static void window_mapgen_base_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_mapgen_base_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_mapgen_base_update(rct_window *w);
 static void window_mapgen_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
@@ -239,20 +239,20 @@ static void window_mapgen_base_invalidate(rct_window *w);
 static void window_mapgen_base_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_mapgen_random_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_mapgen_random_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_mapgen_random_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_mapgen_random_update(rct_window *w);
 static void window_mapgen_random_invalidate(rct_window *w);
 static void window_mapgen_random_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_mapgen_simplex_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_mapgen_simplex_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
+static void window_mapgen_simplex_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_mapgen_simplex_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_mapgen_simplex_update(rct_window *w);
 static void window_mapgen_simplex_invalidate(rct_window *w);
 static void window_mapgen_simplex_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_mapgen_heightmap_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_mapgen_heightmap_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
+static void window_mapgen_heightmap_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_mapgen_heightmap_invalidate(rct_window *w);
 static void window_mapgen_heightmap_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
@@ -654,7 +654,7 @@ static void window_mapgen_base_mouseup(rct_window *w, rct_widgetindex widgetInde
     }
 }
 
-static void window_mapgen_base_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_mapgen_base_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_MAP_SIZE_UP:
@@ -845,7 +845,7 @@ static void window_mapgen_random_mouseup(rct_window *w, rct_widgetindex widgetIn
     }
 }
 
-static void window_mapgen_random_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_mapgen_random_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
 
 }
@@ -917,7 +917,7 @@ static void window_mapgen_simplex_mouseup(rct_window *w, rct_widgetindex widgetI
     }
 }
 
-static void window_mapgen_simplex_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_mapgen_simplex_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_SIMPLEX_LOW_UP:
@@ -1073,7 +1073,7 @@ static void window_mapgen_simplex_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 #pragma region Heightmap page
 
-static void window_mapgen_heightmap_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_mapgen_heightmap_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex)
     {

--- a/src/openrct2/windows/maze_construction.c
+++ b/src/openrct2/windows/maze_construction.c
@@ -89,7 +89,7 @@ static rct_widget window_maze_construction_widgets[] = {
 static void window_maze_construction_close(rct_window *w);
 static void window_maze_construction_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_maze_construction_resize(rct_window *w);
-static void window_maze_construction_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_maze_construction_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_maze_construction_update(rct_window *w);
 static void window_maze_construction_toolupdate(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void window_maze_construction_tooldown(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -270,7 +270,7 @@ static void window_maze_construction_resize(rct_window *w)
  *
  *  rct2: 0x006CD48C
  */
-static void window_maze_construction_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_maze_construction_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_MAZE_BUILD_MODE:

--- a/src/openrct2/windows/multiplayer.c
+++ b/src/openrct2/windows/multiplayer.c
@@ -132,7 +132,7 @@ static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixeli
 
 static void window_multiplayer_groups_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_multiplayer_groups_resize(rct_window *w);
-static void window_multiplayer_groups_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
+static void window_multiplayer_groups_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_multiplayer_groups_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_multiplayer_groups_update(rct_window *w);
 static void window_multiplayer_groups_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -701,7 +701,7 @@ static void window_multiplayer_groups_resize(rct_window *w)
     window_invalidate(w);
 }
 
-static void window_multiplayer_groups_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+static void window_multiplayer_groups_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_DEFAULT_GROUP_DROPDOWN:

--- a/src/openrct2/windows/new_campaign.c
+++ b/src/openrct2/windows/new_campaign.c
@@ -57,7 +57,7 @@ static rct_widget window_new_campaign_widgets[] = {
 
 
 static void window_new_campaign_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_new_campaign_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_new_campaign_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_new_campaign_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_new_campaign_invalidate(rct_window *w);
 static void window_new_campaign_paint(rct_window *w, rct_drawpixelinfo *dpi);
@@ -237,7 +237,7 @@ static void window_new_campaign_mouseup(rct_window *w, rct_widgetindex widgetInd
  *
  *  rct2: 0x0069E51C
  */
-static void window_new_campaign_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_new_campaign_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     rct_widget *dropdownWidget;
 

--- a/src/openrct2/windows/new_ride.c
+++ b/src/openrct2/windows/new_ride.c
@@ -202,7 +202,7 @@ static rct_widget window_new_ride_widgets[] = {
 #pragma region Events
 
 static void window_new_ride_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_new_ride_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_new_ride_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_new_ride_update(rct_window *w);
 static void window_new_ride_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
 static void window_new_ride_scrollmousedown(rct_window *w, sint32 scrollIndex, sint32 x, sint32 y);
@@ -694,7 +694,7 @@ static void window_new_ride_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  *
  *  rct2: 0x006B6B4F
  */
-static void window_new_ride_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_new_ride_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     if (widgetIndex >= WIDX_TAB_1 && widgetIndex <= WIDX_TAB_7)
         window_new_ride_set_page(w, widgetIndex - WIDX_TAB_1);

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -408,7 +408,7 @@ static void window_options_update_height_markers();
 
 static void window_options_close(rct_window *w);
 static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_options_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_options_update(rct_window *w);
 static void window_options_invalidate(rct_window *w);
@@ -941,7 +941,7 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
 *
 *  rct2: 0x006BB01B
 */
-static void window_options_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     uint32 num_items;
 

--- a/src/openrct2/windows/park.c
+++ b/src/openrct2/windows/park.c
@@ -160,7 +160,7 @@ static rct_widget *window_park_page_widgets[] = {
 static void window_park_entrance_close(rct_window *w);
 static void window_park_entrance_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_park_entrance_resize(rct_window *w);
-static void window_park_entrance_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_park_entrance_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_park_entrance_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_park_entrance_update(rct_window *w);
 static void window_park_entrance_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
@@ -181,7 +181,7 @@ static void window_park_guests_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_park_price_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_park_price_resize(rct_window *w);
-static void window_park_price_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_park_price_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_park_price_update(rct_window *w);
 static void window_park_price_invalidate(rct_window *w);
 static void window_park_price_paint(rct_window *w, rct_drawpixelinfo *dpi);
@@ -687,7 +687,7 @@ static void window_park_entrance_resize(rct_window *w)
  *
  *  rct2: 0x006681BF
  */
-static void window_park_entrance_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_park_entrance_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex == WIDX_OPEN_OR_CLOSE) {
         gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
@@ -1198,7 +1198,7 @@ static void window_park_price_resize(rct_window *w)
  *
  *  rct2: 0x0066902C
  */
-static void window_park_price_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_park_price_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint32 newFee;
 

--- a/src/openrct2/windows/player.c
+++ b/src/openrct2/windows/player.c
@@ -93,7 +93,7 @@ rct_widget *window_player_page_widgets[] = {
 void window_player_overview_close(rct_window *w);
 void window_player_overview_mouse_up(rct_window *w, rct_widgetindex widgetIndex);
 void window_player_overview_resize(rct_window *w);
-void window_player_overview_mouse_down(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+void window_player_overview_mouse_down(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 void window_player_overview_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 void window_player_overview_update(rct_window* w);
 void window_player_overview_invalidate(rct_window *w);
@@ -297,7 +297,7 @@ void window_player_overview_mouse_up(rct_window *w, rct_widgetindex widgetIndex)
     }
 }
 
-void window_player_overview_mouse_down(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+void window_player_overview_mouse_down(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch(widgetIndex){
     case WIDX_GROUP_DROPDOWN:

--- a/src/openrct2/windows/research.c
+++ b/src/openrct2/windows/research.c
@@ -109,7 +109,7 @@ static void window_research_development_invalidate(rct_window *w);
 static void window_research_development_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_research_funding_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_research_funding_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_research_funding_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_research_funding_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_research_funding_update(rct_window *w);
 static void window_research_funding_invalidate(rct_window *w);
@@ -458,7 +458,7 @@ static void window_research_funding_mouseup(rct_window *w, rct_widgetindex widge
  *
  *  rct2: 0x0069DB66
  */
-static void window_research_funding_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_research_funding_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     rct_widget *dropdownWidget;
     sint32 i;

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -525,7 +525,7 @@ static void window_ride_init_viewport(rct_window *w);
 
 static void window_ride_main_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_main_resize(rct_window *w);
-static void window_ride_main_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_main_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_main_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_main_update(rct_window *w);
 static void window_ride_main_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
@@ -535,7 +535,7 @@ static void window_ride_main_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_ride_vehicle_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_vehicle_resize(rct_window *w);
-static void window_ride_vehicle_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_vehicle_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_vehicle_update(rct_window *w);
 static void window_ride_vehicle_invalidate(rct_window *w);
@@ -544,7 +544,7 @@ static void window_ride_vehicle_scrollpaint(rct_window *w, rct_drawpixelinfo *dp
 
 static void window_ride_operating_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_operating_resize(rct_window *w);
-static void window_ride_operating_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_operating_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_operating_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_operating_update(rct_window *w);
 static void window_ride_operating_invalidate(rct_window *w);
@@ -552,7 +552,7 @@ static void window_ride_operating_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static void window_ride_maintenance_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_maintenance_resize(rct_window *w);
-static void window_ride_maintenance_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_maintenance_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_maintenance_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_maintenance_update(rct_window *w);
 static void window_ride_maintenance_invalidate(rct_window *w);
@@ -561,7 +561,7 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 static void window_ride_colour_close(rct_window *w);
 static void window_ride_colour_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_colour_resize(rct_window *w);
-static void window_ride_colour_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_colour_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_colour_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_colour_update(rct_window *w);
 static void window_ride_colour_tooldown(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -572,7 +572,7 @@ static void window_ride_colour_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
 
 static void window_ride_music_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_music_resize(rct_window *w);
-static void window_ride_music_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_music_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_music_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_music_update(rct_window *w);
 static void window_ride_music_invalidate(rct_window *w);
@@ -581,7 +581,7 @@ static void window_ride_music_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_ride_measurements_close(rct_window *w);
 static void window_ride_measurements_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_measurements_resize(rct_window *w);
-static void window_ride_measurements_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_measurements_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_measurements_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_measurements_update(rct_window *w);
 static void window_ride_measurements_tooldown(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -592,7 +592,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
 
 static void window_ride_graphs_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_graphs_resize(rct_window *w);
-static void window_ride_graphs_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_graphs_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_graphs_update(rct_window *w);
 static void window_ride_graphs_scrollgetheight(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
 static void window_ride_graphs_15(rct_window *w, sint32 scrollIndex, sint32 scrollAreaType);
@@ -603,7 +603,7 @@ static void window_ride_graphs_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
 
 static void window_ride_income_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_income_resize(rct_window *w);
-static void window_ride_income_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_income_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_income_update(rct_window *w);
 static void window_ride_income_invalidate(rct_window *w);
 static void window_ride_income_paint(rct_window *w, rct_drawpixelinfo *dpi);
@@ -2130,7 +2130,7 @@ static void window_ride_show_open_dropdown(rct_window *w, rct_widget *widget)
  *
  *  rct2: 0x006AF1BD
  */
-static void window_ride_main_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_main_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_VIEW_DROPDOWN:
@@ -2629,7 +2629,7 @@ static void window_ride_vehicle_resize(rct_window *w)
  *
  *  rct2: 0x006B2748
  */
-static void window_ride_vehicle_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_widget *dropdownWidget = widget - 1;
     rct_ride *ride;
@@ -3229,7 +3229,7 @@ static void window_ride_operating_resize(rct_window *w)
  *
  *  rct2: 0x006B10F4
  */
-static void window_ride_operating_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_operating_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_ride *ride = get_ride(w->number);
     uint8 upper_bound, lower_bound;
@@ -3673,7 +3673,7 @@ static void window_ride_maintenance_resize(rct_window *w)
  *
  *  rct2: 0x006B1ACE
  */
-static void window_ride_maintenance_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_maintenance_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_ride *ride = get_ride(w->number);
     rct_ride_entry *ride_type = get_ride_entry(ride->subtype);
@@ -4134,7 +4134,7 @@ static void window_ride_colour_resize(rct_window *w)
  *
  *  rct2: 0x006B02C6
  */
-static void window_ride_colour_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_colour_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_ride *ride;
     uint16 colourSchemeIndex;
@@ -4768,7 +4768,7 @@ static void window_ride_music_resize(rct_window *w)
  *
  *  rct2: 0x006B1EFC
  */
-static void window_ride_music_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_music_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_widget *dropdownWidget;
     sint32 i;
@@ -5047,7 +5047,7 @@ static void window_ride_measurements_resize(rct_window *w)
  *
  *  rct2: 0x006AD4AB
  */
-static void window_ride_measurements_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_measurements_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     if (widgetIndex != WIDX_SAVE_TRACK_DESIGN)
         return;
@@ -5454,7 +5454,7 @@ static void window_ride_graphs_resize(rct_window *w)
  *
  *  rct2: 0x006AE878
  */
-static void window_ride_graphs_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_graphs_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_GRAPH_VELOCITY:
@@ -5944,7 +5944,7 @@ static void window_ride_income_resize(rct_window *w)
  *
  *  rct2: 0x006ADED4
  */
-static void window_ride_income_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_income_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     switch (widgetIndex) {
     case WIDX_PRIMARY_PRICE_INCREASE:

--- a/src/openrct2/windows/ride_construction.c
+++ b/src/openrct2/windows/ride_construction.c
@@ -135,7 +135,7 @@ static rct_widget window_ride_construction_widgets[] = {
 static void window_ride_construction_close(rct_window *w);
 static void window_ride_construction_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_construction_resize(rct_window *w);
-static void window_ride_construction_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget);
+static void window_ride_construction_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_ride_construction_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_construction_update(rct_window *w);
 static void window_ride_construction_toolupdate(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -1293,7 +1293,7 @@ static void window_ride_construction_resize(rct_window *w)
  *
  *  rct2: 0x006C6E6A
  */
-static void window_ride_construction_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget *widget)
+static void window_ride_construction_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
 {
     rct_ride *ride = get_ride(_currentRideIndex);
 

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -76,7 +76,7 @@ static bool _quickDemolishMode = false;
 
 static void window_ride_list_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_ride_list_resize(rct_window *w);
-static void window_ride_list_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_ride_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_ride_list_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_ride_list_update(rct_window *w);
 static void window_ride_list_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -311,7 +311,7 @@ static void window_ride_list_resize(rct_window *w)
  *
  *  rct2: 0x006B3532
  */
-static void window_ride_list_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_ride_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex == WIDX_OPEN_CLOSE_ALL) {
         gDropdownItemsFormat[0] = STR_CLOSE_ALL;

--- a/src/openrct2/windows/scenery.c
+++ b/src/openrct2/windows/scenery.c
@@ -64,7 +64,7 @@ enum {
 static void window_scenery_close(rct_window *w);
 static void window_scenery_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_scenery_resize(rct_window *w);
-static void window_scenery_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
+static void window_scenery_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_scenery_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_scenery_update(rct_window *w);
 static void window_scenery_event_07(rct_window *w);
@@ -667,7 +667,7 @@ static void window_scenery_resize(rct_window *w)
  *
  *  rct2: 0x006E1A25
  */
-static void window_scenery_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget) {
+static void window_scenery_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget) {
     switch (widgetIndex) {
     case WIDX_SCENERY_PRIMARY_COLOUR_BUTTON:
         window_dropdown_show_colour(w, widget, w->colours[1], gWindowSceneryPrimaryColour);

--- a/src/openrct2/windows/sign.c
+++ b/src/openrct2/windows/sign.c
@@ -57,7 +57,7 @@ rct_widget window_sign_widgets[] = {
 };
 
 static void window_sign_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_sign_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_sign_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_sign_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_sign_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_sign_viewport_rotate(rct_window *w);
@@ -269,7 +269,7 @@ static void window_sign_mouseup(rct_window *w, rct_widgetindex widgetIndex)
  *
  *  rct2: 0x6B9784
   & 0x6E6164 */
-static void window_sign_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_sign_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_MAIN_COLOUR:

--- a/src/openrct2/windows/staff.c
+++ b/src/openrct2/windows/staff.c
@@ -132,7 +132,7 @@ void window_staff_viewport_init(rct_window* w);
 void window_staff_overview_close(rct_window *w);
 void window_staff_overview_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 void window_staff_overview_resize(rct_window *w);
-void window_staff_overview_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
+void window_staff_overview_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 void window_staff_overview_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 void window_staff_overview_update(rct_window* w);
 void window_staff_overview_invalidate(rct_window *w);
@@ -149,7 +149,7 @@ void window_staff_options_update(rct_window* w);
 void window_staff_options_invalidate(rct_window *w);
 void window_staff_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 void window_staff_options_tab_paint(rct_window* w, rct_drawpixelinfo* dpi);
-void window_staff_options_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
+void window_staff_options_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 void window_staff_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 
 void window_staff_stats_mouseup(rct_window *w, rct_widgetindex widgetIndex);
@@ -535,7 +535,7 @@ void window_staff_overview_resize(rct_window *w)
  * Handle the dropdown of patrol button.
  *  rct2: 0x006BDF98
  */
-void window_staff_overview_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+void window_staff_overview_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex != WIDX_PATROL) {
         return;
@@ -1278,7 +1278,7 @@ void window_staff_viewport_init(rct_window* w){
 * Handle the costume of staff member.
 * rct2: 0x006BE802
 */
-void window_staff_options_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+void window_staff_options_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex != WIDX_COSTUME_BTN) {
         return;

--- a/src/openrct2/windows/staff_list.c
+++ b/src/openrct2/windows/staff_list.c
@@ -44,7 +44,7 @@ bool _quick_fire_mode = false;
 static void window_staff_list_close(rct_window *w);
 static void window_staff_list_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_staff_list_resize(rct_window *w);
-static void window_staff_list_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_staff_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_staff_list_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_staff_list_update(rct_window *w);
 static void window_staff_list_tooldown(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -269,7 +269,7 @@ static void window_staff_list_resize(rct_window *w)
 *
 *  rct2: 0x006BD971
 */
-static void window_staff_list_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+static void window_staff_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint16 newSelectedTab;
 

--- a/src/openrct2/windows/themes.c
+++ b/src/openrct2/windows/themes.c
@@ -46,7 +46,7 @@ enum {
 
 static void window_themes_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_themes_resize(rct_window *w);
-static void window_themes_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_themes_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_themes_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_themes_update(rct_window *w);
 static void window_themes_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -461,7 +461,7 @@ static void window_themes_resize(rct_window *w)
     }
 }
 
-static void window_themes_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+static void window_themes_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint16 newSelectedTab;
     sint32 num_items;

--- a/src/openrct2/windows/tile_inspector.c
+++ b/src/openrct2/windows/tile_inspector.c
@@ -458,7 +458,7 @@ static rct_map_element tileInspectorCopiedElement;
 
 static void window_tile_inspector_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_tile_inspector_resize(rct_window *w);
-static void window_tile_inspector_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget);
+static void window_tile_inspector_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_tile_inspector_update(rct_window *w);
 static void window_tile_inspector_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -1169,7 +1169,7 @@ static void window_tile_inspector_resize(rct_window *w)
     }
 }
 
-static void window_tile_inspector_mousedown(rct_widgetindex widgetIndex, rct_window *w, rct_widget* widget)
+static void window_tile_inspector_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (w->page) {
     case TILE_INSPECTOR_PAGE_WALL:

--- a/src/openrct2/windows/title_command_editor.c
+++ b/src/openrct2/windows/title_command_editor.c
@@ -102,7 +102,7 @@ static rct_widget window_title_command_editor_widgets[] = {
 };
 
 static void window_title_command_editor_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_title_command_editor_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_title_command_editor_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_command_editor_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_title_command_editor_update(rct_window *w);
 static void window_title_command_editor_invalidate(rct_window *w);
@@ -302,7 +302,7 @@ static void window_title_command_editor_mouseup(rct_window *w, rct_widgetindex w
     }
 }
 
-static void window_title_command_editor_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+static void window_title_command_editor_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     widget--;
     switch (widgetIndex) {

--- a/src/openrct2/windows/title_editor.c
+++ b/src/openrct2/windows/title_editor.c
@@ -47,7 +47,7 @@ enum WINDOW_TITLE_EDITOR_TAB {
 static void window_title_editor_close(rct_window *w);
 static void window_title_editor_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_editor_resize(rct_window *w);
-static void window_title_editor_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_title_editor_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_editor_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_title_editor_update(rct_window *w);
 static void window_title_editor_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
@@ -481,7 +481,7 @@ static void window_title_editor_resize(rct_window *w)
     }
 }
 
-static void window_title_editor_mousedown(rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
+static void window_title_editor_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     switch (widgetIndex) {
     case WIDX_TITLE_EDITOR_PRESETS_TAB:

--- a/src/openrct2/windows/title_menu.c
+++ b/src/openrct2/windows/title_menu.c
@@ -46,7 +46,7 @@ static rct_widget window_title_menu_widgets[] = {
 };
 
 static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_title_menu_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_menu_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y, sint32 *cursorId);
 static void window_title_menu_paint(rct_window *w, rct_drawpixelinfo *dpi);
@@ -176,7 +176,7 @@ static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex
     }
 }
 
-static void window_title_menu_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex == WIDX_GAME_TOOLS) {
         gDropdownItemsFormat[0] = STR_SCENARIO_EDITOR;

--- a/src/openrct2/windows/title_scenarioselect.c
+++ b/src/openrct2/windows/title_scenarioselect.c
@@ -97,7 +97,7 @@ static void window_scenarioselect_init_tabs(rct_window *w);
 
 static void window_scenarioselect_close(rct_window *w);
 static void window_scenarioselect_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_scenarioselect_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_scenarioselect_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_scenarioselect_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height);
 static void window_scenarioselect_scrollmousedown(rct_window *w, sint32 scrollIndex, sint32 x, sint32 y);
 static void window_scenarioselect_scrollmouseover(rct_window *w, sint32 scrollIndex, sint32 x, sint32 y);
@@ -242,7 +242,7 @@ static void window_scenarioselect_mouseup(rct_window *w, rct_widgetindex widgetI
     }
 }
 
-static void window_scenarioselect_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_scenarioselect_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     if (widgetIndex >= WIDX_TAB1 && widgetIndex <= WIDX_TAB8) {
         w->selected_tab = widgetIndex - 4;

--- a/src/openrct2/windows/top_toolbar.c
+++ b/src/openrct2/windows/top_toolbar.c
@@ -222,7 +222,7 @@ static rct_widget window_top_toolbar_widgets[] = {
 };
 
 static void window_top_toolbar_mouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void window_top_toolbar_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget);
+static void window_top_toolbar_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_top_toolbar_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_top_toolbar_tool_update(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void window_top_toolbar_tool_down(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -379,7 +379,7 @@ static void window_top_toolbar_mouseup(rct_window *w, rct_widgetindex widgetInde
  *
  *  rct2: 0x0066CA3B
  */
-static void window_top_toolbar_mousedown(rct_widgetindex widgetIndex, rct_window*w, rct_widget* widget)
+static void window_top_toolbar_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
     sint32 numItems;
 


### PR DESCRIPTION
This PR is optional, it may cause a bit of rebasing to be done on other PRs, but it makes the mousedown arguments match other event argument arrangements. The mousedown is the only one that doesn't have rct_window *w as the first parameter, and that's always bothered me. 