### PR TITLE
Implement #6307: Display arrow on park entrance placement

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Feature: [#6290] Arabic translation (experimental).
 - Feature: [#6292] Allow building queue lines in the Scenario Editor.
 - Feature: [#6295] TrueType fonts are now rendered with light font hinting by default.
+- Feature: [#6307] Arrows are now shown when placing park entrances.
 - Feature: [#6324] Add command to deselect unused objects from the object selection.
 - Feature: [#6325] Allow using g1.dat from RCT Classic.
 - Feature: [#6353] Show custom RCT1 scenarios in New Scenario window.

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1245,6 +1245,7 @@ static void window_map_place_park_entrance_tool_update(sint32 x, sint32 y)
     map_invalidate_selection_rect();
     map_invalidate_map_selection_tiles();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
+    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     place_park_entrance_get_map_position(x, y, &mapX, &mapY, &mapZ, &direction);
     if (mapX == (sint16)-1) {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1262,7 +1262,12 @@ static void window_map_place_park_entrance_tool_update(sint32 x, sint32 y)
     gMapSelectionTiles[3].x = -1;
     gMapSelectionTiles[3].y = -1;
 
-    gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
+    gMapSelectArrowPosition.x = mapX;
+    gMapSelectArrowPosition.y = mapY;
+    gMapSelectArrowPosition.z = mapZ * 16;
+    gMapSelectArrowDirection = direction;
+
+    gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT | MAP_SELECT_FLAG_ENABLE_ARROW;
     map_invalidate_map_selection_tiles();
     if (
         gParkEntranceGhostExists &&


### PR DESCRIPTION
This was a simple fix by adding the correct flag and setting the arrow
position and direction. Also adds a changelog entry.

* *Figure A:* Arrows are easy to see when placing, facing the direction of the park.
* *Figure B:* Arrows are harder to see when placing, facing away from the park.
* *Figure C:* Arrow will still guide placement inside the park even when the entrance is in an unplacable location or the entrance has no visual.
* *Figure D:* Arrow may be harder to see on thicker entrances but still visible enough to register.
* *Figure E:* Arrow may be completely hidden by thick entrances when facing away from the park. However, it should eventually become learned behaviour that when the arrow is not visible or partially obstructed, the entrance is facing towards you.
* *Figure F:* Arrow will still guide placement outside the park even when the entrance is in an unplacable location or the entrance has no visual.

![Previews](https://i.imgur.com/sfK3aMj.png)