### PR TITLE
Fix gParkEntrance locations after loading from file

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1121,6 +1121,22 @@ void game_fix_save_vars()
 
     // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
     fix_invalid_vehicle_sprite_sizes();
+
+    // Fix gEntrance locations for which the map_element no longer exists
+    uint8 entranceNum;
+    for (entranceNum = 0; entranceNum < MAX_PARK_ENTRANCES; ++entranceNum)
+    {
+        if (gParkEntrances[entranceNum].x == LOCATION_NULL)
+            continue;
+
+        if (map_get_park_entrance_element_at(
+            gParkEntrances[entranceNum].x,
+            gParkEntrances[entranceNum].y,
+            gParkEntrances[entranceNum].z >> 3, false) == NULL)
+        {
+            gParkEntrances[entranceNum].x = LOCATION_NULL;
+        }
+    }
 }
 
 void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const utf8 * path, bool loadTitleFirst)


### PR DESCRIPTION
Check the gParkEntrance locations after loading from file and clear those locations for which there is no longer a park entrance map element.
Resolves path finding problems in parks caused, for example, be deleting a park entrance using the tile inspector.

Fixes #6261, #6344, #6520