### PR TITLE
Fix build errors

### DIFF
--- a/src/openrct2/interface/viewport.c
+++ b/src/openrct2/interface/viewport.c
@@ -1482,7 +1482,7 @@ static rct_viewport *viewport_find_from_point(sint32 screenX, sint32 screenY)
 void screen_get_map_xy(sint32 screenX, sint32 screenY, sint16 *x, sint16 *y, rct_viewport **viewport) {
     sint16 my_x, my_y;
     sint32 interactionType;
-    rct_viewport *myViewport;
+    rct_viewport *myViewport = NULL;
     get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_TERRAIN, &my_x, &my_y, &interactionType, NULL, &myViewport);
     if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE) {
         *x = 0x8000;

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -3360,7 +3360,7 @@ static void ride_track_set_map_tooltip(rct_map_element *mapElement)
     set_map_tooltip_format_arg(4, uint32, ride->name_arguments);
 
     rct_string_id formatSecondary;
-    sint32 arg1;
+    sint32 arg1 = 0;
     ride_get_status(rideIndex, &formatSecondary, &arg1);
     set_map_tooltip_format_arg(8, rct_string_id, formatSecondary);
     set_map_tooltip_format_arg(10, uint32, arg1);

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -315,6 +315,9 @@ extern "C"
     const utf8 * title_sequence_manager_get_path(size_t index)
     {
         auto item = TitleSequenceManager::GetItem(index);
+        if (item == nullptr) {
+            return nullptr;
+        }
         const utf8 * name = item->Path.c_str();
         return name;
     }
@@ -322,6 +325,9 @@ extern "C"
     const utf8 * title_sequence_manager_get_config_id(size_t index)
     {
         auto item = TitleSequenceManager::GetItem(index);
+        if (item == nullptr) {
+            return nullptr;
+        }
         const utf8 * name = item->Name.c_str();
         const utf8 * filename = Path::GetFileName(item->Path.c_str());
         for (const auto &pseq : TitleSequenceManager::PredefinedSequences)
@@ -337,6 +343,9 @@ extern "C"
     uint16 title_sequence_manager_get_predefined_index(size_t index)
     {
         auto item = TitleSequenceManager::GetItem(index);
+        if (item == nullptr) {
+            return 0;
+        }
         uint16 predefinedIndex = item->PredefinedIndex;
         return predefinedIndex;
     }


### PR DESCRIPTION
Fixes the build errors I get when building OpenRCT2 with [mxe (M cross environment)](http://mxe.cc/) (gcc 7.1.0), which look like this:
```
/home/cuervo/dev/OpenRCT2/src/openrct2/network/network.cpp: In member function 'void Network::RemoveClient(std::unique_ptr<NetworkConnection>&)':
/home/cuervo/dev/OpenRCT2/src/openrct2/network/network.cpp:2774:52: error: potential null pointer dereference [-Werror=null-dereference]
     return gNetwork.GetMode() == NETWORK_MODE_NONE ? _pickup_peep : gNetwork.GetPlayerByID(playerid)->PickupPeep;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/cuervo/dev/OpenRCT2/src/openrct2/network/network.cpp:2784:52: error: potential null pointer dereference [-Werror=null-dereference]
     return gNetwork.GetMode() == NETWORK_MODE_NONE ? _pickup_peep_old_x : gNetwork.GetPlayerByID(playerid)->PickupPeepOldX;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[...]

/home/cuervo/dev/OpenRCT2/src/openrct2/network/network.cpp:541:12: error: potential null pointer dereference [-Werror=null-dereference]
     return nullptr;
            ^~~~~~~
```

If this gets merged I'll write a wiki page on how to build with mxe as there are some pitfalls.

Questions:
- I'm not sure what to return in certain functions returning an int on `nullptr`? 0 for unsigned, -1 for signed?
- Network version update?