### PR TITLE
Update all windows after changing colour scheme

### DIFF
--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -707,11 +707,7 @@ extern "C"
         ThemeManager::ActiveAvailableThemeIndex = index;
         String::DiscardDuplicate(&gConfigInterface.current_theme_preset, theme_manager_get_available_theme_name(index));
 
-        // Apply the selected theme to all open windows
-        for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
-        {
-            colour_scheme_update(w);
-        }
+        colour_scheme_update_all();
     }
 
     uint8 theme_get_colour(rct_windowclass wc, uint8 index)
@@ -863,9 +859,10 @@ extern "C"
 
     void colour_scheme_update_all()
     {
-        rct_window* w;
-        for (w = g_window_list; w < gWindowNextSlot; w++)
+        for (rct_window *w = g_window_list; w < gWindowNextSlot; w++)
+        {
             colour_scheme_update(w);
+        }
     }
 
     void colour_scheme_update(rct_window * window)

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -861,6 +861,13 @@ extern "C"
         return desc->WindowName;
     }
 
+    void colour_scheme_update_all()
+    {
+        rct_window* w;
+        for (w = g_window_list; w < gWindowNextSlot; w++)
+            colour_scheme_update(w);
+    }
+
     void colour_scheme_update(rct_window * window)
     {
         colour_scheme_update_by_class(window, window->classification);

--- a/src/openrct2/interface/themes.h
+++ b/src/openrct2/interface/themes.h
@@ -28,6 +28,7 @@ enum {
 };
 
 void colour_scheme_update(rct_window *window);
+void colour_scheme_update_all();
 void colour_scheme_update_by_class(rct_window *window, rct_windowclass classification);
 
 void         theme_manager_initialise();

--- a/src/openrct2/windows/themes.c
+++ b/src/openrct2/windows/themes.c
@@ -547,6 +547,7 @@ static void window_themes_dropdown(rct_window *w, rct_widgetindex widgetIndex, s
             uint8 colour = theme_get_colour(wc, _colour_index_2);
             colour = (colour & COLOUR_FLAG_TRANSLUCENT) | dropdownIndex;
             theme_set_colour(wc, _colour_index_2, colour);
+            colour_scheme_update_all();
             window_invalidate_all();
             _colour_index_1 = -1;
             _colour_index_2 = -1;
@@ -628,6 +629,7 @@ void window_themes_scrollmousedown(rct_window *w, sint32 scrollIndex, sint32 x, 
                         colour |= COLOUR_FLAG_TRANSLUCENT;
                     }
                     theme_set_colour(wc, _colour_index_2, colour);
+                    colour_scheme_update_all();
                     window_invalidate_all();
                 }
             }


### PR DESCRIPTION
Since the invalidate functions no longer update the colour scheme of windows, windows would keep their old colour until a new theme is selected. Colours are now updated immediatly when picking a new colour. Fixes a regression in #5472.