### PR TITLE
Increase padding for more scrollable lists and menus

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -56,9 +56,9 @@ static rct_widget window_editor_inventions_list_widgets[] = {
     { WWT_SCROLL,           1,  4,      371,    56,     175,    SCROLL_VERTICAL,        STR_NONE                },
     { WWT_SCROLL,           1,  4,      371,    189,    396,    SCROLL_VERTICAL,        STR_NONE                },
     { WWT_FLATBTN,          1,  431,    544,    106,    219,    0xFFFFFFFF,             STR_NONE                },
-    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    385,    396,    STR_RANDOM_SHUFFLE,     STR_RANDOM_SHUFFLE_TIP  },
-    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    372,    383,    STR_MOVE_ALL_BOTTOM,    STR_NONE                },
-    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    359,    370,    STR_MOVE_ALL_TOP,       STR_NONE                },
+    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    383,    396,    STR_RANDOM_SHUFFLE,     STR_RANDOM_SHUFFLE_TIP  },
+    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    368,    381,    STR_MOVE_ALL_BOTTOM,    STR_NONE                },
+    { WWT_DROPDOWN_BUTTON,  1,  375,    594,    353,    366,    STR_MOVE_ALL_TOP,       STR_NONE                },
     { WIDGETS_END }
 };
 
@@ -438,7 +438,7 @@ static rct_research_item *window_editor_inventions_list_get_item_from_scroll_y(s
     }
 
     for (; researchItem->entryIndex != RESEARCHED_ITEMS_SEPARATOR && researchItem->entryIndex != RESEARCHED_ITEMS_END; researchItem++) {
-        y -= 10;
+        y -= SCROLLABLE_ROW_HEIGHT;
         if (y < 0)
             return researchItem;
     }
@@ -463,7 +463,7 @@ static rct_research_item *window_editor_inventions_list_get_item_from_scroll_y_i
     }
 
     for (; researchItem->entryIndex != RESEARCHED_ITEMS_SEPARATOR && researchItem->entryIndex != RESEARCHED_ITEMS_END; researchItem++) {
-        y -= 10;
+        y -= SCROLLABLE_ROW_HEIGHT;
         if (y < 0)
             return researchItem;
     }
@@ -605,7 +605,7 @@ static void window_editor_inventions_list_scrollgetheight(rct_window *w, sint32 
 
     // Count / skip pre-researched items
     for (researchItem = gResearchItems; researchItem->entryIndex != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
-        *height += 10;
+        *height += SCROLLABLE_ROW_HEIGHT;
 
     if (scrollIndex == 1) {
         researchItem++;
@@ -613,7 +613,7 @@ static void window_editor_inventions_list_scrollgetheight(rct_window *w, sint32 
         // Count non pre-researched items
         *height = 0;
         for (; researchItem->entryIndex != RESEARCHED_ITEMS_END; researchItem++)
-            *height += 10;
+            *height += SCROLLABLE_ROW_HEIGHT;
     }
 }
 
@@ -819,11 +819,12 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
         researchItemEndMarker = RESEARCHED_ITEMS_SEPARATOR;
     }
 
-    // Since this is now a do while need to counteract the +10
-    itemY = -10;
-    do{
-        itemY += 10;
-        if (itemY + 10 < dpi->y || itemY >= dpi->y + dpi->height)
+    // Since this is now a do while need to counteract the +SCROLLABLE_ROW_HEIGHT
+    itemY = -SCROLLABLE_ROW_HEIGHT;
+    do
+    {
+        itemY += SCROLLABLE_ROW_HEIGHT;
+        if (itemY + SCROLLABLE_ROW_HEIGHT < dpi->y || itemY >= dpi->y + dpi->height)
             continue;
 
         uint8 colour = COLOUR_BRIGHT_GREEN | COLOUR_FLAG_TRANSLUCENT;
@@ -831,7 +832,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
             if (_editorInventionsListDraggedItem == nullptr) {
                 // Highlight
                 top = itemY;
-                bottom = itemY + 9;
+                bottom = itemY + SCROLLABLE_ROW_HEIGHT - 1;
             } else {
                 // Drop horizontal rule
                 top = itemY - 1;
@@ -871,7 +872,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
         }
 
         left = 1;
-        top = itemY - 1;
+        top = itemY;
         gfx_draw_string(dpi, buffer, colour, left, top);
     }while(researchItem++->entryIndex != researchItemEndMarker);
 }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -87,6 +87,8 @@ static rct_widget window_guest_list_widgets[] = {
     { WIDGETS_END },
 };
 
+static const uint8 SUMMARISED_GUEST_ROW_HEIGHT = SCROLLABLE_ROW_HEIGHT + 11;
+
 static void window_guest_list_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_guest_list_resize(rct_window *w);
 static void window_guest_list_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
@@ -463,7 +465,7 @@ static void window_guest_list_scrollgetsize(rct_window *w, sint32 scrollIndex, s
             numGuests++;
         }
         w->var_492 = numGuests;
-        y = numGuests * 10;
+        y = numGuests * SCROLLABLE_ROW_HEIGHT;
         _window_guest_list_num_pages = (sint32) ceilf((float)numGuests / 3173);
         if (_window_guest_list_num_pages == 0)
             _window_guest_list_selected_page = 0;
@@ -474,7 +476,7 @@ static void window_guest_list_scrollgetsize(rct_window *w, sint32 scrollIndex, s
         // Find the groups
         window_guest_list_find_groups();
         w->var_492 = _window_guest_list_num_groups;
-        y = _window_guest_list_num_groups * 21;
+        y = _window_guest_list_num_groups * SUMMARISED_GUEST_ROW_HEIGHT;
         break;
     default:
         log_error("Improper tab selected: %d, bailing out.", _window_guest_list_selected_tab);
@@ -516,7 +518,7 @@ static void window_guest_list_scrollmousedown(rct_window *w, sint32 scrollIndex,
 
     switch (_window_guest_list_selected_tab) {
     case PAGE_INDIVIDUAL:
-        i = y / 10;
+        i = y / SCROLLABLE_ROW_HEIGHT;
         i += _window_guest_list_selected_page * 3173;
         FOR_ALL_GUESTS(spriteIndex, peep) {
             if (peep->outside_of_park != 0)
@@ -538,7 +540,7 @@ static void window_guest_list_scrollmousedown(rct_window *w, sint32 scrollIndex,
         }
         break;
     case PAGE_SUMMARISED:
-        i = y / 21;
+        i = y / SUMMARISED_GUEST_ROW_HEIGHT;
         if (i < _window_guest_list_num_groups) {
             memcpy(_window_guest_list_filter_arguments + 0, &_window_guest_list_groups_argument_1[i], 4);
             memcpy(_window_guest_list_filter_arguments + 2, &_window_guest_list_groups_argument_2[i], 4);
@@ -560,7 +562,7 @@ static void window_guest_list_scrollmouseover(rct_window *w, sint32 scrollIndex,
 {
     sint32 i;
 
-    i = y / (_window_guest_list_selected_tab == PAGE_INDIVIDUAL ? 10 : 21);
+    i = y / (_window_guest_list_selected_tab == PAGE_INDIVIDUAL ? SCROLLABLE_ROW_HEIGHT : SUMMARISED_GUEST_ROW_HEIGHT);
     i += _window_guest_list_selected_page * 3173;
     if (i != _window_guest_list_highlighted_index) {
         _window_guest_list_highlighted_index = i;
@@ -707,31 +709,31 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
                 continue;
 
             // Check if y is beyond the scroll control
-            if (y + 11 >= -0x7FFF &&
-                y + 11 > dpi->y &&
+            if (y + SCROLLABLE_ROW_HEIGHT + 1 >= -0x7FFF &&
+                y + SCROLLABLE_ROW_HEIGHT + 1 > dpi->y &&
                 y < 0x7FFF &&
                 y < dpi->y + dpi->height) {
 
                 // Highlight backcolour and text colour (format)
                 format = STR_BLACK_STRING;
                 if (i == _window_guest_list_highlighted_index) {
-                    gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
+                    gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 
                 // Guest name
                 set_format_arg(0, rct_string_id, peep->name_string_idx);
                 set_format_arg(2, uint32, peep->id);
-                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1, 113);
+                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y, 113);
 
                 switch (_window_guest_list_selected_view) {
                 case VIEW_ACTIONS:
                     // Guest face
-                    gfx_draw_sprite(dpi, get_peep_face_sprite_small(peep), 118, y, 0);
+                    gfx_draw_sprite(dpi, get_peep_face_sprite_small(peep), 118, y + 1, 0);
 
                     // Tracking icon
                     if (peep->peep_flags & PEEP_FLAGS_TRACKING)
-                        gfx_draw_sprite(dpi, STR_ENTER_SELECTION_SIZE, 112, y, 0);
+                        gfx_draw_sprite(dpi, STR_ENTER_SELECTION_SIZE, 112, y + 1, 0);
 
                     // Action
 
@@ -739,7 +741,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
                     set_format_arg(0, uint32, argument_1);
                     set_format_arg(4, uint32, argument_2);
-                    gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 133, y - 1, 314);
+                    gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 133, y, 314);
                     break;
                 case VIEW_THOUGHTS:
                     // For each thought
@@ -753,7 +755,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
                             break;
 
                         peep_thought_set_format_args(&peep->thoughts[j]);
-                        gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 118, y - 1, 329);
+                        gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 118, y, 329);
                         break;
                     }
                     break;
@@ -762,7 +764,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
             // Increment list item index and y
             i++;
-            y += 10;
+            y += SCROLLABLE_ROW_HEIGHT;
         }
         break;
     case PAGE_SUMMARISED:
@@ -771,7 +773,7 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
         // For each group of guests
         for (i = 0; i < _window_guest_list_num_groups; i++) {
             // Check if y is beyond the scroll control
-            if (y + 22 >= dpi->y) {
+            if (y + SUMMARISED_GUEST_ROW_HEIGHT + 1 >= dpi->y) {
                 // Check if y is beyond the scroll control
                 if (y >= dpi->y + dpi->height)
                     break;
@@ -779,26 +781,26 @@ static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
                 // Highlight backcolour and text colour (format)
                 format = STR_BLACK_STRING;
                 if (i == _window_guest_list_highlighted_index) {
-                    gfx_filter_rect(dpi, 0, y, 800, y + 20, PALETTE_DARKEN_1);
+                    gfx_filter_rect(dpi, 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT, PALETTE_DARKEN_1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 
                 // Draw guest faces
                 numGuests = _window_guest_list_groups_num_guests[i];
                 for (j = 0; j < 56 && j < numGuests; j++)
-                    gfx_draw_sprite(dpi, _window_guest_list_groups_guest_faces[i * 56 + j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY, j * 8, y + 9, 0);
+                    gfx_draw_sprite(dpi, _window_guest_list_groups_guest_faces[i * 56 + j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY, j * 8, y + 12, 0);
 
                 // Draw action
                 set_format_arg(0, uint32, _window_guest_list_groups_argument_1[i]);
                 set_format_arg(4, uint32, _window_guest_list_groups_argument_2[i]);
                 set_format_arg(10, uint32, numGuests);
-                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1, 414);
+                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y, 414);
 
                 // Draw guest count
                 set_format_arg(8, rct_string_id, STR_GUESTS_COUNT_COMMA_SEP);
-                gfx_draw_string_right(dpi, format, gCommonFormatArgs + 8, COLOUR_BLACK, 326, y - 1);
+                gfx_draw_string_right(dpi, format, gCommonFormatArgs + 8, COLOUR_BLACK, 326, y);
             }
-            y += 21;
+            y += SUMMARISED_GUEST_ROW_HEIGHT;
         }
         break;
     }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -417,7 +417,7 @@ void window_staff_list_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *
         window_invalidate(w);
     }
 
-    *height = staffCount * 10;
+    *height = staffCount * SCROLLABLE_ROW_HEIGHT;
     i = *height - window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + window_staff_list_widgets[WIDX_STAFF_LIST_LIST].top + 21;
     if (i < 0)
         i = 0;
@@ -438,7 +438,7 @@ void window_staff_list_scrollmousedown(rct_window *w, sint32 scrollIndex, sint32
     sint32 i, spriteIndex;
     rct_peep *peep;
 
-    i = y / 10;
+    i = y / SCROLLABLE_ROW_HEIGHT;
     FOR_ALL_STAFF(spriteIndex, peep) {
         if (peep->staff_type != _windowStaffListSelectedTab)
             continue;
@@ -467,7 +467,7 @@ void window_staff_list_scrollmouseover(rct_window *w, sint32 scrollIndex, sint32
 {
     sint32 i;
 
-    i = y / 10;
+    i = y / SCROLLABLE_ROW_HEIGHT;
     if (i != _windowStaffListHighlightedIndex) {
         _windowStaffListHighlightedIndex = i;
         window_invalidate(w);
@@ -662,22 +662,22 @@ void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32
                 sint32 format = (_quick_fire_mode ? STR_RED_STRINGID : STR_BLACK_STRING);
 
                 if (i == _windowStaffListHighlightedIndex) {
-                    gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
+                    gfx_filter_rect(dpi, 0, y, 800, y + (SCROLLABLE_ROW_HEIGHT - 1), PALETTE_DARKEN_1);
                     format = (_quick_fire_mode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
                 }
 
                 set_format_arg(0, rct_string_id, peep->name_string_idx);
                 set_format_arg(2, uint32, peep->id);
-                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1, 107);
+                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y, 107);
 
                 get_arguments_from_action(peep, &argument_1, &argument_2);
                 set_format_arg(0, uint32, argument_1);
                 set_format_arg(4, uint32, argument_2);
-                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 175, y - 1, 305);
+                gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 175, y, 305);
 
                 // True if a patrol path is set for the worker
                 if (gStaffModes[peep->staff_id] & 2) {
-                    gfx_draw_sprite(dpi, SPR_STAFF_PATROL_PATH, 110, y - 1, 0);
+                    gfx_draw_sprite(dpi, SPR_STAFF_PATROL_PATH, 110, y, 0);
                 }
 
                 staffOrderIcon_x = 0x7D;
@@ -687,7 +687,7 @@ void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32
 
                     while (staffOrders != 0) {
                         if (staffOrders & 1) {
-                            gfx_draw_sprite(dpi, staffOrderSprite, staffOrderIcon_x, y - 1, 0);
+                            gfx_draw_sprite(dpi, staffOrderSprite, staffOrderIcon_x, y, 0);
                         }
                         staffOrders = staffOrders >> 1;
                         staffOrderIcon_x += 9;
@@ -695,11 +695,11 @@ void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32
                         staffOrderSprite++;
                     }
                 } else {
-                    gfx_draw_sprite(dpi, staffCostumeSprites[peep->sprite_type - 4], staffOrderIcon_x, y - 1, 0);
+                    gfx_draw_sprite(dpi, staffCostumeSprites[peep->sprite_type - 4], staffOrderIcon_x, y, 0);
                 }
             }
 
-            y += 10;
+            y += SCROLLABLE_ROW_HEIGHT;
             i++;
         }
     }

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -27,7 +27,7 @@ enum WINDOW_TITLE_OPTIONS_WIDGET_IDX {
 };
 
 static rct_widget window_title_options_widgets[] = {
-    { WWT_DROPDOWN_BUTTON, 2, 0, 79, 0, 11, STR_OPTIONS, STR_OPTIONS_TIP },
+    { WWT_DROPDOWN_BUTTON, 2, 0, 79, 0, 13, STR_OPTIONS, STR_OPTIONS_TIP },
     { WIDGETS_END },
 };
 

--- a/src/openrct2/windows/Dropdown.cpp
+++ b/src/openrct2/windows/Dropdown.cpp
@@ -27,6 +27,8 @@
 // The maximum number of rows to list before items overflow into new columns
 #define DROPDOWN_TEXT_MAX_ROWS 32
 
+#define DROPDOWN_ITEM_HEIGHT 12
+
 sint32 gAppropriateImageDropdownItemsPerRow[] = {
     1, 1, 1, 1, 2, 2, 3, 3, 4,
     3, 5, 4, 4, 5, 5, 5, 4, 5,
@@ -180,7 +182,7 @@ void window_dropdown_show_text_custom_width(sint32 x, sint32 y, sint32 extray, u
     
     // Set and calculate num items, rows and columns
     _dropdown_item_width = width;
-    _dropdown_item_height = (flags & DROPDOWN_FLAG_CUSTOM_HEIGHT) ? custom_height : 10;
+    _dropdown_item_height = (flags & DROPDOWN_FLAG_CUSTOM_HEIGHT) ? custom_height : DROPDOWN_ITEM_HEIGHT;
     gDropdownNumItems = (sint32)num_items;
     // There must always be at least one column to prevent dividing by zero
     if (gDropdownNumItems == 0)
@@ -397,7 +399,7 @@ static void window_dropdown_paint(rct_window *w, rct_drawpixelinfo *dpi)
                     item,
                     (void*)(&gDropdownItemsArgs[i]), colour,
                     w->x + 2 + (cell_x * _dropdown_item_width),
-                    w->y + 1 + (cell_y * _dropdown_item_height),
+                    w->y + 2 + (cell_y * _dropdown_item_height),
                     w->width - 5
                 );
             }

--- a/src/openrct2/windows/Ride.cpp
+++ b/src/openrct2/windows/Ride.cpp
@@ -325,7 +325,7 @@ static rct_widget window_ride_music_widgets[] = {
 // 0x009AE5DC
 static rct_widget window_ride_measurements_widgets[] = {
     MAIN_RIDE_WIDGETS,
-    { WWT_FLATBTN,          1,  288,    311,    164,    187,    SPR_FLOPPY,                     STR_SAVE_TRACK_DESIGN                       },
+    { WWT_FLATBTN,          1,  288,    311,    194,    217,    SPR_FLOPPY,                     STR_SAVE_TRACK_DESIGN                       },
     { WWT_DROPDOWN_BUTTON,  1,  4,      157,    128,    139,    STR_SELECT_NEARBY_SCENERY,      STR_NONE                                    },
     { WWT_DROPDOWN_BUTTON,  1,  158,    311,    128,    139,    STR_RESET_SELECTION,            STR_NONE                                    },
     { WWT_DROPDOWN_BUTTON,  1,  4,      157,    178,    189,    STR_DESIGN_SAVE,                STR_NONE                                    },
@@ -5088,7 +5088,7 @@ static void window_ride_measurements_mouseup(rct_window *w, rct_widgetindex widg
  */
 static void window_ride_measurements_resize(rct_window *w)
 {
-    window_set_resize(w, 316, 202, 316, 202);
+    window_set_resize(w, 316, 234, 316, 234);
 }
 
 /**
@@ -5287,7 +5287,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
             set_format_arg(4, rct_string_id, ratingName);
             rct_string_id stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE : STR_EXCITEMENT_RATING;
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, x, y);
-            y += 10;
+            y += LIST_ROW_HEIGHT;
 
             // Intensity
             ratingName = get_rating_name(ride->intensity);
@@ -5301,7 +5301,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                 stringId = STR_INTENSITY_RATING_RED;
 
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, x, y);
-            y += 10;
+            y += LIST_ROW_HEIGHT;
 
             // Nausea
             ratingName = get_rating_name(ride->nausea);
@@ -5309,7 +5309,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
             set_format_arg(4, rct_string_id, ratingName);
             stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, x, y);
-            y += 20;
+            y += 2 * LIST_ROW_HEIGHT;
 
             // Horizontal rule
             gfx_fill_rect_inset(dpi, x, y - 6, x + 303, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
@@ -5319,17 +5319,17 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                     // Holes
                     holes = ride->holes & 0x1F;
                     gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
                 } else {
                     // Max speed
                     maxSpeed = (ride->max_speed * 9) >> 18;
                     gfx_draw_string_left(dpi, STR_MAX_SPEED, &maxSpeed, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Average speed
                     averageSpeed = (ride->average_speed * 9) >> 18;
                     gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &averageSpeed, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Ride time
                     sint32 numTimes = 0;
@@ -5355,7 +5355,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                     set_format_arg(4 + (numTimes * 4), uint16, 0);
                     set_format_arg(6 + (numTimes * 4), uint16, 0);
                     gfx_draw_string_left_clipped(dpi, STR_RIDE_TIME, gCommonFormatArgs, COLOUR_BLACK, x, y, 308);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
                 }
 
                 // Ride length
@@ -5383,7 +5383,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                 set_format_arg(4 + (numLengths * 4), uint16, 0);
                 set_format_arg(6 + (numLengths * 4), uint16, 0);
                 gfx_draw_string_left_clipped(dpi, STR_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, x, y, 308);
-                y += 10;
+                y += LIST_ROW_HEIGHT;
 
                 if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_G_FORCES)) {
                     // Max. positive vertical G's
@@ -5391,38 +5391,38 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                     stringId = maxPositiveVerticalGs >= FIXED_2DP(5,00) ?
                         STR_MAX_POSITIVE_VERTICAL_G_RED : STR_MAX_POSITIVE_VERTICAL_G;
                     gfx_draw_string_left(dpi, stringId, &maxPositiveVerticalGs, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Max. negative vertical G's
                     maxNegativeVerticalGs = ride->max_negative_vertical_g;
                     stringId = maxNegativeVerticalGs <= -FIXED_2DP(2,00) ?
                         STR_MAX_NEGATIVE_VERTICAL_G_RED : STR_MAX_NEGATIVE_VERTICAL_G;
                     gfx_draw_string_left(dpi, stringId, &maxNegativeVerticalGs, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Max lateral G's
                     maxLateralGs = ride->max_lateral_g;
                     stringId = maxLateralGs >= FIXED_2DP(2,80) ?
                         STR_MAX_LATERAL_G_RED : STR_MAX_LATERAL_G;
                     gfx_draw_string_left(dpi, stringId, &maxLateralGs, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Total 'air' time
                     totalAirTime = ride->total_air_time * 3;
                     gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &totalAirTime, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
                 }
 
                 if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_DROPS)) {
                     // Drops
                     drops = ride->drops & 0x3F;
                     gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
 
                     // Highest drop height
                     highestDropHeight = (ride->highest_drop_height * 3) / 4;
                     gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight, COLOUR_BLACK, x, y);
-                    y += 10;
+                    y += LIST_ROW_HEIGHT;
                 }
 
                 if (ride->type != RIDE_TYPE_MINI_GOLF) {
@@ -5430,7 +5430,7 @@ static void window_ride_measurements_paint(rct_window *w, rct_drawpixelinfo *dpi
                     inversions = ride->inversions & 0x1F;
                     if (inversions != 0) {
                         gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, x, y);
-                        y += 10;
+                        y += LIST_ROW_HEIGHT;
                     }
                 }
             }
@@ -5989,7 +5989,7 @@ static void window_ride_income_mouseup(rct_window *w, rct_widgetindex widgetInde
  */
 static void window_ride_income_resize(rct_window *w)
 {
-    window_set_resize(w, 316, 177, 316, 177);
+    window_set_resize(w, 316, 183, 316, 183);
 }
 
 /**
@@ -6190,19 +6190,19 @@ static void window_ride_income_paint(rct_window *w, rct_drawpixelinfo *dpi)
     // Income per hour
     if (ride->income_per_hour != MONEY32_UNDEFINED) {
         gfx_draw_string_left(dpi, STR_INCOME_PER_HOUR, &ride->income_per_hour, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
 
     // Running cost per hour
     costPerHour = ride->upkeep_cost * 16;
     stringId = ride->upkeep_cost == MONEY16_UNDEFINED ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
     gfx_draw_string_left(dpi, stringId, &costPerHour, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Profit per hour
     if (ride->profit != MONEY32_UNDEFINED) {
         gfx_draw_string_left(dpi, STR_PROFIT_PER_HOUR, &ride->profit, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
     y += 5;
 
@@ -6271,7 +6271,7 @@ static void window_ride_customer_mouseup(rct_window *w, rct_widgetindex widgetIn
 static void window_ride_customer_resize(rct_window *w)
 {
     w->flags |= WF_RESIZABLE;
-    window_set_resize(w, 316, 149, 316, 149);
+    window_set_resize(w, 316, 163, 316, 163);
 }
 
 /**
@@ -6353,13 +6353,13 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
     if (gRideClassifications[ride->type] == RIDE_CLASS_RIDE) {
         sint16 customersOnRide = ride->num_riders;
         gfx_draw_string_left(dpi, STR_CUSTOMERS_ON_RIDE, &customersOnRide, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
 
     // Customers per hour
     customersPerHour = ride_customers_per_hour(ride);
     gfx_draw_string_left(dpi, STR_CUSTOMERS_PER_HOUR, &customersPerHour, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Popularity
     popularity = ride->popularity;
@@ -6370,7 +6370,7 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
         popularity *= 4;
     }
     gfx_draw_string_left(dpi, stringId, &popularity, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Satisfaction
     satisfaction = ride->satisfaction;
@@ -6381,7 +6381,7 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
         satisfaction *= 5;
     }
     gfx_draw_string_left(dpi, stringId, &satisfaction, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Queue time
     if (gRideClassifications[ride->type] == RIDE_CLASS_RIDE) {
@@ -6397,7 +6397,7 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
         set_format_arg(0, rct_string_id, ShopItemStringIds[shopItem].plural);
         set_format_arg(2, uint32, ride->no_primary_items_sold);
         gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
 
     // Secondary shop items sold / on-ride photos sold
@@ -6408,12 +6408,12 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
         set_format_arg(0, rct_string_id, ShopItemStringIds[shopItem].plural);
         set_format_arg(2, uint32, ride->no_secondary_items_sold);
         gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
 
     // Total customers
     gfx_draw_string_left(dpi, STR_TOTAL_CUSTOMERS, &ride->total_customers, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Guests favourite
     if (gRideClassifications[ride->type] == RIDE_CLASS_RIDE) {
@@ -6421,7 +6421,7 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi)
             STR_FAVOURITE_RIDE_OF_GUEST :
             STR_FAVOURITE_RIDE_OF_GUESTS;
         gfx_draw_string_left(dpi, stringId, &ride->guests_favourite, COLOUR_BLACK, x, y);
-        y += 10;
+        y += LIST_ROW_HEIGHT;
     }
     y += 2;
 


### PR DESCRIPTION
Like #6502 and #6507 before it, this PR adds some more padding to items in scrollable widgets. Effectively, this makes each row 12px instead of 10px.

Again, my primary motivation for changing these is to make the Japanese translation look a little bit better, but I believe it looks much better for English, too, as the information is less cramped this way.

This PR addresses the following:

* Dropdown items (and therefore menus)
* The rows of guests in the guest window
* The rows of staff in the staff window
* The rows of objects in the invention list window
* The listings in the ride window
* The options button on the title screen

I've opted not to create a separate PR for each of these, but if you would prefer I do so, please let me know.