### PR TITLE
Fix game actions executing wrong callbacks.

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2133,12 +2133,17 @@ void Network::Client_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPa
     }
     action->Serialise(ds);
 
-    auto itr = _gameActionCallbacks.find(action->GetNetworkId());
-    if (itr != _gameActionCallbacks.end())
+    if (player_id == action->GetPlayer())
     {
-        action->SetCallback(itr->second);
+        // Only execute callbacks that belong to us, 
+        // clients can have identical network ids assigned.
+        auto itr = _gameActionCallbacks.find(action->GetNetworkId());
+        if (itr != _gameActionCallbacks.end())
+        {
+            action->SetCallback(itr->second);
 
-        _gameActionCallbacks.erase(itr);
+            _gameActionCallbacks.erase(itr);
+        }
     }
 
     game_command_queue.emplace(tick, std::move(action), _commandId++);


### PR DESCRIPTION
Currently game actions have conflicting network ids because there has been no check if the game action executed actually belongs to the local player. Following things would trigger unexpected behavior:

Player 1 sends "RideCreateAction" at tick 388, action network id 1.
Player 2 sends "RideDemolishAction" at tick 388, action network id 1.

Now the server would send both clients the game actions but whoever sent it first would steal the callback away from each other.