### PR TITLE
Fix disconnected entrances when loading save

### DIFF
--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1125,8 +1125,8 @@ void game_fix_save_vars()
     // Fix gParkEntrance locations for which the map_element no longer exists
     fix_park_entrance_locations();
 
-    // Fix ride entrances that were moved without updating ride->entrances[]
-    fix_ride_entrance_locations();
+    // Fix ride entrances and exits that were moved without updating ride->entrances[] / ride->exits[]
+    fix_ride_entrance_and_exit_locations();
 }
 
 void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const utf8 * path, bool loadTitleFirst)

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1124,6 +1124,9 @@ void game_fix_save_vars()
 
     // Fix gParkEntrance locations for which the map_element no longer exists
     fix_park_entrance_locations();
+
+    // Fix ride entrances that were moved without updating ride->entrances[]
+    fix_ride_entrance_locations();
 }
 
 void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const utf8 * path, bool loadTitleFirst)

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8236,12 +8236,12 @@ void fix_ride_entrance_and_exit_locations()
     {
         for (sint32 stationIndex = 0; stationIndex < MAX_STATIONS; stationIndex++)
         {
-            LocationXY8       entranceLoc        = ride->entrances[stationIndex];
-            LocationXY8       exitLoc            = ride->exits[stationIndex];
-            uint8             entranceExitHeight = ride->station_heights[stationIndex];
-            bool              fixEntrance        = false;
-            bool              fixExit            = false;
-            rct_map_element * mapElement;
+            const LocationXY8       entranceLoc        = ride->entrances[stationIndex];
+            const LocationXY8       exitLoc            = ride->exits[stationIndex];
+            uint8                   entranceExitHeight = ride->station_heights[stationIndex];
+            bool                    fixEntrance        = false;
+            bool                    fixExit            = false;
+            const rct_map_element * mapElement;
 
             // Skip if the station has no entrance
             if (entranceLoc.xy != RCT_XY8_UNDEFINED)

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -8335,6 +8335,18 @@ void fix_ride_entrance_and_exit_locations()
                     }
                 }
             }
+
+            if (fixEntrance && !alreadyFoundEntrance)
+            {
+                ride->entrances[stationIndex].xy = RCT_XY8_UNDEFINED;
+                log_info("Cleared disconnected entrance of ride %d, station %d.", rideIndex, stationIndex);
+
+            }
+            if (fixExit && !alreadyFoundExit)
+            {
+                ride->exits[stationIndex].xy = RCT_XY8_UNDEFINED;
+                log_info("Cleared disconnected exit of ride %d, station %d.", rideIndex, stationIndex);
+            }
         }
     }
 }

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -1214,6 +1214,8 @@ void ride_stop_peeps_queuing(sint32 rideIndex);
 
 LocationXY16 ride_get_rotated_coords(sint16 x, sint16 y, sint16 z);
 
+void fix_ride_entrance_locations();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/openrct2/ride/ride.h
+++ b/src/openrct2/ride/ride.h
@@ -1214,7 +1214,7 @@ void ride_stop_peeps_queuing(sint32 rideIndex);
 
 LocationXY16 ride_get_rotated_coords(sint16 x, sint16 y, sint16 z);
 
-void fix_ride_entrance_locations();
+void fix_ride_entrance_and_exit_locations();
 
 #ifdef __cplusplus
 }

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -3832,6 +3832,30 @@ rct_map_element *map_get_park_entrance_element_at(sint32 x, sint32 y, sint32 z, 
     return NULL;
 }
 
+rct_map_element * map_get_ride_entrance_element_at(sint32 x, sint32 y, sint32 z, bool ghost)
+{
+    rct_map_element * mapElement = map_get_first_element_at(x >> 5, y >> 5);
+    do
+    {
+        if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_ENTRANCE)
+            continue;
+
+        if (mapElement->base_height != z)
+            continue;
+
+        if (mapElement->properties.entrance.type != ENTRANCE_TYPE_RIDE_ENTRANCE)
+            continue;
+
+        if ((ghost == false) && (mapElement->flags & MAP_ELEMENT_FLAG_GHOST))
+            continue;
+
+        return mapElement;
+    }
+    while (!map_element_is_last_for_tile(mapElement++));
+
+    return NULL;
+}
+
 rct_map_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant)
 {
     rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -3856,6 +3856,30 @@ rct_map_element * map_get_ride_entrance_element_at(sint32 x, sint32 y, sint32 z,
     return NULL;
 }
 
+rct_map_element * map_get_ride_exit_element_at(sint32 x, sint32 y, sint32 z, bool ghost)
+{
+    rct_map_element * mapElement = map_get_first_element_at(x >> 5, y >> 5);
+    do
+    {
+        if (map_element_get_type(mapElement) != MAP_ELEMENT_TYPE_ENTRANCE)
+            continue;
+
+        if (mapElement->base_height != z)
+            continue;
+
+        if (mapElement->properties.entrance.type != ENTRANCE_TYPE_RIDE_EXIT)
+            continue;
+
+        if ((ghost == false) && (mapElement->flags & MAP_ELEMENT_FLAG_GHOST))
+            continue;
+
+        return mapElement;
+    }
+    while (!map_element_is_last_for_tile(mapElement++));
+
+    return NULL;
+}
+
 rct_map_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant)
 {
     rct_map_element *mapElement = map_get_first_element_at(x >> 5, y >> 5);

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -415,6 +415,7 @@ rct_map_element* map_get_path_element_at(sint32 x, sint32 y, sint32 z);
 rct_map_element *map_get_wall_element_at(sint32 x, sint32 y, sint32 z, sint32 direction);
 rct_map_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant);
 rct_map_element *map_get_park_entrance_element_at(sint32 x, sint32 y, sint32 z, bool ghost);
+rct_map_element * map_get_ride_entrance_element_at(sint32 x, sint32 y, sint32 z, bool ghost);
 sint32 map_element_height(sint32 x, sint32 y);
 void sub_68B089();
 sint32 map_coord_is_connected(sint32 x, sint32 y, sint32 z, uint8 faceDirection);

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -416,6 +416,7 @@ rct_map_element *map_get_wall_element_at(sint32 x, sint32 y, sint32 z, sint32 di
 rct_map_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant);
 rct_map_element *map_get_park_entrance_element_at(sint32 x, sint32 y, sint32 z, bool ghost);
 rct_map_element * map_get_ride_entrance_element_at(sint32 x, sint32 y, sint32 z, bool ghost);
+rct_map_element * map_get_ride_exit_element_at(sint32 x, sint32 y, sint32 z, bool ghost);
 sint32 map_element_height(sint32 x, sint32 y);
 void sub_68B089();
 sint32 map_coord_is_connected(sint32 x, sint32 y, sint32 z, uint8 faceDirection);


### PR DESCRIPTION
Some parks have had ride entrances moved. This works, but the ride->entrances struct is never updated to reflect this new location.  This causes problems with our pathfinding.

In addition to this, some parks (like [Belmont Shores](https://www.nedesigns.com/park/569/belmont-shores/), with which I tested) have both a disconnected entrance _and_ a sunk entrance! In such cases, the code will pick whatever the highest entrance is.