### PR TITLE
Fix regression in OpenGL DrawImageCommand flags

### DIFF
--- a/data/shaders/drawimage.frag
+++ b/data/shaders/drawimage.frag
@@ -1,5 +1,10 @@
 #version 150
 
+const int FLAG_COLOUR              = (1 << 0);
+const int FLAG_REMAP               = (1 << 1);
+const int FLAG_TRANSPARENT         = (1 << 2);
+const int FLAG_TRANSPARENT_SPECIAL = (1 << 3);
+
 uniform vec4            uPalette[256];
 uniform usampler2DArray uTexture;
 
@@ -30,13 +35,13 @@ void main()
     vec4 texel;
 
     // If remap palette used
-    if ((fFlags & (1 << 1)) != 0)
+    if ((fFlags & FLAG_REMAP) != 0)
     {
         // z is the size of each x pixel in the atlas
         float x = fTexPaletteBounds.x + texture(uTexture, vec3(fTexColourCoords, float(fTexColourAtlas))).r * fTexPaletteBounds.z;
         texel = uPalette[texture(uTexture, vec3(x, fTexPaletteBounds.y, float(fTexPaletteAtlas))).r];
     } // If transparent or special transparent
-    else if ((fFlags & ((1 << 2) | (1 << 3))) != 0)
+    else if ((fFlags & (FLAG_TRANSPARENT | FLAG_TRANSPARENT_SPECIAL)) != 0)
     {
         float line = texture(uTexture,vec3(fTexColourCoords, float(fTexColourAtlas))).r;
         if (line == 0.0)
@@ -44,7 +49,7 @@ void main()
             discard;
         }
         float alpha = 0.5;
-        if ((fFlags & (1 << 2)) != 0)
+        if ((fFlags & FLAG_TRANSPARENT_SPECIAL) != 0)
         {
             alpha = 0.5 + (line - 1.0) / 10.0;
         }
@@ -72,7 +77,7 @@ void main()
     }
     else
     {
-        if ((fFlags & 1) != 0)
+        if ((fFlags & FLAG_COLOUR) != 0)
         {
             oColour = vec4(fColour.rgb, fColour.a * texel.a);
         }

--- a/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.h
@@ -34,6 +34,14 @@ struct DrawImageInstance {
     vec4f colour;
     vec4i bounds;
     sint32 mask;
+
+    enum
+    {
+        FLAG_COLOUR              = (1 << 0),
+        FLAG_REMAP               = (1 << 1),
+        FLAG_TRANSPARENT         = (1 << 2),
+        FLAG_TRANSPARENT_SPECIAL = (1 << 3),
+    };
 };
 
 class DrawImageShader final : public OpenGLShaderProgram

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -786,6 +786,14 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
 
     DrawImageCommand command;
 
+    command.flags = special << 2;
+    if (image & IMAGE_TYPE_TRANSPARENT) {
+        command.flags |= (1 << 3);
+    }
+    else if (image & (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP)) {
+        command.flags |= (1 << 1);
+    }
+
     command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
     command.texColourAtlas = texture.index;
     command.texColourBounds = texture.normalizedBounds;
@@ -798,7 +806,6 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
         (texture2.normalizedBounds.z - texture2.normalizedBounds.x) / (float)(texture2.bounds.z - texture2.bounds.x),
         (texture2.normalizedBounds.w - texture2.normalizedBounds.y) / (float)(texture2.bounds.w - texture2.bounds.y)
     };
-    command.flags = (!!(image & IMAGE_TYPE_TRANSPARENT) << 3) | (!!(image & (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP)) << 1) | (special << 2);
     command.colour = { 0.0f, 0.0f, 0.0f };
     command.bounds = { left, top, right, bottom };
     command.mask = 0;

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -786,14 +786,6 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
 
     DrawImageCommand command;
 
-    command.flags = special << 2;
-    if (image & IMAGE_TYPE_TRANSPARENT) {
-        command.flags |= (1 << 3);
-    }
-    else if (image & (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP)) {
-        command.flags |= (1 << 1);
-    }
-
     command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
     command.texColourAtlas = texture.index;
     command.texColourBounds = texture.normalizedBounds;
@@ -809,6 +801,21 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
     command.colour = { 0.0f, 0.0f, 0.0f };
     command.bounds = { left, top, right, bottom };
     command.mask = 0;
+    command.flags = 0;
+
+    if (special)
+    {
+        command.flags |= DrawImageCommand::FLAG_TRANSPARENT_SPECIAL;
+    }
+
+    if (image & IMAGE_TYPE_TRANSPARENT)
+    {
+        command.flags |= DrawImageCommand::FLAG_TRANSPARENT;
+    }
+    else if (image & (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP))
+    {
+        command.flags |= DrawImageCommand::FLAG_REMAP;
+    }
 
     _commandBuffers.images.emplace_back(std::move(command));
 }
@@ -921,7 +928,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(uint32 image, sint32 x, sint32 y, uin
         (texture.normalizedBounds.z - texture.normalizedBounds.x) / (float)(texture.bounds.z - texture.bounds.x),
         (texture.normalizedBounds.w - texture.normalizedBounds.y) / (float)(texture.bounds.w - texture.bounds.y)
     };
-    command.flags = 1;
+    command.flags = DrawImageCommand::FLAG_COLOUR;
     command.colour = paletteColour;
     command.bounds = { left, top, right, bottom };
     command.mask = 0;


### PR DESCRIPTION
This fixes a change from 5f1bc914af159b67e3047524e1e6d70d9b410d2a which caused two flags to be set at the same time. The DrawImage shader can't handle it, so you end up with water looking like:
![](http://i.imgur.com/zEwVHVq.png)

After this change it returns to looking like:
![](http://i.imgur.com/EKIxxOy.png)
