### PR TITLE
Fix #6308 - Ensure title sequence user data path exists

### DIFF
--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -288,6 +288,7 @@ namespace TitleSequenceManager
     static void GetUserSequencesPath(utf8 * buffer, size_t bufferSize)
     {
         platform_get_user_directory(buffer, "title sequences", bufferSize);
+        platform_ensure_directory_exists(buffer);
     }
 }
 


### PR DESCRIPTION
I believe additional improvements can be made to error handling within Zip and title sequences, however this small change should allow new users to create title sequences generally without issue.

There could still be weird issues if data gets corrupted, files are read-only, or other general filesystem errors. I'd like to work on this if that is okay, though I think it would make sense to open it as a new issue.