### PR TITLE
Fix infinite loop when removing scenery elements with >127 height

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Fix: [#816] Fix Original bug with guest list and map window interaction causing unexpected peeps to flash.
+- Fix: Infinite loop when removing scenery elements with >127 base height.
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -55,7 +55,7 @@ extern "C" {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -27,7 +27,7 @@ extern "C"
     #include "../ride/track_design.h"
 }
 
-static money32 SmallSceneryRemove(sint16 x, sint16 y, sint8 baseHeight, uint8 quadrant, uint8 sceneryType, uint8 flags)
+static money32 SmallSceneryRemove(sint16 x, sint16 y, uint8 baseHeight, uint8 quadrant, uint8 sceneryType, uint8 flags)
 {
     if (!map_is_location_valid(x, y))
     {
@@ -119,7 +119,7 @@ static money32 SmallSceneryRemove(sint16 x, sint16 y, sint8 baseHeight, uint8 qu
     return (gParkFlags & PARK_FLAGS_NO_MONEY) ? 0 : cost;
 }
 
-static money32 SmallScenerySetColour(sint16 x, sint16 y, sint8 baseHeight, uint8 quadrant, uint8 sceneryType, uint8 primaryColour, uint8 secondaryColour, uint8 flags)
+static money32 SmallScenerySetColour(sint16 x, sint16 y, uint8 baseHeight, uint8 quadrant, uint8 sceneryType, uint8 primaryColour, uint8 secondaryColour, uint8 flags)
 {
     gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
     sint32 z = baseHeight * 8;


### PR DESCRIPTION
Bug introduced when refactoring. Type mismatch not picked up by compiler