### PR TITLE
Fix disappearing land/construction rights indicators

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,7 +20,8 @@
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.
-- Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set
+- Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set.
+- Fix: [#5741] Land rights indicators disappear when switching views.
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list.
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch.

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -162,7 +162,6 @@ static void window_land_rights_mouseup(rct_window *w, rct_widgetindex widgetInde
         {
             tool_set(w, WIDX_BUY_LAND_RIGHTS, TOOL_UP_ARROW);
             _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
-            hide_construction_rights();
             show_land_rights();
             window_invalidate(w);
         }
@@ -172,7 +171,6 @@ static void window_land_rights_mouseup(rct_window *w, rct_widgetindex widgetInde
         {
             tool_set(w, WIDX_BUY_CONSTRUCTION_RIGHTS, TOOL_UP_ARROW);
             _landRightsMode = LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS;
-            hide_land_rights();
             show_construction_rights();
             window_invalidate(w);
         }


### PR DESCRIPTION
Currently, when switching between the tools to buy land and construction rights, the flags on the terrain will disappear after switching back and forth once. The reason for this is a double decrement of gShowLandRightsRefCount and gShowConstuctionRightsRefCount, respectively. One decrement happens in window_land_rights_mouseup, the other one in window_land_rights_toolabort, by calling the hide_..._rights functions.