### PR TITLE
prevent infinite loop while fixing invalid research items

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1072,7 +1072,12 @@ void game_fix_save_vars()
     for (sint32 i = 0; i < MAX_RESEARCH_ITEMS; i++) {
         rct_research_item *researchItem = &gResearchItems[i];
         if (researchItem->entryIndex == RESEARCHED_ITEMS_SEPARATOR) continue;
-        if (researchItem->entryIndex == RESEARCHED_ITEMS_END) continue;
+        if (researchItem->entryIndex == RESEARCHED_ITEMS_END)
+        {
+            assert(i < (MAX_RESEARCH_ITEMS - 1));
+            (researchItem+1)->entryIndex = RESEARCHED_ITEMS_END_2;
+            continue;
+        }
         if (researchItem->entryIndex == RESEARCHED_ITEMS_END_2) break;
         if (researchItem->entryIndex & 0x10000) {
             uint8 entryIndex = researchItem->entryIndex & 0xFF;
@@ -1096,7 +1101,6 @@ void game_fix_save_vars()
 
     // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
     fix_invalid_vehicle_sprite_sizes();
-
 }
 
 /**

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1074,9 +1074,12 @@ void game_fix_save_vars()
         if (researchItem->entryIndex == RESEARCHED_ITEMS_SEPARATOR) continue;
         if (researchItem->entryIndex == RESEARCHED_ITEMS_END)
         {
-            assert(i < (MAX_RESEARCH_ITEMS - 1));
-            (researchItem+1)->entryIndex = RESEARCHED_ITEMS_END_2;
-            continue;
+            if (i == MAX_RESEARCH_ITEMS - 1)
+            {
+                (--researchItem)->entryIndex = RESEARCHED_ITEMS_END;
+            }
+            (++researchItem)->entryIndex = RESEARCHED_ITEMS_END_2;
+            break;
         }
         if (researchItem->entryIndex == RESEARCHED_ITEMS_END_2) break;
         if (researchItem->entryIndex & 0x10000) {


### PR DESCRIPTION
Research_remove() does not expect any items between RESEARCHED_ITEMS_END & RESEARCHED_ITEMS_END_2, so make sure, the next item is RESEARCHED_ITEMS_END_2.

Fix infinite loop while loading the save file RR_60glitch.zip from #5311.