### PR TITLE
Fix #6593: Cannot hire entertainers when default scenery groups are not selected

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,6 +54,7 @@
 - Fix: [#6452] Scenario text cut off when switching between 32 and 64-bit builds.
 - Fix: [#6460] Crash when reading corrupt object files.
 - Fix: [#6481] Can't take screenshots of parks with colons in the name.
+- Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1671,6 +1671,9 @@ uint32 staff_get_available_entertainer_costumes()
     // For some reason the flags are +4 from the actual costume IDs
     entertainerCostumes >>= 4;
 
+    // Fix #6593: force enable the default costumes, which normally get enabled through the default scenery groups.
+    entertainerCostumes |= (1 << ENTERTAINER_COSTUME_PANDA) | (1 << ENTERTAINER_COSTUME_TIGER) | (1 << ENTERTAINER_COSTUME_ELEPHANT);
+
     return entertainerCostumes;
 }
 


### PR DESCRIPTION
(Yes, I'll reword the commit to make it shorter)