### PR TITLE
Allow switching between OpenGL and software rendering without restarting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#5858] Crash when using custom ride with no colour presets.
 - Fix: [#5872] Incorrect OpenGL rendering of masked sprites
 - Improved: [#5859] OpenGL rendering performance
+- Improved: [#5863] Switching drawing engines no longer requires the application to restart.
 
 0.1.0 (2017-07-12)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.cpp
@@ -81,8 +81,6 @@ DrawImageShader::~DrawImageShader()
     glDeleteBuffers(1, &_vbo);
     glDeleteBuffers(1, &_vboInstances);
     glDeleteVertexArrays(1, &_vao);
-
-    glBindVertexArray(_vao);
 }
 
 void DrawImageShader::GetLocations()

--- a/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawLineShader.cpp
@@ -41,8 +41,6 @@ DrawLineShader::~DrawLineShader()
 {
     glDeleteBuffers(1, &_vbo);
     glDeleteVertexArrays(1, &_vao);
-
-    glBindVertexArray(_vao);
 }
 
 void DrawLineShader::GetLocations()

--- a/src/openrct2-ui/drawing/engines/opengl/FillRectShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/FillRectShader.cpp
@@ -43,8 +43,6 @@ FillRectShader::~FillRectShader()
 {
     glDeleteBuffers(1, &_vbo);
     glDeleteVertexArrays(1, &_vao);
-
-    glBindVertexArray(_vao);
 }
 
 void FillRectShader::GetLocations()

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.cpp
@@ -121,8 +121,14 @@ static const char * TryLoadAllProcAddresses()
 
 namespace OpenGLState
 {
-    uint16 ActiveTexture = UINT16_MAX;
-    GLuint CurrentProgram = UINT32_MAX;
+    uint16 ActiveTexture;
+    GLuint CurrentProgram;
+
+    void Reset()
+    {
+        ActiveTexture = UINT16_MAX;
+        CurrentProgram = UINT32_MAX;
+    }
 }
 
 void OpenGLAPI::SetTexture(uint16 index, GLenum type, GLuint texture)
@@ -136,6 +142,8 @@ void OpenGLAPI::SetTexture(uint16 index, GLenum type, GLuint texture)
 
 bool OpenGLAPI::Initialise()
 {
+    OpenGLState::Reset();
+
 #ifdef OPENGL_NO_LINK
     const char * failedProcName = TryLoadAllProcAddresses();
     if (failedProcName != nullptr)

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
@@ -198,4 +198,6 @@ namespace OpenGLState
 {
     extern uint16 ActiveTexture;
     extern GLuint CurrentProgram;
+
+    void Reset();
 }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -663,6 +663,11 @@ extern "C"
         return GetContext()->GetUiContext()->SetFullscreenMode((FULLSCREEN_MODE)mode);
     }
 
+    void context_recreate_window()
+    {
+        GetContext()->GetUiContext()->RecreateWindow();
+    }
+
     sint32 context_get_resolutions(Resolution * * outResolutions)
     {
         auto resolutions = GetContext()->GetUiContext()->GetFullscreenResolutions();

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -127,6 +127,7 @@ extern "C"
     bool context_is_input_active();
     void context_trigger_resize();
     void context_set_fullscreen_mode(sint32 mode);
+    void context_recreate_window();
     sint32 context_get_resolutions(struct Resolution * * outResolutions);
     sint32 context_get_width();
     sint32 context_get_height();

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -57,20 +57,18 @@ extern "C"
         return _drawingEngineType;
     }
 
-    bool drawing_engine_requires_restart(sint32 srcEngine, sint32 dstEngine)
+    bool drawing_engine_requires_new_window(sint32 srcEngine, sint32 dstEngine)
     {
-        // Linux requires a restart. This could be improved in the future by recreating the window,
-        // https://github.com/OpenRCT2/OpenRCT2/issues/2015
-        bool requiresRestart = true;
 #ifdef _WIN32
-        if (dstEngine != DRAWING_ENGINE_OPENGL)
+        if (srcEngine != DRAWING_ENGINE_OPENGL && dstEngine != DRAWING_ENGINE_OPENGL)
         {
             // Windows is apparently able to switch to hardware rendering on the fly although
             // using the same window in an unaccelerated and accelerated context is unsupported by SDL2
-            requiresRestart = false;
+            return false;
         }
 #endif
-        return requiresRestart;
+
+        return true;
     }
 
     void drawing_engine_init()
@@ -135,13 +133,11 @@ extern "C"
 
     void drawing_engine_resize()
     {
-        if (_drawingEngine == nullptr)
+        if (_drawingEngine != nullptr)
         {
-            drawing_engine_init();
+            IUiContext * uiContext = GetContext()->GetUiContext();
+            _drawingEngine->Resize(uiContext->GetWidth(), uiContext->GetHeight());
         }
-
-        IUiContext * uiContext = GetContext()->GetUiContext();
-        _drawingEngine->Resize(uiContext->GetWidth(), uiContext->GetHeight());
     }
 
     void drawing_engine_set_palette(const rct_palette_entry * colours)

--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -27,7 +27,7 @@ extern "C"
 extern rct_string_id DrawingEngineStringIds[3];
 
 sint32 drawing_engine_get_type();
-bool drawing_engine_requires_restart(sint32 srcEngine, sint32 dstEngine);
+bool drawing_engine_requires_new_window(sint32 srcEngine, sint32 dstEngine);
 void drawing_engine_init();
 void drawing_engine_resize();
 void drawing_engine_set_palette(const rct_palette_entry * colours);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -86,7 +86,7 @@ void platform_draw_require_end();
 void platform_free();
 void platform_update_palette(const uint8 *colours, sint32 start_index, sint32 num_colours);
 void platform_toggle_windowed_mode();
-void platform_refresh_video();
+void platform_refresh_video(bool recreate_window);
 void platform_get_date_utc(rct2_date *out_date);
 void platform_get_time_utc(rct2_time *out_time);
 void platform_get_date_local(rct2_date *out_date);

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -152,11 +152,19 @@ void platform_toggle_windowed_mode()
     config_save_default();
 }
 
-void platform_refresh_video()
+void platform_refresh_video(bool recreate_window)
 {
-    drawing_engine_dispose();
-    drawing_engine_init();
-    drawing_engine_resize();
+    if (recreate_window)
+    {
+        context_recreate_window();
+    }
+    else
+    {
+        drawing_engine_dispose();
+        drawing_engine_init();
+        drawing_engine_resize();
+    }
+
     drawing_engine_set_palette(gPalette);
     gfx_invalidate_screen();
 }

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -33,6 +33,7 @@ namespace OpenRCT2 { namespace Ui
     public:
         void CreateWindow() override { }
         void CloseWindow() override { }
+        void RecreateWindow() override { }
         void * GetWindow() override { return nullptr; }
         sint32 GetWidth() override { return 0; }
         sint32 GetHeight() override { return 0; }

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -94,6 +94,7 @@ namespace OpenRCT2
             // Window
             virtual void    CreateWindow() abstract;
             virtual void    CloseWindow() abstract;
+            virtual void    RecreateWindow() abstract;
             virtual void *  GetWindow() abstract;
             virtual sint32  GetWidth() abstract;
             virtual sint32  GetHeight() abstract;

--- a/src/openrct2/windows/options.c
+++ b/src/openrct2/windows/options.c
@@ -639,7 +639,7 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             break;
         case WIDX_MINIMIZE_FOCUS_LOSS:
             gConfigGeneral.minimize_fullscreen_focus_loss ^= 1;
-            platform_refresh_video();
+            platform_refresh_video(false);
             config_save_default();
             window_invalidate(w);
             break;
@@ -1308,11 +1308,8 @@ static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, 
                 sint32 dstEngine = dropdownIndex;
 
                 gConfigGeneral.drawing_engine = (uint8)dstEngine;
-                if (drawing_engine_requires_restart(srcEngine, dstEngine)) {
-                    window_error_open(STR_RESTART_REQUIRED, STR_NONE);
-                } else {
-                    platform_refresh_video();
-                }
+                bool recreate_window = drawing_engine_requires_new_window(srcEngine, dstEngine);
+                platform_refresh_video(recreate_window);
                 config_save_default();
                 window_invalidate(w);
             }


### PR DESCRIPTION
This change makes the game re-create its window rather than requiring a restart when switching between software/OpenGL rendering.

Previously it was only necessary to restart the game when switching _to_ OpenGL's renderer, but I noticed some issues when switching from OpenGL whilst in full-screen. Now the window will be re-created when switching either to or from OpenGL rendering.

I also solved a couple of issues that popped up which wouldn't have been noticed until this change:
- The OpenGL renderer had some global state in the `OpenGLState` namespace that would persist when switching render modes. This is now reset each time OpenGL is enabled.
- I removed a couple of invalid calls to `glBindVertexArray` that ran during disposal of the OpenGL renderer. It looks like they were left in by accident at some point.

I've tested this on Windows 10 and Ubuntu 16.04.