### PR TITLE
Fix #5866: Don't tween sprites that did not move.

### DIFF
--- a/src/openrct2/world/sprite.c
+++ b/src/openrct2/world/sprite.c
@@ -767,7 +767,9 @@ void sprite_position_tween_all(float alpha)
         if (sprite_should_tween(sprite)) {
             rct_xyz16 posA = _spritelocations1[i];
             rct_xyz16 posB = _spritelocations2[i];
-
+            if (posA.x == posB.x && posA.y == posB.y && posA.z == posB.z) {
+                continue;
+            }
             sprite_set_coordinates(
                 posB.x * alpha + posA.x * inv,
                 posB.y * alpha + posA.y * inv,


### PR DESCRIPTION
There is no need to tween positions if they did not move to begin with, should fix the twitching in queues and when paused. The reason for the twitching is that it kept adding the alpha from the remaining frame to the integer which rounded it.