### PR TITLE
Fix #6130: Guest list summary not updating after a ride rename

### DIFF
--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -866,8 +866,11 @@ static void get_arguments_from_peep(rct_peep *peep, uint32 *argument_1, uint32* 
     }
 }
 
-/* Force an evaluation of the Guest List*/
-void window_guest_list_find_groups_force_refresh() {
+/**
+ * Force a refresh, called after renaming a ride.
+ */
+void window_guest_list_find_groups_force_refresh()
+{
 	_window_guest_list_last_find_groups_wait = 0;
 	_window_guest_list_last_find_groups_tick = 0;
 	window_guest_list_find_groups();

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -866,6 +866,13 @@ static void get_arguments_from_peep(rct_peep *peep, uint32 *argument_1, uint32* 
     }
 }
 
+/* Force an evaluation of the Guest List*/
+void window_guest_list_find_groups_force_refresh() {
+	_window_guest_list_last_find_groups_wait = 0;
+	_window_guest_list_last_find_groups_tick = 0;
+	window_guest_list_find_groups();
+}
+
 /**
  *
  *  rct2: 0x0069B5AE

--- a/src/openrct2/interface/window.h
+++ b/src/openrct2/interface/window.h
@@ -708,6 +708,7 @@ void window_top_toolbar_open();
 void window_game_bottom_toolbar_open();
 void window_game_bottom_toolbar_invalidate_news_item();
 void window_track_list_open(ride_list_item item);
+void window_guest_list_find_groups_force_refresh();
 void window_map_open();
 void window_guest_open(rct_peep* peep);
 rct_window *window_staff_open(rct_peep* peep);

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5703,7 +5703,7 @@ void game_command_set_ride_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 
     *ebx = 0;
 
-    //After renaming a ride, refresh Guest list if open
+    // Force a refresh of any open Guests windows to make them pick up the new name
     rct_window* window;
 
     window = window_find_by_class(WC_GUEST_LIST);

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5703,15 +5703,14 @@ void game_command_set_ride_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 
     *ebx = 0;
 
-	//After renaming a ride, refresh Guest list if open
-	rct_window* window;
+    //After renaming a ride, refresh Guest list if open
+    rct_window* window;
 
-	window = window_find_by_class(WC_GUEST_LIST);
-	if (window == NULL) {
-		return;
-	}
-
-	window_guest_list_find_groups_force_refresh();
+    window = window_find_by_class(WC_GUEST_LIST);
+    if (window != NULL)
+    {
+        window_guest_list_find_groups_force_refresh();
+    }
 }
 
 /**

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5702,6 +5702,16 @@ void game_command_set_ride_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
     }
 
     *ebx = 0;
+
+	//After renaming a ride, refresh Guest list if open
+	rct_window* window;
+
+	window = window_find_by_class(WC_GUEST_LIST);
+	if (window == NULL) {
+		return;
+	}
+
+	window_guest_list_find_groups_force_refresh();
 }
 
 /**


### PR DESCRIPTION
**Fix Guest List summary not updating after a ride rename**

The Guest List summary screen only updates every several seconds.. If the Guest List summary page is open while renaming a ride, the ride name string will become blank for any actions/thoughts until the auto refresh kicks in. This fix forces a refresh on the summary page (if opened) when a ride is renamed.