### PR TITLE
Fix off-by-one error in placement of centred text

### DIFF
--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -90,7 +90,7 @@ static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * pa
     case TextAlignment::LEFT:
         break;
     case TextAlignment::CENTRE:
-        x -= width / 2;
+        x -= (width - 1) / 2;
         break;
     case TextAlignment::RIGHT:
         x -= width;


### PR DESCRIPTION
This fixes a regression in 79365b7a91080ae6f44fe121ee0822dce956ae20 - an off-by-one error in calculating the position of centred text.

The bug is most clearly seen on the 'close X' button:

**Before 79365b7**
![openrct2_2017-10-31_19-53-56](https://user-images.githubusercontent.com/16639257/32246043-a493a32a-be75-11e7-8ec1-ac9431b65159.png)

**After 79365b7**
![openrct2_2017-10-31_19-57-46](https://user-images.githubusercontent.com/16639257/32246095-cc722f06-be75-11e7-9743-c7a1c67e5d05.png)

**Fixed**
![openrct2_2017-10-31_19-52-32](https://user-images.githubusercontent.com/16639257/32246112-d5d11198-be75-11e7-9965-00412c9f95e4.png)

