### PR TITLE
Hide broken loaded game marker

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Feature: [#5877] Allow up to 16 stations to be synchronised
 - Feature: [#5970] The Bobsleigh Roller Coaster now supports on-ride photos.
 - Feature: [#5991] Allow all tracked rides that can be tested without guests to the Track Designer
+- Change: Loaded game marker temporarily removed due to incorrect saves being marked as loaded.
 - Fix: [#2127, #2229, #5586] Mountain tool cost calculation
 - Fix: [#3589] Crash due to invalid footpathEntry in path_paint
 - Fix: [#3852] Constructing path not clearing scenery on server.

--- a/src/openrct2/windows/LoadSave.cpp
+++ b/src/openrct2/windows/LoadSave.cpp
@@ -531,9 +531,10 @@ static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, s
             gfx_filter_rect(dpi, 0, y, listWidth, y + 9, PALETTE_DARKEN_1);
         }
         // display a marker next to the currently loaded game file
+        // BUG incorrect files are being marked as loaded, this has been disabled until it's fixed.
         if (_listItems[i].loaded) {
-            set_format_arg(0, rct_string_id, STR_RIGHTGUILLEMET);
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1);
+            // set_format_arg(0, rct_string_id, STR_RIGHTGUILLEMET);
+            // gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1);
         }
 
         set_format_arg(0, rct_string_id, STR_STRING);


### PR DESCRIPTION
This is a filler until https://github.com/OpenRCT2/OpenRCT2/pull/5598 is merged. Right now the loaded game marker is broken in many ways, and often marks the wrong files as being loaded. **This can lead to people overwriting the wrong files**, possibly losing files with hours being put into. I'm very worried about this happening to people.

Because #5598 is currently taking some time to be merged, this acts as a placeholder by hiding the marker in the meantime.