### PR TITLE
Fix Maze previews not drawing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,4 +1,4 @@
-0.1.2 (in development)
+﻿0.1.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
 - Feature: [#5826] Add the show_limits command to show map data counts and limits.
@@ -33,6 +33,7 @@
 - Fix: [#6360] Off-by-one filenames when exporting all sprites.
 - Fix: [#5585] Inconsistent zooming with mouse wheel.
 - Fix: [#6358] HTTP requests can point to invalid URL string.
+- Fix: [#6413] Maze previews only showing scenery.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1213,7 +1213,7 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
                 {
                     if (_trackDesignPlaceOperation == PTD_OPERATION_GET_COST)
                     {
-                        flags = GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
+                        flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
                     }
                     else if (_trackDesignPlaceOperation == PTD_OPERATION_4)
                     {
@@ -1245,7 +1245,7 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
                 {
                     if (_trackDesignPlaceOperation == PTD_OPERATION_GET_COST)
                     {
-                        flags = GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
+                        flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
                     }
                     else if (_trackDesignPlaceOperation == PTD_OPERATION_4)
                     {
@@ -1265,7 +1265,7 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
 
                 if (_trackDesignPlaceOperation == PTD_OPERATION_GET_COST)
                 {
-                    flags = GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
+                    flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5;
                 }
                 else if (_trackDesignPlaceOperation == PTD_OPERATION_4)
                 {


### PR DESCRIPTION
Fix #6413: Draw Maze previews correctly.

Mistake made during refactoring. Apply flag was not being passed to the game command and this meant that only the query to check if a maze element could be placed was called.