### PR TITLE
Fix empty dropdown causing division by zero

### DIFF
--- a/src/openrct2/windows/dropdown.c
+++ b/src/openrct2/windows/dropdown.c
@@ -175,6 +175,7 @@ void window_dropdown_show_text_custom_width(sint32 x, sint32 y, sint32 extray, u
     _dropdown_item_height = (flags & DROPDOWN_FLAG_CUSTOM_HEIGHT) ? custom_height : 10;
     gDropdownNumItems = (sint32)num_items;
     _dropdown_num_columns = (gDropdownNumItems + DROPDOWN_TEXT_MAX_ROWS - 1) / DROPDOWN_TEXT_MAX_ROWS;
+    _dropdown_num_columns = max(1, _dropdown_num_columns);
     _dropdown_num_rows = (gDropdownNumItems + _dropdown_num_columns - 1) / _dropdown_num_columns;
     
     // Text dropdowns are listed horizontally

--- a/src/openrct2/windows/dropdown.c
+++ b/src/openrct2/windows/dropdown.c
@@ -174,9 +174,15 @@ void window_dropdown_show_text_custom_width(sint32 x, sint32 y, sint32 extray, u
     _dropdown_item_width = width;
     _dropdown_item_height = (flags & DROPDOWN_FLAG_CUSTOM_HEIGHT) ? custom_height : 10;
     gDropdownNumItems = (sint32)num_items;
-    _dropdown_num_columns = (gDropdownNumItems + DROPDOWN_TEXT_MAX_ROWS - 1) / DROPDOWN_TEXT_MAX_ROWS;
-    _dropdown_num_columns = max(1, _dropdown_num_columns);
-    _dropdown_num_rows = (gDropdownNumItems + _dropdown_num_columns - 1) / _dropdown_num_columns;
+    // There must always be at least one column to prevent dividing by zero
+    if (gDropdownNumItems == 0) {
+        _dropdown_num_columns = 1;
+        _dropdown_num_rows = 0;
+    }
+    else {
+        _dropdown_num_columns = (gDropdownNumItems + DROPDOWN_TEXT_MAX_ROWS - 1) / DROPDOWN_TEXT_MAX_ROWS;
+        _dropdown_num_rows = (gDropdownNumItems + _dropdown_num_columns - 1) / _dropdown_num_columns;
+    }
     
     // Text dropdowns are listed horizontally
     _dropdown_list_vertically = true;
@@ -246,10 +252,17 @@ void window_dropdown_show_image(sint32 x, sint32 y, sint32 extray, uint8 colour,
     _dropdown_item_width = itemWidth;
     _dropdown_item_height = itemHeight;
     gDropdownNumItems = numItems;
-    _dropdown_num_columns = numColumns;
-    _dropdown_num_rows = gDropdownNumItems / _dropdown_num_columns;
-    if (gDropdownNumItems % _dropdown_num_columns != 0)
-        _dropdown_num_rows++;
+    // There must always be at least one column to prevent dividing by zero
+    if (gDropdownNumItems == 0) {
+        _dropdown_num_columns = 1;
+        _dropdown_num_rows = 0;
+    }
+    else {
+        _dropdown_num_columns = numColumns;
+        _dropdown_num_rows = gDropdownNumItems / _dropdown_num_columns;
+        if (gDropdownNumItems % _dropdown_num_columns != 0)
+            _dropdown_num_rows++;
+    }
 
     // image dropdowns are listed horizontally
     _dropdown_list_vertically = false;

--- a/src/openrct2/windows/dropdown.c
+++ b/src/openrct2/windows/dropdown.c
@@ -175,11 +175,13 @@ void window_dropdown_show_text_custom_width(sint32 x, sint32 y, sint32 extray, u
     _dropdown_item_height = (flags & DROPDOWN_FLAG_CUSTOM_HEIGHT) ? custom_height : 10;
     gDropdownNumItems = (sint32)num_items;
     // There must always be at least one column to prevent dividing by zero
-    if (gDropdownNumItems == 0) {
+    if (gDropdownNumItems == 0)
+    {
         _dropdown_num_columns = 1;
         _dropdown_num_rows = 0;
     }
-    else {
+    else
+    {
         _dropdown_num_columns = (gDropdownNumItems + DROPDOWN_TEXT_MAX_ROWS - 1) / DROPDOWN_TEXT_MAX_ROWS;
         _dropdown_num_rows = (gDropdownNumItems + _dropdown_num_columns - 1) / _dropdown_num_columns;
     }
@@ -253,11 +255,13 @@ void window_dropdown_show_image(sint32 x, sint32 y, sint32 extray, uint8 colour,
     _dropdown_item_height = itemHeight;
     gDropdownNumItems = numItems;
     // There must always be at least one column to prevent dividing by zero
-    if (gDropdownNumItems == 0) {
+    if (gDropdownNumItems == 0)
+    {
         _dropdown_num_columns = 1;
         _dropdown_num_rows = 0;
     }
-    else {
+    else
+    {
         _dropdown_num_columns = numColumns;
         _dropdown_num_rows = gDropdownNumItems / _dropdown_num_columns;
         if (gDropdownNumItems % _dropdown_num_columns != 0)


### PR DESCRIPTION
Sometimes a dropdown will have no items, causing a division by zero. This fixes that

An example of an empty dropdown is:
- Open Dynamite Dunes
- Enable "arbritrary ride type" cheat (only this cheat)
- Set Dynamite Blaster (the mine train coaster) ride type to "Spiral slide" (4 ride types above "Mine Train Coaster" setting)
- Open vehicle dropdown.
- Because dynamite dunes does not have spiral slide unlocked, there will be no available vehicle, causing the items to be zero