### PR TITLE
Fix #6023 Train length cheat maxes out trains and cars

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -7704,7 +7704,7 @@ void ride_update_max_vehicles(sint32 rideIndex, bool wasTrackChanged)
         }
         sint32 newCarsPerTrain = max(ride->proposed_num_cars_per_train, rideEntry->min_cars_in_train);
         maxCarsPerTrain = max(maxCarsPerTrain, rideEntry->min_cars_in_train);
-        if (!gCheatsDisableTrainLengthLimit || isCreating) {
+        if (!gCheatsDisableTrainLengthLimit || wasTrackChanged) {
             newCarsPerTrain = min(maxCarsPerTrain, newCarsPerTrain);
         }
         ride->min_max_cars_per_train = maxCarsPerTrain | (rideEntry->min_cars_in_train << 4);
@@ -7779,7 +7779,7 @@ void ride_update_max_vehicles(sint32 rideIndex, bool wasTrackChanged)
         maxNumTrains = rideEntry->cars_per_flat_ride;
     }
 
-    if (gCheatsDisableTrainLengthLimit && !isCreating) {
+    if (gCheatsDisableTrainLengthLimit && !wasTrackChanged) {
         maxNumTrains = 31;
     }
     numVehicles = min(ride->proposed_num_vehicles, maxNumTrains);

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -3865,7 +3865,7 @@ static money32 ride_set_setting(uint8 rideIndex, uint8 setting, uint8 value, uin
             ride_remove_peeps(rideIndex);
 
             ride->mode = value;
-            ride_update_max_vehicles(rideIndex);
+            ride_update_max_vehicles(rideIndex, false);
         }
         break;
     case RIDE_SETTING_DEPARTURE:
@@ -4818,7 +4818,7 @@ static void ride_create_vehicles_find_first_block(rct_ride *ride, rct_xy_element
  */
 static bool ride_create_vehicles(rct_ride *ride, sint32 rideIndex, rct_xy_element *element, sint32 isApplying)
 {
-    ride_update_max_vehicles(rideIndex);
+    ride_update_max_vehicles(rideIndex, false);
     if (ride->subtype == RIDE_ENTRY_INDEX_NULL) {
         return true;
     }
@@ -7664,7 +7664,7 @@ foundTrack:
  *
  *  rct2: 0x006DD57D
  */
-void ride_update_max_vehicles(sint32 rideIndex)
+void ride_update_max_vehicles(sint32 rideIndex, bool wasTrackChanged)
 {
     rct_ride *ride = get_ride(rideIndex);
     if (ride->subtype == RIDE_ENTRY_INDEX_NULL)
@@ -7704,7 +7704,7 @@ void ride_update_max_vehicles(sint32 rideIndex)
         }
         sint32 newCarsPerTrain = max(ride->proposed_num_cars_per_train, rideEntry->min_cars_in_train);
         maxCarsPerTrain = max(maxCarsPerTrain, rideEntry->min_cars_in_train);
-        if (!gCheatsDisableTrainLengthLimit) {
+        if (!gCheatsDisableTrainLengthLimit || isCreating) {
             newCarsPerTrain = min(maxCarsPerTrain, newCarsPerTrain);
         }
         ride->min_max_cars_per_train = maxCarsPerTrain | (rideEntry->min_cars_in_train << 4);
@@ -7779,7 +7779,7 @@ void ride_update_max_vehicles(sint32 rideIndex)
         maxNumTrains = rideEntry->cars_per_flat_ride;
     }
 
-    if (gCheatsDisableTrainLengthLimit) {
+    if (gCheatsDisableTrainLengthLimit && !isCreating) {
         maxNumTrains = 31;
     }
     numVehicles = min(ride->proposed_num_vehicles, maxNumTrains);
@@ -7964,7 +7964,7 @@ static money32 ride_set_vehicles(uint8 rideIndex, uint8 setting, uint8 value, ui
     }
 
     ride->num_circuits = 1;
-    ride_update_max_vehicles(rideIndex);
+    ride_update_max_vehicles(rideIndex, false);
 
     if (ride->overall_view.xy != RCT_XY8_UNDEFINED) {
         rct_xyz16 coord;

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -1152,7 +1152,7 @@ void ride_fix_breakdown(sint32 rideIndex, sint32 reliabilityIncreaseFactor);
 
 void ride_entry_get_train_layout(sint32 rideEntryIndex, sint32 numCarsPerTrain, uint8 *trainLayout);
 uint8 ride_entry_get_vehicle_at_position(sint32 rideEntryIndex, sint32 numCarsPerTrain, sint32 position);
-void ride_update_max_vehicles(sint32 rideIndex);
+void ride_update_max_vehicles(sint32 rideIndex, bool wasTrackChanged);
 uint64 ride_entry_get_supported_track_pieces(rct_ride_entry* rideEntry);
 
 void ride_set_ride_entry(sint32 rideIndex, sint32 rideEntry);

--- a/src/openrct2/ride/track.c
+++ b/src/openrct2/ride/track.c
@@ -1374,7 +1374,7 @@ static money32 track_place(sint32 rideIndex, sint32 type, sint32 originX, sint32
                 track_add_station_element(x, y, baseZ, direction, rideIndex, GAME_COMMAND_FLAG_APPLY);
             }
             sub_6CB945(rideIndex);
-            ride_update_max_vehicles(rideIndex);
+            ride_update_max_vehicles(rideIndex, true);
         }
 
         if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER){
@@ -1634,7 +1634,7 @@ static money32 track_remove(uint8 type, uint8 sequence, sint16 originX, sint16 o
         map_element_remove(mapElement);
         sub_6CB945(rideIndex);
         if (!(flags & (1 << 6))){
-            ride_update_max_vehicles(rideIndex);
+            ride_update_max_vehicles(rideIndex, true);
         }
     }
 


### PR DESCRIPTION
By adding a paramter to ride_update_max_vehicles that is only set true when called from track_add/track_remove, the default train / vehicle setting will be used when a ride is created or a track is modified, while still allowing a user to explicitly modify the train length up to the cheats limit. This will prevent new rides being maxed out if the cheat is enabled.