### PR TITLE
Fix #5609: Vehicle switching may cause '0 cars per train' to be set

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.
+- Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list.
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -49,7 +49,7 @@ enum {
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -7950,8 +7950,8 @@ static money32 ride_set_vehicles(uint8 rideIndex, uint8 setting, uint8 value, ui
         ride->vehicle_change_timeout = 100;
 
         invalidate_test_results(rideIndex);
-        rideEntry = get_ride_entry(ride->subtype);
         ride->subtype = value;
+        rideEntry = get_ride_entry(ride->subtype);
 
         uint8 preset = ex;
         if (!(flags & GAME_COMMAND_FLAG_NETWORKED)) {


### PR DESCRIPTION
Issue caused by reading the old vehicle entry and taking the settings from that, rather than taking them from the new one.