### PR TITLE
Fix #6308 Write errors not being handled correctly when creating title sequences.

### DIFF
--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -47,8 +47,20 @@ public:
 
     ~ZipArchive() override
     {
-        zip_close(_zip);
+		if (_zip != nullptr) zip_discard(_zip);
     }
+
+	bool TryWriteClose() override
+	{
+        //If not open, cannot write
+		if (_zip == nullptr) return false;
+		//zip_close tries to write out the file, and returns zero on success.
+		//If it fails, return is non-zero and _zip is NOT closed.
+		if (zip_close(_zip) != 0) return false;
+
+		_zip = nullptr;
+		return true;
+	}
 
     size_t GetNumFiles() const override
     {

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -47,20 +47,20 @@ public:
 
     ~ZipArchive() override
     {
-		if (_zip != nullptr) zip_discard(_zip);
+        if (_zip != nullptr) zip_discard(_zip);
     }
 
-	bool TryWriteClose() override
-	{
+    bool TryWriteClose() override
+    {
         //If not open, cannot write
-		if (_zip == nullptr) return false;
-		//zip_close tries to write out the file, and returns zero on success.
-		//If it fails, return is non-zero and _zip is NOT closed.
-		if (zip_close(_zip) != 0) return false;
+        if (_zip == nullptr) return false;
+        //zip_close tries to write out the file, and returns zero on success.
+        //If it fails, return is non-zero and _zip is NOT closed.
+        if (zip_close(_zip) != 0) return false;
 
-		_zip = nullptr;
-		return true;
-	}
+        _zip = nullptr;
+        return true;
+    }
 
     size_t GetNumFiles() const override
     {

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -45,7 +45,7 @@ interface IZipArchive
     virtual void DeleteFile(const utf8 * path) abstract;
     virtual void RenameFile(const utf8 * path, const utf8 * newPath) abstract;
 
-	virtual bool TryWriteClose() abstract;
+    virtual bool TryWriteClose() abstract;
 };
 
 enum ZIP_ACCESS

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -44,6 +44,8 @@ interface IZipArchive
 
     virtual void DeleteFile(const utf8 * path) abstract;
     virtual void RenameFile(const utf8 * path, const utf8 * newPath) abstract;
+
+	virtual bool TryWriteClose() abstract;
 };
 
 enum ZIP_ACCESS

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -46,13 +46,18 @@ public:
     ~ZipArchive() override {
         // retrieve the JNI environment.
         JNIEnv *env = (JNIEnv *) SDL_AndroidGetJNIEnv();
-
+        
         jclass zipClass = env->GetObjectClass(_zip);
         jmethodID closeMethod = env->GetMethodID(zipClass, "close", "()V");
-
+        
         env->CallVoidMethod(_zip, closeMethod);
-
+        
         env->DeleteGlobalRef(_zip);
+    }
+
+    bool TryWriteClose() override {
+        //Cannot write, always return false
+        return false
     }
 
     size_t GetNumFiles() const override {

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -193,8 +193,8 @@ extern "C"
         {
             IZipArchive * zip = Zip::TryOpen(seq->Path, ZIP_ACCESS_WRITE);
             zip->SetFileData("script.txt", script, String::SizeOf(script));
-            delete zip;
-            success = true;
+			success = zip->TryWriteClose();
+			delete zip;
         }
         else
         {
@@ -248,12 +248,19 @@ extern "C"
                 IZipArchive * zip = Zip::TryOpen(seq->Path, ZIP_ACCESS_WRITE);
                 if (zip == nullptr)
                 {
+					Memory::Free(fdata);
                     Console::Error::WriteLine("Unable to open '%s'", seq->Path);
                     return false;
                 }
                 zip->SetFileData(name, fdata, fsize);
+				bool ok = zip->TryWriteClose();
                 delete zip;
                 Memory::Free(fdata);
+                if (!ok)
+                {
+					Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+					return false;
+				}
             }
             catch (const Exception &ex)
             {
@@ -289,7 +296,13 @@ extern "C"
                 return false;
             }
             zip->RenameFile(oldRelativePath, name);
-            delete zip;
+			bool ok = zip->TryWriteClose();
+			delete zip;
+			if (!ok)
+			{
+				Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+				return false;
+			}
         }
         else
         {
@@ -326,7 +339,13 @@ extern "C"
                 return false;
             }
             zip->DeleteFile(relativePath);
+			bool ok = zip->TryWriteClose();
             delete zip;
+			if (!ok)
+			{
+				Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+				return false;
+			}
         }
         else
         {

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -193,8 +193,8 @@ extern "C"
         {
             IZipArchive * zip = Zip::TryOpen(seq->Path, ZIP_ACCESS_WRITE);
             zip->SetFileData("script.txt", script, String::SizeOf(script));
-			success = zip->TryWriteClose();
-			delete zip;
+            success = zip->TryWriteClose();
+            delete zip;
         }
         else
         {
@@ -248,19 +248,19 @@ extern "C"
                 IZipArchive * zip = Zip::TryOpen(seq->Path, ZIP_ACCESS_WRITE);
                 if (zip == nullptr)
                 {
-					Memory::Free(fdata);
+                    Memory::Free(fdata);
                     Console::Error::WriteLine("Unable to open '%s'", seq->Path);
                     return false;
                 }
                 zip->SetFileData(name, fdata, fsize);
-				bool ok = zip->TryWriteClose();
+                bool ok = zip->TryWriteClose();
                 delete zip;
                 Memory::Free(fdata);
                 if (!ok)
                 {
-					Console::Error::WriteLine("Unable to write '%s'", seq->Path);
-					return false;
-				}
+                    Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+                    return false;
+                }
             }
             catch (const Exception &ex)
             {
@@ -296,13 +296,13 @@ extern "C"
                 return false;
             }
             zip->RenameFile(oldRelativePath, name);
-			bool ok = zip->TryWriteClose();
-			delete zip;
-			if (!ok)
-			{
-				Console::Error::WriteLine("Unable to write '%s'", seq->Path);
-				return false;
-			}
+            bool ok = zip->TryWriteClose();
+            delete zip;
+            if (!ok)
+            {
+                Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+                return false;
+            }
         }
         else
         {
@@ -339,13 +339,13 @@ extern "C"
                 return false;
             }
             zip->DeleteFile(relativePath);
-			bool ok = zip->TryWriteClose();
+            bool ok = zip->TryWriteClose();
             delete zip;
-			if (!ok)
-			{
-				Console::Error::WriteLine("Unable to write '%s'", seq->Path);
-				return false;
-			}
+            if (!ok)
+            {
+                Console::Error::WriteLine("Unable to write '%s'", seq->Path);
+                return false;
+            }
         }
         else
         {

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -288,6 +288,7 @@ namespace TitleSequenceManager
     static void GetUserSequencesPath(utf8 * buffer, size_t bufferSize)
     {
         platform_get_user_directory(buffer, "title sequences", bufferSize);
+		platform_ensure_directory_exists(buffer);
     }
 }
 

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -288,7 +288,7 @@ namespace TitleSequenceManager
     static void GetUserSequencesPath(utf8 * buffer, size_t bufferSize)
     {
         platform_get_user_directory(buffer, "title sequences", bufferSize);
-		platform_ensure_directory_exists(buffer);
+        platform_ensure_directory_exists(buffer);
     }
 }
 


### PR DESCRIPTION
Added TryWriteClose() to move file writes out of ZipArchive destructor and be aware of write errors. This matches the behavior of libzip's zip_close(), which will try to write before closing

Added check to TitleSequenceManager to ensure user directory exists.

Two things I'm unsure of

1 - I modified the behavior of ZipArchive's desctuctor significantly. Previously, the destructor would attempt to write to a file (and may or may not actually free _zip). Now the destructor will only free the _zip pointer, and not try to write. The only place that Zip is used is within title sequences, so I felt this was okay. However if that is not okay, I can modify it.

2 - As far as I can tell, ZipAndroid does not have the ability to write. If I am incorrect about that, it's implementation of TryWriteClose will need to do something other than say no.

Lastly, it's worth mentioning that if an existing title sequence is read-only, the manager still allows you to modify the sequence in game while silently failing to write. I don't see an easy way to change this outright, so I'll probably try to add some user feedback to let them know things are bad.