### PR TITLE
Fix premature deletion of dependencies

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -88,6 +88,7 @@ namespace OpenRCT2
         ITrackDesignRepository *    _trackDesignRepository = nullptr;
         IScenarioRepository *       _scenarioRepository = nullptr;
 
+        bool    _initialised = false;
         bool    _isWindowMinimised = false;
         uint32  _lastTick = 0;
         uint32  _accumulator = 0;
@@ -125,6 +126,12 @@ namespace OpenRCT2
             EVP_MD_CTX_destroy(gHashCTX);
 #endif // DISABLE_NETWORK
             rct2_interop_dispose();
+
+            delete _scenarioRepository;
+            delete _trackDesignRepository;
+            delete _objectManager;
+            delete _objectRepository;
+
             Instance = nullptr;
         }
 
@@ -157,6 +164,12 @@ namespace OpenRCT2
 
         bool Initialise() final override
         {
+            if (_initialised)
+            {
+                throw std::runtime_error("Context already initialised.");
+            }
+            _initialised = true;
+
 #ifndef DISABLE_NETWORK
             gHashCTX = EVP_MD_CTX_create();
             Guard::Assert(gHashCTX != nullptr, "EVP_MD_CTX_create failed");

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -607,17 +607,17 @@ private:
     }
 };
 
-static std::unique_ptr<ObjectManager> _objectManager;
+static ObjectManager * _objectManager = nullptr;
 
 IObjectManager * CreateObjectManager(IObjectRepository * objectRepository)
 {
-    _objectManager = std::unique_ptr<ObjectManager>(new ObjectManager(objectRepository));
-    return _objectManager.get();
+    _objectManager = new ObjectManager(objectRepository);
+    return _objectManager;
 }
 
 IObjectManager * GetObjectManager()
 {
-    return _objectManager.get();
+    return _objectManager;
 }
 
 extern "C"

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -698,17 +698,17 @@ private:
     }
 };
 
-static std::unique_ptr<ObjectRepository> _objectRepository;
+static ObjectRepository * _objectRepository = nullptr;
 
 IObjectRepository * CreateObjectRepository(IPlatformEnvironment * env)
 {
-    _objectRepository = std::unique_ptr<ObjectRepository>(new ObjectRepository(env));
-    return _objectRepository.get();
+    _objectRepository = new ObjectRepository(env);
+    return _objectRepository;
 }
 
 IObjectRepository * GetObjectRepository()
 {
-    return _objectRepository.get();
+    return _objectRepository;
 }
 
 bool IsObjectCustom(const ObjectRepositoryItem * object)

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -456,17 +456,17 @@ public:
     }
 };
 
-static std::unique_ptr<TrackDesignRepository> _trackDesignRepository;
+static TrackDesignRepository * _trackDesignRepository = nullptr;
 
 ITrackDesignRepository * CreateTrackDesignRepository(IPlatformEnvironment * env)
 {
-    _trackDesignRepository = std::unique_ptr<TrackDesignRepository>(new TrackDesignRepository(env));
-    return _trackDesignRepository.get();
+    _trackDesignRepository = new TrackDesignRepository(env);
+    return _trackDesignRepository;
 }
 
 ITrackDesignRepository * GetTrackDesignRepository()
 {
-    return _trackDesignRepository.get();
+    return _trackDesignRepository;
 }
 
 extern "C"

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -604,17 +604,17 @@ private:
     }
 };
 
-static std::unique_ptr<ScenarioRepository> _scenarioRepository;
+static ScenarioRepository * _scenarioRepository;
 
 IScenarioRepository * CreateScenarioRepository(IPlatformEnvironment * env)
 {
-    _scenarioRepository = std::unique_ptr<ScenarioRepository>(new ScenarioRepository(env));
-    return _scenarioRepository.get();
+    _scenarioRepository = new ScenarioRepository(env);
+    return _scenarioRepository;
 }
 
 IScenarioRepository * GetScenarioRepository()
 {
-    return _scenarioRepository.get();
+    return _scenarioRepository;
 }
 
 extern "C"


### PR DESCRIPTION
In particular, the object repository can potentially be deleted before the object manager is deleted. This causes a crash when the object manager is deleted because it requires the object repository within the destructor.