### PR TITLE
Clean up rct_ride and rct1_ride structs and usage

### DIFF
--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -174,7 +174,7 @@ static void cheat_renew_rides()
         // Set build date to current date (so the ride is brand new)
         ride->build_date = gDateMonthsElapsed;
         // Set reliability to 100
-        ride->reliability = (100 << 8);
+        ride->reliability = RIDE_INITIAL_RELIABILITY;
     }
     window_invalidate_by_class(WC_RIDE);
 }

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -4838,7 +4838,7 @@ static void peep_update_ride_inspected(sint32 rideIndex) {
     rct_ride *ride = get_ride(rideIndex);
     ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
 
-    ride->reliability += ((100 - (ride->reliability >> 8)) >> 2) * (scenario_rand() & 0xFF);
+    ride->reliability += ((100 - ride->reliability_percentage) / 4) * (scenario_rand() & 0xFF);
     ride->last_inspection = 0;
     ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE | RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
 }

--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -50,157 +50,165 @@ assert_struct_size(rct1_entrance, 7);
  * size: 0x260
  */
 typedef struct rct1_ride {
-    uint8 type;
-    uint8 vehicle_type;
-    uint16 lifecycle_flags;
-    uint8 operating_mode;
-    uint8 colour_scheme;
+    uint8 type;                                             // 0x000
+    uint8 vehicle_type;                                     // 0x001
+    uint16 lifecycle_flags;                                 // 0x002
+    uint8 operating_mode;                                   // 0x004
+    uint8 colour_scheme;                                    // 0x005
     struct {
         colour_t body;
         colour_t trim;
-    } vehicle_colours[RCT1_MAX_TRAINS_PER_RIDE];
-    colour_t track_primary_colour;
-    colour_t track_secondary_colour;
-    colour_t track_support_colour;
-    uint8 status;
-    uint16 name;
-    uint16 name_argument_ride;
-    uint16 name_argument_number;
-    uint16 overall_view;
-    uint16 station_starts[RCT12_MAX_STATIONS_PER_RIDE];
-    uint8 station_height[RCT12_MAX_STATIONS_PER_RIDE];
-    uint8 station_length[RCT12_MAX_STATIONS_PER_RIDE];
-    uint8 station_light[RCT12_MAX_STATIONS_PER_RIDE];
-    uint8 station_depart[RCT12_MAX_STATIONS_PER_RIDE];
-    rct_xy8 entrance[RCT12_MAX_STATIONS_PER_RIDE];
-    rct_xy8 exit[RCT12_MAX_STATIONS_PER_RIDE];
-    uint16 last_peep_in_queue[RCT12_MAX_STATIONS_PER_RIDE];
-    uint8 num_peeps_in_queue[RCT12_MAX_STATIONS_PER_RIDE];
-    uint16 vehicles[RCT1_MAX_TRAINS_PER_RIDE];
-    uint8 depart_flags;
-    uint8 num_stations;
-    uint8 num_trains;
-    uint8 num_cars_per_train;
-    uint8 proposed_num_vehicles;    // 0x7A
-    uint8 proposed_num_cars_per_train; // 0x7B
-    uint8 max_trains;
-    uint8 min_max_cars_per_train; // 0x7D
-    uint8 min_waiting_time;
-    uint8 max_waiting_time;
-    uint8 operation_option;
-    uint8 boat_hire_return_direction;
-    rct_xy8 boat_hire_return_position;
-    uint8 data_logging_index;
-    uint8 special_track_elements;
-    uint16 unk_86;
-    sint32 max_speed;
-    sint32 average_speed;
-    uint8 current_test_segment;     // 0x90
-    uint8 average_speed_test_timeout; // 0x91
-    uint8 pad_0E2[0x2]; // 0x92
-    sint32 length[RCT12_MAX_STATIONS_PER_RIDE];
-    uint16 time[RCT12_MAX_STATIONS_PER_RIDE];
-    fixed16_2dp max_positive_vertical_g;
-    fixed16_2dp max_negative_vertical_g;
-    fixed16_2dp max_lateral_g;
-    fixed16_2dp previous_vertical_g;// 0xB2
-    fixed16_2dp previous_lateral_g; // 0xB4
-    uint8 pad_106[0x2];
-    uint32 testing_flags;           // 0xB8
+    } vehicle_colours[RCT1_MAX_TRAINS_PER_RIDE];            // 0x006
+    colour_t track_primary_colour;                          // 0x01E
+    colour_t track_secondary_colour;                        // 0x01F
+    colour_t track_support_colour;                          // 0x020
+    uint8 status;                                           // 0x021
+    uint16 name;                                            // 0x022
+    uint16 name_argument_ride;                              // 0x024
+    uint16 name_argument_number;                            // 0x026
+    uint16 overall_view;                                    // 0x028
+    uint16 station_starts[RCT12_MAX_STATIONS_PER_RIDE];     // 0x02A
+    uint8 station_height[RCT12_MAX_STATIONS_PER_RIDE];      // 0x032
+    uint8 station_length[RCT12_MAX_STATIONS_PER_RIDE];      // 0x036
+    uint8 station_light[RCT12_MAX_STATIONS_PER_RIDE];       // 0x03A
+    uint8 station_depart[RCT12_MAX_STATIONS_PER_RIDE];      // 0x03E
+    rct_xy8 entrance[RCT12_MAX_STATIONS_PER_RIDE];          // 0x042
+    rct_xy8 exit[RCT12_MAX_STATIONS_PER_RIDE];              // 0x04A
+    uint16 last_peep_in_queue[RCT12_MAX_STATIONS_PER_RIDE]; // 0x052
+    uint8 num_peeps_in_queue[RCT12_MAX_STATIONS_PER_RIDE];  // 0x05A
+    uint16 vehicles[RCT1_MAX_TRAINS_PER_RIDE];              // 0x05E
+    uint8 depart_flags;                                     // 0x076
+    uint8 num_stations;                                     // 0x077
+    uint8 num_trains;                                       // 0x078
+    uint8 num_cars_per_train;                               // 0x079
+    uint8 proposed_num_vehicles;                            // 0x07A
+    uint8 proposed_num_cars_per_train;                      // 0x07B
+    uint8 max_trains;                                       // 0x07C
+    uint8 min_max_cars_per_train;                           // 0x07D
+    uint8 min_waiting_time;                                 // 0x07E
+    uint8 max_waiting_time;                                 // 0x07F
+    uint8 operation_option;                                 // 0x080
+    uint8 boat_hire_return_direction;                       // 0x081
+    rct_xy8 boat_hire_return_position;                      // 0x082
+    uint8 data_logging_index;                               // 0x084
+    uint8 special_track_elements;                           // 0x085
+    uint16 unk_86;                                          // 0x086
+    sint32 max_speed;                                       // 0x088
+    sint32 average_speed;                                   // 0x08C
+    uint8 current_test_segment;                             // 0x090
+    uint8 average_speed_test_timeout;                       // 0x091
+    uint8 pad_0E2[0x2];                                     // 0x092
+    sint32 length[RCT12_MAX_STATIONS_PER_RIDE];             // 0x094
+    uint16 time[RCT12_MAX_STATIONS_PER_RIDE];               // 0x0A4
+    fixed16_2dp max_positive_vertical_g;                    // 0x0AC
+    fixed16_2dp max_negative_vertical_g;                    // 0x0AE
+    fixed16_2dp max_lateral_g;                              // 0x0B0
+    fixed16_2dp previous_vertical_g;                        // 0x0B2
+    fixed16_2dp previous_lateral_g;                         // 0x0B4
+    uint8 pad_B6[0x2];                                      // 0x0B6
+    uint32 testing_flags;                                   // 0x0B8
     // x y map location of the current track piece during a test
     // this is to prevent counting special tracks multiple times
-    rct_xy8 cur_test_track_location;    // 0xBC
+    rct_xy8 cur_test_track_location;                        // 0x0BC
     // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
-    uint16 turn_count_default;      // 0xBE X = current turn count
-    uint16 turn_count_banked;       // 0xC0
-    uint16 turn_count_sloped;       // 0xC2 X = number turns > 3 elements
+    uint16 turn_count_default;                              // 0x0BE X = current turn count
+    uint16 turn_count_banked;                               // 0x0C0
+    uint16 turn_count_sloped;                               // 0x0C2 X = number turns > 3 elements
     union {
-        uint8 num_inversions;
+        uint8 num_inversions;                               // 0x0C4
         uint8 num_holes;
     };
-    uint8 num_drops;
-    uint8 start_drop_height;
-    uint8 highest_drop_height;
-    sint32 sheltered_length;
-    uint8 unk_CC[2];
-    uint8 num_sheltered_sections;
+    uint8 num_drops;                                        // 0x0C5
+    uint8 start_drop_height;                                // 0x0C6
+    uint8 highest_drop_height;                              // 0x0C7
+    sint32 sheltered_length;                                // 0x0C8
+    uint8 unk_CC[2];                                        // 0x0CC
+    uint8 num_sheltered_sections;                           // 0x0CE
     // see cur_test_track_location
-    uint8 cur_test_track_z;         // 0xCF
-    sint16 unk_D0;
-    sint16 unk_D2;
-    sint16 customers_per_hour;
-    sint16 unk_D6;
-    sint16 unk_D8;
-    sint16 unk_DA;
-    sint16 unk_DC;
-    sint16 unk_DE;
-    uint16 age;
-    sint16 running_cost;
-    sint16 unk_E4;
-    sint16 unk_E6;
-    money16 price;
-    rct_xy8 chairlift_bullwheel_location[2]; // 0xEA
-    uint8 chairlift_bullwheel_z[2]; // 0xEE
+    uint8 cur_test_track_z;                                 // 0x0CF
+    sint16 unk_D0;                                          // 0x0D0
+    sint16 unk_D2;                                          // 0x0D2
+    sint16 customers_per_hour;                              // 0x0D4
+    sint16 unk_D6;                                          // 0x0D6
+    sint16 unk_D8;                                          // 0x0D8
+    sint16 unk_DA;                                          // 0x0DA
+    sint16 unk_DC;                                          // 0x0DC
+    sint16 unk_DE;                                          // 0x0DE
+    uint16 age;                                             // 0x0E0
+    sint16 running_cost;                                    // 0x0E2
+    sint16 unk_E4;                                          // 0x0E4
+    sint16 unk_E6;                                          // 0x0E6
+    money16 price;                                          // 0x0E8
+    rct_xy8 chairlift_bullwheel_location[2];                // 0x0EA
+    uint8 chairlift_bullwheel_z[2];                         // 0x0EE
     union {
         rating_tuple ratings;
         struct {
-            ride_rating excitement;
-            ride_rating intensity;
-            ride_rating nausea;
+            ride_rating excitement;                         // 0x0F0
+            ride_rating intensity;                          // 0x0F2
+            ride_rating nausea;                             // 0x0F4
         };
     };
-    uint16 value;
-    uint16 chairlift_bullwheel_rotation; // 0xF8
-    uint8 satisfaction;
-    uint8 satisfaction_time_out;
-    uint8 satisfaction_next;
-    uint8 window_invalidate_flags;
-    uint8 unk_FE[2];
-    uint32 total_customers;
-    money32 total_profit;
-    uint8 popularity;
-    uint8 popularity_time_out;
-    uint8 popularity_next;
-    uint8 num_riders;
-    uint8 music_tune_id;            // 0x10C
-    uint8 slide_in_use;             // 0x10D
+    uint16 value;                                           // 0x0F6
+    uint16 chairlift_bullwheel_rotation;                    // 0x0F8
+    uint8 satisfaction;                                     // 0x0FA
+    uint8 satisfaction_time_out;                            // 0x0FB
+    uint8 satisfaction_next;                                // 0x0FC
+    uint8 window_invalidate_flags;                          // 0x0FD
+    uint8 unk_FE[2];                                        // 0x0FE
+    uint32 total_customers;                                 // 0x100
+    money32 total_profit;                                   // 0x104
+    uint8 popularity;                                       // 0x108
+    uint8 popularity_time_out;                              // 0x109
+    uint8 popularity_next;                                  // 0x10A
+    uint8 num_riders;                                       // 0x10B
+    uint8 music_tune_id;                                    // 0x10C
+    uint8 slide_in_use;                                     // 0x10D
     union {
-        uint16 slide_peep;          // 0x10E
-        uint16 maze_tiles;          // 0x10E
+        uint16 slide_peep;                                  // 0x10E
+        uint16 maze_tiles;                                  // 0x10E
     };
-    uint8 pad_110[0xE];
-    uint8 slide_peep_t_shirt_colour;// 0x11E
-    uint8 pad_11F[0x7];
-    uint8 spiral_slide_progress;    // 0x126
-    uint8 pad_127[0x9];
-    sint16 build_date;              // 0x130
-    money16 upkeep_cost;            // 0x131
-    uint16 race_winner;             // 0x132
-    uint8 unk_134[2];
-    uint32 music_position;          // 0x138
-    uint8 breakdown_reason_pending; // 0x13C
-    uint8 mechanic_status;          // 0x13D
-    uint16 mechanic;                // 0x13E
-    uint8 inspection_station;       // 0x140
-    uint8 broken_vehicle;           // 0x141
-    uint8 broken_car;               // 0x142
-    uint8 breakdown_reason;         // 0x143
-    uint8 unk_144[2];
-    uint16 reliability;
-    uint8 unreliability_factor;
-    uint8 unk_148;
-    uint8 inspection_interval;
-    uint8 last_inspection;
-    uint8 unk_14C[20];
-    money32 income_per_hour;
-    money32 profit;
-    uint8 queue_time[RCT12_MAX_STATIONS_PER_RIDE];
-    colour_t track_colour_main[4];
-    colour_t track_colour_additional[4];
-    colour_t track_colour_supports[4];
-    uint8 music;
-    uint8 entrance_style;
-    uint8 unk_17A[230];
+    uint8 pad_110[0xE];                                     // 0x110
+    uint8 slide_peep_t_shirt_colour;                        // 0x11E
+    uint8 pad_11F[0x7];                                     // 0x11F
+    uint8 spiral_slide_progress;                            // 0x126
+    uint8 pad_127[0x9];                                     // 0x127
+    sint16 build_date;                                      // 0x130
+    money16 upkeep_cost;                                    // 0x131
+    uint16 race_winner;                                     // 0x132
+    uint8 unk_134[2];                                       // 0x134
+    uint32 music_position;                                  // 0x138
+    uint8 breakdown_reason_pending;                         // 0x13C
+    uint8 mechanic_status;                                  // 0x13D
+    uint16 mechanic;                                        // 0x13E
+    uint8 inspection_station;                               // 0x140
+    uint8 broken_vehicle;                                   // 0x141
+    uint8 broken_car;                                       // 0x142
+    uint8 breakdown_reason;                                 // 0x143
+    uint8 unk_144[2];                                       // 0x144
+    union
+    {
+        struct
+        {
+            uint8 reliability_subvalue;                     // 0x146, 0 - 255, acts like the decimals for reliability_percentage
+            uint8 reliability_percentage;                   // 0x147, Starts at 100 and decreases from there.
+        };
+        uint16 reliability;                                 // 0x146
+    };
+    uint8 unreliability_factor;                             // 0x148
+    uint8 downtime;                                         // 0x149
+    uint8 inspection_interval;                              // 0x14A
+    uint8 last_inspection;                                  // 0x14B
+    uint8 unk_14C[20];                                      // 0x14C
+    money32 income_per_hour;                                // 0x160
+    money32 profit;                                         // 0x164
+    uint8 queue_time[RCT12_MAX_STATIONS_PER_RIDE];          // 0x168
+    colour_t track_colour_main[4];                          // 0x16C
+    colour_t track_colour_additional[4];                    // 0x170
+    colour_t track_colour_supports[4];                      // 0x174
+    uint8 music;                                            // 0x178
+    uint8 entrance_style;                                   // 0x179
+    uint8 unk_17A[230];                                     // 0x17A
 } rct1_ride;
 assert_struct_size(rct1_ride, 0x260);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -834,6 +834,7 @@ private:
         dst->last_inspection = src->last_inspection;
         dst->reliability = src->reliability;
         dst->unreliability_factor = src->unreliability_factor;
+        dst->downtime = src->downtime;
         dst->breakdown_reason = src->breakdown_reason;
         dst->mechanic_status = src->mechanic_status;
         dst->mechanic = src->mechanic;

--- a/src/openrct2/rct2.h
+++ b/src/openrct2/rct2.h
@@ -19,6 +19,8 @@
 
 #include "common.h"
 
+#define RCT2_MAX_CARS_PER_TRAIN 32
+
 typedef struct rct2_install_info {
     uint32 installLevel;
     char title[260];

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -2343,7 +2343,7 @@ static void ride_breakdown_update(sint32 rideIndex)
     //
     // a 0.8% chance, less the breakdown factor which accumulates as the game
     // continues.
-    if ((ride->reliability == 0 || (sint32)(scenario_rand() & 0x2FFFFF) <= 1 + RIDE_INITIAL_RELIABILITY - ride->reliability)
+    if ((ride->reliability_percentage == 0 || (sint32)(scenario_rand() & 0x2FFFFF) <= 1 + RIDE_INITIAL_RELIABILITY - ride->reliability_percentage)
             && !gCheatsDisableAllBreakdowns) {
         sint32 breakdownReason = ride_get_new_breakdown_problem(ride);
         if (breakdownReason != -1)
@@ -2406,7 +2406,7 @@ static sint32 ride_get_new_breakdown_problem(rct_ride *ride)
         return -1;
 
     monthsOld = gDateMonthsElapsed - ride->build_date;
-    if (monthsOld < 16 || ride->reliability > (50 << 8))
+    if (monthsOld < 16 || ride->reliability_percentage > 50)
         return -1;
 
     return BREAKDOWN_BRAKES_FAILURE;
@@ -6192,7 +6192,7 @@ foundRideEntry:
 
     ride->breakdown_reason = 255;
     ride->upkeep_cost = (money16)-1;
-    ride->reliability = 0x64FF;
+    ride->reliability = RIDE_INITIAL_RELIABILITY;
     ride->unreliability_factor = 1;
     ride->inspection_interval = RIDE_INSPECTION_EVERY_30_MINUTES;
     ride->last_inspection = 0;
@@ -7496,7 +7496,7 @@ void ride_fix_breakdown(sint32 rideIndex, sint32 reliabilityIncreaseFactor)
         }
     }
 
-    uint8 unreliability = 100 - ((ride->reliability >> 8) & 0xFF);
+    uint8 unreliability = 100 - ride->reliability_percentage;
     ride->reliability += reliabilityIncreaseFactor * (unreliability / 2);
 }
 
@@ -7529,8 +7529,8 @@ static void ride_update_vehicle_colours(sint32 rideIndex)
                 coloursExtended = ride->vehicle_colours_extended[i];
                 break;
             case RIDE_COLOUR_SCHEME_DIFFERENT_PER_CAR:
-                colours = ride->vehicle_colours[carIndex > 31 ? 31 : carIndex];
-                coloursExtended = ride->vehicle_colours_extended[carIndex > 31 ? 31 : carIndex];
+                colours = ride->vehicle_colours[max(carIndex, RCT2_MAX_CARS_PER_TRAIN - 1)];
+                coloursExtended = ride->vehicle_colours_extended[max(carIndex, RCT2_MAX_CARS_PER_TRAIN - 1)];
                 break;
             }
 

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -20,6 +20,7 @@
 #include "../common.h"
 #include "../peep/peep.h"
 #include "../rct12.h"
+#include "../rct2.h"
 #include "../world/map.h"
 #include "vehicle.h"
 
@@ -149,206 +150,212 @@ assert_struct_size(rct_ride_entry, 0x1c2);
  * size: 0x0260
  */
 typedef struct rct_ride {
-    uint8 type;                     // 0x000
+    uint8 type;                                                     // 0x000
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
     // 0x4c.
-    uint8 subtype;                  // 0x001
-    uint16 pad_002;
-    uint8 mode;                     // 0x004
-    uint8 colour_scheme_type;       // 0x005
-    rct_vehicle_colour vehicle_colours[32];     // 0x006
-    uint8 pad_046[0x03];            // Used to be track colours in RCT1 without expansions
+    uint8 subtype;                                                  // 0x001
+    uint16 pad_002;                                                 // 0x002
+    uint8 mode;                                                     // 0x004
+    uint8 colour_scheme_type;                                       // 0x005
+    rct_vehicle_colour vehicle_colours[RCT2_MAX_CARS_PER_TRAIN];    // 0x006
+    uint8 pad_046[0x03];                                            // 0x046, Used to be track colours in RCT1 without expansions
     // 0 = closed, 1 = open, 2 = test
-    uint8 status;                   // 0x049
-    rct_string_id name;             // 0x04A
+    uint8 status;                                                   // 0x049
+    rct_string_id name;                                             // 0x04A
     union {
-        uint32 name_arguments;      // 0x04C
+        uint32 name_arguments;                                      // 0x04C
         struct {
-            rct_string_id name_arguments_type_name;     // 0x04C
-            uint16 name_arguments_number;               // 0x04E
+            rct_string_id name_arguments_type_name;                 // 0x04C
+            uint16 name_arguments_number;                           // 0x04E
         };
     };
-    uint16 overall_view;            // 0x050 00XX = X, XX00 = Y (* 32 + 16)
-    uint16 station_starts[RCT12_MAX_STATIONS_PER_RIDE];       // 0x052
-    uint8 station_heights[RCT12_MAX_STATIONS_PER_RIDE];       // 0x05A
-    uint8 station_length[RCT12_MAX_STATIONS_PER_RIDE];        // 0x05E
-    uint8 station_depart[RCT12_MAX_STATIONS_PER_RIDE];        // 0x062
+    uint16 overall_view;                                            // 0x050, 00XX = X, XX00 = Y (* 32 + 16)
+    uint16 station_starts[RCT12_MAX_STATIONS_PER_RIDE];             // 0x052
+    uint8 station_heights[RCT12_MAX_STATIONS_PER_RIDE];             // 0x05A
+    uint8 station_length[RCT12_MAX_STATIONS_PER_RIDE];              // 0x05E
+    uint8 station_depart[RCT12_MAX_STATIONS_PER_RIDE];              // 0x062
     // ride->vehicle index for current train waiting for passengers
     // at station
-    uint8 train_at_station[RCT12_MAX_STATIONS_PER_RIDE];      // 0x066
-    rct_xy8 entrances[RCT12_MAX_STATIONS_PER_RIDE];        // 0x06A
-    rct_xy8 exits[RCT12_MAX_STATIONS_PER_RIDE];                // 0x072
-    uint16 last_peep_in_queue[RCT12_MAX_STATIONS_PER_RIDE];   // 0x07A
-    uint8 pad_082[4];               // Used to be number of peeps in queue in RCT1, but this has moved.
-    uint16 vehicles[MAX_VEHICLES_PER_RIDE];            // 0x086 Points to the first car in the train
-    uint8 depart_flags;             // 0x0C6
+    uint8 train_at_station[RCT12_MAX_STATIONS_PER_RIDE];            // 0x066
+    rct_xy8 entrances[RCT12_MAX_STATIONS_PER_RIDE];                 // 0x06A
+    rct_xy8 exits[RCT12_MAX_STATIONS_PER_RIDE];                     // 0x072
+    uint16 last_peep_in_queue[RCT12_MAX_STATIONS_PER_RIDE];         // 0x07A
+    uint8 pad_082[RCT12_MAX_STATIONS_PER_RIDE];                     // 0x082, Used to be number of peeps in queue in RCT1, but this has moved.
+    uint16 vehicles[MAX_VEHICLES_PER_RIDE];                         // 0x086, Points to the first car in the train
+    uint8 depart_flags;                                             // 0x0C6
 
     // Not sure if these should be uint or sint.
-    uint8 num_stations;             // 0x0C7
-    uint8 num_vehicles;             // 0x0C8
-    uint8 num_cars_per_train;       // 0x0C9
-    uint8 proposed_num_vehicles;    // 0x0CA
-    uint8 proposed_num_cars_per_train; // 0x0CB
-    uint8 max_trains;               // 0x0CC
-    uint8 min_max_cars_per_train;   // 0x0CD
-    uint8 min_waiting_time;         // 0x0CE
-    uint8 max_waiting_time;         // 0x0CF
+    uint8 num_stations;                                             // 0x0C7
+    uint8 num_vehicles;                                             // 0x0C8
+    uint8 num_cars_per_train;                                       // 0x0C9
+    uint8 proposed_num_vehicles;                                    // 0x0CA
+    uint8 proposed_num_cars_per_train;                              // 0x0CB
+    uint8 max_trains;                                               // 0x0CC
+    uint8 min_max_cars_per_train;                                   // 0x0CD
+    uint8 min_waiting_time;                                         // 0x0CE
+    uint8 max_waiting_time;                                         // 0x0CF
     union {
-        uint8 operation_option;     // 0x0D0
-        uint8 time_limit;           // 0x0D0
-        uint8 num_laps;             // 0x0D0
-        uint8 launch_speed;         // 0x0D0
-        uint8 speed;                // 0x0D0
-        uint8 rotations;            // 0x0D0
+        uint8 operation_option;                                     // 0x0D0
+        uint8 time_limit;                                           // 0x0D0
+        uint8 num_laps;                                             // 0x0D0
+        uint8 launch_speed;                                         // 0x0D0
+        uint8 speed;                                                // 0x0D0
+        uint8 rotations;                                            // 0x0D0
     };
 
-    uint8 boat_hire_return_direction;   // 0x0D1
-    rct_xy8 boat_hire_return_position;  // 0x0D2
-    uint8 measurement_index;        // 0x0D4
+    uint8 boat_hire_return_direction;                               // 0x0D1
+    rct_xy8 boat_hire_return_position;                              // 0x0D2
+    uint8 measurement_index;                                        // 0x0D4
     // bits 0 through 4 are the number of helix sections
     // bit 5: spinning tunnel, water splash, or rapids
     // bit 6: log reverser, waterfall
     // bit 7: whirlpool
-    uint8 special_track_elements;   // 0x0D5
-    uint8 pad_0D6[2];
+    uint8 special_track_elements;                                   // 0x0D5
+    uint8 pad_0D6[2];                                               // 0x0D6
     // Divide this value by 29127 to get the human-readable max speed
     // (in RCT2, display_speed = (max_speed * 9) >> 18)
-    sint32 max_speed;               // 0x0D8
-    sint32 average_speed;           // 0x0DC
-    uint8 current_test_segment;     // 0x0E0
-    uint8 average_speed_test_timeout;   // 0x0E1
-    uint8 pad_0E2[0x2];
-    sint32 length[RCT12_MAX_STATIONS_PER_RIDE];               // 0x0E4
-    uint16 time[RCT12_MAX_STATIONS_PER_RIDE];                 // 0x0F4
-    fixed16_2dp max_positive_vertical_g;    // 0x0FC
-    fixed16_2dp max_negative_vertical_g;    // 0x0FE
-    fixed16_2dp max_lateral_g;      // 0x100
-    fixed16_2dp previous_vertical_g;// 0x102
-    fixed16_2dp previous_lateral_g; // 0x104
-    uint8 pad_106[0x2];
-    uint32 testing_flags;           // 0x108
+    sint32 max_speed;                                               // 0x0D8
+    sint32 average_speed;                                           // 0x0DC
+    uint8 current_test_segment;                                     // 0x0E0
+    uint8 average_speed_test_timeout;                               // 0x0E1
+    uint8 pad_0E2[0x2];                                             // 0x0E2
+    sint32 length[RCT12_MAX_STATIONS_PER_RIDE];                     // 0x0E4
+    uint16 time[RCT12_MAX_STATIONS_PER_RIDE];                       // 0x0F4
+    fixed16_2dp max_positive_vertical_g;                            // 0x0FC
+    fixed16_2dp max_negative_vertical_g;                            // 0x0FE
+    fixed16_2dp max_lateral_g;                                      // 0x100
+    fixed16_2dp previous_vertical_g;                                // 0x102
+    fixed16_2dp previous_lateral_g;                                 // 0x104
+    uint8 pad_106[0x2];                                             // 0x106
+    uint32 testing_flags;                                           // 0x108
     // x y map location of the current track piece during a test
     // this is to prevent counting special tracks multiple times
-    rct_xy8 cur_test_track_location;    // 0x10C
+    rct_xy8 cur_test_track_location;                                // 0x10C
     // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
-    uint16 turn_count_default;      // 0x10E X = current turn count
-    uint16 turn_count_banked;       // 0x110
-    uint16 turn_count_sloped;       // 0x112 X = number turns > 3 elements
+    uint16 turn_count_default;                                      // 0x10E X = current turn count
+    uint16 turn_count_banked;                                       // 0x110
+    uint16 turn_count_sloped;                                       // 0x112 X = number turns > 3 elements
     union {
-        uint8 inversions;           // 0x114 (???X XXXX)
-        uint8 holes;                // 0x114 (???X XXXX)
+        uint8 inversions;                                           // 0x114 (???X XXXX)
+        uint8 holes;                                                // 0x114 (???X XXXX)
         // This is a very rough approximation of how much of the ride is undercover.
         // It reaches the maximum value of 7 at about 50% undercover and doesn't increase beyond that.
-        uint8 sheltered_eighths;    // 0x114 (XXX?-????)
+        uint8 sheltered_eighths;                                    // 0x114 (XXX?-????)
     };
     // Y is number of powered lifts, X is drops
-    uint8 drops;                    // 0x115 (YYXX XXXX)
-    uint8 start_drop_height;        // 0x116
-    uint8 highest_drop_height;      // 0x117
-    sint32 sheltered_length;        // 0x118
+    uint8 drops;                                                    // 0x115 (YYXX XXXX)
+    uint8 start_drop_height;                                        // 0x116
+    uint8 highest_drop_height;                                      // 0x117
+    sint32 sheltered_length;                                        // 0x118
     // Unused always 0? Should affect nausea
-    uint16 var_11C;
-    uint8 num_sheltered_sections;   // 0x11E (?abY YYYY)
+    uint16 var_11C;                                                 // 0x11C
+    uint8 num_sheltered_sections;                                   // 0x11E (?abY YYYY)
     // see cur_test_track_location
-    uint8 cur_test_track_z;         // 0x11F
+    uint8 cur_test_track_z;                                         // 0x11F
     // Customer counter in the current 960 game tick (about 30 seconds) interval
-    uint16 cur_num_customers;       // 0x120
+    uint16 cur_num_customers;                                       // 0x120
     // Counts ticks to update customer intervals, resets each 960 game ticks.
-    uint16 num_customers_timeout;   // 0x122
+    uint16 num_customers_timeout;                                   // 0x122
     // Customer count in the last 10 * 960 game ticks (sliding window)
-    uint16 num_customers[10];       // 0x124
-    money16 price;                  // 0x138
-    rct_xy8 chairlift_bullwheel_location[2]; // 0x13A
-    uint8 chairlift_bullwheel_z[2]; // 0x13E
+    uint16 num_customers[10];                                       // 0x124
+    money16 price;                                                  // 0x138
+    rct_xy8 chairlift_bullwheel_location[2];                        // 0x13A
+    uint8 chairlift_bullwheel_z[2];                                 // 0x13E
     union {
-        rating_tuple ratings;       // 0x140
+        rating_tuple ratings;                                       // 0x140
         struct {
-            ride_rating excitement; // 0x140
-            ride_rating intensity;  // 0x142
-            ride_rating nausea;     // 0x144
+            ride_rating excitement;                                 // 0x140
+            ride_rating intensity;                                  // 0x142
+            ride_rating nausea;                                     // 0x144
         };
     };
-    uint16 value;                   // 0x146
-    uint16 chairlift_bullwheel_rotation;    // 0x148
-    uint8 satisfaction;             // 0x14A
-    uint8 satisfaction_time_out;    // 0x14B
-    uint8 satisfaction_next;        // 0x14C
+    uint16 value;                                                   // 0x146
+    uint16 chairlift_bullwheel_rotation;                            // 0x148
+    uint8 satisfaction;                                             // 0x14A
+    uint8 satisfaction_time_out;                                    // 0x14B
+    uint8 satisfaction_next;                                        // 0x14C
     // Various flags stating whether a window needs to be refreshed
-    uint8 window_invalidate_flags;  // 0x14D
-    uint8 pad_14E[0x02];
-    uint32 total_customers;         // 0x150
-    money32 total_profit;           // 0x154
-    uint8 popularity;               // 0x158
-    uint8 popularity_time_out;      // 0x159 Updated every purchase and ?possibly by time?
-    uint8 popularity_next;          // 0x15A When timeout reached this will be the next popularity
-    uint8 num_riders;               // 0x15B
-    uint8 music_tune_id;            // 0x15C
-    uint8 slide_in_use;             // 0x15D
+    uint8 window_invalidate_flags;                                  // 0x14D
+    uint8 pad_14E[0x02];                                            // 0x14E
+    uint32 total_customers;                                         // 0x150
+    money32 total_profit;                                           // 0x154
+    uint8 popularity;                                               // 0x158
+    uint8 popularity_time_out;                                      // 0x159 Updated every purchase and ?possibly by time?
+    uint8 popularity_next;                                          // 0x15A When timeout reached this will be the next popularity
+    uint8 num_riders;                                               // 0x15B
+    uint8 music_tune_id;                                            // 0x15C
+    uint8 slide_in_use;                                             // 0x15D
     union {
-        uint16 slide_peep;          // 0x15E
-        uint16 maze_tiles;          // 0x15E
+        uint16 slide_peep;                                          // 0x15E
+        uint16 maze_tiles;                                          // 0x15E
     };
-    uint8 pad_160[0xE];
-    uint8 slide_peep_t_shirt_colour;// 0x16E
-    uint8 pad_16F[0x7];
-    uint8 spiral_slide_progress;    // 0x176
-    uint8 pad_177[0x9];
-    sint16 build_date;              // 0x180
-    money16 upkeep_cost;            // 0x182
-    uint16 race_winner;             // 0x184
-    uint8 pad_186[0x02];
-    uint32 music_position;          // 0x188
-    uint8 breakdown_reason_pending; // 0x18C
-    uint8 mechanic_status;          // 0x18D
-    uint16 mechanic;                // 0x18E
-    uint8 inspection_station;       // 0x190
-    uint8 broken_vehicle;           // 0x191
-    uint8 broken_car;               // 0x192
-    uint8 breakdown_reason;         // 0x193
-    money16 price_secondary;        // 0x194
-    // Starts at RIDE_INITIAL_RELIABILITY and decreases from there. Right shift
-    // this number by 8 to get a reliability percentage 0-100
-    uint16 reliability;             // 0x196
+    uint8 pad_160[0xE];                                             // 0x160
+    uint8 slide_peep_t_shirt_colour;                                // 0x16E
+    uint8 pad_16F[0x7];                                             // 0x16F
+    uint8 spiral_slide_progress;                                    // 0x176
+    uint8 pad_177[0x9];                                             // 0x177
+    sint16 build_date;                                              // 0x180
+    money16 upkeep_cost;                                            // 0x182
+    uint16 race_winner;                                             // 0x184
+    uint8 pad_186[0x02];                                            // 0x186
+    uint32 music_position;                                          // 0x188
+    uint8 breakdown_reason_pending;                                 // 0x18C
+    uint8 mechanic_status;                                          // 0x18D
+    uint16 mechanic;                                                // 0x18E
+    uint8 inspection_station;                                       // 0x190
+    uint8 broken_vehicle;                                           // 0x191
+    uint8 broken_car;                                               // 0x192
+    uint8 breakdown_reason;                                         // 0x193
+    money16 price_secondary;                                        // 0x194
+    union
+    {
+        struct
+        {
+            uint8 reliability_subvalue;                             // 0x196, 0 - 255, acts like the decimals for reliability_percentage
+            uint8 reliability_percentage;                           // 0x197, Starts at 100 and decreases from there.
+        };
+        uint16 reliability;                                         // 0x196
+    };
     // Small constant used to increase the unreliability as the game continues,
     // making breakdowns more and more likely.
-    uint8 unreliability_factor;     // 0x198
+    uint8 unreliability_factor;                                     // 0x198
     // Range from [0, 100]
-    uint8 downtime;                 // 0x199
-    uint8 inspection_interval;      // 0x19A
-    uint8 last_inspection;          // 0x19B
-    uint8 downtime_history[8];      // 0x19C
-    uint32 no_primary_items_sold;   // 0x1A4
-    uint32 no_secondary_items_sold; // 0x1A8
-    uint8 breakdown_sound_modifier; // 0x1AC
+    uint8 downtime;                                                 // 0x199
+    uint8 inspection_interval;                                      // 0x19A
+    uint8 last_inspection;                                          // 0x19B
+    uint8 downtime_history[8];                                      // 0x19C
+    uint32 no_primary_items_sold;                                   // 0x1A4
+    uint32 no_secondary_items_sold;                                 // 0x1A8
+    uint8 breakdown_sound_modifier;                                 // 0x1AC
     // Used to oscillate the sound when ride breaks down.
     // 0 = no change, 255 = max change
-    uint8 not_fixed_timeout;        // 0x1AD
-    uint8 last_crash_type;          // 0x1AE
-    uint8 connected_message_throttle;   // 0x1AF
-    money32 income_per_hour;        // 0x1B0
-    money32 profit;                 // 0x1B4
-    uint8 queue_time[RCT12_MAX_STATIONS_PER_RIDE];            // 0x1B8
-    uint8 track_colour_main[RCT12_NUM_COLOUR_SCHEMES];     // 0x1BC
-    uint8 track_colour_additional[RCT12_NUM_COLOUR_SCHEMES];   // 0x1C0
-    uint8 track_colour_supports[RCT12_NUM_COLOUR_SCHEMES]; // 0x1C4
-    uint8 music;                    // 0x1C8
-    uint8 entrance_style;           // 0x1C9
-    uint16 vehicle_change_timeout;  // 0x1CA
-    uint8 num_block_brakes;         // 0x1CC
-    uint8 lift_hill_speed;          // 0x1CD
-    uint16 guests_favourite;        // 0x1CE
-    uint32 lifecycle_flags;         // 0x1D0
-    uint8 vehicle_colours_extended[32]; // 0x1D4
-    uint16 total_air_time;          // 0x1F4
-    uint8 current_test_station;     // 0x1F6
-    uint8 num_circuits;             // 0x1F7
-    sint16 cable_lift_x;            // 0x1F8
-    sint16 cable_lift_y;            // 0x1FA
-    uint8 cable_lift_z;             // 0x1FC
-    uint8 pad_1FD;
-    uint16 cable_lift;              // 0x1FE
-    uint16 queue_length[RCT12_MAX_STATIONS_PER_RIDE];         // 0x200
-    uint8 pad_208[0x58];
+    uint8 not_fixed_timeout;                                        // 0x1AD
+    uint8 last_crash_type;                                          // 0x1AE
+    uint8 connected_message_throttle;                               // 0x1AF
+    money32 income_per_hour;                                        // 0x1B0
+    money32 profit;                                                 // 0x1B4
+    uint8 queue_time[RCT12_MAX_STATIONS_PER_RIDE];                  // 0x1B8
+    uint8 track_colour_main[RCT12_NUM_COLOUR_SCHEMES];              // 0x1BC
+    uint8 track_colour_additional[RCT12_NUM_COLOUR_SCHEMES];        // 0x1C0
+    uint8 track_colour_supports[RCT12_NUM_COLOUR_SCHEMES];          // 0x1C4
+    uint8 music;                                                    // 0x1C8
+    uint8 entrance_style;                                           // 0x1C9
+    uint16 vehicle_change_timeout;                                  // 0x1CA
+    uint8 num_block_brakes;                                         // 0x1CC
+    uint8 lift_hill_speed;                                          // 0x1CD
+    uint16 guests_favourite;                                        // 0x1CE
+    uint32 lifecycle_flags;                                         // 0x1D0
+    uint8 vehicle_colours_extended[RCT2_MAX_CARS_PER_TRAIN];        // 0x1D4
+    uint16 total_air_time;                                          // 0x1F4
+    uint8 current_test_station;                                     // 0x1F6
+    uint8 num_circuits;                                             // 0x1F7
+    sint16 cable_lift_x;                                            // 0x1F8
+    sint16 cable_lift_y;                                            // 0x1FA
+    uint8 cable_lift_z;                                             // 0x1FC
+    uint8 pad_1FD;                                                  // 0x1FD
+    uint16 cable_lift;                                              // 0x1FE
+    uint16 queue_length[RCT12_MAX_STATIONS_PER_RIDE];               // 0x200
+    uint8 pad_208[0x58];                                            // 0x208
 } rct_ride;
 assert_struct_size(rct_ride, 0x260);
 
@@ -932,7 +939,7 @@ extern const rct_ride_properties RideProperties[RIDE_TYPE_COUNT];
 
 #define MAX_RIDE_MEASUREMENTS 8
 #define RIDE_VALUE_UNDEFINED 0xFFFF
-#define RIDE_INITIAL_RELIABILITY ((100 << 8) - 1)
+#define RIDE_INITIAL_RELIABILITY ((100 << 8) | - 1)
 
 #define STATION_DEPART_FLAG (1 << 7)
 #define STATION_DEPART_MASK (~STATION_DEPART_FLAG)

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -3935,7 +3935,7 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     x = w->x + widget->left + 4;
     y = w->y + widget->top + 4;
 
-    uint16 reliability = ride->reliability >> 8;
+    uint16 reliability = ride->reliability_percentage;
     gfx_draw_string_left(dpi, STR_RELIABILITY_LABEL_1757, &reliability, COLOUR_BLACK, x, y);
     window_ride_maintenance_draw_bar(w, dpi, x + 103, y, max(10, reliability), COLOUR_BRIGHT_GREEN);
     y += 11;

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -677,7 +677,7 @@ static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, 
             }
             break;
         case INFORMATION_TYPE_RELIABILITY:
-            set_format_arg(2, uint16, ride->reliability >> 8);
+            set_format_arg(2, uint16, ride->reliability_percentage);
             formatSecondary = STR_RELIABILITY_LABEL;
             break;
         case INFORMATION_TYPE_DOWN_TIME:
@@ -867,7 +867,7 @@ static void window_ride_list_refresh_list(rct_window *w)
         case INFORMATION_TYPE_RELIABILITY:
             while (--current_list_position >= 0) {
                 otherRide = get_ride(w->list_item_positions[current_list_position]);
-                if (ride->reliability >> 8 <= otherRide->reliability >> 8)
+                if (ride->reliability_percentage <= otherRide->reliability_percentage)
                     break;
 
                 window_bubble_list_item(w, current_list_position);


### PR DESCRIPTION
Also fixed the definition of RIDE_INITIAL_RELIABILITY - the old define yielded 0x63FF, not 0x64FF as intended.