### PR TITLE
Fix #6202: Avoid breaking occupied benches

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#6188] Viewports not being clipped properly when zoomed out in OpenGL mode.
 - Fix: [#6193] All rings in Space Rings use the same secondary colour
 - Fix: [#6198] You cannot cancel RCT1 directory selection
+- Fix: [#6202] Guests can break occupied benches.
 - Fix: [#6271] Wrong booster speed tooltip text
 - Fix: [#6320] Crash when CSS1.DAT is absent
 - Fix: Infinite loop when removing scenery elements with >127 base height.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -49,7 +49,7 @@ enum {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -5565,6 +5565,31 @@ static void peep_update_walking_break_scenery(rct_peep* peep){
     sint32 edges = map_element->properties.path.edges & 0xF;
     if (edges == 0xF) return;
 
+    uint16 sprite_id = sprite_get_first_in_quadrant(peep->x, peep->y);
+
+    // Check if a peep is already sitting on the bench.
+    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant) 
+    {
+        sprite = get_sprite(sprite_id);
+
+        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        {
+            continue;
+        }
+
+        if (sprite->peep.state != PEEP_STATE_SITTING)
+        {
+            continue;
+        }
+
+        if (peep->z != sprite->peep.z)
+        {
+            continue;
+        }
+
+        return;
+    }
+
     rct_peep* inner_peep;
     uint16 sprite_index;
 

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -5567,22 +5567,14 @@ static void peep_update_walking_break_scenery(rct_peep* peep){
 
     uint16 sprite_id = sprite_get_first_in_quadrant(peep->x, peep->y);
 
-    // Check if a peep is already sitting on the bench.
-    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant) 
+    // Check if a peep is already sitting on the bench. If so, do not vandalise it.
+    for (rct_sprite * sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant) 
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
-        {
-            continue;
-        }
-
-        if (sprite->peep.state != PEEP_STATE_SITTING)
-        {
-            continue;
-        }
-
-        if (peep->z != sprite->peep.z)
+        if ((sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2) ||
+            (sprite->peep.state != PEEP_STATE_SITTING) ||
+            (peep->z != sprite->peep.z))
         {
             continue;
         }


### PR DESCRIPTION
As per @ZehMatt's suggestion on https://github.com/OpenRCT2/OpenRCT2/issues/6202. Peeps will not break benches if the bench is occupied.

Other potential solution would be to eject the sitting peeps when the bench is broken. I personally think however that this fix is more logical.