### PR TITLE
Fix #5800: Crash when opening server from command line

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1129,6 +1129,7 @@ bool game_load_save(const utf8 *path)
             network_send_map();
         }
 
+
         // This ensures that the newly loaded save reflects the user's
         // 'show real names of guests' option, now that it's a global setting
         peep_update_names(gConfigGeneral.show_real_names_of_guests);

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1129,7 +1129,6 @@ bool game_load_save(const utf8 *path)
             network_send_map();
         }
 
-
         // This ensures that the newly loaded save reflects the user's
         // 'show real names of guests' option, now that it's a global setting
         peep_update_names(gConfigGeneral.show_real_names_of_guests);

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -6945,7 +6945,7 @@ void peep_update_crowd_noise()
         return;
 
     viewport = g_music_tracking_viewport;
-    if (viewport == (rct_viewport*)-1)
+    if (viewport == NULL || viewport == (rct_viewport*)-1)
         return;
 
     // Count the number of peeps visible

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -392,7 +392,7 @@ bool rct2_open_file(const char *path)
             return false;
         }
     }
-
+    title_load();
     return false;
 }
 

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -338,6 +338,14 @@ bool rct2_open_file(const char *path)
         if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_OK) {
             ParkLoadResult_Delete(result);
             gFirstTimeSaving = false;
+            if (network_get_mode() == NETWORK_MODE_CLIENT) {
+                network_close();
+            }
+            game_load_init();
+            if (network_get_mode() == NETWORK_MODE_SERVER) {
+                network_send_map();
+            }
+            peep_update_names(gConfigGeneral.show_real_names_of_guests);
             return true;
         }
         else {

--- a/src/openrct2/rct2.c
+++ b/src/openrct2/rct2.c
@@ -329,6 +329,7 @@ bool rct2_open_file(const char *path)
 {
     char *extension = strrchr(path, '.');
     if (extension == NULL) {
+        title_load();
         return false;
     }
     extension++;

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -802,7 +802,7 @@ void vehicle_sounds_update()
             }
         }
         g_music_tracking_viewport = viewport;
-        if (viewport != (rct_viewport*)-1) {
+        if (viewport != NULL && viewport != (rct_viewport*)-1) {
             if (window) {
                 gWindowAudioExclusive = window;
                 gVolumeAdjustZoom = 0;

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -561,6 +561,9 @@ void sprite_move(sint16 x, sint16 y, sint16 z, rct_sprite *sprite)
             rct_sprite *sprite2 = get_sprite(*spriteIndex);
             while (sprite != sprite2) {
                 spriteIndex = &sprite2->unknown.next_in_quadrant;
+                if (*spriteIndex == SPRITE_INDEX_NULL) {
+                    break;
+                }
                 sprite2 = get_sprite(*spriteIndex);
             }
         }


### PR DESCRIPTION
This fixes the root cause of #5800, but also three other potential bugs that it uncovered (relating to not guarding against NULL or invalid values).