### PR TITLE
Fix #6139: All rings in Space Rings use the same secondary colour

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#6115] Random title screen music not random on launch
 - Fix: [#6133] Construction rights not shown after selecting buy mode.
 - Fix: [#6188] Viewports not being clipped properly when zoomed out in OpenGL mode.
+- Fix: [#6193] All rings in Space Rings use the same secondary colour
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: Load/save window now refreshes list if native file dialog is closed/cancelled

--- a/src/openrct2/ride/gentle/space_rings.c
+++ b/src/openrct2/ride/gentle/space_rings.c
@@ -65,7 +65,7 @@ static void paint_space_rings_structure(rct_ride * ride, uint8 direction,  uint3
         }
 
         if (imageColourFlags == IMAGE_TYPE_REMAP) {
-            imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(ride->vehicle_colours[vehicleIndex].body_colour, ride->vehicle_colours[0].trim_colour);
+            imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(ride->vehicle_colours[vehicleIndex].body_colour, ride->vehicle_colours[vehicleIndex].trim_colour);
         }
 
         uint32 imageId = (baseImageId + frameNum) | imageColourFlags;


### PR DESCRIPTION
The Space Rings attraction used the secondary colour of the first ring no matter if the colours are set to all the same or different per ring. Now it uses the right colour for each ring.