### PR TITLE
Enhance #6530: Don't block land rights tool

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Feature: [#6411] Add command to remove the park fence.
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
+- Feature: [#6530] Land rights tool no longer restricted by unavailable land.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,7 +17,7 @@
 - Feature: [#6411] Add command to remove the park fence.
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
-- Feature: [#6530] Land rights tool no longer restricted by unavailable land.
+- Feature: [#6530] Land rights tool no longer blocks when a tile is not for purchase.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "18"
+#define NETWORK_STREAM_VERSION "19"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -1001,10 +1001,10 @@ sint32 map_buy_land_rights(sint32 x0, sint32 y0, sint32 x1, sint32 y1, sint32 se
         for (y = y0; y <= y1; y += 32) {
             for (x = x0; x <= x1; x += 32) {
                 cost = map_buy_land_rights_for_tile(x, y, setting, flags);
-                if (cost == MONEY32_UNDEFINED)
-                    return MONEY32_UNDEFINED;
-
-                totalCost += cost;
+                if (cost != MONEY32_UNDEFINED)
+                {
+                    totalCost += cost;
+                }
             }
         }
     }


### PR DESCRIPTION
Land rights tool no longer cares if part of the available land is
unavailable for purchase. It will not even through an error when none of
the tiles are available. Just like other tools.

Added a changelog entry.

This incremenets the network version.