### PR TITLE
Show real names of staff

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2531,8 +2531,8 @@ STR_2523    :Show map
 STR_2524    :Screenshot
 ### The following need to be reordered to match SDL_keycode layout.
 STR_2525    :???
-STR_2526    :???
-STR_2527    :???
+STR_2526    :Show 'real' names of staff
+STR_2527    :{SMALLFONT}{BLACK}Toggle between showing 'real' names of staff and staff numbers
 STR_2528    :???
 STR_2529    :???
 STR_2530    :???

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -205,6 +205,7 @@ namespace Config
             model->render_weather_gloom = reader->GetBoolean("render_weather_gloom", true);
             model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
             model->show_real_names_of_guests = reader->GetBoolean("show_real_names_of_guests", true);
+            model->show_real_names_of_staff = reader->GetBoolean("show_real_names_of_staff", false);
         }
     }
 
@@ -275,6 +276,7 @@ namespace Config
         writer->WriteBoolean("render_weather_gloom", model->render_weather_gloom);
         writer->WriteBoolean("show_guest_purchases", model->show_guest_purchases);
         writer->WriteBoolean("show_real_names_of_guests", model->show_real_names_of_guests);
+        writer->WriteBoolean("show_real_names_of_staff", model->show_real_names_of_staff);
     }
 
     static void ReadInterface(IIniReader * reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -87,6 +87,7 @@ typedef struct GeneralConfiguration
     bool        scenario_hide_mega_park;
     bool        steam_overlay_pause;
     bool        show_real_names_of_guests;
+    bool        show_real_names_of_staff;
 
     bool        confirmation_prompt;
     sint32      load_save_sort;

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1120,7 +1120,10 @@ bool game_load_save(const utf8 *path)
 
         // This ensures that the newly loaded save reflects the user's
         // 'show real names of guests' option, now that it's a global setting
+
         peep_update_names(gConfigGeneral.show_real_names_of_guests);
+        staff_update_names(gConfigGeneral.show_real_names_of_staff);
+
         return true;
     } else {
         handle_park_load_failure(result, path);

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -1962,9 +1962,8 @@ enum {
     STR_SHORTCUT_SHOW_MAP = 2523,
     STR_SHORTCUT_SCREENSHOT = 2524,
     STR_SHORTCUT_KEY_UNKNOWN = 2525,
-// STR_2525    :???
-// STR_2526    :???
-// STR_2527    :???
+    STR_STAFF_REAL_NAME = 2526,
+    STR_STAFF_REAL_NAME_TIP = 2527,
 // STR_2528    :???
 // STR_2529    :???
 // STR_2530    :???

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1906,6 +1906,7 @@ bool Network::LoadMap(IStream * stream)
         gCheatsAllowArbitraryRideTypeChanges = stream->ReadValue<uint8>() != 0;
         gCheatsDisableRideValueAging = stream->ReadValue<uint8>() != 0;
         gConfigGeneral.show_real_names_of_guests = stream->ReadValue<uint8>() != 0;
+        gConfigGeneral.show_real_names_of_staff = stream->ReadValue<uint8>() != 0;
 
         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
         result = true;
@@ -1953,6 +1954,7 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
         stream->WriteValue<uint8>(gCheatsAllowArbitraryRideTypeChanges);
         stream->WriteValue<uint8>(gCheatsDisableRideValueAging);
         stream->WriteValue<uint8>(gConfigGeneral.show_real_names_of_guests);
+        stream->WriteValue<uint8>(gConfigGeneral.show_real_names_of_staff);
 
         result = true;
     }

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -155,7 +155,6 @@ static sint32 peep_get_height_on_slope(rct_peep *peep, sint32 x, sint32 y);
 static void peep_pick_ride_to_go_on(rct_peep *peep);
 static void peep_head_for_nearest_ride_type(rct_peep *peep, sint32 rideType);
 static void peep_head_for_nearest_ride_with_flags(rct_peep *peep, sint32 rideTypeFlags);
-static void peep_give_real_name(rct_peep *peep);
 static sint32 guest_surface_path_finding(rct_peep* peep);
 static void peep_read_map(rct_peep *peep);
 static bool peep_heading_for_ride_or_park_exit(rct_peep *peep);
@@ -7295,7 +7294,7 @@ rct_peep *peep_generate(sint32 x, sint32 y, sint32 z)
     return peep;
 }
 
-/**
+/**T
 * rct2: 0x00698B0D
 * peep.sprite_index (eax)
 * thought.type (ebx)
@@ -12379,7 +12378,7 @@ static void peep_head_for_nearest_ride_with_flags(rct_peep *peep, sint32 rideTyp
  *
  *  rct2: 0x0069C483
  */
-static void peep_give_real_name(rct_peep *peep)
+void peep_give_real_name(rct_peep *peep)
 {
     // Generate a name_string_idx from the peep id using bit twiddling
     uint16 ax = (uint16)(peep->id + 0xF0B);

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -12381,7 +12381,13 @@ static void peep_head_for_nearest_ride_with_flags(rct_peep *peep, sint32 rideTyp
 void peep_give_real_name(rct_peep *peep)
 {
     // Generate a name_string_idx from the peep id using bit twiddling
-    uint16 ax = (uint16)(peep->id + 0xF0B);
+    uint16 ax;
+    if (peep->type == PEEP_TYPE_GUEST) {
+        ax = (uint16)(peep->id + 0xF0B);
+    } else {
+        ax = (uint16)(peep->staff_id + 0xF0B);
+    }
+   // uint16 ax = (uint16)(peep->id + 0xF0B);
     uint16 dx = 0;
     dx |= ((ax & 0x400) ? 1 : 0) << 13;
     dx |= ((ax & 0x2000) ? 1 : 0) << 12;

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -7294,7 +7294,7 @@ rct_peep *peep_generate(sint32 x, sint32 y, sint32 z)
     return peep;
 }
 
-/**T
+/**
 * rct2: 0x00698B0D
 * peep.sprite_index (eax)
 * thought.type (ebx)

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -12385,6 +12385,7 @@ void peep_give_real_name(rct_peep *peep)
     if (peep->type == PEEP_TYPE_GUEST) {
         ax = (uint16)(peep->id + 0xF0B);
     } else {
+        //Use staff id since peep->id would overlap with other staff types
         ax = (uint16)(peep->staff_id + 0xF0B);
     }
    // uint16 ax = (uint16)(peep->id + 0xF0B);

--- a/src/openrct2/peep/peep.h
+++ b/src/openrct2/peep/peep.h
@@ -789,4 +789,5 @@ void increment_guests_heading_for_park();
 void decrement_guests_in_park();
 void decrement_guests_heading_for_park();
 
+void peep_give_real_name(rct_peep *peep);
 #endif

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -334,13 +334,13 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
             newPeep->energy_growth_rate = 0x60;
             newPeep->var_E2 = 0;
 
+            newPeep->staff_id = newStaffId;
+
             if (gParkFlags & PARK_FLAGS_SHOW_REAL_STAFF_NAMES)
             {
                 peep_give_real_name(newPeep);
             }
             peep_update_name_sort(newPeep);
-
-            newPeep->staff_id = newStaffId;
 
             gStaffModes[newStaffId] = STAFF_MODE_WALK;
 

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -1629,10 +1629,9 @@ void staff_update_names(bool realNames)
                 peep->name_string_idx == STR_MECHANIC_X     ||
                 peep->name_string_idx == STR_ENTERTAINER_X  ||
                 peep->name_string_idx == STR_SECURITY_GUARD_X) {
-
-                // Currently gives each staff type the same
-                // name in order due to the way their id's are set
-                peep_give_real_name(peep);
+                    // Currently gives each staff type the same
+                    // name in order due to the way their id's are set
+                    peep_give_real_name(peep);
                 }
         }
     } else {

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -1624,11 +1624,12 @@ void staff_update_names(bool realNames)
         rct_peep *peep;
         uint16 spriteIndex;
         FOR_ALL_STAFF(spriteIndex, peep) {
+            rct_string_id name_string = peep->name_string_idx;
             //If the staff peep doesn't have a custon name
-            if (peep->name_string_idx == STR_HANDYMAN_X     ||
-                peep->name_string_idx == STR_MECHANIC_X     ||
-                peep->name_string_idx == STR_ENTERTAINER_X  ||
-                peep->name_string_idx == STR_SECURITY_GUARD_X) {
+            if (name_string == STR_HANDYMAN_X     ||
+                name_string == STR_MECHANIC_X     ||
+                name_string == STR_ENTERTAINER_X  ||
+                name_string == STR_SECURITY_GUARD_X) {
                     // Currently gives each staff type the same
                     // name in order due to the way their id's are set
                     peep_give_real_name(peep);
@@ -1642,13 +1643,14 @@ void staff_update_names(bool realNames)
             //If the staff peep has a name, change the name to format of
             //'Handyman X' for example
             if (peep->name_string_idx >= 0xA000 && peep->name_string_idx < 0xE000) {
-                if (peep->staff_type == STAFF_TYPE_HANDYMAN)
+                uint8 staff_type_temp = peep->staff_type;
+                if (staff_type_temp == STAFF_TYPE_HANDYMAN)
                     peep->name_string_idx = STR_HANDYMAN_X;
-                else if (peep->staff_type == STAFF_TYPE_MECHANIC)
+                else if (staff_type_temp == STAFF_TYPE_MECHANIC)
                     peep->name_string_idx = STR_MECHANIC_X;
-                else if (peep->staff_type == STAFF_TYPE_ENTERTAINER)
+                else if (staff_type_temp == STAFF_TYPE_ENTERTAINER)
                     peep->name_string_idx = STR_ENTERTAINER_X;
-                else if (peep->staff_type == STAFF_TYPE_SECURITY)
+                else if (staff_type_temp == STAFF_TYPE_SECURITY)
                     peep->name_string_idx = STR_SECURITY_GUARD_X;
             }
         }

--- a/src/openrct2/peep/staff.c
+++ b/src/openrct2/peep/staff.c
@@ -334,6 +334,10 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
             newPeep->energy_growth_rate = 0x60;
             newPeep->var_E2 = 0;
 
+            if (gParkFlags & PARK_FLAGS_SHOW_REAL_STAFF_NAMES)
+            {
+                peep_give_real_name(newPeep);
+            }
             peep_update_name_sort(newPeep);
 
             newPeep->staff_id = newStaffId;
@@ -1611,4 +1615,46 @@ sint32 staff_get_available_entertainer_costume_list(uint8 * costumeList)
         }
     }
     return numCostumes;
+}
+
+void staff_update_names(bool realNames)
+{
+    if (realNames) {
+        gParkFlags |= PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
+        rct_peep *peep;
+        uint16 spriteIndex;
+        FOR_ALL_STAFF(spriteIndex, peep) {
+            //If the staff peep doesn't have a custon name
+            if (peep->name_string_idx == STR_HANDYMAN_X     ||
+                peep->name_string_idx == STR_MECHANIC_X     ||
+                peep->name_string_idx == STR_ENTERTAINER_X  ||
+                peep->name_string_idx == STR_SECURITY_GUARD_X) {
+
+                // Currently gives each staff type the same
+                // name in order due to the way their id's are set
+                peep_give_real_name(peep);
+                }
+        }
+    } else {
+        gParkFlags &= ~PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
+        rct_peep *peep;
+        uint16 spriteIndex;
+        FOR_ALL_STAFF(spriteIndex, peep) {
+            //If the staff peep has a name, change the name to format of
+            //'Handyman X' for example
+            if (peep->name_string_idx >= 0xA000 && peep->name_string_idx < 0xE000) {
+                if (peep->staff_type == STAFF_TYPE_HANDYMAN)
+                    peep->name_string_idx = STR_HANDYMAN_X;
+                else if (peep->staff_type == STAFF_TYPE_MECHANIC)
+                    peep->name_string_idx = STR_MECHANIC_X;
+                else if (peep->staff_type == STAFF_TYPE_ENTERTAINER)
+                    peep->name_string_idx = STR_ENTERTAINER_X;
+                else if (peep->staff_type == STAFF_TYPE_SECURITY)
+                    peep->name_string_idx = STR_SECURITY_GUARD_X;
+            }
+        }
+    }
+
+    peep_sort();
+    gfx_invalidate_screen();
 }

--- a/src/openrct2/peep/staff.h
+++ b/src/openrct2/peep/staff.h
@@ -95,5 +95,6 @@ colour_t staff_get_colour(uint8 staffType);
 bool staff_set_colour(uint8 staffType, colour_t value);
 uint32 staff_get_available_entertainer_costumes();
 sint32 staff_get_available_entertainer_costume_list(uint8 * costumeList);
+void staff_update_names(bool realNames);
 
 #endif

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -136,6 +136,7 @@ ParkLoadResult * scenario_load_and_play_from_path(const char * path)
     // This ensures that the newly loaded scenario reflects the user's
     // 'show real names of guests' option, now that it's a global setting
     peep_update_names(gConfigGeneral.show_real_names_of_guests);
+    staff_update_names(gConfigGeneral.show_real_names_of_staff);
     return result;
 }
 

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -560,7 +560,7 @@ static uint64 window_options_page_enabled_widgets[] = {
     (1 << WIDX_WINDOW_LIMIT) |
     (1 << WIDX_WINDOW_LIMIT_UP) |
     (1 << WIDX_WINDOW_LIMIT_DOWN) |
-    (1ULL << WIDX_PATH_TO_RCT1_BUTTON) |
+    (1 << WIDX_PATH_TO_RCT1_BUTTON) |
     (1ULL << WIDX_PATH_TO_RCT1_CLEAR) |
     (1ULL << WIDX_STAFF_REAL_NAME_CHECKBOX),
 

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -48,7 +48,6 @@
 #include "dropdown.h"
 #include "error.h"
 
-//be sure to remove this/get a better solution
 enum WINDOW_OPTIONS_PAGE {
     WINDOW_OPTIONS_PAGE_DISPLAY,
     WINDOW_OPTIONS_PAGE_RENDERING,

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -37,6 +37,7 @@
 #include "../localisation/language.h"
 #include "../localisation/localisation.h"
 #include "../network/network.h"
+#include "../peep/staff.h"
 #include "../platform/platform.h"
 #include "../rct2.h"
 #include "../sprites.h"
@@ -47,6 +48,7 @@
 #include "dropdown.h"
 #include "error.h"
 
+//be sure to remove this/get a better solution
 enum WINDOW_OPTIONS_PAGE {
     WINDOW_OPTIONS_PAGE_DISPLAY,
     WINDOW_OPTIONS_PAGE_RENDERING,
@@ -177,6 +179,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_PATH_TO_RCT1_TEXT,
     WIDX_PATH_TO_RCT1_BUTTON,
     WIDX_PATH_TO_RCT1_CLEAR,
+    WIDX_STAFF_REAL_NAME_CHECKBOX,
 
     // Twitch
     WIDX_CHANNEL_BUTTON = WIDX_PAGE_START,
@@ -340,6 +343,7 @@ static rct_widget window_options_misc_widgets[] = {
     { WWT_12,               1,  10,     298,    264,    275,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
     { WWT_DROPDOWN_BUTTON,  1,  10,     289,    278,    289,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
     { WWT_DROPDOWN_BUTTON,  1,  289,    299,    278,    289,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
+    { WWT_CHECKBOX,         2,  10,     299,    293,    304,    STR_STAFF_REAL_NAME,                        STR_STAFF_REAL_NAME_TIP },                          // Show 'real' names of staff
     { WIDGETS_END },
 };
 
@@ -557,8 +561,9 @@ static uint64 window_options_page_enabled_widgets[] = {
     (1 << WIDX_WINDOW_LIMIT) |
     (1 << WIDX_WINDOW_LIMIT_UP) |
     (1 << WIDX_WINDOW_LIMIT_DOWN) |
-    (1 << WIDX_PATH_TO_RCT1_BUTTON) |
-    (1ULL << WIDX_PATH_TO_RCT1_CLEAR),
+    (1ULL << WIDX_PATH_TO_RCT1_BUTTON) |
+    (1ULL << WIDX_PATH_TO_RCT1_CLEAR) |
+    (1ULL << WIDX_STAFF_REAL_NAME_CHECKBOX),
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_CHANNEL_BUTTON) |
@@ -828,6 +833,12 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             config_save_default();
             window_invalidate(w);
             peep_update_names(gConfigGeneral.show_real_names_of_guests);
+            break;
+        case WIDX_STAFF_REAL_NAME_CHECKBOX:
+            gConfigGeneral.show_real_names_of_staff ^= 1;
+            config_save_default();
+            window_invalidate(w);
+            staff_update_names(gConfigGeneral.show_real_names_of_staff);
             break;
         case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
             gConfigGeneral.save_plugin_data ^= 1;
@@ -1714,6 +1725,9 @@ static void window_options_invalidate(rct_window *w)
         if (network_get_mode() != NETWORK_MODE_NONE) {
             w->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
             window_options_misc_widgets[WIDX_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
+
+            w->disabled_widgets |= (1ULL << WIDX_STAFF_REAL_NAME_CHECKBOX);
+            window_options_misc_widgets[WIDX_STAFF_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
         }
 
         w->hold_down_widgets |= (1 << WIDX_WINDOW_LIMIT_UP) | (1 << WIDX_WINDOW_LIMIT_DOWN);
@@ -1722,6 +1736,7 @@ static void window_options_invalidate(rct_window *w)
         window_options_misc_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 
         widget_set_checkbox_value(w, WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_guests);
+        widget_set_checkbox_value(w, WIDX_STAFF_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_staff);
         widget_set_checkbox_value(w, WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
         widget_set_checkbox_value(w, WIDX_TEST_UNFINISHED_TRACKS, gConfigGeneral.test_unfinished_tracks);
         widget_set_checkbox_value(w, WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.auto_staff_placement);
@@ -1752,6 +1767,7 @@ static void window_options_invalidate(rct_window *w)
         window_options_misc_widgets[WIDX_WINDOW_LIMIT_DOWN].type = WWT_DROPDOWN_BUTTON;
         window_options_misc_widgets[WIDX_PATH_TO_RCT1_BUTTON].type = WWT_DROPDOWN_BUTTON;
         window_options_misc_widgets[WIDX_PATH_TO_RCT1_CLEAR].type = WWT_DROPDOWN_BUTTON;
+        window_options_misc_widgets[WIDX_STAFF_REAL_NAME_CHECKBOX].type = WWT_CHECKBOX;
         break;
 
     case WINDOW_OPTIONS_PAGE_TWITCH:

--- a/src/openrct2/world/park.h
+++ b/src/openrct2/world/park.h
@@ -42,7 +42,8 @@ enum {
     PARK_FLAGS_LOCK_REAL_NAMES_OPTION_DEPRECATED = (1 << 15), // Deprecated now we use a persistent 'real names' setting
     PARK_FLAGS_NO_MONEY_SCENARIO = (1 << 17),  // equivalent to PARK_FLAGS_NO_MONEY, but used in scenario editor
     PARK_FLAGS_SPRITES_INITIALISED = (1 << 18), // After a scenario is loaded this prevents edits in the scenario editor
-    PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19) // Not used anymore
+    PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19), // Not used anymore
+    PARK_FLAGS_SHOW_REAL_STAFF_NAMES = (1 << 20)
 };
 
 enum


### PR DESCRIPTION
Implements #5577 
Adds an option in options/misc to enable real names like guests can have.
Staff names use the same pool of names as the guests use.
Setting should be disabled by default