### PR TITLE
Refactor: TitleSequence spelling errors

### DIFF
--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -297,9 +297,9 @@ static void window_title_command_editor_mouseup(rct_window *w, rct_widgetindex w
             _sequence->Commands[insertIndex] = command;
         } else {
             _sequence->Commands[_window_title_command_editor_index] = command;
-            TileSequenceSave(_sequence);
+            TitleSequenceSave(_sequence);
         }
-        TileSequenceSave(_sequence);
+        TitleSequenceSave(_sequence);
 
         rct_window *title_editor_w = window_find_by_class(WC_TITLE_EDITOR);
         if (title_editor_w != nullptr) {

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -398,7 +398,7 @@ static void window_title_editor_mouseup(rct_window *w, rct_widgetindex widgetInd
                 if (w->selected_list_item >= (sint16)_editingTitleSequence->NumCommands) {
                     w->selected_list_item--;
                 }
-                TileSequenceSave(_editingTitleSequence);
+                TitleSequenceSave(_editingTitleSequence);
             }
         }
         break;
@@ -421,7 +421,7 @@ static void window_title_editor_mouseup(rct_window *w, rct_widgetindex widgetInd
                 *a = *b;
                 *b = tmp;
                 w->selected_list_item++;
-                TileSequenceSave(_editingTitleSequence);
+                TitleSequenceSave(_editingTitleSequence);
             }
         }
         break;
@@ -434,7 +434,7 @@ static void window_title_editor_mouseup(rct_window *w, rct_widgetindex widgetInd
                 *b = *a;
                 *a = tmp;
                 w->selected_list_item--;
-                TileSequenceSave(_editingTitleSequence);
+                TitleSequenceSave(_editingTitleSequence);
             }
         }
         break;
@@ -1016,7 +1016,7 @@ static void window_title_editor_add_park_callback(sint32 result, const utf8 * pa
         return;
     }
 
-    TileSequenceAddPark(_editingTitleSequence, path, filename);
+    TitleSequenceAddPark(_editingTitleSequence, path, filename);
 }
 
 static void window_title_editor_rename_park(size_t index, const utf8 * name)
@@ -1036,7 +1036,7 @@ static void window_title_editor_rename_park(size_t index, const utf8 * name)
         }
     }
 
-    if (TileSequenceRenamePark(_editingTitleSequence, index, name)) {
-        TileSequenceSave(_editingTitleSequence);
+    if (TitleSequenceRenamePark(_editingTitleSequence, index, name)) {
+        TitleSequenceSave(_editingTitleSequence);
     }
 }

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -185,7 +185,7 @@ extern "C"
         }
     }
 
-    bool TileSequenceSave(TitleSequence * seq)
+    bool TitleSequenceSave(TitleSequence * seq)
     {
         bool success = false;
         utf8 * script = LegacyScriptWrite(seq);
@@ -217,7 +217,7 @@ extern "C"
         return success;
     }
 
-    bool TileSequenceAddPark(TitleSequence * seq, const utf8 * path, const utf8 * name)
+    bool TitleSequenceAddPark(TitleSequence * seq, const utf8 * path, const utf8 * name)
     {
         // Get new save index
         size_t index = SIZE_MAX;
@@ -275,7 +275,7 @@ extern "C"
         return true;
     }
 
-    bool TileSequenceRenamePark(TitleSequence * seq, size_t index, const utf8 * name)
+    bool TitleSequenceRenamePark(TitleSequence * seq, size_t index, const utf8 * name)
     {
         Guard::Assert(index < seq->NumSaves, GUARD_LINE);
 

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -94,9 +94,9 @@ extern "C"
      * The pointer to the handle is invalid after calling this function.
      */
     void TitleSequenceCloseParkHandle(TitleSequenceParkHandle * handle);
-    bool TileSequenceSave(TitleSequence * seq);
-    bool TileSequenceAddPark(TitleSequence * seq, const utf8 * path, const utf8 * name);
-    bool TileSequenceRenamePark(TitleSequence * seq, size_t index, const utf8 * name);
+    bool TitleSequenceSave(TitleSequence * seq);
+    bool TitleSequenceAddPark(TitleSequence * seq, const utf8 * path, const utf8 * name);
+    bool TitleSequenceRenamePark(TitleSequence * seq, size_t index, const utf8 * name);
     bool TitleSequenceRemovePark(TitleSequence * seq, size_t index);
 
     bool TitleSequenceIsLoadCommand(const TitleCommand * command);

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -151,7 +151,7 @@ namespace TitleSequenceManager
         seq->Path = String::Duplicate(path.c_str());
         seq->IsZip = true;
 
-        bool success = TileSequenceSave(seq);
+        bool success = TitleSequenceSave(seq);
         FreeTitleSequence(seq);
 
         size_t index = SIZE_MAX;


### PR DESCRIPTION
```c++
bool TileSequenceSave(TitleSequence * seq);
bool TileSequenceAddPark(TitleSequence * seq, const utf8 * path, const
utf8 * name);
bool TileSequenceRenamePark(TitleSequence * seq, size_t index, const
utf8 * name);
```

Renamed to:

```c++
bool TitleSequenceSave(TitleSequence * seq);
bool TitleSequenceAddPark(TitleSequence * seq, const utf8 * path, const
utf8 * name);
bool TitleSequenceRenamePark(TitleSequence * seq, size_t index, const
utf8 * name);
```