### PR TITLE
DROPDOWN_ITEMS_MAX_SIZE + Dropdown column overflowing at 32 rows

### DIFF
--- a/src/openrct2/windows/dropdown.c
+++ b/src/openrct2/windows/dropdown.c
@@ -46,8 +46,8 @@ sint32 _dropdown_item_width;
 sint32 _dropdown_item_height;
 
 sint32 gDropdownNumItems;
-rct_string_id gDropdownItemsFormat[64];
-sint64 gDropdownItemsArgs[64];
+rct_string_id gDropdownItemsFormat[DROPDOWN_ITEMS_MAX_SIZE];
+sint64 gDropdownItemsArgs[DROPDOWN_ITEMS_MAX_SIZE];
 uint64 gDropdownItemsChecked;
 uint64 gDropdownItemsDisabled;
 bool gDropdownIsColour;
@@ -337,7 +337,7 @@ static void window_dropdown_paint(rct_window *w, rct_drawpixelinfo *dpi)
                 );
             } else {
                 // Text item
-                if (i < 64) {
+                if (i < DROPDOWN_ITEMS_MAX_SIZE) {
                     if (dropdown_is_checked(i)) {
                         item++;
                     }
@@ -348,7 +348,7 @@ static void window_dropdown_paint(rct_window *w, rct_drawpixelinfo *dpi)
                 if (i == highlightedIndex)
                     colour = COLOUR_WHITE;
                 if (dropdown_is_disabled(i))
-                    if (i < 64)
+                    if (i < DROPDOWN_ITEMS_MAX_SIZE)
                         colour = NOT_TRANSLUCENT(w->colours[0]) | COLOUR_FLAG_INSET;
 
                 // Draw item string

--- a/src/openrct2/windows/dropdown.h
+++ b/src/openrct2/windows/dropdown.h
@@ -23,6 +23,7 @@
 #define DROPDOWN_SEPARATOR            0
 #define DROPDOWN_FORMAT_COLOUR_PICKER 0xFFFE
 #define DROPDOWN_FORMAT_LAND_PICKER   0xFFFF
+#define DROPDOWN_ITEMS_MAX_SIZE       64
 
 enum
 {
@@ -33,8 +34,8 @@ enum
 extern sint32 gAppropriateImageDropdownItemsPerRow[];
 
 extern sint32 gDropdownNumItems;
-extern rct_string_id gDropdownItemsFormat[64];
-extern sint64 gDropdownItemsArgs[64];
+extern rct_string_id gDropdownItemsFormat[DROPDOWN_ITEMS_MAX_SIZE];
+extern sint64 gDropdownItemsArgs[DROPDOWN_ITEMS_MAX_SIZE];
 extern uint64 gDropdownItemsChecked;
 extern uint64 gDropdownItemsDisabled;
 extern bool gDropdownIsColour;


### PR DESCRIPTION
This PR defines the 64 as DROPDOWN_ITEMS_MAX_SIZE and also allows large lists to be split into seperate columns to help aid small screen sizes. An example list you can test it out would be from having the "Unlock All Operating Modes" or "Unlock all vehicles". 

This will be useful for a seperate branch I have in which the 'arbritrary ride types' cheat will be shown as a dropdown which contains 90 items in the list
