### PR TITLE
Render title sequence to screenshots

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -643,6 +643,12 @@ namespace OpenRCT2
 
 #ifndef __EMSCRIPTEN__
             _variableFrame = ShouldRunVariableFrame();
+
+            window_close(window_find_by_class(WC_TITLE_LOGO));
+            window_close(window_find_by_class(WC_TITLE_OPTIONS));
+            window_close(window_find_by_class(WC_TITLE_MENU));
+            window_close(window_find_by_class(WC_TITLE_EXIT));
+            title_set_hide_version_info(true);
             do
             {
                 RunFrame();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -680,6 +680,7 @@ namespace OpenRCT2
 
         void RunFixedFrame()
         {
+            platform_advance_ticks();
             uint32 currentTick = platform_get_ticks();
 
             if (_lastTick == 0)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -666,6 +666,7 @@ namespace OpenRCT2
 
         void RunFrame()
         {
+            platform_advance_ticks();
             // Make sure we catch the state change and reset it.
             bool useVariableFrame = ShouldRunVariableFrame();
             if (_variableFrame != useVariableFrame)
@@ -686,7 +687,6 @@ namespace OpenRCT2
 
         void RunFixedFrame()
         {
-            platform_advance_ticks();
             uint32 currentTick = platform_get_ticks();
 
             if (_lastTick == 0)

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -152,6 +152,7 @@ void drawing_engine_draw()
     {
         _drawingEngine->BeginDraw();
         _painter->Paint(_drawingEngine);
+        _drawingEngine->Screenshot();
         _drawingEngine->EndDraw();
     }
 }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -103,16 +103,7 @@ static sint32 screenshot_get_next_path(char *path, size_t size)
 #endif
 
     // Glue together path and filename
-    safe_strcpy(path, screenshotPath, size);
-    path_end_with_separator(path, size);
-    auto fileNameCh = strchr(path, '\0');
-    if (fileNameCh == nullptr)
-    {
-        log_error("Unable to generate a screenshot filename.");
-        return -1;
-    }
-    const size_t leftBytes = size - strlen(path);
-    snprintf(fileNameCh, leftBytes, "%s %d-%02d-%02d %02d-%02d-%02d.png", park_name, currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute, currentTime.second);
+    snprintf(path, size, "%s%07u.png", screenshotPath, platform_get_ticks());
 
     if (!platform_file_exists(path)) {
         return 0; // path ok
@@ -127,7 +118,7 @@ static sint32 screenshot_get_next_path(char *path, size_t size)
     sint32 i;
     for (i = 1; i < 1000; i++) {
         // Glue together path and filename
-        snprintf(fileNameCh, leftBytes, "%s %d-%02d-%02d %02d-%02d-%02d (%d).png", park_name, currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute, currentTime.second, i);
+        snprintf(path, size, "%s%u.png", screenshotPath, platform_get_ticks());
 
         if (!platform_file_exists(path)) {
             return i;

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -146,11 +146,12 @@ void platform_refresh_video(bool recreate_window)
     gfx_invalidate_screen();
 }
 
-static uint32 _ticks = 0;
+static double _ticks = 0;
 
 void platform_advance_ticks()
 {
-    _ticks += 25;
+    // ms to advance ticks by. 16.67 => 1000/16.67 = 60fps
+    _ticks += 16.67;
 }
 
 static void platform_ticks_init()
@@ -165,7 +166,7 @@ static void platform_ticks_init()
 
 uint32 platform_get_ticks()
 {
-    return _ticks;
+    return round(_ticks);
 }
 
 void platform_sleep(uint32 ms)

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -161,12 +161,6 @@ static void platform_ticks_init()
     _frequency = (uint32)(freq.QuadPart / 1000);
     QueryPerformanceCounter(&_entryTimestamp);
 #endif
-	struct timespec ts;
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
-		log_fatal("clock_gettime failed");
-		exit(-1);
-	}
-	_ticks = (uint32)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 
 uint32 platform_get_ticks()

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -111,6 +111,7 @@ bool platform_file_copy(const utf8 *srcPath, const utf8 *dstPath, bool overwrite
 bool platform_file_move(const utf8 *srcPath, const utf8 *dstPath);
 bool platform_file_delete(const utf8 *path);
 uint32 platform_get_ticks();
+void platform_advance_ticks();
 void platform_sleep(uint32 ms);
 void platform_get_openrct_data_path(utf8 *outPath, size_t outSize);
 void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory, size_t outSize);


### PR DESCRIPTION
This is specifically for @spacek531 and @PFCKrutonium .

This will ensure proper advancing of frames and render all visible frames to PNG screenshots, so you can record title sequence _properly_.

Make sure you have "software" renderer and uncap FPS turned off. Screenshot will be of your window size, you can edit that in `config.ini` too.