### PR TITLE
Fix #6201, #6250: custom RCT1 scenarios cause empty scenario list entry

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#6235] Add drawing debug option for showing visuals when and where blocks of the screen are painted.
 - Feature: [#6292] Allow building queue lines in the Scenario Editor.
 - Feature: [#6325] Allow using g1.dat from RCT Classic.
+- Feature: [#6353] Show custom RCT1 scenarios in New Scenario window.
 - Feature: Allow using object files from RCT Classic.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -460,28 +460,36 @@ private:
     void AddScenario(const scenario_index_entry &entry)
     {
         auto filename = Path::GetFileName(entry.path);
-        auto existingEntry = GetByFilename(filename);
-        if (existingEntry != nullptr)
-        {
-            std::string conflictPath;
-            if (existingEntry->timestamp > entry.timestamp)
-            {
-                // Existing entry is more recent
-                conflictPath = String::ToStd(existingEntry->path);
 
-                // Overwrite existing entry with this one
-                *existingEntry = entry;
+        if (!String::Equals(filename, ""))
+        {
+            auto existingEntry = GetByFilename(filename);
+            if (existingEntry != nullptr)
+            {
+                std::string conflictPath;
+                if (existingEntry->timestamp > entry.timestamp)
+                {
+                    // Existing entry is more recent
+                    conflictPath = String::ToStd(existingEntry->path);
+
+                    // Overwrite existing entry with this one
+                    *existingEntry = entry;
+                }
+                else
+                {
+                    // This entry is more recent
+                    conflictPath = entry.path;
+                }
+                Console::WriteLine("Scenario conflict: '%s' ignored because it is newer.", conflictPath.c_str());
             }
             else
             {
-                // This entry is more recent
-                conflictPath = entry.path;
+                _scenarios.push_back(entry);
             }
-            Console::WriteLine("Scenario conflict: '%s' ignored because it is newer.", conflictPath.c_str());
         }
         else
         {
-            _scenarios.push_back(entry);
+            log_error("Tried to add scenario with an empty filename!");
         }
     }
 


### PR DESCRIPTION
The scenario repository did not correctly handle custom RCT1 scenarios.
They were not listed, but if they existed, an empty entry would appear in the scenario list.
This fixes both issues, and also prints a warning message, should this ever happen again.