### PR TITLE
Fix: Steam path locator Android build error

### DIFF
--- a/src/openrct2/platform/android.c
+++ b/src/openrct2/platform/android.c
@@ -78,4 +78,9 @@ void platform_get_changelog_path(utf8 *outPath, size_t outSize)
     STUB();
 }
 
+bool platform_get_steam_path(utf8 * outPath, size_t outSize)
+{
+    return false;
+}
+
 #endif


### PR DESCRIPTION
Added `platform_get_steam_path` to android.c that was forgotten in #6501.