### PR TITLE
Fix #5849: Missing object window cannot be closed with KB shortcut

### DIFF
--- a/src/openrct2/windows/loadsave.c
+++ b/src/openrct2/windows/loadsave.c
@@ -754,7 +754,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
-        window_close(w);
+        window_close_by_class(WC_LOADSAVE);
         gfx_invalidate_screen();
         break;
     case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME) :

--- a/src/openrct2/windows/object_load_error.c
+++ b/src/openrct2/windows/object_load_error.c
@@ -187,7 +187,7 @@ rct_window * window_object_load_error_open(utf8 * path, size_t numMissingObjects
             WH,
             &window_object_load_error_events,
             WC_OBJECT_LOAD_ERROR,
-            WF_STICK_TO_FRONT
+            0
         );
 
         window->widgets = window_object_load_error_widgets;


### PR DESCRIPTION
This removes the 'stick to front' flag from the object load error window, and uses `window_close_by_class(WC_LOADSAVE)` to close the load/save window in `window_loadsave_select()`.

Previously, without the 'stick to front' flag, the `window_close(w)` call ended up closing the object load window as the windows were reshuffled in memory, leading to `w` pointing to it, rather than the load/save window!