### PR TITLE
Fix #6138: 'Too low' error when placing at lowest Z

### DIFF
--- a/src/openrct2/windows/RideConstruction.cpp
+++ b/src/openrct2/windows/RideConstruction.cpp
@@ -3893,7 +3893,7 @@ void ride_construction_tooldown_construct(sint32 screenX, sint32 screenY)
         z -= bx;
 
         // FIX not sure exactly why it starts trial and error place from a lower Z, but it causes issues with disable clearance
-        if (!gCheatsDisableClearanceChecks) {
+        if (!gCheatsDisableClearanceChecks && z > 16) {
             z -= 16;
         }
     } else {


### PR DESCRIPTION
(also fixes #1833 and #4937)