### PR TITLE
Fix #6052: Unable to place entrance/exit on certain ride types.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#5984] Allow socket binding to same port after crash
 - Fix: [#5998] Staff not getting paid / no loan interest.
 - Fix: [#6026] 'Select ride to advertise' dropdown does not display all items.
+- Fix: [#6052] Unable to place entrance/exit on certain ride types.
 - Improved: [#4301] Leading and trailing whitespace in player name is now removed.
 - Improved: [#5859] OpenGL rendering performance
 - Improved: [#5863] Switching drawing engines no longer requires the application to restart.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -1400,10 +1400,11 @@ void ride_remove_provisional_track_piece()
 
     ride = get_ride(rideIndex);
     if (ride->type == RIDE_TYPE_MAZE) {
-        game_do_command(x     , 41 | (0 << 8), y     , rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
-        game_do_command(x     , 41 | (1 << 8), y + 16, rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
-        game_do_command(x + 16, 41 | (2 << 8), y + 16, rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
-        game_do_command(x + 16, 41 | (3 << 8), y     , rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
+        sint32 flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
+        game_do_command(x     , flags | (0 << 8), y     , rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
+        game_do_command(x     , flags | (1 << 8), y + 16, rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
+        game_do_command(x + 16, flags | (2 << 8), y + 16, rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
+        game_do_command(x + 16, flags | (3 << 8), y     , rideIndex | (2 << 8), GAME_COMMAND_SET_MAZE_TRACK, z, 0);
     } else {
         direction = _unkF440C5.direction;
         if (!(direction & 4)) {
@@ -1411,11 +1412,11 @@ void ride_remove_provisional_track_piece()
             y -= TileDirectionDelta[direction].y;
         }
         rct_xy_element next_track;
-
         if (track_block_get_next_from_zero(x, y, z, rideIndex, direction, &next_track, &z, &direction)) {
+            sint32 flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5 | GAME_COMMAND_FLAG_GHOST;
             game_do_command(
                 next_track.x,
-                105 | ((direction & 3) << 8),
+                flags | ((direction & 3) << 8),
                 next_track.y,
                 next_track.element->properties.track.type | (map_element_get_track_sequence(next_track.element) << 8),
                 GAME_COMMAND_REMOVE_TRACK,

--- a/src/openrct2/ride/track.c
+++ b/src/openrct2/ride/track.c
@@ -1632,8 +1632,8 @@ static money32 track_remove(uint8 type, uint8 sequence, sint16 originX, sint16 o
             footpath_remove_edges_at(x, y, mapElement);
         }
         map_element_remove(mapElement);
-        sub_6CB945(rideIndex);
-        if (!(flags & (1 << 6))){
+        if (!(flags & GAME_COMMAND_FLAG_GHOST)){
+            sub_6CB945(rideIndex);
             ride_update_max_vehicles(rideIndex);
         }
     }


### PR DESCRIPTION
The issue is caused by ride types that don't automatically close the construction window which leads to execute following condition:
https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/map.c#L3374-L3378
Which later executes GAME_COMMAND_REMOVE_TRACK with the ghost flag set:
https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/ride/ride.c#L1416-L1424
But then ignores the ghost flag and removes the entrances. I've also refactored the flags to use the actual named flags.