### PR TITLE
Add /permissive- switch to MSVC

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -47,7 +47,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/utf-8 /std:c++latest</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /std:c++latest /permissive-</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>imm32.lib;version.lib;winmm.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
MSVC2017 has a new compiler switch to become more conformant. See
https://blogs.msdn.microsoft.com/vcblog/2016/11/16/permissive-switch/

On MSVC2015 (as used currently in our AppVeyor setup) this switch is
safely ignored.

This should help reduce the need to fix build errors only found on
Travis et al.