### PR TITLE
Fix #5865: input being handled too early

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#4931] Crash in path_paint - footpathentry was null
 - Fix: [#5768] Prevent loading non-existent title sequences.
 - Fix: [#5858] Crash when using custom ride with no colour presets.
+- Fix: [#5865] Ride preview flickering on uneven terrain or mid air.
 - Fix: [#5872] Incorrect OpenGL rendering of masked sprites
 - Fix: [#5880] Leaving bumper cars without building causes assertion.
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -284,7 +284,7 @@ void game_update()
 {
     gInUpdateCode = true;
 
-    sint32 i, numUpdates;
+    sint32 numUpdates;
 
     // 0x006E3AEC // screen_game_process_mouse_input();
     screenshot_check();
@@ -317,6 +317,25 @@ void game_update()
         network_process_game_commands();
     }
 
+    // Update the game one or more times
+    for (sint32 i = 0; i < numUpdates; i++) {
+        game_logic_update();
+
+        if (gGameSpeed > 1)
+            continue;
+
+        if (input_get_state() == INPUT_STATE_RESET ||
+            input_get_state() == INPUT_STATE_NORMAL
+        ) {
+            if (input_test_flag(INPUT_FLAG_VIEWPORT_SCROLLING)) {
+                input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
     if (!gOpenRCT2Headless)
     {
         input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
@@ -345,25 +364,6 @@ void game_update()
         gUnk141F568 = gUnk13CA740;
 
         game_handle_input();
-    }
-
-    // Update the game one or more times
-    for (i = 0; i < numUpdates; i++) {
-        game_logic_update();
-
-        if (gGameSpeed > 1)
-            continue;
-
-        if (input_get_state() == INPUT_STATE_RESET ||
-            input_get_state() == INPUT_STATE_NORMAL
-        ) {
-            if (input_test_flag(INPUT_FLAG_VIEWPORT_SCROLLING)) {
-                input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);
-                break;
-            }
-        } else {
-            break;
-        }
     }
 
     // Always perform autosave check, even when paused


### PR DESCRIPTION
This is a regression from #60bf508, I moved the input behind the logic which appears to be causing objects to flicker. The upside is there are no new desyncs moving it back to where it initially was. Should fix the issue #5865 