### PR TITLE
Improve OpenGL rendering performance.

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -35,13 +35,4 @@ struct DrawLineCommand {
     sint32 pos[4];
 };
 
-struct DrawImageCommand {
-    uint32 flags;
-    vec4f colour;
-    sint32 clip[4];
-    CachedTextureInfo texMask;
-    CachedTextureInfo texColour;
-    CachedTextureInfo texPalette;
-    sint32 bounds[4];
-    bool mask;
-};
+typedef DrawImageInstance DrawImageCommand;


### PR DESCRIPTION
This PR avoids copying all the rendering commands into another struct. I've simply unified the struct to be the same thing so it can be passed down directly as it is without needing to go over all the data and copying it. I also removed the default initializer since a lot of the members will be overwritten.