### PR TITLE
Initialize result pointer

### DIFF
--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -449,7 +449,7 @@ private:
             hints.ai_flags = AI_PASSIVE;
         }
 
-        addrinfo * result;
+        addrinfo * result = nullptr;
         getaddrinfo(address, serviceName.c_str(), &hints, &result);
         if (result == nullptr)
         {


### PR DESCRIPTION
This fixes a crash in case getaddrinfo returns an error.