### PR TITLE
Fix sending tick message not at exact tick. 

### DIFF
--- a/src/openrct2/network/network.cpp
+++ b/src/openrct2/network/network.cpp
@@ -418,9 +418,8 @@ void Network::UpdateServer()
     }
 
     uint32 ticks = platform_get_ticks();
-    if (ticks > last_tick_sent_time + 25) {
-        Server_Send_TICK();
-    }
+    Server_Send_TICK();
+
     if (ticks > last_ping_sent_time + 3000) {
         Server_Send_PING();
         Server_Send_PINGLIST();


### PR DESCRIPTION
For unknown reasons the tick message was further delayed for another 25ms causing clients having the need to wait longer than required. Since network_update is called per Tick this should send the message at the given time and not further delay it, ticks already run per 25ms.