### PR TITLE
Feature: Preview title sequences in-game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
 - Feature: Allow using object files from RCT Classic.
+- Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1962,7 +1962,7 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
             w->y + window_options_misc_widgets[WIDX_AUTOSAVE].top
         );
 
-        const utf8 * name = title_sequence_manager_get_name(title_get_current_sequence());
+        const utf8 * name = title_sequence_manager_get_name(title_get_config_sequence());
         set_format_arg(0, uintptr_t, (uintptr_t)name);
         gfx_draw_string_left(dpi, STR_TITLE_SEQUENCE, w, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1);
         gfx_draw_string_left_clipped(

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -171,7 +171,7 @@ static LocationXY16 get_location()
         sint32 interactionType;
         rct_map_element *mapElement;
 
-        get_map_coordinates_from_pos(w->viewport->view_width / 2, w->viewport->view_height / 2, VIEWPORT_INTERACTION_MASK_TERRAIN, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, nullptr);
+        get_map_coordinates_from_pos_window(w, w->viewport->view_width / 2, w->viewport->view_height / 2, VIEWPORT_INTERACTION_MASK_TERRAIN, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, nullptr);
         mapCoord.x -= 16;
         mapCoord.x /= 32;
         mapCoord.y -= 16;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -377,15 +377,14 @@ namespace OpenRCT2
             return true;
         }
 
-        bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) final override
+        bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail) final override
         {
             auto fs = FileStream(path, FILE_MODE_OPEN);
             return LoadParkFromStream(&fs, path, loadTitleScreenOnFail);
         }
 
-        bool LoadParkFromStream(void * streamPtr, const std::string &path, bool loadTitleScreenFirstOnFail) final override
+        bool LoadParkFromStream(IStream * stream, const std::string &path, bool loadTitleScreenFirstOnFail) final override
         {
-            IStream *stream = (IStream*)streamPtr;
             ClassifiedFileInfo info;
             if (TryClassifyFile(stream, &info))
             {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -383,6 +383,82 @@ namespace OpenRCT2
             return LoadParkFromStream(&fs, path, loadTitleScreenOnFail);
         }
 
+        bool LoadParkFromStream(void * streamPtr, const std::string &path, bool loadTitleScreenFirstOnFail) final override
+        {
+            IStream *stream = (IStream*)streamPtr;
+            ClassifiedFileInfo info;
+            if (TryClassifyFile(stream, &info))
+            {
+                if (info.Type == FILE_TYPE::SAVED_GAME ||
+                    info.Type == FILE_TYPE::SCENARIO)
+                {
+                    std::unique_ptr<IParkImporter> parkImporter;
+                    if (info.Version <= FILE_TYPE_S4_CUTOFF)
+                    {
+                        // Save is an S4 (RCT1 format)
+                        parkImporter.reset(ParkImporter::CreateS4());
+                    }
+                    else
+                    {
+                        // Save is an S6 (RCT2 format)
+                        parkImporter.reset(ParkImporter::CreateS6(_objectRepository, _objectManager));
+                    }
+
+                    auto result = parkImporter->LoadFromStream(stream, info.Type == FILE_TYPE::SCENARIO, false, path.c_str());
+                    if (result.Error == PARK_LOAD_ERROR_OK)
+                    {
+                        parkImporter->Import();
+                        game_fix_save_vars();
+                        sprite_position_tween_reset();
+                        gScreenAge = 0;
+                        gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
+                        if (info.Type == FILE_TYPE::SAVED_GAME)
+                        {
+                            if (network_get_mode() == NETWORK_MODE_CLIENT)
+                            {
+                                network_close();
+                            }
+                            game_load_init();
+                            if (network_get_mode() == NETWORK_MODE_SERVER)
+                            {
+                                network_send_map();
+                            }
+                        }
+                        else
+                        {
+                            scenario_begin();
+                            if (network_get_mode() == NETWORK_MODE_SERVER)
+                            {
+                                network_send_map();
+                            }
+                            if (network_get_mode() == NETWORK_MODE_CLIENT)
+                            {
+                                network_close();
+                            }
+                        }
+                        // This ensures that the newly loaded save reflects the user's
+                        // 'show real names of guests' option, now that it's a global setting
+                        peep_update_names(gConfigGeneral.show_real_names_of_guests);
+                        return true;
+                    }
+                    else
+                    {
+                        handle_park_load_failure_with_title_opt(&result, path.c_str(), loadTitleScreenFirstOnFail);
+                    }
+
+                }
+                else
+                {
+                    Console::Error::WriteLine("Invalid file type.");
+                }
+            }
+            else
+            {
+                Console::Error::WriteLine("Unable to detect file type.");
+            }
+            return false;
+        }
+
     private:
         std::string GetOrPromptRCT2Path()
         {
@@ -701,81 +777,6 @@ namespace OpenRCT2
             console_update();
         }
 
-        bool LoadParkFromStream(IStream * stream, const std::string &path, bool loadTitleScreenFirstOnFail)
-        {
-            ClassifiedFileInfo info;
-            if (TryClassifyFile(stream, &info))
-            {
-                if (info.Type == FILE_TYPE::SAVED_GAME ||
-                    info.Type == FILE_TYPE::SCENARIO)
-                {
-                    std::unique_ptr<IParkImporter> parkImporter;
-                    if (info.Version <= FILE_TYPE_S4_CUTOFF)
-                    {
-                        // Save is an S4 (RCT1 format)
-                        parkImporter.reset(ParkImporter::CreateS4());
-                    }
-                    else
-                    {
-                        // Save is an S6 (RCT2 format)
-                        parkImporter.reset(ParkImporter::CreateS6(_objectRepository, _objectManager));
-                    }
-
-                    auto result = parkImporter->LoadFromStream(stream, info.Type == FILE_TYPE::SCENARIO, false, path.c_str());
-                    if (result.Error == PARK_LOAD_ERROR_OK)
-                    {
-                        parkImporter->Import();
-                        game_fix_save_vars();
-                        sprite_position_tween_reset();
-                        gScreenAge = 0;
-                        gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
-                        if (info.Type == FILE_TYPE::SAVED_GAME)
-                        {
-                            if (network_get_mode() == NETWORK_MODE_CLIENT)
-                            {
-                                network_close();
-                            }
-                            game_load_init();
-                            if (network_get_mode() == NETWORK_MODE_SERVER)
-                            {
-                                network_send_map();
-                            }
-                        }
-                        else
-                        {
-                            scenario_begin();
-                            if (network_get_mode() == NETWORK_MODE_SERVER)
-                            {
-                                    network_send_map();
-                            }
-                            if (network_get_mode() == NETWORK_MODE_CLIENT)
-                            {
-                                network_close();
-                            }
-                        }
-                        // This ensures that the newly loaded save reflects the user's
-                        // 'show real names of guests' option, now that it's a global setting
-                        peep_update_names(gConfigGeneral.show_real_names_of_guests);
-                        return true;
-                    }
-                    else
-                    {
-                        handle_park_load_failure_with_title_opt(&result, path.c_str(), loadTitleScreenFirstOnFail);
-                    }
-
-                }
-                else
-                {
-                    Console::Error::WriteLine("Invalid file type.");
-                }
-            }
-            else
-            {
-                Console::Error::WriteLine("Unable to detect file type.");
-            }
-            return false;
-        }
-
         /**
         * Copy saved games and landscapes to user directory
         */
@@ -878,6 +879,11 @@ extern "C"
     bool context_load_park_from_file(const utf8 * path)
     {
         return GetContext()->LoadParkFromFile(path);
+    }
+
+    bool context_load_park_from_stream(void * stream)
+    {
+        return GetContext()->LoadParkFromStream((IStream*)stream, "");
     }
 
     void openrct2_write_full_version_info(utf8 * buffer, size_t bufferSize)

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -97,6 +97,7 @@ namespace OpenRCT2
 
         virtual bool Initialise() abstract;
         virtual bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) abstract;
+        virtual bool LoadParkFromStream(void * stream, const std::string &path, bool loadTitleScreenFirstOnFail = false) abstract;
         virtual void Finish() abstract;
         virtual void Quit() abstract;
 
@@ -221,6 +222,7 @@ extern "C"
     void context_quit();
     const utf8 * context_get_path_legacy(sint32 pathId);
     bool context_load_park_from_file(const utf8 * path);
+    bool context_load_park_from_stream(void * stream);
 #ifdef __cplusplus
 }
 #endif

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -69,6 +69,8 @@ enum
 
 #include <string>
 
+interface IStream;
+
 namespace OpenRCT2
 {
     interface IPlatformEnvironment;
@@ -97,7 +99,7 @@ namespace OpenRCT2
 
         virtual bool Initialise() abstract;
         virtual bool LoadParkFromFile(const std::string &path, bool loadTitleScreenOnFail = false) abstract;
-        virtual bool LoadParkFromStream(void * stream, const std::string &path, bool loadTitleScreenFirstOnFail = false) abstract;
+        virtual bool LoadParkFromStream(IStream * stream, const std::string &path, bool loadTitleScreenFirstOnFail = false) abstract;
         virtual void Finish() abstract;
         virtual void Quit() abstract;
 

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -46,6 +46,7 @@
 #include "ride/Vehicle.h"
 #include "scenario/scenario.h"
 #include "title/TitleScreen.h"
+#include "title/TitleSequencePlayer.h"
 #include "util/sawyercoding.h"
 #include "util/util.h"
 #include "windows/Intent.h"
@@ -72,6 +73,8 @@ bool gInMapInitCode = false;
 sint32 gGameCommandNestLevel;
 bool gGameCommandIsNetworked;
 char gCurrentLoadedPath[MAX_PATH];
+
+bool gLoadKeepWindowsOpen = false;
 
 uint8 gUnk13CA740;
 uint8 gUnk141F568;
@@ -291,6 +294,11 @@ void game_update()
     // 0x006E3AEC // screen_game_process_mouse_input();
     screenshot_check();
     game_handle_keyboard_input();
+
+    if (game_is_not_paused() && gTestingTitleSequenceInGame)
+    {
+        title_sequence_player_update((ITitleSequencePlayer*)title_get_sequence_player());
+    }
 
     // Determine how many times we need to update the game
     if (gGameSpeed > 1) {
@@ -1158,8 +1166,11 @@ void game_load_init()
 
     gScreenFlags = SCREEN_FLAGS_PLAYING;
     audio_stop_all_music_and_sounds();
-    viewport_init_all();
-    game_create_windows();
+    if (!gLoadKeepWindowsOpen)
+    {
+        viewport_init_all();
+        game_create_windows();
+    }
     mainWindow = window_get_main();
 
     if (mainWindow != NULL)

--- a/src/openrct2/game.h
+++ b/src/openrct2/game.h
@@ -156,6 +156,8 @@ extern sint32 gGameCommandNestLevel;
 extern bool gGameCommandIsNetworked;
 extern char gCurrentLoadedPath[260];
 
+extern bool gLoadKeepWindowsOpen;
+
 extern uint8 gUnk13CA740;
 extern uint8 gUnk141F568;
 

--- a/src/openrct2/interface/viewport.c
+++ b/src/openrct2/interface/viewport.c
@@ -1349,9 +1349,14 @@ static void sub_68862C(rct_drawpixelinfo * dpi, paint_struct * ps)
  */
 void get_map_coordinates_from_pos(sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport)
 {
+    rct_window* window = window_find_from_point(screenX, screenY);
+    get_map_coordinates_from_pos_window(window, screenX, screenY, flags, x, y, interactionType, mapElement, viewport);
+}
+
+void get_map_coordinates_from_pos_window(rct_window *window, sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport)
+{
     _unk9AC154 = flags & 0xFFFF;
     _interactionSpriteType = 0;
-    rct_window* window = window_find_from_point(screenX, screenY);
     if (window != NULL && window->viewport != NULL)
     {
         rct_viewport* myviewport = window->viewport;

--- a/src/openrct2/interface/viewport.c
+++ b/src/openrct2/interface/viewport.c
@@ -1353,7 +1353,8 @@ void get_map_coordinates_from_pos(sint32 screenX, sint32 screenY, sint32 flags, 
     get_map_coordinates_from_pos_window(window, screenX, screenY, flags, x, y, interactionType, mapElement, viewport);
 }
 
-void get_map_coordinates_from_pos_window(rct_window *window, sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport)
+void get_map_coordinates_from_pos_window(rct_window * window, sint32 screenX, sint32 screenY, sint32 flags, sint16 * x, sint16 * y,
+    sint32 * interactionType, rct_map_element ** mapElement, rct_viewport ** viewport)
 {
     _unk9AC154 = flags & 0xFFFF;
     _interactionSpriteType = 0;

--- a/src/openrct2/interface/viewport.h
+++ b/src/openrct2/interface/viewport.h
@@ -143,6 +143,7 @@ void hide_construction_rights();
 void viewport_set_visibility(uint8 mode);
 
 void get_map_coordinates_from_pos(sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
+void get_map_coordinates_from_pos_window(rct_window *window, sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
 
 sint32 viewport_interaction_get_item_left(sint32 x, sint32 y, viewport_interaction_info *info);
 sint32 viewport_interaction_left_over(sint32 x, sint32 y);

--- a/src/openrct2/interface/viewport.h
+++ b/src/openrct2/interface/viewport.h
@@ -143,7 +143,8 @@ void hide_construction_rights();
 void viewport_set_visibility(uint8 mode);
 
 void get_map_coordinates_from_pos(sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
-void get_map_coordinates_from_pos_window(rct_window *window, sint32 screenX, sint32 screenY, sint32 flags, sint16 *x, sint16 *y, sint32 *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
+void get_map_coordinates_from_pos_window(rct_window * window, sint32 screenX, sint32 screenY, sint32 flags, sint16 * x, sint16 * y,
+    sint32 * interactionType, rct_map_element ** mapElement, rct_viewport ** viewport);
 
 sint32 viewport_interaction_get_item_left(sint32 x, sint32 y, viewport_interaction_info *info);
 sint32 viewport_interaction_left_over(sint32 x, sint32 y);

--- a/src/openrct2/scenario/scenario.c
+++ b/src/openrct2/scenario/scenario.c
@@ -105,7 +105,7 @@ void scenario_begin()
     research_reset_current_item();
     scenery_set_default_placement_configuration();
     news_item_init_queue();
-    if (gScenarioObjectiveType != OBJECTIVE_NONE)
+    if (gScenarioObjectiveType != OBJECTIVE_NONE && !gLoadKeepWindowsOpen)
         context_open_window_view(WV_PARK_OBJECTIVE);
 
     gParkRating = calculate_park_rating();

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -58,9 +58,13 @@ uint16 TitleScreen::GetCurrentSequence()
     return _currentSequence;
 }
 
-void TitleScreen::SetCurrentSequence(uint16 value)
+void TitleScreen::SetCurrentSequence(uint16 value, bool loadSequence)
 {
     _currentSequence = value;
+    if (loadSequence)
+    {
+        TryLoadSequence();
+    }
 }
 
 bool TitleScreen::ShouldHideVersionInfo()
@@ -103,7 +107,7 @@ void TitleScreen::Load()
 
     if (_sequencePlayer != nullptr)
     {
-        _sequencePlayer->Reset();
+        _sequencePlayer->Begin(_currentSequence);
 
         // Force the title sequence to load / update so we
         // don't see a blank screen for a split second.
@@ -187,7 +191,7 @@ void TitleScreen::TitleInitialise()
         IScenarioRepository * scenarioRepository = GetScenarioRepository();
         _sequencePlayer = CreateTitleSequencePlayer(scenarioRepository);
     }
-    size_t seqId = title_sequence_manager_get_index_for_config_id(gConfigInterface.current_title_sequence_preset);
+    size_t seqId = title_get_config_sequence();
     if (seqId == SIZE_MAX)
     {
         seqId = title_sequence_manager_get_index_for_config_id("*OPENRCT2");
@@ -283,6 +287,11 @@ extern "C"
         }
     }
 
+    uint16 title_get_config_sequence()
+    {
+        return (uint16)title_sequence_manager_get_index_for_config_id(gConfigInterface.current_title_sequence_preset);
+    }
+
     uint16 title_get_current_sequence()
     {
         uint16 result = 0;
@@ -293,11 +302,11 @@ extern "C"
         return result;
     }
 
-    void title_set_current_sequence(uint16 value)
+    void title_set_current_sequence(uint16 value, bool loadSequence)
     {
         if (_singleton != nullptr)
         {
-            _singleton->SetCurrentSequence(value);
+            _singleton->SetCurrentSequence(value, loadSequence);
         }
     }
 

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -28,7 +28,7 @@ class TitleScreen final
 public:
     ITitleSequencePlayer *  GetSequencePlayer();
     uint16                  GetCurrentSequence();
-    void                    SetCurrentSequence(uint16 value);
+    void                    SetCurrentSequence(uint16 value, bool loadSequence);
     bool                    ShouldHideVersionInfo();
     void                    SetHideVersionInfo(bool value);
 
@@ -61,8 +61,9 @@ extern "C"
     void title_sequence_change_preset(sint32 preset);
     bool title_should_hide_version_info();
     void title_set_hide_version_info(bool value);
+    uint16 title_get_config_sequence();
     uint16 title_get_current_sequence();
-    void title_set_current_sequence(uint16 value);
+    void title_set_current_sequence(uint16 value, bool loadSequence);
     void DrawOpenRCT2(rct_drawpixelinfo *dpi, sint32 x, sint32 y);
 #ifdef __cplusplus
 }

--- a/src/openrct2/title/TitleSequencePlayer.h
+++ b/src/openrct2/title/TitleSequencePlayer.h
@@ -45,6 +45,9 @@ typedef struct ITitleSequencePlayer ITitleSequencePlayer;
 extern "C"
 {
 #endif
+    // When testing title sequences within a normal game
+    extern bool gTestingTitleSequenceInGame;
+
     sint32 title_sequence_player_get_current_position(ITitleSequencePlayer * player);
     bool title_sequence_player_begin(ITitleSequencePlayer * player, uint32 titleSequenceId);
     void title_sequence_player_reset(ITitleSequencePlayer * player);


### PR DESCRIPTION
Title sequences can now be played back in-game, allowing for much easier
editing.

Improved title sequence playback in general. Clicking play while on a
different title sequence will play the new one. Clicking stop will make
the title screen go back to the config title sequence. And the closing
the title sequence window will also make the game go back to the config
title sequence, and reload the sequence if it was modified.

Changes made to title sequences in-game are now correctly loaded in the
title screen.

Starting a title sequence within the editor will now always reset it
even if it's the current playing sequence. (Not for playing in the
editor though).

Get Location in title sequence command editor now has 100% accuracy
compared to before
where it would usually get some offset value.

Added `get_map_coordinates_from_pos_window` which will allow getting the
viewport coordinates of a specific window even if the input coordinates
are under another window. This has use with getting 2D positions from
the main window without the other windows getting in the way.

Options window will now always specify the config title sequence in the
dropdown and not the current title sequence.

Made a global variable `gLoadKeepWindowsOpen`, in game.h to keep windows
open when loading a park. When loading a title sequence park in-game.
The sequence player will force-close all park-specific windows ahead of
time.

Skipping while testing title sequences no longer needs to reload the
park if the current playback position is already before the target
position and ahead of the load position.

Added changelog entry.