### PR TITLE
Fix #5788: Empty scenario name becomes invisible list entry

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
+- Fix: [#5788] Empty scenario names cause invisible entries in scenario list
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch
 - Fix: [#6133] Construction rights not shown after selecting buy mode.

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -410,11 +410,19 @@ private:
         entry.objective_arg_2 = s6Info->objective_arg_2;
         entry.objective_arg_3 = s6Info->objective_arg_3;
         entry.highscore = nullptr;
-        String::Set(entry.name, sizeof(entry.name), s6Info->name);
-        String::Set(entry.details, sizeof(entry.details), s6Info->details);
+        if (String::IsNullOrEmpty(s6Info->name))
+        {
+            // If the scenario doesn't have a name, set it to the filename
+            String::Set(entry.name, sizeof(entry.name), Path::GetFileNameWithoutExtension(entry.path));
+        }
+        else
+        {
+            String::Set(entry.name, sizeof(entry.name), s6Info->name);
+            // Normalise the name to make the scenario as recognisable as possible.
+            ScenarioSources::NormaliseName(entry.name, sizeof(entry.name), entry.name);
+        }
 
-        // Normalise the name to make the scenario as recognisable as possible.
-        ScenarioSources::NormaliseName(entry.name, sizeof(entry.name), entry.name);
+        String::Set(entry.details, sizeof(entry.details), s6Info->details);
 
         // Look up and store information regarding the origins of this scenario.
         source_desc desc;


### PR DESCRIPTION
Fixes #5788: If the name of a scenario was empty, it would become "invisible" in the
list. This sets its name to the filename instead.