### PR TITLE
Fix #6131: Icon for suspended vehicles aligned too low

### DIFF
--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1309,16 +1309,17 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
             clipDPI.y *= 2;
         }
 
-		//For any suspended rides, move image higher in the vehicle tab on the rides window
-		if (ride->type == RIDE_TYPE_COMPACT_INVERTED_COASTER
-			|| ride->type == RIDE_TYPE_INVERTED_ROLLER_COASTER
-			|| ride->type == RIDE_TYPE_INVERTED_IMPULSE_COASTER	
-			|| ride->type == RIDE_TYPE_SUSPENDED_SWINGING_COASTER
-			|| ride->type == RIDE_TYPE_CHAIRLIFT
-			|| ride->type == RIDE_TYPE_MINI_SUSPENDED_COASTER
-			|| ride->type == RIDE_TYPE_SUSPENDED_MONORAIL) {
-			y /= 4;
-		}
+	//For any suspended rides, move image higher in the vehicle tab on the rides window
+	if (ride->type == RIDE_TYPE_COMPACT_INVERTED_COASTER
+	    || ride->type == RIDE_TYPE_INVERTED_ROLLER_COASTER
+	    || ride->type == RIDE_TYPE_INVERTED_IMPULSE_COASTER	
+	    || ride->type == RIDE_TYPE_SUSPENDED_SWINGING_COASTER
+	    || ride->type == RIDE_TYPE_CHAIRLIFT
+	    || ride->type == RIDE_TYPE_MINI_SUSPENDED_COASTER
+	    || ride->type == RIDE_TYPE_SUSPENDED_MONORAIL) 
+	{
+	    y /= 4;
+	}
 
         const uint8 vehicle = ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, rideEntry->tab_vehicle);
         rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[vehicle];

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1315,7 +1315,8 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
 			|| ride->type == RIDE_TYPE_INVERTED_IMPULSE_COASTER	
 			|| ride->type == RIDE_TYPE_SUSPENDED_SWINGING_COASTER
 			|| ride->type == RIDE_TYPE_CHAIRLIFT
-			|| ride->type == RIDE_TYPE_MINI_SUSPENDED_COASTER) {
+			|| ride->type == RIDE_TYPE_MINI_SUSPENDED_COASTER
+			|| ride->type == RIDE_TYPE_SUSPENDED_MONORAIL) {
 			y /= 4;
 		}
 

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1314,7 +1314,8 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
 			|| ride->type == RIDE_TYPE_INVERTED_ROLLER_COASTER
 			|| ride->type == RIDE_TYPE_INVERTED_IMPULSE_COASTER	
 			|| ride->type == RIDE_TYPE_SUSPENDED_SWINGING_COASTER
-			|| ride->type == RIDE_TYPE_CHAIRLIFT) {
+			|| ride->type == RIDE_TYPE_CHAIRLIFT
+			|| ride->type == RIDE_TYPE_MINI_SUSPENDED_COASTER) {
 			y /= 4;
 		}
 

--- a/src/openrct2/windows/ride.c
+++ b/src/openrct2/windows/ride.c
@@ -1309,6 +1309,15 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo *dpi, rct_window *w)
             clipDPI.y *= 2;
         }
 
+		//For any suspended rides, move image higher in the vehicle tab on the rides window
+		if (ride->type == RIDE_TYPE_COMPACT_INVERTED_COASTER
+			|| ride->type == RIDE_TYPE_INVERTED_ROLLER_COASTER
+			|| ride->type == RIDE_TYPE_INVERTED_IMPULSE_COASTER	
+			|| ride->type == RIDE_TYPE_SUSPENDED_SWINGING_COASTER
+			|| ride->type == RIDE_TYPE_CHAIRLIFT) {
+			y /= 4;
+		}
+
         const uint8 vehicle = ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, rideEntry->tab_vehicle);
         rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[vehicle];
 


### PR DESCRIPTION
**Fix Icon alignment issue on Vehicle Tab on Ride window**

Certain ride icons for the vehicle tab (particularly trains that hang below track) in the Ride Window would be offset to low (y axis). This fix offsets the y axis up by a factor of 4 for these particular rides to center the image properly.