### PR TITLE
Update Travis Xcode image to version 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
           services:
             - docker
         - os: osx
-          osx_image: xcode8
+          osx_image: xcode8.3
           env:
             - secure: "OXn/i72FxW/oh6RGlaN+gHSbkt1ToFe36etaiDOsJQznt6fe9CpFdnE8U1XBHlGokcEjbGNErRU7CFDKYHQuGrPZyHXwgqG2/0emIqFaFt5ti5ypyYKf5qH9x1LLLfdZxDyHkxXdlJ7Etxbp3G7qrV8CGRQiYRNHm1f98AmuufE="
           after_success:


### PR DESCRIPTION
This is in preparation for soon deprecation of Xcode 8 image:
https://blog.travis-ci.com/2017-10-16-a-new-default-os-x-image-is-coming