### PR TITLE
Revert "Fix #5795: Implement sprite cycle checking"

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "27"
+#define NETWORK_STREAM_VERSION "26"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "26"
+#define NETWORK_STREAM_VERSION "28"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -152,7 +152,6 @@ void S6Exporter::Save(IStream * stream, bool isScenario)
 
 void S6Exporter::Export()
 {
-    openrct2_assert(!(check_for_spatial_index_cycles(false) || check_for_sprite_list_cycles(false)), "A sprite cycle exists.");
     _s6.info = gS6Info;
     uint32 researchedTrackPiecesA[128];
     uint32 researchedTrackPiecesB[128];
@@ -450,6 +449,7 @@ extern "C"
 
         map_reorganise_elements();
         sprite_clear_all_unused();
+
         viewport_set_saved_view();
 
         bool result     = false;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -413,10 +413,6 @@ public:
         map_update_tile_pointers();
         game_convert_strings_to_utf8();
         map_count_remaining_land_rights();
-
-        // We try to fix the cycles on import, hence the 'true' parameter
-        check_for_sprite_list_cycles(true);
-        check_for_spatial_index_cycles(true);
     }
 
     void Initialise()

--- a/src/openrct2/world/sprite.h
+++ b/src/openrct2/world/sprite.h
@@ -478,7 +478,6 @@ const char *sprite_checksum();
 
 void sprite_set_flashing(rct_sprite *sprite, bool flashing);
 bool sprite_get_flashing(rct_sprite *sprite);
-bool check_for_sprite_list_cycles(bool fix);
-bool check_for_spatial_index_cycles(bool fix);
+
 #endif
 


### PR DESCRIPTION
Reverts OpenRCT2/OpenRCT2#5801

There are still improvements and review to do.
It is not confirmed the fix will not do any harm,
so just in case I will temporarily revert it.