### PR TITLE
Fix #6500: Failure to load resources when no config file present

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -287,6 +287,13 @@ namespace OpenRCT2
             //  return false;
             // } //This comment was relocated so it would stay where it was in relation to the following lines of code.
 
+            auto rct2InstallPath = GetOrPromptRCT2Path();
+            if (rct2InstallPath.empty())
+            {
+                return false;
+            }
+            _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
+
             _objectRepository = CreateObjectRepository(_env);
             _objectManager = CreateObjectManager(_objectRepository);
             _trackDesignRepository = CreateTrackDesignRepository(_env);
@@ -314,13 +321,6 @@ namespace OpenRCT2
                     _uiContext->ShowMessageBox(elevationWarning);
                 }
             }
-
-            auto rct2InstallPath = GetOrPromptRCT2Path();
-            if (rct2InstallPath.empty())
-            {
-                return false;
-            }
-            _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
 
             if (!gOpenRCT2Headless)
             {


### PR DESCRIPTION
A simple fix of setting the environment paths before the repositories
are loaded.