### PR TITLE
Increase synchronisation range

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -49,7 +49,7 @@ enum {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8476,18 +8476,22 @@ rct_map_element *get_station_platform(sint32 x, sint32 y, sint32 z, sint32 z_tol
 /**
  * Check for an adjacent station to x,y,z in direction.
  */
-static bool check_for_adjacent_station(sint32 x, sint32 y, sint32 z, uint8 direction) {
+static bool check_for_adjacent_station(sint32 x, sint32 y, sint32 z, uint8 direction)
+{
     bool found = false;
     sint32 adjX = x;
     sint32 adjY = y;
-    for (int i = 0; i <= RIDE_ADJACENCY_CHECK_DISTANCE; i++) {
+    for (uint32 i = 0; i <= RIDE_ADJACENCY_CHECK_DISTANCE; i++)
+    {
         adjX += TileDirectionDelta[direction].x;
         adjY += TileDirectionDelta[direction].y;
-        rct_map_element *stationElement = get_station_platform(adjX, adjY, z, 2);
-        if (stationElement != NULL) {
+        rct_map_element * stationElement = get_station_platform(adjX, adjY, z, 2);
+        if (stationElement != NULL)
+        {
             sint32 rideIndex = stationElement->properties.track.ride_index;
-            Ride *ride = get_ride(rideIndex);
-            if (ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS) {
+            Ride * ride = get_ride(rideIndex);
+            if (ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS)
+            {
                 found = true;
             }
         }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8480,7 +8480,7 @@ static bool check_for_adjacent_station(sint32 x, sint32 y, sint32 z, uint8 direc
     bool found = false;
     sint32 adjX = x;
     sint32 adjY = y;
-    for (int i = 0; i < ride_adjacent_station_max_distance; i++) {
+    for (int i = 0; i <= RIDE_ADJACENCY_CHECK_DISTANCE; i++) {
         adjX += TileDirectionDelta[direction].x;
         adjY += TileDirectionDelta[direction].y;
         rct_map_element *stationElement = get_station_platform(adjX, adjY, z, 2);

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8478,14 +8478,18 @@ rct_map_element *get_station_platform(sint32 x, sint32 y, sint32 z, sint32 z_tol
  */
 static bool check_for_adjacent_station(sint32 x, sint32 y, sint32 z, uint8 direction) {
     bool found = false;
-    sint32 adjX = x + TileDirectionDelta[direction].x;
-    sint32 adjY = y + TileDirectionDelta[direction].y;
-    rct_map_element *stationElement = get_station_platform(adjX, adjY, z, 2);
-    if (stationElement != NULL) {
-        sint32 rideIndex = stationElement->properties.track.ride_index;
-        Ride *ride = get_ride(rideIndex);
-        if (ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS) {
-            found = true;
+    sint32 adjX = x;
+    sint32 adjY = y;
+    for (int i = 0; i < ride_adjacent_station_max_distance; i++) {
+        adjX += TileDirectionDelta[direction].x;
+        adjY += TileDirectionDelta[direction].y;
+        rct_map_element *stationElement = get_station_platform(adjX, adjY, z, 2);
+        if (stationElement != NULL) {
+            sint32 rideIndex = stationElement->properties.track.ride_index;
+            Ride *ride = get_ride(rideIndex);
+            if (ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS) {
+                found = true;
+            }
         }
     }
     return found;

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -41,6 +41,7 @@
 #define MAX_RIDES                       255
 #define RIDE_ID_NULL                    255
 
+static const uint8      ride_adjacent_station_max_distance  = 5;
 
 #pragma pack(push, 1)
 

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -40,8 +40,7 @@
 #define RIDE_MEASUREMENT_MAX_ITEMS      4800
 #define MAX_RIDES                       255
 #define RIDE_ID_NULL                    255
-
-static const uint8      ride_adjacent_station_max_distance  = 5;
+#define RIDE_ADJACENCY_CHECK_DISTANCE   5
 
 #pragma pack(push, 1)
 

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2332,6 +2332,10 @@ static rct_synchronised_vehicle* _lastSynchronisedVehicle = NULL;
  */
 static bool try_add_synchronised_station(sint32 x, sint32 y, sint32 z)
 {
+        // make sure we are in map bounds
+    if (x < 0 || y < 0 || (x>>5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1) || (y>>5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
+        return false;
+
     rct_map_element *mapElement = get_station_platform(x, y, z, 2);
     if (mapElement == NULL) {
         /* No station platform element found,
@@ -2432,9 +2436,12 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (!try_add_synchronised_station(x, y, z) && spaceBetween-- == 0) {
-            break;
+        if (try_add_synchronised_station(x, y, z)) {
+            spaceBetween = maxSearchDistance;
+            continue;
         }
+        if (spaceBetween-- == 0)
+            break;
     }
 
     // Reset back to starting tile.
@@ -2447,9 +2454,12 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (!try_add_synchronised_station(x, y, z) && spaceBetween-- == 0) {
-            break;
+        if (try_add_synchronised_station(x, y, z)) {
+            spaceBetween = maxSearchDistance;
+            continue;
         }
+        if (spaceBetween-- == 0)
+            break;
     }
 
     if (_lastSynchronisedVehicle == _synchronisedVehicles) {

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2424,18 +2424,21 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     // Reset the list of synchronised vehicles to empty.
     _lastSynchronisedVehicle = _synchronisedVehicles;
 
-    // Search for stations to sync in both directions from the current tile.
+    /* Search for stations to sync in both directions from the current tile.
+     * We allow for some space between stations, and every time a station
+     *  is found we allow for space between that and the next.
+     */
 
-    // First search direction.
     sint32 direction = (mapElement->type + 1) & 3;
     sint32 spaceBetween;
+    sint32 maxCheckDistance = RIDE_ADJACENCY_CHECK_DISTANCE;
 
-    spaceBetween = ride_adjacent_station_max_distance;
+    spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
         if (try_add_synchronised_station(x, y, z)) {
-            spaceBetween = ride_adjacent_station_max_distance;
+            spaceBetween = maxCheckDistance;
             continue;
         }
         if (spaceBetween-- == 0)
@@ -2448,12 +2451,12 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
 
     // Other search direction.
     direction = (direction ^ 2) & 3;
-    spaceBetween = ride_adjacent_station_max_distance;
+    spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
         if (try_add_synchronised_station(x, y, z)) {
-            spaceBetween = ride_adjacent_station_max_distance;
+            spaceBetween = maxCheckDistance;
             continue;
         }
         if (spaceBetween-- == 0)

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2421,14 +2421,18 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     _lastSynchronisedVehicle = _synchronisedVehicles;
 
     // Search for stations to sync in both directions from the current tile.
+    
+    static const sint32 maxSearchDistance = 5;    //  How many tiles we are allowed to search
 
     // First search direction.
     sint32 direction = (mapElement->type + 1) & 3;
+    sint32 spaceBetween;
 
+    spaceBetween = maxSearchDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (!try_add_synchronised_station(x, y, z)) {
+        if (!try_add_synchronised_station(x, y, z) && spaceBetween-- == 0) {
             break;
         }
     }
@@ -2439,10 +2443,11 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
 
     // Other search direction.
     direction = (direction ^ 2) & 3;
+    spaceBetween = maxSearchDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (!try_add_synchronised_station(x, y, z)) {
+        if (!try_add_synchronised_station(x, y, z) && spaceBetween-- == 0) {
             break;
         }
     }

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2333,19 +2333,23 @@ static rct_synchronised_vehicle* _lastSynchronisedVehicle = NULL;
 static bool try_add_synchronised_station(sint32 x, sint32 y, sint32 z)
 {
         // make sure we are in map bounds
-    if (x < 0 || y < 0 || (x>>5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1) || (y>>5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
+    if (x < 0 || y < 0 || (x >> 5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1) || (y >> 5) > (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
+    {
         return false;
+    }
 
-    rct_map_element *mapElement = get_station_platform(x, y, z, 2);
-    if (mapElement == NULL) {
+    rct_map_element * mapElement = get_station_platform(x, y, z, 2);
+    if (mapElement == NULL)
+    {
         /* No station platform element found,
          * so no station to synchronise */
         return false;
     }
 
     sint32 rideIndex = mapElement->properties.track.ride_index;
-    Ride *ride = get_ride(rideIndex);
-    if (!(ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS)) {
+    Ride * ride = get_ride(rideIndex);
+    if (!(ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS))
+    {
         /* Ride is not set to synchronise with adjacent stations. */
         return false;
     }
@@ -2356,7 +2360,7 @@ static bool try_add_synchronised_station(sint32 x, sint32 y, sint32 z)
 
     sint32 stationIndex = map_element_get_station(mapElement);
 
-    rct_synchronised_vehicle *sv = _lastSynchronisedVehicle;
+    rct_synchronised_vehicle * sv = _lastSynchronisedVehicle;
     sv->ride_id = rideIndex;
     sv->station_id = stationIndex;
     sv->vehicle_id = SPRITE_INDEX_NULL;
@@ -2365,26 +2369,44 @@ static bool try_add_synchronised_station(sint32 x, sint32 y, sint32 z)
     /* Ride vehicles are not on the track (e.g. ride is/was under
      * construction), so just return; vehicle_id for this station
      * is SPRITE_INDEX_NULL. */
-    if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)) {
+    if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
+    {
         return true;
     }
 
     /* Station is not ready to depart, so just return;
      * vehicle_id for this station is SPRITE_INDEX_NULL. */
-    if (!(ride->station_depart[stationIndex] & STATION_DEPART_FLAG)) {
+    if (!(ride->station_depart[stationIndex] & STATION_DEPART_FLAG))
+    {
         return true;
     }
 
     // Look for a vehicle on this station waiting to depart.
-    for (sint32 i = 0; i < ride->num_vehicles; i++) {
+    for (sint32 i = 0; i < ride->num_vehicles; i++)
+    {
         uint16 spriteIndex = ride->vehicles[i];
-        if (spriteIndex == SPRITE_INDEX_NULL) continue;
+        if (spriteIndex == SPRITE_INDEX_NULL)
+        {
+            continue;
+        }
 
-        rct_vehicle *vehicle = GET_VEHICLE(spriteIndex);
-        if (vehicle->status != VEHICLE_STATUS_WAITING_TO_DEPART) continue;
-        if (vehicle->sub_state != 0) continue;
-        if (!(vehicle->update_flags & VEHICLE_UPDATE_FLAG_WAIT_ON_ADJACENT)) continue;
-        if (vehicle->current_station != stationIndex) continue;
+        rct_vehicle * vehicle = GET_VEHICLE(spriteIndex);
+        if (vehicle->status != VEHICLE_STATUS_WAITING_TO_DEPART)
+        {
+            continue;
+        }
+        if (vehicle->sub_state != 0)
+        {
+            continue;
+        }
+        if (!(vehicle->update_flags & VEHICLE_UPDATE_FLAG_WAIT_ON_ADJACENT))
+        {
+            continue;
+        }
+        if (vehicle->current_station != stationIndex)
+        {
+            continue;
+        }
 
         sv->vehicle_id = spriteIndex;
         return true;
@@ -2409,15 +2431,15 @@ static bool try_add_synchronised_station(sint32 x, sint32 y, sint32 z)
  */
 static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
 {
-    Ride *ride = get_ride(vehicle->ride);
+    Ride * ride = get_ride(vehicle->ride);
     sint32 station = vehicle->current_station;
     rct_xy8 location = ride->station_starts[station];
     sint32 x = location.x * 32;
     sint32 y = location.y * 32;
     sint32 z = ride->station_heights[station];
 
-    rct_map_element *mapElement = map_get_track_element_at(x, y, z);
-    if (mapElement == NULL) {
+    rct_map_element * mapElement = map_get_track_element_at(x, y, z);
+    if (mapElement == NULL){
         return false;
     }
 
@@ -2434,15 +2456,19 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     sint32 maxCheckDistance = RIDE_ADJACENCY_CHECK_DISTANCE;
 
     spaceBetween = maxCheckDistance;
-    while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
+    while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1])
+    {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (try_add_synchronised_station(x, y, z)) {
+        if (try_add_synchronised_station(x, y, z))
+        {
             spaceBetween = maxCheckDistance;
             continue;
         }
         if (spaceBetween-- == 0)
+        {
             break;
+        }
     }
 
     // Reset back to starting tile.
@@ -2452,36 +2478,49 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     // Other search direction.
     direction = (direction ^ 2) & 3;
     spaceBetween = maxCheckDistance;
-    while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
+    while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1])
+    {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
-        if (try_add_synchronised_station(x, y, z)) {
+        if (try_add_synchronised_station(x, y, z))
+        {
             spaceBetween = maxCheckDistance;
             continue;
         }
         if (spaceBetween-- == 0)
+        {
             break;
+        }
     }
 
-    if (_lastSynchronisedVehicle == _synchronisedVehicles) {
+    if (_lastSynchronisedVehicle == _synchronisedVehicles)
+    {
         // No adjacent stations, allow depart
         return true;
     }
 
-    for (rct_synchronised_vehicle *sv = _synchronisedVehicles; sv < _lastSynchronisedVehicle; sv++) {
-        Ride *sv_ride = get_ride(sv->ride_id);
+    for (rct_synchronised_vehicle * sv = _synchronisedVehicles; sv < _lastSynchronisedVehicle; sv++)
+    {
+        Ride * sv_ride = get_ride(sv->ride_id);
 
-        if (!(sv_ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)) {
-            if (sv_ride->status != RIDE_STATUS_CLOSED) {
-                if (ride_is_block_sectioned(sv_ride)) {
-                    if (!(sv_ride->station_depart[sv->station_id] & STATION_DEPART_FLAG)) {
+        if (!(sv_ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        {
+            if (sv_ride->status != RIDE_STATUS_CLOSED)
+            {
+                if (ride_is_block_sectioned(sv_ride))
+                {
+                    if (!(sv_ride->station_depart[sv->station_id] & STATION_DEPART_FLAG))
+                    {
                         sv = _synchronisedVehicles;
                         uint8 rideId = 0xFF;
-                        for (; sv < _lastSynchronisedVehicle; sv++) {
-                            if (rideId == 0xFF) {
+                        for (; sv < _lastSynchronisedVehicle; sv++)
+                        {
+                            if (rideId == 0xFF)
+                            {
                                 rideId = sv->ride_id;
                             }
-                            if (rideId != sv->ride_id) {
+                            if (rideId != sv->ride_id)
+                            {
                                 // Here the sync-ed stations are not all from the same ride.
                                 return false;
                             }
@@ -2489,9 +2528,11 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
 
                         /* Here all the of sync-ed stations are from the same ride */
                         ride = get_ride(rideId);
-                        for (sint32 i = 0; i < ride->num_vehicles; i++) {
-                            rct_vehicle *v = GET_VEHICLE(ride->vehicles[i]);
-                            if (v->status != VEHICLE_STATUS_WAITING_TO_DEPART && v->velocity != 0) {
+                        for (sint32 i = 0; i < ride->num_vehicles; i++)
+                        {
+                            rct_vehicle * v = GET_VEHICLE(ride->vehicles[i]);
+                            if (v->status != VEHICLE_STATUS_WAITING_TO_DEPART && v->velocity != 0)
+                            {
                                 // Here at least one vehicle on the ride is moving.
                                 return false;
                             }
@@ -2502,15 +2543,18 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
                     }
                 }
                 // There is no vehicle waiting at this station to sync with.
-                if (sv->vehicle_id == SPRITE_INDEX_NULL) {
+                if (sv->vehicle_id == SPRITE_INDEX_NULL)
+                {
                     // Check conditions for departing without all stations being in sync.
-                    if (_lastSynchronisedVehicle > &_synchronisedVehicles[1]) {
+                    if (_lastSynchronisedVehicle > &_synchronisedVehicles[1])
+                    {
                         // Sync condition: there are at least 3 stations to sync
                         return false;
                     }
                     uint8 someRideIndex = _synchronisedVehicles[0].ride_id;
                     // uint8 currentStation = _synchronisedVehicles[0].station_id
-                    if (someRideIndex != vehicle->ride) {
+                    if (someRideIndex != vehicle->ride)
+                    {
                         // Sync condition: the first station to sync is a different ride
                         return false;
                     }
@@ -2518,33 +2562,42 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
                     sint32 numTrainsAtStation = 0;
                     sint32 numTravelingTrains = 0;
                     sint32 currentStation = sv->station_id;
-                    for (sint32 i = 0; i < sv_ride->num_vehicles; i++) {
+                    for (sint32 i = 0; i < sv_ride->num_vehicles; i++)
+                    {
                         uint16 spriteIndex = sv_ride->vehicles[i];
-                        if (spriteIndex != SPRITE_INDEX_NULL) {
+                        if (spriteIndex != SPRITE_INDEX_NULL)
+                        {
                             rct_vehicle *otherVehicle = GET_VEHICLE(spriteIndex);
-                            if (otherVehicle->status != VEHICLE_STATUS_TRAVELLING) {
-                                if (currentStation == otherVehicle->current_station) {
+                            if (otherVehicle->status != VEHICLE_STATUS_TRAVELLING)
+                            {
+                                if (currentStation == otherVehicle->current_station)
+                                {
                                     if (otherVehicle->status == VEHICLE_STATUS_WAITING_TO_DEPART ||
-                                        otherVehicle->status == VEHICLE_STATUS_MOVING_TO_END_OF_STATION
-                                    ) {
+                                        otherVehicle->status == VEHICLE_STATUS_MOVING_TO_END_OF_STATION)
+                                    {
                                         numTrainsAtStation++;
                                     }
                                 }
-                            } else {
+                            }
+                            else
+                            {
                                 numTravelingTrains++;
                             }
                         }
                     }
 
                     sint32 totalTrains = numTrainsAtStation + numTravelingTrains;
-                    if (totalTrains != sv_ride->num_vehicles || numTravelingTrains >= sv_ride->num_vehicles / 2) {
+                    if (totalTrains != sv_ride->num_vehicles || numTravelingTrains >= sv_ride->num_vehicles / 2)
+                    {
                     //if (numArrivingTrains > 0 || numTravelingTrains >= sv_ride->num_vehicles / 2) {
                         /* Sync condition: If there are trains arriving at the
                          * station or half or more of the ride trains are
                          * travelling, this station must be sync-ed before the
                          * trains can depart! */
                         return false;
-                    } else {
+                    }
+                    else
+                    {
                         /* Sync exception - train is not arriving at the station
                          * and there are less than half the trains for the ride
                          * travelling. */
@@ -2556,8 +2609,10 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     }
 
     // At this point all vehicles in _snychronisedVehicles can depart.
-    for (rct_synchronised_vehicle *sv = _synchronisedVehicles; sv < _lastSynchronisedVehicle; sv++) {
-        if (sv->vehicle_id != SPRITE_INDEX_NULL) {
+    for (rct_synchronised_vehicle *sv = _synchronisedVehicles; sv < _lastSynchronisedVehicle; sv++)
+    {
+        if (sv->vehicle_id != SPRITE_INDEX_NULL)
+        {
             rct_vehicle *v = GET_VEHICLE(sv->vehicle_id);
             v->update_flags &= ~VEHICLE_UPDATE_FLAG_WAIT_ON_ADJACENT;
         }

--- a/src/openrct2/ride/vehicle.c
+++ b/src/openrct2/ride/vehicle.c
@@ -2425,19 +2425,17 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
     _lastSynchronisedVehicle = _synchronisedVehicles;
 
     // Search for stations to sync in both directions from the current tile.
-    
-    static const sint32 maxSearchDistance = 5;    //  How many tiles we are allowed to search
 
     // First search direction.
     sint32 direction = (mapElement->type + 1) & 3;
     sint32 spaceBetween;
 
-    spaceBetween = maxSearchDistance;
+    spaceBetween = ride_adjacent_station_max_distance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
         if (try_add_synchronised_station(x, y, z)) {
-            spaceBetween = maxSearchDistance;
+            spaceBetween = ride_adjacent_station_max_distance;
             continue;
         }
         if (spaceBetween-- == 0)
@@ -2450,12 +2448,12 @@ static bool vehicle_can_depart_synchronised(rct_vehicle *vehicle)
 
     // Other search direction.
     direction = (direction ^ 2) & 3;
-    spaceBetween = maxSearchDistance;
+    spaceBetween = ride_adjacent_station_max_distance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1]) {
         x += TileDirectionDelta[direction].x;
         y += TileDirectionDelta[direction].y;
         if (try_add_synchronised_station(x, y, z)) {
-            spaceBetween = maxSearchDistance;
+            spaceBetween = ride_adjacent_station_max_distance;
             continue;
         }
         if (spaceBetween-- == 0)


### PR DESCRIPTION
Rides with up to 4 empty tiles in-between can be synchronised.

![sync](https://user-images.githubusercontent.com/14242454/30786901-e5bbdfe4-a17d-11e7-944b-b8df94caf1cf.gif)

Practically speaking the vehicle looks a few steps farther in-between stations to see if any can be found, but as before it only picks rides which can be synchronised with.

The number 5 is arbitrary and a better number might have to be chosen.