### PR TITLE
Prevent booster pieces from toggling spinning

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "31"
+#define NETWORK_STREAM_VERSION "32"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -7469,7 +7469,7 @@ loc_6DB41D:
     if (trackType == TRACK_ELEM_ON_RIDE_PHOTO) {
         vehicle_trigger_on_ride_photo(vehicle, mapElement);
     }
-    if (trackType == TRACK_ELEM_ROTATION_CONTROL_TOGGLE) {
+    if (trackType == TRACK_ELEM_ROTATION_CONTROL_TOGGLE && rideType == RIDE_TYPE_WILD_MOUSE) {
         vehicle->update_flags ^= VEHICLE_UPDATE_FLAG_13;
     }
     if (vehicleEntry->flags_a & VEHICLE_ENTRY_FLAG_A_8) {


### PR DESCRIPTION
Since the boosters and the spinning control toggle share the same track piece, booster pieces will turn spinning on/off when used with spinning cars.

As this is presumably undesirable behaviour, this PR checks the track type so that spinning will only be toggled on wild mouse track (as far as I am aware, all other track types treat this piece as a booster).