### PR TITLE
Call tool_set() first.

### DIFF
--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -163,20 +163,20 @@ static void window_land_rights_mouseup(rct_window *w, rct_widgetindex widgetInde
     case WIDX_BUY_LAND_RIGHTS:
         if (_landRightsMode != LAND_RIGHTS_MODE_BUY_LAND)
         {
+            tool_set(w, WIDX_BUY_LAND_RIGHTS, TOOL_UP_ARROW);
             _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
             hide_construction_rights();
             show_land_rights();
-            tool_set(w, WIDX_BUY_LAND_RIGHTS, TOOL_UP_ARROW);
             window_invalidate(w);
         }
         break;
     case WIDX_BUY_CONSTRUCTION_RIGHTS:
         if (_landRightsMode != LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS)
         {
+            tool_set(w, WIDX_BUY_CONSTRUCTION_RIGHTS, TOOL_UP_ARROW);
             _landRightsMode = LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS;
             hide_land_rights();
             show_construction_rights();
-            tool_set(w, WIDX_BUY_CONSTRUCTION_RIGHTS, TOOL_UP_ARROW);
             window_invalidate(w);
         }
         break;


### PR DESCRIPTION
tool_set() cancels the previous tool, so it has to be called first or it will cancel the _landRightsMode that was meant to be activated.

Fix #6133: Signs/flags showing possible land to buy/get construction rights on not shown after selecting construction rights.