### PR TITLE
Fix #6309: Lightfx being enabled with incompatible drawing engine.

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -34,6 +34,7 @@
 #include <openrct2/interface/window.h>
 #include <openrct2/intro.h>
 #include <openrct2/drawing/drawing.h>
+#include <openrct2/drawing/lightfx.h>
 
 #include "../DrawingEngines.h"
 #include "GLSLTypes.h"
@@ -145,6 +146,9 @@ public:
     {
         _window = (SDL_Window *)_uiContext->GetWindow();
         _drawingContext = new OpenGLDrawingContext(this);
+#ifdef __ENABLE_LIGHTFX__
+        lightfx_set_available(false);
+#endif
     }
 
     ~OpenGLDrawingEngine() override

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -138,6 +138,7 @@ X8DrawingEngine::X8DrawingEngine(Ui::IUiContext * uiContext)
 {
     _drawingContext = new X8DrawingContext(this);
 #ifdef __ENABLE_LIGHTFX__
+    lightfx_set_available(true);
     _lastLightFXenabled = (gConfigGeneral.enable_light_fx != 0);
 #endif
 }
@@ -359,7 +360,7 @@ void X8DrawingEngine::ConfigureBits(uint32 width, uint32 height, uint32 pitch)
     ConfigureDirtyGrid();
 
 #ifdef __ENABLE_LIGHTFX__
-        if (gConfigGeneral.enable_light_fx)
+        if (lightfx_is_available())
         {
             lightfx_update_buffers(dpi);
         }

--- a/src/openrct2/drawing/lightfx.c
+++ b/src/openrct2/drawing/lightfx.c
@@ -22,6 +22,7 @@
 #include "../interface/window.h"
 #include "../paint/map_element/map_element.h"
 #include "../world/Climate.h"
+#include "../config/Config.h"
 #include "drawing.h"
 #include "lightfx.h"
 
@@ -34,6 +35,7 @@ static uint8 _bakedLightTexture_spot_1[64 * 64];
 static uint8 _bakedLightTexture_spot_2[128 * 128];
 static uint8 _bakedLightTexture_spot_3[256 * 256];
 static rct_drawpixelinfo    _pixelInfo;
+static bool _lightfxAvailable = false;
 
 static void* _light_rendered_buffer_back = NULL;
 static void* _light_rendered_buffer_front = NULL;
@@ -108,6 +110,16 @@ static void calc_rescale_light_half( uint8 *target, uint8 *source,uint32 targetW
         }
         parcerRead += targetWidth * 2;
     }
+}
+
+void lightfx_set_available(bool available)
+{
+    _lightfxAvailable = available;
+}
+
+bool lightfx_is_available()
+{
+    return _lightfxAvailable && gConfigGeneral.enable_light_fx != 0;
 }
 
 void lightfx_init()

--- a/src/openrct2/drawing/lightfx.h
+++ b/src/openrct2/drawing/lightfx.h
@@ -49,6 +49,9 @@ enum LIGHTFX_LIGHT_QUALIFIER {
 extern "C" {
 #endif
 
+void lightfx_set_available(bool available);
+bool lightfx_is_available();
+
 void lightfx_init();
 
 void lightfx_update_buffers(rct_drawpixelinfo*);

--- a/src/openrct2/paint/map_element/entrance.c
+++ b/src/openrct2/paint/map_element/entrance.c
@@ -43,7 +43,7 @@ static void ride_entrance_exit_paint(paint_session * session, uint8 direction, s
     }
 
 #ifdef __ENABLE_LIGHTFX__
-    if (gConfigGeneral.enable_light_fx) {
+    if (lightfx_is_available()) {
         if (!is_exit) {
             lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 0, height + 45, LIGHTFX_LIGHT_TYPE_LANTERN_3);
         }
@@ -190,7 +190,7 @@ static void park_entrance_paint(paint_session * session, uint8 direction, sint32
         return;
 
 #ifdef __ENABLE_LIGHTFX__
-    if (gConfigGeneral.enable_light_fx) {
+    if (lightfx_is_available()) {
         lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 0, 155, LIGHTFX_LIGHT_TYPE_LANTERN_3);
     }
 #endif

--- a/src/openrct2/paint/map_element/path.c
+++ b/src/openrct2/paint/map_element/path.c
@@ -776,7 +776,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_map
     }
 
 #ifdef __ENABLE_LIGHTFX__
-    if (gConfigGeneral.enable_light_fx) {
+    if (lightfx_is_available()) {
         if (footpath_element_has_path_scenery(map_element) && !(map_element->flags & MAP_ELEMENT_FLAG_BROKEN)) {
             rct_scenery_entry *sceneryEntry = get_footpath_item_entry(footpath_element_get_path_scenery_index(map_element));
             if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP) {

--- a/src/openrct2/paint/sprite/peep.c
+++ b/src/openrct2/paint/sprite/peep.c
@@ -29,7 +29,7 @@
 void peep_paint(paint_session * session, rct_peep * peep, sint32 imageDirection)
 {
 #ifdef __ENABLE_LIGHTFX__
-    if (gConfigGeneral.enable_light_fx) {
+    if (lightfx_is_available()) {
         if (peep->type == PEEP_TYPE_STAFF) {
             sint16 peep_x, peep_y, peep_z;
 

--- a/src/openrct2/platform/shared.c
+++ b/src/openrct2/platform/shared.c
@@ -91,7 +91,7 @@ void platform_update_palette(const uint8* colours, sint32 start_index, sint32 nu
         uint8 b = colours[0];
 
 #ifdef __ENABLE_LIGHTFX__
-        if (gConfigGeneral.enable_light_fx)
+        if (lightfx_is_available())
         {
             lightfx_apply_palette_filter(i, &r, &g, &b);
         }


### PR DESCRIPTION
Currently as soon the lightfx option was enabled it would be always enabled even if its only supposed to work with the software drawing engine. This ensures that the drawing engine will turn it off regardless of the setting. I introduced a new variable that is independent from the configuration as it didn't feel right overwriting the setting to force it off.