### PR TITLE
Fix that Twitch config is not readed correctly

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -452,7 +452,7 @@ namespace Config
 
     static void ReadTwitch(IIniReader * reader)
     {
-        if (reader->ReadSection("sound"))
+        if (reader->ReadSection("twitch"))
         {
             auto model = &gConfigTwitch;
             model->channel = reader->GetCString("channel", nullptr);


### PR DESCRIPTION
Seems that it is a typo caused by ctrl+C,V