### PR TITLE
Fix compilation with gcc 4.9.4

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -265,3 +265,13 @@ if (NOT DISABLE_RCT2)
     # builds without need for -fno-omit-frame-pointer
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/rct2/addresses.c PROPERTIES COMPILE_FLAGS -O0)
 endif ()
+
+if (CXX_WARN_SUGGEST_FINAL_TYPES)
+    # Disable -Wsuggest-final-types via pragmas where due.
+   add_definitions(-D__WARN_SUGGEST_FINAL_TYPES__)
+endif ()
+
+if (CXX_WARN_SUGGEST_FINAL_METHODS)
+    # Disable -Wsuggest-final-methods via pragmas where due.
+   add_definitions(-D__WARN_SUGGEST_FINAL_METHODS__)
+endif ()

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -23,7 +23,7 @@ extern "C" {
 #endif // __cplusplus
 
 void openrct2_assert_va(bool expression, const char * message, va_list va);
-inline void openrct2_assert(bool expression, const char * message, ...)
+static inline void openrct2_assert(bool expression, const char * message, ...)
 {
     if (!expression) return;
     va_list va;

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -133,8 +133,10 @@ void X8RainDrawer::Restore()
     }
 }
 
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
+#endif
 
 X8DrawingEngine::X8DrawingEngine(Ui::IUiContext * uiContext)
 {
@@ -468,7 +470,9 @@ void X8DrawingEngine::DrawDirtyBlocks(uint32 x, uint32 y, uint32 columns, uint32
     window_draw_all(&_bitsDPI, left, top, right, bottom);
 }
 
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
 #pragma GCC diagnostic pop
+#endif
 
 X8DrawingContext::X8DrawingContext(X8DrawingEngine * engine)
 {

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -66,8 +66,10 @@ namespace OpenRCT2
             void Restore();
         };
 
+#ifdef __WARN_SUGGEST_FINAL_TYPES__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#endif
         class X8DrawingEngine : public IDrawingEngine
         {
         protected:
@@ -119,7 +121,9 @@ namespace OpenRCT2
             void DrawAllDirtyBlocks();
             void DrawDirtyBlocks(uint32 x, uint32 y, uint32 columns, uint32 rows);
         };
+#ifdef __WARN_SUGGEST_FINAL_TYPES__
     #pragma GCC diagnostic pop
+#endif
 
         class X8DrawingContext final : public IDrawingContext
         {


### PR DESCRIPTION
This fixes  #6030  which enables compilation with gcc 4.9.4 again. 
It's also more correct: The special warning types are now only disabled via pragmas if the compiler was tested to actually support them. 