### PR TITLE
Experimental support for font hinting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
 - Feature: Allow using object files from RCT Classic.
+- Feature: TrueType fonts are now rendered with font hinting by default.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -494,6 +494,7 @@ namespace Config
             model->height_medium = reader->GetSint32("height_medium", false);
             model->height_big = reader->GetSint32("height_big", false);
             model->enable_hinting = reader->GetBoolean("enable_hinting", true);
+            model->hinting_threshold = reader->GetSint32("hinting_threshold", false);
         }
     }
 
@@ -514,6 +515,7 @@ namespace Config
         writer->WriteSint32("height_medium", model->height_medium);
         writer->WriteSint32("height_big", model->height_big);
         writer->WriteBoolean("enable_hinting", model->enable_hinting);
+        writer->WriteSint32("hinting_threshold", model->hinting_threshold);
     }
 
     static bool SetDefaults()

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -493,6 +493,7 @@ namespace Config
             model->height_small = reader->GetSint32("height_small", false);
             model->height_medium = reader->GetSint32("height_medium", false);
             model->height_big = reader->GetSint32("height_big", false);
+            model->enable_hinting = reader->GetBoolean("enable_hinting", true);
         }
     }
 
@@ -512,6 +513,7 @@ namespace Config
         writer->WriteSint32("height_small", model->height_small);
         writer->WriteSint32("height_medium", model->height_medium);
         writer->WriteSint32("height_big", model->height_big);
+        writer->WriteBoolean("enable_hinting", model->enable_hinting);
     }
 
     static bool SetDefaults()

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -191,6 +191,7 @@ typedef struct FontConfiguration
     sint32      height_small;
     sint32      height_medium;
     sint32      height_big;
+    bool        enable_hinting;
 } FontConfiguration;
 
 enum SORT

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -192,6 +192,7 @@ typedef struct FontConfiguration
     sint32      height_medium;
     sint32      height_big;
     bool        enable_hinting;
+    sint32      hinting_threshold;
 } FontConfiguration;
 
 enum SORT

--- a/src/openrct2/drawing/font.h
+++ b/src/openrct2/drawing/font.h
@@ -48,6 +48,7 @@ typedef struct TTFFontDescriptor {
     sint32 offset_x;
     sint32 offset_y;
     sint32 line_height;
+    sint32 hinting_threshold;
     TTF_Font * font;
 } TTFFontDescriptor;
 

--- a/src/openrct2/drawing/scrolling_text.c
+++ b/src/openrct2/drawing/scrolling_text.c
@@ -1566,8 +1566,12 @@ void scrolling_text_set_bitmap_for_ttf(utf8 *text, sint32 scroll, uint8 *bitmap,
             if (scrollPosition > -1) {
                 uint8 *dst = &bitmap[scrollPosition];
 
-                for (sint32 y = 0; y < height; y++) {
-                    if (src[y * pitch + x] != 0) *dst = colour;
+                for (sint32 y = 0; y < height; y++)
+                {
+                    if (src[y * pitch + x] > 92 || (src[y * pitch + x] != 0 && !gConfigFonts.enable_hinting))
+                    {
+                        *dst = colour;
+                    }
 
                     // Jump to next row
                     dst += 64;

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -717,6 +717,48 @@ static void ttf_draw_string_raw_sprite(rct_drawpixelinfo *dpi, const utf8 *text,
 
 #ifndef NO_TTF
 
+static uint8 colormap[256][256] = {0};
+
+uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
+{
+    sint16 closest = -1;
+    sint32 closestDistance = INT32_MAX;
+
+    for (int i = 0; i < 256; i++)
+    {
+        const int distance =
+            pow(gPalette[i].red - red, 2) + pow(gPalette[i].green - green, 2) + pow(gPalette[i].blue - blue, 2);
+
+        if (distance < closestDistance)
+        {
+            closest = i;
+            closestDistance = distance;
+        }
+    }
+
+    return closest;
+}
+
+uint8 blend(const uint8 base, const uint8 layer)
+{
+    const uint8 cMin = min(base, layer);
+    const uint8 cMax = max(base, layer);
+
+    if (colormap[cMin][cMax] != 0)
+    {
+        return colormap[cMin][cMax];
+    }
+
+    log_info("Blending colours %d and %d", cMin, cMax);
+
+    uint8 red = (gPalette[cMin].red + gPalette[cMax].red) / 2;
+    uint8 green = (gPalette[cMin].green + gPalette[cMax].green) / 2;
+    uint8 blue = (gPalette[cMin].blue + gPalette[cMax].blue) / 2;
+
+    colormap[cMin][cMax] = findClosestIndex(red, green, blue);
+    return colormap[cMin][cMax];
+}
+
 static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, text_draw_info *info)
 {
     if (!ttf_initialise())
@@ -805,36 +847,18 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             // Centre of the glyph: use full colour.
                             *dst = colour;
                         }
-                        else if (*dst < 10 && *src > 50)
-                        {
-                            // For black backgrounds, hint using grey pixels.
-                            *dst = ColourMapA[COLOUR_WHITE].colour_0;
-                        }
-                        else if (*src > 70)
+                        else if (*src > 80)
                         {
                             // Simulate font hinting by shading the background colour instead.
                             if (info->flags & TEXT_DRAW_FLAG_OUTLINE)
                             {
                                 // As outlines are black, these texts should always use a darker shade
                                 // of the foreground colour for font hinting.
-                                *dst = ColourMapA[COLOUR_WHITE].colour_1;
-                            }
-                            else if (colour == ColourMapA[COLOUR_DARK_GREEN].colour_11)
-                            {
-                                // Exception: theme window text colour.
-                                *dst = ColourMapA[COLOUR_DARK_GREEN].lightest;
-                            }
-                            else if (colour == ColourMapA[COLOUR_BRIGHT_RED].light)
-                            {
-                                // Exception: losses in finance window.
-                                *dst = ColourMapA[COLOUR_BRIGHT_RED].lightest;
+                                *dst = blend(colour, PALETTE_INDEX_0);
                             }
                             else
                             {
-                                // For other texts, hinting direction depends on the intensity of the
-                                // foreground colour.
-                                bool intensive = colour % 12 > 4 && colour % 12 < 10;
-                                *dst += intensive ? 2 : -3;
+                                *dst = blend(colour, *dst);
                             }
                         }
                     }

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -717,48 +717,6 @@ static void ttf_draw_string_raw_sprite(rct_drawpixelinfo *dpi, const utf8 *text,
 
 #ifndef NO_TTF
 
-static uint8 colormap[256][256] = {0};
-
-uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
-{
-    sint16 closest = -1;
-    sint32 closestDistance = INT32_MAX;
-
-    for (int i = 0; i < 256; i++)
-    {
-        const int distance =
-            pow(gPalette[i].red - red, 2) + pow(gPalette[i].green - green, 2) + pow(gPalette[i].blue - blue, 2);
-
-        if (distance < closestDistance)
-        {
-            closest = i;
-            closestDistance = distance;
-        }
-    }
-
-    return closest;
-}
-
-uint8 blend(const uint8 base, const uint8 layer)
-{
-    const uint8 cMin = min(base, layer);
-    const uint8 cMax = max(base, layer);
-
-    if (colormap[cMin][cMax] != 0)
-    {
-        return colormap[cMin][cMax];
-    }
-
-    log_info("Blending colours %d and %d", cMin, cMax);
-
-    uint8 red = (gPalette[cMin].red + gPalette[cMax].red) / 2;
-    uint8 green = (gPalette[cMin].green + gPalette[cMax].green) / 2;
-    uint8 blue = (gPalette[cMin].blue + gPalette[cMax].blue) / 2;
-
-    colormap[cMin][cMax] = findClosestIndex(red, green, blue);
-    return colormap[cMin][cMax];
-}
-
 static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, text_draw_info *info)
 {
     if (!ttf_initialise())

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -808,9 +808,19 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                         else if (*src > 70)
                         {
                             // Simulate font hinting by shading the background colour instead.
-                            // uint8 hinting = floor(*src / 12);
-                            // *dst = *dst - (*dst % 12) + hinting;
-                            *dst = *dst + 2;
+                            if (info->flags & TEXT_DRAW_FLAG_OUTLINE)
+                            {
+                                // As outlines are black, these texts should always use a darker shade
+                                // of the foreground colour for font hinting.
+                                *dst = colour - 4;
+                            }
+                            else
+                            {
+                                // For other texts, hinting direction depends on the intensity of the
+                                // foreground colour.
+                                bool intensive = colour % 12 > 4 && colour % 12 < 10;
+                                *dst += intensive ? 2 : -3;
+                            }
                         }
                     }
                     src++;

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../config/Config.h"
 #include "../interface/colour.h"
 #include "../interface/viewport.h"
 #include "../localisation/localisation.h"
@@ -799,7 +800,7 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             *(dst + width + dstScanSkip + 1) = info->palette[3];
                         }
 
-                        if (*src > 180)
+                        if (*src > 180 || !gConfigFonts.enable_hinting)
                         {
                             // Centre of the glyph: use full colour.
                             *dst = colour;

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -812,11 +812,11 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             {
                                 // As outlines are black, these texts should always use a darker shade
                                 // of the foreground colour for font hinting.
-                                *dst = blend(colour, PALETTE_INDEX_0);
+                                *dst = blendColours(colour, PALETTE_INDEX_0);
                             }
                             else
                             {
-                                *dst = blend(colour, *dst);
+                                *dst = blendColours(colour, *dst);
                             }
                         }
                     }

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -798,7 +798,19 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                         if (info->flags & TEXT_DRAW_FLAG_INSET) {
                             *(dst + width + dstScanSkip + 1) = info->palette[3];
                         }
-                        *dst = colour;
+
+                        if (*src > 180)
+                        {
+                            // Centre of the glyph: use full colour.
+                            *dst = colour;
+                        }
+                        else if (*src > 70)
+                        {
+                            // Simulate font hinting by shading the background colour instead.
+                            // uint8 hinting = floor(*src / 12);
+                            // *dst = *dst - (*dst % 12) + hinting;
+                            *dst = *dst + 2;
+                        }
                     }
                     src++;
                     dst++;

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -808,7 +808,7 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                         else if (*dst < 10 && *src > 50)
                         {
                             // For black backgrounds, hint using grey pixels.
-                            *dst = 13;
+                            *dst = ColourMapA[COLOUR_WHITE].colour_0;
                         }
                         else if (*src > 70)
                         {
@@ -817,17 +817,17 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             {
                                 // As outlines are black, these texts should always use a darker shade
                                 // of the foreground colour for font hinting.
-                                *dst = colour - 4;
+                                *dst = ColourMapA[COLOUR_WHITE].colour_1;
                             }
-                            else if (colour == 153)
+                            else if (colour == ColourMapA[COLOUR_DARK_GREEN].colour_11)
                             {
                                 // Exception: theme window text colour.
-                                *dst = 151;
+                                *dst = ColourMapA[COLOUR_DARK_GREEN].lightest;
                             }
-                            else if (colour == 173)
+                            else if (colour == ColourMapA[COLOUR_BRIGHT_RED].light)
                             {
                                 // Exception: losses in finance window.
-                                *dst = 175;
+                                *dst = ColourMapA[COLOUR_BRIGHT_RED].lightest;
                             }
                             else
                             {

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -805,7 +805,7 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             // Centre of the glyph: use full colour.
                             *dst = colour;
                         }
-                        else if (*src > 80)
+                        else if (*src > 60)
                         {
                             // Simulate font hinting by shading the background colour instead.
                             if (info->flags & TEXT_DRAW_FLAG_OUTLINE)

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -805,6 +805,11 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             // Centre of the glyph: use full colour.
                             *dst = colour;
                         }
+                        else if (*dst < 10 && *src > 50)
+                        {
+                            // For black backgrounds, hint using grey pixels.
+                            *dst = 13;
+                        }
                         else if (*src > 70)
                         {
                             // Simulate font hinting by shading the background colour instead.

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -805,7 +805,7 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             // Centre of the glyph: use full colour.
                             *dst = colour;
                         }
-                        else if (*src > 60)
+                        else if (*src > fontDesc->hinting_threshold)
                         {
                             // Simulate font hinting by shading the background colour instead.
                             if (info->flags & TEXT_DRAW_FLAG_OUTLINE)

--- a/src/openrct2/drawing/string.c
+++ b/src/openrct2/drawing/string.c
@@ -819,6 +819,16 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                                 // of the foreground colour for font hinting.
                                 *dst = colour - 4;
                             }
+                            else if (colour == 153)
+                            {
+                                // Exception: theme window text colour.
+                                *dst = 151;
+                            }
+                            else if (colour == 173)
+                            {
+                                // Exception: losses in finance window.
+                                *dst = 175;
+                            }
                             else
                             {
                                 // For other texts, hinting direction depends on the intensity of the

--- a/src/openrct2/drawing/ttf.c
+++ b/src/openrct2/drawing/ttf.c
@@ -60,7 +60,6 @@ static TTF_Font * ttf_open_font(const utf8 * fontPath, sint32 ptSize);
 static void ttf_close_font(TTF_Font * font);
 static uint32 ttf_surface_cache_hash(TTF_Font * font, const utf8 * text);
 static void ttf_surface_cache_dispose(ttf_cache_entry * entry);
-static void ttf_surface_cache_dispose_all();
 static void ttf_getwidth_cache_dispose_all();
 static bool ttf_get_size(TTF_Font * font, const utf8 * text, sint32 * width, sint32 * height);
 static TTFSurface * ttf_render(TTF_Font * font, const utf8 * text);
@@ -144,7 +143,7 @@ static void ttf_surface_cache_dispose(ttf_cache_entry *entry)
     }
 }
 
-static void ttf_surface_cache_dispose_all()
+void ttf_surface_cache_dispose_all()
 {
     for (sint32 i = 0; i < TTF_SURFACE_CACHE_SIZE; i++) {
         ttf_surface_cache_dispose(&_ttfSurfaceCache[i]);

--- a/src/openrct2/drawing/ttf.c
+++ b/src/openrct2/drawing/ttf.c
@@ -276,7 +276,7 @@ static bool ttf_get_size(TTF_Font * font, const utf8 * text, sint32 * outWidth, 
 
 static TTFSurface * ttf_render(TTF_Font * font, const utf8 * text)
 {
-    return TTF_RenderUTF8_Solid(font, text, 0x000000FF);
+    return TTF_RenderUTF8_Shaded(font, text, 0x000000FF, 0x000000FF);
 }
 
 void ttf_free_surface(TTFSurface * surface)

--- a/src/openrct2/drawing/ttf.c
+++ b/src/openrct2/drawing/ttf.c
@@ -60,6 +60,7 @@ static TTF_Font * ttf_open_font(const utf8 * fontPath, sint32 ptSize);
 static void ttf_close_font(TTF_Font * font);
 static uint32 ttf_surface_cache_hash(TTF_Font * font, const utf8 * text);
 static void ttf_surface_cache_dispose(ttf_cache_entry * entry);
+static void ttf_surface_cache_dispose_all();
 static void ttf_getwidth_cache_dispose_all();
 static bool ttf_get_size(TTF_Font * font, const utf8 * text, sint32 * width, sint32 * height);
 static TTFSurface * ttf_render(TTF_Font * font, const utf8 * text);
@@ -72,7 +73,7 @@ bool ttf_initialise()
             return false;
         }
 
-        for (sint32 i = 0; i < 4; i++) {
+        for (sint32 i = 0; i < FONT_SIZE_COUNT; i++) {
             TTFFontDescriptor *fontDesc = &(gCurrentTTFFontSet->size[i]);
 
             utf8 fontPath[MAX_PATH];
@@ -86,7 +87,10 @@ bool ttf_initialise()
                 log_error("Unable to load '%s'", fontPath);
                 return false;
             }
+
         }
+
+        ttf_toggle_hinting();
         _ttfInitialised = true;
     }
     return true;
@@ -143,11 +147,25 @@ static void ttf_surface_cache_dispose(ttf_cache_entry *entry)
     }
 }
 
-void ttf_surface_cache_dispose_all()
+static void ttf_surface_cache_dispose_all()
 {
     for (sint32 i = 0; i < TTF_SURFACE_CACHE_SIZE; i++) {
         ttf_surface_cache_dispose(&_ttfSurfaceCache[i]);
         _ttfSurfaceCacheCount--;
+    }
+}
+
+void ttf_toggle_hinting()
+{
+    for (sint32 i = 0; i < FONT_SIZE_COUNT; i++)
+    {
+        TTFFontDescriptor *fontDesc = &(gCurrentTTFFontSet->size[i]);
+        TTF_SetFontHinting(fontDesc->font, gConfigFonts.enable_hinting ? 1 : 0);
+    }
+
+    if (_ttfSurfaceCacheCount)
+    {
+        ttf_surface_cache_dispose_all();
     }
 }
 

--- a/src/openrct2/drawing/ttf.c
+++ b/src/openrct2/drawing/ttf.c
@@ -19,6 +19,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
+#include "../config/Config.h"
 #include "../localisation/localisation.h"
 #include "../OpenRCT2.h"
 #include "../platform/platform.h"
@@ -276,7 +277,14 @@ static bool ttf_get_size(TTF_Font * font, const utf8 * text, sint32 * outWidth, 
 
 static TTFSurface * ttf_render(TTF_Font * font, const utf8 * text)
 {
-    return TTF_RenderUTF8_Shaded(font, text, 0x000000FF, 0x000000FF);
+    if (gConfigFonts.enable_hinting)
+    {
+        return TTF_RenderUTF8_Shaded(font, text, 0x000000FF, 0x000000FF);
+    }
+    else
+    {
+        return TTF_RenderUTF8_Solid(font, text, 0x000000FF);
+    }
 }
 
 void ttf_free_surface(TTFSurface * surface)

--- a/src/openrct2/drawing/ttf.h
+++ b/src/openrct2/drawing/ttf.h
@@ -44,6 +44,7 @@ extern "C" {
 
 TTFFontDescriptor * ttf_get_font_from_sprite_base(uint16 spriteBase);
 TTFSurface * ttf_surface_cache_get_or_add(TTF_Font * font, const utf8 * text);
+void ttf_surface_cache_dispose_all();
 uint32 ttf_getwidth_cache_get_or_add(TTF_Font * font, const utf8 * text);
 bool ttf_provides_glyph(const TTF_Font * font, codepoint_t codepoint);
 void ttf_free_surface(TTFSurface * surface);

--- a/src/openrct2/drawing/ttf.h
+++ b/src/openrct2/drawing/ttf.h
@@ -54,6 +54,7 @@ TTF_Font * TTF_OpenFont(const char *file, int ptsize);
 int TTF_GlyphIsProvided(const TTF_Font *font, codepoint_t ch);
 int TTF_SizeUTF8(TTF_Font *font, const char *text, int *w, int *h);
 TTFSurface * TTF_RenderUTF8_Solid(TTF_Font *font, const char *text, uint32 colour);
+TTFSurface * TTF_RenderUTF8_Shaded(TTF_Font *font, const char *text, uint32 fg, uint32 bg);
 void TTF_CloseFont(TTF_Font *font);
 void TTF_Quit(void);
 

--- a/src/openrct2/drawing/ttf.h
+++ b/src/openrct2/drawing/ttf.h
@@ -43,8 +43,8 @@ extern "C" {
 #endif
 
 TTFFontDescriptor * ttf_get_font_from_sprite_base(uint16 spriteBase);
+void ttf_toggle_hinting();
 TTFSurface * ttf_surface_cache_get_or_add(TTF_Font * font, const utf8 * text);
-void ttf_surface_cache_dispose_all();
 uint32 ttf_getwidth_cache_get_or_add(TTF_Font * font, const utf8 * text);
 bool ttf_provides_glyph(const TTF_Font * font, codepoint_t codepoint);
 void ttf_free_surface(TTFSurface * surface);
@@ -57,6 +57,7 @@ int TTF_SizeUTF8(TTF_Font *font, const char *text, int *w, int *h);
 TTFSurface * TTF_RenderUTF8_Solid(TTF_Font *font, const char *text, uint32 colour);
 TTFSurface * TTF_RenderUTF8_Shaded(TTF_Font *font, const char *text, uint32 fg, uint32 bg);
 void TTF_CloseFont(TTF_Font *font);
+void TTF_SetFontHinting(TTF_Font* font, int hinting);
 void TTF_Quit(void);
 
 #ifdef __cplusplus

--- a/src/openrct2/drawing/ttf_sdlport.c
+++ b/src/openrct2/drawing/ttf_sdlport.c
@@ -1433,6 +1433,20 @@ static bool CharacterIsDelimiter(char c, const char *delimiters)
     return false;
 }
 
+void TTF_SetFontHinting(TTF_Font* font, int hinting)
+{
+    if (hinting == TTF_HINTING_LIGHT)
+        font->hinting = FT_LOAD_TARGET_LIGHT;
+    else if (hinting == TTF_HINTING_MONO)
+        font->hinting = FT_LOAD_TARGET_MONO;
+    else if (hinting == TTF_HINTING_NONE)
+        font->hinting = FT_LOAD_NO_HINTING;
+    else
+        font->hinting = 0;
+
+    Flush_Cache(font);
+}
+
 void TTF_Quit(void)
 {
     if (TTF_initialized) {

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -25,39 +25,42 @@
 #include "../localisation/language.h"
 
 #ifndef NO_TTF
+uint8 const HINTING_THRESHOLD_LOW    = 40;
+uint8 const HINTING_THRESHOLD_MEDIUM = 60;
+
 TTFFontSetDescriptor TTFFontMSGothic = { {
-    { "msgothic.ttc", "MS PGothic", 9, 1, 0, 15, nullptr },
-    { "msgothic.ttc", "MS PGothic", 12, 1, 0, 17, nullptr },
-    { "msgothic.ttc", "MS PGothic", 12, 1, 0, 17, nullptr },
-    { "msgothic.ttc", "MS PGothic", 13, 1, 0, 20, nullptr },
+    { "msgothic.ttc", "MS PGothic",  9, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "msgothic.ttc", "MS PGothic", 12, 1, 0, 17, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "msgothic.ttc", "MS PGothic", 12, 1, 0, 17, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "msgothic.ttc", "MS PGothic", 13, 1, 0, 20, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontMingLiu = { {
-    { "msjh.ttc", "JhengHei", 9, -1, -3, 6, nullptr },
-    { "mingliu.ttc", "MingLiU", 11, 1, 1, 12, nullptr },
-    { "mingliu.ttc", "MingLiU", 12, 1, 0, 12, nullptr },
-    { "mingliu.ttc", "MingLiU", 13, 1, 0, 20, nullptr },
+    {    "msjh.ttc", "JhengHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "mingliu.ttc",  "MingLiU", 11,  1,  1, 12, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "mingliu.ttc",  "MingLiU", 12,  1,  0, 12, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "mingliu.ttc",  "MingLiU", 13,  1,  0, 20, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontSimSun = { {
-    { "msyh.ttc", "YaHei", 9, -1, -3, 6, nullptr },
-    { "simsun.ttc", "SimSun", 11, 1, -1, 14, nullptr },
-    { "simsun.ttc", "SimSun", 12, 1, -2, 14, nullptr },
-    { "simsun.ttc", "SimSun", 13, 1, 0, 20, nullptr },
+    {   "msyh.ttc",  "YaHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "simsun.ttc", "SimSun", 11,  1, -1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "simsun.ttc", "SimSun", 12,  1, -2, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "simsun.ttc", "SimSun", 13,  1,  0, 20, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontGulim = { {
-    { "gulim.ttc", "Gulim", 11, 1, 0, 15, nullptr },
-    { "gulim.ttc", "Gulim", 12, 1, 0, 17, nullptr },
-    { "gulim.ttc", "Gulim", 12, 1, 0, 17, nullptr },
-    { "gulim.ttc", "Gulim", 13, 1, 0, 20, nullptr },
+    { "gulim.ttc", "Gulim", 11, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "gulim.ttc", "Gulim", 12, 1, 0, 17, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "gulim.ttc", "Gulim", 12, 1, 0, 17, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "gulim.ttc", "Gulim", 13, 1, 0, 20, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontArial = { {
-    { "arial.ttf", "Arial", 8, 0, -1, 6, nullptr },
-    { "arial.ttf", "Arial", 10, 0, -1, 12, nullptr },
-    { "arial.ttf", "Arial", 11, 0, -1, 12, nullptr },
-    { "arial.ttf", "Arial", 12, 0, -1, 20, nullptr },
+    { "arial.ttf", "Arial",  8, 0, -1,  6, HINTING_THRESHOLD_LOW, nullptr },
+    { "arial.ttf", "Arial", 10, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "arial.ttf", "Arial", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "arial.ttf", "Arial", 12, 0, -1, 20, HINTING_THRESHOLD_LOW, nullptr },
 } };
 #endif // NO_TTF
 
@@ -85,13 +88,13 @@ static bool LoadCustomConfigFont()
 {
     static TTFFontSetDescriptor TTFFontCustom = { {
         { gConfigFonts.file_name, gConfigFonts.font_name, gConfigFonts.size_tiny, gConfigFonts.x_offset, gConfigFonts.y_offset,
-          gConfigFonts.height_tiny, nullptr },
+          gConfigFonts.height_tiny, gConfigFonts.hinting_threshold, nullptr },
         { gConfigFonts.file_name, gConfigFonts.font_name, gConfigFonts.size_small, gConfigFonts.x_offset, gConfigFonts.y_offset,
-          gConfigFonts.height_small, nullptr },
+          gConfigFonts.height_small, gConfigFonts.hinting_threshold, nullptr },
         { gConfigFonts.file_name, gConfigFonts.font_name, gConfigFonts.size_medium, gConfigFonts.x_offset,
-          gConfigFonts.y_offset, gConfigFonts.height_medium, nullptr },
+          gConfigFonts.y_offset, gConfigFonts.height_medium, gConfigFonts.hinting_threshold, nullptr },
         { gConfigFonts.file_name, gConfigFonts.font_name, gConfigFonts.size_big, gConfigFonts.x_offset, gConfigFonts.y_offset,
-          gConfigFonts.height_big, nullptr },
+          gConfigFonts.height_big, gConfigFonts.hinting_threshold, nullptr },
     } };
 
     ttf_dispose();

--- a/src/openrct2/interface/colour.c
+++ b/src/openrct2/interface/colour.c
@@ -71,7 +71,7 @@ static uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
     sint16 closest = -1;
     sint32 closestDistance = INT32_MAX;
 
-    for (int i = 0; i < PALETTE_COUNT; i++)
+    for (int i = PALETTE_INDEX_0; i < PALETTE_INDEX_230; i++)
     {
         const int distance =
             pow(gPalette[i].red - red, 2) + pow(gPalette[i].green - green, 2) + pow(gPalette[i].blue - blue, 2);

--- a/src/openrct2/interface/colour.c
+++ b/src/openrct2/interface/colour.c
@@ -62,3 +62,47 @@ void colours_init_maps()
         ColourMapA[i].colour_11 = g1Element->offset[INDEX_COLOUR_11];
     }
 }
+
+#ifndef NO_TTF
+static uint8 BlendColourMap[PALETTE_COUNT][PALETTE_COUNT] = {0};
+
+static uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
+{
+    sint16 closest = -1;
+    sint32 closestDistance = INT32_MAX;
+
+    for (int i = 0; i < PALETTE_COUNT; i++)
+    {
+        const int distance =
+            pow(gPalette[i].red - red, 2) + pow(gPalette[i].green - green, 2) + pow(gPalette[i].blue - blue, 2);
+
+        if (distance < closestDistance)
+        {
+            closest = i;
+            closestDistance = distance;
+        }
+    }
+
+    return closest;
+}
+
+uint8 blend(const uint8 base, const uint8 layer)
+{
+    const uint8 cMin = min(base, layer);
+    const uint8 cMax = max(base, layer);
+
+    if (BlendColourMap[cMin][cMax] != 0)
+    {
+        return BlendColourMap[cMin][cMax];
+    }
+
+    log_info("Blending colours %d and %d", cMin, cMax);
+
+    uint8 red = (gPalette[cMin].red + gPalette[cMax].red) / 2;
+    uint8 green = (gPalette[cMin].green + gPalette[cMax].green) / 2;
+    uint8 blue = (gPalette[cMin].blue + gPalette[cMax].blue) / 2;
+
+    BlendColourMap[cMin][cMax] = findClosestIndex(red, green, blue);
+    return BlendColourMap[cMin][cMax];
+}
+#endif

--- a/src/openrct2/interface/colour.c
+++ b/src/openrct2/interface/colour.c
@@ -86,7 +86,7 @@ static uint8 findClosestPaletteIndex(uint8 red, uint8 green, uint8 blue)
     return closest;
 }
 
-uint8 blend(const uint8 paletteIndex1, const uint8 paletteIndex2)
+uint8 blendColours(const uint8 paletteIndex1, const uint8 paletteIndex2)
 {
     const uint8 cMin = min(paletteIndex1, paletteIndex2);
     const uint8 cMax = max(paletteIndex1, paletteIndex2);

--- a/src/openrct2/interface/colour.c
+++ b/src/openrct2/interface/colour.c
@@ -66,14 +66,14 @@ void colours_init_maps()
 #ifndef NO_TTF
 static uint8 BlendColourMap[PALETTE_COUNT][PALETTE_COUNT] = {0};
 
-static uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
+static uint8 findClosestPaletteIndex(uint8 red, uint8 green, uint8 blue)
 {
     sint16 closest = -1;
     sint32 closestDistance = INT32_MAX;
 
     for (int i = PALETTE_INDEX_0; i < PALETTE_INDEX_230; i++)
     {
-        const int distance =
+        const sint32 distance =
             pow(gPalette[i].red - red, 2) + pow(gPalette[i].green - green, 2) + pow(gPalette[i].blue - blue, 2);
 
         if (distance < closestDistance)
@@ -86,23 +86,21 @@ static uint8 findClosestIndex(uint8 red, uint8 green, uint8 blue)
     return closest;
 }
 
-uint8 blend(const uint8 base, const uint8 layer)
+uint8 blend(const uint8 paletteIndex1, const uint8 paletteIndex2)
 {
-    const uint8 cMin = min(base, layer);
-    const uint8 cMax = max(base, layer);
+    const uint8 cMin = min(paletteIndex1, paletteIndex2);
+    const uint8 cMax = max(paletteIndex1, paletteIndex2);
 
     if (BlendColourMap[cMin][cMax] != 0)
     {
         return BlendColourMap[cMin][cMax];
     }
 
-    log_info("Blending colours %d and %d", cMin, cMax);
-
     uint8 red = (gPalette[cMin].red + gPalette[cMax].red) / 2;
     uint8 green = (gPalette[cMin].green + gPalette[cMax].green) / 2;
     uint8 blue = (gPalette[cMin].blue + gPalette[cMax].blue) / 2;
 
-    BlendColourMap[cMin][cMax] = findClosestIndex(red, green, blue);
+    BlendColourMap[cMin][cMax] = findClosestPaletteIndex(red, green, blue);
     return BlendColourMap[cMin][cMax];
 }
 #endif

--- a/src/openrct2/interface/colour.h
+++ b/src/openrct2/interface/colour.h
@@ -110,6 +110,7 @@ enum
     PALETTE_INDEX_195 = 195,    //
     PALETTE_INDEX_209 = 209,    // Bright Pink (light)
     PALETTE_INDEX_222 = 222,    //
+    PALETTE_INDEX_230 = 230,    //
     PALETTE_INDEX_245 = 245,    //
 
     PALETTE_COUNT = 256,

--- a/src/openrct2/interface/colour.h
+++ b/src/openrct2/interface/colour.h
@@ -111,6 +111,8 @@ enum
     PALETTE_INDEX_209 = 209,    // Bright Pink (light)
     PALETTE_INDEX_222 = 222,    //
     PALETTE_INDEX_245 = 245,    //
+
+    PALETTE_COUNT = 256,
 };
 
 #define TEXT_COLOUR_254         (254)
@@ -147,6 +149,10 @@ extern "C" {
 extern rct_colour_map ColourMapA[COLOUR_COUNT];
 
 void colours_init_maps();
+
+#ifndef NO_TTF
+uint8 blend(const uint8 base, const uint8 layer);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/openrct2/interface/colour.h
+++ b/src/openrct2/interface/colour.h
@@ -152,7 +152,7 @@ extern rct_colour_map ColourMapA[COLOUR_COUNT];
 void colours_init_maps();
 
 #ifndef NO_TTF
-uint8 blend(const uint8 base, const uint8 layer);
+uint8 blend(const uint8 paletteIndex1, const uint8 paletteIndex2);
 #endif
 
 #ifdef __cplusplus

--- a/src/openrct2/interface/colour.h
+++ b/src/openrct2/interface/colour.h
@@ -152,7 +152,7 @@ extern rct_colour_map ColourMapA[COLOUR_COUNT];
 void colours_init_maps();
 
 #ifndef NO_TTF
-uint8 blend(const uint8 paletteIndex1, const uint8 paletteIndex2);
+uint8 blendColours(const uint8 paletteIndex1, const uint8 paletteIndex2);
 #endif
 
 #ifdef __cplusplus

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -45,6 +45,10 @@
 #include "console.h"
 #include "viewport.h"
 
+#ifndef NO_TTF
+#include "../drawing/ttf.h"
+#endif
+
 #define CONSOLE_BUFFER_SIZE 8192
 #define CONSOLE_BUFFER_2_SIZE 256
 #define CONSOLE_HISTORY_SIZE 64
@@ -833,6 +837,11 @@ static sint32 cc_get(const utf8 **argv, sint32 argc)
         else if (strcmp(argv[0], "cheat_disable_support_limits") == 0) {
             console_printf("cheat_disable_support_limits %d", gCheatsDisableSupportLimits);
         }
+#ifndef NO_TTF
+        else if (strcmp(argv[0], "enable_hinting") == 0) {
+            console_printf("enable_hinting %d", gConfigFonts.enable_hinting);
+        }
+#endif
         else {
             console_writeline_warning("Invalid variable.");
         }
@@ -1069,6 +1078,14 @@ static sint32 cc_set(const utf8 **argv, sint32 argc)
             }
             console_execute_silent("get cheat_disable_support_limits");
         }
+#ifndef NO_TTF
+        else if (strcmp(argv[0], "enable_hinting") == 0 && invalidArguments(&invalidArgs, int_valid[0])) {
+            gConfigFonts.enable_hinting = (int_val[0] != 0);
+            config_save_default();
+            console_execute_silent("get enable_hinting");
+            ttf_surface_cache_dispose_all();
+        }
+#endif
         else if (invalidArgs) {
             console_writeline_error("Invalid arguments.");
         }

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1083,7 +1083,7 @@ static sint32 cc_set(const utf8 **argv, sint32 argc)
             gConfigFonts.enable_hinting = (int_val[0] != 0);
             config_save_default();
             console_execute_silent("get enable_hinting");
-            ttf_surface_cache_dispose_all();
+            ttf_toggle_hinting();
         }
 #endif
         else if (invalidArgs) {


### PR DESCRIPTION
Traditionally, RCT2 has used a sprite-based font to render its strings. Since OpenRCT2's inception, support has been added for rendering with *TrueType* fonts to accomodate languages that do not use a Western script, such as Chinese, Korean, and Japanese.

In the past, OpenRCT2's palette has been a point of frustration, as it prevented implementation of direct font hinting ('anti-aliasing'), leading the Korean community to raise their minimum font size from 8 to 11 points (cf. #2317). This is not an ideal solution, however, as it leads text strings to overflow from their containing UI elements, since widgets are currently not flexible.

This PR, while a work in progress, is a crude attempt of implementing support for font hinting in OpenRCT2. Let me start off with some examples.

## Screenshots

(Before on the left, after on the right.)

![scenario_ru_before](https://user-images.githubusercontent.com/604665/30746257-7ee2ce34-9fa9-11e7-91f7-ef79ef5ca252.png) ![scenario_ru_after](https://user-images.githubusercontent.com/604665/30746254-7edf76b2-9fa9-11e7-868e-9c70df2631e2.png)

![settings_jp_before](https://user-images.githubusercontent.com/604665/30746255-7ee03de0-9fa9-11e7-8c06-db2c9f5e9ad0.png) ![settings_jp_after](https://user-images.githubusercontent.com/604665/30746256-7ee03afc-9fa9-11e7-93d5-a466711530e9.png)

![settings_ru_before](https://user-images.githubusercontent.com/604665/30746259-7ee673fe-9fa9-11e7-83a9-e28ba360dfb7.png) ![settings_ru_after](https://user-images.githubusercontent.com/604665/30746258-7ee50b68-9fa9-11e7-884e-af06436bdea3.png)

## Known issues

The current implementation does not play nicely with all window background colours — in some cases even overflowing into the wrong colour family entirely. I am hopeful we can resolve this as my understanding of the palette system deepens, however.

I have been eyeing `ColourMapA` in colour.c — it seems to be exactly what is needed. One caveat: in some cases a darker shade is needed, while the others require a lighter one. Outlined texts, like in window titles, are probably related here.

## In conclusion

Ideas or other contributions would be most appreciated! I'm stuck right now, but excited for the possibilities, so I thought I'd put it the code out here for now.