### PR TITLE
remove unnecessary cast.

### DIFF
--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -175,7 +175,7 @@ void S6Exporter::Export()
         }
         else
         {
-            _s6.objects[i] = *((rct_object_entry *)entry);
+            _s6.objects[i] = *entry;
         }
     }
 


### PR DESCRIPTION
Remove an unnecessary (un-)const-cast as the value is deep copied.