### PR TITLE
Change Path::Combine to use std::initializer_list

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -235,7 +235,7 @@ namespace OpenRCT2
             if (pathId == PATH_ID_CSS50)
             {
                 auto dataPath = _env->GetDirectoryPath(DIRBASE::RCT1, DIRID::DATA);
-                result = Path::Combine(dataPath, "css17.dat");
+                result = Path::Combine( {dataPath, "css17.dat"} );
             }
             else if (pathId >= 0 && pathId < PATH_ID_END)
             {
@@ -243,7 +243,7 @@ namespace OpenRCT2
                 if (fileName != nullptr)
                 {
                     auto dataPath = _env->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA);
-                    result = Path::Combine(dataPath, fileName);
+                    result = Path::Combine( {dataPath, fileName} );
                 }
             }
             return result;
@@ -796,12 +796,12 @@ namespace OpenRCT2
         {
             log_verbose("CopyOriginalUserFilesOver('%s', '%s', '%s')", srcRoot.c_str(), dstRoot.c_str(), pattern.c_str());
 
-            auto scanPattern = Path::Combine(srcRoot, pattern);
+            auto scanPattern = Path::Combine( {srcRoot, pattern} );
             auto scanner = Path::ScanDirectory(scanPattern, true);
             while (scanner->Next())
             {
                 auto src = std::string(scanner->GetPath());
-                auto dst = Path::Combine(dstRoot, scanner->GetPathRelative());
+                auto dst = Path::Combine( {dstRoot, scanner->GetPathRelative()} );
                 auto dstDirectory = Path::GetDirectory(dst);
 
                 // Create the directory if necessary

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -63,7 +63,7 @@ public:
             break;
         }
 
-        return Path::Combine(basePath, directoryName);
+        return Path::Combine( {basePath, directoryName} );
     }
 
     std::string GetFilePath(PATHID pathid) const override

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -618,7 +618,7 @@ namespace Config
         utf8 steamPath[2048] = { 0 };
         if (platform_get_steam_path(steamPath, sizeof(steamPath)))
         {
-            std::string location = Path::Combine(steamPath, "Rollercoaster Tycoon 2");
+            std::string location = Path::Combine( {steamPath, "Rollercoaster Tycoon 2"} );
             if (platform_original_game_data_exists(location.c_str()))
             {
                 return location;

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -155,7 +155,7 @@ private:
         {
             log_verbose("FileIndex:Scanning for %s in '%s'", _pattern.c_str(), directory.c_str());
 
-            auto pattern = Path::Combine(directory, _pattern);
+            auto pattern = Path::Combine( {directory, _pattern} );
             auto scanner = Path::ScanDirectory(pattern, true);
             while (scanner->Next())
             {

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -36,11 +36,21 @@ namespace Path
         return safe_strcat_path(buffer, src, bufferSize);
     }
 
-    std::string Combine(const std::string &a, const std::string &b)
+    std::string Combine(std::initializer_list<const std::string> pathComponents)
     {
         utf8 buffer[MAX_PATH];
-        String::Set(buffer, sizeof(buffer), a.c_str());
-        Path::Append(buffer, sizeof(buffer), b.c_str());
+
+        // Initialise the buffer with the first argument passed
+        auto pathComponent = pathComponents.begin();
+        String::Set(buffer, sizeof(buffer), pathComponent->c_str());
+        pathComponent++;
+
+        // Append each subsequent argument, handling the separator as needed
+        for (; pathComponent != pathComponents.end(); ++pathComponent)
+        {
+            Path::Append(buffer, sizeof(buffer), pathComponent->c_str());
+        }
+
         return std::string(buffer);
     }
 
@@ -241,7 +251,7 @@ namespace Path
                 {
                     if (String::Equals(files[i]->d_name, fileName.c_str(), true))
                     {
-                        result = Path::Combine(directory, std::string(files[i]->d_name));
+                        result = Path::Combine( {directory, std::string(files[i]->d_name)} );
                         break;
                     }
                 }

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -22,13 +22,9 @@
 namespace Path
 {
     utf8 * Append(utf8 * buffer, size_t bufferSize, const utf8 * src);
-    std::string Combine(const std::string &a, const std::string &b);
 
-    template<typename... Args>
-    static std::string Combine(const std::string &a, const std::string &b, Args... args)
-    {
-        return Combine(a, Combine(b, args...));
-    }
+
+    std::string Combine(std::initializer_list<const std::string> pathComponents);
 
     std::string GetDirectory(const std::string &path);
     utf8 * GetDirectory(const utf8 * path);

--- a/src/openrct2/drawing/Sprite.cpp
+++ b/src/openrct2/drawing/Sprite.cpp
@@ -179,7 +179,7 @@ extern "C"
         log_verbose("gfx_load_g1(...)");
         try
         {
-            auto path = Path::Combine(env->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA), "g1.dat");
+            auto path = Path::Combine( {env->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA), "g1.dat"} );
             auto fs = FileStream(path, FILE_MODE_OPEN);
             rct_g1_header header = fs.ReadValue<rct_g1_header>();
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -876,7 +876,7 @@ std::string Network::BeginLog(const std::string &directory, const std::string &f
         throw std::runtime_error("strftime failed");
     }
 
-    return Path::Combine(directory, filename);
+    return Path::Combine( {directory, filename} );
 }
 
 void Network::AppendLog(const std::string &logPath, const std::string &s)

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -328,7 +328,7 @@ public:
             if (!(item->Flags & TRIF_READ_ONLY))
             {
                 std::string directory = Path::GetDirectory(path);
-                std::string newPath = Path::Combine(directory, newName + Path::GetExtension(path));
+                std::string newPath = Path::Combine( {directory, newName + Path::GetExtension(path)} );
                 if (File::Move(path, newPath))
                 {
                     item->Name = newName;
@@ -347,7 +347,7 @@ public:
         std::string fileName = Path::GetFileName(path);
         std::string installDir = _env->GetDirectoryPath(DIRBASE::USER, DIRID::TRACK);
 
-        std::string newPath = Path::Combine(installDir, fileName);
+        std::string newPath = Path::Combine( {installDir, fileName} );
         if (File::Copy(path, newPath, false))
         {
             auto td = _fileIndex.Create(path);

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -454,7 +454,7 @@ private:
     {
         auto mpdatPath = _env->GetFilePath(PATHID::MP_DAT);
         auto scenarioDirectory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::SCENARIO);
-        auto sc21Path = Path::Combine(scenarioDirectory, "sc21.sc4");
+        auto sc21Path = Path::Combine( {scenarioDirectory, "sc21.sc4"} );
         if (File::Exists(mpdatPath) && !File::Exists(sc21Path))
         {
             ConvertMegaPark(mpdatPath, sc21Path);

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -72,7 +72,7 @@ TEST_F(RideRatings, all)
     CalculateRatingsForAllRides();
 
     // Load expected ratings
-    auto expectedDataPath = Path::Combine(TestData::GetBasePath(), "ratings", "bpb.sv6.txt");
+    auto expectedDataPath = Path::Combine( {TestData::GetBasePath(), "ratings", "bpb.sv6.txt"} );
     auto expectedRatings = File::ReadAllLines(expectedDataPath);
 
     // Check ride ratings

--- a/test/tests/TestData.cpp
+++ b/test/tests/TestData.cpp
@@ -10,7 +10,7 @@ namespace TestData
 
     std::string GetParkPath(std::string name)
     {
-        std::string path = Path::Combine(GetBasePath(), "parks", name);
+        std::string path = Path::Combine( {GetBasePath(), "parks", name} );
         return path;
     }
 };


### PR DESCRIPTION
This PR changes `Path::Combine()` to use `std::initializer_list` rather than a recursive variadic template.

In my opinion, this approach is clearer and cleaner than having parts of the implementation in header files.

However, it does have the downside that calling the function is now slightly more involved (you need to pass a vector, e.g. `Path::Combine( {something, somethingelse} )`), and given that most use cases only pass two parameters that may be an unacceptable tradeoff.

Thoughts?