### PR TITLE
Fix tunnel portal drawing for multidim inverted track.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#5489] Sprite index crash for car view on car ride.
 - Fix: [#5730] Unable to uncheck 'No money' in the Scenario Editor.
 - Fix: [#5750] Game freezes when ride queue linked list is corrupted.
+- Fix: [#5819] Vertical multi-dimension coaster tunnels drawn incorrectly
 - Fix: Non-invented vehicles can be used via track designs in select-by-track-type mode.
 - Fix: Track components added by OpenRCT2 are now usable in older scenarios.
 - Technical: [#5047] Add ride ratings tests

--- a/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
+++ b/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
@@ -4209,7 +4209,7 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(uint8 rideIndex, uin
             if (direction == 0 || direction == 3) {
                 paint_util_push_tunnel_rotated(direction, height - 8, TUNNEL_4);
             }
-            paint_util_set_vertical_tunnel(height + 48);
+            paint_util_set_vertical_tunnel(height + 56);
             paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
             paint_util_set_general_support_height(height + 72, 0x20);
             break;


### PR DESCRIPTION
Mistake made from generated code. Missed in #5087. Fixes #5819.

![5819](https://user-images.githubusercontent.com/1277401/27992849-58be9db8-6495-11e7-99f4-e1cd25c6a4bf.PNG)
(Fixed code ignore the render bug on the tunnel its like that in vanilla)