### PR TITLE
Fix hold down speed

### DIFF
--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -1177,7 +1177,7 @@ void input_state_widget_pressed(sint32 x, sint32 y, sint32 state, rct_widgetinde
             _clickRepeatTicks++;
 
             // Handle click repeat
-            if (_clickRepeatTicks >= 16 && (_clickRepeatTicks & 3) != 0) {
+            if (_clickRepeatTicks >= 16 && (_clickRepeatTicks & 3) == 0) {
                 if (w->hold_down_widgets & (1ULL << widgetIndex)) {
                     window_event_mouse_down_call(w, widgetIndex);
                 }


### PR DESCRIPTION
It seems this is using a modulo formula to say "press every so ticks", so it should do it by every 3rd tick, not by every 1st and 2nd tick. My modification still keeps it fast, but makes holding widgets to increase/decrease feel more fluent.

Comparison of `(i & 3) != 0`

0 % 3 = 0 == false
1 % 3 = 1 == true
2 % 3 = 2 == true
3 % 3 = 0 == false
4 % 3 = 1 == true
5 % 3 = 2 == true
6 % 3 = 0 == false

Comparison of `(i & 3) == 0`

0 % 3 = 0 == true
1 % 3 = 1 == false
2 % 3 = 2 == false
3 % 3 = 0 == true
4 % 3 = 1 == false
5 % 3 = 2 == false
6 % 3 = 0 == true

