### PR TITLE
Introduce support for TrueType font families

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		C6352B951F477032006CCEE3 /* RideCreateAction.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C6352B8D1F477032006CCEE3 /* RideCreateAction.hpp */; };
 		C6352B961F477032006CCEE3 /* RideSetStatus.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C6352B8E1F477032006CCEE3 /* RideSetStatus.hpp */; };
 		C6352B971F477032006CCEE3 /* SetParkEntranceFeeAction.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C6352B8F1F477032006CCEE3 /* SetParkEntranceFeeAction.hpp */; };
+		C6415B471FA3B3E400AC4926 /* FontFamilies.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6415B461FA3B3E400AC4926 /* FontFamilies.cpp */; };
 		C64644F81F3FA4120026AC2D /* ClearScenery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C64644EE1F3FA4120026AC2D /* ClearScenery.cpp */; };
 		C64644F91F3FA4120026AC2D /* EditorInventionsList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C64644EF1F3FA4120026AC2D /* EditorInventionsList.cpp */; };
 		C64644FA1F3FA4120026AC2D /* EditorObjectiveOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C64644F01F3FA4120026AC2D /* EditorObjectiveOptions.cpp */; };
@@ -776,6 +777,8 @@
 		C6352B8D1F477032006CCEE3 /* RideCreateAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideCreateAction.hpp; sourceTree = "<group>"; };
 		C6352B8E1F477032006CCEE3 /* RideSetStatus.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideSetStatus.hpp; sourceTree = "<group>"; };
 		C6352B8F1F477032006CCEE3 /* SetParkEntranceFeeAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SetParkEntranceFeeAction.hpp; sourceTree = "<group>"; };
+		C6415B451FA3B3E400AC4926 /* FontFamilies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontFamilies.h; sourceTree = "<group>"; };
+		C6415B461FA3B3E400AC4926 /* FontFamilies.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontFamilies.cpp; sourceTree = "<group>"; };
 		C64644EE1F3FA4120026AC2D /* ClearScenery.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClearScenery.cpp; sourceTree = "<group>"; };
 		C64644EF1F3FA4120026AC2D /* EditorInventionsList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EditorInventionsList.cpp; sourceTree = "<group>"; };
 		C64644F01F3FA4120026AC2D /* EditorObjectiveOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EditorObjectiveOptions.cpp; sourceTree = "<group>"; };
@@ -2047,7 +2050,6 @@
 		F76C83BB1EC4E7CC00FA49E2 /* interface */ = {
 			isa = PBXGroup;
 			children = (
-				4C8B42731EEB1B6F00F015CA /* Screenshot.cpp */,
 				F76C83BC1EC4E7CC00FA49E2 /* chat.c */,
 				F76C83BD1EC4E7CC00FA49E2 /* chat.h */,
 				F76C83BE1EC4E7CC00FA49E2 /* colour.c */,
@@ -2055,18 +2057,21 @@
 				F76C83C01EC4E7CC00FA49E2 /* console.c */,
 				F76C83C11EC4E7CC00FA49E2 /* console.h */,
 				F76C83C21EC4E7CC00FA49E2 /* Cursors.h */,
+				C6415B461FA3B3E400AC4926 /* FontFamilies.cpp */,
+				C6415B451FA3B3E400AC4926 /* FontFamilies.h */,
 				F76C83C31EC4E7CC00FA49E2 /* Fonts.cpp */,
 				F76C83C41EC4E7CC00FA49E2 /* Fonts.h */,
 				F76C83C51EC4E7CC00FA49E2 /* graph.c */,
 				F76C83C61EC4E7CC00FA49E2 /* graph.h */,
 				4CB832A51EFBDCCE00B88761 /* land_tool.c */,
 				4CB832A61EFBDCCE00B88761 /* land_tool.h */,
+				4C8B42731EEB1B6F00F015CA /* Screenshot.cpp */,
 				F76C83CA1EC4E7CC00FA49E2 /* screenshot.h */,
 				F76C83CB1EC4E7CC00FA49E2 /* Theme.cpp */,
 				F76C83CC1EC4E7CC00FA49E2 /* themes.h */,
+				F76C83CF1EC4E7CC00FA49E2 /* viewport_interaction.c */,
 				F76C83CD1EC4E7CC00FA49E2 /* viewport.c */,
 				F76C83CE1EC4E7CC00FA49E2 /* viewport.h */,
-				F76C83CF1EC4E7CC00FA49E2 /* viewport_interaction.c */,
 				F76C83D01EC4E7CC00FA49E2 /* widget.c */,
 				F76C83D11EC4E7CC00FA49E2 /* widget.h */,
 				F76C83D21EC4E7CC00FA49E2 /* window.c */,
@@ -3209,6 +3214,7 @@
 				4C93F13E1F8B744400A9330D /* CorkscrewRollerCoaster.cpp in Sources */,
 				4C93F1401F8B744400A9330D /* GigaCoaster.cpp in Sources */,
 				4CB832A71EFBDCCE00B88761 /* land_tool.c in Sources */,
+				C6415B471FA3B3E400AC4926 /* FontFamilies.cpp in Sources */,
 				4C93F1541F8B744400A9330D /* TwisterRollerCoaster.cpp in Sources */,
 				C666EE7B1F37ACB10061AA04 /* TitleExit.cpp in Sources */,
 				F7D7747F1EC61E5100BE6EBC /* UiContext.macOS.mm in Sources */,

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -16,10 +16,7 @@
 
 #include "Text.h"
 
-extern "C"
-{
-    #include "../localisation/localisation.h"
-}
+#include "../localisation/localisation.h"
 
 static TextPaint _legacyPaint;
 

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -1,0 +1,46 @@
+#pragma region Copyright(c) 2014 - 2017 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#include "FontFamilies.h"
+
+#ifndef NO_TTF
+
+TTFontFamily const TTFFamilyChineseSimplified =
+{
+    &TTFFontMingLiu,
+};
+
+TTFontFamily const TTFFamilyChineseTraditional =
+{
+    &TTFFontSimSun,
+};
+
+TTFontFamily const TTFFamilyJapanese =
+{
+    &TTFFontMSGothic,
+};
+
+TTFontFamily const TTFFamilyKorean =
+{
+    &TTFFontGulim,
+};
+
+TTFontFamily const TTFFamilySansSerif =
+{
+    &TTFFontArial,
+};
+
+#endif // NO_TTF

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -41,6 +41,7 @@ TTFontFamily const TTFFamilyKorean =
 
 TTFontFamily const TTFFamilySansSerif =
 {
+    &TTFFontArialUnicode,
     &TTFFontArial,
 };
 

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -26,6 +26,7 @@ TTFontFamily const TTFFamilyChineseSimplified =
 TTFontFamily const TTFFamilyChineseTraditional =
 {
     &TTFFontSimSun,
+    &TTFFontLiHeiPro,
 };
 
 TTFontFamily const TTFFamilyJapanese =

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -21,6 +21,7 @@
 TTFontFamily const TTFFamilyChineseSimplified =
 {
     &TTFFontMingLiu,
+    &TTFFontHeiti,
 };
 
 TTFontFamily const TTFFamilyChineseTraditional =

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -37,6 +37,7 @@ TTFontFamily const TTFFamilyJapanese =
 TTFontFamily const TTFFamilyKorean =
 {
     &TTFFontGulim,
+    &TTFFontNanum,
 };
 
 TTFontFamily const TTFFamilySansSerif =

--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -30,6 +30,7 @@ TTFontFamily const TTFFamilyChineseTraditional =
 
 TTFontFamily const TTFFamilyJapanese =
 {
+    &TTFFontHiragano,
     &TTFFontMSGothic,
 };
 

--- a/src/openrct2/interface/FontFamilies.h
+++ b/src/openrct2/interface/FontFamilies.h
@@ -1,0 +1,43 @@
+#pragma region Copyright(c) 2014 - 2017 OpenRCT2 Developers
+/*****************************************************************************
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
+#pragma endregion
+
+#ifndef OPENRCT2_FONT_FAMILIES_H
+#define OPENRCT2_FONT_FAMILIES_H
+
+#define FAMILY_OPENRCT2_SPRITE nullptr
+
+#ifndef NO_TTF
+
+#include <vector>
+#include "Fonts.h"
+
+typedef std::vector<TTFFontSetDescriptor *> TTFontFamily;
+
+extern TTFontFamily const TTFFamilyChineseSimplified;
+extern TTFontFamily const TTFFamilyChineseTraditional;
+extern TTFontFamily const TTFFamilyJapanese;
+extern TTFontFamily const TTFFamilyKorean;
+extern TTFontFamily const TTFFamilySansSerif;
+
+#define FAMILY(x) x
+
+#else  // NO_TTF
+
+#define FAMILY(x) FAMILY_OPENRCT2_SPRITE
+
+#endif // NO_TTF
+
+#endif // OPENRCT2_FONT_FAMILIES_H

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -57,6 +57,13 @@ TTFFontSetDescriptor TTFFontSimSun = { {
     { "simsun.ttc", "SimSun", 13,  1,  0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontLiHeiPro = { {
+    { u8"儷黑 Pro.ttf", "LiHei Pro",  9, 1, -1, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"儷黑 Pro.ttf", "LiHei Pro", 11, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"儷黑 Pro.ttf", "LiHei Pro", 12, 1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"儷黑 Pro.ttf", "LiHei Pro", 13, 1,  0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontGulim = { {
     { "gulim.ttc", "Gulim", 11, 1, 0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -50,6 +50,13 @@ TTFFontSetDescriptor TTFFontMingLiu = { {
     { "mingliu.ttc",  "MingLiU", 13,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontHeiti = { {
+    { u8"华文黑体.ttf", "STHeiti",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"华文黑体.ttf", "STHeiti", 11,  1,  1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"华文黑体.ttf", "STHeiti", 12,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"华文黑体.ttf", "STHeiti", 13,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontSimSun = { {
     {   "msyh.ttc",  "YaHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 11,  1, -1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -70,6 +70,13 @@ TTFFontSetDescriptor TTFFontArial = { {
     { "arial.ttf", "Arial", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arial.ttf", "Arial", 12, 0, -1, 14, HINTING_THRESHOLD_LOW, nullptr },
 } };
+
+TTFFontSetDescriptor TTFFontArialUnicode = { {
+    { "arialuni.ttf", "Arial Unicode MS",  8, 0, -1,  6, HINTING_THRESHOLD_LOW, nullptr },
+    { "arialuni.ttf", "Arial Unicode MS", 10, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "arialuni.ttf", "Arial Unicode MS", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
+    { "arialuni.ttf", "Arial Unicode MS", 12, 0, -1, 14, HINTING_THRESHOLD_LOW, nullptr },
+} };
 #endif // NO_TTF
 
 static void LoadSpriteFont()

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -64,6 +64,13 @@ TTFFontSetDescriptor TTFFontGulim = { {
     { "gulim.ttc", "Gulim", 13, 1, 0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontNanum = { {
+    { "NanumGothic.ttc", "Nanum Gothic", 11, 1, 0, 13, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttc", "Nanum Gothic", 13, 1, 0, 16, HINTING_THRESHOLD_LOW, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontArial = { {
     { "arial.ttf", "Arial",  8, 0, -1,  6, HINTING_THRESHOLD_LOW, nullptr },
     { "arial.ttf", "Arial", 10, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -36,6 +36,13 @@ TTFFontSetDescriptor TTFFontMSGothic = { {
     { "msgothic.ttc", "MS PGothic", 13, 1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontHiragano = { {
+    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN",  8, 1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 11, 1,  0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 11, 1,  0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 12, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontMingLiu = { {
     {    "msjh.ttc", "JhengHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "mingliu.ttc",  "MingLiU", 11,  1,  1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -21,6 +21,7 @@
 
 #ifndef NO_TTF
 extern TTFFontSetDescriptor TTFFontMSGothic;
+extern TTFFontSetDescriptor TTFFontHiragano;
 extern TTFFontSetDescriptor TTFFontMingLiu;
 extern TTFFontSetDescriptor TTFFontSimSun;
 extern TTFFontSetDescriptor TTFFontGulim;

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -23,6 +23,7 @@
 extern TTFFontSetDescriptor TTFFontMSGothic;
 extern TTFFontSetDescriptor TTFFontHiragano;
 extern TTFFontSetDescriptor TTFFontMingLiu;
+extern TTFFontSetDescriptor TTFFontHeiti;
 extern TTFFontSetDescriptor TTFFontSimSun;
 extern TTFFontSetDescriptor TTFFontLiHeiPro;
 extern TTFFontSetDescriptor TTFFontGulim;

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -24,6 +24,7 @@ extern TTFFontSetDescriptor TTFFontMSGothic;
 extern TTFFontSetDescriptor TTFFontHiragano;
 extern TTFFontSetDescriptor TTFFontMingLiu;
 extern TTFFontSetDescriptor TTFFontSimSun;
+extern TTFFontSetDescriptor TTFFontLiHeiPro;
 extern TTFFontSetDescriptor TTFFontGulim;
 extern TTFFontSetDescriptor TTFFontNanum;
 extern TTFFontSetDescriptor TTFFontArial;

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -25,6 +25,7 @@ extern TTFFontSetDescriptor TTFFontHiragano;
 extern TTFFontSetDescriptor TTFFontMingLiu;
 extern TTFFontSetDescriptor TTFFontSimSun;
 extern TTFFontSetDescriptor TTFFontGulim;
+extern TTFFontSetDescriptor TTFFontNanum;
 extern TTFFontSetDescriptor TTFFontArial;
 extern TTFFontSetDescriptor TTFFontArialUnicode;
 #define FONT(x) x

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -26,6 +26,7 @@ extern TTFFontSetDescriptor TTFFontMingLiu;
 extern TTFFontSetDescriptor TTFFontSimSun;
 extern TTFFontSetDescriptor TTFFontGulim;
 extern TTFFontSetDescriptor TTFFontArial;
+extern TTFFontSetDescriptor TTFFontArialUnicode;
 #define FONT(x) x
 #else
 #define FONT(x) FONT_OPENRCT2_SPRITE

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -19,35 +19,37 @@
 #include "../core/String.hpp"
 #include "../core/StringBuilder.hpp"
 #include "../interface/Fonts.h"
+#include "../interface/FontFamilies.h"
 #include "../object/ObjectManager.h"
 #include "LanguagePack.h"
 
 #include "../platform/platform.h"
 #include "localisation.h"
 
-const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] = {
-    { "",       "",                     "",                      FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_UNDEFINED
-    { "ar-EG", "Arabic (experimental)", "Arabic (experimental)", FONT(&TTFFontArial),    RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_ARABIC
-    { "ca-ES", "Catalan",               u8"Català",              FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_SPANISH },             // LANGUAGE_CATALAN
-    { "zh-CN", "Chinese (Simplified)",  "Chinese (Simplified)",  FONT(&TTFFontSimSun),   RCT2_LANGUAGE_ID_CHINESE_SIMPLIFIED },  // LANGUAGE_CHINESE_SIMPLIFIED
-    { "zh-TW", "Chinese (Traditional)", "Chinese (Traditional)", FONT(&TTFFontMingLiu),  RCT2_LANGUAGE_ID_CHINESE_TRADITIONAL }, // LANGUAGE_CHINESE_TRADITIONAL
-    { "cs-CZ", "Czech",                 "Czech",                 FONT(&TTFFontArial),    RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_CZECH
-    { "de-DE", "German",                "Deutsch",               FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_GERMAN },              // LANGUAGE_GERMAN
-    { "en-GB", "English (UK)",          "English (UK)",          FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_ENGLISH_UK
-    { "en-US", "English (US)",          "English (US)",          FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_US },          // LANGUAGE_ENGLISH_US
-    { "es-ES", "Spanish",               u8"Español",             FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_SPANISH },             // LANGUAGE_SPANISH
-    { "fr-FR", "French",                u8"Français",            FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_FRENCH },              // LANGUAGE_FRENCH
-    { "it-IT", "Italian",               "Italiano",              FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ITALIAN },             // LANGUAGE_ITALIAN
-    { "ja-JP", "Japanese",              "Japanese",              FONT(&TTFFontMSGothic), RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_JAPANESE
-    { "ko-KR", "Korean",                "Korean",                FONT(&TTFFontGulim),    RCT2_LANGUAGE_ID_KOREAN },              // LANGUAGE_KOREAN
-    { "hu-HU", "Hungarian",             "Magyar",                FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_HUNGARIAN
-    { "nl-NL", "Dutch",                 "Nederlands",            FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_DUTCH },               // LANGUAGE_DUTCH
-    { "nb-NO", "Norwegian",             "Norsk",                 FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_NORWEGIAN
-    { "pl-PL", "Polish",                "Polski",                FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_POLISH
-    { "pt-BR", "Portuguese (BR)",       u8"Português (BR)",      FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_PORTUGUESE },          // LANGUAGE_PORTUGUESE_BR
-    { "ru-RU", "Russian",               "Russian",               FONT(&TTFFontArial),    RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_RUSSIAN
-    { "fi-FI", "Finnish",               "Suomi",                 FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_FINNISH
-    { "sv-SE", "Swedish",               "Svenska",               FONT_OPENRCT2_SPRITE,   RCT2_LANGUAGE_ID_SWEDISH },             // LANGUAGE_SWEDISH
+const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] =
+{
+    { "",       "",                     "",                      FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_UNDEFINED
+    { "ar-EG", "Arabic (experimental)", "Arabic (experimental)", FAMILY(&TTFFamilySansSerif),           RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_ARABIC
+    { "ca-ES", "Catalan",               u8"Català",              FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_SPANISH },             // LANGUAGE_CATALAN
+    { "zh-CN", "Chinese (Simplified)",  "Chinese (Simplified)",  FAMILY(&TTFFamilyChineseSimplified),   RCT2_LANGUAGE_ID_CHINESE_SIMPLIFIED },  // LANGUAGE_CHINESE_SIMPLIFIED
+    { "zh-TW", "Chinese (Traditional)", "Chinese (Traditional)", FAMILY(&TTFFamilyChineseTraditional),  RCT2_LANGUAGE_ID_CHINESE_TRADITIONAL }, // LANGUAGE_CHINESE_TRADITIONAL
+    { "cs-CZ", "Czech",                 "Czech",                 FAMILY(&TTFFamilySansSerif),           RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_CZECH
+    { "de-DE", "German",                "Deutsch",               FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_GERMAN },              // LANGUAGE_GERMAN
+    { "en-GB", "English (UK)",          "English (UK)",          FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_ENGLISH_UK
+    { "en-US", "English (US)",          "English (US)",          FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_US },          // LANGUAGE_ENGLISH_US
+    { "es-ES", "Spanish",               u8"Español",             FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_SPANISH },             // LANGUAGE_SPANISH
+    { "fr-FR", "French",                u8"Français",            FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_FRENCH },              // LANGUAGE_FRENCH
+    { "it-IT", "Italian",               "Italiano",              FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ITALIAN },             // LANGUAGE_ITALIAN
+    { "ja-JP", "Japanese",              "Japanese",              FAMILY(&TTFFamilyJapanese),            RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_JAPANESE
+    { "ko-KR", "Korean",                "Korean",                FAMILY(&TTFFamilyKorean),              RCT2_LANGUAGE_ID_KOREAN },              // LANGUAGE_KOREAN
+    { "hu-HU", "Hungarian",             "Magyar",                FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_HUNGARIAN
+    { "nl-NL", "Dutch",                 "Nederlands",            FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_DUTCH },               // LANGUAGE_DUTCH
+    { "nb-NO", "Norwegian",             "Norsk",                 FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_NORWEGIAN
+    { "pl-PL", "Polish",                "Polski",                FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_POLISH
+    { "pt-BR", "Portuguese (BR)",       u8"Português (BR)",      FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_PORTUGUESE },          // LANGUAGE_PORTUGUESE_BR
+    { "ru-RU", "Russian",               "Russian",               FAMILY(&TTFFamilySansSerif),           RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_RUSSIAN
+    { "fi-FI", "Finnish",               "Suomi",                 FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_FINNISH
+    { "sv-SE", "Swedish",               "Svenska",               FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_SWEDISH },             // LANGUAGE_SWEDISH
 };
 
 extern "C" {

--- a/src/openrct2/localisation/language.h
+++ b/src/openrct2/localisation/language.h
@@ -48,15 +48,19 @@ enum {
 
 #define FONT_OPENRCT2_SPRITE NULL
 
+#ifdef __cplusplus
+#include "../interface/FontFamilies.h"
+#endif
+
 typedef struct language_descriptor {
     const char *locale;
     const utf8 *english_name;
     const utf8 *native_name;
-#ifndef NO_TTF
-    TTFFontSetDescriptor *font;
+#if defined(__cplusplus) && !defined(NO_TTF)
+    TTFontFamily const * font_family;
 #else
-    void * font;
-#endif // NO_TTF
+    void * font_family;
+#endif
     uint8 rct2_original_id;
 } language_descriptor;
 


### PR DESCRIPTION
This PR introduces support for TrueType font families to OpenRCT2. With font families, we can define multiple fonts per language that cover a similar range of characters and have a similar appearance. This should greatly improve the cross-platform compatibility and thereby the out-of-the-box experience of the game.

Rather than just defining a font family per language, we can introduce a sans-serif font family. As of this PR, this is used by the Arabic, Czech, and Russian languages. Furthermore, rather than falling back on just the Arial font, we can now fall back to the sans-serif family.

To this end, I am also introducing 'Arial Unicode MS' as an added compatibility font. On Windows, I believe this is typically already known as 'Arial', but on macOS and some Linux distributions the more verbose name is used.

I plan for this PR to also introduce support for more CJK fonts as well. So far, I have only added support for 'Hiragino Maru Gothic' for use with Japanese. More fonts can easily be added; I welcome PRs to my fork to get things more complete, but we could also add more after this is merged, of course.

Feedback most appreciated.