### PR TITLE
Add missing cheats_get_cheat_string and cheats_reset parameters

### DIFF
--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -556,6 +556,7 @@ void cheats_reset()
     gCheatsFreezeClimate = false;
     gCheatsDisablePlantAging = false;
     gCheatsAllowArbitraryRideTypeChanges = false;
+    gCheatsDisableRideValueAging = false;
 }
 
 //Generates the string to print for the server log when a cheat is used.

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -759,6 +759,9 @@ const char* cheats_get_cheat_string(int cheat, int edx, int edi) {
         }
         case CHEAT_RESETDATE: return language_get_string(STR_CHEAT_RESET_DATE);
         case CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES: return language_get_string(STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES);
+        case CHEAT_SETMONEY: return language_get_string(STR_SET_MONEY);
+        case CHEAT_OWNALLLAND: return language_get_string(STR_CHEAT_OWN_ALL_LAND);
+        case CHEAT_DISABLERIDEVALUEAGING: return language_get_string(STR_CHEAT_DISABLE_RIDE_VALUE_AGING);
     }
 
     return "";


### PR DESCRIPTION
I didn't include a network version bump because it shouldn't cause any compatibility issues. Worst case scenario someone has a line in their command log while another user has a blank line. Correct me if i'm wrong here and i'll change it.