### PR TITLE
Improve rendering of masked sprites in OpenGL drawing engine

### DIFF
--- a/data/shaders/drawimage.frag
+++ b/data/shaders/drawimage.frag
@@ -59,11 +59,16 @@ void main()
     {
         texel = uPalette[texture(uTexture, vec3(fTexColourCoords, float(fTexColourAtlas))).r];
     }
-    vec4 mask = uPalette[texture(uTexture, vec3(fTexMaskCoords, float(fTexMaskAtlas))).r];
 
     if (fMask != 0)
     {
-        oColour = texel * mask;
+        float mask = texture(uTexture, vec3(fTexMaskCoords, float(fTexMaskAtlas))).r;
+        if ( mask == 0.0 )
+        {
+            discard;
+        }
+
+        oColour = texel;
     }
     else
     {


### PR DESCRIPTION
This change corrects rendering of masked sprites in cases where the mask is either 0 or 255. I wasn't able to find any cases where the mask would be somewhere in between, but if any exist they will continue to be broken until a bitwise AND operation is added.

__Before__
![](http://files.facepunch.com/willox/2017-07-12/tcYE6W2W.png)
![](http://files.facepunch.com/willox/2017-07-12/TL4maY9h.png)

__After__
![](http://files.facepunch.com/willox/2017-07-12/Wbr4O2XO.png)
![](http://files.facepunch.com/willox/2017-07-12/cvfO7IyM.png)