### PR TITLE
Clear IME buffer after committing composed text

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#5585] Inconsistent zooming with mouse wheel.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
+- Fix: Clear IME buffer after committing composed text.
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: Load/save window now refreshes list if native file dialog is closed/cancelled.

--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -80,6 +80,7 @@ void TextComposition::HandleMessage(const SDL_Event * e)
     case SDL_TEXTINPUT:
         // will receive an `SDL_TEXTINPUT` event when a composition is committed
         _imeActive = false;
+        _imeBuffer[0] = '\0';
         if (_session.Buffer != nullptr)
         {
             // HACK ` will close console, so don't input any text


### PR DESCRIPTION
When committing a composed text (i.e. pressing enter) the text is inserted correctly, but the IME buffer is not reset until the user starts typing again, even in between different instances of text editing.

This PR addresses this by setting the first byte of the IME buffer to a null byte when composed text is inserted.