### PR TITLE
Fix visual sprite corruption with headless servers

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1093,6 +1093,10 @@ void game_fix_save_vars()
 
     // Fix banner list pointing to NULL map elements
     banner_reset_broken_index();
+
+    // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
+    fix_invalid_vehicle_sprite_sizes();
+
 }
 
 /**

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1851,6 +1851,9 @@ void Network::Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& pa
 
             // Notify user he is now online and which shortcut key enables chat
             network_chat_show_connected_message();
+
+            // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
+            fix_invalid_vehicle_sprite_sizes();
         }
         else
         {

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "28"
+#define NETWORK_STREAM_VERSION "29"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -769,7 +769,7 @@ private:
         {
             dst->vehicles[i] = src->vehicles[i];
         }
-        for (sint32 i = RCT1_MAX_TRAINS_PER_RIDE; i < 32; i++)
+        for (sint32 i = RCT1_MAX_TRAINS_PER_RIDE; i < MAX_VEHICLES_PER_RIDE; i++)
         {
             dst->vehicles[i] = SPRITE_INDEX_NULL;
         }

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -27,6 +27,7 @@
 // The max number of different types of vehicle.
 // Examples of vehicles here are the locomotive, tender and carriage of the Miniature Railway.
 #define MAX_VEHICLES_PER_RIDE_ENTRY     4
+#define MAX_VEHICLES_PER_RIDE           32
 #define RIDE_ENTRY_INDEX_NULL           255
 typedef fixed16_2dp ride_rating;
 
@@ -179,7 +180,7 @@ typedef struct rct_ride {
     uint16 exits[RCT12_MAX_STATIONS_PER_RIDE];                // 0x072
     uint16 last_peep_in_queue[RCT12_MAX_STATIONS_PER_RIDE];   // 0x07A
     uint8 pad_082[4];               // Used to be number of peeps in queue in RCT1, but this has moved.
-    uint16 vehicles[32];            // 0x086 Points to the first car in the train
+    uint16 vehicles[MAX_VEHICLES_PER_RIDE];            // 0x086 Points to the first car in the train
     uint8 depart_flags;             // 0x0C6
 
     // Not sure if these should be uint or sint.
@@ -1199,5 +1200,6 @@ const char * ride_type_get_enum_name(sint32 rideType);
 uint8 ride_entry_get_first_non_null_ride_type(rct_ride_entry * rideEntry);
 bool ride_type_supports_boosters(uint8 rideType);
 sint32 get_booster_speed(uint8 rideType, sint32 rawSpeed);
+void fix_invalid_vehicle_sprite_sizes();
 
 #endif

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -1938,7 +1938,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle* vehicle){
 
         if (ride->depart_flags & RIDE_DEPART_LEAVE_WHEN_ANOTHER_ARRIVES){
 
-            for (sint32 i = 0; i < 32; ++i){
+            for (sint32 i = 0; i < MAX_VEHICLES_PER_RIDE; ++i){
                 uint16 train_id = ride->vehicles[i];
                 if (train_id == SPRITE_INDEX_NULL)
                     continue;

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1618,7 +1618,7 @@ rct_window *window_ride_open_vehicle(rct_vehicle *vehicle)
 
     // Get view index
     sint32 view = 1;
-    for (sint32 i = 0; i < 32; i++) {
+    for (sint32 i = 0; i < MAX_VEHICLES_PER_RIDE; i++) {
         if (ride->vehicles[i] == headVehicleSpriteIndex)
             break;
 


### PR DESCRIPTION
This PR highlights a regression in #5708 that causes the sprite corruption bug @PFCKrutonium discovered when hosting a headless server. 

Reproduction steps:
1. Host a **headless** server
2. Join the server, build a coaster
3. Disconnect, reconnect
4. See something [like this](https://youtu.be/GeYtlrlzm8Q)

This happens because when `gOpenRCT2NoGraphics` is true, `set_vehicle_type_image_max_sizes()` doesn't get called, resulting in the `sprite_width`, `sprite_height_negative` and `sprite_height_positive` fields for vehicle entries being zero.

In this PR, I arbitrarily set these fields to `64`, which does indeed fix the sprite corruption. I also added a sweep to `game_fix_save_vars()` that does the same with any vehicles with zero sprite sizes (thus fixing already bugged saves).

Such an arbitrary fix is almost certainly not what we want - if there is a way to determine the proper size and use it, we should do that instead. I'll look at doing such a thing tomorrow (when my brain is rested from a full day of heisenbug-chasing!).