### PR TITLE
Refactored window flags only being updated every 1000ms.

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -72,8 +72,6 @@ private:
     SDL_Window *    _window = nullptr;
     sint32          _width  = 0;
     sint32          _height = 0;
-    uint32          _windowFlags = 0;
-    uint32          _windowFlagsLastCheckTick = 0;
 
     bool _resolutionsAllowAnyAspectRatio = false;
     std::vector<Resolution> _fsResolutions;
@@ -782,14 +780,7 @@ private:
 
     uint32 GetWindowFlags()
     {
-        // Don't check if window is minimised too frequently (every second is fine)
-        uint32 tick = Platform::GetTicks();
-        if (tick > _windowFlagsLastCheckTick + 1000)
-        {
-            _windowFlags = SDL_GetWindowFlags(_window);
-            _windowFlagsLastCheckTick = tick;
-        }
-        return _windowFlags;
+        return SDL_GetWindowFlags(_window);
     }
 };
 


### PR DESCRIPTION
This removes the logic that would only get the window flags every 1000ms, performance wise its slower to check the time, sdl gets us the flags straight from the window instance as seen here https://github.com/spurious/SDL-mirror/blob/e1c7eb2a19d7d3b039f63dd3f9a2962eb8701e23/src/video/SDL_video.c#L1631-L1636. This also fixes the game scrolling when alt tabbing out for 1000ms.