### PR TITLE
Windows: Fix bad screenshots if park name has ":"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.
+- Fix: [#5585] Inconsistent zooming with mouse wheel.
 - Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set.
 - Fix: [#5741] Land rights indicators disappear when switching views.
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list.
@@ -42,7 +43,6 @@
 - Fix: [#6320] Crash when CSS1.DAT is absent.
 - Fix: [#6331] Scenery costs nothing in track designs.
 - Fix: [#6360] Off-by-one filenames when exporting all sprites.
-- Fix: [#5585] Inconsistent zooming with mouse wheel.
 - Fix: [#6358] HTTP requests can point to invalid URL string.
 - Fix: [#6413] Maze previews only showing scenery.
 - Fix: [#6423] Importing parks containing names with Polish characters.
@@ -50,6 +50,7 @@
 - Fix: [#6445] Guests' favourite ride improperly set when importing from RCT1 or AA.
 - Fix: [#6452] Scenario text cut off when switching between 32 and 64-bit builds.
 - Fix: [#6460] Crash when reading corrupt object files.
+- Fix: [#6481] Can't take screenshots of parks with colons in the name.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -86,6 +86,20 @@ static sint32 screenshot_get_next_path(char *path, size_t size)
     rct2_time currentTime;
     platform_get_time_local(&currentTime);
 
+#ifdef _WIN32
+    // On NTFS filesystems, a colon (:) in a path
+    // indicates you want to write a file stream
+    // (hidden metadata). This will pass the
+    // file_exists and fopen checks, since it is
+    // technically valid. We don't want that, so
+    // replace colons with hyphens in the park name.
+    char * foundColon = park_name;
+    while ((foundColon = strchr(foundColon, ':')) != nullptr)
+    {
+        *foundColon = '-';
+    }
+#endif
+
     // Glue together path and filename
     snprintf(path, size, "%s%s %d-%02d-%02d %02d-%02d-%02d.png", screenshotPath, park_name, currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute, currentTime.second);
 


### PR DESCRIPTION
Fixes issue #6481 where taking a screenshot of a park with a colon in
its name on Windows was causing the screenshot data to get written as an
alternate data stream.

This patch replaces any colons with hyphens in screenshot filenames on
Windows.