### PR TITLE
Unify "separate ride" and "separate ride name" flags

### DIFF
--- a/src/openrct2/management/research.c
+++ b/src/openrct2/management/research.c
@@ -230,7 +230,7 @@ void research_finish_item(sint32 entryIndex)
             {
                 availabilityString = STR_NEWS_ITEM_RESEARCH_NEW_RIDE_AVAILABLE;
 
-                if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)
+                if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)
                 {
                     set_format_arg(0, rct_string_id, rideEntry->naming.name);
                 }
@@ -431,7 +431,7 @@ void research_remove_non_separate_vehicle_types()
             researchItem->entryIndex >= 0x10000
         ) {
             rct_ride_entry *rideEntry = get_ride_entry(researchItem->entryIndex & 0xFF);
-            if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME))) {
+            if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE))) {
                 // Check if ride type already exists further up for a vehicle type that isn't displayed as a ride
                 researchItem2 = researchItem - 1;
                 do {
@@ -440,7 +440,7 @@ void research_remove_non_separate_vehicle_types()
                         researchItem2->entryIndex >= 0x10000
                     ) {
                         rideEntry = get_ride_entry(researchItem2->entryIndex & 0xFF);
-                        if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME))) {
+                        if (!(rideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE))) {
 
                             if (research_get_ride_base_type(researchItem->entryIndex) == research_get_ride_base_type(researchItem2->entryIndex)) {
                                 // Remove item
@@ -728,7 +728,7 @@ rct_string_id research_item_get_name(uint32 researchItem)
         {
             return 0;
         }
-        else if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)
+        else if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)
         {
             return rideEntry->naming.name;
         }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -6004,7 +6004,7 @@ static money32 ride_create(sint32 type, sint32 subType, sint32 flags, sint32 *ou
                 continue;
             }
 
-            if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+            if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
                 subType = *rei;
                 goto foundRideEntry;
             }
@@ -6216,7 +6216,7 @@ foundRideEntry:
 
 void ride_set_name_to_default(Ride * ride, rct_ride_entry * rideEntry)
 {
-    if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+    if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
         ride_set_name_to_track_default(ride, rideEntry);
     } else {
         ride_set_name_to_vehicle_default(ride, rideEntry);
@@ -6292,7 +6292,7 @@ rct_ride_name get_ride_naming(uint8 rideType, rct_ride_entry * rideEntry)
         const ride_group * rideGroup = get_ride_group(rideType, rideEntry);
         return rideGroup->naming;
     }
-    else if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
+    else if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
         return RideNaming[rideType];
     }
     else {

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -444,7 +444,7 @@ enum {
     RIDE_ENTRY_FLAG_PLAY_SPLASH_SOUND_SLIDE         = 1 << 9,
     RIDE_ENTRY_FLAG_COVERED_RIDE                    = 1 << 10,
     RIDE_ENTRY_FLAG_LIMIT_AIRTIME_BONUS             = 1 << 11,
-    RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME              = 1 << 12,
+    RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME_DEPRECATED   = 1 << 12, // Always set with SEPARATE_RIDE, and deprecated in favour of it.
     RIDE_ENTRY_FLAG_SEPARATE_RIDE                   = 1 << 13,
     RIDE_ENTRY_FLAG_CANNOT_BREAK_DOWN               = 1 << 14,
     RIDE_ENTRY_DISABLE_LAST_OPERATING_MODE          = 1 << 15,

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -2714,7 +2714,7 @@ static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetI
                 rideEntryIndex = *currentRideEntryIndex;
                 currentRideEntry = get_ride_entry(rideEntryIndex);
                 // Skip if vehicle wants to be separate, unless subtype switching is enabled
-                if ((currentRideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE | RIDE_ENTRY_FLAG_SEPARATE_RIDE_NAME)) && !(gConfigInterface.select_by_track_type || selectionShouldBeExpanded))
+                if ((currentRideEntry->flags & (RIDE_ENTRY_FLAG_SEPARATE_RIDE)) && !(gConfigInterface.select_by_track_type || selectionShouldBeExpanded))
                     continue;
 
                 // Skip if vehicle type is not invented yet


### PR DESCRIPTION
They're always set together, and only setting one will probably cause undefined behaviour. Deprecate the "separate ride name" flag and instead check the "separate ride" flag in all places.