### PR TITLE
Fix newline for sprite command

### DIFF
--- a/src/openrct2/cmdline_sprite.c
+++ b/src/openrct2/cmdline_sprite.c
@@ -791,7 +791,7 @@ sint32 cmdline_for_sprite(const char **argv, sint32 argc)
         fprintf(stdout, "Finished\n");
         return 1;
     } else {
-        fprintf(stderr, "Unknown sprite command.");
+        fprintf(stderr, "Unknown sprite command.\n");
         return 1;
     }
 }


### PR DESCRIPTION
If I just run

    openrct2 sprite

my shell (zsh) displays a % to indicate that the final newline is missing.

    $ openrct2 sprite
    Unknown sprite command.%                                                                                                                                                                                          
    $
