### PR TITLE
Fix #6009. Actually check for the correct map element when deleteing.

### DIFF
--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -82,6 +82,8 @@ static money32 SmallSceneryRemove(sint16 x, sint16 y, sint8 baseHeight, uint8 qu
     bool sceneryFound = false;
     rct_map_element* mapElement = map_get_first_element_at(x / 32, y / 32);
     do {
+        if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_SCENERY)
+            continue;
         if ((mapElement->type >> 6) != quadrant)
             continue;
         if (mapElement->base_height != baseHeight)


### PR DESCRIPTION
Fix #6009.
Mistake made during refactor. The old code passed the map element type and quadrant in the same parameter. I refactored it so that it only checked the quadrant.