### PR TITLE
Guard against nullptr in AudioMixer.cpp

### DIFF
--- a/src/openrct2/audio/AudioMixer.cpp
+++ b/src/openrct2/audio/AudioMixer.cpp
@@ -85,25 +85,34 @@ void Mixer_Stop_Channel(void * channel)
 void Mixer_Channel_Volume(void * channel, sint32 volume)
 {
     IAudioMixer * audioMixer = GetMixer();
-    audioMixer->Lock();
-    static_cast<IAudioChannel*>(channel)->SetVolume(volume);
-    audioMixer->Unlock();
+    if (audioMixer != nullptr)
+    {
+        audioMixer->Lock();
+        static_cast<IAudioChannel*>(channel)->SetVolume(volume);
+        audioMixer->Unlock();
+    }
 }
 
 void Mixer_Channel_Pan(void * channel, float pan)
 {
     IAudioMixer * audioMixer = GetMixer();
-    audioMixer->Lock();
-    static_cast<IAudioChannel*>(channel)->SetPan(pan);
-    audioMixer->Unlock();
+    if (audioMixer != nullptr)
+    {
+        audioMixer->Lock();
+        static_cast<IAudioChannel*>(channel)->SetPan(pan);
+        audioMixer->Unlock();
+    }
 }
 
 void Mixer_Channel_Rate(void* channel, double rate)
 {
     IAudioMixer * audioMixer = GetMixer();
-    audioMixer->Lock();
-    static_cast<IAudioChannel*>(channel)->SetRate(rate);
-    audioMixer->Unlock();
+    if (audioMixer != nullptr)
+    {
+        audioMixer->Lock();
+        static_cast<IAudioChannel*>(channel)->SetRate(rate);
+        audioMixer->Unlock();
+    }
 }
 
 sint32 Mixer_Channel_IsPlaying(void * channel)
@@ -130,27 +139,30 @@ void * Mixer_Play_Music(sint32 pathId, sint32 loop, sint32 streaming)
 {
     IAudioChannel * channel = nullptr;
     IAudioMixer * mixer = GetMixer();
-    if (streaming)
+    if (mixer != nullptr)
     {
-        const utf8 * path = get_file_path(pathId);
-
-        IAudioContext * audioContext = GetContext()->GetAudioContext();
-        IAudioSource * source = audioContext->CreateStreamFromWAV(path);
-        if (source != nullptr)
+        if (streaming)
         {
-            channel = mixer->Play(source, loop, false, true);
-            if (channel == nullptr)
+            const utf8 * path = get_file_path(pathId);
+
+            IAudioContext * audioContext = GetContext()->GetAudioContext();
+            IAudioSource * source = audioContext->CreateStreamFromWAV(path);
+            if (source != nullptr)
             {
-                delete source;
+                channel = mixer->Play(source, loop, false, true);
+                if (channel == nullptr)
+                {
+                    delete source;
+                }
             }
         }
-    }
-    else
-    {
-        if (mixer->LoadMusic(pathId))
+        else
         {
-            IAudioSource * source = mixer->GetMusicSource(pathId);
-            channel = mixer->Play(source, MIXER_LOOP_INFINITE, false, false);
+            if (mixer->LoadMusic(pathId))
+            {
+                IAudioSource * source = mixer->GetMusicSource(pathId);
+                channel = mixer->Play(source, MIXER_LOOP_INFINITE, false, false);
+            }
         }
     }
     if (channel != nullptr)

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "24"
+#define NETWORK_STREAM_VERSION "25"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
Worth noting that @PFCKrutonium found that the lack of null guard in `Mixer_Play_Music()` could cause headless servers to crash if a Looping Coaster crashed (this was not consistent, didn't happen every time). Whether headless servers should ever get to the point of calling this function is a separate issue, but we should guard against null anyway.

I suggest bumping the network version even though this doesn't affect core logic to ensure that servers upgrade from the vulnerable version.