### PR TITLE
Add openrct2 URI handling to Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,5 +169,6 @@ install(FILES "resources/logo/icon_flag.svg" DESTINATION "${CMAKE_INSTALL_DATARO
 install(FILES "distribution/linux/openrct2.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 install(FILES "distribution/linux/openrct2-savegame.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 install(FILES "distribution/linux/openrct2-scenario.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+install(FILES "distribution/linux/openrct2-uri.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/" RENAME "openrct2.xml")
 install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")

--- a/distribution/linux/openrct2-uri.desktop
+++ b/distribution/linux/openrct2-uri.desktop
@@ -1,0 +1,10 @@
+# http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-1.0.html
+[Desktop Entry]
+Type=Application
+Version=1.0
+Exec=openrct2 handle-uri %u
+Icon=openrct2
+Name=OpenRCT2
+Terminal=false
+NoDisplay=true
+MimeType=x-scheme-handler/openrct2


### PR DESCRIPTION
I saw this (#2691) issue to add an URI scheme to OpenRCT2, which was implemented as a general handler and for made available for Windows. This PR adds this capability to Linux too.