### PR TITLE
Fix #5789: No missing obj notification when loading from command line

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -287,7 +287,6 @@ namespace OpenRCT2
                 if (!parkLoaded)
                 {
                     Console::Error::WriteLine("Failed to load '%s'", gOpenRCT2StartupActionPath);
-                    title_load();
                     break;
                 }
 

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1128,10 +1128,15 @@ bool game_load_save(const utf8 *path)
     }
 }
 
-void handle_park_load_failure(const ParkLoadResult * result, const utf8 * path)
+void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const utf8 * path, bool loadTitleFirst)
 {
     if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_MISSING_OBJECTS)
     {
+        // This option is used when loading parks from the command line
+        // to ensure that the title sequence loads before the window
+        if (loadTitleFirst) {
+            title_load();
+        }
         // The path needs to be duplicated as it's a const here
         // which the window function doesn't like
         window_object_load_error_open(strndup(path, strnlen(path, MAX_PATH)),
@@ -1142,6 +1147,11 @@ void handle_park_load_failure(const ParkLoadResult * result, const utf8 * path)
         // the current park state will be corrupted so just go back to the title screen.
         title_load();
     }
+}
+
+void handle_park_load_failure(const ParkLoadResult * result, const utf8 * path)
+{
+    handle_park_load_failure_with_title_opt(result, path, false);
 }
 
 void game_load_init()

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -179,6 +179,7 @@ bool game_is_paused();
 bool game_is_not_paused();
 void save_game();
 void save_game_as();
+void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const utf8 * path, bool loadTitleFirst);
 void handle_park_load_failure(const ParkLoadResult * result, const utf8 * path);
 void rct2_exit();
 void rct2_exit_reason(rct_string_id title, rct_string_id body);

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -461,6 +461,7 @@ private:
                 if (ori == nullptr)
                 {
                     invalidEntries.push_back(*entry);
+                    ReportMissingObject(entry);
                 }
                 else
                 {
@@ -472,6 +473,7 @@ private:
                         if (loadedObject == nullptr)
                         {
                             invalidEntries.push_back(*entry);
+                            ReportObjectLoadProblem(entry);
                         }
                         delete loadedObject;
                     }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1779,6 +1779,7 @@ private:
             if (ori == nullptr)
             {
                 missingObjects.push_back(entry);
+                Console::Error::WriteLine("[%s] Object not found.", objectName);
             }
             else
             {
@@ -1786,6 +1787,7 @@ private:
                 if (object == nullptr && objectType != OBJECT_TYPE_SCENERY_SETS)
                 {
                     missingObjects.push_back(entry);
+                    Console::Error::WriteLine("[%s] Object could not be loaded.", objectName);
                 }
                 delete object;
             }

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -334,9 +334,16 @@ bool rct2_open_file(const char *path)
     extension++;
 
     if (_stricmp(extension, "sv6") == 0) {
-        if (game_load_save(path)) {
+        ParkLoadResult * result = game_load_sv6_path(path);
+        if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_OK) {
+            ParkLoadResult_Delete(result);
             gFirstTimeSaving = false;
             return true;
+        }
+        else {
+            handle_park_load_failure_with_title_opt(result, path, true);
+            ParkLoadResult_Delete(result);
+            return false;
         }
     } else if (_stricmp(extension, "sc6") == 0) {
         // TODO scenario install
@@ -345,7 +352,7 @@ bool rct2_open_file(const char *path)
             ParkLoadResult_Delete(result);
             return true;
         } else {
-            handle_park_load_failure(result, path);
+            handle_park_load_failure_with_title_opt(result, path, true);
             ParkLoadResult_Delete(result);
             return false;
         }
@@ -353,14 +360,28 @@ bool rct2_open_file(const char *path)
         // TODO track design install
         return true;
     } else if (_stricmp(extension, "sv4") == 0) {
-        if (rct1_load_saved_game(path)) {
+        ParkLoadResult * result = rct1_load_saved_game(path);
+        if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_OK) {
+            ParkLoadResult_Delete(result);
             game_load_init();
             return true;
         }
+        else {
+            handle_park_load_failure_with_title_opt(result, path, true);
+            ParkLoadResult_Delete(result);
+            return false;
+        }
     } else if (_stricmp(extension, "sc4") == 0) {
-        if (rct1_load_scenario(path)) {
+        ParkLoadResult * result = rct1_load_scenario(path);
+        if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_OK) {
+            ParkLoadResult_Delete(result);
             scenario_begin();
             return true;
+        }
+        else {
+            handle_park_load_failure_with_title_opt(result, path, true);
+            ParkLoadResult_Delete(result);
+            return false;
         }
     }
 


### PR DESCRIPTION
This PR hooks up the 'missing objects' window to the function that loads parks when they're passed as a command line argument, fixes #5789.