### PR TITLE
Fix StringTable::Sort comparator

### DIFF
--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -94,7 +94,7 @@ void StringTable::Sort()
         {
             if (a.LanguageId == b.LanguageId)
             {
-                return _strcmpi(a.Text, b.Text) == -1;
+                return _strcmpi(a.Text, b.Text) < 0;
             }
 
             uint8 currentLanguage = LanguagesDescriptors[gCurrentLanguage].rct2_original_id;


### PR DESCRIPTION
Previously, it explicitly compared to -1, while _strcmpi can return
all integers.