### PR TITLE
Fix #5890. Primary and secondary colours now work in zoomed OpenGL

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#2127, #2229, #5586] Mountain tool cost calculation
 - Fix: [#3589] Crash due to invalid footpathEntry in path_paint
 - Fix: [#4455] Crash in window_sign_invalidate due to original bug
+- Fix: [#4715] Fix OpenGL rendering of water when zoomed. See #5890.
 - Fix: [#4931] Crash in path_paint - footpathentry was null
 - Fix: [#5629] Issue with tower ride modes approach to station - incorrect sum caused sawtooth in velocity
 - Fix: [#5768] Prevent loading non-existent title sequences.
@@ -15,6 +16,7 @@
 - Fix: [#5865] Ride preview flickering on uneven terrain or mid air.
 - Fix: [#5872] Incorrect OpenGL rendering of masked sprites
 - Fix: [#5880] Leaving bumper cars without building causes assertion.
+- Fix: [#5890] Fix zoomed OpenGL rendering of special sprites with primary and secondary colours.
 - Fix: [#5912] Negative queue when moving entrance in paused state.
 - Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -708,7 +708,7 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
             zoomedDPI.pitch = _dpi->pitch;
             zoomedDPI.zoom_level = _dpi->zoom_level - 1;
             SetDPI(&zoomedDPI);
-            DrawSprite((image & 0xE0000000) | (g1Id - g1Element->zoomed_offset), x >> 1, y >> 1, tertiaryColour);
+            DrawSprite((image & 0xFFF80000) | (g1Id - g1Element->zoomed_offset), x >> 1, y >> 1, tertiaryColour);
             return;
         }
         if (g1Element->flags & (1 << 5))


### PR DESCRIPTION
Fix #5890.
Mistake made due to a misunderstanding of how the software renderer works. At this point in the software renderer the primary and secondary colours are already calculated into the palette so can be ignored. In OpenGL the colours still need to be passed to the command queue. Fixes #4715 as well.
