### PR TITLE
Fixed #6390 / #6426

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -65,8 +65,8 @@ struct DataSerializerTraits<std::string>
     static void encode(IStream *stream, const std::string& str)
     {
         uint16 len = (uint16)str.size();
-        len = ByteSwapBE(len);
-        stream->Write(&len);
+        uint16 swapped = ByteSwapBE(len);
+        stream->Write(&swapped);
         stream->WriteArray(str.c_str(), len);
     }
     static void decode(IStream *stream, std::string& res)

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
As discussed in #6390, included the fix and a bump in network version as requested. Changed the variable name to match other code where ByteSwapBE is used.