### PR TITLE
Move paint globals to a new struct

### DIFF
--- a/src/openrct2/drawing/lightfx.c
+++ b/src/openrct2/drawing/lightfx.c
@@ -285,7 +285,7 @@ void lightfx_prepare_light_list()
                     dpi->zoom_level = _viewportDpi1.zoom;
                     dpi->height = 1;
                     dpi->width = 1;
-                    gEndOfPaintStructArray = 0xF1A4CC;
+                    gPaintSession.EndOfPaintStructArray = 0xF1A4CC;
                     unk_140E9A8 = dpi;
                     painter_setup();
                     viewport_paint_setup();

--- a/src/openrct2/drawing/lightfx.c
+++ b/src/openrct2/drawing/lightfx.c
@@ -656,8 +656,8 @@ void lightfx_add_3d_light(uint32 lightID, uint16 lightIDqualifier, sint16 x, sin
 
 void lightfx_add_3d_light_magic_from_drawing_tile(sint16 offsetX, sint16 offsetY, sint16 offsetZ, uint8 lightType)
 {
-    sint16 x = gPaintMapPosition.x + offsetX;
-    sint16 y = gPaintMapPosition.y + offsetY;
+    sint16 x = gPaintSession.MapPosition.x + offsetX;
+    sint16 y = gPaintSession.MapPosition.y + offsetY;
 
     switch (get_current_rotation()) {
     case 0:

--- a/src/openrct2/drawing/lightfx.c
+++ b/src/openrct2/drawing/lightfx.c
@@ -286,7 +286,7 @@ void lightfx_prepare_light_list()
                     dpi->height = 1;
                     dpi->width = 1;
                     gPaintSession.EndOfPaintStructArray = 0xF1A4CC;
-                    unk_140E9A8 = dpi;
+                    gPaintSession.Unk140E9A8 = dpi;
                     painter_setup();
                     viewport_paint_setup();
                     paint_arrange_structs();

--- a/src/openrct2/drawing/scrolling_text.c
+++ b/src/openrct2/drawing/scrolling_text.c
@@ -18,6 +18,7 @@
 #include "../config/Config.h"
 #include "../interface/colour.h"
 #include "../localisation/localisation.h"
+#include "../paint/paint.h"
 #include "../sprites.h"
 #include "drawing.h"
 #include "ttf.h"
@@ -1419,7 +1420,7 @@ sint32 scrolling_text_setup(rct_string_id stringId, uint16 scroll, uint16 scroll
 {
     assert(scrollingMode < MAX_SCROLLING_TEXT_MODES);
 
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
 
     if (dpi->zoom_level != 0) return SPR_SCROLLING_TEXT_DEFAULT;
 

--- a/src/openrct2/interface/viewport.c
+++ b/src/openrct2/interface/viewport.c
@@ -754,8 +754,8 @@ static void viewport_paint_column(rct_drawpixelinfo * dpi, uint32 viewFlags)
         viewport_paint_weather_gloom(dpi);
     }
 
-    if (gPaintPSStringHead != NULL) {
-        paint_draw_money_structs(dpi, gPaintPSStringHead);
+    if (gPaintSession.PSStringHead != NULL) {
+        paint_draw_money_structs(dpi, gPaintSession.PSStringHead);
     }
 }
 

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -38,9 +38,9 @@ const rct_xy16 BannerBoundBoxes[][2] = {
 void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 {
     uint16 boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ;
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
 
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_BANNER;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_BANNER;
 
     if (dpi->zoom_level > 1 || gTrackDesignSaveMode) return;
 
@@ -64,7 +64,7 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) // if being placed
     {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         image_id |= construction_markers[gConfigGeneral.construction_marker_colour];
     }
     else{

--- a/src/openrct2/paint/map_element/entrance.c
+++ b/src/openrct2/paint/map_element/entrance.c
@@ -81,11 +81,11 @@ static void ride_entrance_exit_paint(uint8 direction, sint32 height, rct_map_ele
     colour_2 = ride->track_colour_additional[0];
     image_id = (colour_1 << 19) | (colour_2 << 24) | IMAGE_TYPE_REMAP | IMAGE_TYPE_REMAP_2_PLUS;
 
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
     _unk9E32BC = 0;
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST){
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         image_id = construction_markers[gConfigGeneral.construction_marker_colour];
         _unk9E32BC = image_id;
         if (transparant_image_id)
@@ -195,11 +195,11 @@ static void park_entrance_paint(uint8 direction, sint32 height, rct_map_element*
     }
 #endif
 
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
     _unk9E32BC = 0;
     uint32 image_id, ghost_id = 0;
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST){
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         ghost_id = construction_markers[gConfigGeneral.construction_marker_colour];
         _unk9E32BC = ghost_id;
     }
@@ -278,9 +278,9 @@ static void park_entrance_paint(uint8 direction, sint32 height, rct_map_element*
  *  rct2: 0x00664FD4
  */
 void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element){
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_LABEL;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_LABEL;
 
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
 
     if (gCurrentViewportFlags & VIEWPORT_FLAG_PATH_HEIGHTS &&
         dpi->zoom_level == 0){

--- a/src/openrct2/paint/map_element/fence.c
+++ b/src/openrct2/paint/map_element/fence.c
@@ -132,7 +132,7 @@ static void fence_paint_wall(uint32 frameNum, const rct_scenery_entry * sceneryE
  */
 void fence_paint(uint8 direction, sint32 height, rct_map_element * map_element)
 {
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
 
     rct_scenery_entry * sceneryEntry = get_wall_entry(map_element->properties.wall.type);
     if (sceneryEntry == NULL || sceneryEntry == (rct_scenery_entry *)-1) {
@@ -170,7 +170,7 @@ void fence_paint(uint8 direction, sint32 height, rct_map_element * map_element)
     }
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         dword_141F710 = construction_markers[gConfigGeneral.construction_marker_colour];
     }
 

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -106,7 +106,7 @@ void sub_68B2B7(sint32 x, sint32 y)
  */
 static void blank_tiles_paint(sint32 x, sint32 y)
 {
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
 
     sint32 dx = 0;
     switch (get_current_rotation()) {
@@ -134,9 +134,9 @@ static void blank_tiles_paint(sint32 x, sint32 y)
     dx -= 20;
     dx -= dpi->height;
     if (dx >= dpi->y) return;
-    gPaintSpritePosition.x = x;
-    gPaintSpritePosition.y = y;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+    gPaintSession.SpritePosition.x = x;
+    gPaintSession.SpritePosition.y = y;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
     sub_98196C(3123, 0, 0, 32, 32, -1, 16, get_current_rotation());
 }
 
@@ -148,7 +148,7 @@ bool gShowSupportSegmentHeights = false;
  */
 static void sub_68B3FB(sint32 x, sint32 y)
 {
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
 
     gLeftTunnelCount = 0;
     gRightTunnelCount = 0;
@@ -209,9 +209,9 @@ static void sub_68B3FB(sint32 x, sint32 y)
             0x20900C27;
         sint32 arrowZ = gMapSelectArrowPosition.z;
 
-        gPaintSpritePosition.x = x;
-        gPaintSpritePosition.y = y;
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.SpritePosition.x = x;
+        gPaintSession.SpritePosition.y = y;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
 
         sub_98197C(imageId, 0, 0, 32, 32, 0xFF, arrowZ, 0, 0, arrowZ + 18, rotation);
     }
@@ -244,8 +244,8 @@ static void sub_68B3FB(sint32 x, sint32 y)
     if (dx >= dpi->y)
         return;
 
-    gPaintSpritePosition.x = x;
-    gPaintSpritePosition.y = y;
+    gPaintSession.SpritePosition.x = x;
+    gPaintSession.SpritePosition.y = y;
     gDidPassSurface = false;
     do {
         // Only paint map_elements below the clip height.
@@ -255,7 +255,7 @@ static void sub_68B3FB(sint32 x, sint32 y)
         sint32 height = map_element->base_height * 8;
 
         rct_xy16 dword_9DE574 = gPaintMapPosition;
-        g_currently_drawn_item = map_element;
+        gPaintSession.CurrentlyDrawnItem = map_element;
         // Setup the painting of for example: the underground, signs, rides, scenery, etc.
         switch (map_element_get_type(map_element))
         {
@@ -312,10 +312,10 @@ static void sub_68B3FB(sint32 x, sint32 y)
 
     for (sint32 sy = 0; sy < 3; sy++) {
         for (sint32 sx = 0; sx < 3; sx++) {
-            uint16 segmentHeight = gSupportSegments[segmentPositions[sy][sx]].height;
+            uint16 segmentHeight = gPaintSession.SupportSegments[segmentPositions[sy][sx]].height;
             sint32 imageColourFlats = 0b101111 << 19 | IMAGE_TYPE_TRANSPARENT;
             if (segmentHeight == 0xFFFF) {
-                segmentHeight = gSupport.height;
+                segmentHeight = gPaintSession.Support.height;
                 // white: 0b101101
                 imageColourFlats = 0b111011 << 19 | IMAGE_TYPE_TRANSPARENT;
             }
@@ -363,7 +363,7 @@ void paint_util_set_vertical_tunnel(uint16 height)
 
 void paint_util_set_general_support_height(sint16 height, uint8 slope)
 {
-    if (gSupport.height >= height) {
+    if (gPaintSession.Support.height >= height) {
         return;
     }
 
@@ -372,8 +372,8 @@ void paint_util_set_general_support_height(sint16 height, uint8 slope)
 
 void paint_util_force_set_general_support_height(sint16 height, uint8 slope)
 {
-    gSupport.height = height;
-    gSupport.slope = slope;
+    gPaintSession.Support.height = height;
+    gPaintSession.Support.slope = slope;
 }
 
 const uint16 segment_offsets[9] = {
@@ -390,11 +390,12 @@ const uint16 segment_offsets[9] = {
 
 void paint_util_set_segment_support_height(sint32 segments, uint16 height, uint8 slope)
 {
+    support_height * supportSegments = gPaintSession.SupportSegments;
     for (sint32 s = 0; s < 9; s++) {
         if (segments & segment_offsets[s]) {
-            gSupportSegments[s].height = height;
+            supportSegments[s].height = height;
             if (height != 0xFFFF) {
-                gSupportSegments[s].slope = slope;
+                supportSegments[s].slope = slope;
             }
         }
     }

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -32,13 +32,6 @@
 #include "../../game.h"
 #include "../supports.h"
 
-#ifdef NO_RCT2
-uint8 g141E9DB;
-uint16 gUnk141E9DC;
-bool gDidPassSurface;
-rct_map_element * gSurfaceElement;
-#endif
-
 #ifdef __TESTPAINT__
 uint16 testPaintVerticalTunnelHeight;
 #endif
@@ -62,8 +55,8 @@ void map_element_paint_setup(sint32 x, sint32 y)
     ) {
         paint_util_set_segment_support_height(SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_force_set_general_support_height(-1, 0);
-        g141E9DB = 0;
-        gUnk141E9DC = 0xFFFF;
+        gPaintSession.Unk141E9DB = 0;
+        gPaintSession.Unk141E9DC = 0xFFFF;
 
         sub_68B3FB(x, y);
     } else {
@@ -85,8 +78,8 @@ void sub_68B2B7(sint32 x, sint32 y)
     ) {
         paint_util_set_segment_support_height(SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_force_set_general_support_height(-1, 0);
-        gUnk141E9DC = 0xFFFF;
-        g141E9DB = G141E9DB_FLAG_2;
+        gPaintSession.Unk141E9DC = 0xFFFF;
+        gPaintSession.Unk141E9DB = G141E9DB_FLAG_2;
 
         sub_68B3FB(x, y);
     } else {
@@ -240,7 +233,7 @@ static void sub_68B3FB(sint32 x, sint32 y)
 
     gPaintSession.SpritePosition.x = x;
     gPaintSession.SpritePosition.y = y;
-    gDidPassSurface = false;
+    gPaintSession.DidPassSurface = false;
     do {
         // Only paint map_elements below the clip height.
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (map_element->base_height > gClipHeight)) break;

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -37,11 +37,6 @@ uint8 g141E9DB;
 uint16 gUnk141E9DC;
 bool gDidPassSurface;
 rct_map_element * gSurfaceElement;
-tunnel_entry gLeftTunnels[TUNNEL_MAX_COUNT];
-uint8 gLeftTunnelCount;
-tunnel_entry gRightTunnels[TUNNEL_MAX_COUNT];
-uint8 gRightTunnelCount;
-uint8 gVerticalTunnelHeight;
 #endif
 
 #ifdef __TESTPAINT__
@@ -149,12 +144,12 @@ static void sub_68B3FB(sint32 x, sint32 y)
 {
     rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
 
-    gLeftTunnelCount = 0;
-    gRightTunnelCount = 0;
-    gLeftTunnels[0] = (tunnel_entry){0xFF, 0xFF};
-    gRightTunnels[0] = (tunnel_entry){0xFF, 0xFF};
+    gPaintSession.LeftTunnelCount = 0;
+    gPaintSession.RightTunnelCount = 0;
+    gPaintSession.LeftTunnels[0] = (tunnel_entry){0xFF, 0xFF};
+    gPaintSession.RightTunnels[0] = (tunnel_entry){0xFF, 0xFF};
 
-    gVerticalTunnelHeight = 0xFF;
+    gPaintSession.VerticalTunnelHeight = 0xFF;
 
 #ifndef NO_RCT2
     RCT2_GLOBAL(0x009DE56A, uint16) = x;
@@ -336,19 +331,19 @@ static void sub_68B3FB(sint32 x, sint32 y)
 
 void paint_util_push_tunnel_left(uint16 height, uint8 type)
 {
-    gLeftTunnels[gLeftTunnelCount] = (tunnel_entry){.height = (height / 16), .type = type};
-    if (gLeftTunnelCount < TUNNEL_MAX_COUNT - 1) {
-        gLeftTunnels[gLeftTunnelCount + 1] = (tunnel_entry) {0xFF, 0xFF};
-        gLeftTunnelCount++;
+    gPaintSession.LeftTunnels[gPaintSession.LeftTunnelCount] = (tunnel_entry){.height = (height / 16), .type = type};
+    if (gPaintSession.LeftTunnelCount < TUNNEL_MAX_COUNT - 1) {
+        gPaintSession.LeftTunnels[gPaintSession.LeftTunnelCount + 1] = (tunnel_entry) {0xFF, 0xFF};
+        gPaintSession.LeftTunnelCount++;
     }
 }
 
 void paint_util_push_tunnel_right(uint16 height, uint8 type)
 {
-    gRightTunnels[gRightTunnelCount] = (tunnel_entry){.height = (height / 16), .type = type};
-    if (gRightTunnelCount < TUNNEL_MAX_COUNT - 1) {
-        gRightTunnels[gRightTunnelCount + 1] = (tunnel_entry) {0xFF, 0xFF};
-        gRightTunnelCount++;
+    gPaintSession.RightTunnels[gPaintSession.RightTunnelCount] = (tunnel_entry){.height = (height / 16), .type = type};
+    if (gPaintSession.RightTunnelCount < TUNNEL_MAX_COUNT - 1) {
+        gPaintSession.RightTunnels[gPaintSession.RightTunnelCount + 1] = (tunnel_entry) {0xFF, 0xFF};
+        gPaintSession.RightTunnelCount++;
     }
 }
 
@@ -357,7 +352,7 @@ void paint_util_set_vertical_tunnel(uint16 height)
 #ifdef __TESTPAINT__
     testPaintVerticalTunnelHeight = height;
 #endif
-    gVerticalTunnelHeight = height / 16;
+    gPaintSession.VerticalTunnelHeight = height / 16;
 }
 
 void paint_util_set_general_support_height(sint16 height, uint8 slope)

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -35,7 +35,6 @@
 #ifdef NO_RCT2
 uint8 g141E9DB;
 uint16 gUnk141E9DC;
-rct_xy16 gPaintMapPosition;
 bool gDidPassSurface;
 rct_map_element * gSurfaceElement;
 tunnel_entry gLeftTunnels[TUNNEL_MAX_COUNT];
@@ -161,8 +160,8 @@ static void sub_68B3FB(sint32 x, sint32 y)
     RCT2_GLOBAL(0x009DE56A, uint16) = x;
     RCT2_GLOBAL(0x009DE56E, uint16) = y;
 #endif
-    gPaintMapPosition.x = x;
-    gPaintMapPosition.y = y;
+    gPaintSession.MapPosition.x = x;
+    gPaintSession.MapPosition.y = y;
 
     rct_map_element* map_element = map_get_first_element_at(x >> 5, y >> 5);
     uint8 rotation = get_current_rotation();
@@ -196,8 +195,8 @@ static void sub_68B3FB(sint32 x, sint32 y)
     dx >>= 1;
     // Display little yellow arrow when building footpaths?
     if ((gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_ARROW) &&
-        gPaintMapPosition.x == gMapSelectArrowPosition.x &&
-        gPaintMapPosition.y == gMapSelectArrowPosition.y
+        gPaintSession.MapPosition.x == gMapSelectArrowPosition.x &&
+        gPaintSession.MapPosition.y == gMapSelectArrowPosition.y
     ) {
         uint8 arrowRotation =
             (rotation
@@ -254,7 +253,7 @@ static void sub_68B3FB(sint32 x, sint32 y)
         sint32 direction = map_element_get_direction_with_offset(map_element, rotation);
         sint32 height = map_element->base_height * 8;
 
-        rct_xy16 dword_9DE574 = gPaintMapPosition;
+        rct_xy16 dword_9DE574 = gPaintSession.MapPosition;
         gPaintSession.CurrentlyDrawnItem = map_element;
         // Setup the painting of for example: the underground, signs, rides, scenery, etc.
         switch (map_element_get_type(map_element))
@@ -293,7 +292,7 @@ static void sub_68B3FB(sint32 x, sint32 y)
             // An undefined map element is most likely a corrupt element inserted by 8 cars' MOM feature to skip drawing of all elements after it.
             return;
         }
-        gPaintMapPosition = dword_9DE574;
+        gPaintSession.MapPosition = dword_9DE574;
     } while (!map_element_is_last_for_tile(map_element++));
 
     if (!gShowSupportSegmentHeights) {

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -96,7 +96,7 @@ extern uint8 gVerticalTunnelHeight;
 #else
 #define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
 #define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
-#define gPaintMapPosition                   RCT2_GLOBAL(0x009DE574, rct_xy16)
+#define gPaintMapPosition           RCT2_GLOBAL(0x009DE574, rct_xy16)
 #define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
 #define gSurfaceElement             RCT2_GLOBAL(0x009E3250, rct_map_element *)
 #define gLeftTunnels                RCT2_ADDRESS(0x009E3138, tunnel_entry)

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -75,18 +75,6 @@ enum
     G141E9DB_FLAG_2 = 2,
 };
 
-#ifdef NO_RCT2
-extern uint8 g141E9DB;
-extern uint16 gUnk141E9DC;
-extern bool gDidPassSurface;
-extern rct_map_element * gSurfaceElement;
-#else
-#define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
-#define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
-#define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
-#define gSurfaceElement             RCT2_GLOBAL(0x009E3250, rct_map_element *)
-#endif
-
 #ifdef __TESTPAINT__
 extern uint16 testPaintVerticalTunnelHeight;
 #endif

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -69,39 +69,22 @@ enum
     TUNNEL_15 = 0x0F,
 };
 
-typedef struct tunnel_entry {
-    uint8 height;
-    uint8 type;
-} tunnel_entry;
-
 enum
 {
     G141E9DB_FLAG_1 = 1,
     G141E9DB_FLAG_2 = 2,
 };
 
-#define TUNNEL_MAX_COUNT 65
-
 #ifdef NO_RCT2
 extern uint8 g141E9DB;
 extern uint16 gUnk141E9DC;
 extern bool gDidPassSurface;
 extern rct_map_element * gSurfaceElement;
-extern tunnel_entry gLeftTunnels[TUNNEL_MAX_COUNT];
-extern uint8 gLeftTunnelCount;
-extern tunnel_entry gRightTunnels[TUNNEL_MAX_COUNT];
-extern uint8 gRightTunnelCount;
-extern uint8 gVerticalTunnelHeight;
 #else
 #define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
 #define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
 #define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
 #define gSurfaceElement             RCT2_GLOBAL(0x009E3250, rct_map_element *)
-#define gLeftTunnels                RCT2_ADDRESS(0x009E3138, tunnel_entry)
-#define gLeftTunnelCount            RCT2_GLOBAL(0x0141F56A, uint8)
-#define gRightTunnels               RCT2_ADDRESS(0x009E30B6, tunnel_entry)
-#define gRightTunnelCount           RCT2_GLOBAL(0x0141F56B, uint8)
-#define gVerticalTunnelHeight       RCT2_GLOBAL(0x009E323C, uint8)
 #endif
 
 #ifdef __TESTPAINT__

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -85,7 +85,6 @@ enum
 #ifdef NO_RCT2
 extern uint8 g141E9DB;
 extern uint16 gUnk141E9DC;
-extern rct_xy16 gPaintMapPosition;
 extern bool gDidPassSurface;
 extern rct_map_element * gSurfaceElement;
 extern tunnel_entry gLeftTunnels[TUNNEL_MAX_COUNT];
@@ -96,7 +95,6 @@ extern uint8 gVerticalTunnelHeight;
 #else
 #define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
 #define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
-#define gPaintMapPosition           RCT2_GLOBAL(0x009DE574, rct_xy16)
 #define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
 #define gSurfaceElement             RCT2_GLOBAL(0x009E3250, rct_map_element *)
 #define gLeftTunnels                RCT2_ADDRESS(0x009E3138, tunnel_entry)

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -826,14 +826,14 @@ void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_fo
         imageId += 51;
     }
 
-    if (!gDidPassSurface) {
+    if (!gPaintSession.DidPassSurface) {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
         boundBoxSize.x = 26;
         boundBoxSize.y = 26;
     }
 
-    if (!hasFences || !gDidPassSurface) {
+    if (!hasFences || !gPaintSession.DidPassSurface) {
         sub_98197C(imageId | imageFlags, 0, 0, boundBoxSize.x, boundBoxSize.y, 0, height, boundBoxOffset.x, boundBoxOffset.y, height + 1, get_current_rotation());
     } else {
         uint32 image_id;
@@ -940,14 +940,14 @@ void path_paint_box_support(rct_map_element* mapElement, sint16 height, rct_foot
     }
 
     // Below Surface
-    if (!gDidPassSurface) {
+    if (!gPaintSession.DidPassSurface) {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
         boundBoxSize.x = 26;
         boundBoxSize.y = 26;
     }
 
-    if (!hasFences || !gDidPassSurface) {
+    if (!hasFences || !gPaintSession.DidPassSurface) {
         sub_98197C(imageId | imageFlags, 0, 0, boundBoxSize.x, boundBoxSize.y, 0, height, boundBoxOffset.x, boundBoxOffset.y, height + 1, get_current_rotation());
     }
     else {

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -366,7 +366,7 @@ static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp,
 
         uint8 direction = ((map_element->type & 0xC0) >> 6);
         // Draw ride sign
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
         if (footpath_element_is_sloped(map_element)) {
             if (footpath_element_get_slope_direction(map_element) == direction)
                 height += 16;
@@ -419,9 +419,9 @@ static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp,
             sub_98199C(scrolling_text_setup(string_id, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,  boundBoxOffsets.x,  boundBoxOffsets.y,  boundBoxOffsets.z, get_current_rotation());
         }
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
         if (imageFlags != 0) {
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         }
         return;
     }
@@ -596,15 +596,15 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
 
     // Probably drawing benches etc.
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
 
     if (dpi->zoom_level <= 1) {
         if (!gTrackDesignSaveMode) {
             uint8 additions = map_element->properties.path.additions & 0xF;
             if (additions != 0) {
-                gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM;
+                gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM;
                 if (sceneryImageFlags != 0) {
-                    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
 
                 // Draw additional path bits (bins, benches, lamps, queue screens)
@@ -624,10 +624,10 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
                     break;
                 }
 
-                gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+                gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
                 if (sceneryImageFlags != 0) {
-                    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
             }
         }
@@ -672,7 +672,7 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
  */
 void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
 {
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
     bool word_F3F038 = false;
 
@@ -696,7 +696,7 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
     }
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         imageFlags = construction_markers[gConfigGeneral.construction_marker_colour];
     }
 

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -700,7 +700,7 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
         imageFlags = construction_markers[gConfigGeneral.construction_marker_colour];
     }
 
-    sint16 x = gPaintMapPosition.x, y = gPaintMapPosition.y;
+    sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
 
     rct_map_element * surface = map_get_surface_element_at(x / 32, y / 32);
 
@@ -727,8 +727,8 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
         sint32 staffIndex = gStaffDrawPatrolAreas;
         uint8 staffType = staffIndex & 0x7FFF;
         bool is_staff_list = staffIndex & 0x8000;
-        x = gPaintMapPosition.x;
-        y = gPaintMapPosition.y;
+        x = gPaintSession.MapPosition.x;
+        y = gPaintSession.MapPosition.y;
 
         uint8 patrolColour = COLOUR_LIGHT_BLUE;
 

--- a/src/openrct2/paint/map_element/scenery.c
+++ b/src/openrct2/paint/map_element/scenery.c
@@ -44,7 +44,7 @@ static const rct_xy16 lengths[] = {
  */
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) {
     //RCT2_CALLPROC_X(0x6DFF47, 0, 0, direction, height, (sint32)mapElement, 0, 0); return;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SCENERY;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SCENERY;
     rct_xyz16 boxlength;
     rct_xyz16 boxoffset;
     boxoffset.x = 0;
@@ -58,7 +58,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
         }
     }
     if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         baseImageid = construction_markers[gConfigGeneral.construction_marker_colour];
     }
     uint32 dword_F64EB0 = baseImageid;
@@ -152,7 +152,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
     }
 
     if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_ANIMATED) {
-        rct_drawpixelinfo* dpi = unk_140E9A8;
+        rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
         if ( (entry->small_scenery.flags & SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED) || (dpi->zoom_level <= 1) ) {
             // 6E01A9:
             if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1) {
@@ -218,8 +218,8 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
             if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_SWAMP_GOO) {
                 // 6E02F6:
                 sint32 image_id = gCurrentTicks;
-                image_id += gPaintSpritePosition.x / 4;
-                image_id += gPaintSpritePosition.y / 4;
+                image_id += gPaintSession.SpritePosition.x / 4;
+                image_id += gPaintSession.SpritePosition.y / 4;
                 image_id = (image_id / 4) & 15;
                 image_id += entry->image;
                 if (dword_F64EB0 != 0) {
@@ -232,7 +232,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
                 sint32 frame = gCurrentTicks;
                 if (!(entry->small_scenery.flags & SMALL_SCENERY_FLAG_COG)) {
                     // 6E01F8:
-                    frame += ((gPaintSpritePosition.x / 4) + (gPaintSpritePosition.y / 4));
+                    frame += ((gPaintSession.SpritePosition.x / 4) + (gPaintSession.SpritePosition.y / 4));
                     frame += (mapElement->type & 0xC0) / 16;
                 }
                 // 6E0222:

--- a/src/openrct2/paint/map_element/scenery_multiple.c
+++ b/src/openrct2/paint/map_element/scenery_multiple.c
@@ -185,7 +185,7 @@ static const boundbox s98E3C4[] = {
 */
 void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement) {
     //RCT2_CALLPROC_X(0x6B7F0C, 0, 0, direction, height, (sint32)mapElement, 0, 0); return;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY;
     uint32 ebp = mapElement->properties.scenerymultiple.type >> 10;
     rct_scenery_entry *entry = get_large_scenery_entry(mapElement->properties.scenerymultiple.type & 0x3FF);
     if (entry == (void*)-1)
@@ -206,7 +206,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
         }
     }
     if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         ebp = construction_markers[gConfigGeneral.construction_marker_colour];
         image_id &= 0x7FFFF;
         dword_F4387C = ebp;
@@ -243,7 +243,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
                 return;
             }
         }
-        rct_drawpixelinfo* dpi = unk_140E9A8;
+        rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
         if (dpi->zoom_level > 1) {
             scenery_multiple_paint_supports(direction, height, mapElement, dword_F4387C, tile);
             return;
@@ -324,7 +324,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
         }
         return;
     }
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level > 0) {
         scenery_multiple_paint_supports(direction, height, mapElement, dword_F4387C, tile);
         return;

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -1173,7 +1173,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     if (((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode) &&
         gCurrentViewportFlags & VIEWPORT_FLAG_LAND_OWNERSHIP
     ) {
-        rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+        rct_xy16 pos = gPaintMapPosition;
         for (sint32 i = 0; i < MAX_PEEP_SPAWNS; ++i) {
             rct2_peep_spawn * spawn = &gPeepSpawns[i];
 
@@ -1193,7 +1193,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(surfaceShape < countof(byte_97B444));
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE) {
-            rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+            rct_xy16 pos = gPaintMapPosition;
             paint_struct * backup = gPaintSession.UnkF1AD28;
             sint32 height2 = (map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF) + 3;
             sub_98196C(SPR_LAND_OWNERSHIP_AVAILABLE, 16, 16, 1, 1, 0, height2, rotation);
@@ -1208,7 +1208,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) {
             paint_struct * backup = gPaintSession.UnkF1AD28;
-            rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+            rct_xy16 pos = gPaintMapPosition;
             sint32 height2 = map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF;
             sub_98196C(SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE, 16, 16, 1, 1, 0, height2 + 3, rotation);
             gPaintSession.UnkF1AD28 = backup;
@@ -1221,7 +1221,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE) {
         // loc_660FB8:
-        rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+        rct_xy16 pos = gPaintMapPosition;
         if (pos.x >= gMapSelectPositionA.x &&
             pos.x <= gMapSelectPositionB.x &&
             pos.y >= gMapSelectPositionA.y &&
@@ -1284,7 +1284,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     }
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT) {
-        rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+        rct_xy16 pos = gPaintMapPosition;
 
         rct_xy16 * tile;
         for (tile = gMapSelectionTiles; tile->x != -1; tile++) {

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -577,7 +577,7 @@ static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 heigh
             tunnelBounds.x = 32;
             tunnelTopBoundBoxOffset.y = 31;
 
-            tunnelArray = gLeftTunnels;
+            tunnelArray = gPaintSession.LeftTunnels;
             break;
 
         case EDGE_BOTTOMRIGHT:
@@ -592,7 +592,7 @@ static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 heigh
             tunnelBounds.y = 32;
             tunnelTopBoundBoxOffset.x = 31;
 
-            tunnelArray = gRightTunnels;
+            tunnelArray = gPaintSession.RightTunnels;
             break;
 
         default:
@@ -839,7 +839,7 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
             tunnelBounds.x = 32;
             tunnelTopBoundBoxOffset.y = 31;
 
-            tunnelArray = gLeftTunnels;
+            tunnelArray = gPaintSession.LeftTunnels;
             break;
 
         case EDGE_BOTTOMRIGHT:
@@ -854,7 +854,7 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
             tunnelBounds.y = 32;
             tunnelTopBoundBoxOffset.x = 31;
 
-            tunnelArray = gRightTunnels;
+            tunnelArray = gPaintSession.RightTunnels;
             break;
 
         default:
@@ -1065,7 +1065,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
 
     bool has_surface = false;
-    if (gVerticalTunnelHeight * 16 == height) {
+    if (gPaintSession.VerticalTunnelHeight * 16 == height) {
         // Vertical tunnels
         sub_98197C(1575, 0, 0, 1, 30, 39, height, -2, 1, height - 40, rotation);
         sub_98197C(1576, 0, 0, 30, 1, 0, height, 1, 31, height, rotation);
@@ -1344,12 +1344,12 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 #ifdef __MINGW32__
         // The other code crashes mingw 4.8.2, as available on Travis
         for (sint32 i = 0; i < TUNNEL_MAX_COUNT; i++) {
-            backupLeftTunnels[i] = gLeftTunnels[i];
-            backupRightTunnels[i] = gRightTunnels[i];
+            backupLeftTunnels[i] = gPaintSession.LeftTunnels[i];
+            backupRightTunnels[i] = gPaintSession.RightTunnels[i];
         }
 #else
-        memcpy(backupLeftTunnels, gLeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
-        memcpy(backupRightTunnels, gRightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(backupLeftTunnels, gPaintSession.LeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(backupRightTunnels, gPaintSession.RightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
 #endif
 
         viewport_surface_draw_land_side_top(EDGE_TOPLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
@@ -1361,12 +1361,12 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 #ifdef __MINGW32__
         // The other code crashes mingw 4.8.2, as available on Travis
         for (sint32 i = 0; i < TUNNEL_MAX_COUNT; i++) {
-            gLeftTunnels[i] = backupLeftTunnels[i];
-            gRightTunnels[i] = backupRightTunnels[i];
+            gPaintSession.LeftTunnels[i] = backupLeftTunnels[i];
+            gPaintSession.RightTunnels[i] = backupRightTunnels[i];
         }
 #else
-        memcpy(gLeftTunnels, backupLeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
-        memcpy(gRightTunnels, backupRightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(gPaintSession.LeftTunnels, backupLeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(gPaintSession.RightTunnels, backupRightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
 #endif
     }
 

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -1051,7 +1051,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
 
     if ((gCurrentViewportFlags & VIEWPORT_FLAG_LAND_HEIGHTS) && (zoomLevel == 0)) {
-        sint16 x = gPaintMapPosition.x, y = gPaintMapPosition.y;
+        sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
 
         sint32 dx = map_element_height(x + 16, y + 16) & 0xFFFF;
         dx += 3;
@@ -1123,8 +1123,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             case 6:
                 // loc_660C6A
             {
-                sint16 x = gPaintMapPosition.x & 0x20;
-                sint16 y = gPaintMapPosition.y & 0x20;
+                sint16 x = gPaintSession.MapPosition.x & 0x20;
+                sint16 y = gPaintSession.MapPosition.y & 0x20;
                 sint32 index = (y | (x << 1)) >> 5;
 
                 if (branch == 6) {
@@ -1147,7 +1147,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         sint32 staffIndex = gStaffDrawPatrolAreas;
         bool is_staff_list = staffIndex & 0x8000;
         uint8 staffType = staffIndex & 0x7FFF;
-        sint16 x = gPaintMapPosition.x, y = gPaintMapPosition.y;
+        sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
 
         uint32 image_id = IMAGE_TYPE_REMAP;
         uint8 patrolColour = 7;
@@ -1173,7 +1173,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     if (((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode) &&
         gCurrentViewportFlags & VIEWPORT_FLAG_LAND_OWNERSHIP
     ) {
-        rct_xy16 pos = gPaintMapPosition;
+        rct_xy16 pos = gPaintSession.MapPosition;
         for (sint32 i = 0; i < MAX_PEEP_SPAWNS; ++i) {
             rct2_peep_spawn * spawn = &gPeepSpawns[i];
 
@@ -1193,7 +1193,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(surfaceShape < countof(byte_97B444));
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE) {
-            rct_xy16 pos = gPaintMapPosition;
+            rct_xy16 pos = gPaintSession.MapPosition;
             paint_struct * backup = gPaintSession.UnkF1AD28;
             sint32 height2 = (map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF) + 3;
             sub_98196C(SPR_LAND_OWNERSHIP_AVAILABLE, 16, 16, 1, 1, 0, height2, rotation);
@@ -1208,7 +1208,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) {
             paint_struct * backup = gPaintSession.UnkF1AD28;
-            rct_xy16 pos = gPaintMapPosition;
+            rct_xy16 pos = gPaintSession.MapPosition;
             sint32 height2 = map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF;
             sub_98196C(SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE, 16, 16, 1, 1, 0, height2 + 3, rotation);
             gPaintSession.UnkF1AD28 = backup;
@@ -1221,7 +1221,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE) {
         // loc_660FB8:
-        rct_xy16 pos = gPaintMapPosition;
+        rct_xy16 pos = gPaintSession.MapPosition;
         if (pos.x >= gMapSelectPositionA.x &&
             pos.x <= gMapSelectPositionB.x &&
             pos.y >= gMapSelectPositionA.y &&
@@ -1284,7 +1284,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     }
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT) {
-        rct_xy16 pos = gPaintMapPosition;
+        rct_xy16 pos = gPaintSession.MapPosition;
 
         rct_xy16 * tile;
         for (tile = gMapSelectionTiles; tile->x != -1; tile++) {

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -990,8 +990,8 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
  */
 void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 {
-    rct_drawpixelinfo * dpi = unk_140E9A8;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
     gDidPassSurface = true;
     gSurfaceElement = mapElement;
 
@@ -1002,8 +1002,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     uint32 surfaceShape = viewport_surface_paint_setup_get_relative_slope(mapElement, rotation);
 
     rct_xy16 base = {
-        .x = gPaintSpritePosition.x,
-        .y = gPaintSpritePosition.y
+        .x = gPaintSession.SpritePosition.x,
+        .y = gPaintSession.SpritePosition.y
     };
 
     corner_height ch = corner_heights[surfaceShape];
@@ -1373,7 +1373,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     if (map_get_water_height(mapElement) > 0)
     {
         // loc_6615A9: (water height)
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_WATER;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_WATER;
 
         uint16 localHeight = height + 16;
         uint16 waterHeight = map_get_water_height(mapElement) * 16;
@@ -1410,7 +1410,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         !gTrackDesignSaveMode
     ) {
         // Owned land boundary fences
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
 
         registers regs = { 0 };
         regs.al = mapElement->properties.surface.ownership & 0x0F;
@@ -1530,7 +1530,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         }
     }
 
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
     g141E9DB |= G141E9DB_FLAG_1;
 
     switch (surfaceShape) {

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -992,8 +992,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 {
     rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
     gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
-    gDidPassSurface = true;
-    gSurfaceElement = mapElement;
+    gPaintSession.DidPassSurface = true;
+    gPaintSession.SurfaceElement = mapElement;
 
     uint16 zoomLevel = dpi->zoom_level;
 
@@ -1379,7 +1379,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         uint16 waterHeight = map_get_water_height(mapElement) * 16;
 
         if (!gTrackDesignSaveMode) {
-            gUnk141E9DC = waterHeight;
+            gPaintSession.Unk141E9DC = waterHeight;
 
             sint32 image_offset = 0;
             if (waterHeight <= localHeight) {
@@ -1531,7 +1531,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     }
 
     gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
-    g141E9DB |= G141E9DB_FLAG_1;
+    gPaintSession.Unk141E9DB |= G141E9DB_FLAG_1;
 
     switch (surfaceShape) {
         default:

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -446,7 +446,7 @@ static void viewport_surface_smoothen_edge(enum edge_t edge, struct tile_descrip
     uint32 image_id = maskImageBase + byte_97B444[self.slope];
 
     if (paint_attach_to_previous_ps(image_id, 0, 0)) {
-        attached_paint_struct * out = g_aps_F1AD2C;
+        attached_paint_struct * out = gPaintSession.UnkF1AD2C;
         // set content and enable masking
         out->colour_image_id = dword_97B804[neighbour.terrain] + cl;
         out->flags |= PAINT_STRUCT_FLAG_IS_MASKED;
@@ -1194,10 +1194,10 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE) {
             rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
-            paint_struct * backup = g_ps_F1AD28;
+            paint_struct * backup = gPaintSession.UnkF1AD28;
             sint32 height2 = (map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF) + 3;
             sub_98196C(SPR_LAND_OWNERSHIP_AVAILABLE, 16, 16, 1, 1, 0, height2, rotation);
-            g_ps_F1AD28 = backup;
+            gPaintSession.UnkF1AD28 = backup;
         }
     }
 
@@ -1207,11 +1207,11 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(surfaceShape < countof(byte_97B444));
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) {
-            paint_struct * backup = g_ps_F1AD28;
+            paint_struct * backup = gPaintSession.UnkF1AD28;
             rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
             sint32 height2 = map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF;
             sub_98196C(SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE, 16, 16, 1, 1, 0, height2 + 3, rotation);
-            g_ps_F1AD28 = backup;
+            gPaintSession.UnkF1AD28 = backup;
         }
     }
 
@@ -1276,9 +1276,9 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
                 sint32 image_id = (SPR_TERRAIN_SELECTION_CORNER + byte_97B444[local_surfaceShape]) | 0x21300000;
 
-                paint_struct * backup = g_ps_F1AD28;
+                paint_struct * backup = gPaintSession.UnkF1AD28;
                 sub_98196C(image_id, 0, 0, 32, 32, 1, local_height, rotation);
-                g_ps_F1AD28 = backup;
+                gPaintSession.UnkF1AD28 = backup;
             }
         }
     }

--- a/src/openrct2/paint/paint.c
+++ b/src/openrct2/paint/paint.c
@@ -33,13 +33,7 @@ const uint32 construction_markers[] = {
 
 paint_session gPaintSession;
 
-#ifdef NO_RCT2
-void *g_currently_drawn_item;
-rct_xy16 gPaintSpritePosition;
-uint8 gPaintInteractionType;
-support_height gSupportSegments[9] = { 0 };
-support_height gSupport;
-#else
+#ifndef NO_RCT2
 #define _paintQuadrants (RCT2_ADDRESS(0x00F1A50C, paint_struct*))
 #define _paintQuadrantBackIndex RCT2_GLOBAL(0xF1AD0C, uint32)
 #define _paintQuadrantFrontIndex RCT2_GLOBAL(0xF1AD10, uint32)
@@ -148,7 +142,7 @@ static paint_struct * sub_9819_c(paint_session * session, uint32 image_id, rct_x
     sint32 right = left + g1Element->width;
     sint32 top = bottom + g1Element->height;
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = session->Unk140E9A8;
 
     if (right <= dpi->x)return NULL;
     if (top <= dpi->y)return NULL;
@@ -298,7 +292,7 @@ paint_struct * sub_98196C(
     sint16 right = left + g1Element->width;
     sint16 top = bottom + g1Element->height;
 
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = session->Unk140E9A8;
 
     if (right <= dpi->x) return NULL;
     if (top <= dpi->y) return NULL;
@@ -314,7 +308,7 @@ paint_struct * sub_98196C(
     ps->var_29 = 0;
     ps->map_x = session->MapPosition.x;
     ps->map_y = session->MapPosition.y;
-    ps->mapElement = g_currently_drawn_item;
+    ps->mapElement = gPaintSession.CurrentlyDrawnItem;
 
     session->UnkF1AD28 = ps;
 

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -157,24 +157,14 @@ typedef struct paint_session
 
 extern paint_session gPaintSession;
 
-#ifdef NO_RCT2
-extern void *g_currently_drawn_item;
-extern rct_xy16 gPaintSpritePosition;
-#else
-#define gPaintStructs RCT2_ADDRESS(0x00EE788C, paint_entry)
+#ifndef NO_RCT2
+#define gPaintStructs           RCT2_ADDRESS(0x00EE788C, paint_entry)
 #define g_currently_drawn_item  RCT2_GLOBAL(0x009DE578, void*)
 #define gEndOfPaintStructArray  RCT2_GLOBAL(0x00EE7880, paint_entry *)
 #define gPaintSpritePosition    RCT2_GLOBAL(0x009DE568, rct_xy16)
-#endif
-
-#ifndef NO_RCT2
-#define gPaintInteractionType       RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8)
-#define gSupportSegments            RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_SUPPORT_SEGMENTS, support_height)
-#define gSupport                    RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
-#else
-extern uint8 gPaintInteractionType;
-extern support_height gSupportSegments[9];
-extern support_height gSupport;
+#define gPaintInteractionType   RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8)
+#define gSupportSegments        RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_SUPPORT_SEGMENTS, support_height)
+#define gSupport                RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -166,6 +166,7 @@ extern paint_session gPaintSession;
 #define gSupportSegments            RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_SUPPORT_SEGMENTS, support_height)
 #define gSupport                    RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
 #define gWoodenSupportsPrependTo    RCT2_GLOBAL(0x009DEA58, paint_struct *)
+#define gPaintMapPosition           RCT2_GLOBAL(0x009DE574, rct_xy16)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -158,13 +158,14 @@ typedef struct paint_session
 extern paint_session gPaintSession;
 
 #ifndef NO_RCT2
-#define gPaintStructs           RCT2_ADDRESS(0x00EE788C, paint_entry)
-#define g_currently_drawn_item  RCT2_GLOBAL(0x009DE578, void*)
-#define gEndOfPaintStructArray  RCT2_GLOBAL(0x00EE7880, paint_entry *)
-#define gPaintSpritePosition    RCT2_GLOBAL(0x009DE568, rct_xy16)
-#define gPaintInteractionType   RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8)
-#define gSupportSegments        RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_SUPPORT_SEGMENTS, support_height)
-#define gSupport                RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
+#define gPaintStructs               RCT2_ADDRESS(0x00EE788C, paint_entry)
+#define g_currently_drawn_item      RCT2_GLOBAL(0x009DE578, void*)
+#define gEndOfPaintStructArray      RCT2_GLOBAL(0x00EE7880, paint_entry *)
+#define gPaintSpritePosition        RCT2_GLOBAL(0x009DE568, rct_xy16)
+#define gPaintInteractionType       RCT2_GLOBAL(RCT2_ADDRESS_PAINT_SETUP_CURRENT_TYPE, uint8)
+#define gSupportSegments            RCT2_ADDRESS(RCT2_ADDRESS_CURRENT_SUPPORT_SEGMENTS, support_height)
+#define gSupport                    RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
+#define gWoodenSupportsPrependTo    RCT2_GLOBAL(0x009DEA58, paint_struct *)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -168,11 +168,14 @@ typedef struct paint_session
     bool                    DidPassSurface;
     uint8                   Unk141E9DB;
     uint16                  Unk141E9DC;
+    uint32                  TrackColours[4];
 } paint_session;
 
 extern paint_session gPaintSession;
 
-#ifndef NO_RCT2
+#ifdef NO_RCT2
+#define gTrackColours               gPaintSession.TrackColours
+#else
 #define gPaintStructs               RCT2_ADDRESS(0x00EE788C, paint_entry)
 #define g_currently_drawn_item      RCT2_GLOBAL(0x009DE578, void*)
 #define gEndOfPaintStructArray      RCT2_GLOBAL(0x00EE7880, paint_entry *)
@@ -191,6 +194,7 @@ extern paint_session gPaintSession;
 #define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
 #define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
 #define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
+#define gTrackColours   RCT2_ADDRESS(0x00F44198, uint32)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -130,7 +130,13 @@ typedef struct support_height {
     uint8 pad;
 } support_height;
 
+typedef struct tunnel_entry {
+    uint8 height;
+    uint8 type;
+} tunnel_entry;
+
 #define MAX_PAINT_QUADRANTS 512
+#define TUNNEL_MAX_COUNT    65
 
 typedef struct paint_session
 {
@@ -153,6 +159,11 @@ typedef struct paint_session
     paint_string_struct *   LastPSString;
     paint_struct *          WoodenSupportsPrependTo;
     rct_xy16                MapPosition;
+    tunnel_entry            LeftTunnels[TUNNEL_MAX_COUNT];
+    uint8                   LeftTunnelCount;
+    tunnel_entry            RightTunnels[TUNNEL_MAX_COUNT];
+    uint8                   RightTunnelCount;
+    uint8                   VerticalTunnelHeight;
 } paint_session;
 
 extern paint_session gPaintSession;
@@ -167,6 +178,11 @@ extern paint_session gPaintSession;
 #define gSupport                    RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_PAINT_TILE_MAX_HEIGHT, support_height)
 #define gWoodenSupportsPrependTo    RCT2_GLOBAL(0x009DEA58, paint_struct *)
 #define gPaintMapPosition           RCT2_GLOBAL(0x009DE574, rct_xy16)
+#define gLeftTunnels                RCT2_ADDRESS(0x009E3138, tunnel_entry)
+#define gLeftTunnelCount            RCT2_GLOBAL(0x0141F56A, uint8)
+#define gRightTunnels               RCT2_ADDRESS(0x009E30B6, tunnel_entry)
+#define gRightTunnelCount           RCT2_GLOBAL(0x0141F56B, uint8)
+#define gVerticalTunnelHeight       RCT2_GLOBAL(0x009E323C, uint8)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -91,9 +91,6 @@ struct paint_struct {
 assert_struct_size(paint_struct, 0x34);
 #endif
 
-extern paint_struct * g_ps_F1AD28;
-extern attached_paint_struct * g_aps_F1AD2C;
-
 typedef struct paint_string_struct paint_string_struct;
 
 /* size 0x1E */
@@ -133,11 +130,36 @@ typedef struct support_height {
     uint8 pad;
 } support_height;
 
+#define MAX_PAINT_QUADRANTS 512
+
+typedef struct paint_session
+{
+    rct_drawpixelinfo *     Unk140E9A8;
+    paint_entry             PaintStructs[4000];
+    paint_struct *          Quadrants[MAX_PAINT_QUADRANTS];
+    uint32                  QuadrantBackIndex;
+    uint32                  QuadrantFrontIndex;
+    void *                  CurrentlyDrawnItem;
+    paint_entry *           EndOfPaintStructArray;
+    paint_entry *           NextFreePaintStruct;
+    rct_xy16                SpritePosition;
+    paint_struct            UnkF1A4CC;
+    paint_struct *          UnkF1AD28;
+    attached_paint_struct * UnkF1AD2C;
+    uint8                   InteractionType;
+    support_height          SupportSegments[9];
+    support_height          Support;
+    paint_string_struct *   PSStringHead;
+    paint_string_struct *   LastPSString;
+    paint_struct *          WoodenSupportsPrependTo;
+    rct_xy16                MapPosition;
+} paint_session;
+
+extern paint_session gPaintSession;
+
 #ifdef NO_RCT2
 extern void *g_currently_drawn_item;
-extern paint_entry * gEndOfPaintStructArray;
 extern rct_xy16 gPaintSpritePosition;
-extern paint_entry gPaintStructs[4000];
 #else
 #define gPaintStructs RCT2_ADDRESS(0x00EE788C, paint_entry)
 #define g_currently_drawn_item  RCT2_GLOBAL(0x009DE578, void*)
@@ -154,8 +176,6 @@ extern uint8 gPaintInteractionType;
 extern support_height gSupportSegments[9];
 extern support_height gSupport;
 #endif
-
-extern paint_string_struct * gPaintPSStringHead;
 
 /** rct2: 0x00993CC4 */
 extern const uint32 construction_markers[];

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -164,6 +164,10 @@ typedef struct paint_session
     tunnel_entry            RightTunnels[TUNNEL_MAX_COUNT];
     uint8                   RightTunnelCount;
     uint8                   VerticalTunnelHeight;
+    rct_map_element *       SurfaceElement;
+    bool                    DidPassSurface;
+    uint8                   Unk141E9DB;
+    uint16                  Unk141E9DC;
 } paint_session;
 
 extern paint_session gPaintSession;
@@ -183,6 +187,10 @@ extern paint_session gPaintSession;
 #define gRightTunnels               RCT2_ADDRESS(0x009E30B6, tunnel_entry)
 #define gRightTunnelCount           RCT2_GLOBAL(0x0141F56B, uint8)
 #define gVerticalTunnelHeight       RCT2_GLOBAL(0x009E323C, uint8)
+#define gSurfaceElement             RCT2_GLOBAL(0x009E3250, rct_map_element *)
+#define gDidPassSurface             RCT2_GLOBAL(0x009DE57C, bool)
+#define g141E9DB                    RCT2_GLOBAL(0x0141E9DB, uint8)
+#define gUnk141E9DC                 RCT2_GLOBAL(0x0141E9DC, uint16)
 #endif
 
 /** rct2: 0x00993CC4 */

--- a/src/openrct2/paint/sprite/litter.c
+++ b/src/openrct2/paint/sprite/litter.c
@@ -74,7 +74,7 @@ void litter_paint(rct_litter *litter, sint32 imageDirection)
 {
     rct_drawpixelinfo *dpi;
 
-    dpi = unk_140E9A8;
+    dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level != 0) return; // If zoomed at all no litter drawn
 
     // litter has no sprite direction so remove that

--- a/src/openrct2/paint/sprite/misc.c
+++ b/src/openrct2/paint/sprite/misc.c
@@ -39,7 +39,7 @@ extern const uint8 * DuckAnimations[];
  */
 void misc_paint(rct_sprite *misc, sint32 imageDirection)
 {
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
 
     switch (misc->steam_particle.misc_identifier) {
         case SPRITE_MISC_STEAM_PARTICLE: // 0

--- a/src/openrct2/paint/sprite/peep.c
+++ b/src/openrct2/paint/sprite/peep.c
@@ -59,7 +59,7 @@ void peep_paint(rct_peep * peep, sint32 imageDirection)
     }
 #endif
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level > 2) {
         return;
     }

--- a/src/openrct2/paint/sprite/sprite.c
+++ b/src/openrct2/paint/sprite/sprite.c
@@ -38,7 +38,7 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
 
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES) return;
 
-    dpi = unk_140E9A8;
+    dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level > 2) return;
 
 
@@ -51,7 +51,7 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
         // height of the slope element, and consequently clipped.
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (spr->unknown.z > (gClipHeight * 8) )) continue;
 
-        dpi = unk_140E9A8;
+        dpi = gPaintSession.Unk140E9A8;
 
         if (dpi->y + dpi->height <= spr->unknown.sprite_top) continue;
         if (spr->unknown.sprite_bottom <= dpi->y)continue;
@@ -63,10 +63,10 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
         image_direction += spr->unknown.sprite_direction;
         image_direction &= 0x1F;
 
-        g_currently_drawn_item = spr;
-        gPaintSpritePosition.x = spr->unknown.x;
-        gPaintSpritePosition.y = spr->unknown.y;
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = spr;
+        gPaintSession.SpritePosition.x = spr->unknown.x;
+        gPaintSession.SpritePosition.y = spr->unknown.y;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
 
         switch (spr->unknown.sprite_identifier) {
         case SPRITE_IDENTIFIER_VEHICLE:

--- a/src/openrct2/paint/supports.c
+++ b/src/openrct2/paint/supports.c
@@ -359,7 +359,7 @@ bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
         return false;
     }
 
-    sint32 z = floor2(gSupport.height + 15, 16);
+    sint32 z = floor2(gPaintSession.Support.height + 15, 16);
     height -= z;
     if (height < 0) {
         if (underground != NULL) {
@@ -374,7 +374,7 @@ bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
     sint32 rotation = get_current_rotation();
 
     // Draw base support (usually shaped to the slope)
-    sint32 slope = gSupport.slope;
+    sint32 slope = gPaintSession.Support.slope;
     if (slope & (1 << 5)) {
         // Above scenery (just put a base piece above it)
         drawFlatPiece = true;
@@ -514,7 +514,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
         return false;
     }
 
-    uint16 baseHeight = ceil2(gSupport.height, 16);
+    uint16 baseHeight = ceil2(gPaintSession.Support.height, 16);
     sint16 supportLength = height - baseHeight;
 
     if (supportLength < 0) {
@@ -526,9 +526,9 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
     bool goTo662E8B = false;
 
-    if (gSupport.slope & 0x20) {
+    if (gPaintSession.Support.slope & 0x20) {
         goTo662E8B = true;
-    } else if (gSupport.slope & 0x10) {
+    } else if (gPaintSession.Support.slope & 0x10) {
         heightSteps -= 2;
         if (heightSteps < 0) {
             if (underground != NULL) *underground = true; // STC
@@ -540,7 +540,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
             baseHeight += 32;
             goTo662E8B = true;
         } else {
-            imageId += word_97B3C4[gSupport.slope & 0x1F];
+            imageId += word_97B3C4[gPaintSession.Support.slope & 0x1F];
 
             sub_98197C(
                 imageId | imageColourFlags,
@@ -564,7 +564,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
             _9E32B1 = true;
         }
-    } else if ((gSupport.slope & 0x0F) != 0) {
+    } else if ((gPaintSession.Support.slope & 0x0F) != 0) {
         heightSteps -= 1;
         if (heightSteps < 0) {
             if (underground != NULL) *underground = true; // STC
@@ -576,7 +576,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
             baseHeight += 16;
             goTo662E8B = true;
         } else {
-            imageId += word_97B3C4[gSupport.slope & 0x1F];
+            imageId += word_97B3C4[gPaintSession.Support.slope & 0x1F];
 
             sub_98197C(
                 imageId | imageColourFlags,
@@ -689,6 +689,8 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
  */
 bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 special, sint32 height, uint32 imageColourFlags)
 {
+    support_height * supportSegments = gPaintSession.SupportSegments;
+
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS) {
         return false;
     }
@@ -702,7 +704,7 @@ bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
 
     const uint8 rotation = get_current_rotation();
     sint16 unk9E3294 = -1;
-    if (height < gSupportSegments[segment].height){
+    if (height < supportSegments[segment].height){
         unk9E3294 = height;
 
         height -= supportTypeToHeight[supportType];
@@ -712,16 +714,16 @@ bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         const uint8* esi = &(_97AF32[rotation * 2]);
 
         uint8 newSegment = esi[segment * 8];
-        if (height <= gSupportSegments[newSegment].height) {
+        if (height <= supportSegments[newSegment].height) {
             esi += 72;
             newSegment = esi[segment * 8];
-            if (height <= gSupportSegments[newSegment].height) {
+            if (height <= supportSegments[newSegment].height) {
                 esi += 72;
                 newSegment = esi[segment * 8];
-                if (height <= gSupportSegments[newSegment].height) {
+                if (height <= supportSegments[newSegment].height) {
                     esi += 72;
                     newSegment = esi[segment * 8];
-                    if (height <= gSupportSegments[newSegment].height) {
+                    if (height <= supportSegments[newSegment].height) {
                         return false;
                     }
                 }
@@ -745,23 +747,23 @@ bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         segment = newSegment;
     }
     sint16 si = height;
-    if (gSupportSegments[segment].slope & (1 << 5) ||
-        height - gSupportSegments[segment].height < 6 ||
+    if (supportSegments[segment].slope & (1 << 5) ||
+        height - supportSegments[segment].height < 6 ||
         _97B15C[supportType].base_id == 0
         ) {
 
-        height = gSupportSegments[segment].height;
+        height = supportSegments[segment].height;
     }else{
         sint8 xOffset = loc_97AF20[segment].x;
         sint8 yOffset = loc_97AF20[segment].y;
 
         uint32 image_id = _97B15C[supportType].base_id;
-        image_id += metal_supports_slope_image_map[gSupportSegments[segment].slope & 0x1F];
+        image_id += metal_supports_slope_image_map[supportSegments[segment].slope & 0x1F];
         image_id |= imageColourFlags;
 
-        sub_98196C(image_id, xOffset, yOffset, 0, 0, 5, gSupportSegments[segment].height, rotation);
+        sub_98196C(image_id, xOffset, yOffset, 0, 0, 5, supportSegments[segment].height, rotation);
 
-        height = gSupportSegments[segment].height + 6;
+        height = supportSegments[segment].height + 6;
     }
 
 
@@ -817,8 +819,8 @@ bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         height += z;
     }
 
-    gSupportSegments[segment].height = unk9E3294;
-    gSupportSegments[segment].slope = 0x20;
+    supportSegments[segment].height = unk9E3294;
+    supportSegments[segment].slope = 0x20;
 
     height = originalHeight;
     segment = originalSegment;
@@ -885,6 +887,8 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         return eax & 0xFF;
     }
 #endif
+
+    support_height * supportSegments = gPaintSession.SupportSegments;
     uint8 originalSegment = segment;
 
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS) {
@@ -898,7 +902,7 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
     uint16 _9E3294 = 0xFFFF;
     sint32 baseHeight = height;
 
-    if (height < gSupportSegments[segment].height) {
+    if (height < supportSegments[segment].height) {
         _9E3294 = height;
 
         baseHeight -= supportTypeToHeight[supportType];
@@ -909,16 +913,16 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         uint16 baseIndex = get_current_rotation() * 2;
 
         uint8 ebp = _97AF32[baseIndex + segment * 8];
-        if (baseHeight <= gSupportSegments[ebp].height) {
+        if (baseHeight <= supportSegments[ebp].height) {
             baseIndex += 9 * 4 * 2; // 9 segments, 4 directions, 2 values
             uint8 ebp2 = _97AF32[baseIndex + segment * 8];
-            if (baseHeight <= gSupportSegments[ebp2].height) {
+            if (baseHeight <= supportSegments[ebp2].height) {
                 baseIndex += 9 * 4 * 2;
                 uint8 ebp3 = _97AF32[baseIndex + segment * 8];
-                if (baseHeight <= gSupportSegments[ebp3].height) {
+                if (baseHeight <= supportSegments[ebp3].height) {
                     baseIndex += 9 * 4 * 2;
                     uint8 ebp4 = _97AF32[baseIndex + segment * 8];
-                    if (baseHeight <= gSupportSegments[ebp4].height) {
+                    if (baseHeight <= supportSegments[ebp4].height) {
                         return true; // STC
                     }
                 }
@@ -942,23 +946,23 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
 
     sint32 si = baseHeight;
 
-    if ((gSupportSegments[segment].slope & 0x20)
-        || (baseHeight - gSupportSegments[segment].height < 6)
+    if ((supportSegments[segment].slope & 0x20)
+        || (baseHeight - supportSegments[segment].height < 6)
         || (_97B15C[supportType].base_id == 0)) {
-        baseHeight = gSupportSegments[segment].height;
+        baseHeight = supportSegments[segment].height;
     } else {
-        uint32 imageOffset = metal_supports_slope_image_map[gSupportSegments[segment].slope & 0x1F];
+        uint32 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & 0x1F];
         uint32 imageId = _97B15C[supportType].base_id + imageOffset;
 
         sub_98196C(
             imageId | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, 5,
-            gSupportSegments[segment].height,
+            supportSegments[segment].height,
             get_current_rotation()
         );
 
-        baseHeight = gSupportSegments[segment].height + 6;
+        baseHeight = supportSegments[segment].height + 6;
     }
 
     sint16 heightDiff = floor2(baseHeight + 16, 16);
@@ -1017,8 +1021,8 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         i++;
     }
 
-    gSupportSegments[segment].height = _9E3294;
-    gSupportSegments[segment].slope = 0x20;
+    supportSegments[segment].height = _9E3294;
+    supportSegments[segment].slope = 0x20;
 
     if (special != 0) {
         baseHeight = height;
@@ -1086,7 +1090,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
         return false;
     }
 
-    uint16 baseHeight = ceil2(gSupport.height, 16);
+    uint16 baseHeight = ceil2(gPaintSession.Support.height, 16);
     sint32 supportLength = height - baseHeight;
     if (supportLength < 0) {
         if (underground != NULL) *underground = true; // STC
@@ -1097,7 +1101,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
 
     sint16 heightSteps = supportLength / 16;
 
-    if (gSupport.slope & 0x20) {
+    if (gPaintSession.Support.slope & 0x20) {
         //save dx2
         sub_98196C(
             (pathEntry->bridge_image + 48) | imageColourFlags,
@@ -1107,14 +1111,14 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
             get_current_rotation()
         );
         hasSupports = true;
-    } else if (gSupport.slope & 0x10) {
+    } else if (gPaintSession.Support.slope & 0x10) {
         heightSteps -= 2;
         if (heightSteps < 0) {
             if (underground != NULL) *underground = true; // STC
             return false;
         }
 
-        uint32 imageId = (supportType * 24) + word_97B3C4[gSupport.slope & 0x1F] + pathEntry->bridge_image;
+        uint32 imageId = (supportType * 24) + word_97B3C4[gPaintSession.Support.slope & 0x1F] + pathEntry->bridge_image;
 
         sub_98197C(
             imageId | imageColourFlags,
@@ -1138,14 +1142,14 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
 
         hasSupports = true;
 
-    } else if (gSupport.slope & 0x0F) {
+    } else if (gPaintSession.Support.slope & 0x0F) {
         heightSteps -= 1;
         if (heightSteps < 0) {
             if (underground != NULL) *underground = true; // STC
             return false;
         }
 
-        uint32 ebx = (supportType * 24) + word_97B3C4[gSupport.slope & 0x1F] + pathEntry->bridge_image;
+        uint32 ebx = (supportType * 24) + word_97B3C4[gPaintSession.Support.slope & 0x1F] + pathEntry->bridge_image;
 
         sub_98197C(
             ebx | imageColourFlags,
@@ -1254,6 +1258,8 @@ bool path_b_supports_paint_setup(sint32 segment, sint32 special, sint32 height, 
     }
 #endif
 
+    support_height * supportSegments = gPaintSession.SupportSegments;
+
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS) {
         return false; // AND
     }
@@ -1262,19 +1268,19 @@ bool path_b_supports_paint_setup(sint32 segment, sint32 special, sint32 height, 
         return false; // AND
     }
 
-    if (height < gSupportSegments[segment].height) {
+    if (height < supportSegments[segment].height) {
         return true; // STC
     }
 
     uint16 baseHeight;
 
-    if ((gSupportSegments[segment].slope & 0x20)
-        || (height - gSupportSegments[segment].height < 6)
+    if ((supportSegments[segment].slope & 0x20)
+        || (height - supportSegments[segment].height < 6)
         || !(pathEntry->flags & FOOTPATH_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE)) {
-        baseHeight = gSupportSegments[segment].height;
+        baseHeight = supportSegments[segment].height;
     } else {
-        uint8 imageOffset = metal_supports_slope_image_map[gSupportSegments[segment].slope & 0x1F];
-        baseHeight = gSupportSegments[segment].height;
+        uint8 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & 0x1F];
+        baseHeight = supportSegments[segment].height;
 
         sub_98196C(
             (pathEntry->bridge_image + 37 + imageOffset) | imageColourFlags,
@@ -1361,8 +1367,8 @@ bool path_b_supports_paint_setup(sint32 segment, sint32 special, sint32 height, 
     }
 
     // loc_6A34D8
-    gSupportSegments[segment].height = 0xFFFF;
-    gSupportSegments[segment].slope = 0x20;
+    supportSegments[segment].height = 0xFFFF;
+    supportSegments[segment].slope = 0x20;
 
     if (special != 0) {
         sint16 si = special + baseHeight;

--- a/src/openrct2/paint/supports.c
+++ b/src/openrct2/paint/supports.c
@@ -351,7 +351,7 @@ bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
         return false;
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         return false;
     }
 
@@ -429,7 +429,7 @@ bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
     // Draw repeated supports for left over space
     while (height != 0) {
-        if ((z & 16) == 0 && height >= 2 && z + 16 != gUnk141E9DC) {
+        if ((z & 16) == 0 && height >= 2 && z + 16 != gPaintSession.Unk141E9DC) {
             // Full support
             sint32 imageId = WoodenSupportImageIds[supportType].full | imageColourFlags;
             uint8 ah = height == 2 ? 23 : 28;
@@ -505,7 +505,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
         return false;
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         if (underground != NULL) *underground = false; // AND
         return false;
     }
@@ -606,7 +606,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
     if (!skipTo663004) {
         while (heightSteps > 0) {
-            if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + 16 == gUnk141E9DC) {
+            if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + 16 == gPaintSession.Unk141E9DC) {
                 sub_98196C(
                     WoodenSupportImageIds[supportType].half | imageColourFlags,
                     0, 0,
@@ -691,7 +691,7 @@ bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         return false;
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         return false;
     }
 
@@ -891,7 +891,7 @@ bool metal_b_supports_paint_setup(uint8 supportType, uint8 segment, sint32 speci
         return false; // AND
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         return false; // AND
     }
 
@@ -1082,7 +1082,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
         return false;
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         return false;
     }
 
@@ -1161,7 +1161,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
     }
 
     while (heightSteps > 0) {
-        if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + 16 == gUnk141E9DC) {
+        if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + 16 == gPaintSession.Unk141E9DC) {
 
             uint32 imageId = (supportType * 24) + pathEntry->bridge_image + 23;
 
@@ -1260,7 +1260,7 @@ bool path_b_supports_paint_setup(sint32 segment, sint32 special, sint32 height, 
         return false; // AND
     }
 
-    if (!(g141E9DB & G141E9DB_FLAG_1)) {
+    if (!(gPaintSession.Unk141E9DB & G141E9DB_FLAG_1)) {
         return false; // AND
     }
 

--- a/src/openrct2/paint/supports.c
+++ b/src/openrct2/paint/supports.c
@@ -331,10 +331,6 @@ const uint16 word_97B3C4[] = {
 
 extern bool gUseOriginalRidePaint;
 
-#ifdef NO_RCT2
-paint_struct * gWoodenSupportsPrependTo;
-#endif
-
 /**
  * Adds paint structs for wooden supports.
  *  rct2: 0x006629BC
@@ -463,14 +459,14 @@ bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
             unk_supports_desc_bound_box bBox = byte_97B23C[special].bounding_box;
 
-            if (byte_97B23C[special].var_6 == 0 || gWoodenSupportsPrependTo == NULL) {
+            if (byte_97B23C[special].var_6 == 0 || gPaintSession.WoodenSupportsPrependTo == NULL) {
                 sub_98197C(imageId, 0, 0, bBox.length.x, bBox.length.y, bBox.length.z, z, bBox.offset.x, bBox.offset.y, bBox.offset.z + z, rotation);
                 hasSupports = true;
             } else {
                 hasSupports = true;
                 paint_struct* ps = sub_98198C(imageId, 0, 0, bBox.length.x, bBox.length.y, bBox.length.z, z, bBox.offset.x, bBox.offset.y, bBox.offset.z + z, rotation);
                 if (ps != NULL) {
-                    paint_struct* edi = gWoodenSupportsPrependTo;
+                    paint_struct* edi = gPaintSession.WoodenSupportsPrependTo;
                     edi->var_20 = ps;
                 }
             }
@@ -647,7 +643,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
 
             unk_supports_desc_bound_box boundBox = supportsDesc.bounding_box;
 
-            if (supportsDesc.var_6 == 0 || gWoodenSupportsPrependTo == NULL) {
+            if (supportsDesc.var_6 == 0 || gPaintSession.WoodenSupportsPrependTo == NULL) {
                 sub_98197C(
                     imageId | imageColourFlags,
                     0, 0,
@@ -668,7 +664,7 @@ bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 he
                 );
                 _9E32B1 = true;
                 if (paintStruct != NULL) {
-                    gWoodenSupportsPrependTo->var_20 = paintStruct;
+                    gPaintSession.WoodenSupportsPrependTo->var_20 = paintStruct;
                 }
             }
         }
@@ -1203,7 +1199,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
         unk_supports_desc supportsDesc = byte_98D8D4[specialIndex];
         unk_supports_desc_bound_box boundBox = supportsDesc.bounding_box;
 
-        if (supportsDesc.var_6 == 0 || gWoodenSupportsPrependTo == NULL) {
+        if (supportsDesc.var_6 == 0 || gPaintSession.WoodenSupportsPrependTo == NULL) {
             sub_98197C(
                 imageId | imageColourFlags,
                 0, 0,
@@ -1224,7 +1220,7 @@ bool path_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 heig
             );
             hasSupports = true;
             if (paintStruct != NULL) {
-                gWoodenSupportsPrependTo->var_20 = paintStruct;
+                gPaintSession.WoodenSupportsPrependTo->var_20 = paintStruct;
             }
         }
     }

--- a/src/openrct2/paint/supports.h
+++ b/src/openrct2/paint/supports.h
@@ -20,12 +20,6 @@
 #include "../common.h"
 #include "../world/footpath.h"
 
-#ifdef NO_RCT2
-extern paint_struct * gWoodenSupportsPrependTo;
-#else
-#define gWoodenSupportsPrependTo        RCT2_GLOBAL(0x009DEA58, paint_struct *)
-#endif
-
 bool wooden_a_supports_paint_setup(sint32 supportType, sint32 special, sint32 height, uint32 imageColourFlags, bool* underground);
 bool wooden_b_supports_paint_setup(sint32 supportType, sint32 special, sint32 height, uint32 imageColourFlags, bool* underground);
 bool metal_a_supports_paint_setup(uint8 supportType, uint8 segment, sint32 special, sint32 height, uint32 imageColourFlags);

--- a/src/openrct2/ride/coaster/bobsleigh_coaster.c
+++ b/src/openrct2/ride/coaster/bobsleigh_coaster.c
@@ -42,7 +42,7 @@ static void bobsleigh_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14579, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -58,7 +58,7 @@ static void bobsleigh_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14575, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -107,7 +107,7 @@ static void bobsleigh_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14641, 0, 0, 32, 1, 50, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -129,7 +129,7 @@ static void bobsleigh_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14617, 0, 0, 32, 1, 50, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -164,7 +164,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14625, 0, 0, 32, 1, 42, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -186,7 +186,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14601, 0, 0, 32, 1, 42, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -221,7 +221,7 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14633, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -243,7 +243,7 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14609, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -438,7 +438,7 @@ static void bobsleigh_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14649, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -467,7 +467,7 @@ static void bobsleigh_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14657, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -496,7 +496,7 @@ static void bobsleigh_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14655, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -525,7 +525,7 @@ static void bobsleigh_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14647, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -697,7 +697,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14681, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -730,7 +730,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tr
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14689, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -763,7 +763,7 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 tra
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14665, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -796,7 +796,7 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tr
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14673, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -853,7 +853,7 @@ static void bobsleigh_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, u
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14697, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -2214,7 +2214,7 @@ static void bobsleigh_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14585, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -2237,7 +2237,7 @@ static void bobsleigh_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 14591, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/bolliger_mabillard_track.c
+++ b/src/openrct2/ride/coaster/bolliger_mabillard_track.c
@@ -44,7 +44,7 @@ void bolliger_mabillard_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17489, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -58,7 +58,7 @@ void bolliger_mabillard_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17147, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -109,7 +109,7 @@ void bolliger_mabillard_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17501, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -127,7 +127,7 @@ void bolliger_mabillard_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -157,7 +157,7 @@ void bolliger_mabillard_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17517, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -175,7 +175,7 @@ void bolliger_mabillard_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17223, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -205,7 +205,7 @@ void bolliger_mabillard_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17493, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -223,7 +223,7 @@ void bolliger_mabillard_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -255,7 +255,7 @@ void bolliger_mabillard_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17505, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -275,7 +275,7 @@ void bolliger_mabillard_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17211, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -307,7 +307,7 @@ void bolliger_mabillard_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17511, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -327,7 +327,7 @@ void bolliger_mabillard_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17217, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -357,7 +357,7 @@ void bolliger_mabillard_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17497, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -375,7 +375,7 @@ void bolliger_mabillard_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17203, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -557,7 +557,7 @@ void bolliger_mabillard_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequ
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17159, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -583,7 +583,7 @@ void bolliger_mabillard_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17167, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -609,7 +609,7 @@ void bolliger_mabillard_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequ
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17161, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -635,7 +635,7 @@ void bolliger_mabillard_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17165, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -787,7 +787,7 @@ void bolliger_mabillard_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17171, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -817,7 +817,7 @@ void bolliger_mabillard_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17179, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -847,7 +847,7 @@ void bolliger_mabillard_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trac
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17183, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -877,7 +877,7 @@ void bolliger_mabillard_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17191, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -925,7 +925,7 @@ void bolliger_mabillard_track_left_bank(uint8 rideIndex, uint8 trackSequence, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17195, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -2901,7 +2901,7 @@ void bolliger_mabillard_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17149, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -2925,7 +2925,7 @@ void bolliger_mabillard_track_25_deg_up_left_banked(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17917, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -2953,7 +2953,7 @@ void bolliger_mabillard_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trac
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17921, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6115,7 +6115,7 @@ void bolliger_mabillard_track_block_brakes(uint8 rideIndex, uint8 trackSequence,
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17151, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -6519,7 +6519,7 @@ void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17925, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6548,7 +6548,7 @@ void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideInde
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17929, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6577,7 +6577,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17935, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6606,7 +6606,7 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideInde
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17939, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6654,7 +6654,7 @@ void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(uint8 ri
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17945, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6682,7 +6682,7 @@ void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17949, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6710,7 +6710,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(uint8 ri
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17953, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6738,7 +6738,7 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17957, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6787,7 +6787,7 @@ void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17897, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6816,7 +6816,7 @@ void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17901, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6845,7 +6845,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17907, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6874,7 +6874,7 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17911, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -7383,7 +7383,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18042, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             if (direction == 0 || direction == 3) {
@@ -7407,7 +7407,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18043, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 7, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -7428,7 +7428,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18044, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -7449,7 +7449,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18045, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             switch (direction) {
@@ -7485,7 +7485,7 @@ void bolliger_mabillard_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18058, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             if (direction == 0 || direction == 3) {
@@ -7509,7 +7509,7 @@ void bolliger_mabillard_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18059, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 16, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -7530,7 +7530,7 @@ void bolliger_mabillard_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18060, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 13, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -7551,7 +7551,7 @@ void bolliger_mabillard_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8
                     sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18061, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(supportType, 4, 5, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             switch (direction) {
@@ -8172,7 +8172,7 @@ void bolliger_mabillard_track_booster(uint8 rideIndex, uint8 trackSequence, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | SPR_G2_BM_BOOSTER_NW_SE, nw_se_offsetX, nw_se_offsetY, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);

--- a/src/openrct2/ride/coaster/compact_inverted_coaster.c
+++ b/src/openrct2/ride/coaster/compact_inverted_coaster.c
@@ -54,7 +54,7 @@ static void compact_inverted_rc_track_flat(uint8 rideIndex, uint8 trackSequence,
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -118,7 +118,7 @@ static void compact_inverted_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 56, gTrackColours[SCHEME_SUPPORTS]);
@@ -222,7 +222,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 48, gTrackColours[SCHEME_SUPPORTS]);
@@ -334,7 +334,7 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 70, gTrackColours[SCHEME_SUPPORTS]);
@@ -395,7 +395,7 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -602,7 +602,7 @@ static void compact_inverted_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -629,7 +629,7 @@ static void compact_inverted_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -656,7 +656,7 @@ static void compact_inverted_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -683,7 +683,7 @@ static void compact_inverted_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -837,7 +837,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -881,7 +881,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, u
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -925,7 +925,7 @@ static void compact_inverted_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -969,7 +969,7 @@ static void compact_inverted_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, u
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -1037,7 +1037,7 @@ static void compact_inverted_rc_track_left_bank(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -2913,7 +2913,7 @@ static void compact_inverted_rc_track_brakes(uint8 rideIndex, uint8 trackSequenc
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -5905,7 +5905,7 @@ static void compact_inverted_rc_track_block_brakes(uint8 rideIndex, uint8 trackS
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
     }
 

--- a/src/openrct2/ride/coaster/corkscrew_roller_coaster.c
+++ b/src/openrct2/ride/coaster/corkscrew_roller_coaster.c
@@ -44,7 +44,7 @@ static void corkscrew_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16229, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -58,7 +58,7 @@ static void corkscrew_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16225, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -108,7 +108,7 @@ static void corkscrew_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16317, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -126,7 +126,7 @@ static void corkscrew_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16289, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -157,7 +157,7 @@ static void corkscrew_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16333, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -175,7 +175,7 @@ static void corkscrew_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, u
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16305, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -206,7 +206,7 @@ static void corkscrew_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16309, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -224,7 +224,7 @@ static void corkscrew_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16281, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -257,7 +257,7 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16321, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -277,7 +277,7 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16293, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -310,7 +310,7 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16327, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -330,7 +330,7 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16299, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -361,7 +361,7 @@ static void corkscrew_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16313, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -379,7 +379,7 @@ static void corkscrew_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16285, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -570,7 +570,7 @@ static void corkscrew_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16241, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -597,7 +597,7 @@ static void corkscrew_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16249, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -624,7 +624,7 @@ static void corkscrew_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16243, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -651,7 +651,7 @@ static void corkscrew_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16247, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -803,7 +803,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16253, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -834,7 +834,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tr
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16261, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -865,7 +865,7 @@ static void corkscrew_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 tra
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16265, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -896,7 +896,7 @@ static void corkscrew_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tr
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16273, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -949,7 +949,7 @@ static void corkscrew_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, u
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16277, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -3210,7 +3210,7 @@ static void corkscrew_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16231, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -3272,7 +3272,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16800, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3296,7 +3296,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16801, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 7, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3317,7 +3317,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16802, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3338,7 +3338,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16803, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         switch (direction) {
@@ -3374,7 +3374,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16816, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3398,7 +3398,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16817, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 16, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3419,7 +3419,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16818, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 13, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3440,7 +3440,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16819, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 5, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         switch (direction) {
@@ -5888,7 +5888,7 @@ static void corkscrew_rc_track_booster(uint8 rideIndex, uint8 trackSequence, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | sprite_nw_se_after, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/flying_roller_coaster.c
+++ b/src/openrct2/ride/coaster/flying_roller_coaster.c
@@ -45,7 +45,7 @@ static void flying_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 dir
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17489, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -59,7 +59,7 @@ static void flying_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 dir
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17147, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -92,7 +92,7 @@ static void flying_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 dir
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -157,7 +157,7 @@ static void flying_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -201,7 +201,7 @@ static void flying_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -245,7 +245,7 @@ static void flying_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17223, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -298,7 +298,7 @@ static void flying_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequen
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -342,7 +342,7 @@ static void flying_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequen
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 49, gTrackColours[SCHEME_SUPPORTS]);
@@ -388,7 +388,7 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackS
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17211, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -445,7 +445,7 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackS
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17217, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -474,7 +474,7 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackS
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 71, gTrackColours[SCHEME_SUPPORTS]);
@@ -518,7 +518,7 @@ static void flying_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequen
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17203, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -562,7 +562,7 @@ static void flying_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequen
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -885,7 +885,7 @@ static void flying_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequen
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17159, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -908,7 +908,7 @@ static void flying_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequen
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -937,7 +937,7 @@ static void flying_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17167, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -960,7 +960,7 @@ static void flying_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeque
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -989,7 +989,7 @@ static void flying_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequen
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17161, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1012,7 +1012,7 @@ static void flying_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequen
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1041,7 +1041,7 @@ static void flying_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17165, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1064,7 +1064,7 @@ static void flying_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeque
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1336,7 +1336,7 @@ static void flying_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trackS
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17171, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1363,7 +1363,7 @@ static void flying_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trackS
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -1409,7 +1409,7 @@ static void flying_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17179, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1436,7 +1436,7 @@ static void flying_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 track
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -1482,7 +1482,7 @@ static void flying_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trackS
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17183, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1509,7 +1509,7 @@ static void flying_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trackS
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -1555,7 +1555,7 @@ static void flying_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17191, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1582,7 +1582,7 @@ static void flying_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 track
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -1650,7 +1650,7 @@ static void flying_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17195, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1673,7 +1673,7 @@ static void flying_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, uint
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -4864,7 +4864,7 @@ static void flying_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 d
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17149, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -4883,7 +4883,7 @@ static void flying_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 d
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -5862,7 +5862,7 @@ static void flying_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 trackSe
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17917, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -5889,7 +5889,7 @@ static void flying_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 trackSe
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -5933,7 +5933,7 @@ static void flying_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trackS
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17921, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -5960,7 +5960,7 @@ static void flying_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trackS
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -11492,7 +11492,7 @@ static void flying_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence, u
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 39, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -12271,7 +12271,7 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17925, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12298,7 +12298,7 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex, 
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -12343,7 +12343,7 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideIndex,
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17929, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12370,7 +12370,7 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideIndex,
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -12415,7 +12415,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17935, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12442,7 +12442,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, 
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -12487,7 +12487,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideIndex,
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17939, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12514,7 +12514,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideIndex,
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 57, gTrackColours[SCHEME_SUPPORTS]);
@@ -12582,7 +12582,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 ride
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17945, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12609,7 +12609,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 ride
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 49, gTrackColours[SCHEME_SUPPORTS]);
@@ -12653,7 +12653,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 ri
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17949, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12680,7 +12680,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 ri
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 49, gTrackColours[SCHEME_SUPPORTS]);
@@ -12724,7 +12724,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 ride
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17953, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12751,7 +12751,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 ride
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -12795,7 +12795,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 ri
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17957, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12822,7 +12822,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 ri
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -12891,7 +12891,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uint8
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17897, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12918,7 +12918,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uint8
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 49, gTrackColours[SCHEME_SUPPORTS]);
@@ -12963,7 +12963,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17901, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -12990,7 +12990,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, uint
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 49, gTrackColours[SCHEME_SUPPORTS]);
@@ -13035,7 +13035,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uint8
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17907, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -13062,7 +13062,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uint8
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);
@@ -13107,7 +13107,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, uint
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 17911, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -13134,7 +13134,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, uint
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 47, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/giga_coaster.c
+++ b/src/openrct2/ride/coaster/giga_coaster.c
@@ -40,7 +40,7 @@ static void giga_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direc
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18693, 0, 0, 20, 32, 3, height, 6, 0, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else if (track_element_is_lift_hill(mapElement)) {
@@ -58,7 +58,7 @@ static void giga_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direc
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18385, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -72,7 +72,7 @@ static void giga_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direc
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18075, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -121,7 +121,7 @@ static void giga_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18705, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else if (track_element_is_lift_hill(mapElement)) {
@@ -139,7 +139,7 @@ static void giga_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18397, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -157,7 +157,7 @@ static void giga_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18137, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -188,7 +188,7 @@ static void giga_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18721, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -206,7 +206,7 @@ static void giga_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18153, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -237,7 +237,7 @@ static void giga_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18697, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else if (track_element_is_lift_hill(mapElement)) {
@@ -255,7 +255,7 @@ static void giga_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18389, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -273,7 +273,7 @@ static void giga_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18129, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -306,7 +306,7 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18709, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -326,7 +326,7 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18141, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -359,7 +359,7 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18715, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -379,7 +379,7 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18147, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -410,7 +410,7 @@ static void giga_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18701, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else if (track_element_is_lift_hill(mapElement)) {
@@ -428,7 +428,7 @@ static void giga_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18393, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -446,7 +446,7 @@ static void giga_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18133, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -637,7 +637,7 @@ static void giga_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequence
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18089, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -664,7 +664,7 @@ static void giga_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSequenc
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18097, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -691,7 +691,7 @@ static void giga_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequence
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18091, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -718,7 +718,7 @@ static void giga_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSequenc
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18095, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -870,7 +870,7 @@ static void giga_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18101, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -901,7 +901,7 @@ static void giga_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18109, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -932,7 +932,7 @@ static void giga_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18113, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -963,7 +963,7 @@ static void giga_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 trackSe
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18121, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -1016,7 +1016,7 @@ static void giga_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, uint8 
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18125, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -2668,7 +2668,7 @@ static void giga_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 dir
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18083, 0, 0, 32, 1, 11, height, 0, 27, height + 5);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -2693,7 +2693,7 @@ static void giga_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 trackSequ
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18563, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -2722,7 +2722,7 @@ static void giga_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trackSeq
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18567, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -2801,7 +2801,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18734, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -2819,7 +2819,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18672, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -2845,7 +2845,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18735, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 5, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -2863,7 +2863,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18673, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 5, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -2886,7 +2886,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18736, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 7, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -2904,7 +2904,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18674, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 7, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -2927,7 +2927,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18737, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -2945,7 +2945,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(uint8 rideIndex, uint8 tra
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18675, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -2982,7 +2982,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18688, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 16, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3006,7 +3006,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18689, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3027,7 +3027,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18690, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3048,7 +3048,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18691, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 5, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         switch (direction) {
@@ -3096,7 +3096,7 @@ static void giga_rc_track_cable_lift_hill(uint8 rideIndex, uint8 trackSequence, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18701, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3122,7 +3122,7 @@ static void giga_rc_track_cable_lift_hill(uint8 rideIndex, uint8 trackSequence, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18699, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3150,7 +3150,7 @@ static void giga_rc_track_cable_lift_hill(uint8 rideIndex, uint8 trackSequence, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18716, 0, 0, 32, 1, 66, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -3176,7 +3176,7 @@ static void giga_rc_track_cable_lift_hill(uint8 rideIndex, uint8 trackSequence, 
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18719, 0, 0, 32, 1, 98, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -5328,7 +5328,7 @@ static void giga_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence, uin
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18081, 0, 0, 32, 1, 11, height, 0, 27, height + 5);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -5741,7 +5741,7 @@ static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex, ui
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18571, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5771,7 +5771,7 @@ static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideIndex, u
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18575, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5801,7 +5801,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, ui
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18581, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5831,7 +5831,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, u
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18585, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5884,7 +5884,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 rideIn
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18591, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5913,7 +5913,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 ride
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18595, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5942,7 +5942,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 rideIn
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18599, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5971,7 +5971,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 ride
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18603, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6025,7 +6025,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uint8 t
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18543, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6055,7 +6055,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, uint8 
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18547, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6085,7 +6085,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uint8 t
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18553, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6115,7 +6115,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, uint8 
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18557, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6170,7 +6170,7 @@ static void giga_rc_track_booster(uint8 rideIndex, uint8 trackSequence, uint8 di
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | SPR_G2_GIGA_RC_BOOSTER_NW_SE, nw_se_offsetX, nw_se_offsetY, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);

--- a/src/openrct2/ride/coaster/heartline_twister_coaster.c
+++ b/src/openrct2/ride/coaster/heartline_twister_coaster.c
@@ -161,12 +161,12 @@ static void heartline_twister_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSeq
             wooden_a_supports_paint_setup(6, 21, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21403, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21403, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21407, 0, 0, 32, 1, 98, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 22, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21404, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21404, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21408, 0, 0, 32, 1, 98, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 23, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
@@ -184,12 +184,12 @@ static void heartline_twister_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSeq
             wooden_a_supports_paint_setup(6, 21, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21347, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21347, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21351, 0, 0, 32, 1, 98, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 22, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21348, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21348, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21352, 0, 0, 32, 1, 98, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 23, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
@@ -279,12 +279,12 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, u
             wooden_a_supports_paint_setup(6, 13, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21387, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21387, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21391, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 14, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21388, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21388, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21392, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 15, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
@@ -302,12 +302,12 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, u
             wooden_a_supports_paint_setup(6, 13, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21331, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21331, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21335, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 14, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21332, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21332, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21336, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 15, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
@@ -338,12 +338,12 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, u
             wooden_a_supports_paint_setup(6, 17, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21395, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21395, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21399, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 18, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21396, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21396, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21400, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 19, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
@@ -361,12 +361,12 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, u
             wooden_a_supports_paint_setup(6, 17, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 1:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21339, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21339, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21343, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(7, 18, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;
         case 2:
-            gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21340, 0, 0, 32, 20, 2, height, 0, 6, height);
+            gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21340, 0, 0, 32, 20, 2, height, 0, 6, height);
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 21344, 0, 0, 32, 1, 66, height, 0, 27, height);
             wooden_a_supports_paint_setup(6, 19, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             break;

--- a/src/openrct2/ride/coaster/inverted_hairpin_coaster.c
+++ b/src/openrct2/ride/coaster/inverted_hairpin_coaster.c
@@ -58,7 +58,7 @@ static void inverted_hairpin_rc_track_flat(uint8 rideIndex, uint8 trackSequence,
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 30, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -122,7 +122,7 @@ static void inverted_hairpin_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 48, gTrackColours[SCHEME_SUPPORTS]);
@@ -226,7 +226,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 40, gTrackColours[SCHEME_SUPPORTS]);
@@ -338,7 +338,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -399,7 +399,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 t
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
@@ -873,7 +873,7 @@ static void inverted_hairpin_rc_track_brakes(uint8 rideIndex, uint8 trackSequenc
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 30, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -896,7 +896,7 @@ static void inverted_hairpin_rc_track_block_brakes(uint8 rideIndex, uint8 trackS
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 30, gTrackColours[SCHEME_SUPPORTS]);
     }
 

--- a/src/openrct2/ride/coaster/inverted_impulse_coaster.c
+++ b/src/openrct2/ride/coaster/inverted_impulse_coaster.c
@@ -41,7 +41,7 @@ static void inverted_impulse_rc_track_flat(uint8 rideIndex, uint8 trackSequence,
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -88,7 +88,7 @@ static void inverted_impulse_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/inverted_roller_coaster.c
+++ b/src/openrct2/ride/coaster/inverted_roller_coaster.c
@@ -54,7 +54,7 @@ static void inverted_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -118,7 +118,7 @@ static void inverted_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -205,7 +205,7 @@ static void inverted_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -279,7 +279,7 @@ static void inverted_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 76, gTrackColours[SCHEME_SUPPORTS]);
@@ -340,7 +340,7 @@ static void inverted_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -547,7 +547,7 @@ static void inverted_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -574,7 +574,7 @@ static void inverted_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeq
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -601,7 +601,7 @@ static void inverted_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequ
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -628,7 +628,7 @@ static void inverted_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeq
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -782,7 +782,7 @@ static void inverted_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -826,7 +826,7 @@ static void inverted_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -870,7 +870,7 @@ static void inverted_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trac
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -914,7 +914,7 @@ static void inverted_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tra
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -982,7 +982,7 @@ static void inverted_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -2858,7 +2858,7 @@ static void inverted_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -3365,7 +3365,7 @@ static void inverted_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 track
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -3409,7 +3409,7 @@ static void inverted_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trac
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -6050,7 +6050,7 @@ static void inverted_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence,
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -6477,7 +6477,7 @@ static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -6521,7 +6521,7 @@ static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideInde
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -6565,7 +6565,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -6609,7 +6609,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideInde
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -6677,7 +6677,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 ri
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -6721,7 +6721,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -6765,7 +6765,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 ri
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -6809,7 +6809,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -6877,7 +6877,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uin
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -6921,7 +6921,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -6965,7 +6965,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uin
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -7009,7 +7009,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, ui
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/junior_roller_coaster.c
+++ b/src/openrct2/ride/coaster/junior_roller_coaster.c
@@ -1877,7 +1877,7 @@ void junior_rc_paint_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 dire
     sub_98196C_rotated(direction, imageId, 0, 6, 32, 20, 1, height);
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup((direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1941,7 +1941,7 @@ void junior_rc_paint_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8
     uint8 tunnel_type[4] = { TUNNEL_1, TUNNEL_2, TUNNEL_2, TUNNEL_1 };
     paint_util_push_tunnel_rotated(direction, height + tunnel_height[direction], tunnel_type[direction]);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         sint32 supportType = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(supportType, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
@@ -1961,7 +1961,7 @@ void junior_rc_paint_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequenc
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_2);
     }
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         sint32 supportType = (direction & 1) ? 2 : 1;
         uint16 ax = (direction == 0) ? 5 : 3;
         metal_a_supports_paint_setup(supportType, 4, ax, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -1995,7 +1995,7 @@ void junior_rc_paint_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequenc
         paint_util_push_tunnel_left(tunnelHeight, tunnelType);
     }
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         sint32 supportType = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(supportType, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
@@ -2090,7 +2090,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(uint8 rideIndex, uint8 track
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2130,7 +2130,7 @@ static void junior_rc_flat_to_right_bank_paint_setup(uint8 rideIndex, uint8 trac
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2298,7 +2298,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(uint8 rideIndex, uint8 
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2341,7 +2341,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(uint8 rideIndex, uint8
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2399,7 +2399,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(uint8 rideIndex, uint8 
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2450,7 +2450,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(uint8 rideIndex, uint8
         }
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2530,7 +2530,7 @@ static void junior_rc_left_bank_paint_setup(uint8 rideIndex, uint8 trackSequence
         paint_util_push_tunnel_left(height, 0);
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -3342,7 +3342,7 @@ static void junior_rc_brake_paint_setup(uint8 rideIndex, uint8 trackSequence, ui
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -3373,7 +3373,7 @@ static void junior_rc_block_brake_paint_setup(uint8 rideIndex, uint8 trackSequen
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -4296,7 +4296,7 @@ void junior_rc_paint_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8
         break;
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
 
     sint8 support[4] = { 35, 29, 25, 32};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4389,7 +4389,7 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSe
         break;
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
 
     sint8 support[4] = { 12, 12, 12, 14};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4461,7 +4461,7 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSe
         break;
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
 
     if (track_paint_util_should_paint_supports(pos)) {
         metal_a_supports_paint_setup((direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -4705,7 +4705,7 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(uint8 rideIndex, uint8 track
         break;
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
 
     sint8 support[4] = { 12, 12, 12, 14};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4774,7 +4774,7 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(uint8 rideIndex, uint8 track
         break;
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
 
     if (track_paint_util_should_paint_supports(pos)) {
         metal_a_supports_paint_setup((direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK, 4, 20, height - 5, gTrackColours[SCHEME_SUPPORTS]);
@@ -4855,7 +4855,7 @@ static void junior_rc_booster_paint_setup(uint8 rideIndex, uint8 trackSequence, 
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         uint8 supportType = (direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK;
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/junior_roller_coaster.c
+++ b/src/openrct2/ride/coaster/junior_roller_coaster.c
@@ -2090,7 +2090,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(uint8 rideIndex, uint8 track
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2130,7 +2130,7 @@ static void junior_rc_flat_to_right_bank_paint_setup(uint8 rideIndex, uint8 trac
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2298,7 +2298,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(uint8 rideIndex, uint8 
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2341,7 +2341,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(uint8 rideIndex, uint8
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2399,7 +2399,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(uint8 rideIndex, uint8 
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2450,7 +2450,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(uint8 rideIndex, uint8
         }
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -2530,7 +2530,7 @@ static void junior_rc_left_bank_paint_setup(uint8 rideIndex, uint8 trackSequence
         paint_util_push_tunnel_left(height, 0);
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -3342,7 +3342,7 @@ static void junior_rc_brake_paint_setup(uint8 rideIndex, uint8 trackSequence, ui
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -3373,7 +3373,7 @@ static void junior_rc_block_brake_paint_setup(uint8 rideIndex, uint8 trackSequen
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         sint32 edi = (direction & 1) ? 2 : 1;
         metal_a_supports_paint_setup(edi, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -4296,7 +4296,7 @@ void junior_rc_paint_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8
         break;
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
 
     sint8 support[4] = { 35, 29, 25, 32};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4389,7 +4389,7 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSe
         break;
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
 
     sint8 support[4] = { 12, 12, 12, 14};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4461,7 +4461,7 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSe
         break;
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
 
     if (track_paint_util_should_paint_supports(pos)) {
         metal_a_supports_paint_setup((direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
@@ -4705,7 +4705,7 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(uint8 rideIndex, uint8 track
         break;
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
 
     sint8 support[4] = { 12, 12, 12, 14};
     if (track_paint_util_should_paint_supports(pos)) {
@@ -4774,7 +4774,7 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(uint8 rideIndex, uint8 track
         break;
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
 
     if (track_paint_util_should_paint_supports(pos)) {
         metal_a_supports_paint_setup((direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK, 4, 20, height - 5, gTrackColours[SCHEME_SUPPORTS]);
@@ -4855,7 +4855,7 @@ static void junior_rc_booster_paint_setup(uint8 rideIndex, uint8 trackSequence, 
         paint_util_push_tunnel_left(height, TUNNEL_0);
     }
 
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     if (track_paint_util_should_paint_supports(pos)) {
         uint8 supportType = (direction & 1) ? METAL_SUPPORTS_FORK_ALT : METAL_SUPPORTS_FORK;
         metal_a_supports_paint_setup(supportType, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/lay_down_roller_coaster.c
+++ b/src/openrct2/ride/coaster/lay_down_roller_coaster.c
@@ -46,7 +46,7 @@ static void lay_down_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16229, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -60,7 +60,7 @@ static void lay_down_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16225, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -93,7 +93,7 @@ static void lay_down_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -160,7 +160,7 @@ static void lay_down_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16317, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -178,7 +178,7 @@ static void lay_down_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16289, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -223,7 +223,7 @@ static void lay_down_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 51, gTrackColours[SCHEME_SUPPORTS]);
@@ -268,7 +268,7 @@ static void lay_down_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16333, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -286,7 +286,7 @@ static void lay_down_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16305, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -341,7 +341,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16309, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -359,7 +359,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16281, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -404,7 +404,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 43, gTrackColours[SCHEME_SUPPORTS]);
@@ -451,7 +451,7 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16321, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -471,7 +471,7 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16293, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -530,7 +530,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16327, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -550,7 +550,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16299, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -580,7 +580,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 65, gTrackColours[SCHEME_SUPPORTS]);
@@ -625,7 +625,7 @@ static void lay_down_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16313, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -643,7 +643,7 @@ static void lay_down_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16285, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -688,7 +688,7 @@ static void lay_down_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 41, gTrackColours[SCHEME_SUPPORTS]);
@@ -1011,7 +1011,7 @@ static void lay_down_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequ
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16241, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1034,7 +1034,7 @@ static void lay_down_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequ
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1063,7 +1063,7 @@ static void lay_down_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16249, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1086,7 +1086,7 @@ static void lay_down_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeq
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1115,7 +1115,7 @@ static void lay_down_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequ
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16243, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1138,7 +1138,7 @@ static void lay_down_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequ
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1167,7 +1167,7 @@ static void lay_down_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeq
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16247, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1190,7 +1190,7 @@ static void lay_down_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeq
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1462,7 +1462,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16253, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1489,7 +1489,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 41, gTrackColours[SCHEME_SUPPORTS]);
@@ -1535,7 +1535,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16261, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1562,7 +1562,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 41, gTrackColours[SCHEME_SUPPORTS]);
@@ -1608,7 +1608,7 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trac
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16265, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1635,7 +1635,7 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trac
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 41, gTrackColours[SCHEME_SUPPORTS]);
@@ -1681,7 +1681,7 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tra
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16273, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1708,7 +1708,7 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tra
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 41, gTrackColours[SCHEME_SUPPORTS]);
@@ -1776,7 +1776,7 @@ static void lay_down_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16277, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1799,7 +1799,7 @@ static void lay_down_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, ui
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -5696,7 +5696,7 @@ static void lay_down_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16231, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -5715,7 +5715,7 @@ static void lay_down_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -11688,7 +11688,7 @@ static void lay_down_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence,
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 33, gTrackColours[SCHEME_SUPPORTS]);
         }
 

--- a/src/openrct2/ride/coaster/lim_launched_roller_coaster.c
+++ b/src/openrct2/ride/coaster/lim_launched_roller_coaster.c
@@ -907,7 +907,7 @@ static void lim_launched_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, u
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15019, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -1128,7 +1128,7 @@ static void lim_launched_rc_track_block_brakes(uint8 rideIndex, uint8 trackSeque
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15021, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/looping_roller_coaster.c
+++ b/src/openrct2/ride/coaster/looping_roller_coaster.c
@@ -44,7 +44,7 @@ static void looping_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 di
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15009, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -58,7 +58,7 @@ static void looping_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 di
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15005, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -103,7 +103,7 @@ static void looping_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15063, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -121,7 +121,7 @@ static void looping_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15035, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -152,7 +152,7 @@ static void looping_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15079, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -170,7 +170,7 @@ static void looping_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15051, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -201,7 +201,7 @@ static void looping_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15055, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -219,7 +219,7 @@ static void looping_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15027, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -252,7 +252,7 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15067, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -272,7 +272,7 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15039, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -305,7 +305,7 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15073, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -325,7 +325,7 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 track
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15045, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -356,7 +356,7 @@ static void looping_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15059, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -374,7 +374,7 @@ static void looping_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15031, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -565,7 +565,7 @@ static void looping_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSeque
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15083, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -592,7 +592,7 @@ static void looping_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSequ
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15095, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -619,7 +619,7 @@ static void looping_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSeque
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15085, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -646,7 +646,7 @@ static void looping_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSequ
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15093, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -798,7 +798,7 @@ static void looping_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 track
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15099, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -829,7 +829,7 @@ static void looping_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15115, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -860,7 +860,7 @@ static void looping_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 track
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15107, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -891,7 +891,7 @@ static void looping_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 trac
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15119, 0, 0, 32, 1, 34, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -944,7 +944,7 @@ static void looping_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, uin
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15091, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -2952,7 +2952,7 @@ static void looping_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15015, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -2977,7 +2977,7 @@ static void looping_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 trackS
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15597, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -3006,7 +3006,7 @@ static void looping_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 track
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15601, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5455,7 +5455,7 @@ static void looping_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence, 
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15015, 0, 0, 32, 1, 26, height, 0, 27, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -5868,7 +5868,7 @@ static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex,
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15605, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5898,7 +5898,7 @@ static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideIndex
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15609, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5928,7 +5928,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex,
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15615, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -5958,7 +5958,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideIndex
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15619, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6011,7 +6011,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 rid
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15625, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6040,7 +6040,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 r
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15629, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6069,7 +6069,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 rid
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15633, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6098,7 +6098,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 r
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15637, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6152,7 +6152,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uint
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15577, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6182,7 +6182,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, uin
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15581, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6212,7 +6212,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uint
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15587, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6242,7 +6242,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, uin
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15591, 0, 0, 32, 20, 3, height, 0, 6, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -6300,7 +6300,7 @@ static void looping_rc_track_booster(uint8 rideIndex, uint8 trackSequence, uint8
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | sprite_nw_se, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/mine_ride.c
+++ b/src/openrct2/ride/coaster/mine_ride.c
@@ -33,14 +33,14 @@ static void mine_ride_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 dir
     case 0:
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19338, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19339, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -74,25 +74,25 @@ static void mine_ride_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19388, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19389, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19390, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19391, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -112,25 +112,25 @@ static void mine_ride_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequen
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19380, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19381, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19382, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19383, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -150,25 +150,25 @@ static void mine_ride_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequen
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19384, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19385, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19386, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19387, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -336,26 +336,26 @@ static void mine_ride_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequen
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19340, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19348, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19341, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19349, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19342, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19343, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -371,27 +371,27 @@ static void mine_ride_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeque
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19344, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19345, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19346, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19350, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19347, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19351, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -408,26 +408,26 @@ static void mine_ride_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequen
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19346, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19350, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19347, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19351, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19344, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19345, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -443,27 +443,27 @@ static void mine_ride_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeque
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19342, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19343, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19340, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19348, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19341, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19349, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -611,26 +611,26 @@ static void mine_ride_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trackS
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19352, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19356, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19353, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19357, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19354, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19355, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -650,27 +650,27 @@ static void mine_ride_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 track
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19358, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19359, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19360, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19362, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19361, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19363, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -691,26 +691,26 @@ static void mine_ride_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trackS
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19364, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19368, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19365, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19369, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19366, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19367, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -730,27 +730,27 @@ static void mine_ride_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 track
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19370, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19371, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19372, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19374, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19373, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19375, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -794,25 +794,25 @@ static void mine_ride_track_left_bank(uint8 rideIndex, uint8 trackSequence, uint
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19376, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19377, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19378, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19379, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;

--- a/src/openrct2/ride/coaster/mine_train_coaster.c
+++ b/src/openrct2/ride/coaster/mine_train_coaster.c
@@ -150,11 +150,11 @@ static void mine_train_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, 
         wooden_a_supports_paint_setup(6, 21, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 1:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20091, 0, 0, 1, 32, 98, height, 27, 0, height);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20091, 0, 0, 1, 32, 98, height, 27, 0, height);
         wooden_a_supports_paint_setup(7, 22, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 2:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20092, 0, 0, 1, 32, 98, height, 27, 0, height);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20092, 0, 0, 1, 32, 98, height, 27, 0, height);
         wooden_a_supports_paint_setup(6, 23, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 3:
@@ -231,12 +231,12 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 tr
         wooden_a_supports_paint_setup(6, 13, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 1:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20079, 0, 0, 32, 20, 1, height, 0, 6, height);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20079, 0, 0, 32, 20, 1, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20082, 0, 0, 32, 1, 66, height, 0, 27, height);
         wooden_a_supports_paint_setup(7, 14, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 2:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20080, 0, 0, 32, 20, 1, height, 0, 6, height);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20080, 0, 0, 32, 20, 1, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20083, 0, 0, 32, 1, 66, height, 0, 27, height);
         wooden_a_supports_paint_setup(6, 15, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
@@ -263,12 +263,12 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 tr
         wooden_a_supports_paint_setup(6, 17, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 1:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20085, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20085, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20088, 0, 0, 32, 2, 66, height, 0, 4, height);
         wooden_a_supports_paint_setup(7, 18, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;
     case 2:
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20086, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20086, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 20089, 0, 0, 32, 2, 66, height, 0, 4, height);
         wooden_a_supports_paint_setup(6, 19, height, gTrackColours[SCHEME_SUPPORTS], NULL);
         break;

--- a/src/openrct2/ride/coaster/mini_roller_coaster.c
+++ b/src/openrct2/ride/coaster/mini_roller_coaster.c
@@ -33,25 +33,25 @@ static void mini_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direc
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19044, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19045, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19046, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19047, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -61,14 +61,14 @@ static void mini_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direc
         case 0:
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18738, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18739, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -108,25 +108,25 @@ static void mini_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19056, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19057, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19058, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19059, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -135,25 +135,25 @@ static void mini_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18796, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18797, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18798, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18799, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -174,25 +174,25 @@ static void mini_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18812, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 38, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18813, 0, 0, 32, 1, 98, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 38, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18814, 0, 0, 32, 1, 98, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 38, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18815, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 38, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -213,25 +213,25 @@ static void mini_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19048, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19049, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19050, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19051, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -240,25 +240,25 @@ static void mini_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18788, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18789, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18790, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18791, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -279,27 +279,27 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSeq
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18800, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18801, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18804, 0, 0, 32, 1, 66, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18802, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18805, 0, 0, 32, 1, 66, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18803, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 18, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -319,27 +319,27 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18806, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 26, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18807, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18810, 0, 0, 32, 1, 66, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 26, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18808, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18811, 0, 0, 32, 1, 66, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 26, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18809, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 26, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -360,25 +360,25 @@ static void mini_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19052, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19053, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19054, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19055, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -387,25 +387,25 @@ static void mini_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence
         switch (direction) {
         case 0:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18792, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18793, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18794, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18795, 0, 0, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
@@ -592,26 +592,26 @@ static void mini_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequence
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18748, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18756, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18749, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18757, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18750, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18751, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -627,27 +627,27 @@ static void mini_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSequenc
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18752, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18753, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18754, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18758, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18755, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18759, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -664,26 +664,26 @@ static void mini_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequence
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18754, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18758, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18755, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18759, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18752, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18753, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -699,27 +699,27 @@ static void mini_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSequenc
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18750, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18751, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18748, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18756, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18749, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18757, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -867,26 +867,26 @@ static void mini_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18760, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18764, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18761, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18765, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18762, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18763, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -906,27 +906,27 @@ static void mini_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 trackSe
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18766, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18767, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18768, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18770, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18769, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18771, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -947,26 +947,26 @@ static void mini_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trackSeq
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18772, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18776, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18773, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18777, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18774, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18775, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -986,27 +986,27 @@ static void mini_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 trackSe
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18778, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18779, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18780, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18782, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18781, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18783, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -1050,25 +1050,25 @@ static void mini_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, uint8 
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18784, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18785, 0, 0, 32, 1, 26, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18786, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18787, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -2801,14 +2801,14 @@ static void mini_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 dir
     case 0:
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18740, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18741, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -2824,25 +2824,25 @@ static void mini_rc_track_25_deg_up_left_banked(uint8 rideIndex, uint8 trackSequ
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19222, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19223, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19224, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19225, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -2862,25 +2862,25 @@ static void mini_rc_track_25_deg_up_right_banked(uint8 rideIndex, uint8 trackSeq
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19226, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19227, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19228, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19229, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5083,14 +5083,14 @@ static void mini_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence, uin
     case 0:
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18742, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 18743, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5514,26 +5514,26 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(uint8 rideIndex, ui
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19230, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19231, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19238, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19232, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19233, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5553,26 +5553,26 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(uint8 rideIndex, u
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19234, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19235, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19236, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19239, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19237, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5592,26 +5592,26 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, ui
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19240, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19241, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19248, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19242, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19243, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5631,26 +5631,26 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(uint8 rideIndex, u
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19244, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19245, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19246, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19249, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19247, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 14, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5694,25 +5694,25 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(uint8 rideIn
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19250, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19251, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19252, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19253, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5732,25 +5732,25 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(uint8 ride
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19254, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19255, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19256, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19257, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5770,25 +5770,25 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(uint8 rideIn
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19258, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19259, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19260, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19261, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5808,25 +5808,25 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(uint8 ride
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19262, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19263, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19264, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19265, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5870,26 +5870,26 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(uint8 rideIndex, uint8 t
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19202, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19203, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19210, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19204, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19205, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5909,26 +5909,26 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(uint8 rideIndex, uint8 
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19206, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19207, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19208, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19211, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19209, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 9, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5948,26 +5948,26 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(uint8 rideIndex, uint8 t
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19212, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19213, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19220, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19214, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19215, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -5987,26 +5987,26 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(uint8 rideIndex, uint8 
     switch (direction) {
     case 0:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19216, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 1:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19217, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 2:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19218, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19221, 0, 0, 32, 1, 34, height, 0, 27, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
     case 3:
         sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 19219, 0, 0, 32, 20, 3, height, 0, 6, height);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         break;
@@ -6191,14 +6191,14 @@ static void mini_rc_track_booster(uint8 rideIndex, uint8 trackSequence, uint8 di
         case 0:
         case 2:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | SPR_G2_MINI_RC_BOOSTER_NE_SW, ne_sw_offsetX, ne_sw_offsetY, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;
         case 1:
         case 3:
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | SPR_G2_MINI_RC_BOOSTER_NW_SE, nw_se_offsetX, nw_se_offsetY, 32, 20, 3, height, 0, 6, height);
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_FORK_ALT, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
             break;

--- a/src/openrct2/ride/coaster/mini_suspended_coaster.c
+++ b/src/openrct2/ride/coaster/mini_suspended_coaster.c
@@ -54,7 +54,7 @@ static void mini_suspended_rc_track_flat(uint8 rideIndex, uint8 trackSequence, u
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
         case 2:
@@ -127,7 +127,7 @@ static void mini_suspended_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequen
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -188,7 +188,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tra
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 6, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);
@@ -249,7 +249,7 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 tra
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_FORK, 6, 0, height + 38, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
+++ b/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
@@ -41,7 +41,7 @@ static void multi_dimension_rc_track_flat(uint8 rideIndex, uint8 trackSequence, 
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15809, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -55,7 +55,7 @@ static void multi_dimension_rc_track_flat(uint8 rideIndex, uint8 trackSequence, 
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15807, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -75,7 +75,7 @@ static void multi_dimension_rc_track_flat(uint8 rideIndex, uint8 trackSequence, 
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -94,7 +94,7 @@ static void multi_dimension_rc_track_station(uint8 rideIndex, uint8 trackSequenc
         { 15811, 15813, SPR_STATION_INVERTED_BAR_A_NW_SE },
     };
 
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     if (mapElement->properties.track.type == TRACK_ELEM_END_STATION) {
         sub_98197C_rotated(direction, imageIds[direction][1] | gTrackColours[SCHEME_TRACK], 0, 0, 32, 26, 1, height, 0, 3, height + 3);
@@ -146,7 +146,7 @@ static void multi_dimension_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSeque
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15911, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -164,7 +164,7 @@ static void multi_dimension_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSeque
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15883, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -192,7 +192,7 @@ static void multi_dimension_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSeque
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -236,7 +236,7 @@ static void multi_dimension_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15899, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 24, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -290,7 +290,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tr
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15903, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -308,7 +308,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tr
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15875, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -336,7 +336,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tr
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 46, gTrackColours[SCHEME_SUPPORTS]);
@@ -382,7 +382,7 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15887, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -439,7 +439,7 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15893, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 16, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -468,7 +468,7 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uin
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 68, gTrackColours[SCHEME_SUPPORTS]);
@@ -513,7 +513,7 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 tr
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15907, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         } else {
@@ -531,7 +531,7 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 tr
                 sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15879, 0, 0, 32, 20, 3, height, 0, 6, height);
                 break;
             }
-            if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+            if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
             }
         }
@@ -559,7 +559,7 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 tr
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
@@ -882,7 +882,7 @@ static void multi_dimension_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 tr
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15835, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -905,7 +905,7 @@ static void multi_dimension_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 tr
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -934,7 +934,7 @@ static void multi_dimension_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 t
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15843, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -957,7 +957,7 @@ static void multi_dimension_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 t
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -986,7 +986,7 @@ static void multi_dimension_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 tr
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15837, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1009,7 +1009,7 @@ static void multi_dimension_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 tr
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1038,7 +1038,7 @@ static void multi_dimension_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 t
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15841, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1061,7 +1061,7 @@ static void multi_dimension_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 t
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -1333,7 +1333,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15847, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1360,7 +1360,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uin
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
@@ -1406,7 +1406,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15855, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1433,7 +1433,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, ui
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
@@ -1479,7 +1479,7 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uin
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15859, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1506,7 +1506,7 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uin
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
@@ -1552,7 +1552,7 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, ui
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15867, 0, 0, 32, 1, 34, height, 0, 27, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         if (direction == 0 || direction == 3) {
@@ -1579,7 +1579,7 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, ui
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             switch (direction) {
             case 0:
                 metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 6, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
@@ -1647,7 +1647,7 @@ static void multi_dimension_rc_track_left_bank(uint8 rideIndex, uint8 trackSeque
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 15871, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -1670,7 +1670,7 @@ static void multi_dimension_rc_track_left_bank(uint8 rideIndex, uint8 trackSeque
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -4003,7 +4003,7 @@ static void multi_dimension_rc_track_brakes(uint8 rideIndex, uint8 trackSequence
             sub_98197C_rotated(direction, gTrackColours[SCHEME_TRACK] | 16219, 0, 0, 32, 20, 3, height, 0, 6, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
         paint_util_push_tunnel_rotated(direction, height, TUNNEL_6);
@@ -4022,7 +4022,7 @@ static void multi_dimension_rc_track_brakes(uint8 rideIndex, uint8 trackSequence
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 
@@ -9290,7 +9290,7 @@ static void multi_dimension_rc_track_block_brakes(uint8 rideIndex, uint8 trackSe
         }
 
         paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES_INVERTED, 4, 0, height + 36, gTrackColours[SCHEME_SUPPORTS]);
         }
 

--- a/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
+++ b/src/openrct2/ride/coaster/multi_dimension_roller_coaster.c
@@ -94,7 +94,7 @@ static void multi_dimension_rc_track_station(uint8 rideIndex, uint8 trackSequenc
         { 15811, 15813, SPR_STATION_INVERTED_BAR_A_NW_SE },
     };
 
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     if (mapElement->properties.track.type == TRACK_ELEM_END_STATION) {
         sub_98197C_rotated(direction, imageIds[direction][1] | gTrackColours[SCHEME_TRACK], 0, 0, 32, 26, 1, height, 0, 3, height + 3);

--- a/src/openrct2/ride/coaster/reverser_roller_coaster.c
+++ b/src/openrct2/ride/coaster/reverser_roller_coaster.c
@@ -39,8 +39,8 @@ void vehicle_visual_reverser(sint32 x, sint32 imageDirection, sint32 y, sint32 z
     x = (v1->x + v2->x) / 2;
     y = (v1->y + v2->y) / 2;
     z = (v1->z + v2->z) / 2;
-    gPaintSpritePosition.x = x;
-    gPaintSpritePosition.y = y;
+    gPaintSession.SpritePosition.x = x;
+    gPaintSession.SpritePosition.y = y;
     vehicle_visual_default(x, imageDirection, y, z, vehicle, vehicleEntry);
 }
 #endif

--- a/src/openrct2/ride/coaster/stand_up_roller_coaster.c
+++ b/src/openrct2/ride/coaster/stand_up_roller_coaster.c
@@ -44,7 +44,7 @@ static void stand_up_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25454, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -58,7 +58,7 @@ static void stand_up_rc_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 d
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25230, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -108,7 +108,7 @@ static void stand_up_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25399, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -126,7 +126,7 @@ static void stand_up_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, ui
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25245, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -157,7 +157,7 @@ static void stand_up_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25400, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -175,7 +175,7 @@ static void stand_up_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, ui
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25246, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -206,7 +206,7 @@ static void stand_up_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25403, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -224,7 +224,7 @@ static void stand_up_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequ
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25249, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -257,7 +257,7 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25404, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -277,7 +277,7 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trac
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25250, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -310,7 +310,7 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25406, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -330,7 +330,7 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trac
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25252, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -361,7 +361,7 @@ static void stand_up_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25405, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     } else {
@@ -379,7 +379,7 @@ static void stand_up_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequ
             sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25251, 0, 6, 32, 20, 3, height);
             break;
         }
-        if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+        if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
         }
     }
@@ -568,7 +568,7 @@ static void stand_up_rc_track_flat_to_left_bank(uint8 rideIndex, uint8 trackSequ
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25283, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -593,7 +593,7 @@ static void stand_up_rc_track_flat_to_right_bank(uint8 rideIndex, uint8 trackSeq
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25285, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -618,7 +618,7 @@ static void stand_up_rc_track_left_bank_to_flat(uint8 rideIndex, uint8 trackSequ
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25284, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -643,7 +643,7 @@ static void stand_up_rc_track_right_bank_to_flat(uint8 rideIndex, uint8 trackSeq
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25286, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -793,7 +793,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_up(uint8 rideIndex, uint8 trac
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25318, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -822,7 +822,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_up(uint8 rideIndex, uint8 tra
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25322, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -851,7 +851,7 @@ static void stand_up_rc_track_25_deg_up_to_left_bank(uint8 rideIndex, uint8 trac
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25314, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -880,7 +880,7 @@ static void stand_up_rc_track_25_deg_up_to_right_bank(uint8 rideIndex, uint8 tra
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25310, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -933,7 +933,7 @@ static void stand_up_rc_track_left_bank(uint8 rideIndex, uint8 trackSequence, ui
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25326, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -3374,7 +3374,7 @@ static void stand_up_rc_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25570, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -5805,7 +5805,7 @@ static void stand_up_rc_track_block_brakes(uint8 rideIndex, uint8 trackSequence,
         sub_98196C_rotated(direction, gTrackColours[SCHEME_TRACK] | 25572, 0, 6, 32, 20, 3, height);
         break;
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/suspended_swinging_coaster.c
+++ b/src/openrct2/ride/coaster/suspended_swinging_coaster.c
@@ -54,7 +54,7 @@ static void suspended_swinging_rc_track_flat(uint8 rideIndex, uint8 trackSequenc
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -118,7 +118,7 @@ static void suspended_swinging_rc_track_25_deg_up(uint8 rideIndex, uint8 trackSe
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 6, 0, height + 62, gTrackColours[SCHEME_SUPPORTS]);
@@ -205,7 +205,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(uint8 rideIndex, uint8
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 6, 0, height + 54, gTrackColours[SCHEME_SUPPORTS]);
@@ -298,7 +298,7 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 6, 0, height + 76, gTrackColours[SCHEME_SUPPORTS]);
@@ -359,7 +359,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(uint8 rideIndex, uint8
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -1282,7 +1282,7 @@ static void suspended_swinging_rc_track_brakes(uint8 rideIndex, uint8 trackSeque
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -2981,7 +2981,7 @@ static void suspended_swinging_rc_track_block_brakes(uint8 rideIndex, uint8 trac
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height + 44, gTrackColours[SCHEME_SUPPORTS]);
     }
 

--- a/src/openrct2/ride/coaster/virginia_reel.c
+++ b/src/openrct2/ride/coaster/virginia_reel.c
@@ -270,7 +270,7 @@ static void paint_virginia_reel_track_25_deg_up(uint8 rideIndex, uint8 trackSequ
     }
 
     if (direction == 1 || direction == 2) {
-        gWoodenSupportsPrependTo = ps;
+        gPaintSession.WoodenSupportsPrependTo = ps;
     }
 
     switch (direction) {
@@ -315,14 +315,14 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(uint8 rideIndex, uint8 t
             break;
         case 1:
             ps = sub_98197C(imageId, 0, 0, 27, 32, 2, height, 2, 0, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             wooden_a_supports_paint_setup(1, 2, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             paint_util_push_tunnel_right(height, TUNNEL_8);
             break;
         case 2:
             ps = sub_98197C(imageId, 0, 0, 32, 27, 2, height, 0, 2, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             wooden_a_supports_paint_setup(0, 3, height, gTrackColours[SCHEME_SUPPORTS], NULL);
             paint_util_push_tunnel_left(height, TUNNEL_8);
@@ -357,7 +357,7 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(uint8 rideIndex, uint8 t
     }
 
     if (direction == 1 || direction == 2) {
-        gWoodenSupportsPrependTo = ps;
+        gPaintSession.WoodenSupportsPrependTo = ps;
     }
 
     switch (direction) {

--- a/src/openrct2/ride/coaster/virginia_reel.c
+++ b/src/openrct2/ride/coaster/virginia_reel.c
@@ -212,7 +212,7 @@ void vehicle_visual_virginia_reel(sint32 x, sint32 imageDirection, sint32 y, sin
     image_id = baseImage_id | SPRITE_ID_PALETTE_COLOUR_2(vehicle->colours.body_colour, vehicle->colours.trim_colour);
     sub_98197C(image_id, 0, 0, bb->length_x, bb->length_y, bb->length_z, z, bb->offset_x, bb->offset_y, bb->offset_z + z, rotation);
 
-    if (unk_140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
+    if (gPaintSession.Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
         uint8 riding_peep_sprites[4] = {0xFF, 0xFF, 0xFF, 0xFF};
         for (sint32 i = 0; i < vehicle->num_peeps; i++) {
             riding_peep_sprites[((ecx / 8) + i) & 3] = vehicle->peep_tshirt_colours[i];

--- a/src/openrct2/ride/coaster/wild_mouse.c
+++ b/src/openrct2/ride/coaster/wild_mouse.c
@@ -182,7 +182,7 @@ static void wild_mouse_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 di
     uint8 isChained = track_element_is_lift_hill(mapElement) ? 1 : 0;
     uint32 imageId = imageIds[direction][isChained] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -1, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -226,7 +226,7 @@ static void wild_mouse_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uin
     uint8 isChained = track_element_is_lift_hill(mapElement) ? 1 : 0;
     uint32 imageId = imageIds[direction][isChained] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -9, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -255,7 +255,7 @@ static void wild_mouse_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uin
     } else {
         sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 98, height, 0, 27, height);
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         if (direction == 0 || direction == 3) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -33, height, gTrackColours[SCHEME_SUPPORTS]);
         } else {
@@ -284,7 +284,7 @@ static void wild_mouse_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeque
     uint8 isChained = track_element_is_lift_hill(mapElement) ? 1 : 0;
     uint32 imageId = imageIds[direction][isChained] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -4, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -321,7 +321,7 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 track
         sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -13, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -358,7 +358,7 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 track
         sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
         sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -21, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -383,7 +383,7 @@ static void wild_mouse_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeque
     uint8 isChained = track_element_is_lift_hill(mapElement) ? 1 : 0;
     uint32 imageId = imageIds[direction][isChained] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -7, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -660,7 +660,7 @@ static void wild_mouse_track_flat_to_60_deg_up(uint8 rideIndex, uint8 trackSeque
         sub_98197C_rotated(direction, imageId, 0, 0, 1, 24, 43, height, 29, 4, height + 2);
         sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -5, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     if (direction == 0 || direction == 3) {
@@ -697,7 +697,7 @@ static void wild_mouse_track_60_deg_up_to_flat(uint8 rideIndex, uint8 trackSeque
         sub_98197C_rotated(direction, imageId, 0, 0, 1, 24, 43, height, 29, 4, height + 2);
         sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         if (direction == 0 || direction == 3) {
             metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, -17, height, gTrackColours[SCHEME_SUPPORTS]);
         } else {
@@ -730,7 +730,7 @@ static void wild_mouse_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 
 {
     uint32 imageId = _wild_mouse_brakes_image_ids[direction] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -750,7 +750,7 @@ static void wild_mouse_track_rotation_control_toggle(uint8 rideIndex, uint8 trac
 
     uint32 imageId = imageIds[direction] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);
@@ -763,7 +763,7 @@ static void wild_mouse_track_block_brakes(uint8 rideIndex, uint8 trackSequence, 
 {
     uint32 imageId = _wild_mouse_block_brakes_image_ids[direction] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
     paint_util_push_tunnel_rotated(direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/wooden_roller_coaster.c
+++ b/src/openrct2/ride/coaster/wooden_roller_coaster.c
@@ -530,7 +530,7 @@ static void wooden_rc_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint
     if (direction == 0 || direction == 3) {
         wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     } else {
-        gWoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 93, height, 28, 4, height - 16);
+        gPaintSession.WoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 93, height, 28, 4, height - 16);
     }
     wooden_a_supports_paint_setup(direction & 1, 21 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);
 
@@ -592,7 +592,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackS
     if (direction == 0 || direction == 3) {
         wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     } else {
-        gWoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 43, height, 28, 4, height + 2);
+        gPaintSession.WoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 43, height, 28, 4, height + 2);
         wooden_rc_track_paint(imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
     wooden_a_supports_paint_setup(direction & 1, 13 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);
@@ -620,7 +620,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackS
     if (direction == 0 || direction == 3) {
         wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     } else {
-        gWoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 24, 1, 61, height, 4, 28, height - 16);
+        gPaintSession.WoodenSupportsPrependTo = wooden_rc_track_paint(imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 24, 1, 61, height, 4, 28, height - 16);
         wooden_rc_track_paint(imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
     wooden_a_supports_paint_setup(direction & 1, 17 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);

--- a/src/openrct2/ride/coaster/wooden_wild_mouse.c
+++ b/src/openrct2/ride/coaster/wooden_wild_mouse.c
@@ -221,7 +221,7 @@ static void wooden_wild_mouse_track_60_deg_up(uint8 rideIndex, uint8 trackSequen
     if (direction == 0 || direction == 3) {
         sub_98197C_rotated(direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
     } else {
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 93, height, 28, 4, height - 16);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 93, height, 28, 4, height - 16);
     }
 
     wooden_a_supports_paint_setup(direction & 1, 21 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);
@@ -295,7 +295,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint
         sub_98197C_rotated(direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
     } else {
         imageId = imageIds[isChained][direction][0] | gTrackColours[SCHEME_TRACK];
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 43, height, 28, 4, height + 2);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 43, height, 28, 4, height + 2);
         imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
         sub_98197C_rotated(direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }
@@ -336,7 +336,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(uint8 rideIndex, uint8 t
         sub_98197C_rotated(direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
     } else {
         imageId = imageIds[isChained][direction][0] | gTrackColours[SCHEME_TRACK];
-        gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 43, height, 28, 4, height + 2);
+        gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 6, 2, 24, 43, height, 28, 4, height + 2);
         imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
         sub_98197C_rotated(direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }

--- a/src/openrct2/ride/gentle/car_ride.c
+++ b/src/openrct2/ride/gentle/car_ride.c
@@ -420,7 +420,7 @@ static void paint_car_ride_track_spinning_tunnel(uint8 rideIndex, uint8 trackSeq
 /** rct2: 0x006F73B8 */
 static void paint_car_ride_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = car_ride_track_pieces_60_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -466,7 +466,7 @@ static void paint_car_ride_track_60_deg_up(uint8 rideIndex, uint8 trackSequence,
 /** rct2: 0x006F73C8 */
 static void paint_car_ride_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
 
@@ -512,7 +512,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 t
 /** rct2: 0x006F73D8 */
 static void paint_car_ride_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/gentle/car_ride.c
+++ b/src/openrct2/ride/gentle/car_ride.c
@@ -420,7 +420,7 @@ static void paint_car_ride_track_spinning_tunnel(uint8 rideIndex, uint8 trackSeq
 /** rct2: 0x006F73B8 */
 static void paint_car_ride_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = car_ride_track_pieces_60_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -466,7 +466,7 @@ static void paint_car_ride_track_60_deg_up(uint8 rideIndex, uint8 trackSequence,
 /** rct2: 0x006F73C8 */
 static void paint_car_ride_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
 
@@ -512,7 +512,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 t
 /** rct2: 0x006F73D8 */
 static void paint_car_ride_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/gentle/circus_show.c
+++ b/src/openrct2/ride/gentle/circus_show.c
@@ -25,15 +25,15 @@
  */
 static void paint_circus_show_tent(uint8 rideIndex, uint8 direction, sint8 al, sint8 cl, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride * ride = get_ride(rideIndex);
     rct_ride_entry * rideEntry = get_ride_entry(ride->subtype);
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = GET_VEHICLE(ride->vehicles[0]);
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = GET_VEHICLE(ride->vehicles[0]);
     }
 
     uint32 imageColourFlags = gTrackColours[SCHEME_MISC];
@@ -45,8 +45,8 @@ static void paint_circus_show_tent(uint8 rideIndex, uint8 direction, sint8 al, s
 
     sub_98197C(imageId | imageColourFlags, al, cl, 24, 24, 47, height + 3, al + 16, cl + 16, height + 3, get_current_rotation());
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 /**
  * rct2: 0x0076FAD4

--- a/src/openrct2/ride/gentle/circus_show.c
+++ b/src/openrct2/ride/gentle/circus_show.c
@@ -57,7 +57,7 @@ static void paint_circus_show(uint8 rideIndex, uint8 trackSequence, uint8 direct
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/circus_show.c
+++ b/src/openrct2/ride/gentle/circus_show.c
@@ -57,7 +57,7 @@ static void paint_circus_show(uint8 rideIndex, uint8 trackSequence, uint8 direct
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/crooked_house.c
+++ b/src/openrct2/ride/gentle/crooked_house.c
@@ -44,7 +44,7 @@ rct_crooked_house_bound_box crooked_house_data[] = {
  * @param (edx) height
  */
 static void paint_crooked_house_structure(uint8 direction, uint8 x_offset, uint8 y_offset, uint32 segment, sint32 height) {
-    rct_map_element *original_map_element = g_currently_drawn_item;
+    rct_map_element *original_map_element = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride *ride = get_ride(original_map_element->properties.track.ride_index);
 
@@ -53,8 +53,8 @@ static void paint_crooked_house_structure(uint8 direction, uint8 x_offset, uint8
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK) {
         if (ride->vehicles[0] != SPRITE_INDEX_NULL) {
             rct_sprite *sprite = get_sprite(ride->vehicles[0]);
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-            g_currently_drawn_item = sprite;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+            gPaintSession.CurrentlyDrawnItem = sprite;
         }
     }
 

--- a/src/openrct2/ride/gentle/crooked_house.c
+++ b/src/openrct2/ride/gentle/crooked_house.c
@@ -71,7 +71,7 @@ static void paint_crooked_house(uint8 rideIndex, uint8 trackSequence, uint8 dire
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/crooked_house.c
+++ b/src/openrct2/ride/gentle/crooked_house.c
@@ -71,7 +71,7 @@ static void paint_crooked_house(uint8 rideIndex, uint8 trackSequence, uint8 dire
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/dodgems.c
+++ b/src/openrct2/ride/gentle/dodgems.c
@@ -52,7 +52,7 @@ static void paint_dodgems(uint8 rideIndex, uint8 trackSequence, uint8 direction,
 
     sint32 edges = edges_4x4[relativeTrackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/dodgems.c
+++ b/src/openrct2/ride/gentle/dodgems.c
@@ -52,7 +52,7 @@ static void paint_dodgems(uint8 rideIndex, uint8 trackSequence, uint8 direction,
 
     sint32 edges = edges_4x4[relativeTrackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/ferris_wheel.c
+++ b/src/openrct2/ride/gentle/ferris_wheel.c
@@ -140,7 +140,7 @@ static void paint_ferris_wheel(uint8 rideIndex, uint8 trackSequence, uint8 direc
     }
 
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/ferris_wheel.c
+++ b/src/openrct2/ride/gentle/ferris_wheel.c
@@ -140,7 +140,7 @@ static void paint_ferris_wheel(uint8 rideIndex, uint8 trackSequence, uint8 direc
     }
 
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/ferris_wheel.c
+++ b/src/openrct2/ride/gentle/ferris_wheel.c
@@ -58,7 +58,7 @@ static void paint_ferris_wheel_structure(uint8 rideIndex, uint8 direction, sint8
 {
     uint32 imageId, baseImageId;
 
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride * ride = get_ride(rideIndex);
     rct_ride_entry * rideEntry = get_ride_entry(ride->subtype);
@@ -75,8 +75,8 @@ static void paint_ferris_wheel_structure(uint8 rideIndex, uint8 direction, sint8
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
         vehicle = GET_VEHICLE(ride->vehicles[0]);
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     uint32 imageOffset = 0;
@@ -120,8 +120,8 @@ static void paint_ferris_wheel_structure(uint8 rideIndex, uint8 direction, sint8
     imageId = (22150 + (direction & 1) * 2 + 1) | gTrackColours[SCHEME_TRACK];
     sub_98199C(imageId, xOffset, yOffset, boundBox.length_x, boundBox.length_y, 127, height, boundBox.offset_x, boundBox.offset_y, height, get_current_rotation());
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 

--- a/src/openrct2/ride/gentle/flying_saucers.c
+++ b/src/openrct2/ride/gentle/flying_saucers.c
@@ -45,7 +45,7 @@ static void paint_flying_saucers(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_4x4[relativeTrackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/flying_saucers.c
+++ b/src/openrct2/ride/gentle/flying_saucers.c
@@ -45,7 +45,7 @@ static void paint_flying_saucers(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_4x4[relativeTrackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/ghost_train.c
+++ b/src/openrct2/ride/gentle/ghost_train.c
@@ -149,7 +149,7 @@ static const uint32 ghost_train_track_pieces_brakes[4] = {
 /** rct2: 0x00770BEC */
 static void paint_ghost_train_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = ghost_train_track_pieces_flat[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -176,7 +176,7 @@ static void paint_ghost_train_track_flat(uint8 rideIndex, uint8 trackSequence, u
 /** rct2: 0x00770BFC */
 static void paint_ghost_train_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = ghost_train_track_pieces_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -219,7 +219,7 @@ static void paint_ghost_train_track_25_deg_up(uint8 rideIndex, uint8 trackSequen
 /** rct2: 0x00770C0C */
 static void paint_ghost_train_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = ghost_train_track_pieces_flat_to_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -260,7 +260,7 @@ static void paint_ghost_train_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tra
 
 static void paint_ghost_train_track_25_deg_up_to_flat_shared(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -438,7 +438,7 @@ static void paint_ghost_train_track_spinning_tunnel(uint8 rideIndex, uint8 track
 /** rct2: 0x00770CDC */
 static void paint_ghost_train_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = ghost_train_track_pieces_brakes[direction] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/gentle/ghost_train.c
+++ b/src/openrct2/ride/gentle/ghost_train.c
@@ -149,7 +149,7 @@ static const uint32 ghost_train_track_pieces_brakes[4] = {
 /** rct2: 0x00770BEC */
 static void paint_ghost_train_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = ghost_train_track_pieces_flat[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -176,7 +176,7 @@ static void paint_ghost_train_track_flat(uint8 rideIndex, uint8 trackSequence, u
 /** rct2: 0x00770BFC */
 static void paint_ghost_train_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = ghost_train_track_pieces_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -219,7 +219,7 @@ static void paint_ghost_train_track_25_deg_up(uint8 rideIndex, uint8 trackSequen
 /** rct2: 0x00770C0C */
 static void paint_ghost_train_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = ghost_train_track_pieces_flat_to_25_deg_up[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -260,7 +260,7 @@ static void paint_ghost_train_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tra
 
 static void paint_ghost_train_track_25_deg_up_to_flat_shared(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][0] | gTrackColours[SCHEME_TRACK];
     if (direction == 0 || direction == 2) {
@@ -438,7 +438,7 @@ static void paint_ghost_train_track_spinning_tunnel(uint8 rideIndex, uint8 track
 /** rct2: 0x00770CDC */
 static void paint_ghost_train_track_brakes(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = ghost_train_track_pieces_brakes[direction] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/gentle/haunted_house.c
+++ b/src/openrct2/ride/gentle/haunted_house.c
@@ -90,7 +90,7 @@ static void paint_haunted_house(uint8 rideIndex, uint8 trackSequence, uint8 dire
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/haunted_house.c
+++ b/src/openrct2/ride/gentle/haunted_house.c
@@ -90,7 +90,7 @@ static void paint_haunted_house(uint8 rideIndex, uint8 trackSequence, uint8 dire
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/haunted_house.c
+++ b/src/openrct2/ride/gentle/haunted_house.c
@@ -44,7 +44,7 @@ static haunted_house_bound_box haunted_house_data[] = {
  */
 static void paint_haunted_house_structure(uint8 rideIndex, uint8 direction, sint8 xOffset, sint8 yOffset, uint8 part, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     uint8 frameNum = 0;
 
@@ -55,9 +55,9 @@ static void paint_haunted_house_structure(uint8 rideIndex, uint8 direction, sint
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
         rct_vehicle * vehicle = GET_VEHICLE(ride->vehicles[0]);
-        g_currently_drawn_item = vehicle;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
         frameNum = vehicle->vehicle_sprite_type;
     }
 
@@ -65,7 +65,7 @@ static void paint_haunted_house_structure(uint8 rideIndex, uint8 direction, sint
     haunted_house_bound_box boundBox = haunted_house_data[part];
     sub_98197C(imageId, xOffset, yOffset, boundBox.length_x, boundBox.length_y, 127, height, boundBox.offset_x, boundBox.offset_y, height, get_current_rotation());
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level == 0 && frameNum != 0) {
         switch (direction) {
             case 0: imageId = baseImageId + 3 + frameNum; break;
@@ -77,8 +77,8 @@ static void paint_haunted_house_structure(uint8 rideIndex, uint8 direction, sint
         sub_98199C(imageId, xOffset, yOffset, boundBox.length_x, boundBox.length_y, 127, height, boundBox.offset_x, boundBox.offset_y, height, get_current_rotation());
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /**

--- a/src/openrct2/ride/gentle/merry_go_round.c
+++ b/src/openrct2/ride/gentle/merry_go_round.c
@@ -109,7 +109,7 @@ static void paint_merry_go_round(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/merry_go_round.c
+++ b/src/openrct2/ride/gentle/merry_go_round.c
@@ -109,7 +109,7 @@ static void paint_merry_go_round(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/merry_go_round.c
+++ b/src/openrct2/ride/gentle/merry_go_round.c
@@ -35,7 +35,7 @@ static const uint16 merry_go_round_breakdown_vibration[] = {
  */
 static void paint_merry_go_round_structure(uint8 rideIndex, uint8 direction, sint8 xOffset, sint8 yOffset, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
     height += 7;
 
     rct_ride * ride = get_ride(rideIndex);
@@ -46,9 +46,9 @@ static void paint_merry_go_round_structure(uint8 rideIndex, uint8 direction, sin
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
         vehicle = GET_VEHICLE(ride->vehicles[0]);
-        g_currently_drawn_item = vehicle;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
 
         if (ride->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)
             && ride->breakdown_reason_pending == BREAKDOWN_CONTROL_FAILURE
@@ -73,7 +73,7 @@ static void paint_merry_go_round_structure(uint8 rideIndex, uint8 direction, sin
     uint32 imageId = (baseImageId + imageOffset) | imageColourFlags;
     sub_98197C(imageId, xOffset, yOffset, 24, 24, 48, height, xOffset + 16, yOffset + 16, height, get_current_rotation());
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level == 0
         && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && vehicle != NULL) {
@@ -96,8 +96,8 @@ static void paint_merry_go_round_structure(uint8 rideIndex, uint8 direction, sin
         }
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /**

--- a/src/openrct2/ride/gentle/mini_golf.c
+++ b/src/openrct2/ride/gentle/mini_golf.c
@@ -443,12 +443,12 @@ static paint_struct * mini_golf_paint_util_7c(
 
 static bool mini_golf_paint_util_should_draw_fence(rct_map_element * mapElement)
 {
-    if (!gDidPassSurface) {
+    if (!gPaintSession.DidPassSurface) {
         // Should be above ground (have passed surface rendering)
         return false;
     }
 
-    rct_map_element * surfaceElement = gSurfaceElement;
+    rct_map_element * surfaceElement = gPaintSession.SurfaceElement;
     if (surfaceElement->base_height != mapElement->base_height) {
         return true;
     }

--- a/src/openrct2/ride/gentle/mini_golf.c
+++ b/src/openrct2/ride/gentle/mini_golf.c
@@ -623,7 +623,7 @@ static void paint_mini_golf_track_25_deg_down_to_flat(uint8 rideIndex, uint8 tra
 /** rct2: 0x0087F17C, 0x0087F18C, 0x0087F19C */
 static void paint_mini_golf_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     uint32 imageId;

--- a/src/openrct2/ride/gentle/mini_golf.c
+++ b/src/openrct2/ride/gentle/mini_golf.c
@@ -1028,7 +1028,7 @@ void vehicle_visual_mini_golf_player(sint32 x, sint32 imageDirection, sint32 y, 
         return;
     }
 
-    rct_drawpixelinfo *edi = unk_140E9A8;
+    rct_drawpixelinfo *edi = gPaintSession.Unk140E9A8;
     if (edi->zoom_level >= 2) {
         return;
     }
@@ -1057,7 +1057,7 @@ void vehicle_visual_mini_golf_ball(sint32 x, sint32 imageDirection, sint32 y, si
         return;
     }
 
-    rct_drawpixelinfo *edi = unk_140E9A8;
+    rct_drawpixelinfo *edi = gPaintSession.Unk140E9A8;
     if (edi->zoom_level >= 1) {
         return;
     }

--- a/src/openrct2/ride/gentle/mini_golf.c
+++ b/src/openrct2/ride/gentle/mini_golf.c
@@ -623,7 +623,7 @@ static void paint_mini_golf_track_25_deg_down_to_flat(uint8 rideIndex, uint8 tra
 /** rct2: 0x0087F17C, 0x0087F18C, 0x0087F19C */
 static void paint_mini_golf_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     uint32 imageId;

--- a/src/openrct2/ride/gentle/mini_helicopters.c
+++ b/src/openrct2/ride/gentle/mini_helicopters.c
@@ -59,7 +59,7 @@ static void paint_mini_helicopters_track_station(uint8 rideIndex, uint8 trackSeq
 /** rct2: 0x0081F348 */
 static void paint_mini_helicopters_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     uint32 imageId;
 
     if (direction & 1) {
@@ -83,7 +83,7 @@ static void paint_mini_helicopters_track_flat(uint8 rideIndex, uint8 trackSequen
 /** rct2: 0x0081F368 */
 static void paint_mini_helicopters_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     uint32 imageId;
 
     switch (direction) {
@@ -120,7 +120,7 @@ static void paint_mini_helicopters_track_flat_to_25_deg_up(uint8 rideIndex, uint
 /** rct2: 0x0081F358 */
 static void paint_mini_helicopters_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     uint32 imageId;
 
     switch (direction) {
@@ -157,7 +157,7 @@ static void paint_mini_helicopters_track_25_deg_up(uint8 rideIndex, uint8 trackS
 /** rct2: 0x0081F378 */
 static void paint_mini_helicopters_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     uint32 imageId;
 
     switch (direction) {

--- a/src/openrct2/ride/gentle/mini_helicopters.c
+++ b/src/openrct2/ride/gentle/mini_helicopters.c
@@ -59,7 +59,7 @@ static void paint_mini_helicopters_track_station(uint8 rideIndex, uint8 trackSeq
 /** rct2: 0x0081F348 */
 static void paint_mini_helicopters_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     uint32 imageId;
 
     if (direction & 1) {
@@ -83,7 +83,7 @@ static void paint_mini_helicopters_track_flat(uint8 rideIndex, uint8 trackSequen
 /** rct2: 0x0081F368 */
 static void paint_mini_helicopters_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     uint32 imageId;
 
     switch (direction) {
@@ -120,7 +120,7 @@ static void paint_mini_helicopters_track_flat_to_25_deg_up(uint8 rideIndex, uint
 /** rct2: 0x0081F358 */
 static void paint_mini_helicopters_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     uint32 imageId;
 
     switch (direction) {
@@ -157,7 +157,7 @@ static void paint_mini_helicopters_track_25_deg_up(uint8 rideIndex, uint8 trackS
 /** rct2: 0x0081F378 */
 static void paint_mini_helicopters_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     uint32 imageId;
 
     switch (direction) {

--- a/src/openrct2/ride/gentle/observation_tower.c
+++ b/src/openrct2/ride/gentle/observation_tower.c
@@ -75,7 +75,7 @@ static void paint_observation_tower_base(uint8 rideIndex, uint8 trackSequence, u
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/observation_tower.c
+++ b/src/openrct2/ride/gentle/observation_tower.c
@@ -75,7 +75,7 @@ static void paint_observation_tower_base(uint8 rideIndex, uint8 trackSequence, u
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/space_rings.c
+++ b/src/openrct2/ride/gentle/space_rings.c
@@ -90,7 +90,7 @@ static void paint_space_rings(uint8 rideIndex, uint8 trackSequence, uint8 direct
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId;
 

--- a/src/openrct2/ride/gentle/space_rings.c
+++ b/src/openrct2/ride/gentle/space_rings.c
@@ -39,7 +39,7 @@ static const uint32 space_rings_fence_sprites[] = {
 /** rct2: 0x00768A3B */
 static void paint_space_rings_structure(rct_ride * ride, uint8 direction,  uint32 segment, sint32 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     uint32 vehicleIndex = (segment - direction) & 0x3;
 
@@ -53,9 +53,9 @@ static void paint_space_rings_structure(rct_ride * ride, uint8 direction,  uint3
 
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
             && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
             vehicle = GET_VEHICLE(ride->vehicles[vehicleIndex]);
-            g_currently_drawn_item = vehicle;
+            gPaintSession.CurrentlyDrawnItem = vehicle;
             frameNum += (sint8) vehicle->vehicle_sprite_type * 4;
         }
 
@@ -79,8 +79,8 @@ static void paint_space_rings_structure(rct_ride * ride, uint8 direction,  uint3
         }
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /** rct2: 0x00767C40 */

--- a/src/openrct2/ride/gentle/space_rings.c
+++ b/src/openrct2/ride/gentle/space_rings.c
@@ -90,7 +90,7 @@ static void paint_space_rings(uint8 rideIndex, uint8 trackSequence, uint8 direct
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId;
 

--- a/src/openrct2/ride/gentle/spiral_slide.c
+++ b/src/openrct2/ride/gentle/spiral_slide.c
@@ -166,7 +166,7 @@ static void paint_spiral_slide(uint8 rideIndex, uint8 trackSequence, uint8 direc
 
     sint32 edges = edges_2x2[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/gentle/spiral_slide.c
+++ b/src/openrct2/ride/gentle/spiral_slide.c
@@ -101,7 +101,7 @@ static void spiral_slide_paint_tile_front(uint8 rideIndex, uint8 trackSequence, 
         sub_98197C(image_id, 16, 16, 8, 16, 108, height, 8, 0, height + 3, get_current_rotation());
     }
 
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level == 0 && ride->slide_in_use != 0) {
         uint8 slide_progress = ride->spiral_slide_progress;
         if (slide_progress != 0) {

--- a/src/openrct2/ride/gentle/spiral_slide.c
+++ b/src/openrct2/ride/gentle/spiral_slide.c
@@ -166,7 +166,7 @@ static void paint_spiral_slide(uint8 rideIndex, uint8 trackSequence, uint8 direc
 
     sint32 edges = edges_2x2[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/3d_cinema.c
+++ b/src/openrct2/ride/thrill/3d_cinema.c
@@ -25,15 +25,15 @@
  */
 static void paint_3d_cinema_structure(uint8 rideIndex, uint8 direction, sint8 xOffset, sint8 yOffset, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride * ride = get_ride(rideIndex);
     rct_ride_entry * rideEntry = get_ride_entry(ride->subtype);
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = GET_VEHICLE(ride->vehicles[0]);
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = GET_VEHICLE(ride->vehicles[0]);
     }
 
     uint32 imageColourFlags = gTrackColours[SCHEME_MISC];
@@ -44,8 +44,8 @@ static void paint_3d_cinema_structure(uint8 rideIndex, uint8 direction, sint8 xO
     uint32 imageId = (rideEntry->vehicles[0].base_image_id + direction) | imageColourFlags;
     sub_98197C(imageId, xOffset, yOffset, 24, 24, 47, height + 3, xOffset + 16, yOffset + 16, height + 3, get_current_rotation());
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 

--- a/src/openrct2/ride/thrill/3d_cinema.c
+++ b/src/openrct2/ride/thrill/3d_cinema.c
@@ -58,7 +58,7 @@ static void paint_3d_cinema(uint8 rideIndex, uint8 trackSequence, uint8 directio
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/3d_cinema.c
+++ b/src/openrct2/ride/thrill/3d_cinema.c
@@ -58,7 +58,7 @@ static void paint_3d_cinema(uint8 rideIndex, uint8 trackSequence, uint8 directio
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/enterprise.c
+++ b/src/openrct2/ride/thrill/enterprise.c
@@ -81,7 +81,7 @@ static void paint_enterprise(uint8 rideIndex, uint8 trackSequence, uint8 directi
 
     sint32 edges = edges_4x4[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/enterprise.c
+++ b/src/openrct2/ride/thrill/enterprise.c
@@ -81,7 +81,7 @@ static void paint_enterprise(uint8 rideIndex, uint8 trackSequence, uint8 directi
 
     sint32 edges = edges_4x4[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/enterprise.c
+++ b/src/openrct2/ride/thrill/enterprise.c
@@ -26,7 +26,7 @@ static void paint_enterprise_structure(rct_ride * ride, sint8 xOffset, sint8 yOf
 {
     height += 7;
 
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
     rct_ride_entry * rideEntry = get_ride_entry(ride->subtype);
     rct_vehicle * vehicle = NULL;
 
@@ -34,9 +34,9 @@ static void paint_enterprise_structure(rct_ride * ride, sint8 xOffset, sint8 yOf
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
         vehicle = GET_VEHICLE(ride->vehicles[0]);
-        g_currently_drawn_item = vehicle;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     uint32 imageOffset = map_element_get_direction_with_offset(mapElement, get_current_rotation());
@@ -52,7 +52,7 @@ static void paint_enterprise_structure(rct_ride * ride, sint8 xOffset, sint8 yOf
     uint32 imageId = (baseImageId + imageOffset) | imageColourFlags;
     sub_98197C(imageId, xOffset, yOffset, 24, 24, 48, height, 0, 0, height, get_current_rotation());
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
 
     if (dpi->zoom_level == 0
         && imageOffset < 12
@@ -70,8 +70,8 @@ static void paint_enterprise_structure(rct_ride * ride, sint8 xOffset, sint8 yOf
         }
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /** rct2: 0x008A1584 */

--- a/src/openrct2/ride/thrill/go_karts.c
+++ b/src/openrct2/ride/thrill/go_karts.c
@@ -314,7 +314,7 @@ static void paint_go_karts_track_25_deg_down_to_flat(uint8 rideIndex, uint8 trac
 /** rct2: 0x */
 static void paint_go_karts_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
 

--- a/src/openrct2/ride/thrill/go_karts.c
+++ b/src/openrct2/ride/thrill/go_karts.c
@@ -314,7 +314,7 @@ static void paint_go_karts_track_25_deg_down_to_flat(uint8 rideIndex, uint8 trac
 /** rct2: 0x */
 static void paint_go_karts_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
 

--- a/src/openrct2/ride/thrill/go_karts.c
+++ b/src/openrct2/ride/thrill/go_karts.c
@@ -178,7 +178,7 @@ static void paint_go_karts_track_25_deg_up(uint8 rideIndex, uint8 trackSequence,
         sub_98197C(imageId, 0, 0, 1, 32, 11, height, 29, 0, height + 2, get_current_rotation());
     }
 
-    gWoodenSupportsPrependTo = ps;
+    gPaintSession.WoodenSupportsPrependTo = ps;
 
     switch (direction) {
         case 0:
@@ -223,7 +223,7 @@ static void paint_go_karts_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackS
         sub_98197C(imageId, 0, 0, 1, 32, 11, height, 29, 0, height + 2, get_current_rotation());
     }
 
-    gWoodenSupportsPrependTo = ps;
+    gPaintSession.WoodenSupportsPrependTo = ps;
 
     switch (direction) {
         case 0:
@@ -268,7 +268,7 @@ static void paint_go_karts_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackS
         sub_98197C(imageId, 0, 0, 1, 32, 11, height, 29, 0, height + 2, get_current_rotation());
     }
 
-    gWoodenSupportsPrependTo = ps;
+    gPaintSession.WoodenSupportsPrependTo = ps;
 
     switch (direction) {
         case 0:

--- a/src/openrct2/ride/thrill/launched_freefall.c
+++ b/src/openrct2/ride/thrill/launched_freefall.c
@@ -90,7 +90,7 @@ static void paint_launched_freefall_base(uint8 rideIndex, uint8 trackSequence, u
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/launched_freefall.c
+++ b/src/openrct2/ride/thrill/launched_freefall.c
@@ -57,7 +57,7 @@ void vehicle_visual_launched_freefall(sint32 x, sint32 imageDirection, sint32 y,
     sub_98197C(image_id, 0, 0, 16, 16, 41, z, -5, -5, z + 1, rotation);
 
     // Draw peeps:
-    if (unk_140E9A8->zoom_level < 2) {
+    if (gPaintSession.Unk140E9A8->zoom_level < 2) {
         if (vehicle->num_peeps > 0) {
             baseImage_id = vehicleEntry->base_image_id + 9;
             if ((vehicle->restraints_position / 64) == 3) {

--- a/src/openrct2/ride/thrill/launched_freefall.c
+++ b/src/openrct2/ride/thrill/launched_freefall.c
@@ -90,7 +90,7 @@ static void paint_launched_freefall_base(uint8 rideIndex, uint8 trackSequence, u
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/magic_carpet.c
+++ b/src/openrct2/ride/thrill/magic_carpet.c
@@ -136,7 +136,7 @@ static void paint_magic_carpet_vehicle(rct_ride *ride, uint8 direction, uint32 s
     sub_98199C(vehicleImageId | imageColourFlags, (sint8)offset.x, (sint8)offset.y, bbSize.x, bbSize.y, 127, offset.z, bbOffset.x, bbOffset.y, bbOffset.z, get_current_rotation());
 
     // Riders
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level <= 1 && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)) {
         rct_vehicle *vehicle = get_first_vehicle(ride);
         if (vehicle != NULL) {
@@ -154,14 +154,14 @@ static void paint_magic_carpet_vehicle(rct_ride *ride, uint8 direction, uint32 s
 /** rct2: 0x00899104 */
 static void paint_magic_carpet_structure(rct_ride *ride, uint8 direction, sint8 axisOffset, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
     rct_vehicle *vehicle = get_first_vehicle(ride);
 
     uint32 swingImageId = 0;
     if (vehicle != NULL) {
         swingImageId = vehicle->vehicle_sprite_type;
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     bound_box bb = MagicCarpetBounds[direction];
@@ -182,8 +182,8 @@ static void paint_magic_carpet_structure(rct_ride *ride, uint8 direction, sint8 
     paint_magic_carpet_pendulum(PLANE_FRONT, swingImageId, direction, offset, bbOffset, bbSize);
     paint_magic_carpet_frame(PLANE_FRONT, direction, offset, bbOffset, bbSize);
 
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
-    g_currently_drawn_item = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
 }
 
 /** rct2: 0x00898514 */

--- a/src/openrct2/ride/thrill/motion_simulator.c
+++ b/src/openrct2/ride/thrill/motion_simulator.c
@@ -40,15 +40,15 @@ static void paint_motionsimulator_vehicle(sint8 offsetX, sint8 offsetY, uint8 di
     rct_ride *ride = get_ride(mapElement->properties.track.ride_index);
     rct_ride_entry *rideEntry = get_ride_entry_by_ride(ride);
 
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_vehicle *vehicle = NULL;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK) {
         uint16 spriteIndex = ride->vehicles[0];
         if (spriteIndex != SPRITE_INDEX_NULL) {
             vehicle = GET_VEHICLE(spriteIndex);
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-            g_currently_drawn_item = vehicle;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+            gPaintSession.CurrentlyDrawnItem = vehicle;
         }
     }
 
@@ -118,8 +118,8 @@ static void paint_motionsimulator_vehicle(sint8 offsetX, sint8 offsetY, uint8 di
         break;
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /** rct2: 0x008A85C4 */

--- a/src/openrct2/ride/thrill/motion_simulator.c
+++ b/src/openrct2/ride/thrill/motion_simulator.c
@@ -129,7 +129,7 @@ static void paint_motionsimulator(uint8 rideIndex, uint8 trackSequence, uint8 di
 
     sint32 edges = edges_2x2[trackSequence];
     rct_ride *ride = get_ride(rideIndex);
-    rct_xy16 position = { gPaintMapPosition.x, gPaintMapPosition.y };
+    rct_xy16 position = { gPaintSession.MapPosition.x, gPaintSession.MapPosition.y };
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
     track_paint_util_paint_floor(edges, gTrackColours[SCHEME_TRACK], height, floorSpritesCork, get_current_rotation());

--- a/src/openrct2/ride/thrill/pirate_ship.c
+++ b/src/openrct2/ride/thrill/pirate_ship.c
@@ -161,7 +161,7 @@ static void paint_pirate_ship(uint8 rideIndex, uint8 trackSequence, uint8 direct
 {
     uint8 relativeTrackSequence = track_map_1x5[direction][trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId;
     bool hasFence;

--- a/src/openrct2/ride/thrill/pirate_ship.c
+++ b/src/openrct2/ride/thrill/pirate_ship.c
@@ -161,7 +161,7 @@ static void paint_pirate_ship(uint8 rideIndex, uint8 trackSequence, uint8 direct
 {
     uint8 relativeTrackSequence = track_map_1x5[direction][trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId;
     bool hasFence;

--- a/src/openrct2/ride/thrill/pirate_ship.c
+++ b/src/openrct2/ride/thrill/pirate_ship.c
@@ -70,7 +70,7 @@ static void paint_pirate_ship_structure(rct_ride * ride, uint8 direction, sint8 
 {
     uint32 imageId, baseImageId;
 
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride_entry * rideType = get_ride_entry(ride->subtype);
     rct_vehicle * vehicle = NULL;
@@ -84,8 +84,8 @@ static void paint_pirate_ship_structure(rct_ride * ride, uint8 direction, sint8 
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
         vehicle = GET_VEHICLE(ride->vehicles[0]);
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     baseImageId = rideType->vehicles[0].base_image_id + pirate_ship_base_sprite_offset[direction];
@@ -116,7 +116,7 @@ static void paint_pirate_ship_structure(rct_ride * ride, uint8 direction, sint8 
     imageId = baseImageId | imageColourFlags;
     sub_98199C(imageId, xOffset, yOffset, bounds.length_x, bounds.length_y, 80, height, bounds.offset_x, bounds.offset_y, height, get_current_rotation());
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
 
     if (dpi->zoom_level <= 1
         && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
@@ -152,8 +152,8 @@ static void paint_pirate_ship_structure(rct_ride * ride, uint8 direction, sint8 
     imageId = pirate_ship_frame_sprites[(direction & 1)][1] | gTrackColours[SCHEME_TRACK];
     sub_98199C(imageId, xOffset, yOffset, bounds.length_x, bounds.length_y, 80, height, bounds.offset_x, bounds.offset_y, height, get_current_rotation());
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /** rct2: 0x008A85C4 */

--- a/src/openrct2/ride/thrill/roto_drop.c
+++ b/src/openrct2/ride/thrill/roto_drop.c
@@ -90,7 +90,7 @@ static void paint_roto_drop_base(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/roto_drop.c
+++ b/src/openrct2/ride/thrill/roto_drop.c
@@ -90,7 +90,7 @@ static void paint_roto_drop_base(uint8 rideIndex, uint8 trackSequence, uint8 dir
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup((direction & 1), 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/swinging_inverter_ship.c
+++ b/src/openrct2/ride/thrill/swinging_inverter_ship.c
@@ -62,7 +62,7 @@ static const uint32 swinging_inverter_ship_frame_sprites[] = {
 
 static void paint_swinging_inverter_ship_structure(rct_ride * ride, uint8 direction, sint8 axisOffset, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride_entry * rideType = get_ride_entry(ride->subtype);
     rct_vehicle * vehicle = NULL;
@@ -74,8 +74,8 @@ static void paint_swinging_inverter_ship_structure(rct_ride * ride, uint8 direct
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
         vehicle = GET_VEHICLE(ride->vehicles[0]);
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     uint32 vehicleImageId = rideType->vehicles[0].base_image_id + swinging_inverter_ship_base_sprite_offset[direction];
@@ -112,8 +112,8 @@ static void paint_swinging_inverter_ship_structure(rct_ride * ride, uint8 direct
         sub_98199C(vehicleImageId, xOffset, yOffset, boundBox.length_x, boundBox.length_y, 127, height, boundBox.offset_x, boundBox.offset_y, height, get_current_rotation());
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /** rct2: 0x00760260 */

--- a/src/openrct2/ride/thrill/top_spin.c
+++ b/src/openrct2/ride/thrill/top_spin.c
@@ -231,7 +231,7 @@ static void paint_top_spin(uint8 rideIndex, uint8 trackSequence, uint8 direction
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride *ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/top_spin.c
+++ b/src/openrct2/ride/thrill/top_spin.c
@@ -52,7 +52,7 @@ static void top_spin_paint_vehicle(sint8 al, sint8 cl, uint8 rideIndex, uint8 di
     uint16 boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ;
     // As we will be drawing a vehicle we need to backup the mapElement that
     // is assigned to the drawings.
-    rct_map_element* curMapElement = g_currently_drawn_item;
+    rct_map_element* curMapElement = gPaintSession.CurrentlyDrawnItem;
 
     height += 3;
 
@@ -67,8 +67,8 @@ static void top_spin_paint_vehicle(sint8 al, sint8 cl, uint8 rideIndex, uint8 di
         ride->vehicles[0] != SPRITE_INDEX_NULL) {
         vehicle = GET_VEHICLE(ride->vehicles[0]);
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
 
         armRotation = vehicle->vehicle_sprite_type;
         seatRotation = vehicle->bank_rotation;
@@ -164,7 +164,7 @@ static void top_spin_paint_vehicle(sint8 al, sint8 cl, uint8 rideIndex, uint8 di
 
     sub_98199C(image_id, (sint8) seatCoords.x, (sint8) seatCoords.y, lengthX, lengthY, 90, seatCoords.z, boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ, rotation);
 
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level < 2 && vehicle != NULL && vehicle->num_peeps != 0)
     {
         image_id = (seatImageId + (1 * 76)) | SPRITE_ID_PALETTE_COLOUR_2(vehicle->peep_tshirt_colours[0], vehicle->peep_tshirt_colours[1]);
@@ -219,8 +219,8 @@ static void top_spin_paint_vehicle(sint8 al, sint8 cl, uint8 rideIndex, uint8 di
 
     sub_98199C(image_id, al, cl, lengthX, lengthY, 90, height, boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ, rotation);
 
-    g_currently_drawn_item = curMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = curMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 /**

--- a/src/openrct2/ride/thrill/top_spin.c
+++ b/src/openrct2/ride/thrill/top_spin.c
@@ -231,7 +231,7 @@ static void paint_top_spin(uint8 rideIndex, uint8 trackSequence, uint8 direction
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride *ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     wooden_a_supports_paint_setup(direction & 1, 0, height, gTrackColours[SCHEME_MISC], NULL);
 

--- a/src/openrct2/ride/thrill/twist.c
+++ b/src/openrct2/ride/thrill/twist.c
@@ -85,7 +85,7 @@ static void paint_twist(uint8 rideIndex, uint8 trackSequence, uint8 direction, s
 
     const uint8 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId;
 

--- a/src/openrct2/ride/thrill/twist.c
+++ b/src/openrct2/ride/thrill/twist.c
@@ -85,7 +85,7 @@ static void paint_twist(uint8 rideIndex, uint8 trackSequence, uint8 direction, s
 
     const uint8 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId;
 

--- a/src/openrct2/ride/thrill/twist.c
+++ b/src/openrct2/ride/thrill/twist.c
@@ -24,7 +24,7 @@
 /** rct2: 0x0076E5C9 */
 static void paint_twist_structure(rct_ride * ride, uint8 direction, sint8 xOffset, sint8 yOffset, uint16 height)
 {
-    rct_map_element * savedMapElement = g_currently_drawn_item;
+    rct_map_element * savedMapElement = gPaintSession.CurrentlyDrawnItem;
 
     rct_ride_entry * rideEntry = get_ride_entry(ride->subtype);
     rct_vehicle * vehicle = NULL;
@@ -36,8 +36,8 @@ static void paint_twist_structure(rct_ride * ride, uint8 direction, sint8 xOffse
         && ride->vehicles[0] != SPRITE_INDEX_NULL) {
         vehicle = GET_VEHICLE(ride->vehicles[0]);
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
-        g_currently_drawn_item = vehicle;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        gPaintSession.CurrentlyDrawnItem = vehicle;
     }
 
     uint32 frameNum = (direction * 88) % 216;
@@ -58,7 +58,7 @@ static void paint_twist_structure(rct_ride * ride, uint8 direction, sint8 xOffse
     uint32 imageId = (baseImageId + structureFrameNum) | imageColourFlags;
     sub_98197C(imageId, xOffset, yOffset, 24, 24, 48, height, xOffset + 16, yOffset + 16, height, get_current_rotation());
 
-    rct_drawpixelinfo * dpi = unk_140E9A8;
+    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
 
     if (dpi->zoom_level < 1
         && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK
@@ -73,8 +73,8 @@ static void paint_twist_structure(rct_ride * ride, uint8 direction, sint8 xOffse
         }
     }
 
-    g_currently_drawn_item = savedMapElement;
-    gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    gPaintSession.CurrentlyDrawnItem = savedMapElement;
+    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
 }
 
 

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -201,10 +201,6 @@ enum
     SPR_STATION_COVER_OFFSET_TALL
 };
 
-#ifdef NO_RCT2
-uint32 gTrackColours[4];
-#endif
-
 bool gUseOriginalRidePaint = false;
 
 bool track_paint_util_has_fence(enum edge_t edge, rct_xy16 position, rct_map_element * mapElement, rct_ride * ride, uint8 rotation)

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -304,7 +304,7 @@ void track_paint_util_draw_station_3(uint8 rideIndex, uint8 trackSequence, uint8
 
 void track_paint_util_draw_station_impl(uint8 rideIndex, uint8 trackSequence, uint8 direction, uint16 height, uint16 coverHeight, rct_map_element * mapElement, sint32 fenceOffsetA, sint32 fenceOffsetB)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     const bool hasGreenLight = map_element_get_green_light(mapElement);
@@ -438,7 +438,7 @@ void track_paint_util_draw_station_impl(uint8 rideIndex, uint8 trackSequence, ui
 
 void track_paint_util_draw_station_inverted(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement, uint8 stationVariant)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     const bool hasGreenLight = map_element_get_green_light(mapElement);
@@ -647,7 +647,7 @@ bool track_paint_util_draw_station_covers_2(enum edge_t edge, bool hasFence, con
 
 void track_paint_util_draw_station_platform(rct_ride *ride, uint8 direction, sint32 height, sint32 zOffset, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     if (direction & 1) {
         bool hasFence = track_paint_util_has_fence(EDGE_NE, position, mapElement, ride, get_current_rotation());

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -304,7 +304,7 @@ void track_paint_util_draw_station_3(uint8 rideIndex, uint8 trackSequence, uint8
 
 void track_paint_util_draw_station_impl(uint8 rideIndex, uint8 trackSequence, uint8 direction, uint16 height, uint16 coverHeight, rct_map_element * mapElement, sint32 fenceOffsetA, sint32 fenceOffsetB)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     const bool hasGreenLight = map_element_get_green_light(mapElement);
@@ -438,7 +438,7 @@ void track_paint_util_draw_station_impl(uint8 rideIndex, uint8 trackSequence, ui
 
 void track_paint_util_draw_station_inverted(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement, uint8 stationVariant)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     const bool hasGreenLight = map_element_get_green_light(mapElement);
@@ -647,7 +647,7 @@ bool track_paint_util_draw_station_covers_2(enum edge_t edge, bool hasFence, con
 
 void track_paint_util_draw_station_platform(rct_ride *ride, uint8 direction, sint32 height, sint32 zOffset, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     if (direction & 1) {
         bool hasFence = track_paint_util_has_fence(EDGE_NE, position, mapElement, ride, get_current_rotation());

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -1753,7 +1753,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         ride->entrance_style = RIDE_ENTRANCE_STYLE_PLAIN;
     }
 
-    rct_drawpixelinfo *dpi = unk_140E9A8;
+    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
 
     if (!gTrackDesignSaveMode || rideIndex == gTrackDesignSaveRideIndex) {
         sint32 trackType = mapElement->properties.track.type;
@@ -1761,7 +1761,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         sint32 trackColourScheme = mapElement->properties.track.colour & 3;
 
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_TRACK_HEIGHTS) && dpi->zoom_level == 0) {
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             if (TrackHeightMarkerPositions[trackType] & (1 << trackSequence)) {
                 uint16 ax = RideData5[ride->type].z_offset;
                 uint32 ebx = 0x20381689 + (height + 8) / 16;
@@ -1771,7 +1771,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
             }
         }
 
-        gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
         gTrackColours[SCHEME_TRACK] = SPRITE_ID_PALETTE_COLOUR_2(ride->track_colour_main[trackColourScheme], ride->track_colour_additional[trackColourScheme]);
         gTrackColours[SCHEME_SUPPORTS] = SPRITE_ID_PALETTE_COLOUR_1(ride->track_colour_supports[trackColourScheme]);
         gTrackColours[SCHEME_MISC] = IMAGE_TYPE_REMAP;
@@ -1784,7 +1784,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         }
         if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
             uint32 ghost_id = construction_markers[gConfigGeneral.construction_marker_colour];
-            gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             gTrackColours[SCHEME_TRACK] = ghost_id;
             gTrackColours[SCHEME_SUPPORTS] = ghost_id;
             gTrackColours[SCHEME_MISC] = ghost_id;

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -577,7 +577,7 @@ bool track_paint_util_draw_station_covers(enum edge_t edge, bool hasFence, const
 
 bool track_paint_util_draw_station_covers_2(enum edge_t edge, bool hasFence, const rct_ride_entrance_definition * entranceStyle, uint8 direction, uint16 height, uint8 stationVariant)
 {
-    if (!(g141E9DB & (G141E9DB_FLAG_1 | G141E9DB_FLAG_2))) {
+    if (!(gPaintSession.Unk141E9DB & (G141E9DB_FLAG_1 | G141E9DB_FLAG_2))) {
         return false;
     }
 

--- a/src/openrct2/ride/track_paint.h
+++ b/src/openrct2/ride/track_paint.h
@@ -224,12 +224,6 @@ enum {
     STATION_VARIANT_TALL,
 };
 
-#ifdef NO_RCT2
-extern uint32 gTrackColours[4];
-#else
-#define gTrackColours   RCT2_ADDRESS(0x00F44198, uint32)
-#endif
-
 extern const uint32 floorSpritesCork[];
 
 extern const uint32 fenceSpritesRope[];

--- a/src/openrct2/ride/transport/chairlift.c
+++ b/src/openrct2/ride/transport/chairlift.c
@@ -166,7 +166,7 @@ static bool chairlift_paint_util_is_last_track(uint8 rideIndex, const rct_map_el
 
 static void chairlift_paint_station_ne_sw(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     uint8 trackType = mapElement->properties.track.type;
     rct_ride * ride = get_ride(rideIndex);
     uint32 imageId;
@@ -245,7 +245,7 @@ static void chairlift_paint_station_ne_sw(uint8 rideIndex, uint8 trackSequence, 
 
 static void chairlift_paint_station_se_nw(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    const rct_xy16 pos = gPaintMapPosition;
+    const rct_xy16 pos = gPaintSession.MapPosition;
     uint8 trackType = mapElement->properties.track.type;
     rct_ride * ride = get_ride(rideIndex);
     uint32 imageId;

--- a/src/openrct2/ride/transport/chairlift.c
+++ b/src/openrct2/ride/transport/chairlift.c
@@ -100,14 +100,15 @@ static void chairlift_paint_util_draw_supports(sint32 segments, uint16 height)
         return;
     }
 
+    support_height * supportSegments = gPaintSession.SupportSegments;
     for (sint32 s = 0; s < 9; s++) {
         if (!(segments & segment_offsets[s])) {
             continue;
         }
-        uint16 temp = gSupportSegments[s].height;
-        gSupportSegments[s].height = gSupport.height;
+        uint16 temp = supportSegments[s].height;
+        supportSegments[s].height = gPaintSession.Support.height;
         metal_a_supports_paint_setup(METAL_SUPPORTS_TRUSS, s, 0, height, gTrackColours[SCHEME_SUPPORTS]);
-        gSupportSegments[s].height = temp;
+        supportSegments[s].height = temp;
     }
 }
 

--- a/src/openrct2/ride/transport/chairlift.c
+++ b/src/openrct2/ride/transport/chairlift.c
@@ -166,7 +166,7 @@ static bool chairlift_paint_util_is_last_track(uint8 rideIndex, const rct_map_el
 
 static void chairlift_paint_station_ne_sw(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     uint8 trackType = mapElement->properties.track.type;
     rct_ride * ride = get_ride(rideIndex);
     uint32 imageId;
@@ -245,7 +245,7 @@ static void chairlift_paint_station_ne_sw(uint8 rideIndex, uint8 trackSequence, 
 
 static void chairlift_paint_station_se_nw(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    const rct_xy16 pos = {gPaintMapPosition.x, gPaintMapPosition.y};
+    const rct_xy16 pos = gPaintMapPosition;
     uint8 trackType = mapElement->properties.track.type;
     rct_ride * ride = get_ride(rideIndex);
     uint32 imageId;

--- a/src/openrct2/ride/transport/lift.c
+++ b/src/openrct2/ride/transport/lift.c
@@ -79,7 +79,7 @@ static void paint_lift_base(uint8 rideIndex, uint8 trackSequence, uint8 directio
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = SPR_FLOOR_METAL_B | gTrackColours[SCHEME_SUPPORTS];
         sub_98197C(imageId, 0, 0, 32, 32, 1, height, 0, 0, height, get_current_rotation());

--- a/src/openrct2/ride/transport/lift.c
+++ b/src/openrct2/ride/transport/lift.c
@@ -79,7 +79,7 @@ static void paint_lift_base(uint8 rideIndex, uint8 trackSequence, uint8 directio
 
     sint32 edges = edges_3x3[trackSequence];
     rct_ride * ride = get_ride(rideIndex);
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = SPR_FLOOR_METAL_B | gTrackColours[SCHEME_SUPPORTS];
         sub_98197C(imageId, 0, 0, 32, 32, 1, height, 0, 0, height, get_current_rotation());

--- a/src/openrct2/ride/transport/monorail.c
+++ b/src/openrct2/ride/transport/monorail.c
@@ -443,7 +443,7 @@ static const uint32 monorail_track_pieces_diag_25_deg_up[4] = {
 /** rct2: 0x008AE1AC */
 static void paint_monorail_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = monorail_track_pieces_flat[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -510,7 +510,7 @@ static void paint_monorail_station(uint8 rideIndex, uint8 trackSequence, uint8 d
 /** rct2: 0x008AE1BC */
 static void paint_monorail_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = monorail_track_pieces_25_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -538,7 +538,7 @@ static void paint_monorail_track_25_deg_up(uint8 rideIndex, uint8 trackSequence,
 /** rct2: 0x008AE1CC */
 static void paint_monorail_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = monorail_track_pieces_flat_to_25_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -566,7 +566,7 @@ static void paint_monorail_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackS
 /** rct2: 0x008AE1DC */
 static void paint_monorail_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
 
     uint32 imageId = monorail_track_pieces_25_deg_up_to_flat[direction] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/transport/monorail.c
+++ b/src/openrct2/ride/transport/monorail.c
@@ -443,7 +443,7 @@ static const uint32 monorail_track_pieces_diag_25_deg_up[4] = {
 /** rct2: 0x008AE1AC */
 static void paint_monorail_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = monorail_track_pieces_flat[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -510,7 +510,7 @@ static void paint_monorail_station(uint8 rideIndex, uint8 trackSequence, uint8 d
 /** rct2: 0x008AE1BC */
 static void paint_monorail_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = monorail_track_pieces_25_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -538,7 +538,7 @@ static void paint_monorail_track_25_deg_up(uint8 rideIndex, uint8 trackSequence,
 /** rct2: 0x008AE1CC */
 static void paint_monorail_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = monorail_track_pieces_flat_to_25_deg_up[direction] | gTrackColours[SCHEME_TRACK];
 
@@ -566,7 +566,7 @@ static void paint_monorail_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackS
 /** rct2: 0x008AE1DC */
 static void paint_monorail_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
 
     uint32 imageId = monorail_track_pieces_25_deg_up_to_flat[direction] | gTrackColours[SCHEME_TRACK];
 

--- a/src/openrct2/ride/transport/suspended_monorail.c
+++ b/src/openrct2/ride/transport/suspended_monorail.c
@@ -41,7 +41,7 @@ static void suspended_monorail_track_flat(uint8 rideIndex, uint8 trackSequence, 
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height + 42, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -88,7 +88,7 @@ static void suspended_monorail_track_25_deg_up(uint8 rideIndex, uint8 trackSeque
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 60, gTrackColours[SCHEME_SUPPORTS]);
@@ -132,7 +132,7 @@ static void suspended_monorail_track_flat_to_25_deg_up(uint8 rideIndex, uint8 tr
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 52, gTrackColours[SCHEME_SUPPORTS]);
@@ -176,7 +176,7 @@ static void suspended_monorail_track_25_deg_up_to_flat(uint8 rideIndex, uint8 tr
     }
 
     paint_util_set_segment_support_height(paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         switch (direction) {
         case 0:
             metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 6, 0, height + 50, gTrackColours[SCHEME_SUPPORTS]);

--- a/src/openrct2/ride/vehicle_paint.c
+++ b/src/openrct2/ride/vehicle_paint.c
@@ -907,7 +907,7 @@ static void vehicle_sprite_paint(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, s
     if (ps != NULL) {
         ps->tertiary_colour = vehicle->colours_extended;
     }
-    rct_drawpixelinfo* dpi = unk_140E9A8;
+    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
     if (dpi->zoom_level < 2 && vehicle->num_peeps > 0 && vehicleEntry->no_seating_rows > 0) {
         baseImage_id += vehicleEntry->no_vehicle_images;
         for (sint32 i = 0; i < 8; i++){

--- a/src/openrct2/ride/water/boat_ride.c
+++ b/src/openrct2/ride/water/boat_ride.c
@@ -62,7 +62,7 @@ static void paint_boat_ride_track_flat(uint8 rideIndex, uint8 trackSequence, uin
 /** rct2: 0x008B0E50 */
 static void paint_boat_ride_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
 

--- a/src/openrct2/ride/water/boat_ride.c
+++ b/src/openrct2/ride/water/boat_ride.c
@@ -62,7 +62,7 @@ static void paint_boat_ride_track_flat(uint8 rideIndex, uint8 trackSequence, uin
 /** rct2: 0x008B0E50 */
 static void paint_boat_ride_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
 

--- a/src/openrct2/ride/water/dingy_slide.c
+++ b/src/openrct2/ride/water/dingy_slide.c
@@ -379,7 +379,7 @@ static void dinghy_slide_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 
     imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 26, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -436,7 +436,7 @@ static void dinghy_slide_track_25_deg_up(uint8 rideIndex, uint8 trackSequence, u
     imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -465,7 +465,7 @@ static void dinghy_slide_track_60_deg_up(uint8 rideIndex, uint8 trackSequence, u
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 98, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -503,7 +503,7 @@ static void dinghy_slide_track_flat_to_25_deg_up(uint8 rideIndex, uint8 trackSeq
     imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -532,7 +532,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uint8 tra
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -561,7 +561,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uint8 tra
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -599,7 +599,7 @@ static void dinghy_slide_track_25_deg_up_to_flat(uint8 rideIndex, uint8 trackSeq
     imageId = imageIds[isChained][direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -980,7 +980,7 @@ static void dinghy_slide_track_flat_covered(uint8 rideIndex, uint8 trackSequence
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 26, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1005,7 +1005,7 @@ static void dinghy_slide_track_25_deg_up_covered(uint8 rideIndex, uint8 trackSeq
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1034,7 +1034,7 @@ static void dinghy_slide_track_60_deg_up_covered(uint8 rideIndex, uint8 trackSeq
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 98, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 32, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1063,7 +1063,7 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(uint8 rideIndex, uint8 
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1092,7 +1092,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(uint8 rideIndex, u
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 12, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1121,7 +1121,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(uint8 rideIndex, u
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 20, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -1150,7 +1150,7 @@ static void dinghy_slide_track_25_deg_up_to_flat_covered(uint8 rideIndex, uint8 
     imageId = imageIds[direction][1] | gTrackColours[SCHEME_TRACK];
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_TUBES, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 

--- a/src/openrct2/ride/water/log_flume.c
+++ b/src/openrct2/ride/water/log_flume.c
@@ -176,7 +176,7 @@ static void paint_log_flume_track_flat(uint8 rideIndex, uint8 trackSequence, uin
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 26, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 0, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -230,7 +230,7 @@ static void paint_log_flume_track_25_deg_up(uint8 rideIndex, uint8 trackSequence
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -259,7 +259,7 @@ static void paint_log_flume_track_flat_to_25_deg_up(uint8 rideIndex, uint8 track
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -288,7 +288,7 @@ static void paint_log_flume_track_25_deg_up_to_flat(uint8 rideIndex, uint8 track
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -317,7 +317,7 @@ static void paint_log_flume_track_25_deg_down(uint8 rideIndex, uint8 trackSequen
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 8, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -346,7 +346,7 @@ static void paint_log_flume_track_flat_to_25_deg_down(uint8 rideIndex, uint8 tra
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 6, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 
@@ -375,7 +375,7 @@ static void paint_log_flume_track_25_deg_down_to_flat(uint8 rideIndex, uint8 tra
     sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    if (track_paint_util_should_paint_supports(gPaintMapPosition)) {
+    if (track_paint_util_should_paint_supports(gPaintSession.MapPosition)) {
         metal_a_supports_paint_setup(METAL_SUPPORTS_BOXED, 4, 3, height, gTrackColours[SCHEME_SUPPORTS]);
     }
 

--- a/src/openrct2/ride/water/river_rapids.c
+++ b/src/openrct2/ride/water/river_rapids.c
@@ -226,7 +226,7 @@ void vehicle_visual_river_rapids(sint32 x, sint32 imageDirection, sint32 y, sint
     image_id = baseImage_id | SPRITE_ID_PALETTE_COLOUR_2(vehicle->colours.body_colour, vehicle->colours.trim_colour);
     sub_98197C(image_id, 0, 0, bb->length_x, bb->length_y, bb->length_z, z, bb->offset_x, bb->offset_y, bb->offset_z + z, rotation);
 
-    if (unk_140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
+    if (gPaintSession.Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
         // Draw peeps: (this particular vehicle doesn't sort them back to front like others so the back ones sometimes clip, but thats how the original does it...)
         sint32 peeps = ((ecx / 8) + 0) & 3;
         image_id = (baseImage_id + ((peeps + 1) * 72)) | SPRITE_ID_PALETTE_COLOUR_2(vehicle->peep_tshirt_colours[0], vehicle->peep_tshirt_colours[1]) ;

--- a/src/openrct2/ride/water/river_rapids.c
+++ b/src/openrct2/ride/water/river_rapids.c
@@ -313,7 +313,7 @@ static void paint_river_rapids_track_25_deg(uint8 direction, sint32 height, cons
         case 1:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 24, 32, 4, height, 4, 0, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 1, 32, 34, height, 27, 0, height + 16, get_current_rotation());
@@ -325,7 +325,7 @@ static void paint_river_rapids_track_25_deg(uint8 direction, sint32 height, cons
         case 2:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 32, 24, 4, height, 0, 4, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 32, 1, 34, height, 0, 27, height + 16, get_current_rotation());
@@ -370,7 +370,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(uint8 direction, sint32 he
         case 1:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 24, 32, 4, height, 4, 0, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 1, 32, 18, height, 27, 0, height + 16, get_current_rotation());
@@ -382,7 +382,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(uint8 direction, sint32 he
         case 2:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 32, 24, 4, height, 0, 4, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 32, 1, 18, height, 0, 27, height + 16, get_current_rotation());
@@ -427,7 +427,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(uint8 direction, sint32 he
         case 1:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 24, 32, 11, height, 4, 0, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 1, 32, 26, height, 27, 0, height + 16, get_current_rotation());
@@ -439,7 +439,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(uint8 direction, sint32 he
         case 2:
             imageId = sprites[direction][0] | gTrackColours[SCHEME_TRACK];
             ps = sub_98197C(imageId, 0, 0, 32, 24, 11, height, 0, 4, height, get_current_rotation());
-            gWoodenSupportsPrependTo = ps;
+            gPaintSession.WoodenSupportsPrependTo = ps;
 
             imageId = sprites[direction][1] | gTrackColours[SCHEME_TRACK];
             sub_98197C(imageId, 0, 0, 32, 1, 26, height, 0, 27, height + 16, get_current_rotation());

--- a/src/openrct2/ride/water/splash_boats.c
+++ b/src/openrct2/ride/water/splash_boats.c
@@ -1044,10 +1044,10 @@ void vehicle_visual_splash_boats_or_water_coaster(sint32 x, sint32 imageDirectio
     } else {
         vehicle = GET_VEHICLE(vehicle->next_vehicle_on_ride);
     }
-    g_currently_drawn_item = vehicle;
+    gPaintSession.CurrentlyDrawnItem = vehicle;
     imageDirection = ((get_current_rotation() * 8) + vehicle->sprite_direction) & 0x1F;
-    gPaintSpritePosition.x = vehicle->x;
-    gPaintSpritePosition.y = vehicle->y;
+    gPaintSession.SpritePosition.x = vehicle->x;
+    gPaintSession.SpritePosition.y = vehicle->y;
     vehicle_paint(vehicle, imageDirection);
 }
 #endif

--- a/src/openrct2/ride/water/splash_boats.c
+++ b/src/openrct2/ride/water/splash_boats.c
@@ -522,7 +522,7 @@ static void paint_splash_boats_track_60_deg_up(uint8 rideIndex, uint8 trackSeque
     uint32 imageId = SplashBoats60DegUpImageId[direction] | gTrackColours[SCHEME_TRACK];
     uint32 frontImageId = SplashBoats60DegUpFrontImageId[direction] | gTrackColours[SCHEME_TRACK];
 
-    gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
+    gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 98, height, 0, 27, height);
 
     wooden_a_supports_paint_setup((direction & 1), 21 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);
@@ -579,7 +579,7 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(uint8 rideIndex, uin
     uint32 imageId = SplashBoats25DegUpTo60DegUpImageId[direction] | gTrackColours[SCHEME_TRACK];
     uint32 frontImageId = SplashBoats25DegUpTo60DegUpFrontImageId[direction] | gTrackColours[SCHEME_TRACK];
 
-    gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
+    gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
     wooden_a_supports_paint_setup((direction & 1), 13 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);
@@ -598,7 +598,7 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(uint8 rideIndex, uin
     uint32 imageId = SplashBoats60DegUpTo25DegUpImageId[direction] | gTrackColours[SCHEME_TRACK];
     uint32 frontImageId = SplashBoats60DegUpTo25DegUpFrontImageId[direction] | gTrackColours[SCHEME_TRACK];
 
-    gWoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
+    gPaintSession.WoodenSupportsPrependTo = sub_98197C_rotated(direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
     wooden_a_supports_paint_setup((direction & 1), 17 + direction, height, gTrackColours[SCHEME_SUPPORTS], NULL);

--- a/src/openrct2/ride/water/submarine_ride.c
+++ b/src/openrct2/ride/water/submarine_ride.c
@@ -70,7 +70,7 @@ void vehicle_visual_submarine(sint32 x, sint32 imageDirection, sint32 y, sint32 
 
 static void submarine_ride_paint_track_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     sint32 heightLower = height - 16;
@@ -96,7 +96,7 @@ static void submarine_ride_paint_track_station(uint8 rideIndex, uint8 trackSeque
 
 static void submarine_ride_paint_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = {gPaintMapPosition.x, gPaintMapPosition.y};
+    rct_xy16 position = gPaintMapPosition;
     sint32 heightLower = height - 16;
     uint32 imageId;
 

--- a/src/openrct2/ride/water/submarine_ride.c
+++ b/src/openrct2/ride/water/submarine_ride.c
@@ -70,7 +70,7 @@ void vehicle_visual_submarine(sint32 x, sint32 imageDirection, sint32 y, sint32 
 
 static void submarine_ride_paint_track_station(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     rct_ride * ride = get_ride(rideIndex);
     const rct_ride_entrance_definition * entranceStyle = &RideEntranceDefinitions[ride->entrance_style];
     sint32 heightLower = height - 16;
@@ -96,7 +96,7 @@ static void submarine_ride_paint_track_station(uint8 rideIndex, uint8 trackSeque
 
 static void submarine_ride_paint_track_flat(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)
 {
-    rct_xy16 position = gPaintMapPosition;
+    rct_xy16 position = gPaintSession.MapPosition;
     sint32 heightLower = height - 16;
     uint32 imageId;
 

--- a/src/openrct2/windows/RideConstruction.cpp
+++ b/src/openrct2/windows/RideConstruction.cpp
@@ -2315,7 +2315,7 @@ static void window_ride_construction_draw_track_piece(
     }
     dpi->x += x - width / 2;
     dpi->y += y - height / 2 - 16;
-    unk_140E9A8 = dpi;
+    gPaintSession.Unk140E9A8 = dpi;
     uint32 d = unknown << 16;
     d |= rideIndex;
     d |= trackType << 8;
@@ -2347,7 +2347,7 @@ static void sub_6CBCE2(
     gCurrentViewportFlags = 0;
     trackDirection &= 3;
 
-    paint_init(unk_140E9A8);
+    paint_init(gPaintSession.Unk140E9A8);
 
     ride = get_ride(rideIndex);
 
@@ -2451,7 +2451,7 @@ static void sub_6CBCE2(
     gMapSizeMaxXY = preserveMapSizeMaxXY;
 
     paint_struct ps = paint_arrange_structs();
-    paint_draw_structs(unk_140E9A8, &ps, gCurrentViewportFlags);
+    paint_draw_structs(gPaintSession.Unk140E9A8, &ps, gCurrentViewportFlags);
 
     gCurrentViewportFlags = preserve_current_viewport_flags;
 }

--- a/test/testpaint/SideTunnelCall.hpp
+++ b/test/testpaint/SideTunnelCall.hpp
@@ -19,7 +19,7 @@
 #include <openrct2/common.h>
 
 extern "C" {
-#include <openrct2/paint/map_element/map_element.h>
+#include <openrct2/paint/paint.h>
 }
 
 enum {

--- a/test/testpaint/TestPaint.cpp
+++ b/test/testpaint/TestPaint.cpp
@@ -35,6 +35,8 @@ namespace TestPaint
 {
     void ResetEnvironment() {
         gPaintInteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+
         gTrackColours[SCHEME_TRACK] = DEFAULT_SCHEME_TRACK;
         gTrackColours[SCHEME_SUPPORTS] = DEFAULT_SCHEME_SUPPORTS;
         gTrackColours[SCHEME_MISC] = DEFAULT_SCHEME_MISC;
@@ -43,6 +45,7 @@ namespace TestPaint
         rct_drawpixelinfo dpi = { 0 };
         dpi.zoom_level = 1;
         unk_140E9A8 = &dpi;
+        gPaintSession.Unk140E9A8 = &dpi;
 
         rct_ride ride = {0};
         ride.entrance_style = RIDE_ENTRANCE_STYLE_PLAIN;
@@ -56,23 +59,34 @@ namespace TestPaint
         gRideEntries[0] = &rideEntry;
 
         g141E9DB = G141E9DB_FLAG_1 | G141E9DB_FLAG_2;
+        gPaintSession.Unk141E9DB = G141E9DB_FLAG_1 | G141E9DB_FLAG_2;
     }
 
     void ResetTunnels() {
         gLeftTunnelCount = 0;
         gRightTunnelCount = 0;
+        gPaintSession.LeftTunnelCount = 0;
+        gPaintSession.RightTunnelCount = 0;
 
         for (int i = 0; i < TUNNEL_MAX_COUNT; i++) {
             gLeftTunnels[i].height = 0;
             gLeftTunnels[i].type = 0;
             gRightTunnels[i].height = 0;
             gRightTunnels[i].type = 0;
+            gPaintSession.LeftTunnels[i].height = 0;
+            gPaintSession.LeftTunnels[i].type = 0;
+            gPaintSession.RightTunnels[i].height = 0;
+            gPaintSession.RightTunnels[i].type = 0;
         }
 
         gLeftTunnels[0].height = 0xFF;
         gLeftTunnels[0].type = 0xFF;
         gRightTunnels[0].height = 0xFF;
         gRightTunnels[0].type = 0xFF;
+        gPaintSession.LeftTunnels[0].height = 0xFF;
+        gPaintSession.LeftTunnels[0].type = 0xFF;
+        gPaintSession.RightTunnels[0].height = 0xFF;
+        gPaintSession.RightTunnels[0].type = 0xFF;
     }
 
     void ResetSupportHeights() {
@@ -80,10 +94,14 @@ namespace TestPaint
         {
             gSupportSegments[s].height = 0;
             gSupportSegments[s].slope = 0xFF;
+            gPaintSession.SupportSegments[s].height = 0;
+            gPaintSession.SupportSegments[s].slope = 0xFF;
         }
 
         gSupport.height = 0;
         gSupport.slope = 0xFF;
+        gPaintSession.Support.height = 0;
+        gPaintSession.Support.slope = 0xFF;
     }
 
     struct IgnoredEntry

--- a/test/testpaint/TestTrack.cpp
+++ b/test/testpaint/TestTrack.cpp
@@ -272,6 +272,10 @@ static uint8 TestTrackElementPaintCalls(uint8 rideType, uint8 trackType, uint8 t
     gSurfaceElement = &surfaceElement;
     gDidPassSurface = true;
 
+    gPaintSession.CurrentlyDrawnItem = &mapElement;
+    gPaintSession.SurfaceElement = &surfaceElement;
+    gPaintSession.DidPassSurface = true;
+
     TestPaint::ResetEnvironment();
     TestPaint::ResetTunnels();
 
@@ -359,7 +363,7 @@ static uint8 TestTrackElementPaintCalls(uint8 rideType, uint8 trackType, uint8 t
                 PaintIntercept::ClearCalls();
                 testpaint_clear_ignore();
                 TestPaint::ResetSupportHeights();
-                gWoodenSupportsPrependTo = nullptr;
+                gPaintSession.WoodenSupportsPrependTo = nullptr;
 
                 CallNew(rideType, trackType, direction, trackSequence, height, &mapElement);
 
@@ -407,12 +411,16 @@ static uint8 TestTrackElementSegmentSupportHeight(uint8 rideType, uint8 trackTyp
     mapElement.properties.track.type = trackType;
     mapElement.base_height = height / 16;
     g_currently_drawn_item = &mapElement;
-
+    
     rct_map_element surfaceElement = {0};
     surfaceElement.type = MAP_ELEMENT_TYPE_SURFACE;
     surfaceElement.base_height = 2;
     gSurfaceElement = &surfaceElement;
     gDidPassSurface = true;
+
+    gPaintSession.CurrentlyDrawnItem = &mapElement;
+    gPaintSession.SurfaceElement = &surfaceElement;
+    gPaintSession.DidPassSurface = true;
 
     TestPaint::ResetEnvironment();
     TestPaint::ResetTunnels();
@@ -456,8 +464,7 @@ static uint8 TestTrackElementSegmentSupportHeight(uint8 rideType, uint8 trackTyp
             continue;
         }
 
-        std::vector<SegmentSupportCall> newCalls = SegmentSupportHeightCall::getSegmentCalls(gSupportSegments,
-                                                                                             direction);
+        std::vector<SegmentSupportCall> newCalls = SegmentSupportHeightCall::getSegmentCalls(gPaintSession.SupportSegments, direction);
         if (!SegmentSupportHeightCall::CallsEqual(referenceCalls, newCalls)) {
             *error += String::Format(
                 "Segment support heights didn't match. [direction:%d] %s\n",
@@ -489,6 +496,10 @@ static uint8 TestTrackElementGeneralSupportHeight(uint8 rideType, uint8 trackTyp
     surfaceElement.base_height = 2;
     gSurfaceElement = &surfaceElement;
     gDidPassSurface = true;
+
+    gPaintSession.CurrentlyDrawnItem = &mapElement;
+    gPaintSession.SurfaceElement = &surfaceElement;
+    gPaintSession.DidPassSurface = true;
 
     TestPaint::ResetEnvironment();
     TestPaint::ResetTunnels();
@@ -539,11 +550,11 @@ static uint8 TestTrackElementGeneralSupportHeight(uint8 rideType, uint8 trackTyp
 
 
         if (referenceCall.height != -1) {
-            if (gSupport.height != referenceCall.height) {
+            if (gPaintSession.Support.height != referenceCall.height) {
                 *error += String::Format(
                     "General support heights didn't match. (expected height + %d, actual: height + %d) [direction:%d] %s\n",
                     referenceCall.height - height,
-                    gSupport.height - height,
+                    gPaintSession.Support.height - height,
                     direction,
                     state.c_str()
                 );
@@ -551,11 +562,11 @@ static uint8 TestTrackElementGeneralSupportHeight(uint8 rideType, uint8 trackTyp
             }
         }
         if (referenceCall.slope != -1) {
-            if (gSupport.slope != referenceCall.slope) {
+            if (gPaintSession.Support.slope != referenceCall.slope) {
                 *error += String::Format(
                     "General support slopes didn't match. (expected 0x%02X, actual: 0x%02X) [direction:%d] %s\n",
                     referenceCall.slope,
-                    gSupport.slope,
+                    gPaintSession.Support.slope,
                     direction,
                     state.c_str()
                 );
@@ -581,6 +592,10 @@ static uint8 TestTrackElementSideTunnels(uint8 rideType, uint8 trackType, uint8 
     surfaceElement.base_height = 2;
     gSurfaceElement = &surfaceElement;
     gDidPassSurface = true;
+
+    gPaintSession.CurrentlyDrawnItem = &mapElement;
+    gPaintSession.SurfaceElement = &surfaceElement;
+    gPaintSession.DidPassSurface = true;
 
     TestPaint::ResetEnvironment();
     TestPaint::ResetTunnels();
@@ -635,12 +650,8 @@ static uint8 TestTrackElementSideTunnels(uint8 rideType, uint8 trackType, uint8 
         }
 
         bool err = false;
-        newTileTunnelCalls[direction][rightIndex] = SideTunnelCall::ExtractTunnelCalls(gRightTunnels, gRightTunnelCount, height,
-                                                                                       &err);
-
-        newTileTunnelCalls[direction][leftIndex] = SideTunnelCall::ExtractTunnelCalls(gLeftTunnels, gLeftTunnelCount, height,
-                                                                                      &err);
-
+        newTileTunnelCalls[direction][rightIndex] = SideTunnelCall::ExtractTunnelCalls(gPaintSession.RightTunnels, gPaintSession.RightTunnelCount, height, &err);
+        newTileTunnelCalls[direction][leftIndex] = SideTunnelCall::ExtractTunnelCalls(gPaintSession.LeftTunnels, gPaintSession.LeftTunnelCount, height, &err);
         if (err) {
             *error += "Multiple tunnels on one side aren't supported.\n";
             return TEST_FAILED;
@@ -697,6 +708,10 @@ static uint8 TestTrackElementVerticalTunnels(uint8 rideType, uint8 trackType, ui
     surfaceElement.base_height = 2;
     gSurfaceElement = &surfaceElement;
     gDidPassSurface = true;
+
+    gPaintSession.CurrentlyDrawnItem = &mapElement;
+    gPaintSession.SurfaceElement = &surfaceElement;
+    gPaintSession.DidPassSurface = true;
 
     TestPaint::ResetEnvironment();
     TestPaint::ResetTunnels();


### PR DESCRIPTION
Before we can work on multi-threaded painting, we need to remove the global state.
To help remove global state, we can reduce the number of global variables to just one:
`paint_session gPaintSession`.

After this we can start making all the paint functions pass a `paint_session`.
I have cheated with `gTrackColours` by using a `#define`, just to keep the number of differences down for now.