### PR TITLE
Refactored asserts always calling the function regardless of expression.

### DIFF
--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -34,12 +34,9 @@
 
 extern "C"
 {
-    void openrct2_assert(bool expression, const char * message, ...)
+    void openrct2_assert_va(bool expression, const char * message, va_list va)
     {
-        va_list args;
-        va_start(args, message);
-        Guard::Assert_VA(expression, message, args);
-        va_end(args);
+        Guard::Assert_VA(expression, message, va);
     }
 
 }

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -16,16 +16,24 @@
 
 #pragma once
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void openrct2_assert(bool expression, const char * message, ...);
+void openrct2_assert_va(bool expression, const char * message, va_list va);
+inline void openrct2_assert(bool expression, const char * message, ...)
+{
+    if (!expression) return;
+    va_list va;
+    va_start(va, message);
+    openrct2_assert_va(expression, message, va);
+    va_end(va);
+}
 
 #ifdef __cplusplus
 }
-
-#include <stdarg.h>
 
 enum class ASSERT_BEHAVIOUR
 {


### PR DESCRIPTION
When I was profiling I noticed openrct2_assert always showed up, this eliminates the call if the expression isn't true.