### PR TITLE
Fix #6251 - Splash Boats 25deg-to-flat tunnel

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#6196, #6223] Guest's energy underflows and never decreases.
 - Fix: [#6198] You cannot cancel RCT1 directory selection.
 - Fix: [#6202] Guests can break occupied benches (original bug).
+- Fix: [#6251] Splash Boats renders flat-to-25-degree pieces in tunnels incorrectly.
 - Fix: [#6261, #6344, #6520] Broken pathfinding after removing park entrances with the tile inspector
 - Fix: [#6271] Wrong booster speed tooltip text.
 - Fix: [#6308] Cannot create title sequence if title sequences folder does not exist.

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -707,11 +707,21 @@ static void paint_splash_boats_track_25_deg_down_to_flat(paint_session * session
 
     if (direction == 0 || direction == 3)
     {
+#ifdef __TESTPAINT__
+        // FIXME: For some reason, Testpaint does not detect this as an error.
+        paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_7);
+#else
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_8);
+#endif
     }
     else
     {
+#ifdef __TESTPAINT__
+        // FIXME: For some reason, Testpaint does not detect this as an error.
+        paint_util_push_tunnel_rotated(session, direction, height + 24, TUNNEL_8);
+#else
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
+#endif
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -707,11 +707,11 @@ static void paint_splash_boats_track_25_deg_down_to_flat(paint_session * session
 
     if (direction == 0 || direction == 3)
     {
-        paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_7);
+        paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_8);
     }
     else
     {
-        paint_util_push_tunnel_rotated(session, direction, height + 24, TUNNEL_8);
+        paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);


### PR DESCRIPTION
Fixes Splash Boats 25deg-down-to-flat tunnel rendering. This is based on
flat-to-25deg-up (but opposite).

It's been this way since it was originally implemented in fffb4b1d. I am brand new to this, so I don't _totally_ understand the rendering code (especially what each of the TUNNEL_* constants is). It seems to look ok, though:
![2017-10-19 21-26-34](https://user-images.githubusercontent.com/484512/31803012-fd161f2c-b516-11e7-8f5d-bce8b65e5f6b.png)
![2017-10-19 21-26-39](https://user-images.githubusercontent.com/484512/31803013-fe91315c-b516-11e7-9076-b07a795beb8e.png)

