### PR TITLE
Make the energy bar code use the max and min energy values from Peep.h

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1362,7 +1362,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     y += 10;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_ENERGY_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
-    sint32 energy = ((peep->energy - 32) * 85) / 32;
+    sint32 energy = ((peep->energy - PEEP_MIN_ENERGY) * 255) / (PEEP_MAX_ENERGY - PEEP_MIN_ENERGY);
     ebp = COLOUR_BRIGHT_GREEN;
     if (energy < 50){
         ebp |= BAR_BLINK;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -21,8 +21,8 @@
 #include <openrct2/game.h>
 #include <openrct2/input.h>
 #include <openrct2/management/Marketing.h>
-#include <openrct2/peep/Staff.h>
 #include <openrct2/peep/Peep.h>
+#include <openrct2/peep/Staff.h>
 #include <openrct2/ride/ride_data.h>
 #include <openrct2/localisation/localisation.h>
 #include <openrct2/sprites.h>

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -22,6 +22,7 @@
 #include <openrct2/input.h>
 #include <openrct2/management/Marketing.h>
 #include <openrct2/peep/Staff.h>
+#include <openrct2/peep/Peep.h>
 #include <openrct2/ride/ride_data.h>
 #include <openrct2/localisation/localisation.h>
 #include <openrct2/sprites.h>

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -8055,7 +8055,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
 
     /* It looks like 65 is about 50% energy level, so this initialises
      * a peep with approx 50%-100% energy (0x3F = 63, 63 + 65 = 128). */
-    uint8 energy        = (peep_rand() & (PEEP_MAX_ENERGY / 2)) + (PEEP_MAX_ENERGY/2);
+    uint8 energy        = (peep_rand() & 0x3F) + 65;
     peep->energy        = energy;
     peep->energy_target = energy;
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -8055,7 +8055,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
 
     /* It looks like 65 is about 50% energy level, so this initialises
      * a peep with approx 50%-100% energy (0x3F = 63, 63 + 65 = 128). */
-    uint8 energy        = (peep_rand() & 0x3F) + 65;
+    uint8 energy        = (peep_rand() & (PEEP_MAX_ENERGY / 2)) + (PEEP_MAX_ENERGY/2);
     peep->energy        = energy;
     peep->energy_target = energy;
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -8053,8 +8053,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
     uint8 trousers_colour = static_cast<uint8>(peep_rand() % Util::CountOf(trouser_colours));
     peep->trousers_colour = trouser_colours[trousers_colour];
 
-    /* It looks like 65 is about 50% energy level, so this initialises
-     * a peep with approx 50%-100% energy (0x3F = 63, 63 + 65 = 128). */
+    // Initialise a peep with approx 50%-100% energy
     uint8 energy        = (peep_rand() & (PEEP_MAX_ENERGY / 2)) + (PEEP_MAX_ENERGY/2);
     peep->energy        = energy;
     peep->energy_target = energy;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -8053,7 +8053,8 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
     uint8 trousers_colour = static_cast<uint8>(peep_rand() % Util::CountOf(trouser_colours));
     peep->trousers_colour = trouser_colours[trousers_colour];
 
-    // Initialise a peep with approx 50%-100% energy
+    /* It looks like 65 is about 50% energy level, so this initialises
+     * a peep with approx 50%-100% energy (0x3F = 63, 63 + 65 = 128). */
     uint8 energy        = (peep_rand() & (PEEP_MAX_ENERGY / 2)) + (PEEP_MAX_ENERGY/2);
     peep->energy        = energy;
     peep->energy_target = energy;


### PR DESCRIPTION
Make the energy bar code use the max and min energy values from Peep.h. This makes the code more understandable. Before it was using a simplified fraction 85/32 which was the simplified fraction 255/96 (barlength/energyrange). This number is equal to 255 / (PEEP_MAX_ENERGY - PEEP_MIN_ENERGY).
