### PR TITLE
Add 'follow sprite' command for title sequence

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4461,6 +4461,8 @@ STR_6149    :Unable to connect to master server
 STR_6150    :Invalid response from master server (no JSON number)
 STR_6151    :Master server failed to return servers
 STR_6152    :Invalid response from master server (no JSON array)
+STR_6153    :Follow sprite
+STR_6154    :Select sprite
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
 - Feature: [#5826] Add the show_limits command to show map data counts and limits.
+- Feature: [#5930] Add 'follow sprite' command for title sequence
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Feature: [#6181] Map generator now allows adjusting random terrain and tree placement in Simplex Noise tab.
 - Feature: [#6235] Add drawing debug option for showing visuals when and where blocks of the screen are painted.

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -19,6 +19,7 @@
 #include <openrct2/core/Memory.hpp>
 #include <openrct2-ui/windows/Window.h>
 
+#include <openrct2/core/Util.hpp>
 #include <openrct2/game.h>
 #include <openrct2/input.h>
 #include <openrct2/interface/themes.h>
@@ -48,8 +49,7 @@ static TITLE_COMMAND_ORDER _window_title_command_editor_orders[] = {
     { TITLE_SCRIPT_END,         STR_TITLE_EDITOR_END,                   STR_NONE },
 };
 
-// Basically countof(window_title_command_editor_orders)
-#define NUM_COMMANDS (sizeof(_window_title_command_editor_orders) / sizeof(_window_title_command_editor_orders[0]))
+#define NUM_COMMANDS Util::CountOf(_window_title_command_editor_orders)
 
 enum WINDOW_WATER_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -349,7 +349,7 @@ static void window_title_command_editor_mousedown(rct_window *w, rct_widgetindex
     switch (widgetIndex) {
     case WIDX_COMMAND_DROPDOWN:
     {
-        sint32 numItems = NUM_COMMANDS;
+        sint32 numItems = (sint32)NUM_COMMANDS;
         for (sint32 i = 0; i < numItems; i++) {
             gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
             gDropdownItemsArgs[i] = _window_title_command_editor_orders[i].nameStringId;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/interface/viewport.h>
 #include <openrct2/interface/widget.h>
 #include <openrct2/localisation/localisation.h>
+#include <openrct2/sprites.h>
 #include <openrct2/util/util.h>
 #include <openrct2/windows/dropdown.h>
 
@@ -36,17 +37,19 @@ typedef struct TITLE_COMMAND_ORDER {
 } TITLE_COMMAND_ORDER;
 
 static TITLE_COMMAND_ORDER _window_title_command_editor_orders[] = {
-    { TITLE_SCRIPT_LOAD,        STR_TITLE_EDITOR_ACTION_LOAD, STR_TITLE_EDITOR_ARGUMENT_SAVEFILE },
+    { TITLE_SCRIPT_LOAD,        STR_TITLE_EDITOR_ACTION_LOAD,           STR_TITLE_EDITOR_ARGUMENT_SAVEFILE },
     { TITLE_SCRIPT_LOCATION,    STR_TITLE_EDITOR_COMMAND_TYPE_LOCATION, STR_TITLE_EDITOR_ARGUMENT_COORDINATES },
-    { TITLE_SCRIPT_ROTATE,      STR_TITLE_EDITOR_COMMAND_TYPE_ROTATE, STR_TITLE_EDITOR_ARGUMENT_ROTATIONS },
-    { TITLE_SCRIPT_ZOOM,        STR_TITLE_EDITOR_COMMAND_TYPE_ZOOM, STR_TITLE_EDITOR_ARGUMENT_ZOOM_LEVEL },
-    { TITLE_SCRIPT_SPEED,       STR_TITLE_EDITOR_COMMAND_TYPE_SPEED, STR_TITLE_EDITOR_ARGUMENT_SPEED },
-    { TITLE_SCRIPT_WAIT,        STR_TITLE_EDITOR_COMMAND_TYPE_WAIT, STR_TITLE_EDITOR_ARGUMENT_WAIT_SECONDS },
-    { TITLE_SCRIPT_RESTART,     STR_TITLE_EDITOR_RESTART, STR_NONE },
-    { TITLE_SCRIPT_END,         STR_TITLE_EDITOR_END, STR_NONE },
+    { TITLE_SCRIPT_ROTATE,      STR_TITLE_EDITOR_COMMAND_TYPE_ROTATE,   STR_TITLE_EDITOR_ARGUMENT_ROTATIONS },
+    { TITLE_SCRIPT_ZOOM,        STR_TITLE_EDITOR_COMMAND_TYPE_ZOOM,     STR_TITLE_EDITOR_ARGUMENT_ZOOM_LEVEL },
+    { TITLE_SCRIPT_SPEED,       STR_TITLE_EDITOR_COMMAND_TYPE_SPEED,    STR_TITLE_EDITOR_ARGUMENT_SPEED },
+    { TITLE_SCRIPT_FOLLOW,      STR_TITLE_EDITOR_COMMAND_TYPE_FOLLOW,   STR_NONE },
+    { TITLE_SCRIPT_WAIT,        STR_TITLE_EDITOR_COMMAND_TYPE_WAIT,     STR_TITLE_EDITOR_ARGUMENT_WAIT_SECONDS },
+    { TITLE_SCRIPT_RESTART,     STR_TITLE_EDITOR_RESTART,               STR_NONE },
+    { TITLE_SCRIPT_END,         STR_TITLE_EDITOR_END,                   STR_NONE },
 };
 
-#define NUM_COMMANDS 8
+// Basically countof(window_title_command_editor_orders)
+#define NUM_COMMANDS (sizeof(_window_title_command_editor_orders) / sizeof(_window_title_command_editor_orders[0]))
 
 enum WINDOW_WATER_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -60,6 +63,8 @@ enum WINDOW_WATER_WIDGET_IDX {
     WIDX_INPUT,
     WIDX_INPUT_DROPDOWN,
     WIDX_GET,
+    WIDX_SELECT,
+    WIDX_SPRITE_INDEX,
     WIDX_OKAY,
     WIDX_CANCEL
 };
@@ -80,9 +85,9 @@ static TitleCommand command = { TITLE_SCRIPT_LOAD, { 0 } };
 static TitleSequence * _sequence = nullptr;
 
 static rct_widget window_title_command_editor_widgets[] = {
-    { WWT_FRAME,                1,  0,          WW-1,       0,      WH-1,   0xFFFFFFFF,                         STR_NONE },                         // panel / background
-    { WWT_CAPTION,              1,  1,          WW-2,       1,      14,     STR_TITLE_COMMAND_EDITOR_TITLE,                     STR_WINDOW_TITLE_TIP },             // title bar
-    { WWT_CLOSEBOX,             1,  WW-13,      WW-3,       2,      13,     STR_CLOSE_X,                        STR_CLOSE_WINDOW_TIP },             // close x button
+    { WWT_FRAME,                1,  0,          WW-1,       0,      WH-1,   0xFFFFFFFF,                 STR_NONE }, // panel / background
+    { WWT_CAPTION,              1,  1,          WW-2,       1,      14,     STR_TITLE_COMMAND_EDITOR_TITLE, STR_WINDOW_TITLE_TIP }, // title bar
+    { WWT_CLOSEBOX,             1,  WW-13,      WW-3,       2,      13,     STR_CLOSE_X,                STR_CLOSE_WINDOW_TIP }, // close x button
     { WWT_DROPDOWN,             1,  WS,         WW-WS-1,    BY,     BY+11,  STR_NONE,                   STR_NONE }, // Command dropdown
     { WWT_DROPDOWN_BUTTON,      1,  WW-WS-12,   WW-WS-2,    BY+1,   BY+10,  STR_DROPDOWN_GLYPH,         STR_NONE },
     { WWT_TEXT_BOX,             1,  WS,         WW-WS-1,    BY2,    BY2+11, STR_NONE,                   STR_NONE }, // full textbox
@@ -93,7 +98,10 @@ static rct_widget window_title_command_editor_widgets[] = {
     { WWT_DROPDOWN,             1,  16,         WW-17,      BY2,    BY2+11, STR_NONE,                   STR_NONE }, // Save dropdown
     { WWT_DROPDOWN_BUTTON,      1,  WW-28,      WW-18,      BY2+1,  BY2+10, STR_DROPDOWN_GLYPH,         STR_NONE },
 
-    { WWT_DROPDOWN_BUTTON,      1,  WS+WHA+3,   WW-WS-1,    BY2-14, BY2-3,  STR_TITLE_COMMAND_EDITOR_ACTION_GET_LOCATION,                       STR_NONE }, // Get location/zoom/etc
+    { WWT_DROPDOWN_BUTTON,      1,  WS+WHA+3,   WW-WS-1,    BY2-14, BY2-3,  STR_TITLE_COMMAND_EDITOR_ACTION_GET_LOCATION,   STR_NONE }, // Get location/zoom/etc
+
+    { WWT_DROPDOWN_BUTTON,      1,  WS,         WW-WS-1,    BY2-14, BY2-3,  STR_TITLE_COMMAND_EDITOR_SELECT_SPRITE, STR_NONE }, // Select sprite
+    { WWT_SPINNER,              1,  WS,         WW-WS-1,    BY2,    BY2+11, (uint32) SPR_NONE,          STR_NONE }, // Sprite index
 
     { WWT_DROPDOWN_BUTTON,      1,  10,         80,         WH-21,  WH-10,  STR_OK,                     STR_NONE }, // OKAY
     { WWT_DROPDOWN_BUTTON,      1,  WW-80,      WW-10,      WH-21,  WH-10,  STR_CANCEL,                 STR_NONE }, // Cancel
@@ -101,21 +109,22 @@ static rct_widget window_title_command_editor_widgets[] = {
     { WIDGETS_END },
 };
 
+static void window_title_command_editor_close(rct_window *w);
 static void window_title_command_editor_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_command_editor_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_command_editor_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex);
 static void window_title_command_editor_update(rct_window *w);
+static void window_title_command_editor_tool_down(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void window_title_command_editor_invalidate(rct_window *w);
 static void window_title_command_editor_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_title_command_editor_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
-static void window_title_command_editor_inputsize(rct_window *w);
 static sint32 get_command_info_index(sint32 index);
 static TITLE_COMMAND_ORDER get_command_info(sint32 index);
 static rct_xy16 get_location();
 static uint8 get_zoom();
 
 static rct_window_event_list window_title_command_editor_events = {
-    nullptr,
+    window_title_command_editor_close,
     window_title_command_editor_mouseup,
     nullptr,
     window_title_command_editor_mousedown,
@@ -125,7 +134,7 @@ static rct_window_event_list window_title_command_editor_events = {
     nullptr,
     nullptr,
     nullptr,
-    nullptr,
+	window_title_command_editor_tool_down,
     nullptr,
     nullptr,
     nullptr,
@@ -192,6 +201,15 @@ static uint8 get_zoom()
     return zoom;
 }
 
+static bool sprite_selector_tool_is_active()
+{
+    if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
+        return false;
+    if (gCurrentToolWidget.window_classification != WC_TITLE_COMMAND_EDITOR)
+        return false;
+    return true;
+}
+
 void window_title_command_editor_open(TitleSequence * sequence, sint32 index, bool insert)
 {
     _sequence = sequence;
@@ -212,17 +230,18 @@ void window_title_command_editor_open(TitleSequence * sequence, sint32 index, bo
     window_title_command_editor_widgets[WIDX_TEXTBOX_Y].string = textbox2Buffer;
     window->widgets = window_title_command_editor_widgets;
     window->enabled_widgets =
-        (1 << WIDX_CLOSE) |
-        (1 << WIDX_COMMAND) |
-        (1 << WIDX_COMMAND_DROPDOWN) |
-        (1 << WIDX_TEXTBOX_FULL) |
-        (1 << WIDX_TEXTBOX_X) |
-        (1 << WIDX_TEXTBOX_Y) |
-        (1 << WIDX_INPUT) |
-        (1 << WIDX_INPUT_DROPDOWN) |
-        (1 << WIDX_GET) |
-        (1 << WIDX_OKAY) |
-        (1 << WIDX_CANCEL);
+        (1ULL << WIDX_CLOSE) |
+        (1ULL << WIDX_COMMAND) |
+        (1ULL << WIDX_COMMAND_DROPDOWN) |
+        (1ULL << WIDX_TEXTBOX_FULL) |
+        (1ULL << WIDX_TEXTBOX_X) |
+        (1ULL << WIDX_TEXTBOX_Y) |
+        (1ULL << WIDX_INPUT) |
+        (1ULL << WIDX_INPUT_DROPDOWN) |
+        (1ULL << WIDX_GET) |
+        (1ULL << WIDX_SELECT) |
+        (1ULL << WIDX_OKAY) |
+        (1ULL << WIDX_CANCEL);
     window_init_scroll_widgets(window);
 
     _window_title_command_editor_index = index;
@@ -247,6 +266,14 @@ void window_title_command_editor_open(TitleSequence * sequence, sint32 index, bo
     case TITLE_SCRIPT_WAIT:
         snprintf(textbox1Buffer, BUF_SIZE, "%d", command.Milliseconds);
         break;
+    }
+}
+
+static void window_title_command_editor_close(rct_window *w)
+{
+    if (sprite_selector_tool_is_active())
+    {
+        tool_cancel();
     }
 }
 
@@ -285,6 +312,12 @@ static void window_title_command_editor_mouseup(rct_window *w, rct_widgetindex w
             snprintf(textbox1Buffer, BUF_SIZE, "%d", command.Zoom);
         }
         window_invalidate(w);
+        break;
+    case WIDX_SELECT:
+        if (!sprite_selector_tool_is_active())
+        {
+            tool_set(w, WIDX_BACKGROUND, TOOL_CROSSHAIR);
+        }
         break;
     case WIDX_OKAY:
         if (_window_title_command_editor_insert) {
@@ -382,6 +415,12 @@ static void window_title_command_editor_dropdown(rct_window *w, rct_widgetindex 
     if (dropdownIndex == -1)
         return;
 
+    // Cancel sprite selector tool if it's active
+    if (sprite_selector_tool_is_active())
+    {
+        tool_cancel();
+    }
+
     switch (widgetIndex) {
     case WIDX_COMMAND_DROPDOWN:
         if (dropdownIndex == get_command_info_index(command.Type)) {
@@ -405,6 +444,9 @@ static void window_title_command_editor_dropdown(rct_window *w, rct_widgetindex 
         case TITLE_SCRIPT_ZOOM:
             command.Zoom = 0;
             snprintf(textbox1Buffer, BUF_SIZE, "%d", command.Zoom);
+            break;
+        case TITLE_SCRIPT_FOLLOW:
+            command.SpriteIndex = SPRITE_INDEX_NULL;
             break;
         case TITLE_SCRIPT_SPEED:
             command.Speed = 1;
@@ -506,6 +548,19 @@ static void window_title_command_editor_update(rct_window *w)
     }
 }
 
+static void window_title_command_editor_tool_down(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y)
+{
+    viewport_interaction_info info;
+    viewport_interaction_get_item_left(x, y, &info);
+
+    if (info.type == VIEWPORT_INTERACTION_ITEM_SPRITE)
+    {
+        command.SpriteIndex = info.sprite->unknown.sprite_index;
+        tool_cancel();
+        window_invalidate(w);
+    }
+}
+
 static void window_title_command_editor_invalidate(rct_window *w)
 {
     colour_scheme_update_by_class(w, WC_TITLE_EDITOR);
@@ -516,6 +571,8 @@ static void window_title_command_editor_invalidate(rct_window *w)
     window_title_command_editor_widgets[WIDX_INPUT].type = WWT_EMPTY;
     window_title_command_editor_widgets[WIDX_INPUT_DROPDOWN].type = WWT_EMPTY;
     window_title_command_editor_widgets[WIDX_GET].type = WWT_EMPTY;
+    window_title_command_editor_widgets[WIDX_SELECT].type = WWT_EMPTY;
+    window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_EMPTY;
     switch (command.Type) {
     case TITLE_SCRIPT_LOAD:
     case TITLE_SCRIPT_SPEED:
@@ -535,6 +592,14 @@ static void window_title_command_editor_invalidate(rct_window *w)
         window_title_command_editor_widgets[WIDX_GET].type = WWT_DROPDOWN_BUTTON;
         window_title_command_editor_widgets[WIDX_TEXTBOX_FULL].type = WWT_TEXT_BOX;
         break;
+    case TITLE_SCRIPT_FOLLOW:
+        window_title_command_editor_widgets[WIDX_SELECT].type = WWT_DROPDOWN_BUTTON;
+        window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_SPINNER;
+        // Draw button pressed while the tool is active
+        w->pressed_widgets &= ~(1 << WIDX_SELECT);
+        if (sprite_selector_tool_is_active())
+            w->pressed_widgets |= (1 << WIDX_SELECT);
+        break;
     }
 
     if ((gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) == SCREEN_FLAGS_TITLE_DEMO) {
@@ -548,19 +613,27 @@ static void window_title_command_editor_paint(rct_window *w, rct_drawpixelinfo *
 {
     window_draw_widgets(w, dpi);
 
-    gfx_draw_string_left(dpi, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, nullptr, w->colours[1], w->x + WS, w->y + BY - 14);
-    gfx_draw_string_left(dpi, get_command_info(command.Type).descStringId, nullptr, w->colours[1], w->x + WS, w->y + BY2 - 14);
+    TITLE_COMMAND_ORDER command_info = get_command_info(command.Type);
 
+    // "Command:" label
+    gfx_draw_string_left(dpi, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, nullptr, w->colours[1], w->x + WS, w->y + BY - 14);
+
+    // Command dropdown name
     gfx_draw_string_left_clipped(
         dpi,
-        get_command_info(command.Type).nameStringId,
+        command_info.nameStringId,
         nullptr,
         w->colours[1],
         w->x + w->widgets[WIDX_COMMAND].left + 1,
         w->y + w->widgets[WIDX_COMMAND].top,
         w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4);
 
-    if (command.Type == TITLE_SCRIPT_SPEED) {
+    // Label (e.g. "Location:")
+    gfx_draw_string_left(dpi, command_info.descStringId, NULL, w->colours[1], w->x + WS, w->y + BY2 - 14);
+
+    switch (command.Type)
+    {
+    case TITLE_SCRIPT_SPEED:
         gfx_draw_string_left_clipped(
             dpi,
             SpeedNames[command.Speed - 1],
@@ -569,8 +642,20 @@ static void window_title_command_editor_paint(rct_window *w, rct_drawpixelinfo *
             w->x + w->widgets[WIDX_INPUT].left + 1,
             w->y + w->widgets[WIDX_INPUT].top,
             w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
+        break;
+    case TITLE_SCRIPT_FOLLOW:
+    {
+        sint32 value = command.SpriteIndex;
+        gfx_draw_string_left(
+            dpi,
+            STR_FORMAT_INTEGER,
+            &value,
+            w->colours[1],
+            w->x + w->widgets[WIDX_SPRITE_INDEX].left + 1,
+            w->y + w->widgets[WIDX_SPRITE_INDEX].top);
+        break;
     }
-    else if (command.Type == TITLE_SCRIPT_LOAD) {
+    case TITLE_SCRIPT_LOAD:
         if (command.SaveIndex == SAVE_INDEX_INVALID) {
             gfx_draw_string_left_clipped(
                 dpi,
@@ -592,5 +677,6 @@ static void window_title_command_editor_paint(rct_window *w, rct_drawpixelinfo *
                 w->y + w->widgets[WIDX_INPUT].top,
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
         }
+        break;
     }
 }

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -64,7 +64,8 @@ enum WINDOW_WATER_WIDGET_IDX {
     WIDX_INPUT_DROPDOWN,
     WIDX_GET,
     WIDX_SELECT,
-    WIDX_SPRITE_INDEX,
+    //WIDX_SPRITE_INDEX,
+    WIDX_VIEWPORT,
     WIDX_OKAY,
     WIDX_CANCEL
 };
@@ -101,7 +102,8 @@ static rct_widget window_title_command_editor_widgets[] = {
     { WWT_DROPDOWN_BUTTON,      1,  WS+WHA+3,   WW-WS-1,    BY2-14, BY2-3,  STR_TITLE_COMMAND_EDITOR_ACTION_GET_LOCATION,   STR_NONE }, // Get location/zoom/etc
 
     { WWT_DROPDOWN_BUTTON,      1,  WS,         WW-WS-1,    BY2-14, BY2-3,  STR_TITLE_COMMAND_EDITOR_SELECT_SPRITE, STR_NONE }, // Select sprite
-    { WWT_SPINNER,              1,  WS,         WW-WS-1,    BY2,    BY2+11, (uint32) SPR_NONE,          STR_NONE }, // Sprite index
+    //{ WWT_SPINNER,              1,  WS,         WW-WS-1,    BY2,    BY2+11, (uint32) SPR_NONE,          STR_NONE }, // Sprite index
+    { WWT_VIEWPORT,             1, WS,          WW-WS - 1,  BY2,    BY2+22, STR_NONE,                   STR_NONE }, // Viewport
 
     { WWT_DROPDOWN_BUTTON,      1,  10,         80,         WH-21,  WH-10,  STR_OK,                     STR_NONE }, // OKAY
     { WWT_DROPDOWN_BUTTON,      1,  WW-80,      WW-10,      WH-21,  WH-10,  STR_CANCEL,                 STR_NONE }, // Cancel
@@ -243,6 +245,9 @@ void window_title_command_editor_open(TitleSequence * sequence, sint32 index, bo
         (1ULL << WIDX_OKAY) |
         (1ULL << WIDX_CANCEL);
     window_init_scroll_widgets(window);
+
+    rct_widget *const viewportWidget = &window_title_command_editor_widgets[WIDX_VIEWPORT];
+    viewport_create(window, window->x + viewportWidget->left, window->y + viewportWidget->top, viewportWidget->right - viewportWidget->left, viewportWidget->bottom - viewportWidget->top, 0, 0, 0, 0, 0, -1);
 
     _window_title_command_editor_index = index;
     _window_title_command_editor_insert = insert;
@@ -556,6 +561,8 @@ static void window_title_command_editor_tool_down(rct_window *w, rct_widgetindex
     if (info.type == VIEWPORT_INTERACTION_ITEM_SPRITE)
     {
         command.SpriteIndex = info.sprite->unknown.sprite_index;
+        w->viewport_target_sprite = command.SpriteIndex;
+        w->viewport->flags |= VIEWPORT_FOCUS_TYPE_SPRITE;
         tool_cancel();
         window_invalidate(w);
     }
@@ -572,7 +579,8 @@ static void window_title_command_editor_invalidate(rct_window *w)
     window_title_command_editor_widgets[WIDX_INPUT_DROPDOWN].type = WWT_EMPTY;
     window_title_command_editor_widgets[WIDX_GET].type = WWT_EMPTY;
     window_title_command_editor_widgets[WIDX_SELECT].type = WWT_EMPTY;
-    window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_EMPTY;
+    //window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_EMPTY;
+    window_title_command_editor_widgets[WIDX_VIEWPORT].type = WWT_EMPTY;
     switch (command.Type) {
     case TITLE_SCRIPT_LOAD:
     case TITLE_SCRIPT_SPEED:
@@ -594,7 +602,8 @@ static void window_title_command_editor_invalidate(rct_window *w)
         break;
     case TITLE_SCRIPT_FOLLOW:
         window_title_command_editor_widgets[WIDX_SELECT].type = WWT_DROPDOWN_BUTTON;
-        window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_SPINNER;
+        //window_title_command_editor_widgets[WIDX_SPRITE_INDEX].type = WWT_SPINNER;
+        window_title_command_editor_widgets[WIDX_VIEWPORT].type = WWT_VIEWPORT;
         // Draw button pressed while the tool is active
         w->pressed_widgets &= ~(1 << WIDX_SELECT);
         if (sprite_selector_tool_is_active())
@@ -645,14 +654,15 @@ static void window_title_command_editor_paint(rct_window *w, rct_drawpixelinfo *
         break;
     case TITLE_SCRIPT_FOLLOW:
     {
-        sint32 value = command.SpriteIndex;
-        gfx_draw_string_left(
-            dpi,
-            STR_FORMAT_INTEGER,
-            &value,
-            w->colours[1],
-            w->x + w->widgets[WIDX_SPRITE_INDEX].left + 1,
-            w->y + w->widgets[WIDX_SPRITE_INDEX].top);
+        //sint32 value = command.SpriteIndex;
+        //gfx_draw_string_left(
+        //    dpi,
+        //    STR_FORMAT_INTEGER,
+        //    &value,
+        //    w->colours[1],
+        //    w->x + w->widgets[WIDX_SPRITE_INDEX].left + 1,
+        //    w->y + w->widgets[WIDX_SPRITE_INDEX].top);
+        window_draw_viewport(dpi, w);
         break;
     }
     case TITLE_SCRIPT_LOAD:

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -888,14 +888,15 @@ static void window_title_editor_scrollpaint_commands(rct_window *w, rct_drawpixe
             commandName = STR_TITLE_EDITOR_COMMAND_SPEED;
             set_format_arg(0, rct_string_id, SpeedNames[command->Speed - 1]);
             break;
+        case TITLE_SCRIPT_FOLLOW:
+            commandName = STR_TITLE_EDITOR_COMMAND_TYPE_FOLLOW;
+            break;
         case TITLE_SCRIPT_WAIT:
             commandName = STR_TITLE_EDITOR_COMMAND_WAIT;
             set_format_arg(0, uint16, command->Milliseconds);
             break;
         case TITLE_SCRIPT_RESTART:
             commandName = STR_TITLE_EDITOR_RESTART;
-            // TODO: Why the format arg?
-            set_format_arg(0, uint16, command->Zoom);
             break;
         case TITLE_SCRIPT_END:
             commandName = STR_TITLE_EDITOR_END;

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -63,7 +63,7 @@ static rct_window_event_list window_title_logo_events = {
  */
 rct_window * window_title_logo_open()
 {
-    rct_window *window = window_create(0, 0, 200, 106, &window_title_logo_events, WC_TITLE_LOGO, WF_STICK_TO_BACK | WF_TRANSPARENT);
+    rct_window *window = window_create(0, 0, 232, 136, &window_title_logo_events, WC_TITLE_LOGO, WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_logo_widgets;
     window_init_scroll_widgets(window);
     window->colours[0] = TRANSLUCENT(COLOUR_GREY);

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3804,6 +3804,9 @@ enum {
     STR_SERVER_LIST_MASTER_SERVER_FAILED = 6151,
     STR_SERVER_LIST_INVALID_RESPONSE_JSON_ARRAY = 6152,
 
+    STR_TITLE_EDITOR_COMMAND_TYPE_FOLLOW = 6153,
+    STR_TITLE_COMMAND_EDITOR_SELECT_SPRITE = 6154,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -315,6 +315,9 @@ extern "C"
         openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
         gfx_draw_string(dpi, buffer, COLOUR_BLACK, x + 5, y + 5 - 13);
 
+        // Invalidate screen area
+        gfx_set_dirty_blocks(x, y, x + 500, y + 30);
+
         // Write platform information
         snprintf(ch, 256 - (ch - buffer), "%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);
         gfx_draw_string(dpi, buffer, COLOUR_BLACK, x + 5, y + 5);

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -456,6 +456,11 @@ static std::vector<TitleCommand> LegacyScriptRead(utf8 * script, size_t scriptLe
                 command.Type = TITLE_SCRIPT_SPEED;
                 command.Speed = Math::Max(1, Math::Min(4, atoi(part1) & 0xFF));
             }
+            else if (_stricmp(token, "FOLLOW") == 0)
+            {
+                command.Type = TITLE_SCRIPT_FOLLOW;
+                command.SpriteIndex = atoi(part1) & 0xFFFF;
+            }
             else if (_stricmp(token, "WAIT") == 0)
             {
                 command.Type = TITLE_SCRIPT_WAIT;

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -608,6 +608,10 @@ static utf8 * LegacyScriptWrite(TitleSequence * seq)
             String::Format(buffer, sizeof(buffer), "ZOOM %u", command->Zoom);
             sb.Append(buffer);
             break;
+        case TITLE_SCRIPT_FOLLOW:
+            String::Format(buffer, sizeof(buffer), "FOLLOW %u", command->SpriteIndex);
+            sb.Append(buffer);
+            break;
         case TITLE_SCRIPT_SPEED:
             String::Format(buffer, sizeof(buffer), "SPEED %u", command->Speed);
             sb.Append(buffer);

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -22,16 +22,17 @@ typedef struct TitleCommand
 {
     uint8 Type;
     union {
-        uint8 SaveIndex;    // LOAD (this index is internal only)
-        struct              // LOCATION
+        uint8 SaveIndex;     // LOAD (this index is internal only)
+        struct               // LOCATION
         {
             uint8 X;
             uint8 Y;
         };
-        uint8 Rotations;    // ROTATE (counter-clockwise)
-        uint8 Zoom;         // ZOOM
-        uint8 Speed;        // SPEED
-        uint16 Milliseconds;      // WAIT
+        uint8  Rotations;    // ROTATE (counter-clockwise)
+        uint8  Zoom;         // ZOOM
+        uint16 SpriteIndex;  // FOLLOW
+        uint8  Speed;        // SPEED
+        uint16 Milliseconds; // WAIT
     };
 } TitleCommand;
 
@@ -63,6 +64,7 @@ enum TITLE_SCRIPT
     TITLE_SCRIPT_LOCATION,
     TITLE_SCRIPT_ROTATE,
     TITLE_SCRIPT_ZOOM,
+    TITLE_SCRIPT_FOLLOW,
     TITLE_SCRIPT_RESTART,
     TITLE_SCRIPT_LOAD,
     TITLE_SCRIPT_END,

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -281,6 +281,9 @@ private:
         case TITLE_SCRIPT_SPEED:
             gGameSpeed = Math::Clamp<uint8>(1, command->Speed, 4);
             break;
+        case TITLE_SCRIPT_FOLLOW:
+            FollowSprite(command->SpriteIndex);
+            break;
         case TITLE_SCRIPT_RESTART:
             Reset();
             break;
@@ -353,6 +356,14 @@ private:
             {
                 window_rotate_camera(w, 1);
             }
+        }
+    }
+
+    void FollowSprite(uint16 SpriteIndex) {
+        rct_window *const MainWindow = window_get_main();
+        if (MainWindow != nullptr)
+        {
+            MainWindow->viewport_target_sprite = SpriteIndex;
         }
     }
 
@@ -459,6 +470,9 @@ private:
             _lastScreenHeight = w->height;
             _viewCentreLocation.x = x;
             _viewCentreLocation.y = y;
+
+            // Stop following sprites
+            w->viewport_target_sprite = SPRITE_INDEX_NULL;
         }
     }
 


### PR DESCRIPTION
This PR adds a new command to the title sequence player that can set the viewport to follow a given sprite. The related windows have been updated so that the new command can be added to a sequence easily.

I've made a short video to demonstrate how this can be used: http://www.broxzier.com/files/ShareX/2017-07-17_23-45-04.mp4