### PR TITLE
Fix background colour for scenario mode dropdown

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -309,8 +309,8 @@ static rct_widget window_options_controls_and_interface_widgets[] = {
     { WWT_CHECKBOX,         2,  155,    299,    244,        255,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP },  // Recent messages
     { WWT_CHECKBOX,         2,  10,     185,    259,        270,    STR_MUTE_BUTTON_ON_TOOLBAR,             STR_MUTE_BUTTON_ON_TOOLBAR_TIP },           // Mute
     { WWT_CHECKBOX,         2,  10,     299,    279,        285,    STR_SELECT_BY_TRACK_TYPE,               STR_SELECT_BY_TRACK_TYPE_TIP },             // Select by track type
-    { WWT_DROPDOWN,         2,  155,    299,    294,        305,    STR_NONE,                               STR_NONE },                                 // Scenario select mode
-    { WWT_DROPDOWN_BUTTON,  2,  288,    298,    295,        304,    STR_DROPDOWN_GLYPH,                     STR_SCENARIO_GROUPING_TIP },
+    { WWT_DROPDOWN,         1,  155,    299,    294,        305,    STR_NONE,                               STR_NONE },                                 // Scenario select mode
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    295,        304,    STR_DROPDOWN_GLYPH,                     STR_SCENARIO_GROUPING_TIP },
     { WWT_CHECKBOX,         2,  18,     299,    309,        320,    STR_OPTIONS_SCENARIO_UNLOCKING,         STR_SCENARIO_UNLOCKING_TIP },               // Unlocking of scenarios
     { WIDGETS_END },
 };

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -344,7 +344,7 @@ static rct_widget window_options_misc_widgets[] = {
 
 static rct_widget window_options_twitch_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_DROPDOWN_BUTTON,  2,  10,     299,    54,     65,     STR_TWITCH_NAME,            STR_TWITCH_NAME_TIP },              // Twitch channel name
+    { WWT_DROPDOWN_BUTTON,  1,  10,     299,    54,     65,     STR_TWITCH_NAME,            STR_TWITCH_NAME_TIP },              // Twitch channel name
     { WWT_CHECKBOX,         2,  10,     299,    69,     80,     STR_TWITCH_PEEP_FOLLOWERS,  STR_TWITCH_PEEP_FOLLOWERS_TIP },    // Twitch name peeps by follows
     { WWT_CHECKBOX,         2,  10,     299,    84,     95,     STR_TWITCH_FOLLOWERS_TRACK, STR_TWITCH_FOLLOWERS_TRACK_TIP },   // Twitch information on for follows
     { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_TWITCH_PEEP_CHAT,       STR_TWITCH_PEEP_CHAT_TIP },         // Twitch name peeps by chat


### PR DESCRIPTION
Minor change: while experimenting with the colour palette, I stumbled upon both the scenario mode dropdown and the 'Twitch channel name' button not using the right theme colours.

Before:
![screenshot_20171005_134238](https://user-images.githubusercontent.com/604665/31225644-5292ab40-a9d3-11e7-8e5e-2e1326a1c08f.png)

After:
![screenshot_20171005_134114](https://user-images.githubusercontent.com/604665/31225643-527b6f98-a9d3-11e7-84aa-c8e687324def.png)