### PR TITLE
Fix game unable to catch up if rendering below 40 fps.

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -24,6 +24,7 @@
 #include "core/File.h"
 #include "core/FileStream.hpp"
 #include "core/Guard.hpp"
+#include "core/Math.hpp"
 #include "core/MemoryStream.h"
 #include "core/String.hpp"
 #include "FileClassifier.h"
@@ -315,7 +316,7 @@ namespace OpenRCT2
                     }
                     network_begin_server(gNetworkStartPort, gNetworkStartAddress);
                 }
- #endif // DISABLE_NETWORK
+#endif // DISABLE_NETWORK
                 break;
             }
             case STARTUP_ACTION_EDIT:
@@ -396,23 +397,18 @@ namespace OpenRCT2
             }
 
             uint32 elapsed = currentTick - _lastTick;
-            if (elapsed > UPDATE_TIME_MS)
-            {
-                elapsed = UPDATE_TIME_MS;
-            }
-
             _lastTick = currentTick;
-            _accumulator += elapsed;
+            _accumulator = Math::Min(_accumulator + elapsed, (uint32)GAME_UPDATE_MAX_THRESHOLD);
 
             GetContext()->GetUiContext()->ProcessMessages();
 
-            if (_accumulator < UPDATE_TIME_MS)
+            if (_accumulator < GAME_UPDATE_TIME_MS)
             {
-                platform_sleep(UPDATE_TIME_MS - _accumulator - 1);
+                platform_sleep(GAME_UPDATE_TIME_MS - _accumulator - 1);
                 return;
             }
 
-            _accumulator -= UPDATE_TIME_MS;
+            _accumulator -= GAME_UPDATE_TIME_MS;
 
             rct2_update();
             if (!_isWindowMinimised && !gOpenRCT2Headless)
@@ -434,17 +430,13 @@ namespace OpenRCT2
             }
 
             uint32 elapsed = currentTick - _lastTick;
-            if (elapsed > UPDATE_TIME_MS)
-            {
-                elapsed = UPDATE_TIME_MS;
-            }
 
             _lastTick = currentTick;
-            _accumulator += elapsed;
+            _accumulator = Math::Min(_accumulator + elapsed, (uint32)GAME_UPDATE_MAX_THRESHOLD);
 
             GetContext()->GetUiContext()->ProcessMessages();
 
-            while (_accumulator >= UPDATE_TIME_MS)
+            while (_accumulator >= GAME_UPDATE_TIME_MS)
             {
                 // Get the original position of each sprite
                 if(draw)
@@ -452,7 +444,7 @@ namespace OpenRCT2
 
                 rct2_update();
 
-                _accumulator -= UPDATE_TIME_MS;
+                _accumulator -= GAME_UPDATE_TIME_MS;
 
                 // Get the next position of each sprite
                 if(draw)
@@ -461,7 +453,7 @@ namespace OpenRCT2
 
             if (draw)
             {
-                const float alpha = (float)_accumulator / UPDATE_TIME_MS;
+                const float alpha = (float)_accumulator / GAME_UPDATE_TIME_MS;
                 sprite_position_tween_all(alpha);
 
                 platform_draw();

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -100,14 +100,22 @@ namespace OpenRCT2
     IContext * CreateContext();
     IContext * CreateContext(IPlatformEnvironment * env, Audio::IAudioContext * audioContext, Ui::IUiContext * uiContext);
     IContext * GetContext();
-
-    // The game update inverval in milliseconds, (1000 / 40fps) = 25ms
-    constexpr uint32 UPDATE_TIME_MS = 25;
-    // The number of logical update / ticks per second.
-    constexpr uint32 UPDATE_FPS = 40;
 }
 
 #endif // __cplusplus
+
+enum
+{
+    // The game update inverval in milliseconds, (1000 / 40fps) = 25ms
+    GAME_UPDATE_TIME_MS = 25,
+    // The number of logical update / ticks per second.
+    GAME_UPDATE_FPS = 40,
+    // The maximum amount of updates in case rendering is slower
+    GAME_MAX_UPDATES = 4,
+    // The maximum threshold to advance.
+    GAME_UPDATE_MAX_THRESHOLD = GAME_UPDATE_TIME_MS * GAME_MAX_UPDATES,
+};
+
 
 #ifdef __cplusplus
 extern "C"

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -295,8 +295,8 @@ void game_update()
     if (gGameSpeed > 1) {
         numUpdates = 1 << (gGameSpeed - 1);
     } else {
-        numUpdates = gTicksSinceLastUpdate / 31;
-        numUpdates = clamp(1, numUpdates, 4);
+        numUpdates = gTicksSinceLastUpdate / GAME_UPDATE_TIME_MS;
+        numUpdates = clamp(1, numUpdates, GAME_MAX_UPDATES);
     }
 
     if (network_get_mode() == NETWORK_MODE_CLIENT && network_get_status() == NETWORK_STATUS_CONNECTED && network_get_authstatus() == NETWORK_AUTH_OK) {

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -248,7 +248,7 @@ private:
             break;
         case TITLE_SCRIPT_WAIT:
             // The waitCounter is measured in 25-ms game ticks. Previously it was seconds * 40 ticks/second, now it is ms / 25 ms/tick
-            _waitCounter = Math::Max<sint32>(1, command->Milliseconds / UPDATE_TIME_MS);
+            _waitCounter = Math::Max<sint32>(1, command->Milliseconds / (uint32)GAME_UPDATE_TIME_MS);
             break;
         case TITLE_SCRIPT_LOADMM:
         {


### PR DESCRIPTION
This should fix a regression from #5862 which kept the maximum delta to 25ms which is wrong if the renderer falls below 40 fps. This allows the game to catch up like before as seen in game.c game_update where it divides the elapsed time by the tick time. I also refactored the constant in game_update to use the constant from context which is 25ms. Now all the math should be correct to keep the logic at 40hz.

I was not sure where to put the constants so I've put them into an enum and prefixed them with GAME_ I hope thats okay.