### PR TITLE
Take line heights into account in About and Music Credits windows

### DIFF
--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -209,6 +209,8 @@ static void window_about_openrct2_mouseup(rct_window *w, rct_widgetindex widgetI
 
 static void window_about_openrct2_common_paint(rct_window * w, rct_drawpixelinfo * dpi)
 {
+    window_draw_widgets(w, dpi);
+
     sint32 x1, x2, y;
 
     x1 = w->x + (&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->left + 45;
@@ -224,31 +226,38 @@ static void window_about_openrct2_common_paint(rct_window * w, rct_drawpixelinfo
 
 static void window_about_openrct2_paint(rct_window *w, rct_drawpixelinfo *dpi)
 {
-    window_draw_widgets(w, dpi);
     window_about_openrct2_common_paint(w, dpi);
 
     sint32 x, y, width;
     rct_size16 logoSize;
 
-    x = w->x + (w->width / 2);
-    y = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + 10;
-    width = w->width - 20;
-    
-    utf8 buffer[256];
-    utf8 *ch = buffer;
-    openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
+    sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
-    y += gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION, w->colours[2]) + 10;
+    x = w->x + (w->width / 2);
+    y = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight;
+    width = w->width - 20;
+
+    y += gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION, w->colours[2]) + lineHeight;
 
     logoSize = gfx_get_sprite_size(SPR_G2_LOGO);
     gfx_draw_sprite(dpi, SPR_G2_LOGO, x - (logoSize.width / 2), y, 0);
-    y += logoSize.height + 20;
+    y += logoSize.height + lineHeight * 2;
 
-    y += gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION_2, w->colours[2]) + 15;
-    gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, w->colours[2]);
+    // About OpenRCT2 text
+    y += gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION_2, w->colours[2]) + lineHeight + 5;
 
+    // Copyright disclaimer; hidden when using truetype fonts to prevent
+    // the text from overlapping the changelog button.
+    if (!gUseTrueTypeFont)
+    {
+        gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, w->colours[2]);
+    }
+
+    // Version info
+    utf8 buffer[256];
+    utf8 *ch = buffer;
+    openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
     gfx_draw_string_centred_wrapped(dpi, &ch, x, w->y + WH - 25, width, STR_STRING, w->colours[2]);
-
 }
 
 #pragma endregion OpenRCT2
@@ -283,7 +292,6 @@ static void window_about_rct2_paint(rct_window *w, rct_drawpixelinfo *dpi)
 {
     sint32 x, y, yPage;
 
-    window_draw_widgets(w, dpi);
     window_about_openrct2_common_paint(w, dpi);
 
     yPage = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + 5;
@@ -291,23 +299,25 @@ static void window_about_rct2_paint(rct_window *w, rct_drawpixelinfo *dpi)
     x = w->x + 200;
     y = yPage + 5;
 
+    sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+
     // Credits
     gfx_draw_string_centred(dpi, STR_COPYRIGHT_CS, x, y, COLOUR_BLACK, nullptr);
-    y += 84;
+    y += lineHeight + 74;
     gfx_draw_string_centred(dpi, STR_DESIGNED_AND_PROGRAMMED_BY_CS, x, y, COLOUR_BLACK, nullptr);
-    y += 10;
+    y += lineHeight;
     gfx_draw_string_centred(dpi, STR_GRAPHICS_BY_SF, x, y, COLOUR_BLACK, nullptr);
-    y += 10;
+    y += lineHeight;
     gfx_draw_string_centred(dpi, STR_SOUND_AND_MUSIC_BY_AB, x, y, COLOUR_BLACK, nullptr);
-    y += 10;
+    y += lineHeight;
     gfx_draw_string_centred(dpi, STR_ADDITIONAL_SOUNDS_RECORDED_BY_DE, x, y, COLOUR_BLACK, nullptr);
-    y += 13;
+    y += lineHeight + 3;
     gfx_draw_string_centred(dpi, STR_REPRESENTATION_BY_JL, x, y, COLOUR_BLACK, nullptr);
-    y += 25;
+    y += 2 * lineHeight + 5;
     gfx_draw_string_centred(dpi, STR_THANKS_TO, x, y, COLOUR_BLACK, nullptr);
-    y += 10;
+    y += lineHeight;
     gfx_draw_string_centred(dpi, STR_THANKS_TO_PEOPLE, x, y, COLOUR_BLACK, nullptr);
-    y += 25;
+    y += 2 * lineHeight + 5;
     gfx_draw_string_centred(dpi, STR_LICENSED_TO_INFOGRAMES_INTERACTIVE_INC, x, y, COLOUR_BLACK, nullptr);
 
     // Images

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -20,6 +20,7 @@
 #include <openrct2-ui/windows/Window.h>
 
 #include <openrct2/audio/audio.h>
+#include <openrct2/drawing/font.h>
 #include <openrct2/interface/widget.h>
 #include <openrct2/localisation/localisation.h>
 
@@ -119,7 +120,7 @@ rct_window * window_error_open(rct_string_id title, rct_string_id message)
 
     _window_error_num_lines = numLines;
     width = width + 3;
-    height = (numLines + 1) * 10 + 4;
+    height = (numLines + 1) * font_get_line_height(gCurrentFontSpriteBase) + 4;
 
     window_error_widgets[WIDX_BACKGROUND].right = width;
     window_error_widgets[WIDX_BACKGROUND].bottom = height;

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -170,7 +170,8 @@ static void window_music_credits_mouseup(rct_window *w, rct_widgetindex widgetIn
  */
 static void window_music_credits_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height)
 {
-    *height = 460;
+    sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    *height = static_cast<sint32>(Util::CountOf(music_credits) + Util::CountOf(music_credits_rct2)) * lineHeight + 12;
 }
 
 /**
@@ -188,28 +189,29 @@ static void window_music_credits_paint(rct_window *w, rct_drawpixelinfo *dpi)
  */
 static void window_music_credits_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 scrollIndex)
 {
-    sint32 x = 245;
+    sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
+    sint32 x = 245;
     sint32 y = 2;
 
     for (size_t i = 0; i < Util::CountOf(music_credits); i++) {
         gfx_draw_string_centred(dpi, music_credits[i], x, y, COLOUR_BLACK, nullptr);
-        y += 10;
+        y += lineHeight;
     }
 
     // Add 4 more space before "Original recordings ...".
     y += 4;
     gfx_draw_string_centred(dpi, STR_MUSIC_ACKNOWLEDGEMENTS_ORIGINAL_RECORDINGS, x, y, COLOUR_BLACK, nullptr);
-    y += 10;
+    y += lineHeight;
 
     // Draw the separator
     y += 5;
     gfx_fill_rect_inset(dpi, 4, y, 484, y+1, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
-    y += 11;
+    y += lineHeight + 1;
 
     for (size_t i = 0; i < Util::CountOf(music_credits_rct2); i++) {
         gfx_draw_string_centred(dpi, music_credits_rct2[i], x, y, COLOUR_BLACK, nullptr);
-        y += 10;
+        y += lineHeight;
     }
 
 }


### PR DESCRIPTION
This PR addresses line heights in the About and Music Credits windows. Currently, a line height of 10px is assumed, which is causing text to overlap. This PR fixes this by using the font's actual line height instead, fixing #6126.

Caveat: as the window's actual height is only known at the end of the paint function, I've opted to free the changelog button from any overlap by hiding the copyright disclaimer until we have a more flexible windowing system. If anyone has better ideas, I'm open to them, of course.