### PR TITLE
Refactor game loop to use a semi-fixed timestep.

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "30"
+#define NETWORK_STREAM_VERSION "31"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -758,8 +758,10 @@ void sprite_position_tween_store_b()
     store_sprite_locations(_spritelocations2);
 }
 
-void sprite_position_tween_all(float nudge)
+void sprite_position_tween_all(float alpha)
 {
+    const float inv = (1.0f - alpha);
+
     for (uint16 i = 0; i < MAX_SPRITES; i++) {
         rct_sprite * sprite = get_sprite(i);
         if (sprite_should_tween(sprite)) {
@@ -767,9 +769,9 @@ void sprite_position_tween_all(float nudge)
             rct_xyz16 posB = _spritelocations2[i];
 
             sprite_set_coordinates(
-                posB.x + (sint16)((posA.x - posB.x) * nudge),
-                posB.y + (sint16)((posA.y - posB.y) * nudge),
-                posB.z + (sint16)((posA.z - posB.z) * nudge),
+                posB.x * alpha + posA.x * inv,
+                posB.y * alpha + posA.y * inv,
+                posB.z * alpha + posA.z * inv,
                 sprite
             );
             invalidate_sprite_2(sprite);


### PR DESCRIPTION
This version should work regardless of FPS on client/server. Currently there are some issues with the current implementation that causes clients on headless servers to stutter because its forced to fixed frame.

This should fix issue #5841 

Edit: I just realized this also fixes the game becoming slower when uncap fps is enabled #5810