### PR TITLE
Fix #4301: Remove leading/trailing whitespace from playername

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
 - Improved: The land tool buttons can now be held down to increase/decrease size.
+- Improved: [#4301] Leading and trailing whitespace in player name is now removed.
 - Improved: [#5859] OpenGL rendering performance
 - Improved: [#5863] Switching drawing engines no longer requires the application to restart.
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -347,13 +347,13 @@ namespace Config
         {
             // If the `player_name` setting is missing or equal to the empty string
             // use the logged-in user's username instead
-            utf8* playerName = reader->GetCString("player_name", "");
-            if (String::IsNullOrEmpty(playerName))
+            auto playerName = reader->GetString("player_name", "");
+            if (playerName.empty())
             {
-                playerName = String::Duplicate(platform_get_username());
-                if (playerName == nullptr)
+                playerName = String::ToStd(platform_get_username());
+                if (playerName.empty())
                 {
-                    playerName = String::Duplicate("Player");
+                    playerName = "Player";
                 }
             }
 
@@ -362,7 +362,7 @@ namespace Config
             playerName = String::Trim(playerName);
 
             auto model = &gConfigNetwork;
-            model->player_name = playerName;
+            model->player_name = String::Duplicate(playerName);
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);
             model->listen_address = reader->GetCString("listen_address", "");
             model->default_password = reader->GetCString("default_password", nullptr);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -357,6 +357,10 @@ namespace Config
                 }
             }
 
+            // Trim any whitespace before or after the player's name,
+            // to avoid people pretending to be someone else
+            playerName = String::Trim(playerName);
+
             auto model = &gConfigNetwork;
             model->player_name = playerName;
             model->default_port = reader->GetSint32("default_port", NETWORK_DEFAULT_PORT);

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1478,7 +1478,7 @@ NetworkPlayer* Network::AddPlayer(const utf8 *name, const std::string &keyhash)
             if (networkUser == nullptr) {
                 player->Group = GetDefaultGroup();
                 if (!String::IsNullOrEmpty(name)) {
-                    player->SetName(MakePlayerNameUnique(std::string(name)));
+                    player->SetName(MakePlayerNameUnique(String::Trim(std::string(name))));
                 }
             } else {
                 player->Group = networkUser->GroupId.GetValueOrDefault(GetDefaultGroup());
@@ -1488,7 +1488,7 @@ NetworkPlayer* Network::AddPlayer(const utf8 *name, const std::string &keyhash)
             player = std::unique_ptr<NetworkPlayer>(new NetworkPlayer); // change to make_unique in c++14
             player->Id = newid;
             player->Group = GetDefaultGroup();
-            player->SetName(name);
+            player->SetName(String::Trim(std::string(name)));
         }
 
         addedplayer = player.get();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is my first commit and I'm still learning the codebase, so go easy :smirk: 

This implements #4301 and removes any leading or trailing whitespace from a username. There are two checks: once upon starting the game when the config file is read, another in Network::AddPlayer(). I used String::Trim(), I hope that's the best function to use.

This will only remove leading and trailing whitespace, and not spaces inside of the username.  For example, `_John Peep_` (where '_' is whitespace) should become `John Peep`. 

If another player with the same text but a different number of whitespaces tries to connect afterwards, e.g. `__John Peep__` should become `John Peep #2` as it would if there wasn't whitespace.

Will require network version increase.