### PR TITLE
Double closing Park forces guests to leave

### DIFF
--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -715,7 +715,7 @@ static void peep_update_hunger(rct_peep * peep)
  *
  *  rct2: 0x0068F93E
  */
-static void peep_leave_park(rct_peep * peep)
+void peep_leave_park(rct_peep * peep)
 {
     peep->guest_heading_to_ride_id = 0xFF;
     if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -747,6 +747,7 @@ rct_peep * try_get_guest(uint16 spriteIndex);
 sint32     peep_get_staff_count();
 sint32     peep_can_be_picked_up(rct_peep * peep);
 void       peep_update_all();
+void       peep_leave_park(rct_peep * peep);
 void       peep_problem_warnings_update();
 void       peep_stop_crowd_noise();
 void       peep_update_crowd_noise();

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -642,6 +642,21 @@ void park_update_histories()
 
 void park_set_open(sint32 open)
 {
+    if (!park_is_open() && open == 0)
+    {
+        sint32 sprite_index;
+        rct_peep *peep;
+
+        FOR_ALL_GUESTS(sprite_index, peep)
+        {
+            // force them to leave queues
+            if (peep->state == PEEP_STATE_QUEUING)
+            {
+                remove_peep_from_ride(peep);
+            }
+            peep_leave_park(peep);
+        }
+    }
     game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, open << 8, GAME_COMMAND_SET_PARK_OPEN, 0, 0);
 }
 

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -649,6 +649,8 @@ void park_set_open(sint32 open)
 
         FOR_ALL_GUESTS(sprite_index, peep)
         {
+            if (peep->outside_of_park != 0)
+                continue;
             // force them to leave queues
             if (peep->state == PEEP_STATE_QUEUING)
             {


### PR DESCRIPTION
Double closing the Park sets the state of all guests to leave the park. 
Guests currently in queues are also forced to leave the queue.