### PR TITLE
Lower game actions verbosity

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -92,6 +92,7 @@ The following people are not part of the project team, but have been contributin
 * Tomas Dittmann (Chaosmeister)
 * William Wallace (Willox)
 * Christian Friedrich Coors (ccoors)
+* Robbin Voortman (rvoortman)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -172,7 +172,7 @@ namespace GameActions
                 }
             }
 
-            log_info("[%s] GameAction::Execute\n", "sv");
+            log_verbose("[%s] GameAction::Execute\n", "sv");
 
             // Execute the action, changing the game state
             result = action->Execute();

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -152,7 +152,7 @@ namespace GameActions
                 // As a client we have to wait or send it first.
                 if (!(actionFlags & GA_FLAGS::CLIENT_ONLY) && !(flags & GAME_COMMAND_FLAG_NETWORKED))
                 {
-                    log_info("[%s] GameAction::Execute\n", "cl");
+                    log_verbose("[%s] GameAction::Execute\n", "cl");
 
                     network_send_game_action(action);
 
@@ -165,7 +165,7 @@ namespace GameActions
                 // at the beginning of the frame, so we have to put them into the queue.
                 if (!(actionFlags & GA_FLAGS::CLIENT_ONLY) && !(flags & GAME_COMMAND_FLAG_NETWORKED))
                 {
-                    log_info("[%s] GameAction::Execute\n", "sv-cl");
+                    log_verbose("[%s] GameAction::Execute\n", "sv-cl");
                     network_enqueue_game_action(action);
 
                     return result;


### PR DESCRIPTION
This fixes #6561. The game actions should now only be logged when the verbose flag is set. 

My very first (although simple) contribution :)