### PR TITLE
Clean up and improve UI of track install window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3383,7 +3383,7 @@ STR_3372    :{BLACK}= Cash Machine
 STR_3373    :{BLACK}= Toilet
 STR_3374    :Warning: Too many objects selected!
 STR_3375    :Not all objects in this scenery group could be selected
-STR_3376    :Install new track design...
+STR_3376    :Install new
 STR_3377    :{SMALLFONT}{BLACK}Install a new track design file
 STR_3378    :Install
 STR_3379    :Cancel
@@ -4450,6 +4450,8 @@ STR_6138    :OpenRCT2 is the work of many authors, a full list can be found in {
 STR_6139    :All product and company names belong to their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 STR_6140    :Changelog...
 STR_6141    :RCT1 Bottom Toolbar
+STR_6142    :{WINDOW_COLOUR_2}Track name: {BLACK}{STRING}
+STR_6143    :{WINDOW_COLOUR_2}Ride type: {BLACK}{STRINGID}
 
 #############
 # Scenarios #

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -225,8 +225,7 @@ typedef struct scenery_variables {
 } scenery_variables;
 
 typedef struct track_list_variables {
-    uint16 var_480;
-    uint16 var_484;
+    bool track_list_being_updated;
     bool reload_track_designs;
 } track_list_variables;
 

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3788,6 +3788,9 @@ enum {
 
     STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR = 6141,
 
+    STR_TRACK_DESIGN_NAME = 6142,
+    STR_TRACK_DESIGN_TYPE = 6143,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/windows/TrackList.cpp
+++ b/src/openrct2/windows/TrackList.cpp
@@ -144,8 +144,7 @@ static void _window_track_list_open(ride_list_item item)
     w->widgets = window_track_list_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_ROTATE) | (1 << WIDX_TOGGLE_SCENERY) | (1 << WIDX_BACK);
     window_init_scroll_widgets(w);
-    w->track_list.var_480 = 0xFFFF;
-    w->track_list.var_484 = 0;
+    w->track_list.track_list_being_updated = false;
     w->track_list.reload_track_designs = false;
     w->selected_list_item = 0;
     if (_trackDesignsCount != 0 && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
@@ -198,8 +197,6 @@ static void window_track_list_close(rct_window *w)
  */
 static void window_track_list_select(rct_window *w, sint32 index)
 {
-    w->track_list.var_480 = index;
-
     // Displays a message if the ride can't load, fix #4080
     if (_loadedTrackDesign == nullptr) {
         window_error_open(STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TRACK_LOAD_FAILED_ERROR);
@@ -298,7 +295,7 @@ static void window_track_list_scrollgetsize(rct_window *w, sint32 scrollIndex, s
  */
 static void window_track_list_scrollmousedown(rct_window *w, sint32 scrollIndex, sint32 x, sint32 y)
 {
-    if (!(w->track_list.var_484 & 1)) {
+    if (!w->track_list.track_list_being_updated) {
         sint32 i = window_track_list_get_list_item_index_from_position(x, y);
         if (i != -1) {
             window_track_list_select(w, i);
@@ -312,7 +309,7 @@ static void window_track_list_scrollmousedown(rct_window *w, sint32 scrollIndex,
  */
 static void window_track_list_scrollmouseover(rct_window *w, sint32 scrollIndex, sint32 x, sint32 y)
 {
-    if (!(w->track_list.var_484 & 1)) {
+    if (!w->track_list.track_list_being_updated) {
         sint32 i = window_track_list_get_list_item_index_from_position(x, y);
         if (i != -1 && w->selected_list_item != i) {
             w->selected_list_item = i;

--- a/src/openrct2/windows/TrackManage.cpp
+++ b/src/openrct2/windows/TrackManage.cpp
@@ -164,7 +164,7 @@ static void _window_track_manage_open(track_design_file_ref *tdFileRef)
 
     rct_window *trackDesignListWindow = window_find_by_class(WC_TRACK_DESIGN_LIST);
     if (trackDesignListWindow != nullptr) {
-        trackDesignListWindow->track_list.var_484 |= 1;
+        trackDesignListWindow->track_list.track_list_being_updated = true;
     }
 
     _trackDesignFileReference = tdFileRef;
@@ -178,7 +178,7 @@ static void window_track_manage_close(rct_window *w)
 {
     rct_window *trackDesignListWindow = window_find_by_class(WC_TRACK_DESIGN_LIST);
     if (trackDesignListWindow != nullptr) {
-        trackDesignListWindow->track_list.var_484 &= ~1;
+        trackDesignListWindow->track_list.track_list_being_updated = false;
     }
 }
 


### PR DESCRIPTION
This PR cleans up both the code for the 'install track design' window, and the UI it generates. I've also moved the track design name to the bottom section (as it was often hard to see overlain on the preview), and added the ride type to the info as well - it's not always obvious what ride a certain track design is!

![capture](https://user-images.githubusercontent.com/16639257/28783314-e8e3b062-7607-11e7-964d-019b3c3d3ddc.PNG)
