### PR TITLE
Fix #5981: Ride list doesn't update after using quick demolish

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
 - Fix: [#5977] Custom music files not showing up in music list
+- Fix: [#5981] Ride list doesn't update after using quick demolish.
 - Fix: [#5984] Allow socket binding to same port after crash
 - Improved: [#4301] Leading and trailing whitespace in player name is now removed.
 - Improved: [#5859] OpenGL rendering performance

--- a/src/openrct2/windows/ride_list.c
+++ b/src/openrct2/windows/ride_list.c
@@ -441,6 +441,7 @@ static void window_ride_list_scrollmousedown(rct_window *w, sint32 scrollIndex, 
     if (_quickDemolishMode && network_get_mode() != NETWORK_MODE_CLIENT) {
         gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
         game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, rideIndex, GAME_COMMAND_DEMOLISH_RIDE, 0, 0);
+        window_ride_list_refresh_list(w);
     }
     else {
         window_ride_main_open(rideIndex);


### PR DESCRIPTION
Simple brain fart on my part when fixing the invalidation of the list - forgot to put `window_ride_list_refresh_list()` after the quick demolish handling code.