### PR TITLE
Fix null pointer dereference when cancelling an RCT1 location dialog …

### DIFF
--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -118,14 +118,14 @@ namespace OpenRCT2 { namespace Ui
                 panel.canChooseFiles = false;
                 panel.canChooseDirectories = true;
                 panel.allowsMultipleSelection = false;
-                utf8 *url = NULL;
                 if ([panel runModal] == NSFileHandlingPanelOKButton)
                 {
                     NSString *selectedPath = panel.URL.path;
                     const char *path = selectedPath.UTF8String;
-                    url = _strdup(path);
+                    return path;
+                } else {
+                    return "";
                 }
-                return url;
             }
         }
 


### PR DESCRIPTION
…on Mac OS X.

To reproduce, run openrct2 on OSX, go to the options dialog, then to the bottom
of the misc tab, select an RCT1 location. Then, cancel that dialog. This would
trigger a null pointer dereference by returning std::string(nullptr).