### PR TITLE
Fix: Numerous title sequence editor bugs

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -57,6 +57,8 @@
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.
+- Fix: Title sequence editor now gracefully fails to preview a title sequence and lets the user know with an error message.
+- Fix: When preset title sequence fails to load, the preset will forcibly be changed to the first sequence to successfully load.
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -295,7 +295,7 @@ void game_update()
     screenshot_check();
     game_handle_keyboard_input();
 
-    if (game_is_not_paused() && gTestingTitleSequenceInGame)
+    if (game_is_not_paused() && gPreviewingTitleSequenceInGame)
     {
         title_sequence_player_update((ITitleSequencePlayer*)title_get_sequence_player());
     }

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -28,7 +28,9 @@ class TitleScreen final
 public:
     ITitleSequencePlayer *  GetSequencePlayer();
     size_t                  GetCurrentSequence();
-    void                    SetCurrentSequence(size_t value, bool loadSequence);
+    bool                    PreviewSequence(size_t value);
+    void                    StopPreviewingSequence();
+    bool                    IsPreviewingSequence();
     bool                    ShouldHideVersionInfo();
     void                    SetHideVersionInfo(bool value);
 
@@ -38,16 +40,17 @@ public:
     void Load();
     void Update();
     void CreateWindows();
-    void ChangeSequence(size_t preset);
+    void ChangePresetSequence(size_t preset);
 
 private:
     ITitleSequencePlayer *  _sequencePlayer = nullptr;
     size_t                  _loadedTitleSequenceId = SIZE_MAX;
     size_t                  _currentSequence = SIZE_MAX;
     bool                    _hideVersionInfo = false;
+    bool                    _previewingSequence = false;
 
     void TitleInitialise();
-    void TryLoadSequence();
+    bool TryLoadSequence(bool loadPreview = false);
 };
 #endif
 
@@ -63,7 +66,9 @@ extern "C"
     void title_set_hide_version_info(bool value);
     size_t title_get_config_sequence();
     size_t title_get_current_sequence();
-    void title_set_current_sequence(size_t value, bool loadSequence);
+    bool title_preview_sequence(size_t value);
+    void title_stop_previewing_sequence();
+    bool title_is_previewing_sequence();
     void DrawOpenRCT2(rct_drawpixelinfo * dpi, sint32 x, sint32 y);
 #ifdef __cplusplus
 }

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -581,6 +581,13 @@ static utf8 * LegacyScriptWrite(TitleSequence * seq)
     {
         const TitleCommand * command = &seq->Commands[i];
         switch (command->Type) {
+        case TITLE_SCRIPT_LOADMM:
+            sb.Append("LOADMM");
+            break;
+        case TITLE_SCRIPT_LOADRCT1:
+            String::Format(buffer, sizeof(buffer), "LOADRCT1 %u", command->SaveIndex);
+            sb.Append(buffer);
+            break;
         case TITLE_SCRIPT_LOAD:
             if (command->SaveIndex == 0xFF)
             {

--- a/src/openrct2/title/TitleSequencePlayer.cpp
+++ b/src/openrct2/title/TitleSequencePlayer.cpp
@@ -159,8 +159,7 @@ public:
                 }
                 else
                 {
-                    SkipToNextLoadCommand();
-                    if (_position == entryPosition)
+                    if (!SkipToNextLoadCommand() || _position == entryPosition)
                     {
                         Console::Error::WriteLine("Unable to load any parks from %s.", _sequence->Name);
                         return false;
@@ -234,15 +233,17 @@ private:
         }
     }
 
-    void SkipToNextLoadCommand()
+    bool SkipToNextLoadCommand()
     {
+        sint32 entryPosition = _position;
         const TitleCommand * command;
         do
         {
             IncrementPosition();
             command = &_sequence->Commands[_position];
         }
-        while (!TitleSequenceIsLoadCommand(command));
+        while (!TitleSequenceIsLoadCommand(command) && _position != entryPosition);
+        return _position != entryPosition;
     }
 
     bool ExecuteCommand(const TitleCommand * command)
@@ -369,7 +370,7 @@ private:
         bool success = false;
         try
         {
-            if (gTestingTitleSequenceInGame)
+            if (gPreviewingTitleSequenceInGame)
             {
                 gLoadKeepWindowsOpen = true;
                 CloseParkSpecificWindows();
@@ -402,7 +403,7 @@ private:
         bool success = false;
         try
         {
-            if (gTestingTitleSequenceInGame)
+            if (gPreviewingTitleSequenceInGame)
             {
                 gLoadKeepWindowsOpen = true;
                 CloseParkSpecificWindows();
@@ -543,7 +544,7 @@ ITitleSequencePlayer * CreateTitleSequencePlayer(IScenarioRepository * scenarioR
 
 extern "C"
 {
-    bool gTestingTitleSequenceInGame = false;
+    bool gPreviewingTitleSequenceInGame = false;
 
     sint32 title_sequence_player_get_current_position(ITitleSequencePlayer * player)
     {

--- a/src/openrct2/title/TitleSequencePlayer.h
+++ b/src/openrct2/title/TitleSequencePlayer.h
@@ -46,7 +46,7 @@ extern "C"
 {
 #endif
     // When testing title sequences within a normal game
-    extern bool gTestingTitleSequenceInGame;
+    extern bool gPreviewingTitleSequenceInGame;
 
     sint32 title_sequence_player_get_current_position(ITitleSequencePlayer * player);
     bool title_sequence_player_begin(ITitleSequencePlayer * player, uint32 titleSequenceId);


### PR DESCRIPTION
**This will most likely conflict with #6598**

* Change how current title sequence is handled. It can either be
previewing a title sequence, or playing the preset.
* LoadMM and LoadRCT1 now save when script is saved.
* No more infinite failing to load loops.
* No more crashing when attempting to display "no save selected" in
title editor.
* Title editor now gracefully fails to preview a title sequence and lets
the user know with a context error.
* When preset title sequence fails to load, the preset will forcibly be
changed to the first sequence to successfully load.

Added changelog entries for last two items.