### PR TITLE
Add a configure option to allow to use the system googletest suite

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ if (SYSTEM_GTEST)
     find_package(GTest REQUIRED)
 
     set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
+
+    message(WARNING "Gtest strongly advices against using a system installation, see https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#why-is-it-not-recommended-to-install-a-pre-compiled-copy-of-google-test-for-example-into-usrlocal for detailed information. If errors occur please double-check without the SYSTEM_GTEST flag.")
 else (SYSTEM_GTEST)
 
         # Bootstrap GoogleTest

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 2.6)
 
 option(DISABLE_RCT2_TESTS "Disable tests that require RollerCoaster Tycoon 2 assets.")
+option(SYSTEM_GTEST "Use the googletest library provided by the system.")
+
+if (SYSTEM_GTEST)
+    find_package(GTest REQUIRED)
+
+    set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
+else (SYSTEM_GTEST)
 
 # Bootstrap GoogleTest
 INCLUDE(ExternalProject)
@@ -52,11 +59,13 @@ set_property(TARGET ${GTEST_MAIN_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_MAI
 add_dependencies(${GTEST_LIBRARY} googletest)
 add_dependencies(${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
 
+set(GTEST_LIBRARIES gtest gtest_main pthread)
+
+endif (SYSTEM_GTEST)
+
 include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 include_directories("${ROOT_DIR}/src")
 include_directories(${SDL2_INCLUDE_DIRS})
-
-set(GTEST_LIBRARIES gtest gtest_main pthread)
 
 # Some most common files required in tests
 set(COMMON_TEST_SOURCES

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ ExternalProject_Add(
 
 
 # Specify include dir
-set(GTEST_INCLUDE_DIR ${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest/include)
+set(GTEST_INCLUDE_DIRS ${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest/include)
 
 # Library
 ExternalProject_Get_Property(googletest BINARY_DIR)
@@ -52,7 +52,7 @@ set_property(TARGET ${GTEST_MAIN_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_MAI
 add_dependencies(${GTEST_LIBRARY} googletest)
 add_dependencies(${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
 
-include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
+include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 include_directories("${ROOT_DIR}/src")
 include_directories(${SDL2_INCLUDE_DIRS})
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -9,57 +9,57 @@ if (SYSTEM_GTEST)
     set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
 else (SYSTEM_GTEST)
 
-# Bootstrap GoogleTest
-INCLUDE(ExternalProject)
+        # Bootstrap GoogleTest
+        INCLUDE(ExternalProject)
 
-ExternalProject_Add(
-        googletest-distribution
-        URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
-        URL_HASH SHA1=e7e646a6204638fe8e87e165292b8dd9cd4c36ed
-        TIMEOUT 10
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
-)
+        ExternalProject_Add(
+                googletest-distribution
+                URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+                URL_HASH SHA1=e7e646a6204638fe8e87e165292b8dd9cd4c36ed
+                TIMEOUT 10
+                CONFIGURE_COMMAND ""
+                BUILD_COMMAND ""
+                INSTALL_COMMAND ""
+        )
 
-# Specify include dir
-ExternalProject_Get_Property(googletest-distribution SOURCE_DIR)
-set(GOOGLETEST_DISTRIB_SOURCE_DIR "${SOURCE_DIR}")
+        # Specify include dir
+        ExternalProject_Get_Property(googletest-distribution SOURCE_DIR)
+        set(GOOGLETEST_DISTRIB_SOURCE_DIR "${SOURCE_DIR}")
 
-ExternalProject_Add(
-        googletest
-        DEPENDS googletest-distribution
-        DOWNLOAD_COMMAND ""
-        SOURCE_DIR "${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest"
-        CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${TARGET_M}"
-        BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-        BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-        # Disable install step
-        INSTALL_COMMAND ""
-        # Wrap download, configure and build steps in a script to log output
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON)
+        ExternalProject_Add(
+                googletest
+                DEPENDS googletest-distribution
+                DOWNLOAD_COMMAND ""
+                SOURCE_DIR "${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest"
+                CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${TARGET_M}"
+                BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                # Disable install step
+                INSTALL_COMMAND ""
+                # Wrap download, configure and build steps in a script to log output
+                LOG_DOWNLOAD ON
+                LOG_CONFIGURE ON
+                LOG_BUILD ON)
 
 
-# Specify include dir
-set(GTEST_INCLUDE_DIRS ${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest/include)
+        # Specify include dir
+        set(GTEST_INCLUDE_DIRS ${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest/include)
 
-# Library
-ExternalProject_Get_Property(googletest BINARY_DIR)
-set(GOOGLETEST_BINARY_DIR "${BINARY_DIR}")
-set(GTEST_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
-set(GTEST_MAIN_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})
-set(GTEST_LIBRARY gtest)
-set(GTEST_MAIN_LIBRARY gtest_main)
-add_library(${GTEST_LIBRARY} STATIC IMPORTED)
-add_library(${GTEST_MAIN_LIBRARY} STATIC IMPORTED)
-set_property(TARGET ${GTEST_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_LIBRARY_PATH})
-set_property(TARGET ${GTEST_MAIN_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY_PATH})
-add_dependencies(${GTEST_LIBRARY} googletest)
-add_dependencies(${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
+        # Library
+        ExternalProject_Get_Property(googletest BINARY_DIR)
+        set(GOOGLETEST_BINARY_DIR "${BINARY_DIR}")
+        set(GTEST_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
+        set(GTEST_MAIN_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})
+        set(GTEST_LIBRARY gtest)
+        set(GTEST_MAIN_LIBRARY gtest_main)
+        add_library(${GTEST_LIBRARY} STATIC IMPORTED)
+        add_library(${GTEST_MAIN_LIBRARY} STATIC IMPORTED)
+        set_property(TARGET ${GTEST_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_LIBRARY_PATH})
+        set_property(TARGET ${GTEST_MAIN_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY_PATH})
+        add_dependencies(${GTEST_LIBRARY} googletest)
+        add_dependencies(${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
 
-set(GTEST_LIBRARIES gtest gtest_main pthread)
+        set(GTEST_LIBRARIES gtest gtest_main pthread)
 
 endif (SYSTEM_GTEST)
 


### PR DESCRIPTION
This patch set introduces a new configure option SYSTEM_GTEST which forces the build system to use googletest installed on the system instead of downloading it. As long as the flag is not set (the default) the current behaviour does not change.