### PR TITLE
Add "Ignore research status" cheat

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4440,6 +4440,8 @@ STR_6128    :The file could not be loaded as some of the objects referenced in i
 STR_6129    :Copy selected item to clipboard
 STR_6130    :Copy entire list to clipboard
 STR_6131    :Object source
+STR_6132    :Ignore research status
+STR_6133    :{SMALLFONT}{BLACK}Access rides and scenery that have not yet been invented
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.1.1 (in development)
 ------------------------------------------------------------------------
+- Feature: [#5815] Add cheat to ignore research status and access rides/scenery not yet invented.
 - Feature: [#5877] Allow up to 16 stations to be synchronised
 - Fix: [#3589] Crash due to invalid footpathEntry in path_paint
 - Fix: [#4455] Crash in window_sign_invalidate due to original bug

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -51,6 +51,7 @@ bool gCheatsDisablePlantAging = false;
 bool gCheatsEnableChainLiftOnAllTrack = false;
 bool gCheatsAllowArbitraryRideTypeChanges = false;
 bool gCheatsDisableRideValueAging = false;
+bool gCheatsIgnoreResearchStatus = false;
 
 sint32 park_rating_spinner_value;
 
@@ -527,6 +528,7 @@ void game_command_cheat(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint
             case CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES: gCheatsAllowArbitraryRideTypeChanges = *edx != 0; window_invalidate_by_class(WC_RIDE); break;
             case CHEAT_OWNALLLAND: cheat_own_all_land(); break;
             case CHEAT_DISABLERIDEVALUEAGING: gCheatsDisableRideValueAging = *edx != 0; break;
+            case CHEAT_IGNORERESEARCHSTATUS: gCheatsIgnoreResearchStatus = *edx != 0; break;
         }
         if (network_get_mode() == NETWORK_MODE_NONE) {
             config_save_default();
@@ -558,6 +560,7 @@ void cheats_reset()
     gCheatsDisablePlantAging = false;
     gCheatsAllowArbitraryRideTypeChanges = false;
     gCheatsDisableRideValueAging = false;
+    gCheatsIgnoreResearchStatus = false;
 }
 
 //Generates the string to print for the server log when a cheat is used.
@@ -764,6 +767,7 @@ const char* cheats_get_cheat_string(int cheat, int edx, int edi) {
         case CHEAT_SETMONEY: return language_get_string(STR_SET_MONEY);
         case CHEAT_OWNALLLAND: return language_get_string(STR_CHEAT_OWN_ALL_LAND);
         case CHEAT_DISABLERIDEVALUEAGING: return language_get_string(STR_CHEAT_DISABLE_RIDE_VALUE_AGING);
+        case CHEAT_IGNORERESEARCHSTATUS: return language_get_string(STR_CHEAT_IGNORE_RESEARCH_STATUS);
     }
 
     return "";

--- a/src/openrct2/cheats.h
+++ b/src/openrct2/cheats.h
@@ -39,6 +39,7 @@ extern bool gCheatsDisablePlantAging;
 extern bool gCheatsDisableRideValueAging;
 extern bool gCheatsEnableChainLiftOnAllTrack;
 extern bool gCheatsAllowArbitraryRideTypeChanges;
+extern bool gCheatsIgnoreResearchStatus;
 
 
 enum {
@@ -88,6 +89,7 @@ enum {
     CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,
     CHEAT_OWNALLLAND,
     CHEAT_DISABLERIDEVALUEAGING,
+    CHEAT_IGNORERESEARCHSTATUS,
 };
 
 enum {

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3801,6 +3801,9 @@ enum {
     STR_COPY_ALL = 6130,
     STR_OBJECT_SOURCE = 6131,
 
+    STR_CHEAT_IGNORE_RESEARCH_STATUS = 6132,
+    STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP = 6133,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -1909,7 +1909,8 @@ bool Network::LoadMap(IStream * stream)
         gCheatsAllowArbitraryRideTypeChanges = stream->ReadValue<uint8>() != 0;
         gCheatsDisableRideValueAging = stream->ReadValue<uint8>() != 0;
         gConfigGeneral.show_real_names_of_guests = stream->ReadValue<uint8>() != 0;
-
+        gCheatsIgnoreResearchStatus = stream->ReadValue<uint8>() != 0;
+        
         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
         result = true;
     }
@@ -1956,6 +1957,7 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
         stream->WriteValue<uint8>(gCheatsAllowArbitraryRideTypeChanges);
         stream->WriteValue<uint8>(gCheatsDisableRideValueAging);
         stream->WriteValue<uint8>(gConfigGeneral.show_real_names_of_guests);
+        stream->WriteValue<uint8>(gCheatsIgnoreResearchStatus);
 
         result = true;
     }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5995,7 +5995,7 @@ static money32 ride_create(sint32 type, sint32 subType, sint32 flags, sint32 *ou
             rideEntry = get_ride_entry(*rei);
 
             // Can happen in select-by-track-type mode
-            if (!ride_entry_is_invented(*rei))
+            if (!ride_entry_is_invented(*rei) && !gCheatsIgnoreResearchStatus)
             {
                 continue;
             }
@@ -7860,7 +7860,7 @@ static bool ride_is_vehicle_type_valid(rct_ride *ride, uint8 inputRideEntryIndex
         for (uint8 *currentRideEntryIndex = rideEntryIndexPtr; *currentRideEntryIndex != RIDE_ENTRY_INDEX_NULL; currentRideEntryIndex++) {
             uint8 rideEntryIndex = *currentRideEntryIndex;
             if (rideEntryIndex == inputRideEntryIndex) {
-                if (!ride_entry_is_invented(rideEntryIndex)) {
+                if (!ride_entry_is_invented(rideEntryIndex) && !gCheatsIgnoreResearchStatus) {
                     return false;
                 }
 

--- a/src/openrct2/ride/track_design.c
+++ b/src/openrct2/ride/track_design.c
@@ -1394,7 +1394,7 @@ static bool track_design_place_preview(rct_track_td6 *td6, money32 *cost, uint8 
         if (!find_object_in_entry_group(&td6->vehicle_object, &entry_type, &entry_index)) {
             *flags |= TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE;
         }
-        else if (!ride_entry_is_invented(entry_index))
+        else if (!ride_entry_is_invented(entry_index) && !gCheatsIgnoreResearchStatus)
         {
             *flags |= TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE;
         }
@@ -1439,7 +1439,7 @@ static money32 place_track_design(sint16 x, sint16 y, sint16 z, uint8 flags, uin
         entryIndex = 0xFF;
     }
     // Force a fallback if the entry is not invented yet a td6 of it is selected, which can happen in select-by-track-type mode.
-    else if (!ride_entry_is_invented(entryIndex))
+    else if (!ride_entry_is_invented(entryIndex) && !gCheatsIgnoreResearchStatus)
     {
         entryIndex = 0xFF;
     }
@@ -1459,7 +1459,7 @@ static money32 place_track_design(sint16 x, sint16 y, sint16 z, uint8 flags, uin
             {
                 ire = get_ride_entry(*rei);
 
-                if (!ride_entry_is_invented(*rei))
+                if (!ride_entry_is_invented(*rei) && !gCheatsIgnoreResearchStatus)
                 {
                     continue;
                 }

--- a/src/openrct2/windows/cheats.c
+++ b/src/openrct2/windows/cheats.c
@@ -147,6 +147,7 @@ enum WINDOW_CHEATS_WIDGET_IDX {
     WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,
     WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES,
     WIDX_DISABLE_RIDE_VALUE_AGING,
+    WIDX_IGNORE_RESEARCH_STATUS,
 };
 
 #pragma region MEASUREMENTS
@@ -284,6 +285,7 @@ static rct_widget window_cheats_rides_widgets[] = {
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(13),        OHPL(13),       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,   STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP }, // Enable chain lift on all track
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(14),        OHPL(14),       STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,    STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES_TIP },  // Allow arbitrary ride type changes
     { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(15),        OHPL(15),       STR_CHEAT_DISABLE_RIDE_VALUE_AGING, STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP }, // Disable ride ageing
+    { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(16),        OHPL(16),       STR_CHEAT_IGNORE_RESEARCH_STATUS, STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP}, // Ignore Research Status
     { WIDGETS_END },
 };
 
@@ -461,7 +463,7 @@ static uint64 window_cheats_page_enabled_widgets[] = {
         (1ULL << WIDX_MAKE_DESTRUCTIBLE) | (1ULL << WIDX_FIX_ALL) | (1ULL << WIDX_FAST_LIFT_HILL) | (1ULL << WIDX_DISABLE_BRAKES_FAILURE) |
         (1ULL << WIDX_DISABLE_ALL_BREAKDOWNS) | (1ULL << WIDX_BUILD_IN_PAUSE_MODE) | (1ULL << WIDX_RESET_CRASH_STATUS) | (1ULL << WIDX_10_MINUTE_INSPECTIONS) |
         (1ULL << WIDX_SHOW_ALL_OPERATING_MODES) | (1ULL << WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES) | (1ULL << WIDX_DISABLE_TRAIN_LENGTH_LIMITS) |
-        (1ULL << WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK) | (1ULL << WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES) | (1ULL << WIDX_DISABLE_RIDE_VALUE_AGING)
+        (1ULL << WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK) | (1ULL << WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES) | (1ULL << WIDX_DISABLE_RIDE_VALUE_AGING) | (1ULL << WIDX_IGNORE_RESEARCH_STATUS)
 };
 
 static uint64 window_cheats_page_hold_down_widgets[] = {
@@ -834,6 +836,9 @@ static void window_cheats_rides_mouseup(rct_window *w, rct_widgetindex widgetInd
     case WIDX_DISABLE_RIDE_VALUE_AGING:
         game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLERIDEVALUEAGING, !gCheatsDisableRideValueAging, GAME_COMMAND_CHEAT, 0, 0);
         break;
+    case WIDX_IGNORE_RESEARCH_STATUS:
+        game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_IGNORERESEARCHSTATUS, !gCheatsIgnoreResearchStatus, GAME_COMMAND_CHEAT, 0, 0);
+        break;
     }
 }
 
@@ -917,6 +922,7 @@ static void window_cheats_invalidate(rct_window *w)
         widget_set_checkbox_value(w, WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK, gCheatsEnableChainLiftOnAllTrack);
         widget_set_checkbox_value(w, WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES, gCheatsAllowArbitraryRideTypeChanges);
         widget_set_checkbox_value(w, WIDX_DISABLE_RIDE_VALUE_AGING, gCheatsDisableRideValueAging);
+        widget_set_checkbox_value(w, WIDX_IGNORE_RESEARCH_STATUS, gCheatsIgnoreResearchStatus);
         break;
     }
 

--- a/src/openrct2/windows/new_ride.c
+++ b/src/openrct2/windows/new_ride.c
@@ -313,7 +313,7 @@ static void window_new_ride_populate_list()
                 continue;
         }
 
-        if (ride_type_is_invented(rideType)) {
+        if (ride_type_is_invented(rideType) || gCheatsIgnoreResearchStatus) {
 
             if (!ride_type_has_ride_groups(rideType)) {
                 nextListItem = window_new_ride_iterate_over_ride_group(rideType, 0, nextListItem);
@@ -350,7 +350,7 @@ static ride_list_item * window_new_ride_iterate_over_ride_group(uint8 rideType, 
         rideEntryName[8]=0;
 
         // Skip if vehicle type is not invented yet
-        if (!ride_entry_is_invented(rideEntryIndex))
+        if (!ride_entry_is_invented(rideEntryIndex) && !gCheatsIgnoreResearchStatus)
             continue;
 
         // Ride entries

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -2681,7 +2681,7 @@ static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetI
                     continue;
 
                 // Skip if vehicle type is not invented yet
-                if (!ride_entry_is_invented(rideEntryIndex))
+                if (!ride_entry_is_invented(rideEntryIndex) && !gCheatsIgnoreResearchStatus)
                     continue;
 
                 // Skip if vehicle does not belong to the same ride group

--- a/src/openrct2/windows/scenery.c
+++ b/src/openrct2/windows/scenery.c
@@ -193,7 +193,7 @@ void window_scenery_update_scroll(rct_window *w);
  */
 static void init_scenery_entry(rct_scenery_entry *sceneryEntry, sint32 index, uint8 sceneryTabId)
 {
-    if (scenery_is_invented(index)) {
+    if (scenery_is_invented(index) || gCheatsIgnoreResearchStatus) {
         if (sceneryTabId != 0xFF) {
             for (sint32 i = 0; i < SCENERY_ENTRIES_BY_TAB; i++) {
                 if (window_scenery_tab_entries[sceneryTabId][i] == -1)
@@ -249,7 +249,7 @@ void init_scenery()
         sint32 sceneryTabEntryCount = 0;
         for (sint32 i = 0; i < scenerySetEntry->entry_count; i++) {
             uint16 sceneryEntryId = scenerySetEntry->scenery_entries[i];
-            if (scenery_is_invented(sceneryEntryId)) {
+            if (scenery_is_invented(sceneryEntryId) || gCheatsIgnoreResearchStatus) {
                 window_scenery_tab_entries[scenerySetIndex][sceneryTabEntryCount] = sceneryEntryId;
                 window_scenery_tab_entries[scenerySetIndex][++sceneryTabEntryCount] = -1;
             } else {


### PR DESCRIPTION
For a long time I've attempted to make a cheat that would invent all the items, to be used over multiplayer. Despite numerous attempts, I can't seem to grasp the algorithm of the research list. Errors happen, list doesn't organize right, infinite loops, etc. It recently hit me that it could be handled indirectly by having the windows (the only areas the invention status is checked) ignore the status, that way the research list is not actually affected.

This does not reload the windows, however. That will need to be done manually. This is to preserve scroll positions and also prevent someone on multiplayer from enabling/disabling the cheat and throwing off someones click.