### PR TITLE
Fix saving without dialog in new scenario

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -765,6 +765,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
         safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
+        gFirstTimeSaving = true;
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         window_close_by_class(WC_LOADSAVE);
         gfx_invalidate_screen();

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -292,6 +292,7 @@ static void window_scenarioselect_scrollmousedown(rct_window *w, sint32 scrollIn
             y -= 24;
             if (y < 0 && !listItem->scenario.is_locked) {
                 audio_play_sound(SOUND_CLICK_1, 0, w->x + (w->width / 2));
+                gFirstTimeSaving = true;
                 _callback(listItem->scenario.scenario->path);
             }
             break;


### PR DESCRIPTION
When saving a game for the first time, the user asked to pick a save file. On subsequent saves, the user is not asked and the same save file is used every time. After loading a different game or starting a new scenario, the variable that indicates saving without showing the dialog is not reset, which can even cause the user accidentally overwriting an older save game.