### PR TITLE
Fix #5943: Track preview for mazes not drawn when paused

### DIFF
--- a/src/openrct2/ride/track_design.h
+++ b/src/openrct2/ride/track_design.h
@@ -37,7 +37,7 @@ typedef struct rct_td6_maze_element {
             union {
                 uint16 maze_entry;
                 struct{
-                    uint8 unk_2;
+                    uint8 direction;
                     uint8 type;
                 };
             };
@@ -189,6 +189,12 @@ enum {
     PTD_OPERATION_4,
     PTD_OPERATION_GET_COST,
     PTD_OPERATION_CLEAR_OUTLINES,
+};
+
+enum {
+    MAZE_ELEMENT_TYPE_MAZE_TRACK = 0,
+    MAZE_ELEMENT_TYPE_ENTRANCE = (1 << 3),
+    MAZE_ELEMENT_TYPE_EXIT = (1 << 7)
 };
 
 extern rct_track_td6 *gActiveTrackDesign;

--- a/src/openrct2/ride/track_design_save.c
+++ b/src/openrct2/ride/track_design_save.c
@@ -883,7 +883,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
     // Add something that stops this from walking off the end
 
     uint8 entrance_direction = map_element_get_direction(mapElement);
-    maze->unk_2 = entrance_direction;
+    maze->direction = entrance_direction;
     maze->type = 8;
     maze->x = (sint8)((x - startX) / 32);
     maze->y = (sint8)((y - startY) / 32);
@@ -908,7 +908,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
     // Add something that stops this from walking off the end
 
     uint8 exit_direction = map_element_get_direction(mapElement);
-    maze->unk_2 = exit_direction;
+    maze->direction = exit_direction;
     maze->type = 0x80;
     maze->x = (sint8)((x - startX) / 32);
     maze->y = (sint8)((y - startY) / 32);


### PR DESCRIPTION
This fixes #5943 - the root cause there being `GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED ` not being set for mazes if `trackDesignPlaceOperation == PTD_OPERATION_GET_COST` - and also makes an attempt to clean up `track_design_place_maze()`.