### PR TITLE
Pass paint session to more paint functions

### DIFF
--- a/src/openrct2/drawing/drawing.h
+++ b/src/openrct2/drawing/drawing.h
@@ -362,9 +362,11 @@ void gfx_draw_string_with_y_offsets(rct_drawpixelinfo *dpi, const utf8 *text, si
 sint32 gfx_clip_string(char* buffer, sint32 width);
 void shorten_path(utf8 *buffer, size_t bufferSize, const utf8 *path, sint32 availableWidth);
 
+typedef struct paint_session paint_session;
+
 // scrolling text
 void scrolling_text_initialise_bitmaps();
-sint32 scrolling_text_setup(rct_string_id stringId, uint16 scroll, uint16 scrollingMode);
+sint32 scrolling_text_setup(paint_session * session, rct_string_id stringId, uint16 scroll, uint16 scrollingMode);
 
 rct_size16 FASTCALL gfx_get_sprite_size(uint32 image_id);
 

--- a/src/openrct2/drawing/lightfx.c
+++ b/src/openrct2/drawing/lightfx.c
@@ -654,10 +654,10 @@ void lightfx_add_3d_light(uint32 lightID, uint16 lightIDqualifier, sint16 x, sin
 //  log_warning("new 3d light");
 }
 
-void lightfx_add_3d_light_magic_from_drawing_tile(sint16 offsetX, sint16 offsetY, sint16 offsetZ, uint8 lightType)
+void lightfx_add_3d_light_magic_from_drawing_tile(rct_xy16 mapPosition, sint16 offsetX, sint16 offsetY, sint16 offsetZ, uint8 lightType)
 {
-    sint16 x = gPaintSession.MapPosition.x + offsetX;
-    sint16 y = gPaintSession.MapPosition.y + offsetY;
+    sint16 x = mapPosition.x + offsetX;
+    sint16 y = mapPosition.y + offsetY;
 
     switch (get_current_rotation()) {
     case 0:

--- a/src/openrct2/drawing/lightfx.h
+++ b/src/openrct2/drawing/lightfx.h
@@ -20,6 +20,7 @@
 #ifdef __ENABLE_LIGHTFX__
 
 #include "../common.h"
+#include "../world/map.h"
 #include "drawing.h"
 
 enum LIGHTFX_LIGHT_TYPE {
@@ -58,7 +59,7 @@ const rct_palette * lightfx_get_palette();
 
 void lightfx_add_3d_light(uint32 lightID, uint16 lightIDqualifier, sint16 x, sint16 y, uint16 z, uint8 lightType);
 
-void lightfx_add_3d_light_magic_from_drawing_tile(sint16 offsetX, sint16 offsetY, sint16 offsetZ, uint8 lightType);
+void lightfx_add_3d_light_magic_from_drawing_tile(rct_xy16 mapPosition, sint16 offsetX, sint16 offsetY, sint16 offsetZ, uint8 lightType);
 
 void lightfx_add_lights_magic_vehicles();
 

--- a/src/openrct2/drawing/scrolling_text.c
+++ b/src/openrct2/drawing/scrolling_text.c
@@ -1416,11 +1416,11 @@ static const sint16* _scrollPositions[MAX_SCROLLING_TEXT_MODES] = {
  * @param scrollingMode (bp)
  * @returns ebx
  */
-sint32 scrolling_text_setup(rct_string_id stringId, uint16 scroll, uint16 scrollingMode)
+sint32 scrolling_text_setup(paint_session * session, rct_string_id stringId, uint16 scroll, uint16 scrollingMode)
 {
     assert(scrollingMode < MAX_SCROLLING_TEXT_MODES);
 
-    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo* dpi = session->Unk140E9A8;
 
     if (dpi->zoom_level != 0) return SPR_SCROLLING_TEXT_DEFAULT;
 

--- a/src/openrct2/interface/viewport.h
+++ b/src/openrct2/interface/viewport.h
@@ -150,7 +150,7 @@ void sub_68A15E(sint32 screenX, sint32 screenY, sint16 *x, sint16 *y, sint32 *di
 
 void viewport_interaction_remove_park_entrance(rct_map_element *mapElement, sint32 x, sint32 y);
 
-void sub_68B2B7(sint32 x, sint32 y);
+void sub_68B2B7(paint_session * session, sint32 x, sint32 y);
 
 void viewport_invalidate(rct_viewport *viewport, sint32 left, sint32 top, sint32 right, sint32 bottom);
 

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -35,12 +35,12 @@ const rct_xy16 BannerBoundBoxes[][2] = {
  *
  *  rct2: 0x006B9CC4
  */
-void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
+void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element)
 {
     uint16 boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ;
-    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo* dpi = session->Unk140E9A8;
 
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_BANNER;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_BANNER;
 
     if (dpi->zoom_level > 1 || gTrackDesignSaveMode) return;
 
@@ -64,7 +64,7 @@ void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element)
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) // if being placed
     {
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         image_id |= construction_markers[gConfigGeneral.construction_marker_colour];
     }
     else{

--- a/src/openrct2/paint/map_element/banner.c
+++ b/src/openrct2/paint/map_element/banner.c
@@ -113,5 +113,5 @@ void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_m
     uint16 string_width = gfx_get_string_width(gCommonStringFormatBuffer);
     uint16 scroll = (gCurrentTicks / 2) % string_width;
 
-    sub_98199C(scrolling_text_setup(string_id, scroll, scrollingMode), 0, 0, 1, 1, 0x15, height + 22, boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ, get_current_rotation());
+    sub_98199C(scrolling_text_setup(session, string_id, scroll, scrollingMode), 0, 0, 1, 1, 0x15, height + 22, boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ, get_current_rotation());
 }

--- a/src/openrct2/paint/map_element/entrance.c
+++ b/src/openrct2/paint/map_element/entrance.c
@@ -45,21 +45,21 @@ static void ride_entrance_exit_paint(paint_session * session, uint8 direction, s
 #ifdef __ENABLE_LIGHTFX__
     if (gConfigGeneral.enable_light_fx) {
         if (!is_exit) {
-            lightfx_add_3d_light_magic_from_drawing_tile(0, 0, height + 45, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+            lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 0, height + 45, LIGHTFX_LIGHT_TYPE_LANTERN_3);
         }
 
         switch (map_element_get_direction(map_element)) {
         case 0:
-            lightfx_add_3d_light_magic_from_drawing_tile(16, 0, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
+            lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 16, 0, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
             break;
         case 1:
-            lightfx_add_3d_light_magic_from_drawing_tile(0, -16, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
+            lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, -16, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
             break;
         case 2:
-            lightfx_add_3d_light_magic_from_drawing_tile(-16, 0, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
+            lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, -16, 0, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
             break;
         case 3:
-            lightfx_add_3d_light_magic_from_drawing_tile(0, 16, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
+            lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 16, height + 16, LIGHTFX_LIGHT_TYPE_LANTERN_2);
             break;
         };
     }
@@ -166,7 +166,7 @@ static void ride_entrance_exit_paint(paint_session * session, uint8 direction, s
         uint16 string_width = gfx_get_string_width(entrance_string);
         uint16 scroll = (gCurrentTicks / 2) % string_width;
 
-        sub_98199C(scrolling_text_setup(string_id, scroll, style->scrolling_mode), 0, 0, 0x1C, 0x1C, 0x33, height + style->height, 2, 2, height + style->height, get_current_rotation());
+        sub_98199C(scrolling_text_setup(session, string_id, scroll, style->scrolling_mode), 0, 0, 0x1C, 0x1C, 0x33, height + style->height, 2, 2, height + style->height, get_current_rotation());
     }
 
     image_id = _unk9E32BC;
@@ -191,7 +191,7 @@ static void park_entrance_paint(paint_session * session, uint8 direction, sint32
 
 #ifdef __ENABLE_LIGHTFX__
     if (gConfigGeneral.enable_light_fx) {
-        lightfx_add_3d_light_magic_from_drawing_tile(0, 0, 155, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+        lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 0, 155, LIGHTFX_LIGHT_TYPE_LANTERN_3);
     }
 #endif
 
@@ -253,7 +253,7 @@ static void park_entrance_paint(paint_session * session, uint8 direction, sint32
         if (entrance->scrolling_mode == 0xFF)
             break;
 
-        sub_98199C(scrolling_text_setup(park_text_id, scroll, entrance->scrolling_mode + direction / 2), 0, 0, 0x1C, 0x1C, 0x2F, height + entrance->text_height, 2, 2, height + entrance->text_height, get_current_rotation());
+        sub_98199C(scrolling_text_setup(session, park_text_id, scroll, entrance->scrolling_mode + direction / 2), 0, 0, 0x1C, 0x1C, 0x2F, height + entrance->text_height, 2, 2, height + entrance->text_height, get_current_rotation());
         break;
     case 1:
     case 2:

--- a/src/openrct2/paint/map_element/entrance.c
+++ b/src/openrct2/paint/map_element/entrance.c
@@ -32,7 +32,7 @@ static uint32 _unk9E32BC;
  *
  *  rct2: 0x0066508C, 0x00665540
  */
-static void ride_entrance_exit_paint(uint8 direction, sint32 height, rct_map_element* map_element)
+static void ride_entrance_exit_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element)
 {
 
     uint8 is_exit = map_element->properties.entrance.type == ENTRANCE_TYPE_RIDE_EXIT;
@@ -81,11 +81,11 @@ static void ride_entrance_exit_paint(uint8 direction, sint32 height, rct_map_ele
     colour_2 = ride->track_colour_additional[0];
     image_id = (colour_1 << 19) | (colour_2 << 24) | IMAGE_TYPE_REMAP | IMAGE_TYPE_REMAP_2_PLUS;
 
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
     _unk9E32BC = 0;
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST){
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         image_id = construction_markers[gConfigGeneral.construction_marker_colour];
         _unk9E32BC = image_id;
         if (transparant_image_id)
@@ -185,7 +185,7 @@ static void ride_entrance_exit_paint(uint8 direction, sint32 height, rct_map_ele
  *
  *  rct2: 0x006658ED
  */
-static void park_entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element){
+static void park_entrance_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element){
     if (gTrackDesignSaveMode)
         return;
 
@@ -195,11 +195,11 @@ static void park_entrance_paint(uint8 direction, sint32 height, rct_map_element*
     }
 #endif
 
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
     _unk9E32BC = 0;
     uint32 image_id, ghost_id = 0;
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST){
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         ghost_id = construction_markers[gConfigGeneral.construction_marker_colour];
         _unk9E32BC = ghost_id;
     }
@@ -277,10 +277,10 @@ static void park_entrance_paint(uint8 direction, sint32 height, rct_map_element*
  *
  *  rct2: 0x00664FD4
  */
-void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element){
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_LABEL;
+void entrance_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element){
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_LABEL;
 
-    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo* dpi = session->Unk140E9A8;
 
     if (gCurrentViewportFlags & VIEWPORT_FLAG_PATH_HEIGHTS &&
         dpi->zoom_level == 0){
@@ -298,10 +298,10 @@ void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element
     switch (map_element->properties.entrance.type){
     case ENTRANCE_TYPE_RIDE_ENTRANCE:
     case ENTRANCE_TYPE_RIDE_EXIT:
-        ride_entrance_exit_paint(direction, height, map_element);
+        ride_entrance_exit_paint(session, direction, height, map_element);
         break;
     case ENTRANCE_TYPE_PARK_ENTRANCE:
-        park_entrance_paint(direction, height, map_element);
+        park_entrance_paint(session, direction, height, map_element);
         break;
     }
 }

--- a/src/openrct2/paint/map_element/fence.c
+++ b/src/openrct2/paint/map_element/fence.c
@@ -130,9 +130,9 @@ static void fence_paint_wall(uint32 frameNum, const rct_scenery_entry * sceneryE
  * @param height (dx)
  * @param map_element (esi)
  */
-void fence_paint(uint8 direction, sint32 height, rct_map_element * map_element)
+void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element * map_element)
 {
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_WALL;
 
     rct_scenery_entry * sceneryEntry = get_wall_entry(map_element->properties.wall.type);
     if (sceneryEntry == NULL || sceneryEntry == (rct_scenery_entry *)-1) {
@@ -170,7 +170,7 @@ void fence_paint(uint8 direction, sint32 height, rct_map_element * map_element)
     }
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         dword_141F710 = construction_markers[gConfigGeneral.construction_marker_colour];
     }
 

--- a/src/openrct2/paint/map_element/fence.c
+++ b/src/openrct2/paint/map_element/fence.c
@@ -382,5 +382,5 @@ void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_ma
     uint16 string_width = gfx_get_string_width(signString);
     uint16 scroll = (gCurrentTicks / 2) % string_width;
 
-    sub_98199C(scrolling_text_setup(stringId, scroll, scrollingMode), 0, 0, 1, 1, 13, height + 8, boundsOffset.x, boundsOffset.y, boundsOffset.z, get_current_rotation());
+    sub_98199C(scrolling_text_setup(session, stringId, scroll, scrollingMode), 0, 0, 1, 1, 13, height + 8, boundsOffset.x, boundsOffset.y, boundsOffset.z, get_current_rotation());
 }

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -256,7 +256,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             track_paint(direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_SCENERY:
-            scenery_paint(direction, height, map_element);
+            scenery_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_ENTRANCE:
             entrance_paint(session, direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -262,7 +262,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             entrance_paint(direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_WALL:
-            fence_paint(direction, height, map_element);
+            fence_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_SCENERY_MULTIPLE:
             scenery_multiple_paint(session, direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -250,7 +250,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             surface_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_PATH:
-            path_paint(direction, height, map_element);
+            path_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_TRACK:
             track_paint(direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -247,7 +247,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
         switch (map_element_get_type(map_element))
         {
         case MAP_ELEMENT_TYPE_SURFACE:
-            surface_paint(direction, height, map_element);
+            surface_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_PATH:
             path_paint(direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -268,7 +268,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             scenery_multiple_paint(direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_BANNER:
-            banner_paint(direction, height, map_element);
+            banner_paint(session, direction, height, map_element);
             break;
         // A corrupt element inserted by OpenRCT2 itself, which skips the drawing of the next element only.
         case MAP_ELEMENT_TYPE_CORRUPT:
@@ -280,7 +280,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             // An undefined map element is most likely a corrupt element inserted by 8 cars' MOM feature to skip drawing of all elements after it.
             return;
         }
-        gPaintSession.MapPosition = dword_9DE574;
+        session->MapPosition = dword_9DE574;
     } while (!map_element_is_last_for_tile(map_element++));
 
     if (!gShowSupportSegmentHeights) {

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -259,7 +259,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             scenery_paint(direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_ENTRANCE:
-            entrance_paint(direction, height, map_element);
+            entrance_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_WALL:
             fence_paint(session, direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -265,7 +265,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             fence_paint(direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_SCENERY_MULTIPLE:
-            scenery_multiple_paint(direction, height, map_element);
+            scenery_multiple_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_BANNER:
             banner_paint(session, direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.c
+++ b/src/openrct2/paint/map_element/map_element.c
@@ -253,7 +253,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             path_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_TRACK:
-            track_paint(direction, height, map_element);
+            track_paint(session, direction, height, map_element);
             break;
         case MAP_ELEMENT_TYPE_SCENERY:
             scenery_paint(session, direction, height, map_element);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -101,7 +101,7 @@ void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_m
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
-void fence_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
+void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement);
 void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement);
 

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -98,7 +98,7 @@ void map_element_paint_setup(paint_session * session, sint32 x, sint32 y);
 
 void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element);
 void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element);
-void surface_paint(uint8 direction, uint16 height, rct_map_element *mapElement);
+void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void path_paint(uint8 direction, uint16 height, rct_map_element *mapElement);
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
 void fence_paint(uint8 direction, sint32 height, rct_map_element* mapElement);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -97,7 +97,7 @@ uint16 paint_util_rotate_segments(uint16 segments, uint8 rotation);
 void map_element_paint_setup(paint_session * session, sint32 x, sint32 y);
 
 void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element);
-void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element);
+void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element);
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -99,7 +99,7 @@ void map_element_paint_setup(paint_session * session, sint32 x, sint32 y);
 void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element);
 void banner_paint(uint8 direction, sint32 height, rct_map_element* map_element);
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
-void path_paint(uint8 direction, uint16 height, rct_map_element *mapElement);
+void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
 void fence_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
 void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -96,7 +96,7 @@ uint16 paint_util_rotate_segments(uint16 segments, uint8 rotation);
 
 void map_element_paint_setup(paint_session * session, sint32 x, sint32 y);
 
-void entrance_paint(uint8 direction, sint32 height, rct_map_element* map_element);
+void entrance_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element);
 void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element);
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -100,7 +100,7 @@ void entrance_paint(paint_session * session, uint8 direction, sint32 height, rct
 void banner_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* map_element);
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
-void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
+void scenery_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement);
 void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement);
 void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement);

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -103,6 +103,6 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map
 void scenery_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement);
 void fence_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement);
 void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
-void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement);
+void track_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element *mapElement);
 
 #endif

--- a/src/openrct2/paint/map_element/map_element.h
+++ b/src/openrct2/paint/map_element/map_element.h
@@ -102,7 +102,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
 void fence_paint(uint8 direction, sint32 height, rct_map_element* mapElement);
-void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement);
+void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement);
 void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement);
 
 #endif

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -82,9 +82,8 @@ const uint8 byte_98D8A4[] = {
     0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0
 };
 
-void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_footpath_entry * footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);
-
-void path_paint_box_support(rct_map_element* mapElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);
+void path_paint_pole_support(paint_session * session, rct_map_element * mapElement, sint32 height, rct_footpath_entry * footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);
+void path_paint_box_support(paint_session * session, rct_map_element* mapElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);
 
 /* rct2: 0x006A5AE5 */
 static void path_bit_lights_paint(rct_scenery_entry* pathBitEntry, rct_map_element* mapElement, sint32 height, uint8 edges, uint32 pathBitImageFlags) {
@@ -285,7 +284,7 @@ static void path_bit_jumping_fountains_paint(rct_scenery_entry* pathBitEntry, rc
  * @param ebp (ebp)
  * @param base_image_id (0x00F3EF78)
  */
-static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp, bool word_F3F038, rct_footpath_entry * footpathEntry, uint32 base_image_id, uint32 imageFlags)
+static void sub_6A4101(paint_session * session, rct_map_element * map_element, uint16 height, uint32 ebp, bool word_F3F038, rct_footpath_entry * footpathEntry, uint32 base_image_id, uint32 imageFlags)
 {
     if (footpath_element_is_queue(map_element)) {
         uint8 local_ebp = ebp & 0x0F;
@@ -366,7 +365,7 @@ static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp,
 
         uint8 direction = ((map_element->type & 0xC0) >> 6);
         // Draw ride sign
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
         if (footpath_element_is_sloped(map_element)) {
             if (footpath_element_get_slope_direction(map_element) == direction)
                 height += 16;
@@ -419,9 +418,9 @@ static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp,
             sub_98199C(scrolling_text_setup(string_id, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,  boundBoxOffsets.x,  boundBoxOffsets.y,  boundBoxOffsets.z, get_current_rotation());
         }
 
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
         if (imageFlags != 0) {
-            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         }
         return;
     }
@@ -583,7 +582,7 @@ static void sub_6A4101(rct_map_element * map_element, uint16 height, uint32 ebp,
  * @param imageFlags (0x00F3EF70)
  * @param sceneryImageFlags (0x00F3EF74)
  */
-static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, rct_footpath_entry * footpathEntry, uint32 imageFlags, uint32 sceneryImageFlags, bool word_F3F038)
+static void sub_6A3F61(paint_session * session, rct_map_element * map_element, uint16 bp, uint16 height, rct_footpath_entry * footpathEntry, uint32 imageFlags, uint32 sceneryImageFlags, bool word_F3F038)
 {
     // eax --
     // ebx --
@@ -596,15 +595,15 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
 
     // Probably drawing benches etc.
 
-    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo * dpi = session->Unk140E9A8;
 
     if (dpi->zoom_level <= 1) {
         if (!gTrackDesignSaveMode) {
             uint8 additions = map_element->properties.path.additions & 0xF;
             if (additions != 0) {
-                gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM;
+                session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM;
                 if (sceneryImageFlags != 0) {
-                    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
 
                 // Draw additional path bits (bins, benches, lamps, queue screens)
@@ -624,17 +623,17 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
                     break;
                 }
 
-                gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+                session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
                 if (sceneryImageFlags != 0) {
-                    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
             }
         }
 
         // Redundant zoom-level check removed
 
-        sub_6A4101(map_element, height, bp, word_F3F038, footpathEntry, footpathEntry->image | imageFlags, imageFlags);
+        sub_6A4101(session, map_element, height, bp, word_F3F038, footpathEntry, footpathEntry->image | imageFlags, imageFlags);
     }
 
     // This is about tunnel drawing
@@ -670,9 +669,9 @@ static void sub_6A3F61(rct_map_element * map_element, uint16 bp, uint16 height, 
 /**
  * rct2: 0x0006A3590
  */
-void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
+void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element * map_element)
 {
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
     bool word_F3F038 = false;
 
@@ -696,11 +695,11 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
     }
 
     if (map_element->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         imageFlags = construction_markers[gConfigGeneral.construction_marker_colour];
     }
 
-    sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
+    sint16 x = session->MapPosition.x, y = session->MapPosition.y;
 
     rct_map_element * surface = map_get_surface_element_at(x / 32, y / 32);
 
@@ -727,8 +726,8 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
         sint32 staffIndex = gStaffDrawPatrolAreas;
         uint8 staffType = staffIndex & 0x7FFF;
         bool is_staff_list = staffIndex & 0x8000;
-        x = gPaintSession.MapPosition.x;
-        y = gPaintSession.MapPosition.y;
+        x = session->MapPosition.x;
+        y = session->MapPosition.y;
 
         uint8 patrolColour = COLOUR_LIGHT_BLUE;
 
@@ -769,10 +768,10 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
 
     if (footpathEntry != (void*)-1) {
         if (footpathEntry->support_type == FOOTPATH_ENTRY_SUPPORT_TYPE_POLE) {
-            path_paint_pole_support(map_element, height, footpathEntry, word_F3F038, imageFlags, sceneryImageFlags);
+            path_paint_pole_support(session, map_element, height, footpathEntry, word_F3F038, imageFlags, sceneryImageFlags);
         }
         else {
-            path_paint_box_support(map_element, height, footpathEntry, word_F3F038, imageFlags, sceneryImageFlags);
+            path_paint_box_support(session, map_element, height, footpathEntry, word_F3F038, imageFlags, sceneryImageFlags);
         }
     }
 
@@ -799,7 +798,7 @@ void path_paint(uint8 direction, uint16 height, rct_map_element * map_element)
 #endif
 }
 
-void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_footpath_entry * footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags)
+void path_paint_pole_support(paint_session * session, rct_map_element * mapElement, sint32 height, rct_footpath_entry * footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags)
 {
     // Rol edges around rotation
     uint8 edges = ((mapElement->properties.path.edges << get_current_rotation()) & 0xF) |
@@ -826,14 +825,14 @@ void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_fo
         imageId += 51;
     }
 
-    if (!gPaintSession.DidPassSurface) {
+    if (!session->DidPassSurface) {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
         boundBoxSize.x = 26;
         boundBoxSize.y = 26;
     }
 
-    if (!hasFences || !gPaintSession.DidPassSurface) {
+    if (!hasFences || !session->DidPassSurface) {
         sub_98197C(imageId | imageFlags, 0, 0, boundBoxSize.x, boundBoxSize.y, 0, height, boundBoxOffset.x, boundBoxOffset.y, height + 1, get_current_rotation());
     } else {
         uint32 image_id;
@@ -853,7 +852,7 @@ void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_fo
     }
 
 
-    sub_6A3F61(mapElement, edi, height, footpathEntry, imageFlags, sceneryImageFlags, hasFences);
+    sub_6A3F61(session, mapElement, edi, height, footpathEntry, imageFlags, sceneryImageFlags, hasFences);
 
     uint16 ax = 0;
     if (footpath_element_is_sloped(mapElement)) {
@@ -904,7 +903,7 @@ void path_paint_pole_support(rct_map_element * mapElement, sint32 height, rct_fo
     }
 }
 
-void path_paint_box_support(rct_map_element* mapElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags)
+void path_paint_box_support(paint_session * session, rct_map_element* mapElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags)
 {
     // Rol edges around rotation
     uint8 edges = ((mapElement->properties.path.edges << get_current_rotation()) & 0xF) |
@@ -940,14 +939,14 @@ void path_paint_box_support(rct_map_element* mapElement, sint16 height, rct_foot
     }
 
     // Below Surface
-    if (!gPaintSession.DidPassSurface) {
+    if (!session->DidPassSurface) {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
         boundBoxSize.x = 26;
         boundBoxSize.y = 26;
     }
 
-    if (!hasFences || !gPaintSession.DidPassSurface) {
+    if (!hasFences || !session->DidPassSurface) {
         sub_98197C(imageId | imageFlags, 0, 0, boundBoxSize.x, boundBoxSize.y, 0, height, boundBoxOffset.x, boundBoxOffset.y, height + 1, get_current_rotation());
     }
     else {
@@ -967,7 +966,7 @@ void path_paint_box_support(rct_map_element* mapElement, sint16 height, rct_foot
         }
     }
 
-    sub_6A3F61(mapElement, edi, height, footpathEntry, imageFlags, sceneryImageFlags, hasFences); // TODO: arguments
+    sub_6A3F61(session, mapElement, edi, height, footpathEntry, imageFlags, sceneryImageFlags, hasFences); // TODO: arguments
 
     uint16 ax = 0;
     if (footpath_element_is_sloped(mapElement)) {

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -415,7 +415,7 @@ static void sub_6A4101(paint_session * session, rct_map_element * map_element, u
             uint16 string_width = gfx_get_string_width(gCommonStringFormatBuffer);
             uint16 scroll = (gCurrentTicks / 2) % string_width;
 
-            sub_98199C(scrolling_text_setup(string_id, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,  boundBoxOffsets.x,  boundBoxOffsets.y,  boundBoxOffsets.z, get_current_rotation());
+            sub_98199C(scrolling_text_setup(session, string_id, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,  boundBoxOffsets.x,  boundBoxOffsets.y,  boundBoxOffsets.z, get_current_rotation());
         }
 
         session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
@@ -781,16 +781,16 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map
             rct_scenery_entry *sceneryEntry = get_footpath_item_entry(footpath_element_get_path_scenery_index(map_element));
             if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP) {
                 if (!(map_element->properties.path.edges & (1 << 0))) {
-                    lightfx_add_3d_light_magic_from_drawing_tile(-16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                    lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, -16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
                 if (!(map_element->properties.path.edges & (1 << 1))) {
-                    lightfx_add_3d_light_magic_from_drawing_tile(0, 16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                    lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
                 if (!(map_element->properties.path.edges & (1 << 2))) {
-                    lightfx_add_3d_light_magic_from_drawing_tile(16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                    lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
                 if (!(map_element->properties.path.edges & (1 << 3))) {
-                    lightfx_add_3d_light_magic_from_drawing_tile(0, -16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                    lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, -16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
             }
         }

--- a/src/openrct2/paint/map_element/scenery.c
+++ b/src/openrct2/paint/map_element/scenery.c
@@ -42,9 +42,9 @@ static const rct_xy16 lengths[] = {
  *
  *  rct2: 0x006DFF47
  */
-void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) {
+void scenery_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element* mapElement) {
     //RCT2_CALLPROC_X(0x6DFF47, 0, 0, direction, height, (sint32)mapElement, 0, 0); return;
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SCENERY;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_SCENERY;
     rct_xyz16 boxlength;
     rct_xyz16 boxoffset;
     boxoffset.x = 0;
@@ -58,7 +58,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
         }
     }
     if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         baseImageid = construction_markers[gConfigGeneral.construction_marker_colour];
     }
     uint32 dword_F64EB0 = baseImageid;
@@ -152,7 +152,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
     }
 
     if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_ANIMATED) {
-        rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+        rct_drawpixelinfo* dpi = session->Unk140E9A8;
         if ( (entry->small_scenery.flags & SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED) || (dpi->zoom_level <= 1) ) {
             // 6E01A9:
             if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1) {
@@ -218,8 +218,8 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
             if (entry->small_scenery.flags & SMALL_SCENERY_FLAG_SWAMP_GOO) {
                 // 6E02F6:
                 sint32 image_id = gCurrentTicks;
-                image_id += gPaintSession.SpritePosition.x / 4;
-                image_id += gPaintSession.SpritePosition.y / 4;
+                image_id += session->SpritePosition.x / 4;
+                image_id += session->SpritePosition.y / 4;
                 image_id = (image_id / 4) & 15;
                 image_id += entry->image;
                 if (dword_F64EB0 != 0) {
@@ -232,7 +232,7 @@ void scenery_paint(uint8 direction, sint32 height, rct_map_element* mapElement) 
                 sint32 frame = gCurrentTicks;
                 if (!(entry->small_scenery.flags & SMALL_SCENERY_FLAG_COG)) {
                     // 6E01F8:
-                    frame += ((gPaintSession.SpritePosition.x / 4) + (gPaintSession.SpritePosition.y / 4));
+                    frame += ((session->SpritePosition.x / 4) + (session->SpritePosition.y / 4));
                     frame += (mapElement->type & 0xC0) / 16;
                 }
                 // 6E0222:

--- a/src/openrct2/paint/map_element/scenery_multiple.c
+++ b/src/openrct2/paint/map_element/scenery_multiple.c
@@ -109,7 +109,7 @@ static sint32 div_to_minus_infinity(sint32 a, sint32 b) {
     return (a / b) - (a % b < 0);
 }
 
-static void scenery_multiple_sign_paint_line(const utf8 *str, rct_large_scenery_text *text, sint32 textImage, sint32 textColour, uint8 direction, sint32 y_offset)
+static void scenery_multiple_sign_paint_line(paint_session * session, const utf8 *str, rct_large_scenery_text *text, sint32 textImage, sint32 textColour, uint8 direction, sint32 y_offset)
 {
     const utf8 *fitStr = scenery_multiple_sign_fit_text(str, text, false);
     sint32 width = scenery_multiple_sign_text_width(fitStr, text);
@@ -141,12 +141,12 @@ static void scenery_multiple_sign_paint_line(const utf8 *str, rct_large_scenery_
         }
         sint32 image_id = (textImage + glyph_offset + glyph_type) | textColour;
         if (direction == 3) {
-            paint_attach_to_previous_ps(image_id, x_offset, -div_to_minus_infinity(acc, 2));
+            paint_attach_to_previous_ps(session, image_id, x_offset, -div_to_minus_infinity(acc, 2));
         } else {
             if (text->flags & LARGE_SCENERY_TEXT_FLAG_VERTICAL) {
-                paint_attach_to_previous_ps(image_id, x_offset, div_to_minus_infinity(acc, 2));
+                paint_attach_to_previous_ps(session, image_id, x_offset, div_to_minus_infinity(acc, 2));
             } else {
-                paint_attach_to_previous_attach(image_id, x_offset, div_to_minus_infinity(acc, 2));
+                paint_attach_to_previous_attach(session, image_id, x_offset, div_to_minus_infinity(acc, 2));
             }
         }
         x_offset += scenery_multiple_sign_get_glyph(text, codepoint)->width;
@@ -280,7 +280,7 @@ void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 hei
             while ((codepoint = utf8_get_next(fitStrPtr, &fitStrPtr)) != 0) {
                 utf8 str[5] = {0};
                 utf8_write_codepoint(str, codepoint);
-                scenery_multiple_sign_paint_line(str, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset - height2);
+                scenery_multiple_sign_paint_line(session, str, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset - height2);
                 y_offset += scenery_multiple_sign_get_glyph(text, codepoint)->height * 2;
             }
         } else {
@@ -311,15 +311,15 @@ void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 hei
                             *spacedst = 0;
                             src = spacesrc;
                         }
-                        scenery_multiple_sign_paint_line(str1, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
+                        scenery_multiple_sign_paint_line(session, str1, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
                         y_offset += (scenery_multiple_sign_get_glyph(text, 'A')->height + 1) * 2;
                     }
                 } else {
-                    scenery_multiple_sign_paint_line(signString, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
+                    scenery_multiple_sign_paint_line(session, signString, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
                 }
             } else {
                 // Draw one-line sign:
-                scenery_multiple_sign_paint_line(signString, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
+                scenery_multiple_sign_paint_line(session, signString, entry->large_scenery.text, entry->large_scenery.text_image, textColour, direction, y_offset);
             }
         }
         return;

--- a/src/openrct2/paint/map_element/scenery_multiple.c
+++ b/src/openrct2/paint/map_element/scenery_multiple.c
@@ -367,7 +367,7 @@ void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 hei
 
     uint16 string_width = gfx_get_string_width(signString);
     uint16 scroll = (gCurrentTicks / 2) % string_width;
-    sub_98199C(scrolling_text_setup(stringId, scroll, scrollMode), 0, 0, 1, 1, 21, height + 25, boxoffset.x, boxoffset.y, boxoffset.z, get_current_rotation());
+    sub_98199C(scrolling_text_setup(session, stringId, scroll, scrollMode), 0, 0, 1, 1, 21, height + 25, boxoffset.x, boxoffset.y, boxoffset.z, get_current_rotation());
 
     scenery_multiple_paint_supports(direction, height, mapElement, dword_F4387C, tile);
 }

--- a/src/openrct2/paint/map_element/scenery_multiple.c
+++ b/src/openrct2/paint/map_element/scenery_multiple.c
@@ -183,9 +183,9 @@ static const boundbox s98E3C4[] = {
 *
 * rct2: 0x006B7F0C
 */
-void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement) {
+void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) {
     //RCT2_CALLPROC_X(0x6B7F0C, 0, 0, direction, height, (sint32)mapElement, 0, 0); return;
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY;
     uint32 ebp = mapElement->properties.scenerymultiple.type >> 10;
     rct_scenery_entry *entry = get_large_scenery_entry(mapElement->properties.scenerymultiple.type & 0x3FF);
     if (entry == (void*)-1)
@@ -206,7 +206,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
         }
     }
     if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
         ebp = construction_markers[gConfigGeneral.construction_marker_colour];
         image_id &= 0x7FFFF;
         dword_F4387C = ebp;
@@ -243,7 +243,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
                 return;
             }
         }
-        rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+        rct_drawpixelinfo* dpi = session->Unk140E9A8;
         if (dpi->zoom_level > 1) {
             scenery_multiple_paint_supports(direction, height, mapElement, dword_F4387C, tile);
             return;
@@ -324,7 +324,7 @@ void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *map
         }
         return;
     }
-    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo* dpi = session->Unk140E9A8;
     if (dpi->zoom_level > 0) {
         scenery_multiple_paint_supports(direction, height, mapElement, dword_F4387C, tile);
         return;

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -445,7 +445,7 @@ static void viewport_surface_smoothen_edge(paint_session * session, enum edge_t 
 
     uint32 image_id = maskImageBase + byte_97B444[self.slope];
 
-    if (paint_attach_to_previous_ps(image_id, 0, 0)) {
+    if (paint_attach_to_previous_ps(session, image_id, 0, 0)) {
         attached_paint_struct * out = session->UnkF1AD2C;
         // set content and enable masking
         out->colour_image_id = dword_97B804[neighbour.terrain] + cl;
@@ -456,7 +456,7 @@ static void viewport_surface_smoothen_edge(paint_session * session, enum edge_t 
 /**
  * rct2: 0x0065F63B, 0x0065F77D
  */
-static void viewport_surface_draw_land_side_top(enum edge_t edge, uint8 height, uint8 terrain, struct tile_descriptor self, struct tile_descriptor neighbour)
+static void viewport_surface_draw_land_side_top(paint_session * session, enum edge_t edge, uint8 height, uint8 terrain, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
     registers regs;
 
@@ -509,7 +509,7 @@ static void viewport_surface_draw_land_side_top(enum edge_t edge, uint8 height, 
 
         uint32 image_id = _terrainEdgeSpriteIds[terrain][3] + (edge == EDGE_TOPLEFT ? 3 : 0) + incline; // var_c;
         sint16 y = (regs.dl - regs.al) * 16;
-        paint_attach_to_previous_ps(image_id, 0, y);
+        paint_attach_to_previous_ps(session, image_id, 0, y);
         return;
     }
 
@@ -1165,7 +1165,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
 
             image_id |= SPR_TERRAIN_SELECTION_PATROL_AREA + byte_97B444[surfaceShape];
             image_id |= patrolColour << 19;
-            paint_attach_to_previous_ps(image_id, 0, 0);
+            paint_attach_to_previous_ps(session, image_id, 0, 0);
         }
     }
 
@@ -1191,7 +1191,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
         // loc_660E9A:
         if (mapElement->properties.surface.ownership & OWNERSHIP_OWNED) {
             assert(surfaceShape < countof(byte_97B444));
-            paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
+            paint_attach_to_previous_ps(session, SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE) {
             rct_xy16 pos = session->MapPosition;
             paint_struct * backup = session->UnkF1AD28;
@@ -1205,7 +1205,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
         && !(mapElement->properties.surface.ownership & OWNERSHIP_OWNED)) {
         if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED) {
             assert(surfaceShape < countof(byte_97B444));
-            paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
+            paint_attach_to_previous_ps(session, SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) {
             paint_struct * backup = session->UnkF1AD28;
             rct_xy16 pos = session->MapPosition;
@@ -1233,13 +1233,13 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
                 // loc_661089:
                 uint32 eax = ((((mapSelectionType - 9) + rotation) & 3) + 0x21) << 19;
                 uint32 image_id = (SPR_TERRAIN_SELECTION_EDGE + byte_97B444[surfaceShape]) | eax | IMAGE_TYPE_REMAP;
-                paint_attach_to_previous_ps(image_id, 0, 0);
+                paint_attach_to_previous_ps(session, image_id, 0, 0);
             } else if (mapSelectionType >= MAP_SELECT_TYPE_QUARTER_0) {
                 // loc_661051:(no jump)
                 // Selection split into four quarter segments
                 uint32 eax = ((((mapSelectionType - MAP_SELECT_TYPE_QUARTER_0) + rotation) & 3) + 0x27) << 19;
                 uint32 image_id = (SPR_TERRAIN_SELECTION_QUARTER + byte_97B444[surfaceShape]) | eax | IMAGE_TYPE_REMAP;
-                paint_attach_to_previous_ps(image_id, 0, 0);
+                paint_attach_to_previous_ps(session, image_id, 0, 0);
             } else if (mapSelectionType <= MAP_SELECT_TYPE_FULL) {
                 // Corners
                 uint32 eax = mapSelectionType;
@@ -1249,7 +1249,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
 
                 eax = (eax + 0x21) << 19;
                 uint32 image_id = (SPR_TERRAIN_SELECTION_CORNER + byte_97B444[surfaceShape]) | eax | IMAGE_TYPE_REMAP;
-                paint_attach_to_previous_ps(image_id, 0, 0);
+                paint_attach_to_previous_ps(session, image_id, 0, 0);
             } else {
                 sint32 local_surfaceShape = surfaceShape;
                 sint32 local_height = height;
@@ -1298,7 +1298,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
             }
 
             uint32 image_id = (SPR_TERRAIN_SELECTION_CORNER + byte_97B444[surfaceShape]) | colours | IMAGE_TYPE_REMAP;
-            paint_attach_to_previous_ps(image_id, 0, 0);
+            paint_attach_to_previous_ps(session, image_id, 0, 0);
             break;
         }
     }
@@ -1325,7 +1325,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
             base_image = byte_97B84A[terrain_type];
         }
         uint32 image_id = dword_97B7C8[base_image] + image_offset;
-        paint_attach_to_previous_ps(image_id, 0, 0);
+        paint_attach_to_previous_ps(session, image_id, 0, 0);
     }
 
     if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_VERTICAL)) {
@@ -1352,8 +1352,8 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
         memcpy(backupRightTunnels, session->RightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
 #endif
 
-        viewport_surface_draw_land_side_top(EDGE_TOPLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
-        viewport_surface_draw_land_side_top(EDGE_TOPRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[4]);
+        viewport_surface_draw_land_side_top(session, EDGE_TOPLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
+        viewport_surface_draw_land_side_top(session, EDGE_TOPRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[4]);
         viewport_surface_draw_land_side_bottom(session, EDGE_BOTTOMLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[1]);
         viewport_surface_draw_land_side_bottom(session, EDGE_BOTTOMRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[2]);
 
@@ -1389,7 +1389,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
             sint32 image_id = (SPR_WATER_MASK + image_offset) | IMAGE_TYPE_REMAP | IMAGE_TYPE_TRANSPARENT | PALETTE_WATER << 19;
             sub_98196C(image_id, 0, 0, 32, 32, -1, waterHeight, rotation);
 
-            paint_attach_to_previous_ps(SPR_WATER_OVERLAY + image_offset, 0, 0);
+            paint_attach_to_previous_ps(session, SPR_WATER_OVERLAY + image_offset, 0, 0);
 
             // This wasn't in the original, but the code depended on globals that were only set in a different conditional
             uint8 al_edgeStyle = mapElement->properties.surface.slope & 0xE0;

--- a/src/openrct2/paint/map_element/surface.c
+++ b/src/openrct2/paint/map_element/surface.c
@@ -353,7 +353,7 @@ static uint8 viewport_surface_paint_setup_get_relative_slope(rct_map_element * m
 /**
  * rct2: 0x0065E890, 0x0065E946, 0x0065E9FC, 0x0065EAB2
  */
-static void viewport_surface_smoothen_edge(enum edge_t edge, struct tile_descriptor self, struct tile_descriptor neighbour)
+static void viewport_surface_smoothen_edge(paint_session * session, enum edge_t edge, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
 
     if (neighbour.map_element == NULL) {
@@ -446,7 +446,7 @@ static void viewport_surface_smoothen_edge(enum edge_t edge, struct tile_descrip
     uint32 image_id = maskImageBase + byte_97B444[self.slope];
 
     if (paint_attach_to_previous_ps(image_id, 0, 0)) {
-        attached_paint_struct * out = gPaintSession.UnkF1AD2C;
+        attached_paint_struct * out = session->UnkF1AD2C;
         // set content and enable masking
         out->colour_image_id = dword_97B804[neighbour.terrain] + cl;
         out->flags |= PAINT_STRUCT_FLAG_IS_MASKED;
@@ -554,7 +554,7 @@ static void viewport_surface_draw_land_side_top(enum edge_t edge, uint8 height, 
 /**
  * rct2: 0x0065EB7D, 0x0065F0D8
  */
-static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 height, uint8 edgeStyle, struct tile_descriptor self, struct tile_descriptor neighbour)
+static void viewport_surface_draw_land_side_bottom(paint_session * session, enum edge_t edge, uint8 height, uint8 edgeStyle, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
     registers regs;
 
@@ -577,7 +577,7 @@ static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 heigh
             tunnelBounds.x = 32;
             tunnelTopBoundBoxOffset.y = 31;
 
-            tunnelArray = gPaintSession.LeftTunnels;
+            tunnelArray = session->LeftTunnels;
             break;
 
         case EDGE_BOTTOMRIGHT:
@@ -592,7 +592,7 @@ static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 heigh
             tunnelBounds.y = 32;
             tunnelTopBoundBoxOffset.x = 31;
 
-            tunnelArray = gPaintSession.RightTunnels;
+            tunnelArray = session->RightTunnels;
             break;
 
         default:
@@ -714,7 +714,7 @@ static void viewport_surface_draw_land_side_bottom(enum edge_t edge, uint8 heigh
 /**
  * rct2: 0x0066039B, 0x006604F1
  */
-static void viewport_surface_draw_water_side_top(enum edge_t edge, uint8 height, uint8 terrain, struct tile_descriptor self, struct tile_descriptor neighbour)
+static void viewport_surface_draw_water_side_top(paint_session * session, enum edge_t edge, uint8 height, uint8 terrain, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
     registers regs;
 
@@ -816,7 +816,7 @@ static void viewport_surface_draw_water_side_top(enum edge_t edge, uint8 height,
 /**
  * rct2: 0x0065F8B9, 0x0065FE26
  */
-static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 height, uint8 edgeStyle, struct tile_descriptor self, struct tile_descriptor neighbour)
+static void viewport_surface_draw_water_side_bottom(paint_session * session, enum edge_t edge, uint8 height, uint8 edgeStyle, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
     registers regs;
 
@@ -839,7 +839,7 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
             tunnelBounds.x = 32;
             tunnelTopBoundBoxOffset.y = 31;
 
-            tunnelArray = gPaintSession.LeftTunnels;
+            tunnelArray = session->LeftTunnels;
             break;
 
         case EDGE_BOTTOMRIGHT:
@@ -854,7 +854,7 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
             tunnelBounds.y = 32;
             tunnelTopBoundBoxOffset.x = 31;
 
-            tunnelArray = gPaintSession.RightTunnels;
+            tunnelArray = session->RightTunnels;
             break;
 
         default:
@@ -988,12 +988,12 @@ static void viewport_surface_draw_water_side_bottom(enum edge_t edge, uint8 heig
  * @param height (dx)
  * @param map_element (esi)
  */
-void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
+void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element * mapElement)
 {
-    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
-    gPaintSession.DidPassSurface = true;
-    gPaintSession.SurfaceElement = mapElement;
+    rct_drawpixelinfo * dpi = session->Unk140E9A8;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
+    session->DidPassSurface = true;
+    session->SurfaceElement = mapElement;
 
     uint16 zoomLevel = dpi->zoom_level;
 
@@ -1002,8 +1002,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     uint32 surfaceShape = viewport_surface_paint_setup_get_relative_slope(mapElement, rotation);
 
     rct_xy16 base = {
-        .x = gPaintSession.SpritePosition.x,
-        .y = gPaintSession.SpritePosition.y
+        .x = session->SpritePosition.x,
+        .y = session->SpritePosition.y
     };
 
     corner_height ch = corner_heights[surfaceShape];
@@ -1051,7 +1051,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
 
     if ((gCurrentViewportFlags & VIEWPORT_FLAG_LAND_HEIGHTS) && (zoomLevel == 0)) {
-        sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
+        sint16 x = session->MapPosition.x, y = session->MapPosition.y;
 
         sint32 dx = map_element_height(x + 16, y + 16) & 0xFFFF;
         dx += 3;
@@ -1065,7 +1065,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
 
     bool has_surface = false;
-    if (gPaintSession.VerticalTunnelHeight * 16 == height) {
+    if (session->VerticalTunnelHeight * 16 == height) {
         // Vertical tunnels
         sub_98197C(1575, 0, 0, 1, 30, 39, height, -2, 1, height - 40, rotation);
         sub_98197C(1576, 0, 0, 30, 1, 0, height, 1, 31, height, rotation);
@@ -1123,8 +1123,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             case 6:
                 // loc_660C6A
             {
-                sint16 x = gPaintSession.MapPosition.x & 0x20;
-                sint16 y = gPaintSession.MapPosition.y & 0x20;
+                sint16 x = session->MapPosition.x & 0x20;
+                sint16 y = session->MapPosition.y & 0x20;
                 sint32 index = (y | (x << 1)) >> 5;
 
                 if (branch == 6) {
@@ -1141,13 +1141,13 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         has_surface = true;
     }
 
-// Draw Staff Patrol Areas
+    // Draw Staff Patrol Areas
     // loc_660D02
     if (gStaffDrawPatrolAreas != 0xFFFF) {
         sint32 staffIndex = gStaffDrawPatrolAreas;
         bool is_staff_list = staffIndex & 0x8000;
         uint8 staffType = staffIndex & 0x7FFF;
-        sint16 x = gPaintSession.MapPosition.x, y = gPaintSession.MapPosition.y;
+        sint16 x = session->MapPosition.x, y = session->MapPosition.y;
 
         uint32 image_id = IMAGE_TYPE_REMAP;
         uint8 patrolColour = 7;
@@ -1173,7 +1173,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
     if (((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode) &&
         gCurrentViewportFlags & VIEWPORT_FLAG_LAND_OWNERSHIP
     ) {
-        rct_xy16 pos = gPaintSession.MapPosition;
+        rct_xy16 pos = session->MapPosition;
         for (sint32 i = 0; i < MAX_PEEP_SPAWNS; ++i) {
             rct2_peep_spawn * spawn = &gPeepSpawns[i];
 
@@ -1193,11 +1193,11 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(surfaceShape < countof(byte_97B444));
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_SQUARE + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_AVAILABLE) {
-            rct_xy16 pos = gPaintSession.MapPosition;
-            paint_struct * backup = gPaintSession.UnkF1AD28;
+            rct_xy16 pos = session->MapPosition;
+            paint_struct * backup = session->UnkF1AD28;
             sint32 height2 = (map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF) + 3;
             sub_98196C(SPR_LAND_OWNERSHIP_AVAILABLE, 16, 16, 1, 1, 0, height2, rotation);
-            gPaintSession.UnkF1AD28 = backup;
+            session->UnkF1AD28 = backup;
         }
     }
 
@@ -1207,11 +1207,11 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(surfaceShape < countof(byte_97B444));
             paint_attach_to_previous_ps(SPR_TERRAIN_SELECTION_DOTTED + byte_97B444[surfaceShape], 0, 0);
         } else if (mapElement->properties.surface.ownership & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) {
-            paint_struct * backup = gPaintSession.UnkF1AD28;
-            rct_xy16 pos = gPaintSession.MapPosition;
+            paint_struct * backup = session->UnkF1AD28;
+            rct_xy16 pos = session->MapPosition;
             sint32 height2 = map_element_height(pos.x + 16, pos.y + 16) & 0xFFFF;
             sub_98196C(SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE, 16, 16, 1, 1, 0, height2 + 3, rotation);
-            gPaintSession.UnkF1AD28 = backup;
+            session->UnkF1AD28 = backup;
         }
     }
 
@@ -1221,7 +1221,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE) {
         // loc_660FB8:
-        rct_xy16 pos = gPaintSession.MapPosition;
+        rct_xy16 pos = session->MapPosition;
         if (pos.x >= gMapSelectPositionA.x &&
             pos.x <= gMapSelectPositionB.x &&
             pos.y >= gMapSelectPositionA.y &&
@@ -1276,15 +1276,15 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 
                 sint32 image_id = (SPR_TERRAIN_SELECTION_CORNER + byte_97B444[local_surfaceShape]) | 0x21300000;
 
-                paint_struct * backup = gPaintSession.UnkF1AD28;
+                paint_struct * backup = session->UnkF1AD28;
                 sub_98196C(image_id, 0, 0, 32, 32, 1, local_height, rotation);
-                gPaintSession.UnkF1AD28 = backup;
+                session->UnkF1AD28 = backup;
             }
         }
     }
 
     if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT) {
-        rct_xy16 pos = gPaintSession.MapPosition;
+        rct_xy16 pos = session->MapPosition;
 
         rct_xy16 * tile;
         for (tile = gMapSelectionTiles; tile->x != -1; tile++) {
@@ -1308,10 +1308,10 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         && !(gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
         && !(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_BASE)
         && gConfigGeneral.landscape_smoothing) {
-        viewport_surface_smoothen_edge(EDGE_TOPLEFT, tileDescriptors[0], tileDescriptors[3]);
-        viewport_surface_smoothen_edge(EDGE_TOPRIGHT, tileDescriptors[0], tileDescriptors[4]);
-        viewport_surface_smoothen_edge(EDGE_BOTTOMLEFT, tileDescriptors[0], tileDescriptors[1]);
-        viewport_surface_smoothen_edge(EDGE_BOTTOMRIGHT, tileDescriptors[0], tileDescriptors[2]);
+        viewport_surface_smoothen_edge(session, EDGE_TOPLEFT, tileDescriptors[0], tileDescriptors[3]);
+        viewport_surface_smoothen_edge(session, EDGE_TOPRIGHT, tileDescriptors[0], tileDescriptors[4]);
+        viewport_surface_smoothen_edge(session, EDGE_BOTTOMLEFT, tileDescriptors[0], tileDescriptors[1]);
+        viewport_surface_smoothen_edge(session, EDGE_BOTTOMRIGHT, tileDescriptors[0], tileDescriptors[2]);
     }
 
 
@@ -1344,42 +1344,42 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
 #ifdef __MINGW32__
         // The other code crashes mingw 4.8.2, as available on Travis
         for (sint32 i = 0; i < TUNNEL_MAX_COUNT; i++) {
-            backupLeftTunnels[i] = gPaintSession.LeftTunnels[i];
-            backupRightTunnels[i] = gPaintSession.RightTunnels[i];
+            backupLeftTunnels[i] = session->LeftTunnels[i];
+            backupRightTunnels[i] = session->RightTunnels[i];
         }
 #else
-        memcpy(backupLeftTunnels, gPaintSession.LeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
-        memcpy(backupRightTunnels, gPaintSession.RightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(backupLeftTunnels, session->LeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(backupRightTunnels, session->RightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
 #endif
 
         viewport_surface_draw_land_side_top(EDGE_TOPLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
         viewport_surface_draw_land_side_top(EDGE_TOPRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[4]);
-        viewport_surface_draw_land_side_bottom(EDGE_BOTTOMLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[1]);
-        viewport_surface_draw_land_side_bottom(EDGE_BOTTOMRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[2]);
+        viewport_surface_draw_land_side_bottom(session, EDGE_BOTTOMLEFT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[1]);
+        viewport_surface_draw_land_side_bottom(session, EDGE_BOTTOMRIGHT, height / 16, eax / 32, tileDescriptors[0], tileDescriptors[2]);
 
 
 #ifdef __MINGW32__
         // The other code crashes mingw 4.8.2, as available on Travis
         for (sint32 i = 0; i < TUNNEL_MAX_COUNT; i++) {
-            gPaintSession.LeftTunnels[i] = backupLeftTunnels[i];
-            gPaintSession.RightTunnels[i] = backupRightTunnels[i];
+            session->LeftTunnels[i] = backupLeftTunnels[i];
+            session->RightTunnels[i] = backupRightTunnels[i];
         }
 #else
-        memcpy(gPaintSession.LeftTunnels, backupLeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
-        memcpy(gPaintSession.RightTunnels, backupRightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(session->LeftTunnels, backupLeftTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
+        memcpy(session->RightTunnels, backupRightTunnels, sizeof(tunnel_entry) * TUNNEL_MAX_COUNT);
 #endif
     }
 
     if (map_get_water_height(mapElement) > 0)
     {
         // loc_6615A9: (water height)
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_WATER;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_WATER;
 
         uint16 localHeight = height + 16;
         uint16 waterHeight = map_get_water_height(mapElement) * 16;
 
         if (!gTrackDesignSaveMode) {
-            gPaintSession.Unk141E9DC = waterHeight;
+            session->Unk141E9DC = waterHeight;
 
             sint32 image_offset = 0;
             if (waterHeight <= localHeight) {
@@ -1399,10 +1399,10 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
             assert(eax % 32 == 0);
             // end new code
 
-            viewport_surface_draw_water_side_top(EDGE_TOPLEFT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
-            viewport_surface_draw_water_side_top(EDGE_TOPRIGHT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[4]);
-            viewport_surface_draw_water_side_bottom(EDGE_BOTTOMLEFT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[1]);
-            viewport_surface_draw_water_side_bottom(EDGE_BOTTOMRIGHT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[2]);
+            viewport_surface_draw_water_side_top(session, EDGE_TOPLEFT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[3]);
+            viewport_surface_draw_water_side_top(session, EDGE_TOPRIGHT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[4]);
+            viewport_surface_draw_water_side_bottom(session, EDGE_BOTTOMLEFT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[1]);
+            viewport_surface_draw_water_side_bottom(session, EDGE_BOTTOMRIGHT, waterHeight / 16, eax / 32, tileDescriptors[0], tileDescriptors[2]);
         }
     }
 
@@ -1410,7 +1410,7 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         !gTrackDesignSaveMode
     ) {
         // Owned land boundary fences
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_PARK;
 
         registers regs = { 0 };
         regs.al = mapElement->properties.surface.ownership & 0x0F;
@@ -1530,8 +1530,8 @@ void surface_paint(uint8 direction, uint16 height, rct_map_element * mapElement)
         }
     }
 
-    gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
-    gPaintSession.Unk141E9DB |= G141E9DB_FLAG_1;
+    session->InteractionType = VIEWPORT_INTERACTION_ITEM_TERRAIN;
+    session->Unk141E9DB |= G141E9DB_FLAG_1;
 
     switch (surfaceShape) {
         default:

--- a/src/openrct2/paint/paint.c
+++ b/src/openrct2/paint/paint.c
@@ -660,15 +660,15 @@ void paint_session_generate(paint_session * session)
 
         for (; num_vertical_quadrants > 0; --num_vertical_quadrants){
             map_element_paint_setup(session, mapTile.x, mapTile.y);
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
-            sprite_paint_setup(mapTile.x - 32, mapTile.y + 32);
+            sprite_paint_setup(session, mapTile.x - 32, mapTile.y + 32);
 
             map_element_paint_setup(session, mapTile.x, mapTile.y + 32);
-            sprite_paint_setup(mapTile.x, mapTile.y + 32);
+            sprite_paint_setup(session, mapTile.x, mapTile.y + 32);
 
             mapTile.x += 32;
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
             mapTile.y += 32;
         }
@@ -682,15 +682,15 @@ void paint_session_generate(paint_session * session)
 
         for (; num_vertical_quadrants > 0; --num_vertical_quadrants){
             map_element_paint_setup(session, mapTile.x, mapTile.y);
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
-            sprite_paint_setup(mapTile.x - 32, mapTile.y - 32);
+            sprite_paint_setup(session, mapTile.x - 32, mapTile.y - 32);
 
             map_element_paint_setup(session, mapTile.x - 32, mapTile.y);
-            sprite_paint_setup(mapTile.x - 32, mapTile.y);
+            sprite_paint_setup(session, mapTile.x - 32, mapTile.y);
 
             mapTile.y += 32;
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
             mapTile.x -= 32;
         }
@@ -704,16 +704,16 @@ void paint_session_generate(paint_session * session)
 
         for (; num_vertical_quadrants > 0; --num_vertical_quadrants){
             map_element_paint_setup(session, mapTile.x, mapTile.y);
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
-            sprite_paint_setup(mapTile.x + 32, mapTile.y - 32);
+            sprite_paint_setup(session, mapTile.x + 32, mapTile.y - 32);
 
             map_element_paint_setup(session, mapTile.x, mapTile.y - 32);
-            sprite_paint_setup(mapTile.x, mapTile.y - 32);
+            sprite_paint_setup(session, mapTile.x, mapTile.y - 32);
 
             mapTile.x -= 32;
 
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
             mapTile.y -= 32;
         }
@@ -727,16 +727,16 @@ void paint_session_generate(paint_session * session)
 
         for (; num_vertical_quadrants > 0; --num_vertical_quadrants){
             map_element_paint_setup(session, mapTile.x, mapTile.y);
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
-            sprite_paint_setup(mapTile.x + 32, mapTile.y + 32);
+            sprite_paint_setup(session, mapTile.x + 32, mapTile.y + 32);
 
             map_element_paint_setup(session, mapTile.x + 32, mapTile.y);
-            sprite_paint_setup(mapTile.x + 32, mapTile.y);
+            sprite_paint_setup(session, mapTile.x + 32, mapTile.y);
 
             mapTile.y -= 32;
 
-            sprite_paint_setup(mapTile.x, mapTile.y);
+            sprite_paint_setup(session, mapTile.x, mapTile.y);
 
             mapTile.x += 32;
         }

--- a/src/openrct2/paint/paint.c
+++ b/src/openrct2/paint/paint.c
@@ -520,12 +520,10 @@ paint_struct * sub_98199C(
  * @param y (cx)
  * @return (!CF) success
  */
-bool paint_attach_to_previous_attach(uint32 image_id, uint16 x, uint16 y)
+bool paint_attach_to_previous_attach(paint_session * session, uint32 image_id, uint16 x, uint16 y)
 {
-    paint_session * session = &gPaintSession;
-
     if (session->UnkF1AD2C == NULL) {
-        return paint_attach_to_previous_ps(image_id, x, y);
+        return paint_attach_to_previous_ps(session, image_id, x, y);
     }
 
     if (session->NextFreePaintStruct >= session->EndOfPaintStructArray) {
@@ -557,10 +555,8 @@ bool paint_attach_to_previous_attach(uint32 image_id, uint16 x, uint16 y)
  * @param y (cx)
  * @return (!CF) success
  */
-bool paint_attach_to_previous_ps(uint32 image_id, uint16 x, uint16 y)
+bool paint_attach_to_previous_ps(paint_session * session, uint32 image_id, uint16 x, uint16 y)
 {
-    paint_session * session = &gPaintSession;
-
     if (session->NextFreePaintStruct >= session->EndOfPaintStructArray) {
         return false;
     }
@@ -598,10 +594,8 @@ bool paint_attach_to_previous_ps(uint32 image_id, uint16 x, uint16 y)
  * @param y_offsets (di)
  * @param rotation (ebp)
  */
-void paint_floating_money_effect(money32 amount, rct_string_id string_id, sint16 y, sint16 z, sint8 y_offsets[], sint16 offset_x, uint32 rotation)
+void paint_floating_money_effect(paint_session * session, money32 amount, rct_string_id string_id, sint16 y, sint16 z, sint8 y_offsets[], sint16 offset_x, uint32 rotation)
 {
-    paint_session * session = &gPaintSession;
-
     if (session->NextFreePaintStruct >= session->EndOfPaintStructArray) {
         return;
     }

--- a/src/openrct2/paint/paint.h
+++ b/src/openrct2/paint/paint.h
@@ -222,9 +222,9 @@ paint_struct * sub_98199C_rotated(uint8 direction, uint32 image_id, sint8 x_offs
 
 void paint_util_push_tunnel_rotated(uint8 direction, uint16 height, uint8 type);
 
-bool paint_attach_to_previous_attach(uint32 image_id, uint16 x, uint16 y);
-bool paint_attach_to_previous_ps(uint32 image_id, uint16 x, uint16 y);
-void paint_floating_money_effect(money32 amount, rct_string_id string_id, sint16 y, sint16 z, sint8 y_offsets[], sint16 offset_x, uint32 rotation);
+bool paint_attach_to_previous_attach(paint_session * session, uint32 image_id, uint16 x, uint16 y);
+bool paint_attach_to_previous_ps(paint_session * session, uint32 image_id, uint16 x, uint16 y);
+void paint_floating_money_effect(paint_session * session, money32 amount, rct_string_id string_id, sint16 y, sint16 z, sint8 y_offsets[], sint16 offset_x, uint32 rotation);
 
 paint_session * paint_session_alloc(rct_drawpixelinfo * dpi);
 void paint_session_free(paint_session *);

--- a/src/openrct2/paint/sprite/litter.c
+++ b/src/openrct2/paint/sprite/litter.c
@@ -70,11 +70,11 @@ static const litter_sprite litter_sprites[] = {
  * Litter Paint Setup
  *  rct2: 0x006736FC
  */
-void litter_paint(rct_litter *litter, sint32 imageDirection)
+void litter_paint(paint_session * session, rct_litter *litter, sint32 imageDirection)
 {
     rct_drawpixelinfo *dpi;
 
-    dpi = gPaintSession.Unk140E9A8;
+    dpi = session->Unk140E9A8;
     if (dpi->zoom_level != 0) return; // If zoomed at all no litter drawn
 
     // litter has no sprite direction so remove that

--- a/src/openrct2/paint/sprite/misc.c
+++ b/src/openrct2/paint/sprite/misc.c
@@ -58,7 +58,7 @@ void misc_paint(paint_session * session, rct_sprite *misc, sint32 imageDirection
             rct_money_effect * moneyEffect = &misc->money_effect;
             money32 value;
             rct_string_id stringId = money_effect_get_string_id(moneyEffect, &value);
-            paint_floating_money_effect(value, stringId, moneyEffect->y, moneyEffect->z, (sint8 *) &money_wave[moneyEffect->wiggle % 22], moneyEffect->offset_x, get_current_rotation());
+            paint_floating_money_effect(session, value, stringId, moneyEffect->y, moneyEffect->z, (sint8 *) &money_wave[moneyEffect->wiggle % 22], moneyEffect->offset_x, get_current_rotation());
             break;
         }
 

--- a/src/openrct2/paint/sprite/misc.c
+++ b/src/openrct2/paint/sprite/misc.c
@@ -37,9 +37,9 @@ extern const uint8 * DuckAnimations[];
 /**
  * rct2: 0x00672AC9
  */
-void misc_paint(rct_sprite *misc, sint32 imageDirection)
+void misc_paint(paint_session * session, rct_sprite *misc, sint32 imageDirection)
 {
-    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo * dpi = session->Unk140E9A8;
 
     switch (misc->steam_particle.misc_identifier) {
         case SPRITE_MISC_STEAM_PARTICLE: // 0

--- a/src/openrct2/paint/sprite/peep.c
+++ b/src/openrct2/paint/sprite/peep.c
@@ -26,7 +26,7 @@
  *
  *  rct2: 0x0068F0FB
  */
-void peep_paint(rct_peep * peep, sint32 imageDirection)
+void peep_paint(paint_session * session, rct_peep * peep, sint32 imageDirection)
 {
 #ifdef __ENABLE_LIGHTFX__
     if (gConfigGeneral.enable_light_fx) {
@@ -59,7 +59,7 @@ void peep_paint(rct_peep * peep, sint32 imageDirection)
     }
 #endif
 
-    rct_drawpixelinfo * dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo * dpi = session->Unk140E9A8;
     if (dpi->zoom_level > 2) {
         return;
     }

--- a/src/openrct2/paint/sprite/sprite.c
+++ b/src/openrct2/paint/sprite/sprite.c
@@ -26,7 +26,8 @@
  * Paint Quadrant
  *  rct2: 0x0069E8B0
  */
-void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
+void sprite_paint_setup(paint_session * session, const uint16 eax, const uint16 ecx)
+{
     rct_drawpixelinfo* dpi;
 
     if ((eax & 0xe000) | (ecx & 0xe000)) return;
@@ -38,7 +39,7 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
 
     if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES) return;
 
-    dpi = gPaintSession.Unk140E9A8;
+    dpi = session->Unk140E9A8;
     if (dpi->zoom_level > 2) return;
 
 
@@ -51,7 +52,7 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
         // height of the slope element, and consequently clipped.
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (spr->unknown.z > (gClipHeight * 8) )) continue;
 
-        dpi = gPaintSession.Unk140E9A8;
+        dpi = session->Unk140E9A8;
 
         if (dpi->y + dpi->height <= spr->unknown.sprite_top) continue;
         if (spr->unknown.sprite_bottom <= dpi->y)continue;
@@ -63,23 +64,23 @@ void sprite_paint_setup(const uint16 eax, const uint16 ecx) {
         image_direction += spr->unknown.sprite_direction;
         image_direction &= 0x1F;
 
-        gPaintSession.CurrentlyDrawnItem = spr;
-        gPaintSession.SpritePosition.x = spr->unknown.x;
-        gPaintSession.SpritePosition.y = spr->unknown.y;
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
+        session->CurrentlyDrawnItem = spr;
+        session->SpritePosition.x = spr->unknown.x;
+        session->SpritePosition.y = spr->unknown.y;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
 
         switch (spr->unknown.sprite_identifier) {
         case SPRITE_IDENTIFIER_VEHICLE:
-            vehicle_paint((rct_vehicle*)spr, image_direction);
+            vehicle_paint(session, (rct_vehicle*)spr, image_direction);
             break;
         case SPRITE_IDENTIFIER_PEEP:
-            peep_paint((rct_peep*)spr, image_direction);
+            peep_paint(session, (rct_peep*)spr, image_direction);
             break;
         case SPRITE_IDENTIFIER_MISC:
-            misc_paint(spr, image_direction);
+            misc_paint(session, spr, image_direction);
             break;
         case SPRITE_IDENTIFIER_LITTER:
-            litter_paint((rct_litter*)spr, image_direction);
+            litter_paint(session, (rct_litter*)spr, image_direction);
             break;
         default:
             assert(false);

--- a/src/openrct2/paint/sprite/sprite.h
+++ b/src/openrct2/paint/sprite/sprite.h
@@ -20,10 +20,12 @@
 #include "../../common.h"
 #include "../../world/sprite.h"
 
-void sprite_paint_setup(const uint16 eax, const uint16 ecx);
+typedef struct paint_session paint_session;
 
-void misc_paint(rct_sprite *misc, sint32 imageDirection);
-void litter_paint(rct_litter *litter, sint32 imageDirection);
-void peep_paint(rct_peep *peep, sint32 imageDirection);
+void sprite_paint_setup(paint_session * session, const uint16 eax, const uint16 ecx);
+
+void misc_paint(paint_session * session, rct_sprite *misc, sint32 imageDirection);
+void litter_paint(paint_session * session, rct_litter *litter, sint32 imageDirection);
+void peep_paint(paint_session * session, rct_peep *peep, sint32 imageDirection);
 
 #endif

--- a/src/openrct2/ride/coaster/reverser_roller_coaster.c
+++ b/src/openrct2/ride/coaster/reverser_roller_coaster.c
@@ -32,16 +32,16 @@
  *
  *  rct2: 0x006D4453
  */
-void vehicle_visual_reverser(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_reverser(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     rct_vehicle *v1 = GET_VEHICLE(vehicle->prev_vehicle_on_ride);
     rct_vehicle *v2 = GET_VEHICLE(vehicle->next_vehicle_on_ride);
     x = (v1->x + v2->x) / 2;
     y = (v1->y + v2->y) / 2;
     z = (v1->z + v2->z) / 2;
-    gPaintSession.SpritePosition.x = x;
-    gPaintSession.SpritePosition.y = y;
-    vehicle_visual_default(x, imageDirection, y, z, vehicle, vehicleEntry);
+    session->SpritePosition.x = x;
+    session->SpritePosition.y = y;
+    vehicle_visual_default(session, x, imageDirection, y, z, vehicle, vehicleEntry);
 }
 #endif
 

--- a/src/openrct2/ride/coaster/virginia_reel.c
+++ b/src/openrct2/ride/coaster/virginia_reel.c
@@ -175,7 +175,7 @@ static const uint32 virginia_reel_track_pieces_flat_quarter_turn_1_tile[4] = {
  *
  *  rct2: 0x006D5B48
  */
-void vehicle_visual_virginia_reel(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_virginia_reel(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 image_id;
     sint32 baseImage_id = imageDirection;
@@ -212,7 +212,7 @@ void vehicle_visual_virginia_reel(sint32 x, sint32 imageDirection, sint32 y, sin
     image_id = baseImage_id | SPRITE_ID_PALETTE_COLOUR_2(vehicle->colours.body_colour, vehicle->colours.trim_colour);
     sub_98197C(image_id, 0, 0, bb->length_x, bb->length_y, bb->length_z, z, bb->offset_x, bb->offset_y, bb->offset_z + z, rotation);
 
-    if (gPaintSession.Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
+    if (session->Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
         uint8 riding_peep_sprites[4] = {0xFF, 0xFF, 0xFF, 0xFF};
         for (sint32 i = 0; i < vehicle->num_peeps; i++) {
             riding_peep_sprites[((ecx / 8) + i) & 3] = vehicle->peep_tshirt_colours[i];

--- a/src/openrct2/ride/gentle/dodgems.c
+++ b/src/openrct2/ride/gentle/dodgems.c
@@ -43,7 +43,7 @@ static void paint_dodgems_roof(sint32 height, sint32 offset)
     sub_98196C(image_id, 0, 0, 32, 32, 2, height, get_current_rotation());
 
     image_id = (SPR_DODGEMS_ROOF_GLASS + offset) | (PALETTE_DARKEN_3 << 19) | IMAGE_TYPE_TRANSPARENT;
-    paint_attach_to_previous_ps(image_id, 0, 0);
+    paint_attach_to_previous_ps(&gPaintSession, image_id, 0, 0);
 }
 
 static void paint_dodgems(uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height, rct_map_element * mapElement)

--- a/src/openrct2/ride/gentle/mini_golf.c
+++ b/src/openrct2/ride/gentle/mini_golf.c
@@ -1022,13 +1022,13 @@ TRACK_PAINT_FUNCTION get_track_paint_function_mini_golf(sint32 trackType, sint32
 /**
  * rct2: 0x006D42F0
  */
-void vehicle_visual_mini_golf_player(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle)
+void vehicle_visual_mini_golf_player(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle)
 {
     if (vehicle->num_peeps == 0) {
         return;
     }
 
-    rct_drawpixelinfo *edi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo *edi = session->Unk140E9A8;
     if (edi->zoom_level >= 2) {
         return;
     }
@@ -1051,13 +1051,13 @@ void vehicle_visual_mini_golf_player(sint32 x, sint32 imageDirection, sint32 y, 
 /**
  * rct2: 0x006D43C6
  */
-void vehicle_visual_mini_golf_ball(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle)
+void vehicle_visual_mini_golf_ball(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle)
 {
     if (vehicle->mini_golf_current_animation != 1) {
         return;
     }
 
-    rct_drawpixelinfo *edi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo *edi = session->Unk140E9A8;
     if (edi->zoom_level >= 1) {
         return;
     }

--- a/src/openrct2/ride/gentle/observation_tower.c
+++ b/src/openrct2/ride/gentle/observation_tower.c
@@ -34,7 +34,7 @@ enum
  *
  *  rct2: 0x006D6258
  */
-void vehicle_visual_observation_tower(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_observation_tower(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 image_id;
     sint32 baseImage_id = (vehicle->restraints_position / 64);

--- a/src/openrct2/ride/thrill/launched_freefall.c
+++ b/src/openrct2/ride/thrill/launched_freefall.c
@@ -42,7 +42,7 @@ static const uint32 launched_freefall_fence_sprites[] = {
  *
  *  rct2: 0x006D5FAB
  */
-void vehicle_visual_launched_freefall(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_launched_freefall(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 image_id;
     sint32 baseImage_id = vehicleEntry->base_image_id + ((vehicle->restraints_position / 64) * 2);
@@ -57,7 +57,7 @@ void vehicle_visual_launched_freefall(sint32 x, sint32 imageDirection, sint32 y,
     sub_98197C(image_id, 0, 0, 16, 16, 41, z, -5, -5, z + 1, rotation);
 
     // Draw peeps:
-    if (gPaintSession.Unk140E9A8->zoom_level < 2) {
+    if (session->Unk140E9A8->zoom_level < 2) {
         if (vehicle->num_peeps > 0) {
             baseImage_id = vehicleEntry->base_image_id + 9;
             if ((vehicle->restraints_position / 64) == 3) {

--- a/src/openrct2/ride/thrill/roto_drop.c
+++ b/src/openrct2/ride/thrill/roto_drop.c
@@ -36,7 +36,7 @@ enum
  *
  *  rct2: 0x006D5DA9
  */
-void vehicle_visual_roto_drop(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_roto_drop(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 image_id;
     sint32 baseImage_id = (vehicleEntry->base_image_id + 4) + ((vehicle->var_C5 / 4) & 0x3);

--- a/src/openrct2/ride/track_paint.c
+++ b/src/openrct2/ride/track_paint.c
@@ -1733,7 +1733,7 @@ void track_paint_util_left_corkscrew_up_supports(uint8 direction, uint16 height)
  *
  *  rct2: 0x006C4794
  */
-void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
+void track_paint(paint_session * session, uint8 direction, sint32 height, rct_map_element *mapElement)
 {
     sint32 rideIndex = mapElement->properties.track.ride_index;
     rct_ride *ride = get_ride(rideIndex);
@@ -1749,7 +1749,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         ride->entrance_style = RIDE_ENTRANCE_STYLE_PLAIN;
     }
 
-    rct_drawpixelinfo *dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo *dpi = session->Unk140E9A8;
 
     if (!gTrackDesignSaveMode || rideIndex == gTrackDesignSaveRideIndex) {
         sint32 trackType = mapElement->properties.track.type;
@@ -1757,7 +1757,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         sint32 trackColourScheme = mapElement->properties.track.colour & 3;
 
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_TRACK_HEIGHTS) && dpi->zoom_level == 0) {
-            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             if (TrackHeightMarkerPositions[trackType] & (1 << trackSequence)) {
                 uint16 ax = RideData5[ride->type].z_offset;
                 uint32 ebx = 0x20381689 + (height + 8) / 16;
@@ -1767,7 +1767,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
             }
         }
 
-        gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
+        session->InteractionType = VIEWPORT_INTERACTION_ITEM_RIDE;
         gTrackColours[SCHEME_TRACK] = SPRITE_ID_PALETTE_COLOUR_2(ride->track_colour_main[trackColourScheme], ride->track_colour_additional[trackColourScheme]);
         gTrackColours[SCHEME_SUPPORTS] = SPRITE_ID_PALETTE_COLOUR_1(ride->track_colour_supports[trackColourScheme]);
         gTrackColours[SCHEME_MISC] = IMAGE_TYPE_REMAP;
@@ -1780,7 +1780,7 @@ void track_paint(uint8 direction, sint32 height, rct_map_element *mapElement)
         }
         if (mapElement->flags & MAP_ELEMENT_FLAG_GHOST) {
             uint32 ghost_id = construction_markers[gConfigGeneral.construction_marker_colour];
-            gPaintSession.InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+            session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             gTrackColours[SCHEME_TRACK] = ghost_id;
             gTrackColours[SCHEME_SUPPORTS] = ghost_id;
             gTrackColours[SCHEME_MISC] = ghost_id;

--- a/src/openrct2/ride/vehicle_paint.c
+++ b/src/openrct2/ride/vehicle_paint.c
@@ -925,13 +925,13 @@ static void vehicle_sprite_paint(paint_session * session, rct_vehicle *vehicle, 
 }
 
 // 6D520E
-static void vehicle_sprite_paint_6D520E(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_paint_6D520E(paint_session * session, rct_vehicle *vehicle, sint32 ebx, sint32 ecx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicle_sprite_paint(&gPaintSession, vehicle, ebx + vehicle->var_4A, ecx, z, vehicleEntry);
 }
 
 // 6D51EB
-static void vehicle_sprite_paint_6D51EB(rct_vehicle *vehicle, sint32 ebx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_paint_6D51EB(paint_session * session, rct_vehicle *vehicle, sint32 ebx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 ecx = ebx / 2;
     if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_11) {
@@ -945,18 +945,18 @@ static void vehicle_sprite_paint_6D51EB(rct_vehicle *vehicle, sint32 ebx, sint32
 }
 
 // 6D51DE
-static void vehicle_sprite_paint_6D51DE(rct_vehicle *vehicle, sint32 ebx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_paint_6D51DE(paint_session * session, rct_vehicle *vehicle, sint32 ebx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->restraints_position < 64) {
-        vehicle_sprite_paint_6D51EB(vehicle, ebx, z, vehicleEntry);
+        vehicle_sprite_paint_6D51EB(session, vehicle, ebx, z, vehicleEntry);
         return;
     }
     if (!(vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION)) {
-        vehicle_sprite_paint_6D51EB(vehicle, ebx, z, vehicleEntry);
+        vehicle_sprite_paint_6D51EB(session, vehicle, ebx, z, vehicleEntry);
         return;
     }
     if (ebx & 7) {
-        vehicle_sprite_paint_6D51EB(vehicle, ebx, z, vehicleEntry);
+        vehicle_sprite_paint_6D51EB(session, vehicle, ebx, z, vehicleEntry);
         return;
     }
     sint32 ecx = ebx / 2;
@@ -968,61 +968,61 @@ static void vehicle_sprite_paint_6D51DE(rct_vehicle *vehicle, sint32 ebx, sint32
 }
 
 // 6D51DE
-static void vehicle_sprite_0_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
-    vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+    vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
 }
 
 // 6D4EE7
-static void vehicle_sprite_0_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 4) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F34
-static void vehicle_sprite_0_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = (imageDirection / 2) + 108;
         sint32 ebx = ((imageDirection + 16) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F0C
-static void vehicle_sprite_0_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 4) + 8) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F5C
-static void vehicle_sprite_0_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 108;
         sint32 ebx = ((imageDirection + 48) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F84
-static void vehicle_sprite_0_5(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_5(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1030,14 +1030,14 @@ static void vehicle_sprite_0_5(rct_vehicle *vehicle, sint32 imageDirection, sint
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = (imageDirection / 8) + 124;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4FE4
-static void vehicle_sprite_0_6(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_6(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1045,14 +1045,14 @@ static void vehicle_sprite_0_6(rct_vehicle *vehicle, sint32 imageDirection, sint
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = (imageDirection / 8) + 128;
         sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D5055
-static void vehicle_sprite_0_7(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_7(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1060,14 +1060,14 @@ static void vehicle_sprite_0_7(rct_vehicle *vehicle, sint32 imageDirection, sint
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = (imageDirection / 8) + 132;
         sint32 ebx = (((imageDirection / 8) + 16) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D50C6
-static void vehicle_sprite_0_8(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_8(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1075,14 +1075,14 @@ static void vehicle_sprite_0_8(rct_vehicle *vehicle, sint32 imageDirection, sint
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = (imageDirection / 8) + 136;
         sint32 ebx = (((imageDirection / 8) + 24) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D5137
-static void vehicle_sprite_0_9(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_9(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1090,14 +1090,14 @@ static void vehicle_sprite_0_9(rct_vehicle *vehicle, sint32 imageDirection, sint
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = (imageDirection / 8) + 140;
         sint32 ebx = (((imageDirection / 8) + 32) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4FB1
-static void vehicle_sprite_0_10(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_10(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1105,14 +1105,14 @@ static void vehicle_sprite_0_10(rct_vehicle *vehicle, sint32 imageDirection, sin
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 124;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D501B
-static void vehicle_sprite_0_11(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_11(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1120,14 +1120,14 @@ static void vehicle_sprite_0_11(rct_vehicle *vehicle, sint32 imageDirection, sin
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 128;
         sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D508C
-static void vehicle_sprite_0_12(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_12(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1135,14 +1135,14 @@ static void vehicle_sprite_0_12(rct_vehicle *vehicle, sint32 imageDirection, sin
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 132;
         sint32 ebx = (((imageDirection / 8) + 20) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D50FD
-static void vehicle_sprite_0_13(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_13(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1150,14 +1150,14 @@ static void vehicle_sprite_0_13(rct_vehicle *vehicle, sint32 imageDirection, sin
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 136;
         sint32 ebx = (((imageDirection / 8) + 28) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D516E
-static void vehicle_sprite_0_14(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_14(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1165,630 +1165,630 @@ static void vehicle_sprite_0_14(rct_vehicle *vehicle, sint32 imageDirection, sin
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_INLINE_TWISTS) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 140;
         sint32 ebx = (((imageDirection / 8) + 36) * vehicleEntry->var_16) + vehicleEntry->var_34;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4EE4
-static void vehicle_sprite_0_16(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_16(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 4) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F31
-static void vehicle_sprite_0_17(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_17(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = (imageDirection / 2) + 108;
         sint32 ebx = ((imageDirection + 16) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F09
-static void vehicle_sprite_0_18(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_18(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 4) + 8) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4F59
-static void vehicle_sprite_0_19(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0_19(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_BANKED) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 108;
         sint32 ebx = ((imageDirection + 48) * vehicleEntry->var_16) + vehicleEntry->var_30;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D51D7
-static void vehicle_sprite_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3DE4:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_0_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_0_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_0_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_0_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_0_4(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_0_5(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_0_6(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_0_7(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_0_8(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_0_9(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_0_10(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_0_11(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_0_12(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_0_13(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_0_14(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_0_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_0_16(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_0_17(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_0_18(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_0_19(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_0_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_0_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_0_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_0_5(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_0_6(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_0_7(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_0_8(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_0_9(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_0_10(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_0_11(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_0_12(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_0_13(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_0_14(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_0_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_0_16(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_0_17(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_0_18(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_0_19(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D4614
-static void vehicle_sprite_1_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPES) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_20;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4662
-static void vehicle_sprite_1_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (imageDirection * vehicleEntry->var_16) + vehicleEntry->var_38;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D46DB
-static void vehicle_sprite_1_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_48;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_1_1(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_1_1(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D467D
-static void vehicle_sprite_1_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection + 32) * vehicleEntry->var_16) + vehicleEntry->var_38;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D46FD
-static void vehicle_sprite_1_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_48;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_1_3(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_1_3(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D460D
-static void vehicle_sprite_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3C04:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_1_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_1_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_1_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_1_4(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_1_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_1_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_1_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_1_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_1_4(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_1_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_1_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_1_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_1_4(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_1_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_1_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_1_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_1_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_1_4(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D4791
-static void vehicle_sprite_2_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPES) {
         if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_14) {
             sint32 ecx = (imageDirection / 2) + 16;
             sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_20;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             sint32 ecx = (imageDirection / 2) + 16;
             sint32 ebx = ((imageDirection + 8) * vehicleEntry->var_16) + vehicleEntry->var_20;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4833
-static void vehicle_sprite_2_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = (imageDirection / 2) + 16;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_40;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D48D6
-static void vehicle_sprite_2_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS) {
         sint32 ecx = imageDirection / 2;
         if (vehicleEntry->draw_order < 5) {
             ecx += 108;
             sint32 ebx = (imageDirection * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             ecx += 16;
             sint32 ebx = (imageDirection * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4858
-static void vehicle_sprite_2_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = (imageDirection / 2) + 16;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_40;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4910
-static void vehicle_sprite_2_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS) {
         sint32 ecx = imageDirection / 2;
         if (vehicleEntry->draw_order < 5) {
             ecx = (ecx ^ 8) + 108;
             sint32 ebx = ((imageDirection + 32) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             ecx += 16;
             sint32 ebx = ((imageDirection + 32) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D476C
-static void vehicle_sprite_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3CA4:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_2_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_2_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_2_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_2_4(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_2_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_2_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_2_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_2_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_2_4(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_2_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_2_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_2_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_2_4(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_2_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_2_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_2_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_2_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_2_4(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D49DC
-static void vehicle_sprite_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (!(vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES)) {
-        vehicle_sprite_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2(session, vehicle, imageDirection, z, vehicleEntry);
     } else {
         sint32 ecx = (imageDirection / 4) + 32;
         sint32 ebx = ((imageDirection / 4) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     }
 }
 
 // 6D4A31
-static void vehicle_sprite_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (!(vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES)) {
-        vehicle_sprite_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2(session, vehicle, imageDirection, z, vehicleEntry);
     } else {
         sint32 ecx = (imageDirection / 2) + 40;
         sint32 ebx = ((imageDirection + 16) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     }
 }
 
 // 6D463D
-static void vehicle_sprite_5_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPES) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_20;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D469B
-static void vehicle_sprite_5_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection + 64) * vehicleEntry->var_16) + vehicleEntry->var_38;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4722
-static void vehicle_sprite_5_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_48;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_5_1(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_5_1(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D46B9
-static void vehicle_sprite_5_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection + 96) * vehicleEntry->var_16) + vehicleEntry->var_38;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4747
-static void vehicle_sprite_5_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_48;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_5_3(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_5_3(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4636
-static void vehicle_sprite_5(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_5(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3C54:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_5_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_5_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_5_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_5_4(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_5_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_5_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_5_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_5_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_5_4(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_5_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_5_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_5_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_5_4(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_5_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_5_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_5_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_5_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_5_4(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D47E4
-static void vehicle_sprite_6_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPES) {
         if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_14) {
             sint32 ecx = ((imageDirection / 2) ^ 8) + 16;
             sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_20;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             sint32 ecx = ((imageDirection / 2) ^ 8) + 16;
             sint32 ebx = ((imageDirection + 40) * vehicleEntry->var_16) + vehicleEntry->var_20;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4880
-static void vehicle_sprite_6_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 16;
         sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_40;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4953
-static void vehicle_sprite_6_2(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6_2(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS) {
         sint32 ecx = imageDirection / 2;
         if (vehicleEntry->draw_order < 5) {
             ecx += 108;
             sint32 ebx = ((imageDirection + 64) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             ecx = (ecx ^ 8) + 16;
             sint32 ebx = ((imageDirection + 64) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D48AB
-static void vehicle_sprite_6_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 16;
         sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_40;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4996
-static void vehicle_sprite_6_4(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6_4(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS) {
         sint32 ecx = imageDirection / 2;
         if (vehicleEntry->draw_order < 5) {
             ecx = (ecx ^ 8) + 108;
             sint32 ebx = ((imageDirection + 96) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         } else {
             ecx = (ecx ^ 8) + 16;
             sint32 ebx = ((imageDirection + 96) * vehicleEntry->var_16) + vehicleEntry->var_44;
-            vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+            vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
         }
     } else {
-        vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D47DD
-static void vehicle_sprite_6(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_6(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3CF4:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_6_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_6_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_6_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_6_4(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_6_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_6_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_6_2(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_6_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_6_4(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_6_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_6_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_6_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_6_4(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_6_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_6_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_6_2(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_6_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_6_4(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D4A05
-static void vehicle_sprite_7(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_7(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES) {
         sint32 ecx = ((imageDirection / 4) ^ 4) + 32;
         sint32 ebx = (((imageDirection / 4) + 8) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4A59
-static void vehicle_sprite_8(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_8(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 40;
         sint32 ebx = ((imageDirection + 48) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4A81
-static void vehicle_sprite_9(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_9(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 56;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4AE8
-static void vehicle_sprite_10(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_10(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 2) + 60;
         sint32 ebx = ((imageDirection + 8) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4B57
-static void vehicle_sprite_11(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_11(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 76;
         sint32 ebx = (((imageDirection / 8) + 72) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4BB7
-static void vehicle_sprite_12(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_12(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 80;
         sint32 ebx = (((imageDirection / 8) + 80) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4C17
-static void vehicle_sprite_13(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_13(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 84;
         sint32 ebx = (((imageDirection / 8) + 88) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4C77
-static void vehicle_sprite_14(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_14(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 88;
         sint32 ebx = (((imageDirection / 8) + 96) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4CD7
-static void vehicle_sprite_15(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_15(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 92;
         sint32 ebx = (((imageDirection / 8) + 104) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D37
-static void vehicle_sprite_16(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_16(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 96;
         sint32 ebx = (((imageDirection / 8) + 112) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_4(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_4(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4AA3
-static void vehicle_sprite_17(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_17(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         if( (vehicle->track_type >> 2) != TRACK_ELEM_90_DEG_DOWN_TO_60_DEG_DOWN &&
@@ -1799,14 +1799,14 @@ static void vehicle_sprite_17(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 56;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4B0D
-static void vehicle_sprite_18(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_18(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         if( (vehicle->track_type >> 2) != TRACK_ELEM_90_DEG_DOWN &&
@@ -1818,14 +1818,14 @@ static void vehicle_sprite_18(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 60;
         sint32 ebx = ((imageDirection + 40) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4B80
-static void vehicle_sprite_19(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_19(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1833,14 +1833,14 @@ static void vehicle_sprite_19(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 76;
         sint32 ebx = (((imageDirection / 8) + 76) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4BE0
-static void vehicle_sprite_20(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_20(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1848,14 +1848,14 @@ static void vehicle_sprite_20(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 80;
         sint32 ebx = (((imageDirection / 8) + 84) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4C40
-static void vehicle_sprite_21(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_21(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1863,14 +1863,14 @@ static void vehicle_sprite_21(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 84;
         sint32 ebx = (((imageDirection / 8) + 92) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4CA0
-static void vehicle_sprite_22(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_22(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1878,14 +1878,14 @@ static void vehicle_sprite_22(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 88;
         sint32 ebx = (((imageDirection / 8) + 100) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D00
-static void vehicle_sprite_23(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_23(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1893,14 +1893,14 @@ static void vehicle_sprite_23(rct_vehicle *vehicle, sint32 imageDirection, sint3
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 92;
         sint32 ebx = (((imageDirection / 8) + 108) * vehicleEntry->var_16) + vehicleEntry->var_28;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_8(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_8(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D51A5
-static void vehicle_sprite_24(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_24(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->update_flags & VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES) {
         vehicleEntry--;
@@ -1909,235 +1909,235 @@ static void vehicle_sprite_24(rct_vehicle *vehicle, sint32 imageDirection, sint3
         sint32 eax = ((vehicle->vehicle_sprite_type - 24) * 4);
         sint32 ecx = (imageDirection / 8) + eax + 144;
         sint32 ebx = (((imageDirection / 8) + eax) * vehicleEntry->var_16) + vehicleEntry->var_4C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_paint_6D51DE(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_paint_6D51DE(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D67
-static void vehicle_sprite_50_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_50_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4DB5
-static void vehicle_sprite_50_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_50_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = ((imageDirection / 8) * vehicleEntry->var_16) + vehicleEntry->var_3C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4DD3
-static void vehicle_sprite_50_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_50_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_3C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D60
-static void vehicle_sprite_50(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_50(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3D44:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_50_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_50_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_50_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_50_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_50_0(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_50_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_50_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_50_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_50_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_50_0(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D4E3A
-static void vehicle_sprite_51(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_51(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 100;
         sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4E8F
-static void vehicle_sprite_52(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_52(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = (imageDirection / 8) + 104;
         sint32 ebx = (((imageDirection / 8) + 16) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D90
-static void vehicle_sprite_53_0(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_53_0(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 4) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4DF4
-static void vehicle_sprite_53_1(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_53_1(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 8) * vehicleEntry->var_16) + vehicleEntry->var_3C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4E15
-static void vehicle_sprite_53_3(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_53_3(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS) {
         sint32 ecx = imageDirection / 2;
         sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_3C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4D89
-static void vehicle_sprite_53(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_53(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     // 0x009A3D94:
     switch (vehicle->bank_rotation) {
-        case 0:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 1:  vehicle_sprite_53_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 2:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 3:  vehicle_sprite_53_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 4:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 5:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 6:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 7:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 8:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 9:  vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 10: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 11: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 12: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 13: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 14: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 15: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 16: vehicle_sprite_53_1(vehicle, imageDirection, z, vehicleEntry); break;
-        case 17: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
-        case 18: vehicle_sprite_53_3(vehicle, imageDirection, z, vehicleEntry); break;
-        case 19: vehicle_sprite_53_0(vehicle, imageDirection, z, vehicleEntry); break;
+        case 0:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 1:  vehicle_sprite_53_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 2:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 3:  vehicle_sprite_53_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 4:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 5:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 6:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 7:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 8:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 9:  vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 10: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 11: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 12: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 13: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 14: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 15: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 16: vehicle_sprite_53_1(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 17: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 18: vehicle_sprite_53_3(session, vehicle, imageDirection, z, vehicleEntry); break;
+        case 19: vehicle_sprite_53_0(session, vehicle, imageDirection, z, vehicleEntry); break;
     }
 }
 
 // 6D4E63
-static void vehicle_sprite_54(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_54(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 100;
         sint32 ebx = (((imageDirection / 8) + 12) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4EB8
-static void vehicle_sprite_55(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_55(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES) {
         sint32 ecx = ((imageDirection / 8) ^ 2) + 104;
         sint32 ebx = (((imageDirection / 8) + 20) * vehicleEntry->var_16) + vehicleEntry->var_2C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_0(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_0(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D47DA
-static void vehicle_sprite_56(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_56(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
-    vehicle_sprite_6(vehicle, imageDirection, z, vehicleEntry);
+    vehicle_sprite_6(session, vehicle, imageDirection, z, vehicleEntry);
 }
 
 // 6D4A02
-static void vehicle_sprite_57(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_57(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES) {
         sint32 ecx = ((imageDirection / 4) ^ 4) + 32;
         sint32 ebx = (((imageDirection / 4) + 8) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4A56
-static void vehicle_sprite_58(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_58(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     vehicleEntry--;
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_STEEP_SLOPES) {
         sint32 ecx = ((imageDirection / 2) ^ 8) + 40;
         sint32 ebx = ((imageDirection + 48) * vehicleEntry->var_16) + vehicleEntry->var_24;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_6(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_6(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 6D4773
-static void vehicle_sprite_59(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_59(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_14) {
         sint32 ecx = (imageDirection / 2) + 16;
         sint32 ebx = (imageDirection * vehicleEntry->var_16) + vehicleEntry->var_4C;
-        vehicle_sprite_paint_6D520E(vehicle, ebx, ecx, z, vehicleEntry);
+        vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
     } else {
-        vehicle_sprite_2(vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_2(session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 
 // 0x009A3B14:
-typedef void (*vehicle_sprite_func)(rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry);
+typedef void (*vehicle_sprite_func)(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection, sint32 z, const rct_ride_entry_vehicle *vehicleEntry);
 vehicle_sprite_func vehicle_sprite_funcs[] = {
     vehicle_sprite_0,
     vehicle_sprite_1,
@@ -2325,7 +2325,7 @@ void vehicle_visual_default(paint_session * session, sint32 x, sint32 imageDirec
 {
     assert(vehicle->vehicle_sprite_type < countof(vehicle_sprite_funcs));
     if (vehicle->vehicle_sprite_type < countof(vehicle_sprite_funcs)) {
-        vehicle_sprite_funcs[vehicle->vehicle_sprite_type](vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_funcs[vehicle->vehicle_sprite_type](session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 

--- a/src/openrct2/ride/vehicle_paint.c
+++ b/src/openrct2/ride/vehicle_paint.c
@@ -2333,7 +2333,7 @@ void vehicle_visual_default(sint32 x, sint32 imageDirection, sint32 y, sint32 z,
  *
  *  rct2: 0x006D4244
  */
-void vehicle_paint(rct_vehicle *vehicle, sint32 imageDirection)
+void vehicle_paint(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection)
 {
     rct_ride_entry *rideEntry = 0;
     const rct_ride_entry_vehicle *vehicleEntry;

--- a/src/openrct2/ride/vehicle_paint.c
+++ b/src/openrct2/ride/vehicle_paint.c
@@ -890,7 +890,7 @@ const vehicle_boundbox VehicleBoundboxes[16][224] = {
 };
 
 // 6D5214
-static void vehicle_sprite_paint(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
+static void vehicle_sprite_paint(paint_session * session, rct_vehicle *vehicle, sint32 ebx, sint32 ecx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
 
     sint32 baseImage_id = ebx;
@@ -907,7 +907,7 @@ static void vehicle_sprite_paint(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, s
     if (ps != NULL) {
         ps->tertiary_colour = vehicle->colours_extended;
     }
-    rct_drawpixelinfo* dpi = gPaintSession.Unk140E9A8;
+    rct_drawpixelinfo* dpi = session->Unk140E9A8;
     if (dpi->zoom_level < 2 && vehicle->num_peeps > 0 && vehicleEntry->no_seating_rows > 0) {
         baseImage_id += vehicleEntry->no_vehicle_images;
         for (sint32 i = 0; i < 8; i++){
@@ -921,13 +921,13 @@ static void vehicle_sprite_paint(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, s
             }
         }
     }
-    vehicle_visual_splash_effect(z, vehicle, vehicleEntry);
+    vehicle_visual_splash_effect(session, z, vehicle, vehicleEntry);
 }
 
 // 6D520E
 static void vehicle_sprite_paint_6D520E(rct_vehicle *vehicle, sint32 ebx, sint32 ecx, sint32 z, const rct_ride_entry_vehicle *vehicleEntry)
 {
-    vehicle_sprite_paint(vehicle, ebx + vehicle->var_4A, ecx, z, vehicleEntry);
+    vehicle_sprite_paint(&gPaintSession, vehicle, ebx + vehicle->var_4A, ecx, z, vehicleEntry);
 }
 
 // 6D51EB
@@ -941,7 +941,7 @@ static void vehicle_sprite_paint_6D51EB(rct_vehicle *vehicle, sint32 ebx, sint32
         ebx = ebx / 8;
     }
     ebx = (ebx * vehicleEntry->var_16) + vehicle->var_4A + vehicleEntry->base_image_id;
-    vehicle_sprite_paint(vehicle, ebx, ecx, z, vehicleEntry);
+    vehicle_sprite_paint(&gPaintSession, vehicle, ebx, ecx, z, vehicleEntry);
 }
 
 // 6D51DE
@@ -964,7 +964,7 @@ static void vehicle_sprite_paint_6D51DE(rct_vehicle *vehicle, sint32 ebx, sint32
     ebx += ((vehicle->restraints_position - 64) / 64) * 4;
     ebx *= vehicleEntry->var_16;
     ebx += vehicleEntry->var_1C;
-    vehicle_sprite_paint(vehicle, ebx, ecx, z, vehicleEntry);
+    vehicle_sprite_paint(&gPaintSession, vehicle, ebx, ecx, z, vehicleEntry);
 }
 
 // 6D51DE
@@ -2304,7 +2304,7 @@ static void vehicle_visual_splash5_effect(sint32 z, rct_vehicle *vehicle, const 
     sub_98199C(image_id, 0, 0, 1, 1, 0, z, 0, 0, z, get_current_rotation());
 }
 
-void vehicle_visual_splash_effect(sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_splash_effect(paint_session * session, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     switch (vehicleEntry->effect_visual) {
         case 1: /* nullsub */ break;
@@ -2321,7 +2321,7 @@ void vehicle_visual_splash_effect(sint32 z, rct_vehicle *vehicle, const rct_ride
  *
  *  rct2: 0x006D45F8
  */
-void vehicle_visual_default(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_default(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     assert(vehicle->vehicle_sprite_type < countof(vehicle_sprite_funcs));
     if (vehicle->vehicle_sprite_type < countof(vehicle_sprite_funcs)) {
@@ -2365,16 +2365,16 @@ void vehicle_paint(paint_session * session, rct_vehicle *vehicle, sint32 imageDi
     }
 
     switch (vehicleEntry->car_visual) {
-    case VEHICLE_VISUAL_DEFAULT:                        vehicle_visual_default(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_LAUNCHED_FREEFALL:              vehicle_visual_launched_freefall(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_OBSERVATION_TOWER:              vehicle_visual_observation_tower(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_RIVER_RAPIDS:                   vehicle_visual_river_rapids(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_MINI_GOLF_PLAYER:               vehicle_visual_mini_golf_player(x, imageDirection, y, z, vehicle); break;
-    case VEHICLE_VISUAL_MINI_GOLF_BALL:                 vehicle_visual_mini_golf_ball(x, imageDirection, y, z, vehicle); break;
-    case VEHICLE_VISUAL_REVERSER:                       vehicle_visual_reverser(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_SPLASH_BOATS_OR_WATER_COASTER:  vehicle_visual_splash_boats_or_water_coaster(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_ROTO_DROP:                      vehicle_visual_roto_drop(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_VIRGINIA_REEL:                  vehicle_visual_virginia_reel(x, imageDirection, y, z, vehicle, vehicleEntry); break;
-    case VEHICLE_VISUAL_SUBMARINE:                      vehicle_visual_submarine(x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_DEFAULT:                        vehicle_visual_default(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_LAUNCHED_FREEFALL:              vehicle_visual_launched_freefall(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_OBSERVATION_TOWER:              vehicle_visual_observation_tower(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_RIVER_RAPIDS:                   vehicle_visual_river_rapids(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_MINI_GOLF_PLAYER:               vehicle_visual_mini_golf_player(session, x, imageDirection, y, z, vehicle); break;
+    case VEHICLE_VISUAL_MINI_GOLF_BALL:                 vehicle_visual_mini_golf_ball(session, x, imageDirection, y, z, vehicle); break;
+    case VEHICLE_VISUAL_REVERSER:                       vehicle_visual_reverser(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_SPLASH_BOATS_OR_WATER_COASTER:  vehicle_visual_splash_boats_or_water_coaster(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_ROTO_DROP:                      vehicle_visual_roto_drop(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_VIRGINIA_REEL:                  vehicle_visual_virginia_reel(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
+    case VEHICLE_VISUAL_SUBMARINE:                      vehicle_visual_submarine(session, x, imageDirection, y, z, vehicle, vehicleEntry); break;
     }
 }

--- a/src/openrct2/ride/vehicle_paint.h
+++ b/src/openrct2/ride/vehicle_paint.h
@@ -32,17 +32,17 @@ extern const vehicle_boundbox VehicleBoundboxes[16][224];
 
 void vehicle_paint(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection);
 
-void vehicle_visual_default(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_roto_drop(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_observation_tower(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_river_rapids(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_reverser(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_splash_boats_or_water_coaster(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_launched_freefall(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_splash_effect(sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_virginia_reel(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_submarine(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
-void vehicle_visual_mini_golf_player(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle);
-void vehicle_visual_mini_golf_ball(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle);
+void vehicle_visual_default(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_roto_drop(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_observation_tower(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_river_rapids(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_reverser(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_splash_boats_or_water_coaster(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_launched_freefall(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_splash_effect(paint_session * session, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_virginia_reel(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_submarine(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_mini_golf_player(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle);
+void vehicle_visual_mini_golf_ball(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle);
 
 #endif

--- a/src/openrct2/ride/vehicle_paint.h
+++ b/src/openrct2/ride/vehicle_paint.h
@@ -30,7 +30,7 @@ typedef struct vehicle_boundbox {
 
 extern const vehicle_boundbox VehicleBoundboxes[16][224];
 
-void vehicle_paint(rct_vehicle *vehicle, sint32 imageDirection);
+void vehicle_paint(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection);
 
 void vehicle_visual_default(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
 void vehicle_visual_roto_drop(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);

--- a/src/openrct2/ride/water/river_rapids.c
+++ b/src/openrct2/ride/water/river_rapids.c
@@ -189,7 +189,7 @@ static const uint32 river_rapids_track_pieces_25_deg_down_to_flat[][2] = {
  *
  *  rct2: 0x006D5889
  */
-void vehicle_visual_river_rapids(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_river_rapids(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 image_id;
     sint32 baseImage_id = imageDirection;
@@ -226,7 +226,7 @@ void vehicle_visual_river_rapids(sint32 x, sint32 imageDirection, sint32 y, sint
     image_id = baseImage_id | SPRITE_ID_PALETTE_COLOUR_2(vehicle->colours.body_colour, vehicle->colours.trim_colour);
     sub_98197C(image_id, 0, 0, bb->length_x, bb->length_y, bb->length_z, z, bb->offset_x, bb->offset_y, bb->offset_z + z, rotation);
 
-    if (gPaintSession.Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
+    if (session->Unk140E9A8->zoom_level < 2 && vehicle->num_peeps > 0) {
         // Draw peeps: (this particular vehicle doesn't sort them back to front like others so the back ones sometimes clip, but thats how the original does it...)
         sint32 peeps = ((ecx / 8) + 0) & 3;
         image_id = (baseImage_id + ((peeps + 1) * 72)) | SPRITE_ID_PALETTE_COLOUR_2(vehicle->peep_tshirt_colours[0], vehicle->peep_tshirt_colours[1]) ;
@@ -248,7 +248,7 @@ void vehicle_visual_river_rapids(sint32 x, sint32 imageDirection, sint32 y, sint
         }
     }
 
-    vehicle_visual_splash_effect(z, vehicle, vehicleEntry);
+    vehicle_visual_splash_effect(session, z, vehicle, vehicleEntry);
 }
 #endif
 

--- a/src/openrct2/ride/water/splash_boats.c
+++ b/src/openrct2/ride/water/splash_boats.c
@@ -1048,6 +1048,6 @@ void vehicle_visual_splash_boats_or_water_coaster(sint32 x, sint32 imageDirectio
     imageDirection = ((get_current_rotation() * 8) + vehicle->sprite_direction) & 0x1F;
     gPaintSession.SpritePosition.x = vehicle->x;
     gPaintSession.SpritePosition.y = vehicle->y;
-    vehicle_paint(vehicle, imageDirection);
+    vehicle_paint(&gPaintSession, vehicle, imageDirection);
 }
 #endif

--- a/src/openrct2/ride/water/splash_boats.c
+++ b/src/openrct2/ride/water/splash_boats.c
@@ -1037,17 +1037,17 @@ TRACK_PAINT_FUNCTION get_track_paint_function_splash_boats(sint32 trackType, sin
  *
  *  rct2: 0x006D4295
  */
-void vehicle_visual_splash_boats_or_water_coaster(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_splash_boats_or_water_coaster(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     if (vehicle->is_child) {
         vehicle = GET_VEHICLE(vehicle->prev_vehicle_on_ride);
     } else {
         vehicle = GET_VEHICLE(vehicle->next_vehicle_on_ride);
     }
-    gPaintSession.CurrentlyDrawnItem = vehicle;
+    session->CurrentlyDrawnItem = vehicle;
     imageDirection = ((get_current_rotation() * 8) + vehicle->sprite_direction) & 0x1F;
-    gPaintSession.SpritePosition.x = vehicle->x;
-    gPaintSession.SpritePosition.y = vehicle->y;
-    vehicle_paint(&gPaintSession, vehicle, imageDirection);
+    session->SpritePosition.x = vehicle->x;
+    session->SpritePosition.y = vehicle->y;
+    vehicle_paint(session, vehicle, imageDirection);
 }
 #endif

--- a/src/openrct2/ride/water/submarine_ride.c
+++ b/src/openrct2/ride/water/submarine_ride.c
@@ -27,7 +27,7 @@
  *
  *  rct2: 0x006D44D5
  */
-void vehicle_visual_submarine(sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
+void vehicle_visual_submarine(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry)
 {
     sint32 baseImage_id = imageDirection;
     sint32 image_id;

--- a/src/openrct2/windows/RideConstruction.cpp
+++ b/src/openrct2/windows/RideConstruction.cpp
@@ -2433,7 +2433,7 @@ static void sub_6CBCE2(
         _tempTrackMapElement.properties.track.ride_index = rideIndex;
 
         // Draw this map tile
-        sub_68B2B7(x, y);
+        sub_68B2B7(session, x, y);
 
         // Restore map elements
         map_set_tile_elements(tileX + 0, tileY + 0, _backupMapElementArrays[0]);

--- a/test/testpaint/PaintIntercept.cpp
+++ b/test/testpaint/PaintIntercept.cpp
@@ -385,7 +385,7 @@ paint_struct *sub_98199C(
     );
 }
 
-bool paint_attach_to_previous_ps(uint32 image_id, uint16 x, uint16 y) {
+bool paint_attach_to_previous_ps(paint_session * session, uint32 image_id, uint16 x, uint16 y) {
     return false;
 }
 

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -83,7 +83,7 @@ uint8 gMapSelectArrowDirection;
 void entrance_paint(uint8 direction, int height, rct_map_element *map_element) { }
 void banner_paint(uint8 direction, int height, rct_map_element *map_element) { }
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
-void path_paint(uint8 direction, uint16 height, rct_map_element *mapElement) { }
+void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }
 void fence_paint(uint8 direction, int height, rct_map_element *mapElement) { }
 void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement) { }

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -80,7 +80,7 @@ rct_xy16 gMapSelectPositionB;
 rct_xyz16 gMapSelectArrowPosition;
 uint8 gMapSelectArrowDirection;
 
-void entrance_paint(uint8 direction, int height, rct_map_element *map_element) { }
+void entrance_paint(paint_session * session, uint8 direction, int height, rct_map_element *map_element) { }
 void banner_paint(paint_session * session, uint8 direction, int height, rct_map_element *map_element) { }
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -86,7 +86,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }
 void fence_paint(uint8 direction, int height, rct_map_element *mapElement) { }
-void scenery_multiple_paint(uint8 direction, uint16 height, rct_map_element *mapElement) { }
+void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 
 rct_ride *get_ride(int index) {
     if (index < 0 || index >= MAX_RIDES) {

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -85,7 +85,7 @@ void banner_paint(paint_session * session, uint8 direction, int height, rct_map_
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }
-void fence_paint(uint8 direction, int height, rct_map_element *mapElement) { }
+void fence_paint(paint_session * session, uint8 direction, int height, rct_map_element *mapElement) { }
 void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 
 rct_ride *get_ride(int index) {

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -82,7 +82,7 @@ uint8 gMapSelectArrowDirection;
 
 void entrance_paint(uint8 direction, int height, rct_map_element *map_element) { }
 void banner_paint(uint8 direction, int height, rct_map_element *map_element) { }
-void surface_paint(uint8 direction, uint16 height, rct_map_element *mapElement) { }
+void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void path_paint(uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }
 void fence_paint(uint8 direction, int height, rct_map_element *mapElement) { }

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -84,7 +84,7 @@ void entrance_paint(paint_session * session, uint8 direction, int height, rct_ma
 void banner_paint(paint_session * session, uint8 direction, int height, rct_map_element *map_element) { }
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
-void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }
+void scenery_paint(paint_session * session, uint8 direction, int height, rct_map_element *mapElement) { }
 void fence_paint(paint_session * session, uint8 direction, int height, rct_map_element *mapElement) { }
 void scenery_multiple_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -81,7 +81,7 @@ rct_xyz16 gMapSelectArrowPosition;
 uint8 gMapSelectArrowDirection;
 
 void entrance_paint(uint8 direction, int height, rct_map_element *map_element) { }
-void banner_paint(uint8 direction, int height, rct_map_element *map_element) { }
+void banner_paint(paint_session * session, uint8 direction, int height, rct_map_element *map_element) { }
 void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map_element *mapElement) { }
 void scenery_paint(uint8 direction, int height, rct_map_element *mapElement) { }


### PR DESCRIPTION
Reducing number of `gPaintSession` occurrences and passing `paint_session` by argument instead. Mostly done now apart from the track functions.