### PR TITLE
Multiplayer Clickable Links (revival attempt) (WIP) (need help)

### DIFF
--- a/src/openrct2/input.c
+++ b/src/openrct2/input.c
@@ -89,7 +89,6 @@ void map_element_right_click(sint32 type, rct_map_element *mapElement, sint32 x,
 static void game_handle_input_mouse(sint32 x, sint32 y, sint32 state);
 static void input_widget_left(sint32 x, sint32 y, rct_window *w, rct_widgetindex widgetIndex);
 void input_state_widget_pressed(sint32 x, sint32 y, sint32 state, rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
-void set_cursor(uint8 cursor_id);
 static void input_window_position_continue(rct_window *w, sint32 lastX, sint32 lastY, sint32 newX, sint32 newY);
 static void input_window_position_end(rct_window *w, sint32 x, sint32 y);
 static void input_window_resize_begin(rct_window *w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -1053,7 +1052,7 @@ void process_mouse_over(sint32 x, sint32 y)
             case WWT_VIEWPORT:
                 if (!(_inputFlags & INPUT_FLAG_TOOL_ACTIVE)) {
                     if (viewport_interaction_left_over(x, y)) {
-                        set_cursor(CURSOR_HAND_POINT);
+                        input_set_cursor(CURSOR_HAND_POINT);
                         return;
                     }
                     break;
@@ -1073,7 +1072,7 @@ void process_mouse_over(sint32 x, sint32 y)
                 cursorId = edi;
                 if ((ebx & 0xFF) != 0)
                 {
-                    set_cursor(cursorId);
+                    input_set_cursor(cursorId);
                     return;
                 }
                 break;
@@ -1122,7 +1121,7 @@ void process_mouse_over(sint32 x, sint32 y)
     }
 
     viewport_interaction_right_over(x, y);
-    set_cursor(cursorId);
+    input_set_cursor(cursorId);
 }
 
 /**
@@ -1434,7 +1433,7 @@ sint32 get_next_key()
 *
 *  rct2: 0x006ED990
 */
-void set_cursor(uint8 cursor_id)
+void input_set_cursor(uint8 cursor_id)
 {
     if (_inputState == INPUT_STATE_RESIZING) {
         cursor_id = CURSOR_DIAGONAL_ARROWS;

--- a/src/openrct2/input.h
+++ b/src/openrct2/input.h
@@ -115,4 +115,6 @@ void reset_tooltip_not_shown();
 
 void input_reset_place_obj_modifier();
 
+void input_set_cursor(uint8 cursor_id);
+
 #endif

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -82,7 +82,10 @@ void chat_update()
     // Clicking the chat
     if (!input_test_flag(INPUT_FLAG_5))
     {
-        sint32 y = _chatBottom - (15 * 2);
+        char* inputLine = _chatCurrentLine;
+        sint32 stringHeight = chat_string_wrapped_get_height((void*)&inputLine, _chatWidth - 10) + 5;
+
+        sint32 y = _chatBottom - stringHeight - 15;
 
         const CursorState * cursorState = context_get_cursor_state();
         sint32 mX = cursorState->x;
@@ -106,8 +109,12 @@ void chat_update()
                 char* lineCh = lineBuffer;
                 safe_strcpy(lineBuffer, chat_history_get(i), CHAT_INPUT_SIZE + 10);
 
+                // TODO this part is not yet used.
+                stringHeight = chat_string_wrapped_get_height((void*)&lineCh, _chatWidth - 10);
+
                 if (mY > y && mY - 15 < y && !str_is_null_or_empty(lineCh)) {
                     chat_handle_hover_msg(lineCh, i, cursorState, mX - _chatLeft, mY - y);
+                    break;
                 }
             }
         }

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -185,8 +185,15 @@ void chat_draw(rct_drawpixelinfo * dpi)
 
         safe_strcpy(lineBuffer, chat_history_get(i), sizeof(lineBuffer));
 
-        stringHeight = chat_history_draw_string(dpi, (void*) &lineCh, x, y, _chatWidth - 10) + 5;
-        gfx_set_dirty_blocks(x, y - stringHeight, x + _chatWidth, y + 20);
+        // TODO remove this code (or revert "(DEBUG) Shift text to right when hovered over") when finished
+        sint32 _x = x;
+        if (_chatMouseOver == i) {
+            _x += 5;
+        }
+
+        stringHeight = chat_history_draw_string(dpi, (void*) &lineCh, _x, y, _chatWidth - 10) + 5;
+
+        gfx_set_dirty_blocks(x, y - stringHeight, _x + _chatWidth, y + 20);
 
         if ((y - stringHeight) < 50) {
             break;

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -98,9 +98,11 @@ void chat_update()
             char* lineCh = lineBuffer;
             safe_strcpy(lineBuffer, chat_history_get(i), CHAT_INPUT_SIZE + 10);
 
-            char* url = url_from_string(lineBuffer);
+            char url[256];
+            char* urlBuffer = url;
+            url_from_string(urlBuffer, lineBuffer, sizeof(url));
 
-            if (mY > y && mY - 15 < y && mX > x && mX < _chatRight && url != 0) {
+            if (mY > y && mY - 15 < y && mX > x && mX < _chatRight && url != NULL) {
                 _chatMouseOver = i;
                 if (cursorState->left == CURSOR_RELEASED) {
                     chat_handle_press(lineBuffer);
@@ -208,10 +210,12 @@ void chat_draw(rct_drawpixelinfo * dpi)
 
 void chat_handle_press(char* handle)
 {
-    char *ufs = url_from_string(handle);
-
-    if (ufs != 0) {
-        platform_open_browser(ufs);
+    char url[256];
+    char* urlBuffer = url;
+    url_from_string(urlBuffer, handle, sizeof(url));
+    
+    if (url != NULL) {
+        platform_open_browser(url);
     }
 }
 

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -280,6 +280,15 @@ void chat_handle_hover_msg(char* msg, sint32 msgIndex, const CursorState* curSta
             platform_open_browser(url);
         }
     }
+    // TODO Remove this code or revert "(DEBUG) Allow clearing chat history by clicking non-url messages" once lineHeight is working properly
+    else {
+        if (curState->left == CURSOR_RELEASED) {
+            for (sint32 i = 0; i < CHAT_HISTORY_SIZE; i++) {
+                memset(_chatHistory[i], 0, CHAT_INPUT_SIZE);
+            }
+            _chatHistoryIndex = 0;
+        }
+    }
 }
 
 void chat_history_add(const char * src)

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -89,8 +89,8 @@ void chat_update()
         _chatMouseOver = -1;
 
         for (sint32 i = 0; i < CHAT_HISTORY_SIZE; i++, y -= 15) {
-            // TODO find new SDL_TICKS_PASSED, SDL_GetTicks()
-            if (!gChatOpen && SDL_TICKS_PASSED(SDL_GetTicks(), chat_history_get_time(i) + 10000)) {
+            uint32 expireTime = chat_history_get_time(i) + 10000;
+            if (!gChatOpen && platform_get_ticks() > expireTime) {
                 break;
             }
 

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -82,8 +82,9 @@ void chat_update()
         sint32 x = _chatLeft;
         sint32 y = _chatBottom - (15 * 2);
 
-        sint32 mX = 0;// gCursorState.x; // TODO find new gCursorState equivalent
-        sint32 mY = 0;// gCursorState.y; // TODO find new gCursorState equivalent
+        const CursorState * cursorState = context_get_cursor_state();
+        sint32 mX = cursorState->x;
+        sint32 mY = cursorState->y;
 
         _chatMouseOver = -1;
 
@@ -101,9 +102,7 @@ void chat_update()
 
             if (mY > y && mY - 15 < y && mX > x && mX < _chatRight && url != 0) {
                 _chatMouseOver = i;
-                // TODO find new gCursorState equivalent
-                //if (gCursorState.left == CURSOR_RELEASED) {
-                if (false) {
+                if (cursorState->left == CURSOR_RELEASED) {
                     chat_handle_press(lineBuffer);
                 }
             }

--- a/src/openrct2/interface/chat.c
+++ b/src/openrct2/interface/chat.c
@@ -93,6 +93,11 @@ void debug_ui_box_hide()
     debug_ui_box_show = false;
 }
 
+// TODO remove these lines once stringHeight is properly working
+bool subtract_lineY_by_stringHeight     = true;
+bool compare_mouseY_to_stringHeight     = true;
+bool adjust_debugUiBoxY_by_stringHeight = true;
+
 void chat_update()
 {
     // Flash the caret
@@ -102,7 +107,8 @@ void chat_update()
     if (!input_test_flag(INPUT_FLAG_5))
     {
         char* inputLine = _chatCurrentLine;
-        sint32 stringHeight = chat_string_wrapped_get_height((void*)&inputLine, _chatWidth - 10) + 5;
+        // TODO the stringHeights need some work on for multiple lines.
+        sint32 stringHeight = chat_string_wrapped_get_height((void*)&inputLine, _chatWidth - 10) - 5;
 
         sint32 y = _chatBottom - stringHeight - 15;
 
@@ -123,7 +129,7 @@ void chat_update()
         if (mX > _chatLeft && mX < _chatRight && mY > _chatTop && mY < _chatBottom) {
             debug_mouse_x = mX;
             debug_mouse_y = mY;
-            for (sint32 i = 0; i < CHAT_HISTORY_SIZE; i++, y -= 15) {
+            for (sint32 i = 0; i < CHAT_HISTORY_SIZE; i++, y -= (subtract_lineY_by_stringHeight ? stringHeight : 15)) {
                 uint32 expireTime = chat_history_get_time(i) + 10000;
                 if (!gChatOpen && platform_get_ticks() > expireTime) {
                     break;
@@ -133,11 +139,11 @@ void chat_update()
                 char* lineCh = lineBuffer;
                 safe_strcpy(lineBuffer, chat_history_get(i), CHAT_INPUT_SIZE + 10);
 
-                // TODO this part is not yet used.
+                // TODO the stringHeights need some work on for multiple lines.
                 stringHeight = chat_string_wrapped_get_height((void*)&lineCh, _chatWidth - 10) + 5;
 
-                if (mY > y && mY - 15 < y && !str_is_null_or_empty(lineCh)) {
-                    debug_ui_box_set(_chatLeft, y, _chatRight, y + 15);
+                if (mY > y && mY - (compare_mouseY_to_stringHeight ? stringHeight : 15) < y && !str_is_null_or_empty(lineCh)) {
+                    debug_ui_box_set(_chatLeft, y, _chatRight, y + (adjust_debugUiBoxY_by_stringHeight ? stringHeight : 15));
                     chat_handle_hover_msg(lineCh, i, cursorState, mX - _chatLeft, mY - y);
                 }
             }

--- a/src/openrct2/interface/chat.h
+++ b/src/openrct2/interface/chat.h
@@ -42,8 +42,6 @@ void chat_init();
 void chat_update();
 void chat_draw(rct_drawpixelinfo * dpi);
 
-void chat_handle_press(char* handle);
-
 void chat_history_add(const char *src);
 void chat_input(CHAT_INPUT input);
 

--- a/src/openrct2/interface/chat.h
+++ b/src/openrct2/interface/chat.h
@@ -42,6 +42,8 @@ void chat_init();
 void chat_update();
 void chat_draw(rct_drawpixelinfo * dpi);
 
+void chat_handle_press(char* handle);
+
 void chat_history_add(const char *src);
 void chat_input(CHAT_INPUT input);
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -576,6 +576,25 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     char* ptrtext = lineCh;
     safe_strcpy(lineCh, text, 800);
     utf8_remove_format_codes((utf8*)ptrtext, true);
+
+    // Highlight urls in babyblue
+    lineCh = strstr(formatted, "http://");
+    if (!lineCh) {
+        lineCh = strstr(formatted, "https://");
+    }
+    if (lineCh) {
+        char formatted2[1024];
+        safe_strcpy(formatted2, lineCh, 800);
+        lineCh = utf8_write_codepoint(lineCh, FORMAT_BABYBLUE);
+        safe_strcpy(lineCh, formatted2, 800);
+        lineCh = url_end(lineCh);
+        if (lineCh != 0) {
+            safe_strcpy(formatted2, lineCh, 800);
+            lineCh = utf8_write_codepoint(lineCh, FORMAT_WHITE);
+            safe_strcpy(lineCh, formatted2, 800);
+        }
+    }
+
     return formatted;
 }
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -578,10 +578,7 @@ const char* Network::FormatChat(NetworkPlayer* fromplayer, const char* text)
     utf8_remove_format_codes((utf8*)ptrtext, true);
 
     // Highlight urls in babyblue
-    lineCh = strstr(formatted, "http://");
-    if (!lineCh) {
-        lineCh = strstr(formatted, "https://");
-    }
+    lineCh = url_begin(formatted);
     if (lineCh) {
         char formatted2[1024];
         safe_strcpy(formatted2, lineCh, 800);

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -268,4 +268,14 @@ bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size)
 }
 #endif // NO_TTF
 
+void platform_open_browser(const char* url)
+{
+    int exit_value;
+    char cmd[MAX_PATH];
+
+    sprintf(cmd, MAX_PATH, "%s %s", "xdg-open", url);
+
+    execute_cmd(cmd, &exit_value, 0, 0);
+}
+
 #endif

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -209,4 +209,12 @@ uint8 platform_get_locale_measurement_format()
     }
 }
 
+void platform_open_browser(const char* url)
+{
+    @autoreleasepool
+    {
+        [[NSWorkspace sharedWorkspace]] openURL:[NSURL URLWithString:[NSString stringWithUTF8String:url]]];
+    }
+}
+
 #endif

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -168,4 +168,6 @@ void core_init();
     utf8* macos_str_decomp_to_precomp();
 #endif
 
+    void platform_open_browser(const char* url);
+
 #endif

--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -1030,4 +1030,8 @@ bool platform_setup_uri_protocol()
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void platform_open_browser(const char* url)
+{
+    ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+}
 #endif

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -550,7 +550,7 @@ size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const 
     return 0;
 }
 
-char* url_from_string(char *data)
+void url_from_string(char* buffer, char *data, size_t bufferSize)
 {
     char *ret = url_begin(data);
 
@@ -563,11 +563,12 @@ char* url_from_string(char *data)
         ret2 = url_end(url);
         *ret2 = '\0';
 
-        return url;
-
+        safe_strcpy(buffer, url, bufferSize);
+        SafeFree(url);
     }
-
-    return 0;
+    else {
+        buffer[0] = 0;
+    }
 }
 
 char* url_begin(char* data)

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -552,11 +552,7 @@ size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const 
 
 char* url_from_string(char *data)
 {
-    char *ret = strstr(data, "http://");
-
-    if (!ret) {
-        ret = strstr(data, "https://");
-    }
+    char *ret = url_begin(data);
 
     if (ret) {
         char *ret2 = url_end(ret);
@@ -572,6 +568,17 @@ char* url_from_string(char *data)
     }
 
     return 0;
+}
+
+char* url_begin(char* data)
+{
+    char *ret = strstr(data, "http://");
+
+    if (!ret) {
+        ret = strstr(data, "https://");
+    }
+
+    return ret;
 }
 
 char* url_end(char *data)

--- a/src/openrct2/util/util.c
+++ b/src/openrct2/util/util.c
@@ -549,3 +549,54 @@ size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const 
     }
     return 0;
 }
+
+char* url_from_string(char *data)
+{
+    char *ret = strstr(data, "http://");
+
+    if (!ret) {
+        ret = strstr(data, "https://");
+    }
+
+    if (ret) {
+        char *ret2 = url_end(ret);
+        char *url = malloc(256 * sizeof(char));
+
+        strncpy(url, ret, ret2 - ret);
+
+        ret2 = url_end(url);
+        *ret2 = '\0';
+
+        return url;
+
+    }
+
+    return 0;
+}
+
+char* url_end(char *data)
+{
+    // find the end of an url.
+    while (*data) {
+        if (!isalnum(*data)
+            && *data != '-'
+            && *data != '_'
+            && *data != '.'
+            && *data != '?'
+            && *data != '#'
+            && *data != '['
+            && *data != ']'
+            && *data != '~'
+            && *data != '@'
+            && *data != '%'
+            && *data != ':'
+            && *data != '/'
+        ) {
+            break;
+        }
+
+        data++;
+    }
+
+    return data;
+}

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -65,4 +65,7 @@ money32 add_clamp_money32(money32 value, money32 value_to_add);
 
 size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const struct tm * tp);
 
+char* url_from_string(char* data);
+char* url_end(char* data);
+
 #endif

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -65,7 +65,7 @@ money32 add_clamp_money32(money32 value, money32 value_to_add);
 
 size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const struct tm * tp);
 
-char* url_from_string(char* data);
+void url_from_string(char* buffer, char* data, size_t bufferSize);
 char* url_begin(char* data);
 char* url_end(char* data);
 

--- a/src/openrct2/util/util.h
+++ b/src/openrct2/util/util.h
@@ -66,6 +66,7 @@ money32 add_clamp_money32(money32 value, money32 value_to_add);
 size_t strcatftime(char * buffer, size_t bufferSize, const char * format, const struct tm * tp);
 
 char* url_from_string(char* data);
+char* url_begin(char* data);
 char* url_end(char* data);
 
 #endif


### PR DESCRIPTION
This is an attempt to get the previous pull request from 0.0.5 where multiplayer would have clickable links. The original pull request can be found here: https://github.com/OpenRCT2/OpenRCT2/pull/3168

I have isolated the bits of code specific to links (the original PR had some extra group functionality), along with updated outddated code. I am still working on the stuff that @IntelOrca  wanted to be improved from the original pull request:

- [ ] Multiple links in a message.
- [ ] Hotspot should only be around the link, not the whole message (and empty space)
- [x] Hotspot should change cursor to hand pointer.
- [x] Hotspot should not shift message right 

What I would still like to add to it
- [x] Support for multiline messages (previous PR was messages didn't wrap to multiple lines).
- [ ] An OK/Cancel dialog that says "you are about to open X in an external browser, continue?" 

EDIT:
I have fixed the issue that I previously had involving the lineHeights not working correctly.
I now still have to figure out how to get multiple urls in and to get cursor to detect which url it's over. My plan is to split the messages up by sections like `wolfreak99: this is http://google.com/ and this is http://yahoo.com/ something something` split to:
`wolfreak99: this is ` `http://google.com/` ` and this is ` `http://yahoo.com/` ` something something`
That way the each portion can have it's width measured until the width matches or exceeds rMouseY.