### PR TITLE
Include stdbool.h in Guard.hpp

### DIFF
--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <stdarg.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
C only has `bool` type when `stdbool.h` is included.