### PR TITLE
Refactor game load functions, resolves #6011

### DIFF
--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <openrct2/Context.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/ParkImporter.h>
 #include <openrct2/network/network.h>
@@ -169,18 +170,14 @@ static void window_server_start_close(rct_window *w)
 static void window_server_start_scenarioselect_callback(const utf8 *path)
 {
     network_set_password(_password);
-    ParkLoadResult * result = scenario_load_and_play_from_path(path);
-    if (ParkLoadResult_GetError(result) == PARK_LOAD_ERROR_OK) {
+    if (context_load_park_from_file(path)) {
         network_begin_server(gConfigNetwork.default_port, gConfigNetwork.listen_address);
-    } else {
-        handle_park_load_failure(result, path);
     }
-    ParkLoadResult_Delete(result);
 }
 
 static void window_server_start_loadsave_callback(sint32 result, const utf8 * path)
 {
-    if (result == MODAL_RESULT_OK && game_load_save_or_scenario(path)) {
+    if (result == MODAL_RESULT_OK && context_load_park_from_file(path)) {
         network_begin_server(gConfigNetwork.default_port, gConfigNetwork.listen_address);
     }
 }

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -134,9 +134,7 @@ rct_window * window_title_menu_open()
 
 static void window_title_menu_scenarioselect_callback(const utf8 *path)
 {
-    ParkLoadResult * result = scenario_load_and_play_from_path(path);
-    handle_park_load_failure(result, path);
-    ParkLoadResult_Delete(result);
+    context_load_park_from_file(path);
 }
 
 static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -373,7 +373,7 @@ namespace OpenRCT2
         bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) final override
         {
             auto fs = FileStream(path, FILE_MODE_OPEN);
-            return LoadParkFromStream(&fs, path, false);
+            return LoadParkFromStream(&fs, path, loadTitleScreenOnFail);
         }
 
     private:

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -466,7 +466,10 @@ namespace OpenRCT2
                 {
                     try
                     {
-                        LoadParkFromFile(gOpenRCT2StartupActionPath, true);
+                        if (!LoadParkFromFile(gOpenRCT2StartupActionPath, true))
+                        {
+                            break;
+                        }
                     }
                     catch (const std::exception &ex)
                     {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -712,21 +712,25 @@ namespace OpenRCT2
                         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
                         if (info.Type == FILE_TYPE::SAVED_GAME)
                         {
-                            if (network_get_mode() == NETWORK_MODE_CLIENT) {
+                            if (network_get_mode() == NETWORK_MODE_CLIENT)
+                            {
                                 network_close();
                             }
                             game_load_init();
-                            if (network_get_mode() == NETWORK_MODE_SERVER) {
+                            if (network_get_mode() == NETWORK_MODE_SERVER)
+                            {
                                 network_send_map();
                             }
                         }
                         else
                         {
                             scenario_begin();
-                            if (network_get_mode() == NETWORK_MODE_SERVER) {
+                            if (network_get_mode() == NETWORK_MODE_SERVER)
+                            {
                                     network_send_map();
                             }
-                            if (network_get_mode() == NETWORK_MODE_CLIENT) {
+                            if (network_get_mode() == NETWORK_MODE_CLIENT)
+                            {
                                 network_close();
                             }
                         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -370,10 +370,10 @@ namespace OpenRCT2
             return true;
         }
 
-        void Open(const std::string &path) final override
+        bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) final override
         {
             auto fs = FileStream(path, FILE_MODE_OPEN);
-            OpenParkAutoDetectFormat(&fs, path);
+            return LoadParkFromStream(&fs, path, false);
         }
 
     private:
@@ -454,7 +454,7 @@ namespace OpenRCT2
                     }
 
                     auto ms = MemoryStream(data, dataSize, MEMORY_ACCESS::OWNER);
-                    if (!OpenParkAutoDetectFormat(&ms, gOpenRCT2StartupActionPath))
+                    if (!LoadParkFromStream(&ms, gOpenRCT2StartupActionPath, true))
                     {
                         Console::Error::WriteLine("Failed to load '%s'", gOpenRCT2StartupActionPath);
                         title_load();
@@ -466,7 +466,7 @@ namespace OpenRCT2
                 {
                     try
                     {
-                        Open(gOpenRCT2StartupActionPath);
+                        LoadParkFromFile(gOpenRCT2StartupActionPath, true);
                     }
                     catch (const std::exception &ex)
                     {
@@ -679,21 +679,23 @@ namespace OpenRCT2
             console_update();
         }
 
-        bool OpenParkAutoDetectFormat(IStream * stream, const std::string &path)
+        bool LoadParkFromStream(IStream * stream, const std::string &path, bool loadTitleScreenFirstOnFail)
         {
-            ClassifiedFile info;
+            ClassifiedFileInfo info;
             if (TryClassifyFile(stream, &info))
             {
                 if (info.Type == FILE_TYPE::SAVED_GAME ||
                     info.Type == FILE_TYPE::SCENARIO)
                 {
                     std::unique_ptr<IParkImporter> parkImporter;
-                    if (info.Version <= 2)
+                    if (info.Version <= FILE_TYPE_S4_CUTOFF)
                     {
+                        // Save is an S4 (RCT1 format)
                         parkImporter.reset(ParkImporter::CreateS4());
                     }
                     else
                     {
+                        // Save is an S6 (RCT2 format)
                         parkImporter.reset(ParkImporter::CreateS6(_objectRepository, _objectManager));
                     }
 
@@ -707,20 +709,34 @@ namespace OpenRCT2
                         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
                         if (info.Type == FILE_TYPE::SAVED_GAME)
                         {
+                            if (network_get_mode() == NETWORK_MODE_CLIENT) {
+                                network_close();
+                            }
                             game_load_init();
+                            if (network_get_mode() == NETWORK_MODE_SERVER) {
+                                network_send_map();
+                            }
                         }
                         else
                         {
-                            reset_sprite_spatial_index();
-                            reset_all_sprite_quadrant_placements();
                             scenario_begin();
+                            if (network_get_mode() == NETWORK_MODE_SERVER) {
+                                    network_send_map();
+                            }
+                            if (network_get_mode() == NETWORK_MODE_CLIENT) {
+                                network_close();
+                            }
                         }
+                        // This ensures that the newly loaded save reflects the user's
+                        // 'show real names of guests' option, now that it's a global setting
+                        peep_update_names(gConfigGeneral.show_real_names_of_guests);
                         return true;
                     }
                     else
                     {
-                        handle_park_load_failure_with_title_opt(&result, path.c_str(), true);
+                        handle_park_load_failure_with_title_opt(&result, path.c_str(), loadTitleScreenFirstOnFail);
                     }
+
                 }
                 else
                 {
@@ -828,6 +844,11 @@ namespace OpenRCT2
 
 extern "C"
 {
+    bool context_load_park_from_file(const utf8 * path)
+    {
+        return GetContext()->LoadParkFromFile(path);
+    }
+
     void openrct2_write_full_version_info(utf8 * buffer, size_t bufferSize)
     {
         String::Set(buffer, bufferSize, gVersionInfoFull);

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -96,7 +96,7 @@ namespace OpenRCT2
         virtual sint32 RunOpenRCT2(int argc, char * * argv) abstract;
 
         virtual bool Initialise() abstract;
-        virtual void Open(const std::string &path) abstract;
+        virtual bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) abstract;
         virtual void Finish() abstract;
         virtual void Quit() abstract;
 
@@ -214,6 +214,7 @@ extern "C"
     bool context_read_bmp(void * * outPixels, uint32 * outWidth, uint32 * outHeight, const utf8 * path);
     void context_quit();
     const utf8 * context_get_path_legacy(sint32 pathId);
+    bool context_load_park_from_file(const utf8 * path);
 #ifdef __cplusplus
 }
 #endif

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -25,11 +25,11 @@ extern "C"
     #include "util/sawyercoding.h"
 }
 
-static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result);
-static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result);
-static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFile * result);
+static bool TryClassifyAsS6(IStream * stream, ClassifiedFileInfo * result);
+static bool TryClassifyAsS4(IStream * stream, ClassifiedFileInfo * result);
+static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFileInfo * result);
 
-bool TryClassifyFile(const std::string &path, ClassifiedFile * result)
+bool TryClassifyFile(const std::string &path, ClassifiedFileInfo * result)
 {
     try
     {
@@ -42,7 +42,7 @@ bool TryClassifyFile(const std::string &path, ClassifiedFile * result)
     }
 }
 
-bool TryClassifyFile(IStream * stream, ClassifiedFile * result)
+bool TryClassifyFile(IStream * stream, ClassifiedFileInfo * result)
 {
     // TODO Currently track designs get classified as SC4s because they use the
     //      same checksum algorithm. The only way after to tell the difference
@@ -70,7 +70,7 @@ bool TryClassifyFile(IStream * stream, ClassifiedFile * result)
     return false;
 }
 
-static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result)
+static bool TryClassifyAsS6(IStream * stream, ClassifiedFileInfo * result)
 {
     bool success = false;
     uint64 originalPosition = stream->GetPosition();
@@ -96,7 +96,7 @@ static bool TryClassifyAsS6(IStream * stream, ClassifiedFile * result)
     return success;
 }
 
-static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result)
+static bool TryClassifyAsS4(IStream * stream, ClassifiedFileInfo * result)
 {
     uint64 originalPosition = stream->GetPosition();
     size_t dataLength = (size_t)stream->GetLength();
@@ -124,7 +124,7 @@ static bool TryClassifyAsS4(IStream * stream, ClassifiedFile * result)
     return false;
 }
 
-static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFile * result)
+static bool TryClassifyAsTD4_TD6(IStream * stream, ClassifiedFileInfo * result)
 {
     bool success = false;
     uint64 originalPosition = stream->GetPosition();

--- a/src/openrct2/FileClassifier.h
+++ b/src/openrct2/FileClassifier.h
@@ -45,14 +45,15 @@ enum class FILE_TYPE
     TRACK_DESIGN,
 };
 
-struct ClassifiedFile
+struct ClassifiedFileInfo
 {
     FILE_TYPE Type;
     uint32    Version;
 };
 
-bool TryClassifyFile(const std::string &path, ClassifiedFile * result);
-bool TryClassifyFile(IStream * stream, ClassifiedFile * result);
+#define FILE_TYPE_S4_CUTOFF 2
+bool TryClassifyFile(const std::string &path, ClassifiedFileInfo * result);
+bool TryClassifyFile(IStream * stream, ClassifiedFileInfo * result);
 
 #endif // __cplusplus
 

--- a/src/openrct2/editor.c
+++ b/src/openrct2/editor.c
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include "audio/audio.h"
+#include "Context.h"
 #include "drawing/drawing.h"
 #include "editor.h"
 #include "FileClassifier.h"
@@ -121,7 +122,7 @@ static void editor_convert_save_to_scenario_callback(sint32 result, const utf8 *
         return;
     }
 
-    if (!game_load_save_or_scenario(path)) {
+    if (!context_load_park_from_file(path)) {
         return;
     }
 
@@ -232,7 +233,7 @@ bool editor_load_landscape(const utf8 *path)
  */
 static sint32 editor_load_landscape_from_sv4(const char *path)
 {
-    rct1_load_saved_game(path);
+    load_from_sv4(path);
     editor_clear_map_for_editing(true);
 
     gS6Info.editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
@@ -246,7 +247,7 @@ static sint32 editor_load_landscape_from_sv4(const char *path)
 
 static sint32 editor_load_landscape_from_sc4(const char *path)
 {
-    rct1_load_scenario(path);
+    load_from_sc4(path);
     editor_clear_map_for_editing(false);
 
     gS6Info.editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
@@ -267,9 +268,9 @@ static sint32 editor_read_s6(const char *path)
     ParkLoadResult * loadResult = NULL;
     const char *extension = path_get_extension(path);
     if (_stricmp(extension, ".sc6") == 0) {
-        loadResult = scenario_load(path);
+        loadResult = load_from_sc6(path);
     } else if (_stricmp(extension, ".sv6") == 0) {
-        loadResult = game_load_sv6_path(path);
+        loadResult = load_from_sv6(path);
     }
     if (ParkLoadResult_GetError(loadResult) != PARK_LOAD_ERROR_OK) {
         ParkLoadResult_Delete(loadResult);

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -169,8 +169,7 @@ sint32 game_do_command_p(sint32 command, sint32 *eax, sint32 *ebx, sint32 *ecx, 
 void game_log_multiplayer_command(int command, int *eax, int* ebx, int* ecx, int* edx, int* edi, int* ebp);
 
 void game_load_or_quit_no_save_prompt();
-ParkLoadResult * game_load_sv6_path(const char * path);
-bool game_load_save(const utf8 *path);
+ParkLoadResult * load_from_sv6(const char * path);
 void game_load_init();
 void game_pause_toggle(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp);
 void pause_toggle();
@@ -187,7 +186,6 @@ void game_convert_strings_to_utf8();
 void game_convert_news_items_to_utf8();
 void game_convert_strings_to_rct2(rct_s6_data *s6);
 void game_fix_save_vars();
-bool game_load_save_or_scenario(const utf8 * path);
 void game_init_all(sint32 mapSize);
 
 #endif

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -268,7 +268,7 @@ sint32 cmdline_for_gfxbench(const char **argv, sint32 argc)
     if (context->Initialise())
     {
         drawing_engine_init();
-        context->Open(inputPath);
+        context->LoadParkFromFile(inputPath);
 
         gIntroState = INTRO_STATE_NONE;
         gScreenFlags = SCREEN_FLAGS_PLAYING;
@@ -387,7 +387,7 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
     if (context->Initialise())
     {
         drawing_engine_init();
-        context->Open(inputPath);
+        context->LoadParkFromFile(inputPath);
 
         gIntroState = INTRO_STATE_NONE;
         gScreenFlags = SCREEN_FLAGS_PLAYING;

--- a/src/openrct2/rct1.h
+++ b/src/openrct2/rct1.h
@@ -1217,8 +1217,8 @@ extern const uint8 gRideCategories[RIDE_TYPE_COUNT];
 
 bool rideTypeShouldLoseSeparateFlag(const rct_ride_entry *rideEntry);
 
-ParkLoadResult * rct1_load_saved_game(const char *path);
-ParkLoadResult * rct1_load_scenario(const char *path);
+ParkLoadResult * load_from_sv4(const char *path);
+ParkLoadResult * load_from_sc4(const char *path);
 
 colour_t rct1_get_colour(colour_t colour);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2631,7 +2631,7 @@ IParkImporter * ParkImporter::CreateS4()
 /////////////////////////////////////////
 extern "C"
 {
-    ParkLoadResult * rct1_load_saved_game(const utf8 * path)
+    ParkLoadResult * load_from_sv4(const utf8 * path)
     {
         ParkLoadResult * result = nullptr;
         auto s4Importer = std::make_unique<S4Importer>();
@@ -2651,7 +2651,7 @@ extern "C"
         return result;
     }
 
-    ParkLoadResult * rct1_load_scenario(const utf8 * path)
+    ParkLoadResult * load_from_sc4(const utf8 * path)
     {
         ParkLoadResult * result = nullptr;
         auto s4Importer = std::make_unique<S4Importer>();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -670,7 +670,7 @@ IParkImporter * ParkImporter::CreateS6(IObjectRepository * objectRepository, IOb
 
 extern "C"
 {
-    ParkLoadResult * game_load_sv6_path(const char * path)
+    ParkLoadResult * load_from_sv6(const char * path)
     {
         ParkLoadResult * result = nullptr;
         auto s6Importer = new S6Importer(GetObjectRepository(), GetObjectManager());
@@ -722,7 +722,7 @@ extern "C"
      *  rct2: 0x00676053
      * scenario (ebx)
      */
-    ParkLoadResult * scenario_load(const char * path)
+    ParkLoadResult * load_from_sc6(const char * path)
     {
         ParkLoadResult * result = nullptr;
         auto s6Importer = new S6Importer(GetObjectRepository(), GetObjectManager());

--- a/src/openrct2/scenario/scenario.h
+++ b/src/openrct2/scenario/scenario.h
@@ -391,8 +391,7 @@ extern uint32 gLastAutoSaveUpdate;
 
 extern char gScenarioFileName[260];
 
-ParkLoadResult * scenario_load(const char *path);
-ParkLoadResult * scenario_load_and_play_from_path(const char *path);
+ParkLoadResult * load_from_sc6(const char *path);
 void scenario_begin();
 void scenario_update();
 

--- a/src/openrct2/windows/TopToolbar.cpp
+++ b/src/openrct2/windows/TopToolbar.cpp
@@ -520,9 +520,7 @@ static void window_top_toolbar_mousedown(rct_window *w, rct_widgetindex widgetIn
 
 static void window_top_toolbar_scenarioselect_callback(const utf8 *path)
 {
-    ParkLoadResult * result = scenario_load_and_play_from_path(path);
-    handle_park_load_failure(result, path);
-    ParkLoadResult_Delete(result);
+    context_load_park_from_file(path);
 }
 
 /**

--- a/test/tests/MultiLaunch.cpp
+++ b/test/tests/MultiLaunch.cpp
@@ -30,7 +30,7 @@ TEST(MultiLaunchTest, all)
         bool initialised = context->Initialise();
         ASSERT_TRUE(initialised);
 
-        ParkLoadResult * plr = game_load_sv6_path(path.c_str());
+        ParkLoadResult * plr = load_from_sv6(path.c_str());
 
         ASSERT_EQ(ParkLoadResult_GetError(plr), PARK_LOAD_ERROR_OK);
         ParkLoadResult_Delete(plr);

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -67,7 +67,7 @@ TEST_F(RideRatings, all)
     bool initialised = context->Initialise();
     ASSERT_TRUE(initialised);
 
-    game_load_sv6_path(path.c_str());
+    load_from_sv6(path.c_str());
 
     // Check ride count to check load was successful
     ASSERT_EQ(gRideCount, 134);


### PR DESCRIPTION
This PR refactors the various disparate 'load this file and run it' functions - there is now one overarching 'load and play' function - `Context->LoadParkFromFile()`, and a C wrapper `context_load_park_from_file()` that autodetects the format and calls the appropriate lower-level functions.

I've also renamed the ParkImporter C wrappers to follow a standard pattern - `load_from_EXT`. This way it is clearer what does what, and it'll be easy to extend this with a `load_from_orct2park` (or whatever we'll call our own file format).

(I'm aware that the editor still relies on the lower-level functions, and that there may be more scope for streamlining withing Context.cpp, but this is the first step at least.)