### PR TITLE
Fix viewport coordinates being set too late.

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1165,6 +1165,10 @@ void game_load_init()
         }
         mainWindow->saved_view_x -= mainWindow->viewport->view_width >> 1;
         mainWindow->saved_view_y -= mainWindow->viewport->view_height >> 1;
+
+        // Make sure the viewport has correct coordinates set.
+        viewport_update_position(mainWindow);
+
         window_invalidate(mainWindow);
     }
 

--- a/src/openrct2/interface/viewport.c
+++ b/src/openrct2/interface/viewport.c
@@ -1614,23 +1614,15 @@ sint16 get_height_marker_offset()
 
 void viewport_set_saved_view()
 {
-    sint16 viewX = 0;
-    sint16 viewY = 0;
-    uint8 viewZoom = 0;
-    uint8 viewRotation = 0;
-
     rct_window * w = window_get_main();
-    if (w != NULL) {
+    if (w != NULL) 
+    {
         rct_viewport *viewport = w->viewport;
 
-        viewX = viewport->view_width / 2 + viewport->view_x;
-        viewY = viewport->view_height / 2 + viewport->view_y;
-        viewZoom = viewport->zoom;
-        viewRotation = get_current_rotation();
-    }
+        gSavedViewX = viewport->view_width / 2 + viewport->view_x;
+        gSavedViewY = viewport->view_height / 2 + viewport->view_y;
 
-    gSavedViewX = viewX;
-    gSavedViewY = viewY;
-    gSavedViewZoom = viewZoom;
-    gSavedViewRotation = viewRotation;
+        gSavedViewZoom = viewport->zoom;
+        gSavedViewRotation = get_current_rotation();
+    }
 }


### PR DESCRIPTION
This PR will fix following things:
1. When the server loaded a new save the viewport would have not been yet set which would be sent to the client uninitialized.
2. Headless server has no window and so the viewport would be always at 0,0 instead of the position from the savegame.