### PR TITLE
Minor performance improvements

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.cpp
@@ -35,17 +35,17 @@ DrawImageShader::DrawImageShader() : OpenGLShaderProgram("drawimage")
     glVertexAttribIPointer(vIndex, 1, GL_INT, 0, nullptr);
 
     glBindBuffer(GL_ARRAY_BUFFER, _vboInstances);
-    glVertexAttribIPointer(vClip, 4, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, clip));
-    glVertexAttribIPointer(vTexColourAtlas, 1, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texColourAtlas));
-    glVertexAttribPointer(vTexColourBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texColourBounds));
-    glVertexAttribIPointer(vTexMaskAtlas, 1, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texMaskAtlas));
-    glVertexAttribPointer(vTexMaskBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texMaskBounds));
-    glVertexAttribIPointer(vTexPaletteAtlas, 1, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texPaletteAtlas));
-    glVertexAttribPointer(vTexPaletteBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, texPaletteBounds));
-    glVertexAttribIPointer(vFlags, 1, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, flags));
-    glVertexAttribPointer(vColour, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, colour));
-    glVertexAttribIPointer(vBounds, 4, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, bounds));
-    glVertexAttribIPointer(vMask, 1, GL_INT, sizeof(DrawImageInstance), (void*) offsetof(DrawImageInstance, mask));
+    glVertexAttribIPointer(vClip, 4, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, clip));
+    glVertexAttribIPointer(vTexColourAtlas, 1, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texColourAtlas));
+    glVertexAttribPointer(vTexColourBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texColourBounds));
+    glVertexAttribIPointer(vTexMaskAtlas, 1, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texMaskAtlas));
+    glVertexAttribPointer(vTexMaskBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texMaskBounds));
+    glVertexAttribIPointer(vTexPaletteAtlas, 1, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texPaletteAtlas));
+    glVertexAttribPointer(vTexPaletteBounds, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, texPaletteBounds));
+    glVertexAttribIPointer(vFlags, 1, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, flags));
+    glVertexAttribPointer(vColour, 4, GL_FLOAT, GL_FALSE, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, colour));
+    glVertexAttribIPointer(vBounds, 4, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, bounds));
+    glVertexAttribIPointer(vMask, 1, GL_INT, sizeof(DrawImageCommand), (void*) offsetof(DrawImageCommand, mask));
 
     glEnableVertexAttribArray(vIndex);
     glEnableVertexAttribArray(vClip);
@@ -113,12 +113,12 @@ void DrawImageShader::SetPalette(const vec4f *glPalette)
     glUniform4fv(uPalette, 256, (const GLfloat *) glPalette);
 }
 
-void DrawImageShader::DrawInstances(const std::vector<DrawImageInstance>& instances)
+void DrawImageShader::DrawInstances(const ImageCommandBatch& instances)
 {
     glBindVertexArray(_vao);
 
     glBindBuffer(GL_ARRAY_BUFFER, _vboInstances);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(instances[0]) * instances.size(), instances.data(), GL_STREAM_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(DrawImageCommand) * instances.size(), instances.data(), GL_STREAM_DRAW);
 
     glDrawArraysInstanced(GL_TRIANGLES, 0, 6, (GLsizei)instances.size());
 }

--- a/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawImageShader.h
@@ -18,31 +18,9 @@
 
 #include "GLSLTypes.h"
 #include "OpenGLShaderProgram.h"
+#include "DrawCommands.h"
 #include <SDL_pixels.h>
 #include <vector>
-
-// Per-instance data for images
-struct DrawImageInstance {
-    vec4i clip;
-    sint32 texColourAtlas;
-    vec4f texColourBounds;
-    sint32 texMaskAtlas;
-    vec4f texMaskBounds;
-    sint32 texPaletteAtlas;
-    vec4f texPaletteBounds;
-    sint32 flags;
-    vec4f colour;
-    vec4i bounds;
-    sint32 mask;
-
-    enum
-    {
-        FLAG_COLOUR              = (1 << 0),
-        FLAG_REMAP               = (1 << 1),
-        FLAG_TRANSPARENT         = (1 << 2),
-        FLAG_TRANSPARENT_SPECIAL = (1 << 3),
-    };
-};
 
 class DrawImageShader final : public OpenGLShaderProgram
 {
@@ -74,7 +52,7 @@ public:
 
     void SetScreenSize(sint32 width, sint32 height);
     void SetPalette(const vec4f *glPalette);
-    void DrawInstances(const std::vector<DrawImageInstance>& instances);
+    void DrawInstances(const ImageCommandBatch& instances);
 
 private:
     void GetLocations();

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -67,6 +67,7 @@ struct CachedTextureInfo
     GLuint slot;
     vec4i bounds;
     vec4f normalizedBounds;
+    vec4f computedBounds;
 };
 
 // Represents a texture atlas that images of a given maximum size can be allocated from
@@ -195,8 +196,8 @@ private:
     GLint _atlasesTextureIndicesLimit = 0;
     std::vector<Atlas> _atlases;
 
-    std::unordered_map<uint32, CachedTextureInfo> _imageTextureMap;
     std::unordered_map<GlyphId, CachedTextureInfo, GlyphId::Hash, GlyphId::Equal> _glyphTextureMap;
+    std::unordered_map<uint32, CachedTextureInfo> _imageTextureMap;
     std::unordered_map<uint32, CachedTextureInfo> _paletteTextureMap;
 
     SDL_Color _palette[256];
@@ -206,9 +207,9 @@ public:
     ~TextureCache();
     void SetPalette(const SDL_Color * palette);
     void InvalidateImage(uint32 image);
-    CachedTextureInfo GetOrLoadImageTexture(uint32 image);
+    const CachedTextureInfo* GetOrLoadImageTexture(uint32 image);
     CachedTextureInfo GetOrLoadGlyphTexture(uint32 image, uint8 * palette);
-    CachedTextureInfo GetOrLoadPaletteTexture(uint32 image, uint32 tertiaryColour, bool special);
+    const CachedTextureInfo* GetOrLoadPaletteTexture(uint32 image, uint32 tertiaryColour, bool special);
 
     GLuint GetAtlasesTexture();
 

--- a/src/openrct2/paint/paint.c
+++ b/src/openrct2/paint/paint.c
@@ -83,7 +83,6 @@ void paint_session_free(paint_session * session)
 
 static void paint_session_init(paint_session * session, rct_drawpixelinfo * dpi)
 {
-    memset(session, 0, sizeof(paint_session));
     session->Unk140E9A8 = dpi;
     session->EndOfPaintStructArray = &session->PaintStructs[4000 - 1];
     session->NextFreePaintStruct = session->PaintStructs;
@@ -97,6 +96,8 @@ static void paint_session_init(paint_session * session, rct_drawpixelinfo * dpi)
     session->PSStringHead = NULL;
     session->LastPSString = NULL;
     session->WoodenSupportsPrependTo = NULL;
+    session->CurrentlyDrawnItem = NULL;
+    session->SurfaceElement = NULL;
 }
 
 static void paint_session_add_ps_to_quadrant(paint_session * session, paint_struct * ps, sint32 positionHash)


### PR DESCRIPTION
This PR eliminates a lot of memory copying which should provide a great benefit on older hardware where memory bandwidth is still pretty bad. Also I introduced the CommandBatch container which reuses the memory in a better way than clearing and inserting elements and provides a reference on allocation.

Electric Fields OpenGL, 1600x1024:
**Before:** 
- Zoom 0: Min: 325, Max: 342, Average: 338
- Zoom 1: Min: 149, Max: 150, Average: 148
- Zoom 2: Min: 59, Max: 64, Average: 62
- Zoom 3: Min: 19, Max: 21, Average: 21

**After:**
 - Zoom 0: Min: 390, Max: 400, Average: 398
- Zoom 1: Min: 170, Max: 180, Average: 179
- Zoom 2: Min: 69, Max: 75, Average: 71
- Zoom 3: Min: 19, Max: 21, Average: 21

So there is a gain of 40-50 additional FPS on my end considering the average.
