### PR TITLE
Fix #6196: Guest's energy underflows and never decreases

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#6133] Construction rights not shown after selecting buy mode.
 - Fix: [#6188] Viewports not being clipped properly when zoomed out in OpenGL mode.
 - Fix: [#6193] All rings in Space Rings use the same secondary colour.
+- Fix: [#6196] Guest's energy underflows and never decreases.
 - Fix: [#6198] You cannot cancel RCT1 directory selection.
 - Fix: [#6202] Guests can break occupied benches.
 - Fix: [#6271] Wrong booster speed tooltip text.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -675,10 +675,11 @@ static uint8 peep_assess_surroundings(sint16 centre_x, sint16 centre_y, sint16 c
  *  rct2: 0x0068F9A9
  */
 static void peep_update_hunger(rct_peep *peep){
-    if (peep->hunger >= 3){
+    if (peep->hunger >= 3)
+    {
         peep->hunger -= 2;
-        // Originally capped at 255 instead of 128 (the actual max value), like a mistake since most other values do max out at 255.
-        peep->energy_target = min(peep->energy_target + 2, PEEP_MAX_ENERGY);
+
+        peep->energy_target = min(peep->energy_target + 2, PEEP_MAX_ENERGY_TARGET);
         peep->bathroom = min(peep->bathroom + 1, 255);
     }
 }
@@ -1206,7 +1207,8 @@ static void sub_68F41A(rct_peep *peep, sint32 index)
 
         peep->nausea_target = max(peep->nausea_target - 2, 0);
 
-        if (peep->energy <= 50){
+        if (peep->energy <= 50)
+        {
             peep->energy = max(peep->energy - 2, 0);
         }
 
@@ -1292,25 +1294,28 @@ static void sub_68F41A(rct_peep *peep, sint32 index)
     }
 
     uint8 energy = peep->energy;
-    uint8 energy_growth = peep->energy_target;
-    if (energy >= energy_growth){
+    uint8 energy_target = peep->energy_target;
+    if (energy >= energy_target)
+    {
         energy -= 2;
-        if (energy < energy_growth)
-            energy = energy_growth;
+        if (energy < energy_target)
+            energy = energy_target;
     }
-    else{
-        energy = min(255, energy + 4);
-        if (energy > energy_growth)
-            energy = energy_growth;
+    else
+    {
+        energy = min(PEEP_MAX_ENERGY_TARGET, energy + 4);
+        if (energy > energy_target)
+            energy = energy_target;
     }
 
     if (energy < 32)
         energy = 32;
 
     /* Previous code here suggested maximum energy is 128. */
-    energy = max(PEEP_MAX_ENERGY, energy);
+    energy = min(PEEP_MAX_ENERGY, energy);
 
-    if (energy != peep->energy){
+    if (energy != peep->energy)
+    {
         peep->energy = energy;
         peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_2;
     }

--- a/src/openrct2/peep/peep.h
+++ b/src/openrct2/peep/peep.h
@@ -31,8 +31,9 @@
 #define PEEP_NOEXIT_WARNING_THRESHOLD 8
 #define PEEP_LOST_WARNING_THRESHOLD 8
 
-#define PEEP_MAX_HAPPINESS 255
-#define PEEP_MAX_ENERGY    128
+#define PEEP_MAX_HAPPINESS     255
+#define PEEP_MAX_ENERGY        128
+#define PEEP_MAX_ENERGY_TARGET 255 // Oddly, this differs from max energy!
 
 enum PEEP_TYPE {
     PEEP_TYPE_GUEST,


### PR DESCRIPTION
Issue caused by using max where min was intended.
This also reverts an earlier change in capping the energy target, since it seems to max out at 255, unlike energy itself.