### PR TITLE
Add debug option to show dirty blocks

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4452,6 +4452,7 @@ STR_6140    :Changelog...
 STR_6141    :RCT1 Bottom Toolbar
 STR_6142    :{WINDOW_COLOUR_2}Track name: {BLACK}{STRING}
 STR_6143    :{WINDOW_COLOUR_2}Ride type: {BLACK}{STRINGID}
+STR_6144    :Show dirty visuals
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Feature: [#6181] Map generator now allows adjusting random terrain and tree placement in Simplex Noise tab.
+- Feature: [#6235] Add drawing debug option for showing visuals when and where blocks of the screen are painted.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -31,16 +31,18 @@ enum WINDOW_DEBUG_PAINT_WIDGET_IDX
     WIDX_TOGGLE_OLD_DRAWING,
     WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS,
     WIDX_TOGGLE_SHOW_BOUND_BOXES,
+    WIDX_TOGGLE_SHOW_DIRTY_VISUALS,
 };
 
 #define WINDOW_WIDTH    (200)
-#define WINDOW_HEIGHT   (8 + 15 + 15 + 11 + 8)
+#define WINDOW_HEIGHT   (8 + 15 + 15 + 15 + 11 + 8)
 
 static rct_widget window_debug_paint_widgets[] = {
-    { WWT_FRAME,    0,  0,  WINDOW_WIDTH - 1,   0,              WINDOW_HEIGHT - 1,  0xFFFFFFFF,                             STR_NONE},
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8,              8 + 11,             STR_DEBUG_PAINT_USE_OLD_DRAWING,        STR_NONE},
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15,         8 + 15 + 11,        STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS,   STR_NONE},
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 + 15,    8 + 15 + 15 + 11,   STR_DEBUG_PAINT_SHOW_BOUND_BOXES,       STR_NONE},
+    { WWT_FRAME,    0,  0,  WINDOW_WIDTH - 1,   0,                  WINDOW_HEIGHT - 1,      0xFFFFFFFF,                             STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8,                  8 + 11,                 STR_DEBUG_PAINT_USE_OLD_DRAWING,        STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15,             8 + 15 + 11,            STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS,   STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 + 15,        8 + 15 + 15 + 11,       STR_DEBUG_PAINT_SHOW_BOUND_BOXES,       STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 + 15 + 15,   8 + 15 + 15 + 15 + 11,  STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS,     STR_NONE },
     { WIDGETS_END },
 };
 
@@ -99,7 +101,11 @@ rct_window * window_debug_paint_open()
     );
 
     window->widgets = window_debug_paint_widgets;
-    window->enabled_widgets = (1 << WIDX_TOGGLE_OLD_DRAWING) | (1 << WIDX_TOGGLE_SHOW_BOUND_BOXES) | (1 << WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS);
+    window->enabled_widgets =
+        (1 << WIDX_TOGGLE_OLD_DRAWING) |
+        (1 << WIDX_TOGGLE_SHOW_BOUND_BOXES) |
+        (1 << WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS) |
+        (1 << WIDX_TOGGLE_SHOW_DIRTY_VISUALS);
     window_init_scroll_widgets(window);
     window_push_others_below(window);
 
@@ -126,6 +132,11 @@ static void window_debug_paint_mouseup(rct_window * w, rct_widgetindex widgetInd
             gPaintBoundingBoxes = !gPaintBoundingBoxes;
             gfx_invalidate_screen();
             break;
+
+        case WIDX_TOGGLE_SHOW_DIRTY_VISUALS:
+            gShowDirtyVisuals = !gShowDirtyVisuals;
+            gfx_invalidate_screen();
+            break;
     }
 }
 
@@ -134,6 +145,7 @@ static void window_debug_paint_invalidate(rct_window * w)
     widget_set_checkbox_value(w, WIDX_TOGGLE_OLD_DRAWING, gUseOriginalRidePaint);
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS, gShowSupportSegmentHeights);
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);
+    widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
 }
 
 static void window_debug_paint_paint(rct_window * w, rct_drawpixelinfo * dpi)

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -369,6 +369,10 @@ void X8DrawingEngine::ConfigureBits(uint32 width, uint32 height, uint32 pitch)
 #endif
 }
 
+void X8DrawingEngine::OnDrawDirtyBlock(uint32 x, uint32 y, uint32 columns, uint32 rows)
+{
+}
+
 void X8DrawingEngine::ConfigureDirtyGrid()
 {
     _dirtyGrid.BlockShiftX = 7;
@@ -466,6 +470,7 @@ void X8DrawingEngine::DrawDirtyBlocks(uint32 x, uint32 y, uint32 columns, uint32
     }
 
     // Draw region
+    OnDrawDirtyBlock(x, y, columns, rows);
     window_draw_all(&_bitsDPI, left, top, right, bottom);
 }
 

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -114,6 +114,7 @@ namespace OpenRCT2
 
         protected:
             void ConfigureBits(uint32 width, uint32 height, uint32 pitch);
+            virtual void OnDrawDirtyBlock(uint32 x, uint32 y, uint32 columns, uint32 rows);
 
         private:
             void ConfigureDirtyGrid();

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3791,6 +3791,8 @@ enum {
     STR_TRACK_DESIGN_NAME = 6142,
     STR_TRACK_DESIGN_TYPE = 6143,
 
+    STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS = 6144,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/paint/paint.c
+++ b/src/openrct2/paint/paint.c
@@ -75,6 +75,7 @@ static const uint8 BoundBoxDebugColours[] = {
     222, // BANNER
 };
 
+bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 
 static void paint_attached_ps(rct_drawpixelinfo * dpi, paint_struct * ps, uint32 viewFlags);

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -161,6 +161,7 @@ extern paint_string_struct * gPaintPSStringHead;
 
 /** rct2: 0x00993CC4 */
 extern const uint32 construction_markers[];
+extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;
 
 paint_struct * sub_98196C(uint32 image_id, sint8 x_offset, sint8 y_offset, sint16 bound_box_length_x, sint16 bound_box_length_y, sint8 bound_box_length_z, sint16 z_offset, uint32 rotation);


### PR DESCRIPTION
This adds a new drawing debug option to show when blocks on the screen are invalidated (redrawn). This can be turned on via the debug drawing window.

This is currently only supported in the hardware display drawing engine.

![dirty visuals](https://files.gitter.im/IntelOrca/dU08/image.png)