### PR TITLE
Implement #5826: Add command to show map data counts and limits

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#6292] Allow building queue lines in the Scenario Editor.
 - Feature: [#6325] Allow using g1.dat from RCT Classic.
 - Feature: [#6353] Show custom RCT1 scenarios in New Scenario window.
+- Feature: [#6368] Add the show_limits command to show map data counts and limits.
 - Feature: Allow using object files from RCT Classic.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,13 +1,13 @@
 0.1.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
+- Feature: [#5826] Add the show_limits command to show map data counts and limits.
 - Feature: [#6078] Game now converts mp.dat to SC21.SC4 (Mega Park) automatically.
 - Feature: [#6181] Map generator now allows adjusting random terrain and tree placement in Simplex Noise tab.
 - Feature: [#6235] Add drawing debug option for showing visuals when and where blocks of the screen are painted.
 - Feature: [#6292] Allow building queue lines in the Scenario Editor.
 - Feature: [#6325] Allow using g1.dat from RCT Classic.
 - Feature: [#6353] Show custom RCT1 scenarios in New Scenario window.
-- Feature: [#6368] Add the show_limits command to show map data counts and limits.
 - Feature: Allow using object files from RCT Classic.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1214,6 +1214,53 @@ static sint32 cc_remove_unused_objects(const utf8 **argv, sint32 argc)
     return 0;
 }
 
+static sint32 cc_object_limits(const utf8 ** argv, sint32 argc)
+{
+    map_reorganise_elements();
+    sint32 mapElementCount = gNextFreeMapElement - gMapElements - 1;
+
+    sint32 rideCount = 0;
+    for (sint32 i = 0; i < MAX_RIDES; ++i) 
+    {
+        Ride * ride = get_ride(i);
+        if (ride->type != RIDE_TYPE_NULL) 
+        {
+            rideCount++;
+        }
+    }
+
+    sint32 spriteCount = 0;
+    for (sint32 i = 1; i < NUM_SPRITE_LISTS; ++i)
+    {
+        spriteCount += gSpriteListCount[i];
+    }
+
+    sint32 staffCount = 0;
+    for (sint32 i = 0; i < STAFF_MAX_COUNT; ++i) 
+    {
+        if (gStaffModes[i] & 1)
+        {
+            staffCount++;
+        }
+    }
+
+    sint32 bannerCount = 0;
+    for (sint32 i = 0; i < MAX_BANNERS; ++i)
+    {
+        if (gBanners[i].type != BANNER_NULL)
+        {
+            bannerCount++;
+        }
+    }
+
+    console_printf("Sprites: %d/%d", spriteCount, MAX_SPRITES);
+    console_printf("Map Elements: %d/%d", mapElementCount, MAX_MAP_ELEMENTS);
+    console_printf("Banners: %d/%d", bannerCount, MAX_BANNERS);
+    console_printf("Rides: %d/%d", rideCount, MAX_RIDES);
+    console_printf("Staff: %d/%d", staffCount, STAFF_MAX_COUNT);
+    return 0;
+}
+
 
 typedef sint32 (*console_command_func)(const utf8 **argv, sint32 argc);
 typedef struct console_command {
@@ -1289,6 +1336,7 @@ console_command console_command_table[] = {
     { "rides", cc_rides, "Ride management.", "rides <subcommand>" },
     { "staff", cc_staff, "Staff management.", "staff <subcommand>"},
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
+    { "object_limits", cc_object_limits, "Shows the number of objects placed on the map compared to the object limits.", "object_limits" },
 };
 
 static sint32 cc_windows(const utf8 **argv, sint32 argc) {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1336,7 +1336,7 @@ console_command console_command_table[] = {
     { "rides", cc_rides, "Ride management.", "rides <subcommand>" },
     { "staff", cc_staff, "Staff management.", "staff <subcommand>"},
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
-    { "show_limits", cc_show_limits, "Shows the map data counts and limits..", "show_limits" },
+    { "show_limits", cc_show_limits, "Shows the map data counts and limits.", "show_limits" },
 };
 
 static sint32 cc_windows(const utf8 **argv, sint32 argc) {

--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -1214,7 +1214,7 @@ static sint32 cc_remove_unused_objects(const utf8 **argv, sint32 argc)
     return 0;
 }
 
-static sint32 cc_object_limits(const utf8 ** argv, sint32 argc)
+static sint32 cc_show_limits(const utf8 ** argv, sint32 argc)
 {
     map_reorganise_elements();
     sint32 mapElementCount = gNextFreeMapElement - gMapElements - 1;
@@ -1336,7 +1336,7 @@ console_command console_command_table[] = {
     { "rides", cc_rides, "Ride management.", "rides <subcommand>" },
     { "staff", cc_staff, "Staff management.", "staff <subcommand>"},
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
-    { "object_limits", cc_object_limits, "Shows the number of objects placed on the map compared to the object limits.", "object_limits" },
+    { "show_limits", cc_show_limits, "Shows the map data counts and limits..", "show_limits" },
 };
 
 static sint32 cc_windows(const utf8 **argv, sint32 argc) {


### PR DESCRIPTION
This PR adds the `show_limits` command to show the map-data counts and limits. As suggested in https://github.com/OpenRCT2/OpenRCT2/issues/5826.

![objlimits](https://user-images.githubusercontent.com/2348094/31191437-640aa200-a93e-11e7-8760-2c9abbbeffb7.PNG)
