### PR TITLE
Fix #5417: Crooked House tracked rides do not dispatch vehicles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
+- Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -1855,7 +1855,14 @@ static int ride_get_train_index_from_vehicle(rct_ride* ride, uint16 spriteIndex)
     while (ride->vehicles[trainIndex] != spriteIndex)
     {
         trainIndex++;
-        if (trainIndex >= ride->num_vehicles || trainIndex >= countof(ride->vehicles))
+        if (trainIndex >= ride->num_vehicles)
+        {
+            // This should really return VEHICLE_INVALID_ID, but doing so
+            // would break some hacked parks that hide track by setting tracked rides'
+            // track type to, e.g., Crooked House
+            break;
+        }
+        else if (trainIndex >= countof(ride->vehicles))
         {
             return VEHICLE_INVALID_ID;
         }


### PR DESCRIPTION
I'll freely admit that I do not like this - I'm not sure we should be allowing potentially buggy behaviour. However, it seems this is a widely-used hack, so until we have a better way to handle arbitrary track/vehicle combinations this may be the best option.