### PR TITLE
Fix highscore saving for RCT1 parks

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -718,7 +718,7 @@ namespace OpenRCT2
                         parkImporter.reset(ParkImporter::CreateS6(_objectRepository, _objectManager));
                     }
 
-                    auto result = parkImporter->LoadFromStream(stream, info.Type == FILE_TYPE::SCENARIO);
+                    auto result = parkImporter->LoadFromStream(stream, info.Type == FILE_TYPE::SCENARIO, false, path.c_str());
                     if (result.Error == PARK_LOAD_ERROR_OK)
                     {
                         parkImporter->Import();

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -40,6 +40,7 @@ typedef enum PARK_LOAD_ERROR
 #include <string>
 #include <vector>
 #include "scenario/ScenarioRepository.h"
+#include "core/String.hpp"
 
 interface IObjectManager;
 interface IObjectRepository;
@@ -72,7 +73,10 @@ public:
     virtual ParkLoadResult  Load(const utf8 * path) abstract;
     virtual ParkLoadResult  LoadSavedGame(const utf8 * path, bool skipObjectCheck = false) abstract;
     virtual ParkLoadResult  LoadScenario(const utf8 * path, bool skipObjectCheck = false) abstract;
-    virtual ParkLoadResult  LoadFromStream(IStream * stream, bool isScenario, bool skipObjectCheck = false) abstract;
+    virtual ParkLoadResult  LoadFromStream(IStream * stream,
+                                           bool isScenario,
+                                           bool skipObjectCheck = false,
+                                           const utf8 * path = String::Empty) abstract;
 
     virtual void Import() abstract;
     virtual bool GetDetails(scenario_index_entry * dst) abstract;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -114,7 +114,10 @@ public:
         return result;
     }
 
-    ParkLoadResult LoadFromStream(IStream * stream, bool isScenario, bool skipObjectCheck = false) override
+    ParkLoadResult LoadFromStream(IStream * stream,
+                                  bool isScenario,
+                                  bool skipObjectCheck = false,
+                                  const utf8 * path = String::Empty) override
     {
         if (isScenario && !gConfigGeneral.allow_loading_with_incorrect_checksum && !SawyerEncoding::ValidateChecksum(stream))
         {


### PR DESCRIPTION
This fixes bugs when completing an RCT1 scenario, where the highscore would be saved for the wrong park because gScenarioFileName hasn't been updated on load.
The highscores are saved with gScenarioFileName as the "key". Because it's not updated for RCT1 parks, the filename is of the park loaded before, e.g. Six Flags Magic Mountain. This should fix #6252.
There's a similar bug for RCT2 scenarios. gScenarioFileName gets set to a string loaded from inside the file, but apparently that string isn't always correct (e.g. for Africa - Victoria Falls). This is the cause of #6248, and the fix would be pretty much the same. However I let it be for now, because I'm not 100% sure that there isn't something else going wrong.