### PR TITLE
Fix #6010: Assert triggered when loading SC6 via file assoc

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -591,6 +591,8 @@ namespace OpenRCT2
                         }
                         else
                         {
+                            reset_sprite_spatial_index();
+                            reset_all_sprite_quadrant_placements();
                             scenario_begin();
                         }
                         return true;


### PR DESCRIPTION
`OpenParkAutoDetectFormat()` didn't call `reset_sprite_spatial_index();` or `reset_all_sprite_quadrant_placements();`, which caused `duck_remove_all();` to trigger the assert as the `gSpriteSpatialIndex` was uninitialised.

(These functions all need cleaning up, see #6011, but this is an interim fix).