### PR TITLE
Remove unnecessary ceil call

### DIFF
--- a/src/openrct2/interface/console.c
+++ b/src/openrct2/interface/console.c
@@ -413,7 +413,7 @@ void console_scroll(sint32 linesToScroll)
 // Calculates the amount of visible lines, based on the console size, excluding the input line.
 static sint32 console_get_num_visible_lines()
 {
-    return ceil((_consoleBottom - _consoleTop) / font_get_line_height(gCurrentFontSpriteBase)) - 1;
+    return ((_consoleBottom - _consoleTop) / font_get_line_height(gCurrentFontSpriteBase)) - 1;
 }
 
 void console_clear()


### PR DESCRIPTION
This addresses a [comment](https://github.com/OpenRCT2/OpenRCT2/pull/6511/files#r146216880) by @janisozaur on `ceil` usage.

I think I initially used `ceil` because the improper line heights for fonts were yielding unexpected results. However, now that #6528 has been merged, that certainly is no longer necessary.