### PR TITLE
Fix #5636: Pausing game no longer affects mute button

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
+- Fix: [#5636] Pausing the game shows mute button as active.
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch
 - Fix: [#6133] Construction rights not shown after selecting buy mode.

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -415,6 +415,7 @@ void audio_close()
 void audio_toggle_all_sounds()
 {
     gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
+    gConfigSound.ride_music_enabled = !gConfigSound.ride_music_enabled;
     if (gConfigSound.sound_enabled)
     {
         audio_unpause_sounds();

--- a/src/openrct2/windows/TopToolbar.cpp
+++ b/src/openrct2/windows/TopToolbar.cpp
@@ -797,7 +797,7 @@ static void window_top_toolbar_invalidate(rct_window *w)
     else
         w->pressed_widgets &= ~(1 << WIDX_PAUSE);
 
-    if (!gGameSoundsOff)
+    if (gConfigSound.sound_enabled)
         window_top_toolbar_widgets[WIDX_MUTE].image = IMAGE_TYPE_REMAP | SPR_G2_TOOLBAR_MUTE;
     else
         window_top_toolbar_widgets[WIDX_MUTE].image = IMAGE_TYPE_REMAP | SPR_G2_TOOLBAR_UNMUTE;


### PR DESCRIPTION
Fix #5636: The mute button state is no longer affected by pausing the game. 

In my opinion, changing the configuration to mute the game is a somewhat confusing way to do it, but that would best be addressed once the GameState refactoring is finished.

I also fixed a very minor issue about the ride music not being disabled properly. This lead to the ride music being resumed without the game sounds when muting, pausing, then unpausing the game.