### PR TITLE
Remove redundant check in peep_update_answering

### DIFF
--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -6684,11 +6684,8 @@ static void peep_update_answering(rct_peep * peep)
         peep->var_74++;
         if (peep->var_74 > 2500)
         {
-            if (ride->mechanic_status == RIDE_MECHANIC_STATUS_HEADING)
-            {
-                ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
-                ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE;
-            }
+            ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
+            ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE;
             peep_decrement_num_riders(peep);
             peep->state = PEEP_STATE_FALLING;
             peep_window_state_update(peep);


### PR DESCRIPTION
The field `mechanic_status` is verified to be RIDE_MECHANIC_STATUS_HEADING
when entering the function

See https://github.com/OpenRCT2/OpenRCT2/pull/961#commitcomment-25285793 https://github.com/OpenRCT2/OpenRCT2/blob/c7c0c15abf5b0738039f1ea449bdf5dda2f08fe1/src/openrct2/peep/Peep.cpp#L6642-L6653