### PR TITLE
Improve: RCT2 Steam path locator

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -615,7 +615,7 @@ namespace Config
             }
         }
 
-        utf8 steamPath[MAX_PATH] = { 0 };
+        utf8 steamPath[2048] = { 0 };
         if (platform_get_steam_path(steamPath, sizeof(steamPath)))
         {
             std::string location = Path::Combine(steamPath, "Rollercoaster Tycoon 2");

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -614,6 +614,17 @@ namespace Config
                 return location;
             }
         }
+
+        utf8 steamPath[MAX_PATH] = { 0 };
+        if (platform_get_steam_path(steamPath, sizeof(steamPath)))
+        {
+            std::string location = Path::Combine(steamPath, "Rollercoaster Tycoon 2");
+            if (platform_original_game_data_exists(location.c_str()))
+            {
+                return location;
+            }
+        }
+
         if (platform_original_game_data_exists(gExePath))
         {
             return gExePath;

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -253,7 +253,7 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
     safe_strcat_path(outPath, "changelog.txt", outSize);
 }
 
-bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
     const char * steamRoot = getenv("STEAMROOT");
     if (steamRoot != NULL)

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -253,6 +253,52 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
     safe_strcat_path(outPath, "changelog.txt", outSize);
 }
 
+bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+{
+    const char *steamRoot = getenv("STEAMROOT");
+    if (steamRoot != NULL)
+    {
+        safe_strcpy(outPath, steamRoot, outSize);
+        safe_strcat_path(outPath, "steamapps/common", outSize);
+        return true;
+    }
+
+    char steamPath[1024] = { 0 };
+    const char *localSharePath = getenv("XDG_DATA_HOME");
+    if (localSharePath != NULL)
+    {
+        safe_strcpy(steamPath, localSharePath, sizeof(steamPath));
+        safe_strcat_path(steamPath, "Steam/steamapps/common", sizeof(steamPath));
+        if (platform_directory_exists(steamPath))
+        {
+            safe_strcpy(outPath, steamPath, outSize);
+            return true;
+        }
+    }
+
+    const char *homeDir = getenv("HOME");
+    if (homeDir != NULL)
+    {
+        safe_strcpy(steamPath, homeDir, sizeof(steamPath));
+        safe_strcat_path(steamPath, ".local/share/Steam/steamapps/common", sizeof(steamPath));
+        if (platform_directory_exists(steamPath))
+        {
+            safe_strcpy(outPath, steamPath, outSize);
+            return true;
+        }
+
+        memset(steamPath, 0, sizeof(steamPath));
+        safe_strcpy(steamPath, homeDir, sizeof(steamPath));
+        safe_strcat_path(steamPath, ".steam/steam/steamapps/common", sizeof(steamPath));
+        if (platform_directory_exists(steamPath))
+        {
+            safe_strcpy(outPath, steamPath, outSize);
+            return true;
+        }
+    }
+    return false;
+}
+
 #ifndef NO_TTF
 bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size)
 {

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -255,7 +255,7 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
 
 bool platform_get_steam_path(utf8 *outPath, size_t outSize)
 {
-    const char *steamRoot = getenv("STEAMROOT");
+    const char * steamRoot = getenv("STEAMROOT");
     if (steamRoot != NULL)
     {
         safe_strcpy(outPath, steamRoot, outSize);
@@ -264,7 +264,7 @@ bool platform_get_steam_path(utf8 *outPath, size_t outSize)
     }
 
     char steamPath[1024] = { 0 };
-    const char *localSharePath = getenv("XDG_DATA_HOME");
+    const char * localSharePath = getenv("XDG_DATA_HOME");
     if (localSharePath != NULL)
     {
         safe_strcpy(steamPath, localSharePath, sizeof(steamPath));
@@ -276,7 +276,7 @@ bool platform_get_steam_path(utf8 *outPath, size_t outSize)
         }
     }
 
-    const char *homeDir = getenv("HOME");
+    const char * homeDir = getenv("HOME");
     if (homeDir != NULL)
     {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -34,6 +34,7 @@
 #endif // NO_TTF
 #include <fnmatch.h>
 #include <locale.h>
+#include <pwd.h>
 
 #include "../config/Config.h"
 #include "../localisation/language.h"
@@ -276,7 +277,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
         }
     }
 
-    const char * homeDir = getpwuid(getuid())->pw_dir
+    const char * homeDir = getpwuid(getuid())->pw_dir;
     if (homeDir != NULL)
     {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));

--- a/src/openrct2/platform/linux.c
+++ b/src/openrct2/platform/linux.c
@@ -276,7 +276,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
         }
     }
 
-    const char * homeDir = getenv("HOME");
+    const char * homeDir = getpwuid(getuid())->pw_dir
     if (homeDir != NULL)
     {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -19,6 +19,7 @@
 @import AppKit;
 @import Foundation;
 #include <mach-o/dyld.h>
+#include <pwd.h>
 #include "platform.h"
 #include "../util/util.h"
 #include "../localisation/language.h"

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -215,4 +215,14 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
     safe_strcat_path(outPath, "changelog.txt", outSize);
 }
 
+bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+{
+	const char *steamPath = "~/Library/Application Support/Steam/steamapps/common";
+	if (platform_directory_exists(steamPath)) {
+		safe_strcpy(outPath, steamPath, outSize);
+		return true;
+	}
+	return false;
+}
+
 #endif

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -217,11 +217,16 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
 
 bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
-    const char * steamPath = "~/Library/Application Support/Steam/steamapps/common";
-    if (platform_directory_exists(steamPath))
-    {
-        safe_strcpy(outPath, steamPath, outSize);
-        return true;
+    char steamPath[1024] = { 0 };
+    const char * homeDir = getpwuid(getuid())->pw_dir;
+    if (homeDir != NULL) {
+        safe_strcpy(steamPath, homeDir, sizeof(steamPath));
+        safe_strcat_path(steamPath, "Library/Application Support/Steam/steamapps/common", sizeof(steamPath));
+        if (platform_directory_exists(steamPath))
+        {
+            safe_strcpy(outPath, steamPath, outSize);
+            return true;
+        }
     }
     return false;
 }

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -215,14 +215,15 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
     safe_strcat_path(outPath, "changelog.txt", outSize);
 }
 
-bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
-	const char *steamPath = "~/Library/Application Support/Steam/steamapps/common";
-	if (platform_directory_exists(steamPath)) {
-		safe_strcpy(outPath, steamPath, outSize);
-		return true;
-	}
-	return false;
+    const char * steamPath = "~/Library/Application Support/Steam/steamapps/common";
+    if (platform_directory_exists(steamPath))
+    {
+        safe_strcpy(outPath, steamPath, outSize);
+        return true;
+    }
+    return false;
 }
 
 #endif

--- a/src/openrct2/platform/macos.m
+++ b/src/openrct2/platform/macos.m
@@ -220,7 +220,8 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
     char steamPath[1024] = { 0 };
     const char * homeDir = getpwuid(getuid())->pw_dir;
-    if (homeDir != NULL) {
+    if (homeDir != NULL)
+    {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));
         safe_strcat_path(steamPath, "Library/Application Support/Steam/steamapps/common", sizeof(steamPath));
         if (platform_directory_exists(steamPath))

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -135,6 +135,7 @@ uint8 platform_get_locale_temperature_format();
 uint8 platform_get_locale_date_format();
 bool platform_process_is_elevated();
 void platform_get_changelog_path(utf8 *outPath, size_t outSize);
+bool platform_get_steam_path(utf8 *outPath, size_t outSize);
 
 #ifndef NO_TTF
 bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -135,7 +135,7 @@ uint8 platform_get_locale_temperature_format();
 uint8 platform_get_locale_date_format();
 bool platform_process_is_elevated();
 void platform_get_changelog_path(utf8 *outPath, size_t outSize);
-bool platform_get_steam_path(utf8 *outPath, size_t outSize);
+bool platform_get_steam_path(utf8 * outPath, size_t outSize);
 
 #ifndef NO_TTF
 bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size);

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -27,6 +27,7 @@
 #include <libgen.h>
 #include <locale.h>
 #include <pwd.h>
+#include <stdlib.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -842,6 +843,36 @@ utf8* platform_get_username() {
     } else {
         return NULL;
     }
+}
+
+bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+{
+#if defined(__unix__)
+    char *steamRoot = getenv("STEAMROOT");
+    if (steamRoot != NULL)
+    {
+        safe_strcpy(outPath, steamRoot, outSize);
+        safe_strcat_path(outPath, "steamapps/common", outSize);
+        return true;
+    }
+    else
+    {
+        if (platform_directory_exists("~/.local/share/Steam/steamapps/common"))
+        {
+            safe_strcpy(outPath, "~/.local/share/Steam/steamapps/common", outSize);
+            return true;
+        }
+        else if (platform_directory_exists("~/.steam/steam/steamapps/common"))
+        {
+            safe_strcpy(outPath, "~/.steam/steam/steamapps/common", outSize);
+            return true;
+        }
+    }
+#elif (defined(__APPLE__) && defined(__MACH__))
+    safe_strcpy(outPath, "~/Library/Application Support/Steam/steamapps/common", outSize);
+    return true;
+#endif
+    return false;
 }
 
 bool platform_process_is_elevated()

--- a/src/openrct2/platform/posix.c
+++ b/src/openrct2/platform/posix.c
@@ -845,36 +845,6 @@ utf8* platform_get_username() {
     }
 }
 
-bool platform_get_steam_path(utf8 *outPath, size_t outSize)
-{
-#if defined(__unix__)
-    char *steamRoot = getenv("STEAMROOT");
-    if (steamRoot != NULL)
-    {
-        safe_strcpy(outPath, steamRoot, outSize);
-        safe_strcat_path(outPath, "steamapps/common", outSize);
-        return true;
-    }
-    else
-    {
-        if (platform_directory_exists("~/.local/share/Steam/steamapps/common"))
-        {
-            safe_strcpy(outPath, "~/.local/share/Steam/steamapps/common", outSize);
-            return true;
-        }
-        else if (platform_directory_exists("~/.steam/steam/steamapps/common"))
-        {
-            safe_strcpy(outPath, "~/.steam/steam/steamapps/common", outSize);
-            return true;
-        }
-    }
-#elif (defined(__APPLE__) && defined(__MACH__))
-    safe_strcpy(outPath, "~/Library/Application Support/Steam/steamapps/common", outSize);
-    return true;
-#endif
-    return false;
-}
-
 bool platform_process_is_elevated()
 {
 #ifndef __EMSCRIPTEN__

--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -506,6 +506,26 @@ void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory, size_t
     }
 }
 
+bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+{
+    char subkeySteam[MAX_PATH];
+    HKEY hKey;
+    DWORD type, size;
+
+    safe_strcpy(subkeySteam, "Software\\Valve\\Steam", sizeof(subkeySteam));
+
+    if (RegOpenKeyA(HKEY_CURRENT_USER, subkeySteam, &hKey) != ERROR_SUCCESS)
+        return false;
+
+    size = (DWORD)outSize;
+    LSTATUS result = RegQueryValueExA(hKey, "SteamPath", 0, &type, (LPBYTE)outPath, &size);
+    if (result == ERROR_SUCCESS)
+    {
+        safe_strcat_path(outPath, "steamapps\\common", outSize);
+    }
+    return result == ERROR_SUCCESS;
+}
+
 /**
  *
  *  rct2: 0x00407978

--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -508,21 +508,32 @@ void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory, size_t
 
 bool platform_get_steam_path(utf8 *outPath, size_t outSize)
 {
-    char subkeySteam[MAX_PATH];
+    wchar_t * wSteamPath;
     HKEY hKey;
     DWORD type, size;
+    LRESULT result;
 
-    safe_strcpy(subkeySteam, "Software\\Valve\\Steam", sizeof(subkeySteam));
-
-    if (RegOpenKeyA(HKEY_CURRENT_USER, subkeySteam, &hKey) != ERROR_SUCCESS)
+    if (RegOpenKeyW(HKEY_CURRENT_USER, L"Software\\Valve\\Steam", &hKey) != ERROR_SUCCESS)
         return false;
 
-    size = (DWORD)outSize;
-    LSTATUS result = RegQueryValueExA(hKey, "SteamPath", 0, &type, (LPBYTE)outPath, &size);
+    // Get the size of the path first
+    if (RegQueryValueExW(hKey, L"SteamPath", 0, &type, NULL, &size) != ERROR_SUCCESS)
+    {
+        RegCloseKey(hKey);
+        return false;
+    }
+
+    wSteamPath = (wchar_t*)malloc(size);
+    result = RegQueryValueExW(hKey, L"SteamPath", 0, &type, (LPBYTE)wSteamPath, &size);
     if (result == ERROR_SUCCESS)
     {
+        utf8 * utf8SteamPath = widechar_to_utf8(wSteamPath);
+        safe_strcpy(outPath, utf8SteamPath, outSize);
         safe_strcat_path(outPath, "steamapps\\common", outSize);
+        free(utf8SteamPath);
     }
+    free(wSteamPath);
+    RegCloseKey(hKey);
     return result == ERROR_SUCCESS;
 }
 

--- a/src/openrct2/platform/windows.c
+++ b/src/openrct2/platform/windows.c
@@ -506,7 +506,7 @@ void platform_get_user_directory(utf8 *outPath, const utf8 *subDirectory, size_t
     }
 }
 
-bool platform_get_steam_path(utf8 *outPath, size_t outSize)
+bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
     wchar_t * wSteamPath;
     HKEY hKey;


### PR DESCRIPTION
Now looks for RCT2 install within OS-specific steam install directories.

Also checks the registry in Windows in case Steam has a custom install path.