### PR TITLE
Turn 'unlock all prices' into a regular option

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3495,7 +3495,7 @@ STR_5153    :Edit Themes...
 STR_5154    :Hardware display
 STR_5155    :Allow testing of unfinished tracks
 STR_5156    :{SMALLFONT}{BLACK}Allows testing of most ride types even when the track is unfinished, does not apply to block sectioned modes
-STR_5157    :Unlock all prices
+STR_5157    :<removed string - do not use>
 STR_5158    :Quit to menu
 STR_5159    :Exit OpenRCT2
 STR_5160    :{POP16}{MONTH} {PUSH16}{PUSH16}{STRINGID}, Year {POP16}{COMMA16}
@@ -4461,6 +4461,7 @@ STR_6149    :Unable to connect to master server
 STR_6150    :Invalid response from master server (no JSON number)
 STR_6151    :Master server failed to return servers
 STR_6152    :Invalid response from master server (no JSON array)
+STR_6153    :Pay to enter park / Pay per ride
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/localisation/localisation.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/util.h>
+#include <openrct2/world/park.h>
 #include <openrct2/windows/dropdown.h>
 
 #define CHEATS_MONEY_DEFAULT MONEY(10000,00)
@@ -103,7 +104,6 @@ enum WINDOW_CHEATS_WIDGET_IDX {
     WIDX_SANDBOX_MODE,
     WIDX_RESET_DATE,
     WIDX_OWN_ALL_LAND,
-    WIDX_UNLOCK_ALL_PRICES,
     WIDX_FORCE_PARK_RATING,
     WIDX_PARK_RATING_SPINNER,
     WIDX_INCREASE_PARK_RATING,
@@ -239,7 +239,6 @@ static rct_widget window_cheats_misc_widgets[] = {
     { WWT_CLOSEBOX,         1,      XPL(0),                 WPL(0),                 YPL(2),         HPL(2),         STR_CHEAT_SANDBOX_MODE,             STR_CHEAT_SANDBOX_MODE_TIP },           // Sandbox mode (edit land ownership in-game)
     { WWT_CLOSEBOX,         1,      XPL(1),                 WPL(1),                 YPL(2),         HPL(2),         STR_CHEAT_RESET_DATE,               STR_NONE },                             // Reset date
     { WWT_CLOSEBOX,         1,      XPL(0),                 WPL(0),                 YPL(3),         HPL(3),         STR_CHEAT_OWN_ALL_LAND,             STR_CHEAT_OWN_ALL_LAND_TIP },           // Own all land
-    { WWT_CHECKBOX,         1,      XPL(0),                 OWPL,                   YPL(4),         OHPL(4),        STR_CHEAT_UNLOCK_PRICES,            STR_CHEAT_UNLOCK_PRICES_TIP },          // Unlock all prices
     { WWT_CHECKBOX,         1,      XPL(0),                 WPL(0),                 YPL(5),         HPL(5),         STR_FORCE_PARK_RATING,              STR_NONE },                             // Force park rating
     { WWT_SPINNER,          1,      XPL(1),                 WPL(1) - 10,            YPL(5) + 2,     HPL(5) - 3,     STR_NONE,                           STR_NONE },                             // park rating
     { WWT_DROPDOWN_BUTTON,  1,      WPL(1) - 10,            WPL(1),                 YPL(5) + 3,     YPL(5) + 7,     STR_NUMERIC_UP,                     STR_NONE },                             // increase rating
@@ -452,7 +451,7 @@ static uint64 window_cheats_page_enabled_widgets[] = {
     MAIN_CHEAT_ENABLED_WIDGETS | (1ULL << WIDX_FREEZE_CLIMATE) |
         (1ULL << WIDX_OPEN_CLOSE_PARK) | (1ULL << WIDX_WEATHER) | (1ULL << WIDX_WEATHER_DROPDOWN_BUTTON) | (1ULL << WIDX_CLEAR_GRASS) | (1ULL << WIDX_MOWED_GRASS) |
         (1ULL << WIDX_WATER_PLANTS) | (1ULL << WIDX_DISABLE_PLANT_AGING) | (1ULL << WIDX_FIX_VANDALISM) | (1ULL << WIDX_REMOVE_LITTER) | (1ULL << WIDX_WIN_SCENARIO) | (1ULL << WIDX_HAVE_FUN) | (1ULL << WIDX_OWN_ALL_LAND) |
-        (1ULL << WIDX_NEVERENDING_MARKETING) | (1ULL << WIDX_UNLOCK_ALL_PRICES) | (1ULL << WIDX_SANDBOX_MODE) | (1ULL << WIDX_RESET_DATE) | (1ULL << WIDX_FAST_STAFF) | (1ULL << WIDX_NORMAL_STAFF) |
+        (1ULL << WIDX_NEVERENDING_MARKETING) | (1ULL << WIDX_SANDBOX_MODE) | (1ULL << WIDX_RESET_DATE) | (1ULL << WIDX_FAST_STAFF) | (1ULL << WIDX_NORMAL_STAFF) |
         (1ULL << WIDX_PARK_PARAMETERS) | (1ULL << WIDX_FORCE_PARK_RATING) | (1ULL << WIDX_INCREASE_PARK_RATING) | (1ULL << WIDX_DECREASE_PARK_RATING),
     MAIN_CHEAT_ENABLED_WIDGETS | (1ULL << WIDX_RENEW_RIDES) |
         (1ULL << WIDX_MAKE_DESTRUCTIBLE) | (1ULL << WIDX_FIX_ALL) | (1ULL << WIDX_FAST_LIFT_HILL) | (1ULL << WIDX_DISABLE_BRAKES_FAILURE) |
@@ -734,9 +733,6 @@ static void window_cheats_misc_mouseup(rct_window *w, rct_widgetindex widgetInde
     case WIDX_NEVERENDING_MARKETING:
         game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_NEVERENDINGMARKETING, !gCheatsNeverendingMarketing, GAME_COMMAND_CHEAT, 0, 0);
         break;
-    case WIDX_UNLOCK_ALL_PRICES:
-        game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_UNLOCKALLPRICES, !gCheatsUnlockAllPrices, GAME_COMMAND_CHEAT, 0, 0);
-        break;
     case WIDX_SANDBOX_MODE:
         game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_SANDBOXMODE, !gCheatsSandboxMode, GAME_COMMAND_CHEAT, 0, 0);
         // To prevent tools from staying active after disabling cheat
@@ -903,7 +899,6 @@ static void window_cheats_invalidate(rct_window *w)
         break;
     case WINDOW_CHEATS_PAGE_MISC:
         w->widgets[WIDX_OPEN_CLOSE_PARK].text = (gParkFlags & PARK_FLAGS_PARK_OPEN) ? STR_CHEAT_CLOSE_PARK : STR_CHEAT_OPEN_PARK;
-        widget_set_checkbox_value(w, WIDX_UNLOCK_ALL_PRICES, gCheatsUnlockAllPrices);
         widget_set_checkbox_value(w, WIDX_FORCE_PARK_RATING, get_forced_park_rating() >= 0);
         w->widgets[WIDX_SANDBOX_MODE].text = gCheatsSandboxMode ? STR_CHEAT_SANDBOX_MODE_DISABLE : STR_CHEAT_SANDBOX_MODE;
         w->widgets[WIDX_FREEZE_CLIMATE].text = gCheatsFreezeClimate ? STR_CHEAT_UNFREEZE_CLIMATE : STR_CHEAT_FREEZE_CLIMATE;

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/game.h>
 #include <openrct2/interface/widget.h>
 #include <openrct2/localisation/localisation.h>
+#include <openrct2/localisation/string_ids.h>
 #include <openrct2/sprites.h>
 #include <openrct2/windows/dropdown.h>
 
@@ -1337,6 +1338,8 @@ static void window_editor_scenario_options_park_mousedown(rct_window *w, rct_wid
         gDropdownItemsArgs[0] = STR_FREE_PARK_ENTER;
         gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
         gDropdownItemsArgs[1] = STR_PAY_PARK_ENTER;
+        gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItemsArgs[2] = STR_PAID_ENTRY_PAID_RIDES;
 
         window_dropdown_show_text_custom_width(
             w->x + dropdownWidget->left,
@@ -1345,11 +1348,17 @@ static void window_editor_scenario_options_park_mousedown(rct_window *w, rct_wid
             w->colours[1],
             0,
             DROPDOWN_FLAG_STAY_OPEN,
-            2,
+            3,
             dropdownWidget->right - dropdownWidget->left - 3
         );
 
-        dropdown_set_checked((gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY ? 0 : 1), true);
+        if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+            dropdown_set_checked(2, true);
+        else if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+            dropdown_set_checked(0, true);
+        else
+            dropdown_set_checked(1, true);
+
         break;
     }
 }
@@ -1405,7 +1414,9 @@ static void window_editor_scenario_options_park_invalidate(rct_window *w)
         (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && (gParkFlags & PARK_FLAGS_NO_MONEY))) {
         for (sint32 i = WIDX_LAND_COST; i <= WIDX_ENTRY_PRICE_DECREASE; i++)
             w->widgets[i].type = WWT_EMPTY;
-    } else {
+    }
+    else
+    {
         w->widgets[WIDX_LAND_COST].type = WWT_SPINNER;
         w->widgets[WIDX_LAND_COST_INCREASE].type = WWT_DROPDOWN_BUTTON;
         w->widgets[WIDX_LAND_COST_DECREASE].type = WWT_DROPDOWN_BUTTON;
@@ -1415,11 +1426,14 @@ static void window_editor_scenario_options_park_invalidate(rct_window *w)
         w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type = WWT_DROPDOWN;
         w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 
-        if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) {
+        if (!park_entry_price_unlocked())
+        {
             w->widgets[WIDX_ENTRY_PRICE].type = WWT_EMPTY;
             w->widgets[WIDX_ENTRY_PRICE_INCREASE].type = WWT_EMPTY;
             w->widgets[WIDX_ENTRY_PRICE_DECREASE].type = WWT_EMPTY;
-        } else {
+        }
+        else
+        {
             w->widgets[WIDX_ENTRY_PRICE].type = WWT_SPINNER;
             w->widgets[WIDX_ENTRY_PRICE_INCREASE].type = WWT_DROPDOWN_BUTTON;
             w->widgets[WIDX_ENTRY_PRICE_DECREASE].type = WWT_DROPDOWN_BUTTON;
@@ -1496,8 +1510,14 @@ static void window_editor_scenario_options_park_paint(rct_window *w, rct_drawpix
         y = w->y + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].top;
         gfx_draw_string_left(dpi, STR_FREE_PARK_ENTER, nullptr, COLOUR_BLACK, x, y);
 
-        // Pay for park or rides value
-        stringId = gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY ? STR_FREE_PARK_ENTER : STR_PAY_PARK_ENTER;
+        // Pay for park and/or rides value
+        if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+            stringId = STR_PAID_ENTRY_PAID_RIDES;
+        else if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+            stringId = STR_FREE_PARK_ENTER;
+        else
+            stringId = STR_PAY_PARK_ENTER;
+
         gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, x, y);
     }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1256,20 +1256,21 @@ static void window_park_price_invalidate(rct_window *w)
     window_park_price_widgets[WIDX_PRICE_LABEL].tooltip = STR_NONE;
     window_park_price_widgets[WIDX_PRICE].tooltip = STR_NONE;
 
-    if ((gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) && !gCheatsUnlockAllPrices)
+    if (!park_entry_price_unlocked())
     {
         window_park_price_widgets[WIDX_PRICE_LABEL].tooltip = STR_ADMISSION_PRICE_PAY_PER_RIDE_TIP;
         window_park_price_widgets[WIDX_PRICE].tooltip = STR_ADMISSION_PRICE_PAY_PER_RIDE_TIP;
     }
 
     // If the entry price is locked at free, disable the widget, unless the unlock_all_prices cheat is active.
-    if ((gParkFlags & PARK_FLAGS_NO_MONEY) ||
-        ((gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) && !gCheatsUnlockAllPrices)
-    ) {
+    if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !park_entry_price_unlocked())
+    {
         window_park_price_widgets[WIDX_PRICE].type = WWT_12;
         window_park_price_widgets[WIDX_INCREASE_PRICE].type = WWT_EMPTY;
         window_park_price_widgets[WIDX_DECREASE_PRICE].type = WWT_EMPTY;
-    } else {
+    }
+    else
+    {
         window_park_price_widgets[WIDX_PRICE].type = WWT_SPINNER;
         window_park_price_widgets[WIDX_INCREASE_PRICE].type = WWT_DROPDOWN_BUTTON;
         window_park_price_widgets[WIDX_DECREASE_PRICE].type = WWT_DROPDOWN_BUTTON;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -706,36 +706,39 @@ namespace Editor
             {
                 if (*edx == 0)
                 {
-                    if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY))
-                    {
-                        gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                        gParkEntranceFee = MONEY(0, 00);
-                    }
+                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gParkEntranceFee = MONEY(0, 00);
+                }
+                else if (*edx == 1)
+                {
+                    gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gParkEntranceFee = MONEY(10, 00);
                 }
                 else
                 {
-                    if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
-                    {
-                        gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                        gParkEntranceFee = MONEY(10, 00);
-                    }
+                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                    gParkEntranceFee = MONEY(10, 00);
                 }
             }
             else
             {
                 if (*edx == 0)
                 {
-                    if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY))
-                    {
-                        gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                    }
+                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                }
+                else if (*edx == 1)
+                {
+                    gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 else
                 {
-                    if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
-                    {
-                        gParkFlags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                    }
+                    gParkFlags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                    gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
                 }
                 window_invalidate_by_class(WC_PARK_INFORMATION);
                 window_invalidate_by_class(WC_RIDE);

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -196,7 +196,7 @@ public:
 
             if (rideEntry->shop_item == SHOP_ITEM_NONE)
             {
-                if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) && !gCheatsUnlockAllPrices)
+                if (!park_ride_prices_unlocked())
                 {
                     ride->price = 0;
                 }

--- a/src/openrct2/actions/SetParkEntranceFeeAction.hpp
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.hpp
@@ -51,7 +51,7 @@ public:
     GameActionResult::Ptr Query() const override
     {
         bool noMoney = (gParkFlags & PARK_FLAGS_NO_MONEY) != 0;
-        bool forceFreeEntry = (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) && !gCheatsUnlockAllPrices;
+        bool forceFreeEntry = !park_entry_price_unlocked();
         if (noMoney || forceFreeEntry)
         {
             return std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, STR_NONE);

--- a/src/openrct2/cheats.c
+++ b/src/openrct2/cheats.c
@@ -39,7 +39,6 @@ bool gCheatsShowVehiclesFromOtherTrackTypes = false;
 bool gCheatsFastLiftHill = false;
 bool gCheatsDisableBrakesFailure = false;
 bool gCheatsDisableAllBreakdowns = false;
-bool gCheatsUnlockAllPrices = false;
 bool gCheatsBuildInPauseMode = false;
 bool gCheatsIgnoreRideIntensity = false;
 bool gCheatsDisableVandalism = false;
@@ -484,56 +483,57 @@ static void cheat_own_all_land()
 void game_command_cheat(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
 {
     sint32 cheat = *ecx;
-    if (*ebx & GAME_COMMAND_FLAG_APPLY) {
-        switch (cheat) {
-            case CHEAT_SANDBOXMODE: gCheatsSandboxMode = *edx != 0; window_invalidate_by_class(WC_MAP); window_invalidate_by_class(WC_FOOTPATH); break;
-            case CHEAT_DISABLECLEARANCECHECKS: gCheatsDisableClearanceChecks = *edx != 0; break;
-            case CHEAT_DISABLESUPPORTLIMITS: gCheatsDisableSupportLimits = *edx != 0; break;
-            case CHEAT_SHOWALLOPERATINGMODES: gCheatsShowAllOperatingModes = *edx != 0; break;
-            case CHEAT_SHOWVEHICLESFROMOTHERTRACKTYPES: gCheatsShowVehiclesFromOtherTrackTypes = *edx != 0; break;
-            case CHEAT_FASTLIFTHILL: gCheatsFastLiftHill = *edx != 0; break;
-            case CHEAT_DISABLEBRAKESFAILURE: gCheatsDisableBrakesFailure = *edx != 0; break;
-            case CHEAT_DISABLEALLBREAKDOWNS: gCheatsDisableAllBreakdowns = *edx != 0; break;
-            case CHEAT_DISABLETRAINLENGTHLIMIT: gCheatsDisableTrainLengthLimit = *edx != 0; break;
-            case CHEAT_ENABLECHAINLIFTONALLTRACK: gCheatsEnableChainLiftOnAllTrack = *edx != 0; break;
-            case CHEAT_UNLOCKALLPRICES: gCheatsUnlockAllPrices = *edx != 0; window_invalidate_by_class(WC_RIDE); window_invalidate_by_class(WC_PARK_INFORMATION); break;
-            case CHEAT_BUILDINPAUSEMODE: gCheatsBuildInPauseMode = *edx != 0; break;
-            case CHEAT_IGNORERIDEINTENSITY: gCheatsIgnoreRideIntensity = *edx != 0; break;
-            case CHEAT_DISABLEVANDALISM: gCheatsDisableVandalism = *edx != 0; break;
-            case CHEAT_DISABLELITTERING: gCheatsDisableLittering = *edx != 0; break;
-            case CHEAT_NOMONEY: cheat_no_money(*edx != 0); break;
-            case CHEAT_ADDMONEY: cheat_add_money(*edx); break;
-            case CHEAT_SETMONEY: cheat_set_money(*edx); break;
-            case CHEAT_CLEARLOAN: cheat_clear_loan(); break;
-            case CHEAT_SETGUESTPARAMETER: cheat_set_guest_parameter(*edx, *edi); break;
-            case CHEAT_GENERATEGUESTS: cheat_generate_guests(*edx); break;
-            case CHEAT_REMOVEALLGUESTS: cheat_remove_all_guests(); break;
-            case CHEAT_EXPLODEGUESTS: cheat_explode_guests(); break;
-            case CHEAT_GIVEALLGUESTS: cheat_give_all_guests(*edx); break;
-            case CHEAT_SETGRASSLENGTH: cheat_set_grass_length(*edx); break;
-            case CHEAT_WATERPLANTS: cheat_water_plants(); break;
-            case CHEAT_FIXVANDALISM: cheat_fix_vandalism(); break;
-            case CHEAT_REMOVELITTER: cheat_remove_litter(); break;
-            case CHEAT_DISABLEPLANTAGING: gCheatsDisablePlantAging = *edx != 0; break;
-            case CHEAT_SETSTAFFSPEED: cheat_set_staff_speed(*edx); break;
-            case CHEAT_RENEWRIDES: cheat_renew_rides(); break;
-            case CHEAT_MAKEDESTRUCTIBLE: cheat_make_destructible(); break;
-            case CHEAT_FIXRIDES: cheat_fix_rides(); break;
-            case CHEAT_RESETCRASHSTATUS: cheat_reset_crash_status(); break;
-            case CHEAT_10MINUTEINSPECTIONS: cheat_10_minute_inspections(); break;
-            case CHEAT_WINSCENARIO: scenario_success(); break;
-            case CHEAT_FORCEWEATHER: climate_force_weather(*edx); break;
-            case CHEAT_FREEZECLIMATE: gCheatsFreezeClimate = *edx != 0; break;
-            case CHEAT_NEVERENDINGMARKETING: gCheatsNeverendingMarketing = *edx != 0; break;
-            case CHEAT_OPENCLOSEPARK: park_set_open(park_is_open() ? 0 : 1); break;
-            case CHEAT_HAVEFUN: gScenarioObjectiveType = OBJECTIVE_HAVE_FUN; break;
-            case CHEAT_SETFORCEDPARKRATING: if(*edx > -1) { park_rating_spinner_value = *edx; } set_forced_park_rating(*edx); break;
-            case CHEAT_RESETDATE: date_reset(); window_invalidate_by_class(WC_BOTTOM_TOOLBAR); break;
-            case CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES: gCheatsAllowArbitraryRideTypeChanges = *edx != 0; window_invalidate_by_class(WC_RIDE); break;
-            case CHEAT_OWNALLLAND: cheat_own_all_land(); break;
-            case CHEAT_DISABLERIDEVALUEAGING: gCheatsDisableRideValueAging = *edx != 0; break;
-            case CHEAT_IGNORERESEARCHSTATUS: gCheatsIgnoreResearchStatus = *edx != 0; break;
-            case CHEAT_ENABLEALLDRAWABLETRACKPIECES: gCheatsEnableAllDrawableTrackPieces = *edx != 0; break;
+    if (*ebx & GAME_COMMAND_FLAG_APPLY)
+    {
+        switch (cheat)
+        {
+        case CHEAT_SANDBOXMODE: gCheatsSandboxMode = *edx != 0; window_invalidate_by_class(WC_MAP); window_invalidate_by_class(WC_FOOTPATH); break;
+        case CHEAT_DISABLECLEARANCECHECKS: gCheatsDisableClearanceChecks = *edx != 0; break;
+        case CHEAT_DISABLESUPPORTLIMITS: gCheatsDisableSupportLimits = *edx != 0; break;
+        case CHEAT_SHOWALLOPERATINGMODES: gCheatsShowAllOperatingModes = *edx != 0; break;
+        case CHEAT_SHOWVEHICLESFROMOTHERTRACKTYPES: gCheatsShowVehiclesFromOtherTrackTypes = *edx != 0; break;
+        case CHEAT_FASTLIFTHILL: gCheatsFastLiftHill = *edx != 0; break;
+        case CHEAT_DISABLEBRAKESFAILURE: gCheatsDisableBrakesFailure = *edx != 0; break;
+        case CHEAT_DISABLEALLBREAKDOWNS: gCheatsDisableAllBreakdowns = *edx != 0; break;
+        case CHEAT_DISABLETRAINLENGTHLIMIT: gCheatsDisableTrainLengthLimit = *edx != 0; break;
+        case CHEAT_ENABLECHAINLIFTONALLTRACK: gCheatsEnableChainLiftOnAllTrack = *edx != 0; break;
+        case CHEAT_BUILDINPAUSEMODE: gCheatsBuildInPauseMode = *edx != 0; break;
+        case CHEAT_IGNORERIDEINTENSITY: gCheatsIgnoreRideIntensity = *edx != 0; break;
+        case CHEAT_DISABLEVANDALISM: gCheatsDisableVandalism = *edx != 0; break;
+        case CHEAT_DISABLELITTERING: gCheatsDisableLittering = *edx != 0; break;
+        case CHEAT_NOMONEY: cheat_no_money(*edx != 0); break;
+        case CHEAT_ADDMONEY: cheat_add_money(*edx); break;
+        case CHEAT_SETMONEY: cheat_set_money(*edx); break;
+        case CHEAT_CLEARLOAN: cheat_clear_loan(); break;
+        case CHEAT_SETGUESTPARAMETER: cheat_set_guest_parameter(*edx, *edi); break;
+        case CHEAT_GENERATEGUESTS: cheat_generate_guests(*edx); break;
+        case CHEAT_REMOVEALLGUESTS: cheat_remove_all_guests(); break;
+        case CHEAT_EXPLODEGUESTS: cheat_explode_guests(); break;
+        case CHEAT_GIVEALLGUESTS: cheat_give_all_guests(*edx); break;
+        case CHEAT_SETGRASSLENGTH: cheat_set_grass_length(*edx); break;
+        case CHEAT_WATERPLANTS: cheat_water_plants(); break;
+        case CHEAT_FIXVANDALISM: cheat_fix_vandalism(); break;
+        case CHEAT_REMOVELITTER: cheat_remove_litter(); break;
+        case CHEAT_DISABLEPLANTAGING: gCheatsDisablePlantAging = *edx != 0; break;
+        case CHEAT_SETSTAFFSPEED: cheat_set_staff_speed(*edx); break;
+        case CHEAT_RENEWRIDES: cheat_renew_rides(); break;
+        case CHEAT_MAKEDESTRUCTIBLE: cheat_make_destructible(); break;
+        case CHEAT_FIXRIDES: cheat_fix_rides(); break;
+        case CHEAT_RESETCRASHSTATUS: cheat_reset_crash_status(); break;
+        case CHEAT_10MINUTEINSPECTIONS: cheat_10_minute_inspections(); break;
+        case CHEAT_WINSCENARIO: scenario_success(); break;
+        case CHEAT_FORCEWEATHER: climate_force_weather(*edx); break;
+        case CHEAT_FREEZECLIMATE: gCheatsFreezeClimate = *edx != 0; break;
+        case CHEAT_NEVERENDINGMARKETING: gCheatsNeverendingMarketing = *edx != 0; break;
+        case CHEAT_OPENCLOSEPARK: park_set_open(park_is_open() ? 0 : 1); break;
+        case CHEAT_HAVEFUN: gScenarioObjectiveType = OBJECTIVE_HAVE_FUN; break;
+        case CHEAT_SETFORCEDPARKRATING: if(*edx > -1) { park_rating_spinner_value = *edx; } set_forced_park_rating(*edx); break;
+        case CHEAT_RESETDATE: date_reset(); window_invalidate_by_class(WC_BOTTOM_TOOLBAR); break;
+        case CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES: gCheatsAllowArbitraryRideTypeChanges = *edx != 0; window_invalidate_by_class(WC_RIDE); break;
+        case CHEAT_OWNALLLAND: cheat_own_all_land(); break;
+        case CHEAT_DISABLERIDEVALUEAGING: gCheatsDisableRideValueAging = *edx != 0; break;
+        case CHEAT_IGNORERESEARCHSTATUS: gCheatsIgnoreResearchStatus = *edx != 0; break;
+        case CHEAT_ENABLEALLDRAWABLETRACKPIECES: gCheatsEnableAllDrawableTrackPieces = *edx != 0; break;
         }
         if (network_get_mode() == NETWORK_MODE_NONE) {
             config_save_default();
@@ -555,7 +555,6 @@ void cheats_reset()
     gCheatsFastLiftHill = false;
     gCheatsDisableBrakesFailure = false;
     gCheatsDisableAllBreakdowns = false;
-    gCheatsUnlockAllPrices = false;
     gCheatsBuildInPauseMode = false;
     gCheatsIgnoreRideIntensity = false;
     gCheatsDisableVandalism = false;
@@ -586,7 +585,6 @@ const char* cheats_get_cheat_string(int cheat, int edx, int edi) {
         case CHEAT_DISABLEALLBREAKDOWNS: return language_get_string(STR_CHEAT_DISABLE_BREAKDOWNS);
         case CHEAT_DISABLETRAINLENGTHLIMIT: return language_get_string(STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT);
         case CHEAT_ENABLECHAINLIFTONALLTRACK: return language_get_string(STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK);
-        case CHEAT_UNLOCKALLPRICES: return language_get_string(STR_CHEAT_UNLOCK_PRICES);
         case CHEAT_BUILDINPAUSEMODE: return language_get_string(STR_CHEAT_BUILD_IN_PAUSE_MODE);
         case CHEAT_IGNORERIDEINTENSITY: return language_get_string(STR_CHEAT_IGNORE_INTENSITY);
         case CHEAT_DISABLEVANDALISM: return language_get_string(STR_CHEAT_DISABLE_VANDALISM);

--- a/src/openrct2/cheats.h
+++ b/src/openrct2/cheats.h
@@ -31,7 +31,6 @@ extern bool gCheatsShowVehiclesFromOtherTrackTypes;
 extern bool gCheatsFastLiftHill;
 extern bool gCheatsDisableBrakesFailure;
 extern bool gCheatsDisableAllBreakdowns;
-extern bool gCheatsUnlockAllPrices;
 extern bool gCheatsBuildInPauseMode;
 extern bool gCheatsIgnoreRideIntensity;
 extern bool gCheatsDisableVandalism;

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3804,6 +3804,8 @@ enum {
     STR_SERVER_LIST_MASTER_SERVER_FAILED = 6151,
     STR_SERVER_LIST_INVALID_RESPONSE_JSON_ARRAY = 6152,
 
+    STR_PAID_ENTRY_PAID_RIDES = 6153,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/management/marketing.c
+++ b/src/openrct2/management/marketing.c
@@ -196,12 +196,12 @@ bool marketing_is_campaign_type_applicable(sint32 campaignType)
     switch (campaignType) {
     case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
     case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-        if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+        if (!park_entry_price_unlocked())
             return false;
         return true;
 
     case ADVERTISING_CAMPAIGN_RIDE_FREE:
-        if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY))
+        if (!park_ride_prices_unlocked())
             return false;
 
         // fall-through

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2009,7 +2009,6 @@ bool Network::LoadMap(IStream * stream)
         gCheatsFastLiftHill = stream->ReadValue<uint8>() != 0;
         gCheatsDisableBrakesFailure = stream->ReadValue<uint8>() != 0;
         gCheatsDisableAllBreakdowns = stream->ReadValue<uint8>() != 0;
-        gCheatsUnlockAllPrices = stream->ReadValue<uint8>() != 0;
         gCheatsBuildInPauseMode = stream->ReadValue<uint8>() != 0;
         gCheatsIgnoreRideIntensity = stream->ReadValue<uint8>() != 0;
         gCheatsDisableVandalism = stream->ReadValue<uint8>() != 0;
@@ -2057,7 +2056,6 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
         stream->WriteValue<uint8>(gCheatsFastLiftHill);
         stream->WriteValue<uint8>(gCheatsDisableBrakesFailure);
         stream->WriteValue<uint8>(gCheatsDisableAllBreakdowns);
-        stream->WriteValue<uint8>(gCheatsUnlockAllPrices);
         stream->WriteValue<uint8>(gCheatsBuildInPauseMode);
         stream->WriteValue<uint8>(gCheatsIgnoreRideIntensity);
         stream->WriteValue<uint8>(gCheatsDisableVandalism);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/peep.c
+++ b/src/openrct2/peep/peep.c
@@ -5669,7 +5669,7 @@ static void peep_update_buying(rct_peep* peep)
         }
         else{
             rct_ride_entry* ride_type = get_ride_entry(ride->subtype);
-            if (ride_type->shop_item_secondary != 0xFF){
+            if (ride_type->shop_item_secondary != SHOP_ITEM_NONE){
                 money16 price = ride->price_secondary;
 
                 item_bought = peep_decide_and_buy_item(peep, peep->current_ride, ride_type->shop_item_secondary, price);
@@ -5678,7 +5678,7 @@ static void peep_update_buying(rct_peep* peep)
                 }
             }
 
-            if (!item_bought && ride_type->shop_item != 0xFF){
+            if (!item_bought && ride_type->shop_item != SHOP_ITEM_NONE){
                 money16 price = ride->price;
 
                 item_bought = peep_decide_and_buy_item(peep, peep->current_ride, ride_type->shop_item, price);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2120,11 +2120,7 @@ private:
         // If this flag is not set, the player can ask money for both rides and entry.
         if (!(_s4.park_flags & RCT1_PARK_FLAGS_PARK_ENTRY_LOCKED_AT_FREE))
         {
-            gCheatsUnlockAllPrices = true;
-        }
-        else
-        {
-            gCheatsUnlockAllPrices = false;
+            gParkFlags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
         }
 
         // RCT2 uses two flags for no money (due to the scenario editor). RCT1 used only one.

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -217,8 +217,6 @@ public:
         gBankLoan        = _s6.current_loan;
         gParkFlags       = _s6.park_flags;
         gParkEntranceFee = _s6.park_entrance_fee;
-        // Force RCT2 scenarios to Unlock All Prices being false
-        gCheatsUnlockAllPrices = false;
         // rct1_park_entrance_x
         // rct1_park_entrance_y
         // pad_013573EE

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -7769,8 +7769,8 @@ money16 ride_get_price(Ride * ride)
 {
     if (gParkFlags & PARK_FLAGS_NO_MONEY) return 0;
     if (ride_is_ride(ride)) {
-        if (!gCheatsUnlockAllPrices) {
-            if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)) return 0;
+        if (!park_ride_prices_unlocked()) {
+            return 0;
         }
     }
     return ride->price;

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -4617,7 +4617,7 @@ static void window_ride_colour_paint(rct_window *w, rct_drawpixelinfo *dpi)
     track_colour trackColour = ride_get_track_colour(ride, w->ride_colour);
 
     //
-    if (rideEntry->shop_item == 0xFF) {
+    if (rideEntry->shop_item == SHOP_ITEM_NONE) {
         sint32 x = w->x + widget->left;
         sint32 y = w->y + widget->top;
 
@@ -4643,7 +4643,7 @@ static void window_ride_colour_paint(rct_window *w, rct_drawpixelinfo *dpi)
         sint32 x = w->x + (widget->left + widget->right) / 2 - 8;
         sint32 y = w->y + (widget->bottom + widget->top) / 2 - 6;
 
-        uint8 shopItem = rideEntry->shop_item_secondary == 255 ? rideEntry->shop_item : rideEntry->shop_item_secondary;
+        uint8 shopItem = rideEntry->shop_item_secondary == SHOP_ITEM_NONE ? rideEntry->shop_item : rideEntry->shop_item_secondary;
         sint32 spriteIndex = ShopItemImage[shopItem];
         spriteIndex |= SPRITE_ID_PALETTE_COLOUR_1(ride->track_colour_main[0]);
 
@@ -5866,7 +5866,7 @@ static void window_ride_income_toggle_secondary_price(rct_window *w)
     ride_type = get_ride_entry(ride->subtype);
 
     shop_item = ride_type->shop_item_secondary;
-    if (shop_item == 0xFF)
+    if (shop_item == SHOP_ITEM_NONE)
         shop_item = RidePhotoItems[ride->type];
 
     update_same_price_throughout_flags(shop_item);
@@ -5887,10 +5887,11 @@ static void window_ride_income_increase_primary_price(rct_window *w)
     ride = get_ride(w->number);
     ride_type = get_ride_entry(ride->subtype);
 
-    if ((gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) == 0) {
-        if (ride->type != RIDE_TYPE_TOILETS && ride_type->shop_item == 0xFF) {
-            if (!gCheatsUnlockAllPrices)
-                return;
+    if (!park_ride_prices_unlocked())
+    {
+        if (ride->type != RIDE_TYPE_TOILETS && ride_type->shop_item == SHOP_ITEM_NONE)
+        {
+            return;
         }
     }
     money16 price = ride->price;
@@ -5912,10 +5913,11 @@ static void window_ride_income_decrease_primary_price(rct_window *w)
     ride = get_ride(w->number);
     ride_type = get_ride_entry(ride->subtype);
 
-    if ((gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) == 0) {
-        if (ride->type != RIDE_TYPE_TOILETS && ride_type->shop_item == 0xFF) {
-            if (!gCheatsUnlockAllPrices)
-                return;
+    if (!park_ride_prices_unlocked())
+    {
+        if (ride->type != RIDE_TYPE_TOILETS && ride_type->shop_item == SHOP_ITEM_NONE)
+        {
+            return;
         }
     }
     money16 price = ride->price;
@@ -6071,9 +6073,8 @@ static void window_ride_income_invalidate(rct_window *w)
     window_ride_income_widgets[WIDX_PRIMARY_PRICE_LABEL].tooltip = STR_NONE;
     window_ride_income_widgets[WIDX_PRIMARY_PRICE].tooltip = STR_NONE;
 
-    // If the park doesn't have free entry, lock the admission price, unless the cheat to unlock all prices is activated.
-    if ((!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) && rideEntry->shop_item == SHOP_ITEM_NONE && ride->type != RIDE_TYPE_TOILETS)
-        && (!gCheatsUnlockAllPrices))
+    // If ride prices are locked, do not allow setting the price, unless we're dealing with a shop or toilet.
+    if (!park_ride_prices_unlocked() && rideEntry->shop_item == SHOP_ITEM_NONE && ride->type != RIDE_TYPE_TOILETS)
     {
         w->disabled_widgets |= (1 << WIDX_PRIMARY_PRICE);
         window_ride_income_widgets[WIDX_PRIMARY_PRICE_LABEL].tooltip = STR_RIDE_INCOME_ADMISSION_PAY_FOR_ENTRY_TIP;

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -1038,22 +1038,54 @@ void game_command_buy_land_rights(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 
 }
 
 
-void set_forced_park_rating(sint32 rating){
+void set_forced_park_rating(sint32 rating)
+{
     _forcedParkRating = rating;
     gParkRating = calculate_park_rating();
     gToolbarDirtyFlags |= BTM_TB_DIRTY_FLAG_PARK_RATING;
     window_invalidate_by_class(WC_PARK_INFORMATION);
 }
 
-sint32 get_forced_park_rating(){
+sint32 get_forced_park_rating()
+{
     return _forcedParkRating;
 }
 
 money16 park_get_entrance_fee()
 {
-    if (gParkFlags & PARK_FLAGS_NO_MONEY) return 0;
-    if (!gCheatsUnlockAllPrices) {
-        if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY) return 0;
+    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    {
+        return 0;
+    }
+    if (!park_entry_price_unlocked())
+    {
+        return 0;
     }
     return gParkEntranceFee;
+}
+
+bool park_ride_prices_unlocked()
+{
+    if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+    {
+        return true;
+    }
+    if (gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY)
+    {
+        return true;
+    }
+    return false;
+}
+
+bool park_entry_price_unlocked()
+{
+    if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+    {
+        return true;
+    }
+    if (!(gParkFlags & PARK_FLAGS_PARK_FREE_ENTRY))
+    {
+        return true;
+    }
+    return false;
 }

--- a/src/openrct2/world/park.h
+++ b/src/openrct2/world/park.h
@@ -42,7 +42,8 @@ enum {
     PARK_FLAGS_LOCK_REAL_NAMES_OPTION_DEPRECATED = (1 << 15), // Deprecated now we use a persistent 'real names' setting
     PARK_FLAGS_NO_MONEY_SCENARIO = (1 << 17),  // equivalent to PARK_FLAGS_NO_MONEY, but used in scenario editor
     PARK_FLAGS_SPRITES_INITIALISED = (1 << 18), // After a scenario is loaded this prevents edits in the scenario editor
-    PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19) // Not used anymore
+    PARK_FLAGS_SIX_FLAGS_DEPRECATED = (1 << 19), // Not used anymore
+    PARK_FLAGS_UNLOCK_ALL_PRICES = (1u << 31), // OpenRCT2 only!
 };
 
 enum
@@ -115,6 +116,9 @@ void game_command_set_park_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 void game_command_buy_land_rights(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp);
 
 money16 park_get_entrance_fee();
+
+bool park_ride_prices_unlocked();
+bool park_entry_price_unlocked();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This uses a previously unused S6 flag to save this option persistently.
This should not make S6 import much harder, but should reduce the amount of questions about S4 import. This is why it deviates from our usual course of telling people to wait for our new save format.

Also refactor the checks whether the user can ask money for rides or entry. This should make it a lot easier when our own save format comes around.


