### PR TITLE
Fix #5797: Ride previews going out of bounds.

### DIFF
--- a/src/openrct2/object_list.c
+++ b/src/openrct2/object_list.c
@@ -134,7 +134,7 @@ void object_create_identifier_name(char* string_buffer, size_t size, const rct_o
  * ecx = entry_type
  */
 sint32 find_object_in_entry_group(const rct_object_entry* entry, uint8* entry_type, uint8* entry_index){
-    if ((entry->flags & 0xF) >= _countof(object_entry_groups)) {
+    if ((entry->flags & 0xF) >= countof(object_entry_groups)) {
         return 0;
     }
     *entry_type = entry->flags & 0xF;

--- a/src/openrct2/object_list.c
+++ b/src/openrct2/object_list.c
@@ -134,8 +134,10 @@ void object_create_identifier_name(char* string_buffer, size_t size, const rct_o
  * ecx = entry_type
  */
 sint32 find_object_in_entry_group(const rct_object_entry* entry, uint8* entry_type, uint8* entry_index){
+    if ((entry->flags & 0xF) >= _countof(object_entry_groups)) {
+        return 0;
+    }
     *entry_type = entry->flags & 0xF;
-
     rct_object_entry_group entry_group = object_entry_groups[*entry_type];
     for (*entry_index = 0;
         *entry_index < object_entry_group_counts[*entry_type];


### PR DESCRIPTION
This should prevent #5797 from crashing. To my understanding this crash happens if some scenery is not loaded which is referenced however.