### PR TITLE
Improve the error console output.

### DIFF
--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -162,7 +162,7 @@ public:
                     SkipToNextLoadCommand();
                     if (_position == entryPosition)
                     {
-                        Console::Error::WriteLine("Unable to load any parks within title sequence.");
+                        Console::Error::WriteLine("Unable to load any parks from %s.", _sequence->Name);
                         return false;
                     }
                 }


### PR DESCRIPTION
Output the sequence name from which the parks could not get loaded.