### PR TITLE
Fix #816. Correctly reset flash filter by considering all peeps.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.1.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
+- Fix: [#816] Fix Original bug with guest list and map window interaction causing unexpected peeps to flash.
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------

--- a/src/openrct2/windows/GuestList.cpp
+++ b/src/openrct2/windows/GuestList.cpp
@@ -718,11 +718,11 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
             if (_window_guest_list_tracking_only && !(peep->peep_flags & PEEP_FLAGS_TRACKING))
                 continue;
 
-            //
-            if (y + 11 >= -0x7FFF && y + 11 > dpi->y && y < 0x7FFF) {
-                // Check if y is beyond the scroll control
-                if (y > dpi->y + dpi->height)
-                    break;
+            // Check if y is beyond the scroll control
+            if (y + 11 >= -0x7FFF &&
+                y + 11 > dpi->y &&
+                y < 0x7FFF &&
+                y < dpi->y + dpi->height) {
 
                 // Highlight backcolour and text colour (format)
                 format = STR_BLACK_STRING;


### PR DESCRIPTION
Fix #816. Correctly reset flash filter by considering all peeps.

This is an original bug likely introduced by trying to save processing time by assuming that since the display list can not be drawn that it can stop processing. But as this loop also handles resetting flashing peeps it will leave peeps unprocessed