### PR TITLE
Refactored openrct2_assert to not rely on inlining.

### DIFF
--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -34,11 +34,13 @@
 
 extern "C"
 {
-    void openrct2_assert_va(bool expression, const char * message, va_list va)
+    void openrct2_assert_fwd(bool expression, const char * message, ...)
     {
+        va_list va;
+        va_start(va, message);
         Guard::Assert_VA(expression, message, va);
+        va_end(va);
     }
-
 }
 
 namespace Guard

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -22,15 +22,9 @@
 extern "C" {
 #endif // __cplusplus
 
-void openrct2_assert_va(bool expression, const char * message, va_list va);
-static inline void openrct2_assert(bool expression, const char * message, ...)
-{
-    if (!expression) return;
-    va_list va;
-    va_start(va, message);
-    openrct2_assert_va(expression, message, va);
-    va_end(va);
-}
+void openrct2_assert_fwd(bool expression, const char * message, ...);
+
+#define openrct2_assert(expr, msg, ...) if(!(expr)) { openrct2_assert_fwd((expr), msg, ##__VA_ARGS__); }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Using a macro will guarantee that it will be inlined and it also fixes a small mistake of having the expression tested wrong for the early exit made in #6031.