### PR TITLE
Fix #6460: Crash when reading corrupt object files

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -46,6 +46,7 @@
 - Fix: [#6423] Polish characters now correctly drawn when using the sprite font.
 - Fix: [#6445] Guests' favourite ride improperly set when importing from RCT1 or AA.
 - Fix: [#6452] Scenario text cut off when switching between 32 and 64-bit builds.
+- Fix: [#6460] Crash when reading corrupt object files.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -363,7 +363,7 @@ private:
         std::sort(_items.begin(), _items.end(), [](const ObjectRepositoryItem &a,
                                                    const ObjectRepositoryItem &b) -> bool
         {
-            return strcmp(a.Name, b.Name) < 0;
+            return String::Compare(a.Name, b.Name) < 0;
         });
 
         // Fix the IDs

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -142,13 +142,8 @@ size_t SawyerChunkReader::DecodeChunk(void * dst, size_t dstCapacity, const void
         resultLength = DecodeChunkRLE(dst, dstCapacity, src, header.length);
         break;
     case CHUNK_ENCODING_RLECOMPRESSED:
-    {
-        auto immBufferLength = MAX_UNCOMPRESSED_CHUNK_SIZE;
-        auto immBuffer = std::make_unique<uint8[]>(immBufferLength);
-        auto immLength = DecodeChunkRLE(immBuffer.get(), immBufferLength, src, header.length);
-        resultLength = DecodeChunkRepeat(dst, dstCapacity, immBuffer.get(), immLength);
+        resultLength = DecodeChunkRLERepeat(dst, dstCapacity, src, header.length);
         break;
-    }
     case CHUNK_ENCODING_ROTATE:
         resultLength = DecodeChunkRotate(dst, dstCapacity, src, header.length);
         break;
@@ -156,6 +151,14 @@ size_t SawyerChunkReader::DecodeChunk(void * dst, size_t dstCapacity, const void
         throw SawyerChunkException(EXCEPTION_MSG_INVALID_CHUNK_ENCODING);
     }
     return resultLength;
+}
+
+size_t SawyerChunkReader::DecodeChunkRLERepeat(void * dst, size_t dstCapacity, const void * src, size_t srcLength)
+{
+    auto immBufferLength = MAX_UNCOMPRESSED_CHUNK_SIZE;
+    auto immBuffer = std::make_unique<uint8[]>(immBufferLength);
+    auto immLength = DecodeChunkRLE(immBuffer.get(), immBufferLength, src, srcLength);
+    return DecodeChunkRepeat(dst, dstCapacity, immBuffer.get(), immLength);
 }
 
 size_t SawyerChunkReader::DecodeChunkRLE(void * dst, size_t dstCapacity, const void * src, size_t srcLength)

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -17,12 +17,16 @@
 #include "../core/Exception.hpp"
 #include "../core/IStream.hpp"
 #include "../core/Math.hpp"
+#include "../core/Memory.hpp"
 #include "SawyerChunkReader.h"
-
-#include "../util/sawyercoding.h"
 
 // Allow chunks to be uncompressed to a maximum of 16 MiB
 constexpr size_t MAX_UNCOMPRESSED_CHUNK_SIZE = 16 * 1024 * 1024;
+
+constexpr const char * EXCEPTION_MSG_CORRUPT_CHUNK_SIZE = "Corrupt chunk size.";
+constexpr const char * EXCEPTION_MSG_DESTINATION_TOO_SMALL = "Chunk data larger than allocated destination capacity.";
+constexpr const char * EXCEPTION_MSG_INVALID_CHUNK_ENCODING = "Invalid chunk encoding.";
+constexpr const char * EXCEPTION_MSG_CORRUPT_RLE = "Corrupt RLE compression data.";
 
 class SawyerChunkException : public IOException
 {
@@ -67,7 +71,7 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunk()
             std::unique_ptr<uint8[]> compressedData(new uint8[header.length]);
             if (_stream->TryRead(compressedData.get(), header.length) != header.length)
             {
-                throw SawyerChunkException("Corrupt chunk size.");
+                throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_CHUNK_SIZE);
             }
 
             // Allow 16MiB for chunk data
@@ -78,7 +82,7 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunk()
                 throw Exception("Unable to allocate buffer.");
             }
 
-            size_t uncompressedLength = sawyercoding_read_chunk_buffer(buffer, compressedData.get(), header, bufferSize);
+            size_t uncompressedLength = DecodeChunk(buffer, bufferSize, compressedData.get(), header);
             Guard::Assert(uncompressedLength != 0, "Encountered zero-sized chunk!");
             buffer = Memory::Reallocate(buffer, uncompressedLength);
             if (buffer == nullptr)
@@ -89,7 +93,7 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunk()
             return std::make_shared<SawyerChunk>((SAWYER_ENCODING)header.encoding, buffer, uncompressedLength);
         }
         default:
-            throw SawyerChunkException("Invalid chunk encoding.");
+            throw SawyerChunkException(EXCEPTION_MSG_INVALID_CHUNK_ENCODING);
         }
     }
     catch (Exception)
@@ -119,4 +123,127 @@ void SawyerChunkReader::ReadChunk(void * dst, size_t length)
             Memory::Set(offset, 0, remainingLength);
         }
     }
+}
+
+size_t SawyerChunkReader::DecodeChunk(void * dst, size_t dstCapacity, const void * src, const sawyercoding_chunk_header &header)
+{
+    size_t resultLength;
+    switch (header.encoding)
+    {
+    case CHUNK_ENCODING_NONE:
+        if (header.length > dstCapacity)
+        {
+            throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
+        }
+        Memory::Copy(dst, src, header.length);
+        resultLength = header.length;
+        break;
+    case CHUNK_ENCODING_RLE:
+        resultLength = DecodeChunkRLE(dst, dstCapacity, src, header.length);
+        break;
+    case CHUNK_ENCODING_RLECOMPRESSED:
+    {
+        auto immBufferLength = MAX_UNCOMPRESSED_CHUNK_SIZE;
+        auto immBuffer = std::make_unique<uint8[]>(immBufferLength);
+        auto immLength = DecodeChunkRLE(immBuffer.get(), immBufferLength, src, header.length);
+        resultLength = DecodeChunkRepeat(dst, dstCapacity, immBuffer.get(), immLength);
+        break;
+    }
+    case CHUNK_ENCODING_ROTATE:
+        resultLength = DecodeChunkRotate(dst, dstCapacity, src, header.length);
+        break;
+    default:
+        throw SawyerChunkException(EXCEPTION_MSG_INVALID_CHUNK_ENCODING);
+    }
+    return resultLength;
+}
+
+size_t SawyerChunkReader::DecodeChunkRLE(void * dst, size_t dstCapacity, const void * src, size_t srcLength)
+{
+    auto src8 = static_cast<const uint8 *>(src);
+    auto dst8 = static_cast<uint8 *>(dst);
+    auto dstEnd = dst8 + dstCapacity;
+    for (size_t i = 0; i < srcLength; i++)
+    {
+        uint8 rleCodeByte = src8[i];
+        if (rleCodeByte & 128)
+        {
+            i++;
+            size_t count = 257 - rleCodeByte;
+
+            if (i >= srcLength)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_RLE);
+            }
+            if (dst8 + count > dstEnd)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
+            }
+
+            Memory::Set(dst8, src8[i], count);
+            dst8 += count;
+        }
+        else
+        {
+            if (i + 1 >= srcLength)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_RLE);
+            }
+            if (dst8 + rleCodeByte + 1 > dstEnd)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
+            }
+
+            Memory::Copy(dst8, src8 + i + 1, rleCodeByte + 1);
+            dst8 += rleCodeByte + 1;
+            i += rleCodeByte + 1;
+        }
+    }
+    return (uintptr_t)dst8 - (uintptr_t)dst;
+}
+
+size_t SawyerChunkReader::DecodeChunkRepeat(void * dst, size_t dstCapacity, const void * src, size_t srcLength)
+{
+    auto src8 = static_cast<const uint8 *>(src);
+    auto dst8 = static_cast<uint8 *>(dst);
+    auto dstEnd = dst8 + dstCapacity;
+    for (size_t i = 0; i < srcLength; i++)
+    {
+        if (src8[i] == 0xFF)
+        {
+            *dst8++ = src8[++i];
+        }
+        else
+        {
+            size_t count = (src8[i] & 7) + 1;
+            const uint8 * copySrc = dst8 + (sint32)(src8[i] >> 3) - 32;
+
+            if (dst8 + count >= dstEnd || copySrc + count >= dstEnd)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
+            }
+
+            Memory::Copy(dst8, copySrc, count);
+            dst8 += count;
+        }
+    }
+    return (uintptr_t)dst8 - (uintptr_t)dst;
+}
+
+size_t SawyerChunkReader::DecodeChunkRotate(void * dst, size_t dstCapacity, const void * src, size_t srcLength)
+{
+    if (srcLength > dstCapacity)
+    {
+        throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
+    }
+
+    auto src8 = static_cast<const uint8 *>(src);
+    auto dst8 = static_cast<uint8 *>(dst);
+    uint8 code = 1;
+    for (size_t i = 0; i < srcLength; i++)
+    {
+        dst8[i] = ror8(src8[i], code);
+        code = (code + 2) % 8;
+    }
+    return srcLength;
 }

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include "../common.h"
+#include "../util/sawyercoding.h"
 #include "SawyerChunk.h"
 
 interface IStream;
@@ -69,6 +70,12 @@ public:
         ReadChunk(&result, sizeof(result));
         return result;
     }
+
+private:
+    static size_t DecodeChunk(void * dst, size_t dstCapacity, const void * src, const sawyercoding_chunk_header &header);
+    static size_t DecodeChunkRLE(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
+    static size_t DecodeChunkRepeat(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
+    static size_t DecodeChunkRotate(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
 };
 
 #endif

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -73,6 +73,7 @@ public:
 
 private:
     static size_t DecodeChunk(void * dst, size_t dstCapacity, const void * src, const sawyercoding_chunk_header &header);
+    static size_t DecodeChunkRLERepeat(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
     static size_t DecodeChunkRLE(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
     static size_t DecodeChunkRepeat(void * dst, size_t dstCapacity, const void * src, size_t srcLength);
     static size_t DecodeChunkRotate(void * dst, size_t dstCapacity, const void * src, size_t srcLength);

--- a/src/openrct2/util/sawyercoding.h
+++ b/src/openrct2/util/sawyercoding.h
@@ -54,7 +54,6 @@ extern "C" {
 extern bool gUseRLE;
 
 uint32 sawyercoding_calculate_checksum(const uint8* buffer, size_t length);
-size_t sawyercoding_read_chunk_buffer(uint8 *dst_buffer, const uint8 *src_buffer, sawyercoding_chunk_header chunkHeader, size_t dst_buffer_size);
 size_t sawyercoding_write_chunk_buffer(uint8 *dst_file, const uint8 *src_buffer, sawyercoding_chunk_header chunkHeader);
 size_t sawyercoding_decode_sv4(const uint8 *src, uint8 *dst, size_t length, size_t bufferLength);
 size_t sawyercoding_decode_sc4(const uint8 *src, uint8 *dst, size_t length, size_t bufferLength);

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -102,12 +102,14 @@ endif ()
 
 set(SAWYERCODING_TEST_SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/sawyercoding_test.cpp"
-        "${ROOT_DIR}/src/openrct2/diagnostic.c"
+        "${ROOT_DIR}/src/openrct2/core/IStream.cpp"
+        "${ROOT_DIR}/src/openrct2/core/MemoryStream.cpp"
+        "${ROOT_DIR}/src/openrct2/rct12/SawyerChunk.cpp"
+        "${ROOT_DIR}/src/openrct2/rct12/SawyerChunkReader.cpp"
         "${ROOT_DIR}/src/openrct2/util/sawyercoding.c"
-        "${ROOT_DIR}/src/openrct2/localisation/utf8.c"
         )
 add_executable(test_sawyercoding ${SAWYERCODING_TEST_SOURCES})
-target_link_libraries(test_sawyercoding ${GTEST_LIBRARIES})
+target_link_libraries(test_sawyercoding ${GTEST_LIBRARIES} test-common ${LDL} z)
 add_test(NAME sawyercoding COMMAND test_sawyercoding)
 
 # LanguagePack test
@@ -120,7 +122,7 @@ if (UNIX AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
     # Include libdl for dlopen
     set(LDL dl)
 endif ()
-target_link_libraries(test_languagepack ${GTEST_LIBRARIES} test-common ${LDL} z SDL2)
+target_link_libraries(test_languagepack ${GTEST_LIBRARIES} test-common ${LDL} z)
 add_test(NAME languagepack COMMAND test_languagepack)
 
 # INI test

--- a/test/tests/sawyercoding_test.cpp
+++ b/test/tests/sawyercoding_test.cpp
@@ -1,11 +1,9 @@
-// Make MSVC shut up about M_PI
-#include <cmath>
-
-#include "openrct2/util/sawyercoding.h"
-
 #include <gtest/gtest.h>
+#include <openrct2/core/MemoryStream.h>
+#include <openrct2/rct12/SawyerChunkReader.h>
+#include <openrct2/util/sawyercoding.h>
 
-#define BUFFER_SIZE 0x600000
+constexpr size_t BUFFER_SIZE = 0x600000;
 
 class SawyerCodingTest : public testing::Test
 {
@@ -18,36 +16,39 @@ protected:
 
     void test_encode_decode(uint8 encoding_type)
     {
-        sawyercoding_chunk_header chdr_in, chdr_out;
+        // Encode
+        sawyercoding_chunk_header chdr_in;
         chdr_in.encoding          = encoding_type;
         chdr_in.length            = sizeof(randomdata);
         uint8 * encodedDataBuffer = new uint8[BUFFER_SIZE];
         size_t  encodedDataSize   = sawyercoding_write_chunk_buffer(encodedDataBuffer, (const uint8 *)randomdata, chdr_in);
         ASSERT_GT(encodedDataSize, sizeof(sawyercoding_chunk_header));
-        memcpy(&chdr_out, encodedDataBuffer, sizeof(sawyercoding_chunk_header));
-        ASSERT_EQ(chdr_out.encoding, encoding_type);
-        uint8 * decodeBuffer    = new uint8[BUFFER_SIZE];
-        size_t  decodedDataSize = sawyercoding_read_chunk_buffer(
-            decodeBuffer, encodedDataBuffer + sizeof(sawyercoding_chunk_header), chdr_out, BUFFER_SIZE);
-        ASSERT_EQ(decodedDataSize, sizeof(randomdata));
-        int result = memcmp(decodeBuffer, randomdata, sizeof(randomdata));
+
+        // Decode
+        MemoryStream ms(encodedDataBuffer, encodedDataSize);
+        SawyerChunkReader reader(&ms);
+        auto chunk = reader.ReadChunk();
+        ASSERT_EQ((uint8)chunk->GetEncoding(), chdr_in.encoding);
+        ASSERT_EQ(chunk->GetLength(), chdr_in.length);
+        auto result = memcmp(chunk->GetData(), randomdata, sizeof(randomdata));
         ASSERT_EQ(result, 0);
-        delete[] decodeBuffer;
+
         delete[] encodedDataBuffer;
     }
 
     void test_decode(const uint8 * data, size_t size)
     {
-        sawyercoding_chunk_header chdr_in;
-        memcpy(&chdr_in, data, sizeof(sawyercoding_chunk_header));
-        ASSERT_EQ(chdr_in.length, size - sizeof(sawyercoding_chunk_header));
-        uint8 * decodeBuffer = new uint8[BUFFER_SIZE];
-        size_t  decodedDataSize =
-            sawyercoding_read_chunk_buffer(decodeBuffer, data + sizeof(sawyercoding_chunk_header), chdr_in, BUFFER_SIZE);
-        ASSERT_EQ(decodedDataSize, sizeof(randomdata));
-        int result = memcmp(decodeBuffer, randomdata, sizeof(randomdata));
+        auto expectedLength = size - sizeof(sawyercoding_chunk_header);
+        auto chdr_in = reinterpret_cast<const sawyercoding_chunk_header *>(data);
+        ASSERT_EQ(chdr_in->length, expectedLength);
+
+        MemoryStream ms(data, size);
+        SawyerChunkReader reader(&ms);
+        auto chunk = reader.ReadChunk();
+        ASSERT_EQ((uint8)chunk->GetEncoding(), chdr_in->encoding);
+        ASSERT_EQ(chunk->GetLength(), sizeof(randomdata));
+        auto result = memcmp(chunk->GetData(), randomdata, sizeof(randomdata));
         ASSERT_EQ(result, 0);
-        delete[] decodeBuffer;
     }
 };
 


### PR DESCRIPTION
Move / copy sawyer decoding functions to SawyerChunkReader and replace assertions with exceptions in the process to prevent access violations when reading corrupt chunks.