### PR TITLE
Reintroduce error titles to game actions. Small refactor.

### DIFF
--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -105,7 +105,6 @@ static void window_ride_demolish_mouseup(rct_window *w, rct_widgetindex widgetIn
     switch (widgetIndex) {
     case WIDX_DEMOLISH:
     {
-        gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
         ride_demolish(w->number, GAME_COMMAND_FLAG_APPLY);
 
         // Prevents demolished rides sticking around in the ride list window

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1129,9 +1129,6 @@ void window_guest_overview_text_input(rct_window *w, rct_widgetindex widgetIndex
 
     if (text == nullptr)
         return;
-
-    gGameCommandErrorTitle = STR_CANT_NAME_GUEST;
-
     guest_set_name(w->number, text);
 }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1326,10 +1326,11 @@ static void window_map_place_park_entrance_tool_down(sint32 x, sint32 y)
     sint16 mapX, mapY, mapZ;
     sint32 direction;
     place_park_entrance_get_map_position(x, y, &mapX, &mapY, &mapZ, &direction);
-    if (mapX != LOCATION_NULL) {
-        gGameCommandErrorTitle = STR_CANT_BUILD_PARK_ENTRANCE_HERE;
+    if (mapX != LOCATION_NULL)
+    {
         money32 price = place_park_entrance(mapX, mapY, mapZ, direction);
-        if (price != MONEY32_UNDEFINED) {
+        if (price != MONEY32_UNDEFINED)
+        {
             audio_play_sound_at_location(
                 SOUND_PLACE_ITEM,
                 gCommandPosition.x,

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -438,7 +438,6 @@ static void window_ride_list_scrollmousedown(rct_window *w, sint32 scrollIndex, 
     // Open ride window
     uint8 rideIndex = w->list_item_positions[index];
     if (_quickDemolishMode && network_get_mode() != NETWORK_MODE_CLIENT) {
-        gGameCommandErrorTitle = STR_CANT_DEMOLISH_RIDE;
         ride_demolish(rideIndex, GAME_COMMAND_FLAG_APPLY);
         window_ride_list_refresh_list(w);
     }
@@ -913,11 +912,6 @@ static void window_ride_list_close_all(rct_window *w)
             continue;
         if (ride->status == RIDE_STATUS_CLOSED)
             continue;
-
-        gGameCommandErrorTitle = STR_CANT_CLOSE;
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32, ride->name_arguments);
-
         ride_set_status(i, RIDE_STATUS_CLOSED);
     }
 }
@@ -932,11 +926,6 @@ static void window_ride_list_open_all(rct_window *w)
             continue;
         if (ride->status == RIDE_STATUS_OPEN)
             continue;
-
-        gGameCommandErrorTitle = STR_CANT_OPEN;
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32, ride->name_arguments);
-
         ride_set_status(i, RIDE_STATUS_OPEN);
     }
 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1175,9 +1175,6 @@ void window_staff_overview_text_input(rct_window *w, rct_widgetindex widgetIndex
 
     if (text == nullptr)
         return;
-
-    gGameCommandErrorTitle = STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER;
-
     staff_set_name(w->number, text);
 }
 

--- a/src/openrct2/actions/GuestSetNameAction.hpp
+++ b/src/openrct2/actions/GuestSetNameAction.hpp
@@ -56,26 +56,26 @@ public:
         
         if (_spriteIndex >= MAX_SPRITES)
         {
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_NAME_GUEST, STR_NONE);
         }
 
         if (_name.empty())
         {
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_ERR_INVALID_NAME_FOR_GUEST);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_NAME_GUEST, STR_ERR_INVALID_NAME_FOR_GUEST);
         }
 
         rct_peep * peep = GET_PEEP(_spriteIndex);
         if (peep->type != PEEP_TYPE_GUEST)
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_NAME_GUEST, STR_NONE);
         }
 
         rct_string_id newUserStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, _name.c_str());
         if (newUserStringId == 0)
         {
             // TODO: Probably exhausted, introduce new error.
-            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, gGameCommandErrorText);
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_CANT_NAME_GUEST, gGameCommandErrorText);
         }
         user_string_free(newUserStringId);
 
@@ -88,14 +88,14 @@ public:
         if (newUserStringId == 0)
         {
             // TODO: Probably exhausted, introduce new error.
-            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, gGameCommandErrorText);
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_CANT_NAME_GUEST, gGameCommandErrorText);
         }
         
         rct_peep * peep = GET_PEEP(_spriteIndex);
         if (peep->type != PEEP_TYPE_GUEST)
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_NAME_GUEST, STR_NONE);
         }
 
         set_format_arg(0, uint32, peep->id);

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -26,17 +26,7 @@
 #include "../world/park.h"
 #include "../world/footpath.h"
 
-class PlaceParkEntranceGameActionResult final : public GameActionResult
-{
-public:
-    PlaceParkEntranceGameActionResult() : GameActionResult(GA_ERROR::OK, 0) {}
-    PlaceParkEntranceGameActionResult(GA_ERROR error, rct_string_id message) : GameActionResult(error, message)
-    {
-        ErrorTitle = STR_CANT_BUILD_PARK_ENTRANCE_HERE;
-    }
-};
-
-struct PlaceParkEntranceAction : public GameActionBase<GAME_COMMAND_PLACE_PARK_ENTRANCE, PlaceParkEntranceGameActionResult>
+struct PlaceParkEntranceAction : public GameActionBase<GAME_COMMAND_PLACE_PARK_ENTRANCE, GameActionResult>
 {
 private:
     sint16 _x;
@@ -70,7 +60,7 @@ public:
     {
         if (!(gScreenFlags & SCREEN_FLAGS_EDITOR) && !gCheatsSandboxMode)
         {
-            return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::NOT_IN_EDITOR_MODE, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::NOT_IN_EDITOR_MODE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
         }
 
         gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
@@ -81,12 +71,12 @@ public:
 
         if (!map_check_free_elements_and_reorganise(3))
         {
-            return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::NO_FREE_ELEMENTS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::NO_FREE_ELEMENTS, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
         }
 
         if (_x <= 32 || _y <= 32 || _x >= (gMapSizeUnits - 32) || _y >= (gMapSizeUnits - 32))
         {
-            return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_TOO_CLOSE_TO_EDGE_OF_MAP);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TOO_CLOSE_TO_EDGE_OF_MAP);
         }
 
         sint8 entranceNum = -1;
@@ -101,7 +91,7 @@ public:
 
         if (entranceNum == -1)
         {
-            return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_ERR_TOO_MANY_PARK_ENTRANCES);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_ERR_TOO_MANY_PARK_ENTRANCES);
         }
 
         sint8 zLow = _z * 2;
@@ -124,7 +114,7 @@ public:
             {
                 if (!map_can_construct_at(entranceLoc.x, entranceLoc.y, zLow, zHigh, 0xF))
                 {
-                    return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::NO_CLEARANCE, STR_NONE);
+                    return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
                 }
             }
 
@@ -132,11 +122,11 @@ public:
             rct_map_element* entranceElement = map_get_park_entrance_element_at(entranceLoc.x, entranceLoc.y, zLow, false);
             if (entranceElement != NULL)
             {
-                return std::make_unique<PlaceParkEntranceGameActionResult>(GA_ERROR::ITEM_ALREADY_PLACED, STR_NONE);
+                return std::make_unique<GameActionResult>(GA_ERROR::ITEM_ALREADY_PLACED, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
             }
         }
 
-        return std::make_unique<PlaceParkEntranceGameActionResult>();
+        return std::make_unique<GameActionResult>();
     }
 
     GameActionResult::Ptr Execute() const override
@@ -222,6 +212,6 @@ public:
             }
         }
 
-        return std::make_unique<PlaceParkEntranceGameActionResult>();
+        return std::make_unique<GameActionResult>();
     }
 };

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -55,12 +55,12 @@ public:
         if (ride->type == RIDE_TYPE_NULL)
         {
             log_warning("Invalid game command for ride %u", _rideIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_DEMOLISH_RIDE, STR_NONE);
         }
 
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
         {
-            return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, 
+            return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, STR_CANT_DEMOLISH_RIDE,
                 STR_LOCAL_AUTHORITY_FORBIDS_DEMOLITION_OR_MODIFICATIONS_TO_THIS_RIDE);
         }
 
@@ -73,7 +73,7 @@ public:
         if (ride->type == RIDE_TYPE_NULL)
         {
             log_warning("Invalid game command for ride %u", _rideIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_DEMOLISH_RIDE, STR_NONE);
         }
 
         sint32 refundPrice = ride_get_refund_price(_rideIndex);

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -80,7 +80,6 @@ public:
             {
                 if (!ride_is_valid_for_test(_rideIndex, _status == RIDE_STATUS_OPEN, 0))
                 {
-                    log_warning("Ride %u not valid for test", _rideIndex);
                     res->Error = GA_ERROR::UNKNOWN;
                     res->ErrorMessage = gGameCommandErrorText;
                     return res;
@@ -89,7 +88,6 @@ public:
             else if (_status == RIDE_STATUS_OPEN) {
                 if (!ride_is_valid_for_open(_rideIndex, _status == RIDE_STATUS_OPEN, 0))
                 {
-                    log_warning("Ride %u not valid for open", _rideIndex);
                     res->Error = GA_ERROR::UNKNOWN;
                     res->ErrorMessage = gGameCommandErrorText;
                     return res;
@@ -162,7 +160,6 @@ public:
                 {
                     if (!ride_is_valid_for_test(_rideIndex, _status == RIDE_STATUS_OPEN, 1))
                     {
-                        log_warning("Ride %u not valid for test", _rideIndex);
                         res->Error = GA_ERROR::UNKNOWN;
                         res->ErrorMessage = gGameCommandErrorText;
                         return res;
@@ -170,7 +167,6 @@ public:
                 }
                 else if (!ride_is_valid_for_open(_rideIndex, _status == RIDE_STATUS_OPEN, 1))
                 {
-                    log_warning("Ride %u not valid for open", _rideIndex);
                     res->Error = GA_ERROR::UNKNOWN;
                     res->ErrorMessage = gGameCommandErrorText;
                     return res;

--- a/src/openrct2/actions/StaffSetNameAction.hpp
+++ b/src/openrct2/actions/StaffSetNameAction.hpp
@@ -56,7 +56,7 @@ public:
     {
         if (_spriteIndex >= MAX_SPRITES)
         {
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, STR_NONE);
         }
 
         if (_name.empty())
@@ -68,14 +68,14 @@ public:
         if (peep->type != PEEP_TYPE_STAFF)
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, STR_NONE);
         }
 
         rct_string_id newUserStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, _name.c_str());
         if (newUserStringId == 0)
         {
             // TODO: Probably exhausted, introduce new error.
-            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, gGameCommandErrorText);
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, gGameCommandErrorText);
         }
         user_string_free(newUserStringId);
 
@@ -88,14 +88,14 @@ public:
         if (newUserStringId == 0)
         {
             // TODO: Probably exhausted, introduce new error.
-            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, gGameCommandErrorText);
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, gGameCommandErrorText);
         }
 
         rct_peep * peep = GET_PEEP(_spriteIndex);
         if (peep->type != PEEP_TYPE_STAFF)
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
-            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
+            return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, STR_NONE);
         }
 
         set_format_arg(0, uint32, peep->id);

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -1934,7 +1934,6 @@ static void window_ride_rename(rct_window *w)
 static void window_ride_main_mouseup(rct_window *w, rct_widgetindex widgetIndex)
 {
     uint8 rideIndex;
-    Ride *ride;
     sint32 status;
 
     switch (widgetIndex) {
@@ -1972,10 +1971,8 @@ static void window_ride_main_mouseup(rct_window *w, rct_widgetindex widgetIndex)
     case WIDX_CLOSE_LIGHT:
     case WIDX_TEST_LIGHT:
     case WIDX_OPEN_LIGHT:
-
-        ride = get_ride(w->number);
-
-        switch (widgetIndex) {
+        switch (widgetIndex)
+        {
         default:
         case WIDX_CLOSE_LIGHT:
             status = RIDE_STATUS_CLOSED;

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -1979,20 +1979,15 @@ static void window_ride_main_mouseup(rct_window *w, rct_widgetindex widgetIndex)
         default:
         case WIDX_CLOSE_LIGHT:
             status = RIDE_STATUS_CLOSED;
-            gGameCommandErrorTitle = STR_CANT_CLOSE;
             break;
         case WIDX_TEST_LIGHT:
             status = RIDE_STATUS_TESTING;
-            gGameCommandErrorTitle = STR_CANT_TEST;
             break;
         case WIDX_OPEN_LIGHT:
             status = RIDE_STATUS_OPEN;
-            gGameCommandErrorTitle = STR_CANT_OPEN;
             break;
         }
 
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32, ride->name_arguments);
         ride_set_status(w->number, status);
         break;
     }
@@ -2244,20 +2239,14 @@ static void window_ride_main_dropdown(rct_window *w, rct_widgetindex widgetIndex
         switch (dropdownIndex) {
         case 0:
             status = RIDE_STATUS_CLOSED;
-            gGameCommandErrorTitle = STR_CANT_CLOSE;
             break;
         case 1:
             status = RIDE_STATUS_TESTING;
-            gGameCommandErrorTitle = STR_CANT_TEST;
             break;
         case 2:
             status = RIDE_STATUS_OPEN;
-            gGameCommandErrorTitle = STR_CANT_OPEN;
             break;
         }
-
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32, ride->name_arguments);
         ride_set_status(w->number, status);
         break;
     case WIDX_RIDE_TYPE:


### PR DESCRIPTION
Further cleanup of game action errors. I think this captures everything. Also removed the log warnings as discussed in the chat.

Removed setting error titles in any calling functions.
Refactored place park entrance result to conform with other game actions.