### PR TITLE
Fix compilation with older clang

### DIFF
--- a/src/openrct2/core/textinputbuffer.c
+++ b/src/openrct2/core/textinputbuffer.c
@@ -108,7 +108,7 @@ void textinputbuffer_cursor_right(textinputbuffer * tib)
             selectionOffset++;
         } while (!utf8_is_codepoint_start(ch) && selectionOffset < selectionMaxOffset);
 
-        tib->selection_size = max(0, tib->selection_size - (selectionOffset - tib->selection_offset));
+        tib->selection_size = tib->selection_size - (selectionOffset - tib->selection_offset);
         tib->selection_offset = selectionOffset;
     }
 }

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -10830,7 +10830,7 @@ static void peep_update_ride_nausea_growth(rct_peep *peep, Ride *ride)
     uint32 nauseaGrowthRateChange = (ride->nausea * nauseaMultiplier) / 512;
     nauseaGrowthRateChange *= max(128, peep->hunger) / 64;
     nauseaGrowthRateChange >>= (peep->nausea_tolerance & 3);
-    peep->nausea_target = (uint8)clamp(0, peep->nausea_target + nauseaGrowthRateChange, 255);
+    peep->nausea_target = (uint8)max(peep->nausea_target + nauseaGrowthRateChange, 255);
 }
 
 static bool peep_should_go_on_ride_again(rct_peep *peep, Ride *ride)


### PR DESCRIPTION
Older clang would expand the macros and spot that clamping unsigned
values to [0, MAX] is a tautological operation and produce an error.

As these are tautological operations, no network version change should
be needed.