### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -7460,6 +7460,7 @@ loc_6DB41D:
     }
 
     trackType = mapElement->properties.track.type;
+    rideType = get_ride(mapElement->properties.track.ride_index)->type;
     if (trackType != TRACK_ELEM_BRAKES) {
         vehicle->target_seat_rotation = mapElement->properties.track.colour >> 4;
     }


### PR DESCRIPTION
The last PR I submitted used a variable that might be uninitialized. This should fix that, but the last PR has already been merged so I'm submitting a new one.