### PR TITLE
Don't trigger assert on invalid TopSpin paint

### DIFF
--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "../../core/Util.hpp"
 #include "../../interface/viewport.h"
 #include "../../localisation/localisation.h"
 #include "../../paint/paint.h"
@@ -148,9 +149,12 @@ static void top_spin_paint_vehicle(paint_session * session, sint8 al, sint8 cl, 
 
     LocationXYZ16 seatCoords = { al, cl, static_cast<sint16>(height) };
 
+    if (armRotation >= static_cast<sint8>(Util::CountOf(TopSpinSeatHeightOffset)))
+    {
+        return;
+    }
     seatCoords.z += TopSpinSeatHeightOffset[armRotation];
 
-    assert(armRotation < static_cast<sint8>(sizeof(TopSpinSeatPositionOffset)));
     switch (direction)
     {
     case 0:


### PR DESCRIPTION
Similar to https://github.com/OpenRCT2/OpenRCT2/pull/6457, only for TopSpin.cpp

I found in both cases rides were set to an invalid mode, "Rotation mode" which is not available by default, perhaps it was used via cheats.

Attached is the park that triggers, the ride in question is "Trump has just crashed".

[thjc.sv6.zip](https://github.com/OpenRCT2/OpenRCT2/files/1405312/thjc.sv6.zip)
