### PR TITLE
Fix #5912: Negative queue when moving entrance in paused state.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#5858] Crash when using custom ride with no colour presets.
 - Fix: [#5872] Incorrect OpenGL rendering of masked sprites
 - Fix: [#5880] Leaving bumper cars without building causes assertion.
+- Fix: [#5912] Negative queue when moving entrance in paused state.
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
 - Fix: [#5977] Custom music files not showing up in music list

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -2317,7 +2317,13 @@ void remove_peep_from_queue(rct_peep* peep)
     rct_ride* ride = get_ride(peep->current_ride);
 
     uint8 cur_station = peep->current_ride_station;
-    ride->queue_length[cur_station]--;
+    // Make sure we don't underflow, building while paused might reset it to 0 where peeps have 
+    // not yet left the queue.
+    if (ride->queue_length[cur_station] > 0)
+    {
+        ride->queue_length[cur_station]--;
+    }
+
     if (peep->sprite_index == ride->last_peep_in_queue[cur_station])
     {
         ride->last_peep_in_queue[cur_station] = peep->next_in_queue;


### PR DESCRIPTION
When moving the entrance with queued peeps it would reset the queue back to zero while peeps are still within the queue. Once resumed peeps would update their state and call remove_peep_from_queue causing a underflow which resulted peeps in thinking the queue is full.