### PR TITLE
AVX2 blending

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		F775F5351EE35A89001F00E7 /* DummyUiContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5331EE35A6B001F00E7 /* DummyUiContext.cpp */; };
 		F775F5381EE3725C001F00E7 /* DummyAudioContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F775F5361EE3724F001F00E7 /* DummyAudioContext.cpp */; };
 		F79F428F1F3260F1009E42F8 /* changelog.txt in Resources */ = {isa = PBXBuildFile; fileRef = F79F428E1F3260F1009E42F8 /* changelog.txt */; };
+		F7C44AF82030E8D3007E099F /* AVX2Drawing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7C44AF62030E74B007E099F /* AVX2Drawing.cpp */; settings = {COMPILER_FLAGS = "-mavx2"; }; };
 		F7CB863F1EEDA0B50030C877 /* WindowManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7CB863D1EEDA0B50030C877 /* WindowManager.cpp */; };
 		F7CB864A1EEDA1330030C877 /* KeyboardShortcuts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7CB86471EEDA1330030C877 /* KeyboardShortcuts.cpp */; };
 		F7CB864E1EEDA2050030C877 /* DummyWindowManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7CB864B1EEDA1A80030C877 /* DummyWindowManager.cpp */; };
@@ -1362,6 +1363,7 @@
 		F7B2048B2024E7800000AD7E /* DefaultObjects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultObjects.cpp; sourceTree = "<group>"; };
 		F7B2048D2024E8A90000AD7E /* DefaultObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultObjects.h; sourceTree = "<group>"; };
 		F7B2048E2024E8B30000AD7E /* _legacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = _legacy.cpp; sourceTree = "<group>"; };
+		F7C44AF62030E74B007E099F /* AVX2Drawing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AVX2Drawing.cpp; sourceTree = "<group>"; };
 		F7CB863D1EEDA0B50030C877 /* WindowManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WindowManager.cpp; sourceTree = "<group>"; };
 		F7CB863E1EEDA0B50030C877 /* WindowManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WindowManager.h; sourceTree = "<group>"; };
 		F7CB86471EEDA1330030C877 /* KeyboardShortcuts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyboardShortcuts.cpp; sourceTree = "<group>"; };
@@ -1897,6 +1899,7 @@
 		F76C839D1EC4E7CC00FA49E2 /* drawing */ = {
 			isa = PBXGroup;
 			children = (
+				F7C44AF62030E74B007E099F /* AVX2Drawing.cpp */,
 				4C7B53D520002CA400A52E21 /* Drawing.cpp */,
 				F76C839F1EC4E7CC00FA49E2 /* drawing.h */,
 				F76C83A01EC4E7CC00FA49E2 /* DrawingFast.cpp */,
@@ -2980,6 +2983,7 @@
 				C68313C81FDB4ED4006DB3D8 /* MouseInput.cpp in Sources */,
 				C68878C920289B710084B384 /* TextureCache.cpp in Sources */,
 				C61ADB1F1FB6A0A70024F2EF /* TopToolbar.cpp in Sources */,
+				F7C44AF72030E74B007E099F /* AVX2Drawing.cpp in Sources */,
 				F76C887B1EC5324E00FA49E2 /* FileAudioSource.cpp in Sources */,
 				C68878CA20289B710084B384 /* TransparencyDepth.cpp in Sources */,
 				C64644FD1F3FA4120026AC2D /* Land.cpp in Sources */,
@@ -3067,6 +3071,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7C44AF82030E8D3007E099F /* AVX2Drawing.cpp in Sources */,
 				C68878A320289B200084B384 /* User.cpp in Sources */,
 				F70839931FFC0B61002DCEFA /* Scenario.cpp in Sources */,
 				C688791C20289B9B0084B384 /* Facility.cpp in Sources */,
@@ -3272,7 +3277,7 @@
 				C688789420289B140084B384 /* Screenshot.cpp in Sources */,
 				C688790620289B9B0084B384 /* TwisterRollerCoaster.cpp in Sources */,
 				C688786720289A4A0084B384 /* SawyerCoding.cpp in Sources */,
-				F76C86A61EC4E88400FA49E2 /* macos.m in Sources */,
+				F76C86A61EC4E88400FA49E2 /* macos.mm in Sources */,
 				C68878FE20289B9B0084B384 /* MiniSuspendedCoaster.cpp in Sources */,
 				F76C86AD1EC4E88400FA49E2 /* PlatformEnvironment.cpp in Sources */,
 				C688791220289B9B0084B384 /* GhostTrain.cpp in Sources */,
@@ -3529,6 +3534,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CLANG_X86_VECTOR_INSTRUCTIONS = default;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3565,6 +3571,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CLANG_X86_VECTOR_INSTRUCTIONS = default;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -51,7 +51,7 @@
              C4549: 'operator': operator before comma has no effect; did you intend 'operator'?
              C4555: expression has no effect; expected expression with side-effect
       -->
-      <PreprocessorDefinitions>__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;CURL_STATICLIB;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;ZIP_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__AVX2__;__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;CURL_STATICLIB;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;ZIP_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -125,6 +125,7 @@ file(GLOB_RECURSE OPENRCT2_GUI_SOURCES
 
 if(X86 OR X86_64)
     set_source_files_properties(${ORCT2_ROOT}/src/openrct2/drawing/SSE41Drawing.cpp PROPERTIES COMPILE_FLAGS -msse4.1)
+    set_source_files_properties(${ORCT2_ROOT}/src/openrct2/drawing/AVX2Drawing.cpp PROPERTIES COMPILE_FLAGS -mavx2)
 endif()
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -213,4 +213,5 @@ endif()
 
 if(X86 OR X86_64)
 set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/SSE41Drawing.cpp PROPERTIES COMPILE_FLAGS -msse4.1)
+set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/AVX2Drawing.cpp PROPERTIES COMPILE_FLAGS -mavx2)
 endif()

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -106,6 +106,13 @@ if (NOT DISABLE_NETWORK)
     endif ()
 endif ()
 
+if (NOT APPLE AND NOT MINGW)
+    # This is ugly hack to work around https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899.
+    # Once C++17 is enabled (and thus old compilers are no longer supported, this needs to be gone.
+    # We cannot simply detect the _compiler_ version, as the bug exists with the C++ _library_
+    target_link_libraries(${PROJECT} gcc_s gcc)
+endif ()
+
 if (NOT DISABLE_TTF)
     if (STATIC)
         target_link_libraries(${PROJECT} ${FREETYPE_STATIC_LIBRARIES})

--- a/src/openrct2/drawing/AVX2Drawing.cpp
+++ b/src/openrct2/drawing/AVX2Drawing.cpp
@@ -1,0 +1,62 @@
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#include "../common.h"
+#include "../core/Guard.hpp"
+#include "Drawing.h"
+
+#ifdef __AVX2__
+
+#include <immintrin.h>
+
+void mask_avx2(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
+               uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap)
+{
+    if (width == 32)
+    {
+        const sint32 maskWrapSIMD = maskWrap + 32;
+        const sint32 colourWrapSIMD = colourWrap + 32;
+        const sint32 dstWrapSIMD = dstWrap + 32;
+        const __m256i zero = {};
+        for (sint32 yy = 0; yy < height; yy++) {
+            const __m256i colour   = _mm256_lddqu_si256((const __m256i *)(colourSrc + yy * colourWrapSIMD));
+            const __m256i mask     = _mm256_lddqu_si256((const __m256i *)(maskSrc   + yy * maskWrapSIMD));
+            const __m256i dest     = _mm256_lddqu_si256((const __m256i *)(dst       + yy * dstWrapSIMD));
+            const __m256i mc       = _mm256_and_si256 (colour, mask);
+            const __m256i saturate = _mm256_cmpeq_epi8(mc, zero);
+            const __m256i blended  = _mm256_blendv_epi8(mc, dest, saturate);
+            _mm256_storeu_si256 ((__m256i *)(dst + yy * dstWrapSIMD), blended);
+        }
+    }
+    else
+    {
+        mask_scalar(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+    }
+}
+
+#else
+
+#ifdef OPENRCT2_X86
+#error You have to compile this file with AVX2 enabled, when targeting x86!
+#endif
+
+void mask_avx2(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
+               uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap)
+{
+    openrct2_assert(false, "AVX2 function called on a CPU that doesn't support AVX2");
+}
+
+#endif // __AVX2__

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -478,7 +478,12 @@ void (*mask_fn)(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, con
 
 void mask_init()
 {
-    if (sse41_available())
+    if (avx2_available())
+    {
+        log_verbose("registering AVX2 mask function");
+        mask_fn = mask_avx2;
+    }
+    else if (sse41_available())
     {
         log_verbose("registering SSE4.1 mask function");
         mask_fn = mask_sse4_1;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -343,10 +343,12 @@ sint32 scrolling_text_setup(paint_session * session, rct_string_id stringId, uin
 
 rct_size16 FASTCALL gfx_get_sprite_size(uint32 image_id);
 
-void mask_sse4_1(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
-                 uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap);
 void mask_scalar(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
                  uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap);
+void mask_sse4_1(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
+                 uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap);
+void mask_avx2(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
+               uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap);
 void mask_init();
 
 extern void (*mask_fn)(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -188,10 +188,10 @@ sint32 bitscanforward(sint32 source)
 #endif
 
 #ifdef OPENRCT2_X86
-static bool cpuid_x86(uint32 * cpuid_outdata, sint32 eax, sint32 ecx = 0)
+static bool cpuid_x86(uint32 * cpuid_outdata, sint32 eax)
 {
 #if defined(OpenRCT2_CPUID_GNUC_X86)
-    int ret = __get_cpuid_count(eax, ecx, &cpuid_outdata[0], &cpuid_outdata[1], &cpuid_outdata[2], &cpuid_outdata[3]);
+    int ret = __get_cpuid(eax, &cpuid_outdata[0], &cpuid_outdata[1], &cpuid_outdata[2], &cpuid_outdata[3]);
     return ret == 1;
 #elif defined(OpenRCT2_CPUID_MSVC_X86)
     __cpuid((int *)cpuid_outdata, (int)eax);
@@ -218,12 +218,20 @@ bool sse41_available()
 bool avx2_available()
 {
 #ifdef OPENRCT2_X86
+// For GCC and similar use the builtin function, as cpuid changed its semantics in
+// https://github.com/gcc-mirror/gcc/commit/132fa33ce998df69a9f793d63785785f4b93e6f1
+// which causes it to ignore subleafs, but the new function is unavailable on Ubuntu's
+// prehistoric toolchains
+#if defined(OpenRCT2_CPUID_GNUC_X86)
+    return __builtin_cpu_supports("avx2");
+#else
     // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7, ECX = 0).
     uint32 regs[4] = { 0 };
     if (cpuid_x86(regs, 7))
     {
         return (regs[1] & (1 << 5));
     }
+#endif
 #endif
     return false;
 }

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -188,10 +188,10 @@ sint32 bitscanforward(sint32 source)
 #endif
 
 #ifdef OPENRCT2_X86
-static bool cpuid_x86(uint32 * cpuid_outdata, sint32 eax)
+static bool cpuid_x86(uint32 * cpuid_outdata, sint32 eax, sint32 ecx = 0)
 {
 #if defined(OpenRCT2_CPUID_GNUC_X86)
-    int ret = __get_cpuid(eax, &cpuid_outdata[0], &cpuid_outdata[1], &cpuid_outdata[2], &cpuid_outdata[3]);
+    int ret = __get_cpuid_count(eax, ecx, &cpuid_outdata[0], &cpuid_outdata[1], &cpuid_outdata[2], &cpuid_outdata[3]);
     return ret == 1;
 #elif defined(OpenRCT2_CPUID_MSVC_X86)
     __cpuid((int *)cpuid_outdata, (int)eax);
@@ -218,7 +218,7 @@ bool sse41_available()
 bool avx2_available()
 {
 #ifdef OPENRCT2_X86
-    // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7).
+    // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7, ECX = 0).
     uint32 regs[4] = { 0 };
     if (cpuid_x86(regs, 7))
     {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -215,6 +215,19 @@ bool sse41_available()
     return false;
 }
 
+bool avx2_available()
+{
+#ifdef OPENRCT2_X86
+    // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7).
+    uint32 regs[4] = { 0 };
+    if (cpuid_x86(regs, 7))
+    {
+        return (regs[1] & (1 << 5));
+    }
+#endif
+    return false;
+}
+
 static bool bitcount_popcnt_available()
 {
 #ifdef OPENRCT2_X86

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -38,6 +38,7 @@ bool readentirefile(const utf8 *path, void **outBuffer, size_t *outLength);
 bool writeentirefile(const utf8 * path, const void * buffer, size_t length);
 
 bool sse41_available();
+bool avx2_available();
 
 sint32 bitscanforward(sint32 source);
 void bitcount_init();


### PR DESCRIPTION
AVX2 hype.

This is preliminary support for some AVX2 code. It is best pronounced in debug builds (duh) and on skylake+ (_looking at you @Gymnasiast and @IntelOrca_).

`benchgfx ../test/tests/testdata/bpb.sv6` results:
Skylake, `Debug`, went down from 19.42s to 18.05s.
Skylake, `RelWithDebInfo`, went down from 8.12s to 7.65s
Haswell, `Debug`, went down from 13.72s to 12.64s.

I am aware this will break non-AVX2 CPUs, I still need to do run-time AVX2 selection with some fallback. It is also not yet exactly correct, some pro- and epilogue may be required.