### PR TITLE
Fix #6293: Stop all sounds when pausing game, but allow new sounds to play

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -46,6 +46,7 @@
 - Fix: [#6251] Splash Boats renders flat-to-25-degree pieces in tunnels incorrectly.
 - Fix: [#6261, #6344, #6520] Broken pathfinding after removing park entrances with the tile inspector.
 - Fix: [#6271] Wrong booster speed tooltip text.
+- Fix: [#6293] Restored interface sounds while gameplay is paused.
 - Fix: [#6301] Track list freezes after deleting track in Track Manager.
 - Fix: [#6308] Cannot create title sequence if title sequences folder does not exist.
 - Fix: [#6318] Cannot sack staff that have not been placed

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -906,9 +906,7 @@ void pause_toggle()
     gGamePaused ^= GAME_PAUSED_NORMAL;
     window_invalidate_by_class(WC_TOP_TOOLBAR);
     if (gGamePaused & GAME_PAUSED_NORMAL) {
-        audio_pause_sounds();
-    } else {
-        audio_unpause_sounds();
+        audio_stop_all_music_and_sounds();
     }
 }
 


### PR DESCRIPTION
- Allows interface sounds to function while paused.
- Fixes #6293.

I have one concern about this, and that's that it pauses title music, which it didn't before.  I couldn't find any use case where that would be a concern, but if someone knows of a case where it would be a problem, let me know, and I'll address it.