### PR TITLE
Add #5809: Support Steam RCT1 file layout

### DIFF
--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -57,6 +57,17 @@ public:
         switch (base) {
         default:
         case DIRBASE::RCT1:
+            directoryName = DirectoryNamesRCT1[(size_t)did];
+            if (did == DIRID::DATA)
+            {
+                std::string steamPath = Path::Combine(basePath, DirectoryNamesRCT1[(size_t)DIRID::DATA_STEAM]);
+                if (platform_directory_exists(steamPath.c_str()))
+                {
+                    // If RCTdeluxe_install/Data exists, use that instead.
+                    directoryName = DirectoryNamesRCT1[(size_t)DIRID::DATA_STEAM];
+                }
+            }
+            break;
         case DIRBASE::RCT2:
             directoryName = DirectoryNamesRCT2[(size_t)did];
             break;
@@ -73,11 +84,7 @@ public:
     {
         const utf8 * fileName = FileNames[(size_t)pathid];
         const utf8 * basePath = _basePath[(size_t)DIRBASE::USER].c_str();
-        if (pathid == PATHID::MP_DAT)
-        {
-            basePath = _basePath[(size_t)DIRBASE::RCT1].c_str();
-        }
-        else if (pathid == PATHID::SCORES_RCT2)
+        if (pathid == PATHID::SCORES_RCT2)
         {
             basePath = _basePath[(size_t)DIRBASE::RCT2].c_str();
         }
@@ -94,6 +101,7 @@ public:
     }
 
 private:
+    static const char * DirectoryNamesRCT1[];
     static const char * DirectoryNamesRCT2[];
     static const char * DirectoryNamesOpenRCT2[];
     static const char * FileNames[];
@@ -144,9 +152,29 @@ IPlatformEnvironment * OpenRCT2::CreatePlatformEnvironment()
     return env;
 }
 
+const char * PlatformEnvironment::DirectoryNamesRCT1[] =
+{
+    "Data",                 // DATA
+    "RCTdeluxe_install" PATH_SEPARATOR "Data", // DATA_STEAM
+    "Landscapes",           // LANDSCAPE
+    nullptr,                // LANGUAGE
+    nullptr,                // LOG_CHAT
+    nullptr,                // LOG_SERVER
+    nullptr,                // NETWORK_KEY
+    nullptr,                // OBJECT
+    "Saved Games",          // SAVE
+    "Scenarios",            // SCENARIO
+    nullptr,                // SCREENSHOT
+    nullptr,                // SEQUENCE
+    nullptr,                // SHADER
+    nullptr,                // THEME
+    "Tracks",               // TRACK
+};
+
 const char * PlatformEnvironment::DirectoryNamesRCT2[] =
 {
     "Data",                 // DATA
+    nullptr,                // DATA_STEAM
     "Landscapes",           // LANDSCAPE
     nullptr,                // LANGUAGE
     nullptr,                // LOG_CHAT
@@ -165,6 +193,7 @@ const char * PlatformEnvironment::DirectoryNamesRCT2[] =
 const char * PlatformEnvironment::DirectoryNamesOpenRCT2[] =
 {
     "data",                 // DATA
+    nullptr,                // DATA_STEAM
     "landscape",            // LANDSCAPE
     "language",             // LANGUAGE
     "chatlogs",             // LOG_CHAT
@@ -186,7 +215,6 @@ const char * PlatformEnvironment::FileNames[] =
     "hotkeys.dat",          // CONFIG_KEYBOARD
     "objects.idx",          // CACHE_OBJECTS
     "tracks.idx",           // CACHE_TRACKS
-    "RCTdeluxe_install" PATH_SEPARATOR "Data" PATH_SEPARATOR "mp.dat", // MP_DAT
     "groups.json",          // NETWORK_GROUPS
     "servers.cfg",          // NETWORK_SERVERS
     "users.json",           // NETWORK_USERS

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -34,6 +34,7 @@ namespace OpenRCT2
     enum class DIRID
     {
         DATA,               // Contains g1.dat, music etc.
+        DATA_STEAM,         // Contains data files for the Steam version of RCT1.
         LANDSCAPE,          // Contains scenario editor landscapes (SC6).
         LANGUAGE,           // Contains language packs.
         LOG_CHAT,           // Contains chat logs.
@@ -55,7 +56,6 @@ namespace OpenRCT2
         CONFIG_KEYBOARD,    // Keyboard shortcuts. (hotkeys.cfg)
         CACHE_OBJECTS,      // Object repository cache (objects.idx).
         CACHE_TRACKS,       // Track repository cache (tracks.idx).
-        MP_DAT,             // Mega Park data, Steam RCT1 only (\RCTdeluxe_install\Data\mp.dat)
         NETWORK_GROUPS,     // Server groups with permissions (groups.json).
         NETWORK_SERVERS,    // Saved servers (servers.cfg).
         NETWORK_USERS,      // Users and their groups (users.json).

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -150,13 +150,13 @@ public:
         std::string rct1dir = _env->GetDirectoryPath(DIRBASE::RCT1, DIRID::SCENARIO);
         std::string rct2dir = _env->GetDirectoryPath(DIRBASE::RCT2, DIRID::SCENARIO);
         std::string openrct2dir = _env->GetDirectoryPath(DIRBASE::USER, DIRID::SCENARIO);
-        std::string mpdatdir = _env->GetFilePath(PATHID::MP_DAT);
+        std::string rct1datdir = _env->GetDirectoryPath(DIRBASE::RCT1, DIRID::DATA);
 
         Scan(rct1dir);
         Scan(rct2dir);
         Scan(openrct2dir);
 
-        ConvertMegaPark(mpdatdir, openrct2dir);
+        ConvertMegaPark(rct1datdir, openrct2dir);
 
         Sort();
         LoadScores();
@@ -276,13 +276,14 @@ private:
         delete scanner;
     }
 
-    void ConvertMegaPark(std::string &mpdatDir, std::string &scenarioDir)
+    void ConvertMegaPark(std::string &rct1datDir, std::string &scenarioDir)
     {
         //Convert mp.dat from RCT1 Data directory into SC21.SC4 (Mega Park)
         utf8 mpdatPath[MAX_PATH];
         utf8 sc21Path[MAX_PATH];
 
-        String::Set(mpdatPath, sizeof(mpdatPath), mpdatDir.c_str());
+        String::Set(mpdatPath, sizeof(mpdatPath), rct1datDir.c_str());
+        Path::Append(mpdatPath, sizeof(mpdatPath), "mp.dat");
 
         if (platform_file_exists(mpdatPath))
         {


### PR DESCRIPTION
This PR is still incomplete: `css17.dat` and `mp.dat` are now recognized, but `csg.1.1` still isn't. That will require adding a PlatformEnvironment class to `drawing\sprite.cpp`, and I don't know best way to do it.

This also fixes a concern brought up by @Gymnasiast in #6078 about `mp.dat` not being loaded on other versions of the game.