### PR TITLE
Stop using (void*)-1 for invalid pointers.

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -307,8 +307,6 @@ static void research_always_researched_setup()
     research_scenery_sets_setup();
 }
 
-
-
 /**
  *
  *  rct2: 0x00685A93
@@ -760,7 +758,7 @@ static void window_editor_inventions_list_paint(rct_window *w, rct_drawpixelinfo
 
     void *chunk = object_entry_groups[objectEntryType].chunks[researchItem->entryIndex & 0xFF];
 
-    if (chunk == nullptr || chunk == (void*)-1)
+    if (chunk == nullptr)
         return;
 
     rct_object_entry * entry = &object_entry_groups[objectEntryType].entries[researchItem->entryIndex & 0xFF].entry;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -827,8 +827,6 @@ static void window_editor_objective_options_main_invalidate(rct_window *w)
     rct_stex_entry *stex;
 
     stex = g_stexEntries[0];
-    if (stex == (rct_stex_entry*)-1)
-        stex = nullptr;
 
     widgets = window_editor_objective_options_widgets[w->page];
     if (w->widgets != widgets) {
@@ -897,8 +895,6 @@ static void window_editor_objective_options_main_paint(rct_window *w, rct_drawpi
     window_editor_objective_options_draw_tab_images(w, dpi);
 
     stex = g_stexEntries[0];
-    if (stex == (rct_stex_entry*)-1)
-        stex = nullptr;
 
     // Objective label
     x = w->x + 8;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -241,14 +241,14 @@ rct_window * window_footpath_open()
 {
     // If a restricted path was selected when the game is no longer in Sandbox mode, reset it
     rct_footpath_entry * pathEntry = get_footpath_entry(gFootpathSelectedId);
-    if (pathEntry != (rct_footpath_entry *) -1 &&
+    if (pathEntry != nullptr &&
         (pathEntry->flags & FOOTPATH_ENTRY_FLAG_SHOW_ONLY_IN_SCENARIO_EDITOR) && !gCheatsSandboxMode)
     {
-        pathEntry = (rct_footpath_entry *) -1;
+        pathEntry = nullptr;
     }
 
     // Select the default path if we don't have one
-    if (pathEntry == (rct_footpath_entry *) -1)
+    if (pathEntry == nullptr)
     {
         if (!footpath_select_default())
         {
@@ -443,7 +443,7 @@ static void window_footpath_dropdown(rct_window * w, rct_widgetindex widgetIndex
         for (; i < MAX_PATH_OBJECTS; i++)
         {
             rct_footpath_entry * pathType = get_footpath_entry(i);
-            if (pathType == (rct_footpath_entry *) -1)
+            if (pathType == nullptr)
             {
                 continue;
             }
@@ -729,7 +729,7 @@ static void window_footpath_show_footpath_types_dialog(rct_window * w, rct_widge
     for (i = 0; i < MAX_PATH_OBJECTS; i++)
     {
         pathType = get_footpath_entry(i);
-        if (pathType == (rct_footpath_entry *) -1)
+        if (pathType == nullptr)
         {
             continue;
         }
@@ -1319,7 +1319,7 @@ static bool footpath_select_default()
     for (sint32 i          = 0; i < object_entry_group_counts[OBJECT_TYPE_PATHS]; i++)
     {
         rct_footpath_entry * pathEntry = get_footpath_entry(i);
-        if (pathEntry != (rct_footpath_entry *) -1)
+        if (pathEntry != nullptr)
         {
             footpathId = i;
 

--- a/src/openrct2/drawing/drawing.c
+++ b/src/openrct2/drawing/drawing.c
@@ -522,7 +522,7 @@ void load_palette()
 
     uint32 palette = 0x5FC;
 
-    if ((intptr_t)water_type != -1) {
+    if (water_type != NULL) {
         openrct2_assert(water_type->image_id != (uint32)-1, "Failed to load water palette");
         palette = water_type->image_id;
     }

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -171,7 +171,7 @@ void update_palette_effects()
         // Change palette to lighter colour during lightning
         sint32 palette = SPR_GAME_PALETTE_DEFAULT;
 
-        if ((intptr_t)water_type != -1) {
+        if (water_type != NULL) {
             palette = water_type->image_id;
         }
         rct_g1_element g1_element = g1Elements[palette];
@@ -190,7 +190,7 @@ void update_palette_effects()
             // Change palette back to normal after lightning
             sint32 palette = SPR_GAME_PALETTE_DEFAULT;
 
-            if ((intptr_t)water_type != -1) {
+            if (water_type != NULL) {
                 palette = water_type->image_id;
             }
 
@@ -220,7 +220,7 @@ void update_palette_effects()
         uint32 j = gPaletteEffectFrame;
         j = (((uint16)((~j / 2) * 128) * 15) >> 16);
         uint32 waterId = SPR_GAME_PALETTE_WATER;
-        if ((intptr_t)water_type != -1) {
+        if (water_type != NULL) {
             waterId = water_type->palette_index_1;
         }
         rct_g1_element g1_element = g1Elements[shade + waterId];
@@ -239,7 +239,7 @@ void update_palette_effects()
         }
 
         waterId = SPR_GAME_PALETTE_3;
-        if ((intptr_t)water_type != -1) {
+        if (water_type != NULL) {
             waterId = water_type->palette_index_2;
         }
         g1_element = g1Elements[shade + waterId];
@@ -1108,7 +1108,7 @@ void game_fix_save_vars()
         } else {
             uint8 entryIndex = researchItem->entryIndex;
             rct_scenery_set_entry *sceneryGroupEntry = get_scenery_group_entry(entryIndex);
-            if (sceneryGroupEntry == NULL || sceneryGroupEntry == (rct_scenery_set_entry*)-1) {
+            if (sceneryGroupEntry == NULL) {
                 research_remove(researchItem->entryIndex);
                 i--;
             }

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1167,7 +1167,7 @@ static sint32 cc_object_count(const utf8 **argv, sint32 argc) {
 
         sint32 entryGroupIndex = 0;
         for (; entryGroupIndex < object_entry_group_counts[i]; entryGroupIndex++){
-            if (object_entry_groups[i].chunks[entryGroupIndex] == (uint8*)-1){
+            if (object_entry_groups[i].chunks[entryGroupIndex] == NULL){
                 break;
             }
         }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -311,7 +311,7 @@ void research_finish_item(uint32 entryIndex)
     {
         // Scenery
         rct_scenery_set_entry * scenerySetEntry = get_scenery_group_entry(entryIndex & 0xFFFF);
-        if (scenerySetEntry != nullptr && scenerySetEntry != (rct_scenery_set_entry *) -1)
+        if (scenerySetEntry != nullptr)
         {
             for (sint32 i = 0; i < scenerySetEntry->entry_count; i++)
             {
@@ -448,7 +448,7 @@ void research_reset_current_item()
     for (sint32 i = 0; i < MAX_SCENERY_GROUP_OBJECTS; ++i)
     {
         rct_scenery_set_entry * scenery_set = get_scenery_group_entry(i);
-        if ((intptr_t) scenery_set == -1)
+        if (scenery_set == nullptr)
         {
             continue;
         }
@@ -665,7 +665,7 @@ void research_populate_list_random()
     for (sint32 i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
         rct_scenery_set_entry * scenerySetEntry = get_scenery_group_entry(i);
-        if (scenerySetEntry == (rct_scenery_set_entry *) -1)
+        if (scenerySetEntry == nullptr)
         {
             continue;
         }
@@ -700,7 +700,7 @@ void research_populate_list_researched()
     for (sint32 i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
         rct_scenery_set_entry * scenerySetEntry = get_scenery_group_entry(i);
-        if (scenerySetEntry == (rct_scenery_set_entry *) -1)
+        if (scenerySetEntry == nullptr)
         {
             continue;
         }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -866,7 +866,7 @@ rct_string_id research_item_get_name(uint32 researchItem)
     else
     {
         rct_scenery_set_entry * sceneryEntry = get_scenery_group_entry(researchItem & 0xFF);
-        if (sceneryEntry == nullptr || sceneryEntry == (rct_scenery_set_entry *) -1)
+        if (sceneryEntry == nullptr)
         {
             return 0;
         }

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -381,8 +381,8 @@ private:
             void * * legacyChunk = &object_entry_groups[objectType].chunks[entryIndex];
             if (loadedObject == nullptr)
             {
-                Memory::Set(legacyEntry, 0xFF, sizeof(rct_object_entry_extended));
-                *legacyChunk = (void *)-1;
+                Memory::Set(legacyEntry, 0x00, sizeof(rct_object_entry_extended));
+                *legacyChunk = nullptr;
             }
             else
             {

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -469,28 +469,31 @@ private:
         {
             const rct_object_entry * entry = &entries[i];
             const ObjectRepositoryItem * ori = nullptr;
-            if (!object_entry_is_empty(entry))
+            if (object_entry_is_empty(entry))
             {
-                ori = _objectRepository->FindObject(entry);
-                if (ori == nullptr)
+                Memory::Set(entry, 0, sizeof(rct_object_entry));
+                continue;
+            }
+
+            ori = _objectRepository->FindObject(entry);
+            if (ori == nullptr)
+            {
+                invalidEntries.push_back(*entry);
+                ReportMissingObject(entry);
+            }
+            else
+            {
+                Object * loadedObject = nullptr;
+                loadedObject = ori->LoadedObject;
+                if (loadedObject == nullptr)
                 {
-                    invalidEntries.push_back(*entry);
-                    ReportMissingObject(entry);
-                }
-                else
-                {
-                    Object * loadedObject = nullptr;
-                    loadedObject = ori->LoadedObject;
+                    loadedObject = _objectRepository->LoadObject(ori);
                     if (loadedObject == nullptr)
                     {
-                        loadedObject = _objectRepository->LoadObject(ori);
-                        if (loadedObject == nullptr)
-                        {
-                            invalidEntries.push_back(*entry);
-                            ReportObjectLoadProblem(entry);
-                        }
-                        delete loadedObject;
+                        invalidEntries.push_back(*entry);
+                        ReportObjectLoadProblem(entry);
                     }
+                    delete loadedObject;
                 }
             }
         }

--- a/src/openrct2/object_list.c
+++ b/src/openrct2/object_list.c
@@ -145,7 +145,7 @@ sint32 find_object_in_entry_group(const rct_object_entry* entry, uint8* entry_ty
         entry_group.chunks++,
         entry_group.entries++){
 
-        if (*entry_group.chunks == (uint8*)-1) continue;
+        if (*entry_group.chunks == NULL) continue;
 
         if (object_entry_compare((rct_object_entry*)entry_group.entries, entry))break;
     }

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -48,7 +48,7 @@ void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_m
 
     rct_scenery_entry* banner_scenery = get_banner_entry(gBanners[map_element->properties.banner.index].type);
 
-    if ((banner_scenery == (rct_scenery_entry *)-1) || (banner_scenery == NULL)) {
+    if (banner_scenery == NULL) {
         return;
     }
 

--- a/src/openrct2/paint/map_element/entrance.c
+++ b/src/openrct2/paint/map_element/entrance.c
@@ -214,7 +214,7 @@ static void park_entrance_paint(paint_session * session, uint8 direction, sint32
 
     switch (part_index){
     case 0:
-        if (path_entry != (void*)-1) {
+        if (path_entry != NULL) {
             image_id = (path_entry->image + 5 * (1 + (direction & 1))) | ghost_id;
                 sub_98197C(session, image_id, 0, 0, 32, 0x1C, 0, height, 0, 2, height, get_current_rotation());
         }

--- a/src/openrct2/paint/map_element/fence.c
+++ b/src/openrct2/paint/map_element/fence.c
@@ -136,7 +136,7 @@ void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_ma
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
 
     rct_scenery_entry * sceneryEntry = get_wall_entry(map_element->properties.wall.type);
-    if (sceneryEntry == NULL || sceneryEntry == (rct_scenery_entry *)-1) {
+    if (sceneryEntry == NULL) {
         return;
     }
     uint32 frameNum = 0;

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -761,7 +761,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map
     uint8 pathType = (map_element->properties.path.type & 0xF0) >> 4;
     rct_footpath_entry * footpathEntry = get_footpath_entry(pathType);
 
-    if (footpathEntry != (void*)-1) {
+    if (footpathEntry != NULL) {
         if (footpathEntry->support_type == FOOTPATH_ENTRY_SUPPORT_TYPE_POLE) {
             path_paint_pole_support(session, map_element, height, footpathEntry, word_F3F038, imageFlags, sceneryImageFlags);
         }

--- a/src/openrct2/paint/map_element/scenery.c
+++ b/src/openrct2/paint/map_element/scenery.c
@@ -65,7 +65,7 @@ void scenery_paint(paint_session * session, uint8 direction, sint32 height, rct_
 
     rct_scenery_entry *entry = get_small_scenery_entry(mapElement->properties.scenery.type);
 
-    if (entry == (rct_scenery_entry*)-1)
+    if (entry == NULL)
     {
         return;
     }

--- a/src/openrct2/paint/map_element/scenery_multiple.c
+++ b/src/openrct2/paint/map_element/scenery_multiple.c
@@ -188,7 +188,7 @@ void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 hei
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY;
     uint32 ebp = mapElement->properties.scenerymultiple.type >> 10;
     rct_scenery_entry *entry = get_large_scenery_entry(mapElement->properties.scenerymultiple.type & 0x3FF);
-    if (entry == (void*)-1)
+    if (entry == NULL)
         return;
 
     uint32 image_id = (ebp << 2) + entry->image + 4 + direction;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -6785,8 +6785,7 @@ static sint32 peep_update_patrolling_find_watering(rct_peep * peep)
 
             rct_scenery_entry * sceneryEntry = get_small_scenery_entry(map_element->properties.scenery.type);
 
-            if (sceneryEntry == (rct_scenery_entry *)-1 ||
-                !(sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_CAN_BE_WATERED))
+            if (sceneryEntry == nullptr || !(sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_CAN_BE_WATERED))
             {
                 continue;
             }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2218,16 +2218,13 @@ private:
     void ClearExtraTileEntries()
     {
         // Reset the map tile pointers
-        for (size_t i = 0; i < 0x10000; i++)
-        {
-            gMapElementTilePointers[i] = (rct_map_element *)-1;
-        }
+        Memory::Set(gMapElementTilePointers, 0, sizeof(rct_map_element*) * MAX_TILE_MAP_ELEMENT_POINTERS);
 
         // Get the first free map element
         rct_map_element * nextFreeMapElement = gMapElements;
-        for (size_t i = 0; i < 128 * 128; i++)
+        for (size_t i = 0; i < RCT1_MAX_MAP_SIZE * RCT1_MAX_MAP_SIZE; i++)
         {
-            do { } while (!map_element_is_last_for_tile(nextFreeMapElement++));
+            while (!map_element_is_last_for_tile(nextFreeMapElement++));
         }
 
         rct_map_element * mapElement = gMapElements;
@@ -2240,7 +2237,7 @@ private:
             for (sint32 y = 0; y < RCT1_MAX_MAP_SIZE; y++)
             {
                 *tilePointer++ = mapElement;
-                do { } while (!map_element_is_last_for_tile(mapElement++));
+                while (!map_element_is_last_for_tile(mapElement++));
             }
 
             // Fill the rest of the row with blank tiles

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -171,6 +171,7 @@ public:
         }
 
         auto missingObjects = _objectManager->GetInvalidObjects(_s6.objects);
+
         if (missingObjects.size() > 0)
         {
             return ParkLoadResult::CreateMissingObjects(missingObjects);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -766,7 +766,7 @@ track_design_place_scenery(rct_td6_scenery_element * scenery_start, uint8 rideIn
                          path                      = get_footpath_entry(entry_index), entry_index++
                         )
                     {
-                        if (path == (rct_footpath_entry *) -1)
+                        if (path == nullptr)
                         {
                             continue;
                         }
@@ -894,7 +894,7 @@ track_design_place_scenery(rct_td6_scenery_element * scenery_start, uint8 rideIn
                          path                      = get_footpath_entry(entry_index), entry_index++)
                     {
 
-                        if (path == (rct_footpath_entry *) -1)
+                        if (path == nullptr)
                         {
                             continue;
                         }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -234,12 +234,7 @@ rct_ride_entry * get_ride_entry(sint32 index)
         return NULL;
     }
 
-    rct_ride_entry * retVal = gRideEntries[index];
-
-    if (retVal == (rct_ride_entry *)-1)
-        return NULL;
-    else
-        return retVal;
+    return gRideEntries[index];
 }
 
 void get_ride_entry_name(char *name, sint32 index)

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8040,7 +8040,7 @@ void fix_invalid_vehicle_sprite_sizes()
                 }
 
                 rct_ride_entry_vehicle * vehicleEntry = vehicle_get_vehicle_entry(vehicle);
-                if (vehicleEntry == NULL || vehicleEntry == (rct_ride_entry_vehicle*)-1) {
+                if (vehicleEntry == NULL) {
                     break;
                 }
 

--- a/src/openrct2/ride/track_design_save.c
+++ b/src/openrct2/ride/track_design_save.c
@@ -61,15 +61,15 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
 void track_design_save_init()
 {
     _trackSavedMapElementsCount = 0;
+    _trackSavedMapElementsDescCount = 0;
+
 #ifdef NO_RCT2
     memset(_trackSavedMapElements, 0, sizeof(_trackSavedMapElements));
 #else
     memset(_trackSavedMapElements, 0, sizeof(rct_map_element*) * TRACK_MAX_SAVED_MAP_ELEMENTS);
-    _trackSavedMapElements[0] = (rct_map_element*)-1;
 #endif
 
-    _trackSavedMapElementsDescCount = 0;
-    memset(_trackSavedMapElementsDesc, 0xFF, sizeof(_trackSavedMapElementsDesc));
+    memset(_trackSavedMapElementsDesc, 0, sizeof(_trackSavedMapElementsDesc));
 }
 
 /**
@@ -260,7 +260,7 @@ static void track_design_save_push_map_element(sint32 x, sint32 y, rct_map_eleme
 
 #ifndef NO_RCT2
         // Required as drawing still uses 0xFFFFFFFF as a list terminator
-        _trackSavedMapElements[_trackSavedMapElementsCount] = (rct_map_element*)-1;
+        _trackSavedMapElements[_trackSavedMapElementsCount] = NULL;
 #endif
     }
 }
@@ -428,7 +428,7 @@ static void track_design_save_pop_map_element(sint32 x, sint32 y, rct_map_elemen
 #ifdef NO_RCT2
         _trackSavedMapElements[_trackSavedMapElementsCount] = NULL;
 #else
-        _trackSavedMapElements[_trackSavedMapElementsCount] = (rct_map_element*)-1;
+        _trackSavedMapElements[_trackSavedMapElementsCount] = NULL;
 #endif
     }
 }

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -4624,9 +4624,9 @@ static void vehicle_update_doing_circus_show(rct_vehicle *vehicle)
 static rct_map_element* vehicle_check_collision(sint16 x, sint16 y, sint16 z) {
     rct_map_element* mapElement = map_get_first_element_at(x / 32, y / 32);
     if (mapElement == NULL)
-        // Can't return null as that implies no collision,
-        // but should still cause a crash when dereferenced.
-        return (rct_map_element *) -1;
+    {
+        return NULL;
+    }
 
     uint8 bl;
     if ((x & 0x1F) >= 16) {

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -338,7 +338,7 @@ static void scenario_week_update()
 
     rct_water_type* water_type = (rct_water_type*)object_entry_groups[OBJECT_TYPE_WATER].chunks[0];
 
-    if (month <= MONTH_APRIL && (intptr_t)water_type != -1 && water_type->flags & WATER_FLAGS_ALLOW_DUCKS) {
+    if (month <= MONTH_APRIL && water_type != NULL && water_type->flags & WATER_FLAGS_ALLOW_DUCKS) {
         // 100 attempts at finding some water to create a few ducks at
         for (sint32 i = 0; i < 100; i++) {
             if (scenario_create_ducks())
@@ -708,8 +708,8 @@ static sint32 scenario_write_available_objects(FILE *file)
     rct_object_entry *dstEntry = (rct_object_entry*)buffer;
     for (sint32 i = 0; i < OBJECT_ENTRY_COUNT; i++) {
         void *entryData = get_loaded_object_chunk(i);
-        if (entryData == (void*)-1) {
-            memset(dstEntry, 0xFF, sizeof(rct_object_entry));
+        if (entryData == NULL) {
+            memset(dstEntry, 0, sizeof(rct_object_entry));
         } else {
             *dstEntry = *get_loaded_object_entry(i);
         }

--- a/src/openrct2/windows/EditorObjectSelection.cpp
+++ b/src/openrct2/windows/EditorObjectSelection.cpp
@@ -431,7 +431,7 @@ void window_editor_object_selection_open()
     window->var_4AE = 0;
     window->selected_tab = 0;
     window->selected_list_item = -1;
-    window->object_entry = (rct_object_entry *)-1;
+    window->object_entry = nullptr;
     window->min_width = 600;
     window->min_height = 400;
     window->max_width = 1200;
@@ -508,7 +508,7 @@ static void setup_in_use_selection_flags()
 
     for (uint8 object_type = 0; object_type < 11; object_type++){
         for (uint16 i = 0; i < object_entry_group_counts[object_type]; i++){
-            if (object_entry_groups[object_type].chunks[i] != (uint8*)-1) {
+            if (object_entry_groups[object_type].chunks[i] != nullptr) {
                 Editor::SelectedObjects[object_type][i] |= (1 << 1);
             }
         }
@@ -775,7 +775,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetinde
         visible_list_refresh(w);
 
         w->selected_list_item = -1;
-        w->object_entry = (rct_object_entry *)-1;
+        w->object_entry = nullptr;
         w->scrolls[0].v_top = 0;
         window_invalidate(w);
         break;
@@ -794,7 +794,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetinde
         visible_list_refresh(w);
 
         w->selected_list_item = -1;
-        w->object_entry = (rct_object_entry *)-1;
+        w->object_entry = nullptr;
         w->scrolls[0].v_top = 0;
         w->frame_no = 0;
         window_invalidate(w);
@@ -1449,7 +1449,7 @@ static void window_editor_object_set_page(rct_window *w, sint32 page)
 
     w->selected_tab = page;
     w->selected_list_item = -1;
-    w->object_entry = (rct_object_entry *)-1;
+    w->object_entry = nullptr;
     w->scrolls[0].v_top = 0;
     w->frame_no = 0;
 
@@ -1653,7 +1653,7 @@ static void window_editor_object_selection_manage_tracks()
     gS6Info.editor_step = EDITOR_STEP_TRACK_DESIGNS_MANAGER;
 
     sint32 entry_index = 0;
-    for (; ((intptr_t)object_entry_groups[0].chunks[entry_index]) == -1; ++entry_index);
+    for (; (object_entry_groups[0].chunks[entry_index]) == nullptr; ++entry_index);
 
     rct_ride_entry* ride_entry = get_ride_entry(entry_index);
     uint8 ride_type = ride_entry_get_first_non_null_ride_type(ride_entry);

--- a/src/openrct2/windows/Scenery.cpp
+++ b/src/openrct2/windows/Scenery.cpp
@@ -240,7 +240,7 @@ void init_scenery()
             continue;
 
         rct_scenery_set_entry* scenerySetEntry = get_scenery_group_entry(scenerySetIndex);
-        if (scenerySetEntry == (rct_scenery_set_entry *)-1)
+        if (scenerySetEntry == nullptr)
             continue;
 
         sint32 sceneryTabEntryCount = 0;
@@ -257,7 +257,7 @@ void init_scenery()
 
     // small scenery
     for (uint16 sceneryId = SCENERY_SMALL_SCENERY_ID_MIN; sceneryId < SCENERY_SMALL_SCENERY_ID_MAX; sceneryId++) {
-        if (get_small_scenery_entry(sceneryId) == (rct_scenery_entry *)-1)
+        if (get_small_scenery_entry(sceneryId) == nullptr)
             continue;
 
         rct_scenery_entry* sceneryEntry = get_small_scenery_entry(sceneryId);
@@ -268,7 +268,7 @@ void init_scenery()
     for (sint32 sceneryId = SCENERY_LARGE_SCENERY_ID_MIN; sceneryId < SCENERY_LARGE_SCENERY_ID_MAX; sceneryId++) {
         sint32 largeSceneryIndex = sceneryId - SCENERY_LARGE_SCENERY_ID_MIN;
 
-        if (get_large_scenery_entry(largeSceneryIndex) == (rct_scenery_entry *)-1)
+        if (get_large_scenery_entry(largeSceneryIndex) == nullptr)
             continue;
 
         rct_scenery_entry* sceneryEntry = get_large_scenery_entry(largeSceneryIndex);
@@ -279,7 +279,7 @@ void init_scenery()
     for (sint32 sceneryId = SCENERY_WALLS_ID_MIN; sceneryId < SCENERY_WALLS_ID_MAX; sceneryId++) {
         sint32 wallSceneryIndex = sceneryId - SCENERY_WALLS_ID_MIN;
 
-        if (get_wall_entry(wallSceneryIndex) == (rct_scenery_entry *)-1)
+        if (get_wall_entry(wallSceneryIndex) == nullptr)
             continue;
 
         rct_scenery_entry* sceneryEntry = get_wall_entry(wallSceneryIndex);
@@ -290,7 +290,7 @@ void init_scenery()
     for (sint32 sceneryId = SCENERY_BANNERS_ID_MIN; sceneryId < SCENERY_BANNERS_ID_MAX; sceneryId++) {
         sint32 bannerIndex = sceneryId - SCENERY_BANNERS_ID_MIN;
 
-        if (get_banner_entry(bannerIndex) == (rct_scenery_entry *)-1)
+        if (get_banner_entry(bannerIndex) == nullptr)
             continue;
 
         rct_scenery_entry* sceneryEntry = get_banner_entry(bannerIndex);
@@ -301,7 +301,7 @@ void init_scenery()
     for (sint32 sceneryId = SCENERY_PATH_SCENERY_ID_MIN; sceneryId < SCENERY_PATH_SCENERY_ID_MAX; sceneryId++) {
         sint32 pathBitIndex = sceneryId - SCENERY_PATH_SCENERY_ID_MIN;
 
-        if (get_footpath_item_entry(pathBitIndex) == (rct_scenery_entry *)-1)
+        if (get_footpath_item_entry(pathBitIndex) == nullptr)
             continue;
 
         rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathBitIndex);
@@ -317,7 +317,7 @@ void init_scenery()
 
     for (sint32 scenerySetId = 0; scenerySetId < MAX_SCENERY_GROUP_OBJECTS; scenerySetId++) {
         rct_scenery_set_entry* sceneryEntry = get_scenery_group_entry(scenerySetId);
-        if (sceneryEntry == (rct_scenery_set_entry *)-1)
+        if (sceneryEntry == nullptr)
             continue;
 
         tabIndexes[usedValues] = scenerySetId;
@@ -901,7 +901,7 @@ void window_scenery_invalidate(rct_window *w)
     uint32 titleStringId = STR_MISCELLANEOUS;
     if (tabIndex < SCENERY_WINDOW_TABS - 1) {
         rct_scenery_set_entry * sgEntry = get_scenery_group_entry(tabIndex);
-        if (sgEntry != nullptr && sgEntry != (rct_scenery_set_entry *)-1) {
+        if (sgEntry != nullptr) {
             titleStringId = sgEntry->name;
         }
     }

--- a/src/openrct2/windows/TopToolbar.cpp
+++ b/src/openrct2/windows/TopToolbar.cpp
@@ -1044,7 +1044,7 @@ static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex wid
     {
         sint32 entryIndex = mapElement->properties.scenery.type;
         rct_scenery_entry * sceneryEntry = get_small_scenery_entry(entryIndex);
-        if (sceneryEntry != nullptr && sceneryEntry != (rct_scenery_entry *)-1) {
+        if (sceneryEntry != nullptr) {
             sint32 sceneryId = get_scenery_id_from_entry_index(OBJECT_TYPE_SMALL_SCENERY, entryIndex);
             if (sceneryId != -1 && window_scenery_set_selected_item(sceneryId)) {
                 gWindowSceneryRotation = (get_current_rotation() + map_element_get_direction(mapElement)) & 3;
@@ -1059,7 +1059,7 @@ static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex wid
     {
         sint32 entryIndex = mapElement->properties.wall.type;
         rct_scenery_entry * sceneryEntry = get_wall_entry(entryIndex);
-        if (sceneryEntry != nullptr && sceneryEntry != (rct_scenery_entry *)-1) {
+        if (sceneryEntry != nullptr) {
             sint32 sceneryId = get_scenery_id_from_entry_index(OBJECT_TYPE_WALLS, entryIndex);
             if (sceneryId != -1 && window_scenery_set_selected_item(sceneryId)) {
                 gWindowSceneryPrimaryColour = mapElement->properties.wall.colour_1 & 0x1F;
@@ -1074,7 +1074,7 @@ static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex wid
     {
         sint32 entryIndex = mapElement->properties.scenerymultiple.type & MAP_ELEMENT_LARGE_TYPE_MASK;
         rct_scenery_entry * sceneryEntry = get_large_scenery_entry(entryIndex);
-        if (sceneryEntry != nullptr && sceneryEntry != (rct_scenery_entry *)-1) {
+        if (sceneryEntry != nullptr) {
             sint32 sceneryId = get_scenery_id_from_entry_index(OBJECT_TYPE_LARGE_SCENERY, entryIndex);
             if (sceneryId != -1 && window_scenery_set_selected_item(sceneryId)) {
                 gWindowSceneryRotation = (get_current_rotation() + map_element_get_direction(mapElement)) & 3;
@@ -1090,7 +1090,7 @@ static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex wid
         sint32 bannerIndex = mapElement->properties.banner.index;
         rct_banner *banner = &gBanners[bannerIndex];
         rct_scenery_entry * sceneryEntry = get_banner_entry(banner->type);
-        if (sceneryEntry != nullptr && sceneryEntry != (rct_scenery_entry *)-1) {
+        if (sceneryEntry != nullptr) {
             sint32 sceneryId = get_scenery_id_from_entry_index(OBJECT_TYPE_BANNERS, banner->type);
             if (sceneryId != -1 && window_scenery_set_selected_item(sceneryId)) {
                 gWindowSceneryEyedropperEnabled = false;
@@ -1102,7 +1102,7 @@ static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex wid
     {
         sint32 entryIndex = footpath_element_get_path_scenery_index(mapElement);
         rct_scenery_entry * sceneryEntry = get_footpath_item_entry(entryIndex);
-        if (sceneryEntry != nullptr && sceneryEntry != (rct_scenery_entry *)-1) {
+        if (sceneryEntry != nullptr) {
             sint32 sceneryId = get_scenery_id_from_entry_index(OBJECT_TYPE_PATH_BITS, entryIndex);
             if (sceneryId != -1 && window_scenery_set_selected_item(sceneryId)) {
                 gWindowSceneryEyedropperEnabled = false;

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -92,7 +92,7 @@ static money32 BannerRemove(sint16 x, sint16 y, uint8 baseHeight, uint8 directio
     rct_banner *banner = &gBanners[mapElement->properties.banner.index];
     rct_scenery_entry *bannerEntry = get_banner_entry(banner->type);
     money32 refund = 0;
-    if (bannerEntry != nullptr && bannerEntry != (rct_scenery_entry *)-1)
+    if (bannerEntry != nullptr)
     {
         refund = -((bannerEntry->banner.price * 3) / 4);
     }
@@ -265,7 +265,7 @@ static money32 BannerPlace(sint16 x, sint16 y, uint8 pathBaseHeight, uint8 direc
     }
 
     rct_scenery_entry *bannerEntry = get_banner_entry(type);
-    if ((bannerEntry == nullptr) || (bannerEntry == (rct_scenery_entry *)-1))
+    if (bannerEntry == nullptr)
     {
         return MONEY32_UNDEFINED;
     }

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -33,7 +33,7 @@ static money32 SmallSceneryRemove(sint16 x, sint16 y, uint8 baseHeight, uint8 qu
     money32 cost;
 
     rct_scenery_entry *entry = get_small_scenery_entry(sceneryType);
-    if (entry == (rct_scenery_entry *)-1)
+    if (entry == nullptr)
     {
         log_warning("Invalid game command for scenery removal, scenery_type = %u", sceneryType);
         return MONEY32_UNDEFINED;

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -454,9 +454,8 @@ static money32 WallPlace(uint8 wallType,
     }
     sint32 bannerIndex = 0xFF;
     rct_scenery_entry * wallEntry = get_wall_entry(wallType);
-    // Have to check both -1 and nullptr, as one can be a invalid object,
-    // while the other can be invalid index
-    if ((uintptr_t)wallEntry == (uintptr_t)-1 || wallEntry == nullptr)
+
+    if (wallEntry == nullptr)
     {
         return MONEY32_UNDEFINED;
     }

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -4096,7 +4096,7 @@ bool map_surface_is_blocked(sint16 x, sint16 y){
             return true;
 
         rct_scenery_entry* scenery = get_small_scenery_entry(mapElement->properties.scenery.type);
-        if (scenery == (rct_scenery_entry*)-1)
+        if (scenery == NULL)
         {
             return false;
         }

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -2674,7 +2674,7 @@ void game_command_place_large_scenery(sint32* eax, sint32* ebx, sint32* ecx, sin
     }
 
     rct_scenery_entry *scenery_entry = get_large_scenery_entry(entry_index);
-    if (scenery_entry == (rct_scenery_entry *)-1)
+    if (scenery_entry == NULL)
     {
         log_warning("Invalid game command for scenery placement, entry_index = %u", entry_index);
         *ebx = MONEY32_UNDEFINED;

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -292,7 +292,7 @@ enum
 
 #define MAP_ELEMENT_LARGE_TYPE_MASK 0x3FF
 
-#define TILE_UNDEFINED_MAP_ELEMENT (rct_map_element*)-1
+#define TILE_UNDEFINED_MAP_ELEMENT NULL
 
 #pragma pack(push, 1)
 typedef struct rct_xy8 {

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -521,11 +521,6 @@ static bool map_animation_invalidate_wall(sint32 x, sint32 y, sint32 baseZ)
 
         sceneryEntry = get_wall_entry(mapElement->properties.scenery.type);
 
-        if (sceneryEntry == NULL)
-        {
-            continue;
-        }
-
         if (!(sceneryEntry->wall.flags2 & WALL_SCENERY_2_FLAG5) && sceneryEntry->wall.scrolling_mode == 255)
             continue;
 

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -184,45 +184,44 @@ static bool map_animation_invalidate_small_scenery(sint32 x, sint32 y, sint32 ba
             continue;
 
         sceneryEntry = get_small_scenery_entry(mapElement->properties.scenery.type);
-        if (sceneryEntry != NULL) {
-            if (sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO | SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS)) {
-                map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
-                return false;
-            }
-
-            if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_IS_CLOCK) {
-                // Peep, looking at scenery
-                if (!(gCurrentTicks & 0x3FF) && game_is_not_paused()) {
-                    sint32 direction = map_element_get_direction(mapElement);
-                    sint32 x2 = x - TileDirectionDelta[direction].x;
-                    sint32 y2 = y - TileDirectionDelta[direction].y;
-
-                    uint16 spriteIdx = sprite_get_first_in_quadrant(x2, y2);
-                    for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->unknown.next_in_quadrant) {
-                        sprite = get_sprite(spriteIdx);
-                        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
-                            continue;
-
-                        peep = &sprite->peep;
-                        if (peep->state != PEEP_STATE_WALKING)
-                            continue;
-                        if (peep->z != mapElement->base_height * 8)
-                            continue;
-                        if (peep->action < PEEP_ACTION_NONE_1)
-                            continue;
-
-                        peep->action = PEEP_ACTION_CHECK_TIME;
-                        peep->action_frame = 0;
-                        peep->action_sprite_image_offset = 0;
-                        peep_update_current_action_sprite_type(peep);
-                        invalidate_sprite_1((rct_sprite*)peep);
-                        break;
-                    }
-                }
-                map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
-                return false;
-            }
+        if (sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO | SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS)) {
+            map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
+            return false;
         }
+
+        if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_IS_CLOCK) {
+            // Peep, looking at scenery
+            if (!(gCurrentTicks & 0x3FF) && game_is_not_paused()) {
+                sint32 direction = map_element_get_direction(mapElement);
+                sint32 x2 = x - TileDirectionDelta[direction].x;
+                sint32 y2 = y - TileDirectionDelta[direction].y;
+
+                uint16 spriteIdx = sprite_get_first_in_quadrant(x2, y2);
+                for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->unknown.next_in_quadrant) {
+                    sprite = get_sprite(spriteIdx);
+                    if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+                        continue;
+
+                    peep = &sprite->peep;
+                    if (peep->state != PEEP_STATE_WALKING)
+                        continue;
+                    if (peep->z != mapElement->base_height * 8)
+                        continue;
+                    if (peep->action < PEEP_ACTION_NONE_1)
+                        continue;
+
+                    peep->action = PEEP_ACTION_CHECK_TIME;
+                    peep->action_frame = 0;
+                    peep->action_sprite_image_offset = 0;
+                    peep_update_current_action_sprite_type(peep);
+                    invalidate_sprite_1((rct_sprite*)peep);
+                    break;
+                }
+            }
+            map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
+            return false;
+        }
+
     } while (!map_element_is_last_for_tile(mapElement++));
     return true;
 }

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -184,42 +184,44 @@ static bool map_animation_invalidate_small_scenery(sint32 x, sint32 y, sint32 ba
             continue;
 
         sceneryEntry = get_small_scenery_entry(mapElement->properties.scenery.type);
-        if (sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO | SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS)) {
-            map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
-            return false;
-        }
-
-        if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_IS_CLOCK) {
-            // Peep, looking at scenery
-            if (!(gCurrentTicks & 0x3FF) && game_is_not_paused()) {
-                sint32 direction = map_element_get_direction(mapElement);
-                sint32 x2 = x - TileDirectionDelta[direction].x;
-                sint32 y2 = y - TileDirectionDelta[direction].y;
-
-                uint16 spriteIdx = sprite_get_first_in_quadrant(x2, y2);
-                for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->unknown.next_in_quadrant) {
-                    sprite = get_sprite(spriteIdx);
-                    if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
-                        continue;
-
-                    peep = &sprite->peep;
-                    if (peep->state != PEEP_STATE_WALKING)
-                        continue;
-                    if (peep->z != mapElement->base_height * 8)
-                        continue;
-                    if (peep->action < PEEP_ACTION_NONE_1)
-                        continue;
-
-                    peep->action = PEEP_ACTION_CHECK_TIME;
-                    peep->action_frame = 0;
-                    peep->action_sprite_image_offset = 0;
-                    peep_update_current_action_sprite_type(peep);
-                    invalidate_sprite_1((rct_sprite*)peep);
-                    break;
-                }
+        if (sceneryEntry != NULL) {
+            if (sceneryEntry->small_scenery.flags & (SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO | SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS)) {
+                map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
+                return false;
             }
-            map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
-            return false;
+
+            if (sceneryEntry->small_scenery.flags & SMALL_SCENERY_FLAG_IS_CLOCK) {
+                // Peep, looking at scenery
+                if (!(gCurrentTicks & 0x3FF) && game_is_not_paused()) {
+                    sint32 direction = map_element_get_direction(mapElement);
+                    sint32 x2 = x - TileDirectionDelta[direction].x;
+                    sint32 y2 = y - TileDirectionDelta[direction].y;
+
+                    uint16 spriteIdx = sprite_get_first_in_quadrant(x2, y2);
+                    for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->unknown.next_in_quadrant) {
+                        sprite = get_sprite(spriteIdx);
+                        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+                            continue;
+
+                        peep = &sprite->peep;
+                        if (peep->state != PEEP_STATE_WALKING)
+                            continue;
+                        if (peep->z != mapElement->base_height * 8)
+                            continue;
+                        if (peep->action < PEEP_ACTION_NONE_1)
+                            continue;
+
+                        peep->action = PEEP_ACTION_CHECK_TIME;
+                        peep->action_frame = 0;
+                        peep->action_sprite_image_offset = 0;
+                        peep_update_current_action_sprite_type(peep);
+                        invalidate_sprite_1((rct_sprite*)peep);
+                        break;
+                    }
+                }
+                map_invalidate_tile_zoom1(x, y, mapElement->base_height * 8, mapElement->clearance_height * 8);
+                return false;
+            }
         }
     } while (!map_element_is_last_for_tile(mapElement++));
     return true;
@@ -519,6 +521,12 @@ static bool map_animation_invalidate_wall(sint32 x, sint32 y, sint32 baseZ)
             continue;
 
         sceneryEntry = get_wall_entry(mapElement->properties.scenery.type);
+
+        if (sceneryEntry == NULL)
+        {
+            continue;
+        }
+
         if (!(sceneryEntry->wall.flags2 & WALL_SCENERY_2_FLAG5) && sceneryEntry->wall.scrolling_mode == 255)
             continue;
 

--- a/src/openrct2/world/mapgen.c
+++ b/src/openrct2/world/mapgen.c
@@ -268,7 +268,7 @@ static void mapgen_place_trees()
         rct_scenery_entry *sceneryEntry = get_small_scenery_entry(i);
         rct_object_entry_extended *entry = &object_entry_groups[OBJECT_TYPE_SMALL_SCENERY].entries[i];
 
-        if (sceneryEntry == (rct_scenery_entry*)-1 || sceneryEntry == NULL)
+        if (sceneryEntry == NULL)
             continue;
 
         sint32 j;

--- a/src/openrct2/world/scenery.c
+++ b/src/openrct2/world/scenery.c
@@ -94,7 +94,7 @@ void scenery_update_tile(sint32 x, sint32 y)
         } else if (map_element_get_type(mapElement) == MAP_ELEMENT_TYPE_PATH) {
             if (footpath_element_has_path_scenery(mapElement) && !footpath_element_path_scenery_is_ghost(mapElement)) {
                 rct_scenery_entry *sceneryEntry = get_footpath_item_entry(footpath_element_get_path_scenery_index(mapElement));
-                if (sceneryEntry != (void*)-1) {
+                if (sceneryEntry != NULL) {
                     if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER) {
                         jumping_fountain_begin(JUMPING_FOUNTAIN_TYPE_WATER, x, y, mapElement);
                     }
@@ -117,7 +117,7 @@ void scenery_update_age(sint32 x, sint32 y, rct_map_element *mapElement)
     rct_scenery_entry *sceneryEntry;
 
     sceneryEntry = get_small_scenery_entry(mapElement->properties.scenery.type);
-    if (sceneryEntry == (rct_scenery_entry*)-1)
+    if (sceneryEntry == NULL)
     {
         return;
     }

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -103,11 +103,7 @@ rct_ride_entry *get_ride_entry(int index) {
         return NULL;
     }
 
-    rct_ride_entry * retVal = gRideEntries[index];
-    if (retVal == (rct_ride_entry *)-1)
-        return NULL;
-    else
-        return retVal;
+    return gRideEntries[index];
 }
 
 rct_ride_entry *get_ride_entry_by_ride(Ride *ride) {


### PR DESCRIPTION
Use NULL/nullptr instead. This removes the need for guarding against (void*)-1.
Improve code readability by:
* using Memory::Set() instead of for-loop.
* using Macros instead of Numbers.
* using while-loops instead of do-while-loops.