### PR TITLE
Fix #6617. Maze deletion no longer costs 0x8000000 for certain mazes.

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix #6617. Maze deletion no longer costs 0x8000000 for certain mazes.

When a maze does not have a completely hollowed out hedge the game command would return 0x80000000 as it tries to remove an element that has already been deleted. As game actions no longer use 0x80000000 to indicate a failure this would get interpreted as the refund price and cause the issue.

Fix was to introduce checks when adding up the refund price. This was done rather than changing the game action so that it can be properly fixed when get_refund_price is converted into a game action