### PR TITLE
 Fix #6547: logging does not work if server contains CJK characters 

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -93,6 +93,7 @@ The following people are not part of the project team, but have been contributin
 * William Wallace (Willox)
 * Christian Friedrich Coors (ccoors)
 * Robbin Voortman (rvoortman)
+* (telk5093)
 
 ## Toolchain
 * (Balletie) - macOS
@@ -127,7 +128,7 @@ The following people are not part of the project team, but have been contributin
 * German - (danidoedel), (atmaxinger), (Yepoleb), Daniel Kessel (dkessel), Leon (AllGoodNamesAreTaken), (raidcookie)
 * Italian - Luca Andrea Rossi (LucaRed)
 * Japanese - Aaron van Geffen (AaronVanGeffen), Nick Hall (nickhall), (jhako), Harry Lam (daihakken)
-* Korean - "TELK" (telk5093), (NeverDruid); small fixes: (kexplo)
+* Korean - (telk5093), (NeverDruid); small fixes: (kexplo)
 * Polish - Adrian Wielgosik (adrian17), (lopezloo), Michał Janiszewski (janisozaur)
 * Portuguese (BR) - (kaudy), (renansimoes)
 * Russian - (Soosisya)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -61,6 +61,7 @@
 - Fix: [#6460] Crash when reading corrupt object files.
 - Fix: [#6481] Can't take screenshots of parks with colons in the name.
 - Fix: [#6500] Failure to load resources when config file is missing.
+- Fix: [#6547] The server log is not logged if the server name contains CJK
 - Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
 - Fix: [#6657] Guest list is missing tracking icon after reopening.
 - Fix: Infinite loop when removing scenery elements with >127 base height.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -884,7 +884,7 @@ void Network::LoadGroups()
     group_list.at(0)->ActionsAllowed.fill(0xFF);
 }
 
-std::string Network::BeginLog(const std::string &directory, const std::string &filenameFormat)
+std::string Network::BeginLog(const std::string &directory, const std::string &midName, const std::string &filenameFormat)
 {
     utf8 filename[256];
     time_t timer;
@@ -894,7 +894,7 @@ std::string Network::BeginLog(const std::string &directory, const std::string &f
         throw std::runtime_error("strftime failed");
     }
 
-    return Path::Combine(directory, filename);
+    return Path::Combine(directory, midName, filename);
 }
 
 void Network::AppendLog(const std::string &logPath, const std::string &s)
@@ -927,7 +927,7 @@ void Network::AppendLog(const std::string &logPath, const std::string &s)
 void Network::BeginChatLog()
 {
     auto directory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_CHAT);
-    _chatLogPath = BeginLog(directory, _chatLogFilenameFormat);
+    _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
 }
 
 void Network::AppendChatLog(const std::string &s)
@@ -944,7 +944,7 @@ void Network::CloseChatLog()
 void Network::BeginServerLog()
 {
     auto directory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_SERVER);
-    _serverLogPath = BeginLog(directory, (ServerName + _serverLogFilenameFormat));
+    _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
 
     // Log server start event
     utf8 logMessage[256];

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -127,7 +127,7 @@ public:
     void SaveGroups();
     void LoadGroups();
 
-    std::string BeginLog(const std::string &directory, const std::string &filenameFormat);
+    std::string BeginLog(const std::string &directory, const std::string &midName, const std::string &filenameFormat);
     void AppendLog(const std::string &logPath, const std::string &s);
 
     void BeginChatLog();
@@ -254,7 +254,7 @@ private:
     std::string _chatLogPath;
     std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
     std::string _serverLogPath;
-    std::string _serverLogFilenameFormat = "-%Y%m%d-%H%M%S.txt";
+    std::string _serverLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
     OpenRCT2::IPlatformEnvironment * _env = nullptr;
 
     void UpdateServer();


### PR DESCRIPTION
First, I'm not good at C/C++ and github, please notice me if something is wrong.

I changed code to log serverlog correctly if the server name contains CJK characters. (#6547)
Since it was hard to deal with UTF8 file path, so I changed the path where server logs is stored like this:

 * **Before:** ``/serverlogs/{SERVERNAME}-{DATEFORMAT}.txt``
 * **After:** ``/serverlogs/{SERVERNAME}/{DATEFORMAT}.txt``

Please let me know if something is wrong.