### PR TITLE
Fix #6500: Failure to load resources when no config file present

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,6 +54,7 @@
 - Fix: [#6452] Scenario text cut off when switching between 32 and 64-bit builds.
 - Fix: [#6460] Crash when reading corrupt object files.
 - Fix: [#6481] Can't take screenshots of parks with colons in the name.
+- Fix: [#6500] Failure to load resources when config file is missing.
 - Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -287,6 +287,13 @@ namespace OpenRCT2
             //  return false;
             // } //This comment was relocated so it would stay where it was in relation to the following lines of code.
 
+            auto rct2InstallPath = GetOrPromptRCT2Path();
+            if (rct2InstallPath.empty())
+            {
+                return false;
+            }
+            _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
+
             _objectRepository = CreateObjectRepository(_env);
             _objectManager = CreateObjectManager(_objectRepository);
             _trackDesignRepository = CreateTrackDesignRepository(_env);
@@ -314,13 +321,6 @@ namespace OpenRCT2
                     _uiContext->ShowMessageBox(elevationWarning);
                 }
             }
-
-            auto rct2InstallPath = GetOrPromptRCT2Path();
-            if (rct2InstallPath.empty())
-            {
-                return false;
-            }
-            _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
 
             if (!gOpenRCT2Headless)
             {


### PR DESCRIPTION
A simple fix of setting the environment paths before the repositories
are loaded.

Added a changelog entry