### PR TITLE
Fix #5977: Custom music being discarded due length being 0.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#5880] Leaving bumper cars without building causes assertion.
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
+- Fix: [#5977] Custom music files not showing up in music list
 - Improved: [#4301] Leading and trailing whitespace in player name is now removed.
 - Improved: [#5859] OpenGL rendering performance
 - Improved: [#5863] Switching drawing engines no longer requires the application to restart.

--- a/src/openrct2/audio/audio.cpp
+++ b/src/openrct2/audio/audio.cpp
@@ -370,6 +370,13 @@ void audio_init_ride_sounds_and_info()
                 {
                     rideMusicInfo->length = 0;
                 }
+                // FIX: Custom ones have no length set and while populating the combo box
+                //      they are ignored if 0.
+                if ((m == 36 || m == 37) && rideMusicInfo->length == 0)
+                {
+                    // Try to get it.
+                    rideMusicInfo->length = fs.GetLength();
+                }
             }
             catch (const Exception &)
             {


### PR DESCRIPTION
When the music list is populated it checks if length is 0 and discards those, also the audio mixer is incapable of playing when length is 0 it seems. This PR sets the length to the file size at runtime while other entries have it set compile time except for custom ones.

Should fix #5977 