### PR TITLE
Change to utf8_remove_formatting() in Twitch integration to support non-latin characters

### DIFF
--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -550,18 +550,6 @@ namespace Twitch
             buffer[0] = (utf8)(uint8)FORMAT_TOPAZ;
             safe_strcpy(buffer + 1, message, sizeof(buffer) - 1);
 
-            // Remove unsupported characters
-            // TODO allow when OpenRCT2 gains unicode support
-            char * ch = buffer + 1;
-            while (ch[0] != '\0')
-            {
-                if ((uint8)ch[0] < 32 || (uint8)ch[0] > 122)
-                {
-                    ch[0] = ' ';
-                }
-                ch++;
-            }
-
             // TODO Create a new news item type for twitch which has twitch icon
             news_item_add_to_queue_raw(NEWS_ITEM_BLANK, buffer, 0);
         }

--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -550,6 +550,8 @@ namespace Twitch
             buffer[0] = (utf8)(uint8)FORMAT_TOPAZ;
             safe_strcpy(buffer + 1, message, sizeof(buffer) - 1);
 
+	    utf8_remove_formatting(buffer, false);
+	    
             // TODO Create a new news item type for twitch which has twitch icon
             news_item_add_to_queue_raw(NEWS_ITEM_BLANK, buffer, 0);
         }


### PR DESCRIPTION
It seems that it works if the block which removes unsupported characters is removed since OpenRCT2 supports UTF-8 now.
I'm not good at C++, so please let me know if something is wrong even though I have tested it by compiling.

It is about OpenRCT2/OpenRCT2#4806