### PR TITLE
Fix #6318: Can't fire staff that are being placed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#6202] Guests can break occupied benches (original bug).
 - Fix: [#6271] Wrong booster speed tooltip text.
 - Fix: [#6308] Cannot create title sequence if title sequences folder does not exist.
+- Fix: [#6318] Cannot sack staff that have not been placed
 - Fix: [#6320] Crash when CSS1.DAT is absent.
 - Fix: [#6331] Scenery costs nothing in track designs.
 - Fix: [#6360] Off-by-one filenames when exporting all sprites.

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -549,12 +549,6 @@ void game_command_fire_staff_member(sint32 * eax, sint32 * ebx, sint32 * ecx, si
             *ebx = MONEY32_UNDEFINED;
             return;
         }
-        if (peep->state == PEEP_STATE_PICKED)
-        {
-            *ebx = MONEY32_UNDEFINED;
-            return;
-        }
-        remove_peep_from_ride(peep);
         peep_sprite_remove(peep);
     }
     *ebx = 0;


### PR DESCRIPTION
Removed `peep->state == PEEP_STATE_PICKED` check as well as the
redundant `remove_peep_from_ride` from `game_command_fire_staff_member`.