### PR TITLE
Fix #6470: Title sequence naming issues

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4464,7 +4464,7 @@ STR_6152    :Invalid response from master server (no JSON array)
 STR_6153    :Pay to enter park / Pay per ride
 STR_6154    :It is not recommended to run OpenRCT2 with elevated permissions.
 STR_6155    :Neither KDialog nor Zenity are installed. Please install one, or configure from the command line.
-
+STR_6156    :Name is reserved
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3809,6 +3809,8 @@ enum {
     STR_ADMIN_NOT_RECOMMENDED = 6154,
     STR_MISSING_DIALOG_APPLICATION_ERROR = 6155,
 
+    STR_ERROR_RESERVED_NAME = 6156,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/title/TitleSequenceManager.h
+++ b/src/openrct2/title/TitleSequenceManager.h
@@ -53,6 +53,7 @@ extern "C" {
     uint16 title_sequence_manager_get_predefined_index(size_t index);
     size_t title_sequence_manager_get_index_for_config_id(const utf8 * configId);
     size_t title_sequence_manager_get_index_for_name(const utf8 * name);
+    bool title_sequence_manager_is_name_reserved(const utf8 * name);
     void title_sequence_manager_scan();
     void title_sequence_manager_delete(size_t i);
     size_t title_sequence_manager_rename(size_t i, const utf8 * name);


### PR DESCRIPTION
Predefined title sequence filenames are now treated as "reserved".
Custom title sequences cannot use reserved names and an error will
appear if the user tries.

Duplicating predefined title sequence now uses default text of
predefined sequence's proper name instead of filename.

Renamed `WIDX_TITLE_EDITOR_RENAME_SAVE_BUTTON` to
`WIDX_TITLE_EDITOR_RENAME_BUTTON` to follow formatting of other preset
button ids.

Added string id 6156, `STR_ERROR_RESERVED_NAME`, "Name is reserved".

![Window](https://i.imgur.com/rwnzheQ.png) ![Error](https://i.imgur.com/PQJ80XF.png)