### PR TITLE
Add a visible notification for missing KDialog/Zenity

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4462,6 +4462,9 @@ STR_6150    :Invalid response from master server (no JSON number)
 STR_6151    :Master server failed to return servers
 STR_6152    :Invalid response from master server (no JSON array)
 STR_6153    :Pay to enter park / Pay per ride
+STR_6154    :It is not recommended to run OpenRCT2 with elevated permissions.
+STR_6155    :Neither KDialog nor Zenity are installed. Please install one, or configure from the command line.
+
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -21,9 +21,10 @@
 #include <stdexcept>
 #include <openrct2/common.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/localisation/localisation.h>
 #include <openrct2/ui/UiContext.h>
 #include "UiContext.h"
-#include "openrct2/localisation/localisation.h"
+
 
 #include <SDL.h>
 

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -371,6 +371,8 @@ namespace OpenRCT2 { namespace Ui
 
         static void ThrowMissingDialogApp()
         {
+            IUiContext * uiContext = GetContext()->GetUiContext();
+            uiContext->ShowMessageBox("Neither KDialog nor Zenity are installed. Please install one.");
             throw std::runtime_error("KDialog or Zenity not installed.");
         }
     };

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/ui/UiContext.h>
 #include "UiContext.h"
+#include "openrct2/localisation/localisation.h"
 
 #include <SDL.h>
 
@@ -372,8 +373,9 @@ namespace OpenRCT2 { namespace Ui
         static void ThrowMissingDialogApp()
         {
             IUiContext * uiContext = GetContext()->GetUiContext();
-            uiContext->ShowMessageBox("Neither KDialog nor Zenity are installed. Please install one.");
-            throw std::runtime_error("KDialog or Zenity not installed.");
+            std::string dialogMissingWarning = language_get_string(6155);
+            uiContext->ShowMessageBox(dialogMissingWarning);
+            throw std::runtime_error(dialogMissingWarning);
         }
     };
 

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -374,7 +374,7 @@ namespace OpenRCT2 { namespace Ui
         static void ThrowMissingDialogApp()
         {
             IUiContext * uiContext = GetContext()->GetUiContext();
-            std::string dialogMissingWarning = language_get_string(6155);
+            std::string dialogMissingWarning = language_get_string(STR_MISSING_DIALOG_APPLICATION_ERROR);
             uiContext->ShowMessageBox(dialogMissingWarning);
             throw std::runtime_error(dialogMissingWarning);
         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -303,7 +303,7 @@ namespace OpenRCT2
 
             if (platform_process_is_elevated())
             {
-                std::string elevationWarning = language_get_string(6154);
+                std::string elevationWarning = language_get_string(STR_ADMIN_NOT_RECOMMENDED);
                 if (gOpenRCT2Headless)
                 {
                     Console::Error::WriteLine(elevationWarning.c_str());

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -303,7 +303,7 @@ namespace OpenRCT2
 
             if (platform_process_is_elevated())
             {
-                std::string elevationWarning = "For security reasons, it is strongly recommended not to run OpenRCT2 with elevated permissions.";
+                std::string elevationWarning = language_get_string(6154);
                 if (gOpenRCT2Headless)
                 {
                     Console::Error::WriteLine(elevationWarning.c_str());

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -280,6 +280,27 @@ namespace OpenRCT2
                 config_save_default();
             }
 
+            // TODO add configuration option to allow multiple instances
+            // if (!gOpenRCT2Headless && !platform_lock_single_instance()) {
+            //  log_fatal("OpenRCT2 is already running.");
+            //  return false;
+            // } //This comment was relocated so it would stay where it was in relation to the following lines of code.
+
+            _objectRepository = CreateObjectRepository(_env);
+            _objectManager = CreateObjectManager(_objectRepository);
+            _trackDesignRepository = CreateTrackDesignRepository(_env);
+            _scenarioRepository = CreateScenarioRepository(_env);
+
+            if (!language_open(gConfigGeneral.language))
+            {
+                log_error("Failed to open configured language...");
+                if (!language_open(LANGUAGE_ENGLISH_UK))
+                {
+                    log_fatal("Failed to open fallback language...");
+                    return false;
+                }
+            }
+
             if (platform_process_is_elevated())
             {
                 std::string elevationWarning = "For security reasons, it is strongly recommended not to run OpenRCT2 with elevated permissions.";
@@ -305,26 +326,10 @@ namespace OpenRCT2
                 _uiContext->CreateWindow();
             }
 
-            // TODO add configuration option to allow multiple instances
-            // if (!gOpenRCT2Headless && !platform_lock_single_instance()) {
-            //  log_fatal("OpenRCT2 is already running.");
-            //  return false;
-            // }
 
-            _objectRepository = CreateObjectRepository(_env);
-            _objectManager = CreateObjectManager(_objectRepository);
-            _trackDesignRepository = CreateTrackDesignRepository(_env);
-            _scenarioRepository = CreateScenarioRepository(_env);
 
-            if (!language_open(gConfigGeneral.language))
-            {
-                log_error("Failed to open configured language...");
-                if (!language_open(LANGUAGE_ENGLISH_UK))
-                {
-                    log_fatal("Failed to open fallback language...");
-                    return false;
-                }
-            }
+
+
 
             // TODO Ideally we want to delay this until we show the title so that we can
             //      still open the game window and draw a progress screen for the creation

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3806,6 +3806,9 @@ enum {
 
     STR_PAID_ENTRY_PAID_RIDES = 6153,
 
+    STR_ADMIN_NOT_RECOMMENDED = 6154,
+    STR_MISSING_DIALOG_APPLICATION_ERROR = 6155,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
Because most users are not running the game from the command line, the message about missing KDialog/Zenity is not visible to them. This adds a dialog box that is shown to the user when KDialog/Zenity can not be found.