### PR TITLE
Implement #3994: Show bottom toolbar with map tooltip

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4450,7 +4450,6 @@ STR_6138    :OpenRCT2 is the work of many authors, a full list can be found in {
 STR_6139    :All product and company names belong to their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 STR_6140    :Changelog...
 STR_6141    :RCT1 Bottom Toolbar
-STR_6142    :OpenRCT2
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4449,6 +4449,8 @@ STR_6137    :OpenRCT2, a free and open source clone of Roller Coaster Tycoon 2.
 STR_6138    :OpenRCT2 is the work of many authors, a full list can be found in {OPENQUOTES}contributors.md{ENDQUOTES}. For more information, visit http://github.com/OpenRCT2/OpenRCT2
 STR_6139    :All product and company names belong to their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 STR_6140    :Changelog...
+STR_6141    :RCT1 Bottom Toolbar
+STR_6142    :OpenRCT2
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -112,7 +112,8 @@ enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_THEMES_LIST,
     WIDX_THEMES_RCT1_RIDE_LIGHTS,
     WIDX_THEMES_RCT1_PARK_LIGHTS,
-    WIDX_THEMES_RCT1_SCENARIO_FONT
+    WIDX_THEMES_RCT1_SCENARIO_FONT,
+    WIDX_THEMES_RCT1_BOTTOM_TOOLBAR
 };
 
 static rct_widget window_themes_widgets[] = {
@@ -139,6 +140,7 @@ static rct_widget window_themes_widgets[] = {
     { WWT_CHECKBOX,         1,  10,     299,    54,     65,     STR_THEMES_OPTION_RCT1_RIDE_CONTROLS,           STR_NONE },                             // rct1 ride lights
     { WWT_CHECKBOX,         1,  10,     299,    69,     80,     STR_THEMES_OPTION_RCT1_PARK_CONTROLS,           STR_NONE },                             // rct1 park lights
     { WWT_CHECKBOX,         1,  10,     299,    84,     95,     STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT, STR_NONE },                             // rct1 scenario font
+    { WWT_CHECKBOX,         1,  10,     299,    99,     110,    STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR,          STR_NONE },                             // rct1 bottom toolbar
     { WIDGETS_END },
 };
 
@@ -340,7 +342,8 @@ rct_window * window_themes_open()
         (1 << WIDX_THEMES_RENAME_BUTTON) |
         (1 << WIDX_THEMES_RCT1_RIDE_LIGHTS) |
         (1 << WIDX_THEMES_RCT1_PARK_LIGHTS) |
-        (1 << WIDX_THEMES_RCT1_SCENARIO_FONT);
+        (1 << WIDX_THEMES_RCT1_SCENARIO_FONT) |
+        (1 << WIDX_THEMES_RCT1_BOTTOM_TOOLBAR);
 
     window_themes_init_vars();
 
@@ -416,9 +419,9 @@ static void window_themes_resize(rct_window *w)
     }
     else if (_selected_tab == WINDOW_THEMES_TAB_FEATURES) {
         w->min_width = 320;
-        w->min_height = 107;
+        w->min_height = 122;
         w->max_width = 320;
-        w->max_height = 107;
+        w->max_height = 122;
 
         if (w->width < w->min_width) {
             w->width = w->min_width;
@@ -536,6 +539,14 @@ static void window_themes_mousedown(rct_window *w, rct_widgetindex widgetIndex, 
             window_invalidate_all();
         }
         break;
+    case WIDX_THEMES_RCT1_BOTTOM_TOOLBAR:
+        if (theme_get_flags() & UITHEME_FLAG_PREDEFINED) {
+            window_error_open(STR_THEMES_ERR_CANT_CHANGE_THIS_THEME, STR_NONE);
+        } else {
+            theme_set_flags(theme_get_flags() ^ UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
+            theme_save();
+            window_invalidate_all();
+        }
     }
 }
 
@@ -722,6 +733,7 @@ void window_themes_invalidate(rct_window *w)
     window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_EMPTY;
     window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_EMPTY;
     window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WWT_EMPTY;
+    window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WWT_EMPTY;
     window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WWT_EMPTY;
     window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WWT_EMPTY;
     window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_EMPTY;
@@ -734,6 +746,7 @@ void window_themes_invalidate(rct_window *w)
         window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WWT_DROPDOWN_BUTTON;
         window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WWT_DROPDOWN_BUTTON;
         window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_DROPDOWN_BUTTON;
@@ -745,6 +758,7 @@ void window_themes_invalidate(rct_window *w)
         window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_CHECKBOX;
         window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_CHECKBOX;
         window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WWT_CHECKBOX;
+        window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WWT_CHECKBOX;
         window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_EMPTY;
@@ -754,6 +768,7 @@ void window_themes_invalidate(rct_window *w)
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_RIDE_LIGHTS, theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_PARK_LIGHTS, theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_PARK);
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_SCENARIO_FONT, theme_get_flags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT);
+        widget_set_checkbox_value(w, WIDX_THEMES_RCT1_BOTTOM_TOOLBAR, theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
     }
     else {
         window_themes_widgets[WIDX_THEMES_LIST].type = WWT_SCROLL;

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -210,7 +210,8 @@ UIThemeWindowEntry PredefinedThemeRCT2_Entries[] =
 const UITheme PredefinedThemeRCT1 = UITheme::CreatePredefined(
     "RCT1", PredefinedThemeRCT1_Entries, UITHEME_FLAG_USE_LIGHTS_RIDE |
                                          UITHEME_FLAG_USE_LIGHTS_PARK |
-                                         UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT);
+                                         UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT |
+                                         UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
 
 const UITheme PredefinedThemeRCT2 = UITheme::CreatePredefined(
     "RCT2", PredefinedThemeRCT2_Entries, 0);
@@ -393,6 +394,7 @@ json_t * UITheme::ToJson() const
     json_object_set_new(jsonTheme,
                         "useAltScenarioSelectFont",
                         json_boolean(Flags & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT));
+	json_object_set_new(jsonTheme, "useFullBottomToolbar", json_boolean(Flags & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR));
 
     return jsonTheme;
 }
@@ -442,6 +444,10 @@ UITheme * UITheme::FromJson(const json_t * json)
         if (json_is_true(json_object_get(json, "useAltScenarioSelectFont")))
         {
             result->Flags |= UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT;
+        }
+        if (json_is_true(json_object_get(json, "useFullBottomToolbar")))
+        {
+            result->Flags |= UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR;
         }
 
         const char * jkey;

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -394,7 +394,7 @@ json_t * UITheme::ToJson() const
     json_object_set_new(jsonTheme,
                         "useAltScenarioSelectFont",
                         json_boolean(Flags & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT));
-	json_object_set_new(jsonTheme, "useFullBottomToolbar", json_boolean(Flags & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR));
+    json_object_set_new(jsonTheme, "useFullBottomToolbar", json_boolean(Flags & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR));
 
     return jsonTheme;
 }

--- a/src/openrct2/interface/themes.h
+++ b/src/openrct2/interface/themes.h
@@ -25,6 +25,7 @@ enum {
     UITHEME_FLAG_USE_LIGHTS_RIDE                       = 1 << 1,
     UITHEME_FLAG_USE_LIGHTS_PARK                       = 1 << 2,
     UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT  = 1 << 3,
+    UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR               = 1 << 4
 };
 
 void colour_scheme_update(rct_window *window);

--- a/src/openrct2/interface/themes.h
+++ b/src/openrct2/interface/themes.h
@@ -25,7 +25,7 @@ enum {
     UITHEME_FLAG_USE_LIGHTS_RIDE                       = 1 << 1,
     UITHEME_FLAG_USE_LIGHTS_PARK                       = 1 << 2,
     UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT  = 1 << 3,
-    UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR               = 1 << 4
+    UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR               = 1 << 4,
 };
 
 void colour_scheme_update(rct_window *window);

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3786,6 +3786,9 @@ enum {
 
     STR_CHANGELOG_ELLIPSIS = 6140,
 
+    STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR = 6141,
+    STR_BOTTOM_TOOLBAR_CREDITS = 6142,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3787,7 +3787,6 @@ enum {
     STR_CHANGELOG_ELLIPSIS = 6140,
 
     STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR = 6141,
-    STR_BOTTOM_TOOLBAR_CREDITS = 6142,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/windows/GameBottomToolbar.cpp
+++ b/src/openrct2/windows/GameBottomToolbar.cpp
@@ -24,6 +24,7 @@ extern "C"
 {
     #include "../game.h"
     #include "../input.h"
+    #include "../interface/themes.h"
     #include "../interface/widget.h"
     #include "../localisation/date.h"
     #include "../localisation/localisation.h"
@@ -84,6 +85,7 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
 static void window_game_bottom_toolbar_draw_park_rating(rct_drawpixelinfo *dpi, rct_window *w, sint32 colour, sint32 x, sint32 y, uint8 factor);
 static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, rct_window *w);
 static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo *dpi, rct_window *w);
+static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi, rct_window *w);
 
 /**
  *
@@ -179,7 +181,14 @@ static void window_game_bottom_toolbar_mouseup(rct_window *w, rct_widgetindex wi
         window_park_rating_open();
         break;
     case WIDX_MIDDLE_INSET:
-        news_item_close_current();
+        if (news_item_is_queue_empty())
+        {
+            context_open_window(WC_RECENT_NEWS);
+        }
+        else
+        {
+            news_item_close_current();
+        }
         break;
     case WIDX_NEWS_SUBJECT:
         newsItem = news_item_get(0);
@@ -268,16 +277,27 @@ static void window_game_bottom_toolbar_invalidate(rct_window *w)
     window_game_bottom_toolbar_widgets[WIDX_RIGHT_INSET].type = WWT_EMPTY;
 
     if (news_item_is_queue_empty()) {
-        window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].type = WWT_EMPTY;
-        window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].type = WWT_EMPTY;
-        window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].type = WWT_EMPTY;
-        window_game_bottom_toolbar_widgets[WIDX_NEWS_LOCATE].type = WWT_EMPTY;
+        if (!(theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)) {
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].type = WWT_EMPTY;
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].type = WWT_EMPTY;
+            window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].type = WWT_EMPTY;
+            window_game_bottom_toolbar_widgets[WIDX_NEWS_LOCATE].type = WWT_EMPTY;
+        } else {
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].type = WWT_IMGBTN;
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].type = WWT_25;
+            window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].type = WWT_EMPTY;
+            window_game_bottom_toolbar_widgets[WIDX_NEWS_LOCATE].type = WWT_EMPTY;
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].colour = 0;
+            window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].colour = 0;
+        }
     } else {
         newsItem = news_item_get(0);
         window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].type = WWT_IMGBTN;
         window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].type = WWT_25;
         window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].type = WWT_FLATBTN;
         window_game_bottom_toolbar_widgets[WIDX_NEWS_LOCATE].type = WWT_FLATBTN;
+        window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].colour = 2;
+        window_game_bottom_toolbar_widgets[WIDX_MIDDLE_INSET].colour = 2;
         w->disabled_widgets &= ~(1 << WIDX_NEWS_SUBJECT);
         w->disabled_widgets &= ~(1 << WIDX_NEWS_LOCATE);
 
@@ -348,6 +368,18 @@ static void window_game_bottom_toolbar_paint(rct_window *w, rct_drawpixelinfo *d
         w->y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom,
         PALETTE_51
     );
+    if (theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
+    {
+        // Draw grey background
+        gfx_filter_rect(
+            dpi,
+            w->x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].left,
+            w->y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].top,
+            w->x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].right,
+            w->y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].bottom,
+            PALETTE_51
+        );
+    }
 
     window_draw_widgets(w, dpi);
 
@@ -355,7 +387,13 @@ static void window_game_bottom_toolbar_paint(rct_window *w, rct_drawpixelinfo *d
     window_game_bottom_toolbar_draw_right_panel(dpi, w);
 
     if (!news_item_is_queue_empty())
+    {
         window_game_bottom_toolbar_draw_news_item(dpi, w);
+    }
+    else if (theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
+    {
+        window_game_bottom_toolbar_draw_middle_panel(dpi, w);
+    }
 }
 
 static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, rct_window *w)
@@ -600,6 +638,38 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo *dpi, rc
     case NEWS_ITEM_GRAPH:
         gfx_draw_sprite(dpi, SPR_GRAPH, x, y, 0);
         break;
+    }
+}
+
+static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi, rct_window *w)
+{
+    rct_widget *middleOutsetWidget = &window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET];
+
+    gfx_fill_rect_inset(
+        dpi,
+        w->x + middleOutsetWidget->left + 1,
+        w->y + middleOutsetWidget->top + 1,
+        w->x + middleOutsetWidget->right - 1,
+        w->y + middleOutsetWidget->bottom - 1,
+        w->colours[1],
+        INSET_RECT_F_30
+    );
+
+    sint32 x = w->x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
+    sint32 y = w->y + middleOutsetWidget->top + 11;
+    sint32 width = middleOutsetWidget->right - middleOutsetWidget->left - 62;
+
+    // Check if there is a map tooltip to draw
+    rct_string_id stringId;
+    memcpy(&stringId, gMapTooltipFormatArgs, sizeof(rct_string_id));
+    if (stringId == STR_NONE)
+    {
+        gfx_draw_string_centred_wrapped(dpi, gMapTooltipFormatArgs, x, y, width, STR_BOTTOM_TOOLBAR_CREDITS, w->colours[0]);
+    }
+    else
+    {
+        // Show tooltip in bottom toolbar
+        gfx_draw_string_centred_wrapped(dpi, gMapTooltipFormatArgs, x, y, width, STR_STRINGID, w->colours[0]);
     }
 }
 

--- a/src/openrct2/windows/GameBottomToolbar.cpp
+++ b/src/openrct2/windows/GameBottomToolbar.cpp
@@ -664,7 +664,7 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi,
     memcpy(&stringId, gMapTooltipFormatArgs, sizeof(rct_string_id));
     if (stringId == STR_NONE)
     {
-        gfx_draw_string_centred_wrapped(dpi, gMapTooltipFormatArgs, x, y, width, STR_BOTTOM_TOOLBAR_CREDITS, w->colours[0]);
+        gfx_draw_string_centred_wrapped(dpi, gMapTooltipFormatArgs, x, y, width, STR_TITLE_SEQUENCE_OPENRCT2, w->colours[0]);
     }
     else
     {

--- a/src/openrct2/windows/MapTooltip.cpp
+++ b/src/openrct2/windows/MapTooltip.cpp
@@ -19,6 +19,7 @@
 extern "C"
 {
     #include "../input.h"
+    #include "../interface/themes.h"
     #include "../interface/widget.h"
     #include "../localisation/localisation.h"
 }
@@ -76,6 +77,13 @@ static void window_map_tooltip_open();
  */
 void window_map_tooltip_update_visibility()
 {
+    if (theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
+    {
+        // The map tooltip is drawn by the bottom toolbar
+        window_invalidate_by_class(WC_BOTTOM_TOOLBAR);
+        return;
+    }
+
     sint32 cursorX, cursorY;
 
     const CursorState * state = context_get_cursor_state();


### PR DESCRIPTION
Shows the bottom toolbar like in RCT1 and moves the map tooltips to the bottom toolbar.
This can be enabled in the theme window and is enabled by default in the RCT1 theme. Clicking the toolbar opens the news window to match RCT1 behaviour. Not enabling the RCT1 bottom toolbar doesn't change anything.

There is some freedom in what to draw when there's no map tooltip. I've tested some different texts and colours and decided that 'OpenRCT2' in the same colour as the map tooltips was the best option.