### PR TITLE
Change: Predefined themes use proper names

### DIFF
--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -661,25 +661,15 @@ static void window_themes_textinput(rct_window *w, rct_widgetindex widgetIndex, 
     case WIDX_THEMES_DUPLICATE_BUTTON:
     case WIDX_THEMES_RENAME_BUTTON:
         if (filename_valid_characters(text)) {
-            bool nameTaken = false;
-            sint32 numAvailableThemes = (sint32)theme_manager_get_num_available_themes();
-            for (sint32 i = 0; i < numAvailableThemes; i++) {
-                const utf8 * themeName = theme_manager_get_available_theme_name(i);
-                if (strcmp(themeName, text) == 0) {
-                    if (widgetIndex != WIDX_THEMES_RENAME_BUTTON) {
-                        context_show_error(STR_THEMES_ERR_NAME_ALREADY_EXISTS, STR_NONE);
-                    }
-                    nameTaken = true;
-                    break;
-                }
-            }
-            if (!nameTaken) {
+            if (theme_get_index_for_name(text) == SIZE_MAX) {
                 if (widgetIndex == WIDX_THEMES_DUPLICATE_BUTTON) {
                     theme_duplicate(text);
                 } else {
                     theme_rename(text);
                 }
                 window_invalidate(w);
+            } else {
+                context_show_error(STR_THEMES_ERR_NAME_ALREADY_EXISTS, STR_NONE);
             }
         } else {
             context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE);

--- a/src/openrct2/interface/themes.h
+++ b/src/openrct2/interface/themes.h
@@ -40,9 +40,11 @@ void         theme_manager_initialise();
 void         theme_manager_load_available_themes();
 size_t       theme_manager_get_num_available_themes();
 const utf8 * theme_manager_get_available_theme_path(size_t index);
+const utf8 * theme_manager_get_available_theme_config_name(size_t index);
 const utf8 * theme_manager_get_available_theme_name(size_t index);
 size_t       theme_manager_get_active_available_theme_index();
 void         theme_manager_set_active_available_theme(size_t index);
+size_t       theme_get_index_for_name(const utf8 * name);
 
 colour_t theme_get_colour(rct_windowclass wc, uint8 index);
 void     theme_set_colour(rct_windowclass wc, uint8 index, colour_t colour);


### PR DESCRIPTION
Predefined themes *RCT1* and *RCT2* will now be called their respective
game name, *RollerCoaster Tycoon 1* or *RollerCoaster Tycoon 2* in the
current language.

Predefined themes in the config file now are prefixed with an asterisk
like they are supposed to be. AKA `*RCT1` instead of `RCT1`.

This will invalidate the user's currently selected theme in the config
file, but only if they were using RCT1's theme.