### PR TITLE
trap getaddrinfo return codes

### DIFF
--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -450,7 +450,6 @@ private:
         }
 
         addrinfo * result = nullptr;
-        getaddrinfo(address, serviceName.c_str(), &hints, &result);
         int errorcode = getaddrinfo(address, serviceName.c_str(), &hints, &result);
         if (errorcode != 0)
         {

--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -451,6 +451,13 @@ private:
 
         addrinfo * result = nullptr;
         getaddrinfo(address, serviceName.c_str(), &hints, &result);
+        int errorcode = getaddrinfo(address, serviceName.c_str(), &hints, &result);
+        if (errorcode != 0)
+        {
+            log_error("Resolving address failed: Code %d.", errorcode);
+            log_error("Resolution error message: %s.", gai_strerror(errorcode));
+            return false;
+        }
         if (result == nullptr)
         {
             return false;


### PR DESCRIPTION
`result` being unmodified when `getaddrinfo` isn't documented/defined behavior (and depending on your libc, isn't guaranteed / the pointer might get mangled). We should be checking the return code and using that to evaluate success instead.