### PR TITLE
Fix failing link on Ubuntu due to missing libiconv

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -193,7 +193,7 @@ if (NOT DISABLE_TTF)
     endif ()
 endif ()
 
-if (APPLE OR STATIC OR ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+if (UNIX OR STATIC OR ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
     find_library(ICONV_LIBRARIES NAMES iconv libiconv libiconv-2 c)
     target_link_libraries(${PROJECT} ${ICONV_LIBRARIES})
 endif()


### PR DESCRIPTION
On Ubuntu we need to link to libiconv explicitly for the dynamic build. I am not sure about other Linux flavours, but I think the change is necessary for those, too.