### PR TITLE
Fix #6007: 'Felicity Anderson' can affect peeps entering rides

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -11273,7 +11273,7 @@ static void peep_make_passing_peeps_sick(rct_peep *peep, rct_peep *otherPeep)
 {
     if (peep == otherPeep)
         return;
-    if (otherPeep->state == PEEP_STATE_QUEUING)
+    if (otherPeep->state != PEEP_STATE_WALKING)
         return;
 
     if (otherPeep->action == PEEP_ACTION_NONE_1 || otherPeep->action == PEEP_ACTION_NONE_2) {


### PR DESCRIPTION
Turns out that #6007 is another form of #1992 - this PR expands the fix for #1992 by ensuring that the 'Felicity Anderson' easter egg can only affect peeps who are walking on paths not (for example) entering a ride.