### PR TITLE
Fix #5795: Implement sprite cycle checking

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "26"
+#define NETWORK_STREAM_VERSION "27"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -152,6 +152,7 @@ void S6Exporter::Save(IStream * stream, bool isScenario)
 
 void S6Exporter::Export()
 {
+    openrct2_assert(!(check_for_spatial_index_cycles(false) || check_for_sprite_list_cycles(false)), "A sprite cycle exists.");
     _s6.info = gS6Info;
     uint32 researchedTrackPiecesA[128];
     uint32 researchedTrackPiecesB[128];
@@ -449,7 +450,6 @@ extern "C"
 
         map_reorganise_elements();
         sprite_clear_all_unused();
-
         viewport_set_saved_view();
 
         bool result     = false;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -413,6 +413,10 @@ public:
         map_update_tile_pointers();
         game_convert_strings_to_utf8();
         map_count_remaining_land_rights();
+
+        // We try to fix the cycles on import, hence the 'true' parameter
+        check_for_sprite_list_cycles(true);
+        check_for_spatial_index_cycles(true);
     }
 
     void Initialise()

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -262,6 +262,10 @@ void sprite_clear_all_unused()
         sprite_reset(sprite);
         sprite->linked_list_type_offset = SPRITE_LIST_NULL * 2;
 
+        // This shouldn't be necessary, as sprite_reset() preserves the index
+        // but it has been left in as a safety net in case the index isn't set correctly
+        sprite->sprite_index = spriteIndex;
+
         // sprite->next_in_quadrant will only end up as zero owing to corruption
         // most likely due to previous builds not preserving it when resetting sprites
         // We reset it to SPRITE_INDEX_NULL to prevent cycles in the sprite lists

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -903,7 +903,7 @@ static bool sprite_is_in_quadrant_cycle(uint16 sprite_idx)
 bool check_for_sprite_list_cycles(bool fix)
 {
     for (sint32 i = 0; i < NUM_SPRITE_LISTS; i++) {
-        if (sprite_is_in_cycle(gSpriteListHead[i], fix)) {
+        if (sprite_is_in_cycle(gSpriteListHead[i])) {
             if (fix)
             {
                 rct_sprite * spr = get_sprite(gSpriteListHead[i]);

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -247,34 +247,6 @@ const char * sprite_checksum()
 
 #endif // DISABLE_NETWORK
 
-/**
- * Clears all the unused sprite memory to zero. Probably so that it can be compressed better when saving.
- *  rct2: 0x0069EBA4
- */
-void sprite_clear_all_unused()
-{
-    rct_unk_sprite *sprite;
-    uint16 spriteIndex, nextSpriteIndex, previousSpriteIndex;
-
-    spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
-    while (spriteIndex != SPRITE_INDEX_NULL) {
-        sprite = &get_sprite(spriteIndex)->unknown;
-        sprite_reset(sprite);
-        sprite->linked_list_type_offset = SPRITE_LIST_NULL * 2;
-
-        // This shouldn't be necessary, as sprite_reset() preserves the index
-        // but it has been left in as a safety net in case the index isn't set correctly
-        sprite->sprite_index = spriteIndex;
-
-        // sprite->next_in_quadrant will only end up as zero owing to corruption
-        // most likely due to previous builds not preserving it when resetting sprites
-        // We reset it to SPRITE_INDEX_NULL to prevent cycles in the sprite lists
-        if (sprite->next_in_quadrant == 0) { sprite->next_in_quadrant = SPRITE_INDEX_NULL; }
-        _spriteFlashingList[spriteIndex] = false;
-        spriteIndex = nextSpriteIndex;
-    }
-}
-
 static void sprite_reset(rct_unk_sprite *sprite)
 {
     // Need to retain how the sprite is linked in lists
@@ -293,6 +265,35 @@ static void sprite_reset(rct_unk_sprite *sprite)
     sprite->previous = prev;
     sprite->sprite_index = sprite_index;
     sprite->sprite_identifier = SPRITE_IDENTIFIER_NULL;
+}
+
+/**
+* Clears all the unused sprite memory to zero. Probably so that it can be compressed better when saving.
+*  rct2: 0x0069EBA4
+*/
+void sprite_clear_all_unused()
+{
+    rct_unk_sprite *sprite;
+    uint16 spriteIndex, nextSpriteIndex;
+
+    spriteIndex = gSpriteListHead[SPRITE_LIST_NULL];
+    while (spriteIndex != SPRITE_INDEX_NULL) {
+        sprite = &get_sprite(spriteIndex)->unknown;
+        nextSpriteIndex = sprite->next;
+        sprite_reset(sprite);
+        sprite->linked_list_type_offset = SPRITE_LIST_NULL * 2;
+
+        // This shouldn't be necessary, as sprite_reset() preserves the index
+        // but it has been left in as a safety net in case the index isn't set correctly
+        sprite->sprite_index = spriteIndex;
+
+        // sprite->next_in_quadrant will only end up as zero owing to corruption
+        // most likely due to previous builds not preserving it when resetting sprites
+        // We reset it to SPRITE_INDEX_NULL to prevent cycles in the sprite lists
+        if (sprite->next_in_quadrant == 0) { sprite->next_in_quadrant = SPRITE_INDEX_NULL; }
+        _spriteFlashingList[spriteIndex] = false;
+        spriteIndex = nextSpriteIndex;
+    }
 }
 
 // Resets all sprites in SPRITE_LIST_NULL list

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -478,6 +478,7 @@ const char *sprite_checksum();
 
 void sprite_set_flashing(rct_sprite *sprite, bool flashing);
 bool sprite_get_flashing(rct_sprite *sprite);
-
+bool check_for_sprite_list_cycles(bool fix);
+bool check_for_spatial_index_cycles(bool fix);
 #endif
 


### PR DESCRIPTION
This PR implements a check for cycles in the sprite linked lists on import and export. On import, an attempt to fix this is made (the fix is sub-optimal, and suggestions on improvements are more than welcome). On export, an assert is generated.

Furthermore, two causes of the cycles have been fixed - in both cases it was due to the `next_in_quadrant` field being improperly reset.

I've yet to find a way to repair SV6s that are corrupted, but this will stop any more from ending up in a bugged state.

This fixes #5795 (unable to get the game to lock up on autosave with this applied).

Massive thanks to @IntelOrca & @janisozaur for the sprite cycle checking function basics, and the aforementioned along with @PFCKrutonium for helping us track this heisenbug down!