### PR TITLE
Fix strings in Intents

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -162,15 +162,15 @@ public:
         case WC_FIRE_PROMPT:
             return window_staff_fire_prompt_open((rct_peep*)intent->GetPointerExtra(INTENT_EXTRA_PEEP));
         case WC_INSTALL_TRACK:
-            return window_install_track_open(intent->GetStringExtra(INTENT_EXTRA_PATH));
+            return window_install_track_open(intent->GetStringExtra(INTENT_EXTRA_PATH).c_str());
         case WC_GUEST_LIST:
             return window_guest_list_open_with_filter(intent->GetSIntExtra(INTENT_EXTRA_GUEST_LIST_FILTER), intent->GetSIntExtra(INTENT_EXTRA_RIDE_ID));
         case WC_LOADSAVE:
         {
             uint32 type = intent->GetUIntExtra(INTENT_EXTRA_LOADSAVE_TYPE);
-            const utf8 *defaultName = intent->GetStringExtra(INTENT_EXTRA_PATH);
+            std::string defaultName = intent->GetStringExtra(INTENT_EXTRA_PATH);
             loadsave_callback callback = (loadsave_callback) intent->GetPointerExtra(INTENT_EXTRA_CALLBACK);
-            rct_window *w = window_loadsave_open(type, defaultName);
+            rct_window *w = window_loadsave_open(type, defaultName.c_str());
             window_loadsave_set_loadsave_callback(callback);
 
             return w;

--- a/src/openrct2-ui/WindowManager.h
+++ b/src/openrct2-ui/WindowManager.h
@@ -14,6 +14,7 @@
 *****************************************************************************/
 #pragma endregion
 
+#include <string>
 #include <openrct2/common.h>
 
 namespace OpenRCT2 { namespace Ui

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -1,5 +1,6 @@
-#include "Intent.h"
+#include <utility>
 #include "../core/Guard.hpp"
+#include "Intent.h"
 
 Intent::Intent(rct_windowclass windowclass)
 {
@@ -39,10 +40,10 @@ Intent * Intent::putExtra(uint32 key, sint32 value)
     return this;
 }
 
-Intent * Intent::putExtra(uint32 key, utf8string value)
+Intent * Intent::putExtra(uint32 key, std::string value)
 {
     IntentData data = {};
-    data.stringVal = value;
+    data.stringVal = std::move(value);
     data.type = IntentData::DT_STRING;
 
     _Data.insert(std::make_pair(key, data));
@@ -91,7 +92,7 @@ sint32 Intent::GetSIntExtra(uint32 key)
     return data.intVal.signedInt;
 }
 
-utf8string Intent::GetStringExtra(uint32 key)
+std::string Intent::GetStringExtra(uint32 key)
 {
     if (_Data.count(key) == 0)
     {
@@ -121,7 +122,8 @@ extern "C" {
 
     void intent_set_string(Intent *intent, uint32 key, utf8string value)
     {
-        intent->putExtra(key, value);
+        std::string str { value };
+        intent->putExtra(key, str);
     }
 
     void intent_set_pointer(Intent *intent, uint32 key, void *value)

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -5,6 +5,7 @@
 #include "../interface/window.h"
 #ifdef __cplusplus
 #include <map>
+#include <string>
 #endif // __cplusplus
 
 
@@ -17,7 +18,7 @@ struct IntentData
         uint32 unsignedInt;
         sint32 signedInt;
     } intVal;
-    utf8string stringVal;
+    std::string stringVal;
     void * pointerVal;
 };
 
@@ -30,13 +31,13 @@ public:
     explicit Intent(rct_windowclass windowclass);
     rct_windowclass GetWindowClass();
     void * GetPointerExtra(uint32 key);
-    utf8string GetStringExtra(uint32 key);
+    std::string GetStringExtra(uint32 key);
     uint32 GetUIntExtra(uint32 key);
     sint32 GetSIntExtra(uint32 key);
     Intent * putExtra(uint32 key, uint32 value);
     Intent * putExtra(uint32 key, void * value);
     Intent * putExtra(uint32 key, sint32 value);
-    Intent * putExtra(uint32 key, utf8string value);
+    Intent * putExtra(uint32 key, std::string value);
 };
 #else
 // Allow C code to use `Intent *`


### PR DESCRIPTION
`IntentData.stringVal` pointed to a stack variable it didn't have ownership of, which sometimes resulted in the text in the save prompt getting corrupted.

Default text sometimes appeared as some random characters:
![2017-10-07-135931_5120x1080_scrot](https://user-images.githubusercontent.com/8963459/31307587-d31abdc6-ab67-11e7-9659-ec703cce965e.png)
