### PR TITLE
Remove unused global palette pointer

### DIFF
--- a/src/openrct2/drawing/drawing.c
+++ b/src/openrct2/drawing/drawing.c
@@ -39,7 +39,6 @@ uint32 gPickupPeepImage;
 sint32 gPickupPeepX;
 sint32 gPickupPeepY;
 
-uint8 *gCurrentColourPalette;
 #ifdef NO_RCT2
 rct_drawpixelinfo *unk_140E9A8;
 #endif

--- a/src/openrct2/drawing/drawing.h
+++ b/src/openrct2/drawing/drawing.h
@@ -281,7 +281,6 @@ extern rct_g1_element *g1Elements;
 extern rct_drawpixelinfo gScreenDPI;
 extern rct_drawpixelinfo gWindowDPI;
 
-extern uint8 *gCurrentColourPalette;
 #ifdef NO_RCT2
 extern rct_drawpixelinfo *unk_140E9A8;
 #else

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -437,7 +437,6 @@ static void colour_char(uint8 colour, uint16* current_font_flags, uint8* palette
     palette_pointer[2] = (eax >> 8) & 0xFF;
     palette_pointer[3] = (eax >> 16) & 0xFF;
     palette_pointer[4] = (eax >> 24) & 0xFF;
-    gCurrentColourPalette = palette_pointer;
 }
 
 /**
@@ -458,7 +457,6 @@ static void colour_char_window(uint8 colour, uint16* current_font_flags,uint8* p
     palette_pointer[2] = (eax >> 8) & 0xFF;
     palette_pointer[3] = (eax >> 16) & 0xFF;
     palette_pointer[4] = (eax >> 24) & 0xFF;
-    gCurrentColourPalette = palette_pointer;
 }
 
 /**
@@ -694,7 +692,6 @@ static void ttf_draw_character_sprite(rct_drawpixelinfo *dpi, sint32 codepoint, 
     sint32 sprite = font_sprite_get_codepoint_sprite(info->font_sprite_base, codepoint);
 
     if (!(info->flags & TEXT_DRAW_FLAG_NO_DRAW)) {
-        gCurrentColourPalette = info->palette;
 
         sint32 x = info->x;
         sint32 y = info->y;
@@ -852,9 +849,6 @@ static const utf8 *ttf_process_format_code(rct_drawpixelinfo *dpi, const utf8 *t
         // Adjust the text palette
         memcpy(info->palette + 3, &(g1Element->offset[247]), 2);
         memcpy(info->palette + 5, &(g1Element->offset[250]), 2);
-
-        // Set the palette pointer
-        gCurrentColourPalette = info->palette;
         break;
     }
     case 3:
@@ -1034,7 +1028,6 @@ static void ttf_process_initial_colour(sint32 colour, text_draw_info *info)
             info->palette[2] = (eax >> 8) & 0xFF;
             info->palette[3] = (eax >> 16) & 0xFF;
             info->palette[4] = (eax >> 24) & 0xFF;
-            gCurrentColourPalette = info->palette;
             eax = 0;
         }
     }


### PR DESCRIPTION
Moved one use of the palette pointer into a parameter.

