### PR TITLE
Validate size of utf8 strings

### DIFF
--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -89,12 +89,12 @@ namespace String
     const utf8 * SkipBOM(const utf8 * buffer);
 
     size_t      GetCodepointLength(codepoint_t codepoint);
-    codepoint_t GetNextCodepoint(utf8 * ptr, utf8 * * nextPtr = nullptr);
-    codepoint_t GetNextCodepoint(const utf8 * ptr, const utf8 * * nextPtr = nullptr);
+    codepoint_t GetNextCodepoint(utf8 * ptr, sint32 len, utf8 * * nextPtr = nullptr);
+    codepoint_t GetNextCodepoint(const utf8 * ptr, sint32 len, const utf8 * * nextPtr = nullptr);
     utf8 *      WriteCodepoint(utf8 * dst, codepoint_t codepoint);
 
-    utf8 *          Trim(utf8 * str);
-    const utf8 *    TrimStart(const utf8 * str);
-    utf8 *          TrimStart(utf8 * buffer, size_t bufferSize, const utf8 * src);
+    utf8 *          Trim(utf8 * str, size_t len);
+    const utf8 *    TrimStart(const utf8 * str, size_t len);
+    utf8 *          TrimStart(utf8 * buffer, size_t bufferSize, const utf8 * src, size_t len);
     std::string     Trim(const std::string &s);
 }

--- a/src/openrct2/core/StringReader.hpp
+++ b/src/openrct2/core/StringReader.hpp
@@ -38,7 +38,6 @@ public:
     {
         text = String::SkipBOM(text);
 
-        _text = text;
         _current = text;
     }
 
@@ -46,7 +45,7 @@ public:
     {
         if (_current == nullptr) return false;
 
-        codepoint_t codepoint = String::GetNextCodepoint(_current);
+        codepoint_t codepoint = String::GetNextCodepoint(_current, 4);
         *outCodepoint = codepoint;
         return true;
     }
@@ -55,7 +54,7 @@ public:
     {
         if (_current == nullptr) return false;
 
-        codepoint_t codepoint = String::GetNextCodepoint(_current, &_current);
+        codepoint_t codepoint = String::GetNextCodepoint(_current, 4, &_current);
         *outCodepoint = codepoint;
         if (codepoint == 0)
         {
@@ -77,6 +76,5 @@ public:
     }
 
 private:
-    const utf8 *_text;
     const utf8 *_current;
 };

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -46,7 +46,7 @@ void utf8_remove_format_codes(utf8 * text, bool allowcolours)
     const utf8 * ch = text;
     utf8 * dstCh = text;
     sint32 codepoint;
-    while ((codepoint = String::GetNextCodepoint(ch, &ch)) != 0)
+    while ((codepoint = String::GetNextCodepoint(ch, 4, &ch)) != 0)
     {
         if (!utf8_is_format_code(codepoint) || (allowcolours && utf8_is_colour_code(codepoint)))
         {

--- a/src/openrct2/localisation/language.h
+++ b/src/openrct2/localisation/language.h
@@ -75,6 +75,7 @@ bool language_open(sint32 id);
 void language_close_all();
 
 uint32 utf8_get_next(const utf8 *char_ptr, const utf8 **nextchar_ptr);
+uint32 utf8_get_next_bounded(const utf8 *char_ptr, const utf8 **nextchar_ptr, sint32 len);
 utf8 *utf8_write_codepoint(utf8 *dst, uint32 codepoint);
 sint32 utf8_insert_codepoint(utf8 *dst, uint32 codepoint);
 bool utf8_is_codepoint_start(const utf8 *text);

--- a/src/openrct2/localisation/utf8.c
+++ b/src/openrct2/localisation/utf8.c
@@ -45,6 +45,38 @@ uint32 utf8_get_next(const utf8 *char_ptr, const utf8 **nextchar_ptr)
     return result;
 }
 
+uint32 utf8_get_next_bounded(const utf8 *char_ptr, const utf8 **nextchar_ptr, sint32 len)
+{
+    sint32 result;
+    sint32 numBytes;
+
+    if (len == 0)
+    {
+        return 0;
+    }
+    if (!(char_ptr[0] & 0x80) && len >= 1) {
+        result = char_ptr[0];
+        numBytes = 1;
+    } else if ((char_ptr[0] & 0xE0) == 0xC0 && len >= 2) {
+        result = ((char_ptr[0] & 0x1F) << 6) | (char_ptr[1] & 0x3F);
+        numBytes = 2;
+    } else if ((char_ptr[0] & 0xF0) == 0xE0 && len >= 3) {
+        result = ((char_ptr[0] & 0x0F) << 12) | ((char_ptr[1] & 0x3F) << 6) | (char_ptr[2] & 0x3F);
+        numBytes = 3;
+    } else if ((char_ptr[0] & 0xF8) == 0xF0 && len >= 4) {
+        result = ((char_ptr[0] & 0x07) << 18) | ((char_ptr[1] & 0x3F) << 12) | ((char_ptr[1] & 0x3F) << 6) | (char_ptr[2] & 0x3F);
+        numBytes = 4;
+    } else {
+        // TODO 4 bytes
+        result = ' ';
+        numBytes = 1;
+    }
+
+    if (nextchar_ptr != NULL)
+        *nextchar_ptr = char_ptr + numBytes;
+    return result;
+}
+
 utf8 *utf8_write_codepoint(utf8 *dst, uint32 codepoint)
 {
     if (codepoint <= 0x7F) {

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -64,7 +64,8 @@ void StringTable::Read(IReadObjectContext * context, IStream * stream, uint8 id)
             {
                 entry.LanguageId = RCT2_LANGUAGE_ID_BLANK;
             }
-            String::Trim(stringAsUtf8);
+            size_t len = strlen(stringAsUtf8);
+            String::Trim(stringAsUtf8, len);
 
             entry.Text = stringAsUtf8;
             _strings.push_back(entry);

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -344,7 +344,7 @@ namespace ScenarioSources
         }
 
         // Trim (for the sake of the above and WW / TT scenarios
-        String::TrimStart(buffer, bufferSize, name);
+        String::TrimStart(buffer, bufferSize, name, nameLength);
 
         // American scenario titles should be converted to British name
         // Don't worry, names will be translated using language packs later


### PR DESCRIPTION
This adds a bounded version of utf8_get_next that properly handles
malformed strings.