### PR TITLE
Fix: don't show " (DEBUG)" if DEBUG is set but is 0.

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -76,7 +76,7 @@
       <SDLCheck />
       <OmitFramePointers />
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>

--- a/src/openrct2/Version.cpp
+++ b/src/openrct2/Version.cpp
@@ -33,7 +33,7 @@ const char gVersionInfoFull[] =
 #ifdef OPENRCT2_BUILD_SERVER
     " provided by " OPENRCT2_BUILD_SERVER
 #endif
-#ifdef DEBUG
+#ifndef NDEBUG
     " (DEBUG)"
 #endif
     ;


### PR DESCRIPTION
Fixes issue #5924.

I've tested it on my Linux x86_64, although it is fairly trivial I'm not familiar with other build systems (Windows) and if the `#if` directive will work the same way there too.