### PR TITLE
Clean up ride groups

### DIFF
--- a/src/openrct2/management/research.c
+++ b/src/openrct2/management/research.c
@@ -197,7 +197,7 @@ void research_finish_item(sint32 entryIndex)
             // Determine if the ride group this entry belongs to was invented before.
             if (gConfigInterface.select_by_track_type && ride_type_has_ride_groups(base_ride_type))
             {
-                const ride_group * rideGroup = get_ride_group(base_ride_type, rideEntry);
+                const RideGroup * rideGroup = get_ride_group(base_ride_type, rideEntry);
 
                 if (ride_group_is_invented(rideGroup))
                 {
@@ -781,8 +781,8 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8 trackType, rct_rid
     {
         if (ride_type_has_ride_groups(trackType))
         {
-            const ride_group * rideGroup = get_ride_group(trackType, rideEntry);
-            return rideGroup->naming.name;
+            const RideGroup * rideGroup = get_ride_group(trackType, rideEntry);
+            return rideGroup->Naming.name;
         }
         else
         {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -359,18 +359,18 @@ void RideObject::SetRepositoryItem(ObjectRepositoryItem * item) const
     // Determines the ride group. Will fall back to 0 if there is none found.
     uint8 rideGroupIndex = 0;
 
-    const ride_group * rideGroup = get_ride_group(rideTypeIdx, (rct_ride_entry *)&_legacyType);
+    const RideGroup * rideGroup = RideGroupManager::GetRideGroup(rideTypeIdx, (rct_ride_entry *)&_legacyType);
 
     // If the ride group is nullptr, the track type does not have ride groups.
     if (rideGroup != nullptr)
     {
         for (uint8 i = rideGroupIndex + 1; i < MAX_RIDE_GROUPS_PER_RIDE_TYPE; i++)
         {
-            ride_group * irg = ride_group_find(rideTypeIdx, i);
+            const RideGroup * irg = RideGroupManager::RideGroupFind(rideTypeIdx, i);
 
             if (irg != nullptr)
             {
-                if (ride_groups_are_equal(irg, rideGroup))
+                if (RideGroupManager::RideGroupsAreEqual(irg, rideGroup))
                 {
                     rideGroupIndex = i;
                     break;

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -27,335 +27,310 @@
 #include "track.h"
 #include "track_data.h"
 
-class RideGroupManager final : public IRideGroupManager
-{
-public:
-    ride_group ride_group_corkscrew_rc = {
-        /*.ride_type =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
-        /*.maximum_height =*/ 28,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
-        /*.naming =*/ { STR_CORKSCREW_RC_GROUP, STR_CORKSCREW_RC_GROUP_DESC },
-    };
-
-    ride_group ride_group_hypercoaster = {
-        /*.ride_type =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
-        /*.maximum_height =*/ 45,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_STEEP_LONG),
-        /*.naming =*/ { STR_HYPERCOASTER_GROUP, STR_HYPERCOASTER_GROUP_DESC },
-    };
-
-    ride_group ride_group_car_ride = {
-        /*.ride_type =*/ RIDE_TYPE_CAR_RIDE,
-        /*.maximum_height =*/ 6,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_SPINNING_TUNNEL),
-        /*.naming =*/ { STR_CAR_RIDE_GROUP, STR_CAR_RIDE_GROUP_DESC },
-    };
-
-    ride_group ride_group_monster_trucks = {
-        /*.ride_type =*/ RIDE_TYPE_CAR_RIDE,
-        /*.maximum_height =*/ 18,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_RAPIDS),
-        /*.naming =*/ { STR_MONSTER_TRUCKS_GROUP, STR_MONSTER_TRUCKS_GROUP_DESC },
-    };
-
-    ride_group ride_group_steel_twister_rc = {
-        /*.ride_type =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
-        /*.maximum_height =*/ 34,
-        /*.available_track_pieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_SLOPE_VERTICAL) | (1ULL << TRACK_BARREL_ROLL) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_HALF_LOOP_LARGE) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG) | (1ULL << TRACK_CURVE_VERTICAL) | (1ULL << TRACK_QUARTER_LOOP) | (1ULL << TRACK_BOOSTER),
-        /*.naming =*/ { STR_STEEL_TWISTER_GROUP, STR_STEEL_TWISTER_GROUP_DESC },
-    };
-
-    ride_group ride_group_hyper_twister = {
-        /*.ride_type =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
-        /*.maximum_height =*/ 54,
-        /*.available_track_pieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG),
-        /*.naming =*/ { STR_HYPER_TWISTER_GROUP, STR_HYPER_TWISTER_GROUP_DESC },
-    };
-
-    ride_group ride_group_junior_rc = {
-        /*.ride_type =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
-        /*.maximum_height =*/ 12,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
-        /*.naming =*/ { STR_JUNIOR_RC_GROUP, STR_JUNIOR_RC_GROUP_DESC },
-    };
-
-    ride_group ride_group_midi_coaster = {
-        /*.ride_type =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
-        /*.maximum_height =*/ 15,
-        /*.available_track_pieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
-        /*.naming =*/ { STR_MIDI_COASTER_GROUP, STR_MIDI_COASTER_GROUP_DESC },
-    };
-
-    ride_group corkscrew_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_corkscrew_rc, ride_group_hypercoaster };
-    ride_group junior_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_junior_rc, ride_group_midi_coaster };
-    ride_group car_ride_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_car_ride, ride_group_monster_trucks };
-    ride_group twister_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_steel_twister_rc, ride_group_hyper_twister };
-
-    const ride_group * GetRideGroup(uint8 rideType, rct_ride_entry * rideEntry) const override
-    {
-        switch (rideType) {
-            case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
-                if (rideEntry->enabledTrackPieces & (1ULL << TRACK_VERTICAL_LOOP))
-                    return (ride_group *) &ride_group_corkscrew_rc;
-                else
-                    return (ride_group *) &ride_group_hypercoaster;
-            case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
-                if (ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_SLOPE_STEEP))
-                    return (ride_group *) &ride_group_midi_coaster;
-                else
-                    return (ride_group *) &ride_group_junior_rc;
-            case RIDE_TYPE_CAR_RIDE:
-                if (rideEntry->enabledTrackPieces & (1ULL << TRACK_SLOPE_STEEP))
-                    return (ride_group *) &ride_group_monster_trucks;
-                else
-                    return (ride_group *) &ride_group_car_ride;
-            case RIDE_TYPE_TWISTER_ROLLER_COASTER:
-                if (rideEntry->enabledTrackPieces & (1ULL << TRACK_VERTICAL_LOOP))
-                    return (ride_group *) &ride_group_steel_twister_rc;
-                else
-                    return (ride_group *) &ride_group_hyper_twister;
-            default:
-                return nullptr;
-        }
-    }
-
-    bool RideTypeHasRideGroups(uint8 rideType) const override
-    {
-        if (!gConfigInterface.select_by_track_type) {
-            return false;
-        }
-
-        switch (rideType)
-        {
-            case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
-            case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
-            case RIDE_TYPE_CAR_RIDE:
-            case RIDE_TYPE_TWISTER_ROLLER_COASTER:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    ride_group * RideGroupFind(uint8 rideType, uint8 index) const override
-    {
-        ride_group * rideGroup;
-
-        switch(rideType)
-        {
-            case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
-                rideGroup = (ride_group *) &corkscrew_rc_groups[index];
-                break;
-            case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
-                rideGroup = (ride_group *) &junior_rc_groups[index];
-                break;
-            case RIDE_TYPE_CAR_RIDE:
-                rideGroup = (ride_group *) &car_ride_groups[index];
-                break;
-            case RIDE_TYPE_TWISTER_ROLLER_COASTER:
-                rideGroup = (ride_group *) &twister_rc_groups[index];
-                break;
-            default:
-                return nullptr;
-        }
-
-        return rideGroup;
-    }
-
-    bool RideGroupsAreEqual(const ride_group * a, const ride_group * b) const override
-    {
-        if (a != nullptr && b != nullptr && (a->naming.name == b->naming.name && a->naming.description == b->naming.description))
-        {
-            return true;
-        }
-        return false;
-    }
-
-    bool RideGroupIsInvented(const ride_group * rideGroup) const override
-    {
-        if (!ride_type_is_invented(rideGroup->ride_type))
-            return false;
-
-        uint8 *rideEntryIndexPtr = get_ride_entry_indices_for_ride_type(rideGroup->ride_type);
-
-        while (*rideEntryIndexPtr != RIDE_ENTRY_INDEX_NULL)
-        {
-            uint8 rideEntryIndex = *rideEntryIndexPtr++;
-
-            if (!ride_entry_is_invented(rideEntryIndex))
-                continue;
-
-            rct_ride_entry *rideEntry = get_ride_entry(rideEntryIndex);
-            const ride_group * rideEntryRideGroup = GetRideGroup(rideGroup->ride_type, rideEntry);
-
-            if (!RideGroupsAreEqual(rideGroup, rideEntryRideGroup))
-                continue;
-
-            // The ride entry is invented and belongs to the same ride group. This means the ride group is invented.
-            return true;
-        }
-
-        return false;
-    }
-
-    const std::vector<const char *> GetPreferedRideEntryOrder(uint8 rideType) const override
-    {
-        static const std::vector<const char *> preferedRideEntryOrder[] =
-        {
-            { "SPDRCR  "},                                                              // RIDE_TYPE_SPIRAL_ROLLER_COASTER
-            { "TOGST   "},                                                              // RIDE_TYPE_STAND_UP_ROLLER_COASTER
-            { "ARRSW1  ", "VEKVAMP ", "ARRSW2 "},                                       // RIDE_TYPE_SUSPENDED_SWINGING_COASTER
-            { "NEMT    "},                                                              // RIDE_TYPE_INVERTED_ROLLER_COASTER
-            { "ZLDB    ", "ZLOG    "},                                                  // RIDE_TYPE_JUNIOR_ROLLER_COASTER
-            { "NRL     ", "NRL2    ", "AML1    ", "TRAM1   "},                          // RIDE_TYPE_MINIATURE_RAILWAY
-            { "MONO1   ", "MONO2   ", "MONO3   "},                                      // RIDE_TYPE_MONORAIL
-            { "BATFL   ", "SKYTR   "},                                                  // RIDE_TYPE_MINI_SUSPENDED_COASTER
-            { "RBOAT   ", "BBOAT   ", "CBOAT   ", "SWANS   ", "TRIKE   ", "JSKI    " }, // RIDE_TYPE_BOAT_RIDE
-            { "WMOUSE  ", "WMMINE  "},                                                  // RIDE_TYPE_WOODEN_WILD_MOUSE
-            { "STEEP1  ", "STEEP2  ", "SBOX    "},                                      // RIDE_TYPE_STEEPLECHASE
-            { "SPCAR   ", "RCR     ", "TRUCK1  ", "VCR     ", "CTCAR   " },             // RIDE_TYPE_CAR_RIDE
-            { "SSC1    " },                                                             // RIDE_TYPE_LAUNCHED_FREEFALL
-            { "BOB1    ", "INTBOB  " },                                                 // RIDE_TYPE_BOBSLEIGH_COASTER
-            { "OBS1    ", "OBS2    " },                                                 // RIDE_TYPE_OBSERVATION_TOWER
-            { "SCHT1   " },                                                             // RIDE_TYPE_LOOPING_ROLLER_COASTER
-            { "DING1   " },                                                             // RIDE_TYPE_DINGHY_SLIDE
-            { "AMT1    " },                                                             // RIDE_TYPE_MINE_TRAIN_COASTER
-            { "CLIFT1  ", "CLIFT2  " },                                                 // RIDE_TYPE_CHAIRLIFT
-            { "ARRT1   ", "ARRT2   " },                                                 // RIDE_TYPE_CORKSCREW_ROLLER_COASTER
-            { },                                                                        // RIDE_TYPE_MAZE
-            { },                                                                        // RIDE_TYPE_SPIRAL_SLIDE
-            { "KART1   " },                                                             // RIDE_TYPE_GO_KARTS
-            { "LFB1    " },                                                             // RIDE_TYPE_LOG_FLUME
-            { "RAPBOAT " },                                                             // RIDE_TYPE_RIVER_RAPIDS
-            { },                                                                        // RIDE_TYPE_DODGEMS
-            { },                                                                        // RIDE_TYPE_PIRATE_SHIP
-            { },                                                                        // RIDE_TYPE_SWINGING_INVERTER_SHIP
-            { },                                                                        // RIDE_TYPE_FOOD_STALL
-            { },                                                                        // RIDE_TYPE_1D
-            { },                                                                        // RIDE_TYPE_DRINK_STALL
-            { },                                                                        // RIDE_TYPE_1F
-            { },                                                                        // RIDE_TYPE_SHOP
-            { },                                                                        // RIDE_TYPE_MERRY_GO_ROUND
-            { },                                                                        // RIDE_TYPE_22
-            { },                                                                        // RIDE_TYPE_INFORMATION_KIOSK
-            { },                                                                        // RIDE_TYPE_TOILETS
-            { },                                                                        // RIDE_TYPE_FERRIS_WHEEL
-            { },                                                                        // RIDE_TYPE_MOTION_SIMULATOR
-            { },                                                                        // RIDE_TYPE_3D_CINEMA
-            { },                                                                        // RIDE_TYPE_TOP_SPIN
-            { },                                                                        // RIDE_TYPE_SPACE_RINGS
-            { "REVF1   " },                                                             // RIDE_TYPE_REVERSE_FREEFALL_COASTER
-            { "LIFT1   " },                                                             // RIDE_TYPE_LIFT
-            { "BMVD    " },                                                             // RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER
-            { },                                                                        // RIDE_TYPE_CASH_MACHINE
-            { },                                                                        // RIDE_TYPE_TWIST
-            { },                                                                        // RIDE_TYPE_HAUNTED_HOUSE
-            { },                                                                        // RIDE_TYPE_FIRST_AID
-            { },                                                                        // RIDE_TYPE_CIRCUS_SHOW
-            { "GTC     ", "HMCAR   " },                                                 // RIDE_TYPE_GHOST_TRAIN
-            { "BMSD    ", "BMSU    ", "BMFL    ", "BMRB    ", "GOLTR   " },             // RIDE_TYPE_TWISTER_ROLLER_COASTER
-            { "PTCT1   ", "MFT     ", "PTCT2   " },                                     // RIDE_TYPE_WOODEN_ROLLER_COASTER
-            { "SFRIC1  " },                                                             // RIDE_TYPE_SIDE_FRICTION_ROLLER_COASTER
-            { "SMC1    ", "SMC2    ", "WMSPIN  " },                                     // RIDE_TYPE_WILD_MOUSE
-            { "ARRX    " },                                                             // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER
-            { },                                                                        // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER_ALT
-            { "BMAIR   " },                                                             // RIDE_TYPE_FLYING_ROLLER_COASTER
-            { },                                                                        // RIDE_TYPE_FLYING_ROLLER_COASTER_ALT
-            { "VREEL   " },                                                             // RIDE_TYPE_VIRGINIA_REEL
-            { "SPBOAT  " },                                                             // RIDE_TYPE_SPLASH_BOATS
-            { "HELICAR " },                                                             // RIDE_TYPE_MINI_HELICOPTERS
-            { "VEKST   " },                                                             // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER
-            { "SMONO   " },                                                             // RIDE_TYPE_SUSPENDED_MONORAIL
-            { },                                                                        // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER_ALT
-            { "REVCAR  " },                                                             // RIDE_TYPE_REVERSER_ROLLER_COASTER
-            { "UTCAR   ", "UTCARR  " },                                                 // RIDE_TYPE_HEARTLINE_TWISTER_COASTER
-            { },                                                                        // RIDE_TYPE_MINI_GOLF
-            { "INTST   " },                                                             // RIDE_TYPE_GIGA_COASTER
-            { "GDROP1  " },                                                             // RIDE_TYPE_ROTO_DROP
-            { },                                                                        // RIDE_TYPE_FLYING_SAUCERS
-            { },                                                                        // RIDE_TYPE_CROOKED_HOUSE
-            { "MONBK   " },                                                             // RIDE_TYPE_MONORAIL_CYCLES
-            { "SLCT    ", "SLCFO    ", "VEKDV   " },                                    // RIDE_TYPE_COMPACT_INVERTED_COASTER
-            { "CSTBOAT " },                                                             // RIDE_TYPE_WATER_COASTER
-            { "THCAR   " },                                                             // RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER
-            { "IVMC1   " },                                                             // RIDE_TYPE_INVERTED_HAIRPIN_COASTER
-            { },                                                                        // RIDE_TYPE_MAGIC_CARPET
-            { "SUBMAR  " },                                                             // RIDE_TYPE_SUBMARINE_RIDE
-            { "RFTBOAT " },                                                             // RIDE_TYPE_RIVER_RAFTS
-            { },                                                                        // RIDE_TYPE_50
-            { },                                                                        // RIDE_TYPE_ENTERPRISE
-            { },                                                                        // RIDE_TYPE_52
-            { },                                                                        // RIDE_TYPE_53
-            { },                                                                        // RIDE_TYPE_54
-            { },                                                                        // RIDE_TYPE_55
-            { "INTINV  " },                                                             // RIDE_TYPE_INVERTED_IMPULSE_COASTER
-            { "WCATC   ", "RCKC     ", "JSTAR1  " },                                    // RIDE_TYPE_MINI_ROLLER_COASTER
-            { "PMT1    " },                                                             // RIDE_TYPE_MINE_RIDE
-            { },                                                                        // RIDE_TYPE_59
-            { "PREMT1  " },                                                             // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER
-       };
-        return preferedRideEntryOrder[rideType];
-    }
+static const RideGroup ride_group_corkscrew_rc = {
+    /*.RideType =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 28,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
+    /*.Naming =*/ { STR_CORKSCREW_RC_GROUP, STR_CORKSCREW_RC_GROUP_DESC },
 };
 
-static std::unique_ptr<RideGroupManager> _rideGroupManager = std::unique_ptr<RideGroupManager>(new RideGroupManager());
-IRideGroupManager * GetRideGroupManager()
+static const RideGroup ride_group_hypercoaster = {
+    /*.RideType =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 45,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_STEEP_LONG),
+    /*.Naming =*/ { STR_HYPERCOASTER_GROUP, STR_HYPERCOASTER_GROUP_DESC },
+};
+
+static const RideGroup ride_group_car_ride = {
+    /*.RideType =*/ RIDE_TYPE_CAR_RIDE,
+    /*.MaximumHeight =*/ 6,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_SPINNING_TUNNEL),
+    /*.Naming =*/ { STR_CAR_RIDE_GROUP, STR_CAR_RIDE_GROUP_DESC },
+};
+
+static const RideGroup ride_group_monster_trucks = {
+    /*.RideType =*/ RIDE_TYPE_CAR_RIDE,
+    /*.MaximumHeight =*/ 18,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_RAPIDS),
+    /*.Naming =*/ { STR_MONSTER_TRUCKS_GROUP, STR_MONSTER_TRUCKS_GROUP_DESC },
+};
+
+static const RideGroup ride_group_steel_twister_rc = {
+    /*.RideType =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 34,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_SLOPE_VERTICAL) | (1ULL << TRACK_BARREL_ROLL) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_HALF_LOOP_LARGE) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG) | (1ULL << TRACK_CURVE_VERTICAL) | (1ULL << TRACK_QUARTER_LOOP) | (1ULL << TRACK_BOOSTER),
+    /*.Naming =*/ { STR_STEEL_TWISTER_GROUP, STR_STEEL_TWISTER_GROUP_DESC },
+};
+
+static const RideGroup ride_group_hyper_twister = {
+    /*.RideType =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 54,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG),
+    /*.Naming =*/ { STR_HYPER_TWISTER_GROUP, STR_HYPER_TWISTER_GROUP_DESC },
+};
+
+static const RideGroup ride_group_junior_rc = {
+    /*.RideType =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 12,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
+    /*.Naming =*/ { STR_JUNIOR_RC_GROUP, STR_JUNIOR_RC_GROUP_DESC },
+};
+
+static const RideGroup ride_group_midi_coaster = {
+    /*.RideType =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
+    /*.MaximumHeight =*/ 15,
+    /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
+    /*.Naming =*/ { STR_MIDI_COASTER_GROUP, STR_MIDI_COASTER_GROUP_DESC },
+};
+
+static const RideGroup corkscrew_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_corkscrew_rc, ride_group_hypercoaster };
+static const RideGroup junior_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_junior_rc, ride_group_midi_coaster };
+static const RideGroup car_ride_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_car_ride, ride_group_monster_trucks };
+static const RideGroup twister_rc_groups[MAX_RIDE_GROUPS_PER_RIDE_TYPE] = { ride_group_steel_twister_rc, ride_group_hyper_twister };
+
+const RideGroup * RideGroupManager::GetRideGroup(uint8 rideType, rct_ride_entry * rideEntry)
 {
-    return _rideGroupManager.get();
+    switch (rideType) {
+        case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
+            if (rideEntry->enabledTrackPieces & (1ULL << TRACK_VERTICAL_LOOP))
+                return (RideGroup *) &ride_group_corkscrew_rc;
+            else
+                return (RideGroup *) &ride_group_hypercoaster;
+        case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
+            if (ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_SLOPE_STEEP))
+                return (RideGroup *) &ride_group_midi_coaster;
+            else
+                return (RideGroup *) &ride_group_junior_rc;
+        case RIDE_TYPE_CAR_RIDE:
+            if (rideEntry->enabledTrackPieces & (1ULL << TRACK_SLOPE_STEEP))
+                return (RideGroup *) &ride_group_monster_trucks;
+            else
+                return (RideGroup *) &ride_group_car_ride;
+        case RIDE_TYPE_TWISTER_ROLLER_COASTER:
+            if (rideEntry->enabledTrackPieces & (1ULL << TRACK_VERTICAL_LOOP))
+                return (RideGroup *) &ride_group_steel_twister_rc;
+            else
+                return (RideGroup *) &ride_group_hyper_twister;
+        default:
+            return nullptr;
+    }
+}
+
+const bool RideGroupManager::RideTypeHasRideGroups(uint8 rideType)
+{
+    if (!gConfigInterface.select_by_track_type) {
+        return false;
+    }
+
+    switch (rideType)
+    {
+        case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
+        case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
+        case RIDE_TYPE_CAR_RIDE:
+        case RIDE_TYPE_TWISTER_ROLLER_COASTER:
+            return true;
+        default:
+            return false;
+    }
+}
+
+const RideGroup * RideGroupManager::RideGroupFind(uint8 rideType, uint8 index)
+{
+    RideGroup * rideGroup;
+
+    switch(rideType)
+    {
+        case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
+            rideGroup = (RideGroup *) &corkscrew_rc_groups[index];
+            break;
+        case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
+            rideGroup = (RideGroup *) &junior_rc_groups[index];
+            break;
+        case RIDE_TYPE_CAR_RIDE:
+            rideGroup = (RideGroup *) &car_ride_groups[index];
+            break;
+        case RIDE_TYPE_TWISTER_ROLLER_COASTER:
+            rideGroup = (RideGroup *) &twister_rc_groups[index];
+            break;
+        default:
+            return nullptr;
+    }
+
+    return rideGroup;
+}
+
+const bool RideGroupManager::RideGroupsAreEqual(const RideGroup * a, const RideGroup * b)
+{
+    if (a != nullptr && b != nullptr && (a->Naming.name == b->Naming.name && a->Naming.description == b->Naming.description))
+    {
+        return true;
+    }
+    return false;
+}
+
+const bool RideGroupManager::RideGroupIsInvented(const RideGroup * rideGroup)
+{
+    if (!ride_type_is_invented(rideGroup->RideType))
+        return false;
+
+    uint8 *rideEntryIndexPtr = get_ride_entry_indices_for_ride_type(rideGroup->RideType);
+
+    while (*rideEntryIndexPtr != RIDE_ENTRY_INDEX_NULL)
+    {
+        uint8 rideEntryIndex = *rideEntryIndexPtr++;
+
+        if (!ride_entry_is_invented(rideEntryIndex))
+            continue;
+
+        rct_ride_entry *rideEntry = get_ride_entry(rideEntryIndex);
+        const RideGroup * rideEntryRideGroup = GetRideGroup(rideGroup->RideType, rideEntry);
+
+        if (!RideGroupsAreEqual(rideGroup, rideEntryRideGroup))
+            continue;
+
+        // The ride entry is invented and belongs to the same ride group. This means the ride group is invented.
+        return true;
+    }
+
+    return false;
+}
+
+const std::vector<const char *> RideGroupManager::GetPreferredRideEntryOrder(uint8 rideType)
+{
+    static const std::vector<const char *> preferredRideEntryOrder[] =
+    {
+        { "SPDRCR  " },                                                             // RIDE_TYPE_SPIRAL_ROLLER_COASTER
+        { "TOGST   " },                                                             // RIDE_TYPE_STAND_UP_ROLLER_COASTER
+        { "ARRSW1  ", "VEKVAMP ", "ARRSW2  " },                                     // RIDE_TYPE_SUSPENDED_SWINGING_COASTER
+        { "NEMT    " },                                                             // RIDE_TYPE_INVERTED_ROLLER_COASTER
+        { "ZLDB    ", "ZLOG    ", "ZPANDA  " },                                     // RIDE_TYPE_JUNIOR_ROLLER_COASTER
+        { "NRL     ", "NRL2    ", "AML1    ", "TRAM1   " },                         // RIDE_TYPE_MINIATURE_RAILWAY
+        { "MONO1   ", "MONO2   ", "MONO3   " },                                     // RIDE_TYPE_MONORAIL
+        { "BATFL   ", "SKYTR   "},                                                  // RIDE_TYPE_MINI_SUSPENDED_COASTER
+        { "RBOAT   ", "BBOAT   ", "CBOAT   ", "SWANS   ", "TRIKE   ", "JSKI    " }, // RIDE_TYPE_BOAT_RIDE
+        { "WMOUSE  ", "WMMINE  "},                                                  // RIDE_TYPE_WOODEN_WILD_MOUSE
+        { "STEEP1  ", "STEEP2  ", "SBOX    " },                                     // RIDE_TYPE_STEEPLECHASE
+        { "SPCAR   ", "RCR     ", "TRUCK1  ", "VCR     ", "CTCAR   " },             // RIDE_TYPE_CAR_RIDE
+        { "SSC1    " },                                                             // RIDE_TYPE_LAUNCHED_FREEFALL
+        { "BOB1    ", "INTBOB  " },                                                 // RIDE_TYPE_BOBSLEIGH_COASTER
+        { "OBS1    ", "OBS2    " },                                                 // RIDE_TYPE_OBSERVATION_TOWER
+        { "SCHT1   " },                                                             // RIDE_TYPE_LOOPING_ROLLER_COASTER
+        { "DING1   " },                                                             // RIDE_TYPE_DINGHY_SLIDE
+        { "AMT1    " },                                                             // RIDE_TYPE_MINE_TRAIN_COASTER
+        { "CLIFT1  ", "CLIFT2  " },                                                 // RIDE_TYPE_CHAIRLIFT
+        { "ARRT1   ", "ARRT2   " },                                                 // RIDE_TYPE_CORKSCREW_ROLLER_COASTER
+        { },                                                                        // RIDE_TYPE_MAZE
+        { },                                                                        // RIDE_TYPE_SPIRAL_SLIDE
+        { "KART1   " },                                                             // RIDE_TYPE_GO_KARTS
+        { "LFB1    " },                                                             // RIDE_TYPE_LOG_FLUME
+        { "RAPBOAT " },                                                             // RIDE_TYPE_RIVER_RAPIDS
+        { },                                                                        // RIDE_TYPE_DODGEMS
+        { },                                                                        // RIDE_TYPE_PIRATE_SHIP
+        { },                                                                        // RIDE_TYPE_SWINGING_INVERTER_SHIP
+        { },                                                                        // RIDE_TYPE_FOOD_STALL
+        { },                                                                        // RIDE_TYPE_1D
+        { },                                                                        // RIDE_TYPE_DRINK_STALL
+        { },                                                                        // RIDE_TYPE_1F
+        { },                                                                        // RIDE_TYPE_SHOP
+        { },                                                                        // RIDE_TYPE_MERRY_GO_ROUND
+        { },                                                                        // RIDE_TYPE_22
+        { },                                                                        // RIDE_TYPE_INFORMATION_KIOSK
+        { },                                                                        // RIDE_TYPE_TOILETS
+        { },                                                                        // RIDE_TYPE_FERRIS_WHEEL
+        { },                                                                        // RIDE_TYPE_MOTION_SIMULATOR
+        { },                                                                        // RIDE_TYPE_3D_CINEMA
+        { },                                                                        // RIDE_TYPE_TOP_SPIN
+        { },                                                                        // RIDE_TYPE_SPACE_RINGS
+        { "REVF1   " },                                                             // RIDE_TYPE_REVERSE_FREEFALL_COASTER
+        { "LIFT1   " },                                                             // RIDE_TYPE_LIFT
+        { "BMVD    " },                                                             // RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER
+        { },                                                                        // RIDE_TYPE_CASH_MACHINE
+        { },                                                                        // RIDE_TYPE_TWIST
+        { },                                                                        // RIDE_TYPE_HAUNTED_HOUSE
+        { },                                                                        // RIDE_TYPE_FIRST_AID
+        { },                                                                        // RIDE_TYPE_CIRCUS_SHOW
+        { "GTC     ", "HMCAR   " },                                                 // RIDE_TYPE_GHOST_TRAIN
+        { "BMSD    ", "BMSU    ", "BMFL    ", "BMRB    ", "GOLTR   " },             // RIDE_TYPE_TWISTER_ROLLER_COASTER
+        { "PTCT1   ", "MFT     ", "PTCT2   " },                                     // RIDE_TYPE_WOODEN_ROLLER_COASTER
+        { "SFRIC1  " },                                                             // RIDE_TYPE_SIDE_FRICTION_ROLLER_COASTER
+        { "SMC1    ", "SMC2    ", "WMSPIN  " },                                     // RIDE_TYPE_WILD_MOUSE
+        { "ARRX    " },                                                             // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER
+        { },                                                                        // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER_ALT
+        { "BMAIR   " },                                                             // RIDE_TYPE_FLYING_ROLLER_COASTER
+        { },                                                                        // RIDE_TYPE_FLYING_ROLLER_COASTER_ALT
+        { "VREEL   " },                                                             // RIDE_TYPE_VIRGINIA_REEL
+        { "SPBOAT  " },                                                             // RIDE_TYPE_SPLASH_BOATS
+        { "HELICAR " },                                                             // RIDE_TYPE_MINI_HELICOPTERS
+        { "VEKST   " },                                                             // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER
+        { "SMONO   " },                                                             // RIDE_TYPE_SUSPENDED_MONORAIL
+        { },                                                                        // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER_ALT
+        { "REVCAR  " },                                                             // RIDE_TYPE_REVERSER_ROLLER_COASTER
+        { "UTCAR   ", "UTCARR  " },                                                 // RIDE_TYPE_HEARTLINE_TWISTER_COASTER
+        { },                                                                        // RIDE_TYPE_MINI_GOLF
+        { "INTST   " },                                                             // RIDE_TYPE_GIGA_COASTER
+        { "GDROP1  " },                                                             // RIDE_TYPE_ROTO_DROP
+        { },                                                                        // RIDE_TYPE_FLYING_SAUCERS
+        { },                                                                        // RIDE_TYPE_CROOKED_HOUSE
+        { "MONBK   " },                                                             // RIDE_TYPE_MONORAIL_CYCLES
+        { "SLCT    ", "SLCFO    ", "VEKDV   " },                                    // RIDE_TYPE_COMPACT_INVERTED_COASTER
+        { "CSTBOAT " },                                                             // RIDE_TYPE_WATER_COASTER
+        { "THCAR   " },                                                             // RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER
+        { "IVMC1   " },                                                             // RIDE_TYPE_INVERTED_HAIRPIN_COASTER
+        { },                                                                        // RIDE_TYPE_MAGIC_CARPET
+        { "SUBMAR  " },                                                             // RIDE_TYPE_SUBMARINE_RIDE
+        { "RFTBOAT " },                                                             // RIDE_TYPE_RIVER_RAFTS
+        { },                                                                        // RIDE_TYPE_50
+        { },                                                                        // RIDE_TYPE_ENTERPRISE
+        { },                                                                        // RIDE_TYPE_52
+        { },                                                                        // RIDE_TYPE_53
+        { },                                                                        // RIDE_TYPE_54
+        { },                                                                        // RIDE_TYPE_55
+        { "INTINV  " },                                                             // RIDE_TYPE_INVERTED_IMPULSE_COASTER
+        { "WCATC   ", "RCKC     ", "JSTAR1  " },                                    // RIDE_TYPE_MINI_ROLLER_COASTER
+        { "PMT1    " },                                                             // RIDE_TYPE_MINE_RIDE
+        { },                                                                        // RIDE_TYPE_59
+        { "PREMT1  " },                                                             // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER
+   };
+    return preferredRideEntryOrder[rideType];
+}
+
+/**
+ * This function keeps a list of the preferred vehicle for every generic track
+ * type, out of the available vehicle types in the current game. It determines
+ * which picture is shown on the new ride tab and which train type is selected
+ * by default.
+ */
+const sint32 RideGroupManager::VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b)
+{
+    std::vector<const char *> rideEntryOrder = RideGroupManager::GetPreferredRideEntryOrder(rideType);
+    for (const char * object : rideEntryOrder)
+    {
+        if (String::Equals(object, a, true))
+        {
+            return -1;
+        }
+        if (String::Equals(object, b, true))
+        {
+            return  1;
+        }
+    }
+    return 0;
 }
 
 extern "C"
 {
-    const ride_group * get_ride_group(uint8 rideType, rct_ride_entry * rideEntry)
+    const RideGroup * get_ride_group(uint8 rideType, rct_ride_entry * rideEntry)
     {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        return rideGroupManager->GetRideGroup(rideType, rideEntry);
+        return RideGroupManager::GetRideGroup(rideType, rideEntry);
     }
 
     bool ride_type_has_ride_groups(uint8 rideType)
     {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        return rideGroupManager->RideTypeHasRideGroups(rideType);
+        return RideGroupManager::RideTypeHasRideGroups(rideType);
     }
 
-    ride_group * ride_group_find(uint8 rideType, uint8 index)
+    bool ride_group_is_invented(const RideGroup * rideGroup)
     {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        return rideGroupManager->RideGroupFind(rideType, index);
-    }
-
-    bool ride_groups_are_equal(const ride_group * a, const ride_group * b)
-    {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        return rideGroupManager->RideGroupsAreEqual(a, b);
-    }
-    bool ride_group_is_invented(const ride_group * rideGroup)
-    {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        return rideGroupManager->RideGroupIsInvented(rideGroup);
-    }
-
-    /**
-     * This function keeps a list of the preferred vehicle for every generic track
-     * type, out of the available vehicle types in the current game. It determines
-     * which picture is shown on the new ride tab and which train type is selected
-     * by default.
-     */
-    sint32 vehicle_preference_compare(uint8 rideType, const char * a, const char * b)
-    {
-        const IRideGroupManager * rideGroupManager = GetRideGroupManager();
-        std::vector<const char *> rideEntryOrder = rideGroupManager->GetPreferedRideEntryOrder(rideType);
-        for (const char * object : rideEntryOrder)
-        {
-            if (String::Equals(object, a, true))
-            {
-                return -1;
-            }
-            if (String::Equals(object, b, true))
-            {
-                return  1;
-            }
-        }
-        return 0;
+        return RideGroupManager::RideGroupIsInvented(rideGroup);
     }
 }

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -116,7 +116,7 @@ const RideGroup * RideGroupManager::GetRideGroup(uint8 rideType, rct_ride_entry 
     }
 }
 
-const bool RideGroupManager::RideTypeHasRideGroups(uint8 rideType)
+bool RideGroupManager::RideTypeHasRideGroups(uint8 rideType)
 {
     if (!gConfigInterface.select_by_track_type) {
         return false;
@@ -159,7 +159,7 @@ const RideGroup * RideGroupManager::RideGroupFind(uint8 rideType, uint8 index)
     return rideGroup;
 }
 
-const bool RideGroupManager::RideGroupsAreEqual(const RideGroup * a, const RideGroup * b)
+bool RideGroupManager::RideGroupsAreEqual(const RideGroup * a, const RideGroup * b)
 {
     if (a != nullptr && b != nullptr && (a->Naming.name == b->Naming.name && a->Naming.description == b->Naming.description))
     {
@@ -168,7 +168,7 @@ const bool RideGroupManager::RideGroupsAreEqual(const RideGroup * a, const RideG
     return false;
 }
 
-const bool RideGroupManager::RideGroupIsInvented(const RideGroup * rideGroup)
+bool RideGroupManager::RideGroupIsInvented(const RideGroup * rideGroup)
 {
     if (!ride_type_is_invented(rideGroup->RideType))
         return false;
@@ -300,7 +300,7 @@ const std::vector<const char *> RideGroupManager::GetPreferredRideEntryOrder(uin
  * which picture is shown on the new ride tab and which train type is selected
  * by default.
  */
-const sint32 RideGroupManager::VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b)
+sint32 RideGroupManager::VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b)
 {
     std::vector<const char *> rideEntryOrder = RideGroupManager::GetPreferredRideEntryOrder(rideType);
     for (const char * object : rideEntryOrder)

--- a/src/openrct2/ride/RideGroupManager.h
+++ b/src/openrct2/ride/RideGroupManager.h
@@ -43,13 +43,13 @@ class RideGroupManager
 {
     public:
     static const RideGroup * GetRideGroup(uint8 trackType, rct_ride_entry * rideEntry);
-    static const bool RideTypeHasRideGroups(uint8 trackType);
+    static bool RideTypeHasRideGroups(uint8 trackType);
     static const RideGroup * RideGroupFind(uint8 rideType, uint8 index);
-    static const bool RideGroupsAreEqual(const RideGroup * a, const RideGroup * b);
-    static const bool RideGroupIsInvented(const RideGroup * rideGroup);
+    static bool RideGroupsAreEqual(const RideGroup * a, const RideGroup * b);
+    static bool RideGroupIsInvented(const RideGroup * rideGroup);
 
     static const std::vector<const char *> GetPreferredRideEntryOrder(uint8 rideType);
-    static const sint32 VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b);
+    static sint32 VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b);
 };
 
 

--- a/src/openrct2/ride/RideGroupManager.h
+++ b/src/openrct2/ride/RideGroupManager.h
@@ -30,39 +30,35 @@ extern "C"
 
 #define MAX_RIDE_GROUPS_PER_RIDE_TYPE 2
 
-typedef struct ride_group {
-    uint8 ride_type;
-    uint16 maximum_height;
-    uint64 available_track_pieces;
-    rct_ride_name naming;
-} ride_group;
+typedef struct RideGroup
+{
+    uint8 RideType;
+    uint16 MaximumHeight;
+    uint64 AvailableTrackPieces;
+    rct_ride_name Naming;
+} RideGroup;
 
 #ifdef __cplusplus
-interface IRideGroupManager
+class RideGroupManager
 {
-    virtual ~IRideGroupManager() { }
+    public:
+    static const RideGroup * GetRideGroup(uint8 trackType, rct_ride_entry * rideEntry);
+    static const bool RideTypeHasRideGroups(uint8 trackType);
+    static const RideGroup * RideGroupFind(uint8 rideType, uint8 index);
+    static const bool RideGroupsAreEqual(const RideGroup * a, const RideGroup * b);
+    static const bool RideGroupIsInvented(const RideGroup * rideGroup);
 
-    virtual const ride_group * GetRideGroup(uint8 trackType, rct_ride_entry * rideEntry) const abstract;
-    virtual bool RideTypeHasRideGroups(uint8 trackType) const abstract;
-    virtual ride_group * RideGroupFind(uint8 rideType, uint8 index) const abstract;
-    virtual bool RideGroupsAreEqual(const ride_group * a, const ride_group * b) const abstract;
-    virtual bool RideGroupIsInvented(const ride_group * rideGroup) const abstract;
-
-    virtual const std::vector<const char *> GetPreferedRideEntryOrder(uint8 rideType) const abstract;
+    static const std::vector<const char *> GetPreferredRideEntryOrder(uint8 rideType);
+    static const sint32 VehiclePreferenceCompare(uint8 rideType, const char * a, const char * b);
 };
 
-
-IRideGroupManager * GetRideGroupManager();
 
 extern "C"
 {
 #endif
-    const ride_group * get_ride_group(uint8 rideType, rct_ride_entry * rideEntry);
+    const RideGroup * get_ride_group(uint8 rideType, rct_ride_entry * rideEntry);
     bool ride_type_has_ride_groups(uint8 rideType);
-    ride_group * ride_group_find(uint8 rideType, uint8 index);
-    bool ride_groups_are_equal(const ride_group * a, const ride_group * b);
-    bool ride_group_is_invented(const ride_group * rideGroup);
-    sint32 vehicle_preference_compare(uint8 rideType, const char * a, const char * b);
+    bool ride_group_is_invented(const RideGroup * rideGroup);
 #ifdef __cplusplus
 }
 #endif

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1855,14 +1855,14 @@ static money32 place_track_design(sint16 x, sint16 y, sint16 z, uint8 flags, uin
     }
 
     // The rest of the cases are handled by the code in ride_create()
-    if (ride_type_has_ride_groups(td6->type) && entryIndex == 0xFF)
+    if (RideGroupManager::RideTypeHasRideGroups(td6->type) && entryIndex == 0xFF)
     {
         const ObjectRepositoryItem * ori = object_repository_find_object_by_name(rideEntryObject->name);
         if (ori != NULL)
         {
-            uint8          rideGroupIndex = ori->RideGroupIndex;
-            ride_group     * td6RideGroup = ride_group_find(td6->type, rideGroupIndex);
-            rct_ride_entry * ire;
+            uint8             rideGroupIndex = ori->RideGroupIndex;
+            const RideGroup * td6RideGroup = RideGroupManager::RideGroupFind(td6->type, rideGroupIndex);
+            rct_ride_entry  * ire;
 
             uint8      * availableRideEntries = get_ride_entry_indices_for_ride_type(td6->type);
             for (uint8 * rei                  = availableRideEntries; *rei != RIDE_ENTRY_INDEX_NULL; rei++)
@@ -1874,8 +1874,8 @@ static money32 place_track_design(sint16 x, sint16 y, sint16 z, uint8 flags, uin
                     continue;
                 }
 
-                const ride_group * irg = get_ride_group(td6->type, ire);
-                if (ride_groups_are_equal(td6RideGroup, irg))
+                const RideGroup * irg = RideGroupManager::GetRideGroup(td6->type, ire);
+                if (RideGroupManager::RideGroupsAreEqual(td6RideGroup, irg))
                 {
                     entryIndex = *rei;
                     break;

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -192,7 +192,7 @@ public:
         return count;
     }
 
-    size_t GetCountForRideGroup(uint8 rideType, const ride_group * rideGroup) const override
+    size_t GetCountForRideGroup(uint8 rideType, const RideGroup * rideGroup) const override
     {
         size_t count = 0;
         const IObjectRepository * repo = GetObjectRepository();
@@ -206,9 +206,9 @@ public:
 
             const ObjectRepositoryItem * ori = repo->FindObject(item.ObjectEntry.c_str());
             uint8 rideGroupIndex = (ori != nullptr) ? ori->RideGroupIndex : 0;
-            ride_group * itemRideGroup = ride_group_find(rideType, rideGroupIndex);
+            const RideGroup * itemRideGroup = RideGroupManager::RideGroupFind(rideType, rideGroupIndex);
 
-            if (itemRideGroup != nullptr && ride_groups_are_equal(itemRideGroup, rideGroup))
+            if (itemRideGroup != nullptr && RideGroupManager::RideGroupsAreEqual(itemRideGroup, rideGroup))
             {
                 count++;
             }
@@ -258,7 +258,7 @@ public:
         return refs.size();
     }
 
-    size_t GetItemsForRideGroup(track_design_file_ref **outRefs, uint8 rideType, const ride_group * rideGroup) const override
+    size_t GetItemsForRideGroup(track_design_file_ref **outRefs, uint8 rideType, const RideGroup * rideGroup) const override
     {
         std::vector<track_design_file_ref> refs;
         const IObjectRepository * repo = GetObjectRepository();
@@ -272,9 +272,9 @@ public:
 
             const ObjectRepositoryItem * ori = repo->FindObject(item.ObjectEntry.c_str());
             uint8 rideGroupIndex = (ori != nullptr) ? ori->RideGroupIndex : 0;
-            ride_group * itemRideGroup = ride_group_find(rideType, rideGroupIndex);
+            const RideGroup * itemRideGroup = RideGroupManager::RideGroupFind(rideType, rideGroupIndex);
 
-            if (itemRideGroup != nullptr && ride_groups_are_equal(itemRideGroup, rideGroup))
+            if (itemRideGroup != nullptr && RideGroupManager::RideGroupsAreEqual(itemRideGroup, rideGroup))
             {
                 track_design_file_ref ref;
                 ref.name = String::Duplicate(GetNameFromTrackPath(item.Path));
@@ -426,7 +426,7 @@ extern "C"
         return repo->GetCountForObjectEntry(rideType, String::ToStd(entry));
     }
 
-    size_t track_repository_get_count_for_ride_group(uint8 rideType, const ride_group * rideGroup)
+    size_t track_repository_get_count_for_ride_group(uint8 rideType, const RideGroup * rideGroup)
     {
         ITrackDesignRepository * repo = GetTrackDesignRepository();
         return repo->GetCountForRideGroup(rideType, rideGroup);
@@ -438,7 +438,7 @@ extern "C"
         return repo->GetItemsForObjectEntry(outRefs, rideType, String::ToStd(entry));
     }
 
-    size_t track_repository_get_items_for_ride_group(track_design_file_ref * * outRefs, uint8 rideType, const ride_group * rideGroup)
+    size_t track_repository_get_items_for_ride_group(track_design_file_ref * * outRefs, uint8 rideType, const RideGroup * rideGroup)
     {
         ITrackDesignRepository * repo = GetTrackDesignRepository();
         return repo->GetItemsForRideGroup(outRefs, rideType, rideGroup);

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -41,13 +41,13 @@ interface ITrackDesignRepository
 
     virtual size_t GetCount() const abstract;
     virtual size_t GetCountForObjectEntry(uint8 rideType, const std::string &entry) const abstract;
-    virtual size_t GetCountForRideGroup(uint8 rideType, const ride_group * rideGroup) const abstract;
+    virtual size_t GetCountForRideGroup(uint8 rideType, const RideGroup * rideGroup) const abstract;
     virtual size_t GetItemsForObjectEntry(track_design_file_ref * * outRefs,
                                           uint8 rideType,
                                           const std::string &entry) const abstract;
     virtual size_t GetItemsForRideGroup(track_design_file_ref **outRefs,
                                         uint8 rideType,
-                                        const ride_group * rideGroup) const abstract;
+                                        const RideGroup * rideGroup) const abstract;
 
     virtual void Scan() abstract;
     virtual bool Delete(const std::string &path) abstract;
@@ -66,9 +66,9 @@ extern "C"
 #endif
     void    track_repository_scan();
     size_t  track_repository_get_count_for_ride(uint8 rideType, const utf8 * entry);
-    size_t  track_repository_get_count_for_ride_group(uint8 rideType, const ride_group * rideGroup);
+    size_t  track_repository_get_count_for_ride_group(uint8 rideType, const RideGroup * rideGroup);
     size_t  track_repository_get_items_for_ride(track_design_file_ref * * outRefs, uint8 rideType, const utf8 * entry);
-    size_t  track_repository_get_items_for_ride_group(track_design_file_ref * * outRefs, uint8 rideType, const ride_group * rideGroup);
+    size_t  track_repository_get_items_for_ride_group(track_design_file_ref * * outRefs, uint8 rideType, const RideGroup * rideGroup);
     utf8 *  track_repository_get_name_from_path(const utf8 *path);
     bool    track_repository_delete(const utf8 *path);
     bool    track_repository_rename(const utf8 *path, const utf8 *newName);

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -5742,8 +5742,8 @@ void ride_set_name_to_track_default(Ride *ride, rct_ride_entry * rideEntry)
         name_args.type_name = STR_HYPER_TWISTER_GROUP;
     }
     else if (ride_type_has_ride_groups(ride->type)) {
-        const ride_group * rideGroup = get_ride_group(ride->type, rideEntry);
-        name_args.type_name = rideGroup->naming.name;
+        const RideGroup * rideGroup = get_ride_group(ride->type, rideEntry);
+        name_args.type_name = rideGroup->Naming.name;
     } else {
         name_args.type_name = RideNaming[ride->type].name;
     }
@@ -5796,8 +5796,8 @@ rct_ride_name get_ride_naming(uint8 rideType, rct_ride_entry * rideEntry)
     }
 
     if (ride_type_has_ride_groups(rideType)) {
-        const ride_group * rideGroup = get_ride_group(rideType, rideEntry);
-        return rideGroup->naming;
+        const RideGroup * rideGroup = get_ride_group(rideType, rideEntry);
+        return rideGroup->Naming;
     }
     else if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
         return RideNaming[rideType];

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -428,7 +428,7 @@ enum {
     RIDE_LIFECYCLE_SIX_FLAGS_DEPRECATED = 1 << 19 // Not used anymore
 };
 
-// Constants used by the RideType->flags property at 0x008
+// Constants used by the ride_type->flags property at 0x008
 enum {
     RIDE_ENTRY_FLAG_VEHICLE_TAB_SCALE_HALF          = 1 << 0,
     RIDE_ENTRY_FLAG_NO_INVERSIONS                   = 1 << 1,

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -428,7 +428,7 @@ enum {
     RIDE_LIFECYCLE_SIX_FLAGS_DEPRECATED = 1 << 19 // Not used anymore
 };
 
-// Constants used by the ride_type->flags property at 0x008
+// Constants used by the RideType->flags property at 0x008
 enum {
     RIDE_ENTRY_FLAG_VEHICLE_TAB_SCALE_HALF          = 1 << 0,
     RIDE_ENTRY_FLAG_NO_INVERSIONS                   = 1 << 1,

--- a/src/openrct2/ride/track.c
+++ b/src/openrct2/ride/track.c
@@ -1229,8 +1229,8 @@ static money32 track_place(sint32 rideIndex, sint32 type, sint32 originX, sint32
                 uint16 maxHeight;
                 if (gConfigInterface.select_by_track_type) {
                     if (ride_type_has_ride_groups(ride->type)) {
-                        const ride_group * rideGroup = get_ride_group(ride->type, rideEntry);
-                        maxHeight = rideGroup->maximum_height;
+                        const RideGroup * rideGroup = get_ride_group(ride->type, rideEntry);
+                        maxHeight = rideGroup->MaximumHeight;
                     } else {
                         maxHeight = RideData5[ride->type].max_height;
                     }

--- a/src/openrct2/windows/NewRide.cpp
+++ b/src/openrct2/windows/NewRide.cpp
@@ -313,7 +313,7 @@ static void window_new_ride_populate_list()
 
         if (ride_type_is_invented(rideType) || gCheatsIgnoreResearchStatus) {
 
-            if (!ride_type_has_ride_groups(rideType)) {
+            if (!RideGroupManager::RideTypeHasRideGroups(rideType)) {
                 nextListItem = window_new_ride_iterate_over_ride_group(rideType, 0, nextListItem);
             }
             else {
@@ -358,12 +358,12 @@ static ride_list_item * window_new_ride_iterate_over_ride_group(uint8 rideType, 
         if (!gConfigInterface.select_by_track_type && !ride_entry_has_category(rideEntry, currentCategory))
             continue;
 
-        if (ride_type_has_ride_groups(rideType))
+        if (RideGroupManager::RideTypeHasRideGroups(rideType))
         {
-            const ride_group * rideEntryRideGroup = get_ride_group(rideType, rideEntry);
-            const ride_group * rideGroup = ride_group_find(rideType, rideGroupIndex);
+            const RideGroup * rideEntryRideGroup = RideGroupManager::GetRideGroup(rideType, rideEntry);
+            const RideGroup * rideGroup = RideGroupManager::RideGroupFind(rideType, rideGroupIndex);
 
-            if (!ride_groups_are_equal(rideEntryRideGroup, rideGroup))
+            if (!RideGroupManager::RideGroupsAreEqual(rideEntryRideGroup, rideGroup))
                 continue;
         }
 
@@ -373,7 +373,7 @@ static ride_list_item * window_new_ride_iterate_over_ride_group(uint8 rideType, 
                 safe_strcpy(preferredVehicleName, rideEntryName, sizeof(preferredVehicleName));
                 preferredVehicleName[8] = 0;
             } else {
-                if (vehicle_preference_compare(rideType, preferredVehicleName, rideEntryName) == 1) {
+                if (RideGroupManager::VehiclePreferenceCompare(rideType, preferredVehicleName, rideEntryName) == 1) {
                     safe_strcpy(preferredVehicleName, rideEntryName, sizeof(preferredVehicleName));
                     preferredVehicleName[8] = 0;
                 } else {
@@ -539,13 +539,13 @@ void window_new_ride_focus(ride_list_item rideItem)
     // In this case, select the first entry that belongs to the same ride group.
     if (!entryFound && gConfigInterface.select_by_track_type)
     {
-        const ride_group * rideGroup = get_ride_group(rideTypeIndex, rideEntry);
+        const RideGroup * rideGroup = RideGroupManager::GetRideGroup(rideTypeIndex, rideEntry);
 
         for (ride_list_item *listItem = _windowNewRideListItems; listItem->type != RIDE_TYPE_NULL; listItem++) {
             if (listItem->type == rideItem.type) {
-                const ride_group * irg = get_ride_group(rideTypeIndex, rideEntry);
+                const RideGroup * irg = RideGroupManager::GetRideGroup(rideTypeIndex, rideEntry);
 
-                if (!ride_type_has_ride_groups(rideTypeIndex) || ride_groups_are_equal(rideGroup, irg)) {
+                if (!RideGroupManager::RideTypeHasRideGroups(rideTypeIndex) || RideGroupManager::RideGroupsAreEqual(rideGroup, irg)) {
                     _windowNewRideHighlightedItem[0] = rideItem;
                     w->new_ride.highlighted_ride_id = rideItem.ride_type_and_entry;
                     window_new_ride_scroll_to_focused_ride(w);
@@ -916,9 +916,9 @@ static sint32 get_num_track_designs(ride_list_item item)
         }
     }
 
-    if (rideEntry != nullptr && ride_type_has_ride_groups(item.type))
+    if (rideEntry != nullptr && RideGroupManager::RideTypeHasRideGroups(item.type))
     {
-        const ride_group * rideGroup = get_ride_group(item.type, rideEntry);
+        const RideGroup * rideGroup = RideGroupManager::GetRideGroup(item.type, rideEntry);
         return (sint32)track_repository_get_count_for_ride_group(item.type, rideGroup);
     }
 

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -2676,7 +2676,7 @@ static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetI
     rct_widget *dropdownWidget = widget - 1;
     Ride *ride;
     rct_ride_entry *rideEntry, *currentRideEntry;
-    const ride_group * rideGroup, * currentRideGroup;
+    const RideGroup * rideGroup, * currentRideGroup;
     sint32 numItems, rideEntryIndex, selectedIndex, rideTypeIterator, rideTypeIteratorMax;
     uint8 *rideEntryIndexPtr;
     bool selectionShouldBeExpanded;
@@ -2722,12 +2722,12 @@ static void window_ride_vehicle_mousedown(rct_window *w, rct_widgetindex widgetI
                     continue;
 
                 // Skip if vehicle does not belong to the same ride group
-                if (ride_type_has_ride_groups(ride->type) && !selectionShouldBeExpanded)
+                if (RideGroupManager::RideTypeHasRideGroups(ride->type) && !selectionShouldBeExpanded)
                 {
-                    rideGroup = get_ride_group(ride->type, rideEntry);
-                    currentRideGroup = get_ride_group(ride->type, currentRideEntry);
+                    rideGroup = RideGroupManager::GetRideGroup(ride->type, rideEntry);
+                    currentRideGroup = RideGroupManager::GetRideGroup(ride->type, currentRideEntry);
 
-                    if (!ride_groups_are_equal(rideGroup, currentRideGroup))
+                    if (!RideGroupManager::RideGroupsAreEqual(rideGroup, currentRideGroup))
                         continue;
                 }
 

--- a/src/openrct2/windows/RideConstruction.cpp
+++ b/src/openrct2/windows/RideConstruction.cpp
@@ -2730,10 +2730,10 @@ static void window_ride_construction_update_enabled_track_pieces()
     }
     else
     {
-        if (ride_type_has_ride_groups(rideType))
+        if (RideGroupManager::RideTypeHasRideGroups(rideType))
         {
-            const ride_group * rideGroup = get_ride_group(rideType, rideEntry);
-            _enabledRidePieces = rideGroup->available_track_pieces;
+            const RideGroup * rideGroup = RideGroupManager::GetRideGroup(rideType, rideEntry);
+            _enabledRidePieces = rideGroup->AvailableTrackPieces;
         }
         else
         {

--- a/src/openrct2/windows/TrackList.cpp
+++ b/src/openrct2/windows/TrackList.cpp
@@ -611,7 +611,7 @@ static void window_track_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
 static void track_list_load_designs(ride_list_item item)
 {
-    if (!ride_type_has_ride_groups(item.type)) {
+    if (!RideGroupManager::RideTypeHasRideGroups(item.type)) {
         char entry[9];
         const char *entryPtr = nullptr;
         if (item.type < 0x80) {
@@ -624,7 +624,7 @@ static void track_list_load_designs(ride_list_item item)
         _trackDesignsCount = track_repository_get_items_for_ride(&_trackDesigns, item.type, entryPtr);
     } else {
         rct_ride_entry *rideEntry = get_ride_entry(item.entry_index);
-        const ride_group * rideGroup = get_ride_group(item.type, rideEntry);
+        const RideGroup * rideGroup = RideGroupManager::GetRideGroup(item.type, rideEntry);
         _trackDesignsCount = track_repository_get_items_for_ride_group(&_trackDesigns, item.type, rideGroup);
     }
 }


### PR DESCRIPTION
- Replace the singleton-ish implementation with a regular class with static members
- Use const more often
- Do not use the C-transfer functions from C++ code
- Update vehicle preference table
- Remove unused C-transfer functions