### PR TITLE
Fix #6394: RideCreateAction not working with empty colour presets.

### DIFF
--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -99,8 +99,8 @@ public:
 
         rct_ride_entry *rideEntry = get_ride_entry(rideEntryIndex);
         vehicle_colour_preset_list *presetList = rideEntry->vehicle_preset_list;
-        if ((presetList->count == 255 && _colour2 != 255) ||
-            (presetList->count != 255 && _colour2 >= presetList->count))
+        if ((presetList->count > 0 && presetList->count != 255) &&
+            _colour2 >= presetList->count)
         {
             // FIXME: Add new error string.
             return std::make_unique<RideCreateGameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_INVALID_RIDE_TYPE);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
As the title suggests, I did not consider empty colour presets.