### PR TITLE
Fix #6301 and #5836: Track list freezes after deletion in Track Manager

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,8 +41,9 @@
 - Fix: [#6198] You cannot cancel RCT1 directory selection.
 - Fix: [#6202] Guests can break occupied benches (original bug).
 - Fix: [#6251] Splash Boats renders flat-to-25-degree pieces in tunnels incorrectly.
-- Fix: [#6261, #6344, #6520] Broken pathfinding after removing park entrances with the tile inspector
+- Fix: [#6261, #6344, #6520] Broken pathfinding after removing park entrances with the tile inspector.
 - Fix: [#6271] Wrong booster speed tooltip text.
+- Fix: [#6301] Track list freezes after deleting track in Track Manager.
 - Fix: [#6308] Cannot create title sequence if title sequences folder does not exist.
 - Fix: [#6318] Cannot sack staff that have not been placed
 - Fix: [#6320] Crash when CSS1.DAT is absent.

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -337,6 +337,7 @@ static void window_track_list_update(rct_window *w)
         track_list_load_designs(_window_track_list_item);
         w->selected_list_item = 0;
         window_invalidate(w);
+        w->track_list.reload_track_designs = false;
     }
 }
 


### PR DESCRIPTION
`track_list.reload_track_designs` wasn't getting set back to false after reloading, leaving the track list stuck.