### PR TITLE
Take line heights into account in Recent Messages window

### DIFF
--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -74,7 +74,7 @@ static rct_widget window_news_options_widgets[] = {
     { WWT_TAB,              1,  34,         64,     17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_NONE },             // tab 2
     { WWT_TAB,              1,  65,         95,     17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_NONE },             // tab 2
 
-    { WWT_CHECKBOX,         2,  3,          349,    46,     59,     STR_NONE,                       STR_NONE },
+    { WWT_CHECKBOX,         2,  7,          349,    49,     62,     STR_NONE,                       STR_NONE },
     { WWT_CHECKBOX,         2,  0,          0,      0,      0,      STR_NONE,                       STR_NONE },
     { WWT_CHECKBOX,         2,  0,          0,      0,      0,      STR_NONE,                       STR_NONE },
     { WWT_CHECKBOX,         2,  0,          0,      0,      0,      STR_NONE,                       STR_NONE },
@@ -224,7 +224,7 @@ static void window_news_options_invalidate(rct_window *w)
         checkboxWidget->left = baseCheckBox->left;
         checkboxWidget->right = baseCheckBox->right;
         checkboxWidget->top = y;
-        checkboxWidget->bottom = checkboxWidget->top + 13;
+        checkboxWidget->bottom = checkboxWidget->top + LIST_ROW_HEIGHT + 3;
         checkboxWidget->text = ndef->caption;
 
         const bool *configValue = get_notification_value_ptr(ndef);
@@ -232,7 +232,7 @@ static void window_news_options_invalidate(rct_window *w)
 
         checkboxWidgetIndex++;
         checkboxWidget++;
-        y += 13;
+        y += LIST_ROW_HEIGHT + 3;
     }
 
     // Remove unused checkboxes


### PR DESCRIPTION
The 'recent messages' window currently does not take line height into account. For English, this means 42px are used to display four lines. For TTF languages, like Japanese and Korean, this means only three lines or fewer fit in the news line.

This PR addresses the issue by making the news item height relative to the font height used. When using the sprite font, the behaviour should be unaffected. When using a TrueType font, the entire news message now fits.

As a bonus, the 'Notification Options' window has its options padded to fit translations as well.

**Messages:**
English: [before](https://user-images.githubusercontent.com/604665/32073372-1dd010e0-ba96-11e7-88cc-da48ad72bf04.png), [after](https://user-images.githubusercontent.com/604665/32073371-1db7c7c4-ba96-11e7-8b75-402c994345c7.png)
Japanese: [before](https://user-images.githubusercontent.com/604665/32073374-1e01b9f6-ba96-11e7-8531-325ab6393ee6.png), [after](https://user-images.githubusercontent.com/604665/32073373-1de80204-ba96-11e7-8943-2c011a426ce9.png)

**Notification Options:**
English: [before](https://user-images.githubusercontent.com/604665/32073376-1e30d150-ba96-11e7-963f-85fcc1678bc9.png), [after](https://user-images.githubusercontent.com/604665/32073375-1e199206-ba96-11e7-865a-99ada18421a1.png)