### PR TITLE
Fix #6383: macOS deprecation errors when compiling

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -35,6 +35,7 @@
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: Load/save window now refreshes list if native file dialog is closed/cancelled.
+- Technical: [#6384] On macOS, address NSFileHandlingPanel deprecation by using NSModalResponse instead.
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -102,7 +102,8 @@ namespace OpenRCT2 { namespace Ui
                 panel.title = [NSString stringWithUTF8String:desc.Title.c_str()];
                 panel.allowedFileTypes = extensions;
                 panel.directoryURL = [NSURL fileURLWithPath:directory];
-                if ([panel runModal] == NSFileHandlingPanelCancelButton){
+                if ([panel runModal] == NSModalResponseCancel)
+                {
                     return std::string();
                 } else {
                     return panel.URL.path.UTF8String;
@@ -118,7 +119,7 @@ namespace OpenRCT2 { namespace Ui
                 panel.canChooseFiles = false;
                 panel.canChooseDirectories = true;
                 panel.allowsMultipleSelection = false;
-                if ([panel runModal] == NSFileHandlingPanelOKButton)
+                if ([panel runModal] == NSModalResponseOK)
                 {
                     NSString *selectedPath = panel.URL.path;
                     const char *path = selectedPath.UTF8String;


### PR DESCRIPTION
Compiling on macOS High Sierra (10.13) yields deprecation errors for the `NSFileHandlingPanelCancelButton` and `NSFileHandlingPanelOKButton`. Instead, `NSModalResponseCancel` and `NSModalResponseOK` should be used, respectively.

The new constants were introduced in 10.9, so there should not be any compatibility issues.