### PR TITLE
Fix MinGW release builds

### DIFF
--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -70,7 +70,8 @@ NewsItem * news_item_get(sint32 index)
 
 bool news_item_is_empty(sint32 index)
 {
-    return news_item_get(index)->Type == NEWS_ITEM_NULL;
+    NewsItem * news = news_item_get(index);
+    return news && news->Type == NEWS_ITEM_NULL;
 }
 
 bool news_item_is_queue_empty()

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -71,7 +71,7 @@ NewsItem * news_item_get(sint32 index)
 bool news_item_is_empty(sint32 index)
 {
     NewsItem * news = news_item_get(index);
-    return news && news->Type == NEWS_ITEM_NULL;
+    return news != nullptr && news->Type == NEWS_ITEM_NULL;
 }
 
 bool news_item_is_queue_empty()


### PR DESCRIPTION
```
../src/openrct2/management/NewsItem.cpp: In function ‘bool news_item_is_empty(sint32)’:
../src/openrct2/management/NewsItem.cpp:73:34: error: potential null pointer dereference [-Werror=null-dereference]
     return news_item_get(index)->Type == NEWS_ITEM_NULL;
            ~~~~~~~~~~~~~~~~~~~~~~^~~~
```