### PR TITLE
Increase sync station limit

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2299,9 +2299,9 @@ typedef struct rct_synchronised_vehicle {
 assert_struct_size(rct_synchronised_vehicle, 4);
 #pragma pack(pop)
 
-#define SYNCHRONISED_VEHICLE_COUNT 8
+#define SYNCHRONISED_VEHICLE_COUNT 16
 
-// 8 synchronised vehicle info
+// Synchronised vehicle info
 rct_synchronised_vehicle _synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT] = { 0 };
 
 static rct_synchronised_vehicle* _lastSynchronisedVehicle = NULL;


### PR DESCRIPTION
Increased SYNCHRONISED_VEHICLE_COUNT to 16 to permit duelling coasters with more coasters. Otherwise no changes to the game logic. Feature requested in the forums: https://openrct2.org/forums/topic/2544-synchronized-stations-dont-work-passed-8-stations/

This will impact network games which already have duelling coasters built with more than 8 adjacent stations, so a new network version is necessary (included).

Briefly tested in single player with a simple 10-way duelling coaster - working as expected.