### PR TITLE
Fix demolishing rides causing errors.

### DIFF
--- a/src/openrct2/windows/RideConstruction.cpp
+++ b/src/openrct2/windows/RideConstruction.cpp
@@ -644,13 +644,24 @@ static void window_ride_construction_close(rct_window *w)
     hide_gridlines();
 
     uint8 rideIndex = _currentRideIndex;
-    if (ride_try_get_origin_element(rideIndex, nullptr)) {
-        Ride *ride = get_ride(rideIndex);
+    Ride * ride = get_ride(rideIndex);
+
+    // If we demolish a ride all windows will be closed including the construction window,
+    // the ride at this point is already gone.
+    if (ride == nullptr || ride->type == RIDE_TYPE_NULL)
+    {
+        return;
+    }
+
+    if (ride_try_get_origin_element(rideIndex, nullptr)) 
+    {
         // Auto open shops if required.
-        if (ride->mode == RIDE_MODE_SHOP_STALL && gConfigGeneral.auto_open_shops) {
+        if (ride->mode == RIDE_MODE_SHOP_STALL && gConfigGeneral.auto_open_shops) 
+        {
             // HACK: Until we find a good a way to defer the game command for opening the shop, stop this
             //       from getting stuck in an infinite loop as opening the ride will try to close this window
-            if (!_autoOpeningShop) {
+            if (!_autoOpeningShop) 
+            {
                 _autoOpeningShop = true;
                 ride_set_status(rideIndex, RIDE_STATUS_OPEN);
                 _autoOpeningShop = false;
@@ -658,14 +669,14 @@ static void window_ride_construction_close(rct_window *w)
         }
 
         ride_set_to_default_inspection_interval(rideIndex);
-
         window_ride_main_open(rideIndex);
-    } else {
-        sint32 eax = gGamePaused;
-
+    }
+    else 
+    {
+        sint32 previousPauseState = gGamePaused;
         gGamePaused = 0;
         ride_demolish(rideIndex, GAME_COMMAND_FLAG_APPLY);
-        gGamePaused = eax;
+        gGamePaused = previousPauseState;
     }
 }
 


### PR DESCRIPTION
This should fix the error showing up for no reason, currently ride_demolish calls at some point window_close_by_number(WC_RIDE_CONSTRUCTION, _rideIndex); which has ride_demolish on the window close event however the ride no longer exists. The fix will just close the window as requested and will only demolish it if the ride still exists.
I should mention this only happens if the construction window of the same ride is still open when demolishing it.