### PR TITLE
Close #6639: Integrate Discord Rich Presence

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
 - Feature: [#6530] Land rights tool no longer blocks when a tile is not for purchase.
 - Feature: [#6568] Add smooth nearest neighbour scaling.
+- Feature: [#6651] Integrate Discord Rich Presence.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -21,7 +21,7 @@
     <Version>0.1.2</Version>
     <VersionExtra Condition="'$(GIT_BRANCH)'!=''">-$(GIT_BRANCH)-$(GIT_COMMIT_SHA1_SHORT)</VersionExtra>
     <VersionExtra Condition="'$(GIT_TAG)'!=''"></VersionExtra>
-    <TargetLibsVersion>13</TargetLibsVersion>
+    <TargetLibsVersion>14</TargetLibsVersion>
 
     <!-- Set dynamic OpenRCT2 #defines -->
     <OPENRCT2_CL_ADDITIONALOPTIONS Condition="'$(BUILD_SERVER)'!=''">/D "OPENRCT2_BUILD_SERVER=\"$(BUILD_SERVER)\"" $(OPENRCT2_CL_ADDITIONALOPTIONS)</OPENRCT2_CL_ADDITIONALOPTIONS>
@@ -63,7 +63,7 @@
   <PropertyGroup>
     <DependenciesCheckFile>$(RootDir).dependencies</DependenciesCheckFile>
     <LibsUrl>https://github.com/OpenRCT2/Dependencies/releases/download/v$(TargetLibsVersion)/openrct2-libs-vs2017.zip</LibsUrl>
-    <LibsSha1>00d4eaf3ed7653a1abf82df0c255338fa0d6f9b0</LibsSha1>
+    <LibsSha1>f9bee9fa8ae8c5f12ca3c603ef2aa3fc179e48fc</LibsSha1>
     <GtestVersion>1.8.0</GtestVersion>
     <GtestUrl>https://github.com/google/googletest/archive/release-1.8.0.zip</GtestUrl>
     <GtestSha1>667f873ab7a4d246062565fad32fb6d8e203ee73</GtestSha1>

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -59,6 +59,7 @@
 #include "intro.h"
 #include "localisation/date.h"
 #include "localisation/language.h"
+#include "network/DiscordService.h"
 #include "network/http.h"
 #include "network/network.h"
 #include "network/twitch.h"
@@ -87,6 +88,9 @@ namespace OpenRCT2
         IObjectManager *            _objectManager = nullptr;
         ITrackDesignRepository *    _trackDesignRepository = nullptr;
         IScenarioRepository *       _scenarioRepository = nullptr;
+#ifdef __ENABLE_DISCORD__
+        DiscordService *            _discordService = nullptr;
+#endif
 
         // Game states
         TitleScreen * _titleScreen = nullptr;
@@ -133,6 +137,9 @@ namespace OpenRCT2
 
             delete _titleScreen;
 
+#ifdef __ENABLE_DISCORD__
+            delete _discordService;
+#endif
             delete _scenarioRepository;
             delete _trackDesignRepository;
             delete _objectManager;
@@ -298,6 +305,9 @@ namespace OpenRCT2
             _objectManager = CreateObjectManager(_objectRepository);
             _trackDesignRepository = CreateTrackDesignRepository(_env);
             _scenarioRepository = CreateScenarioRepository(_env);
+#ifdef __ENABLE_DISCORD__
+            _discordService = new DiscordService();
+#endif
 
             if (!language_open(gConfigGeneral.language))
             {
@@ -770,6 +780,13 @@ namespace OpenRCT2
             {
                 game_update();
             }
+
+#ifdef __ENABLE_DISCORD__
+            if (_discordService != nullptr)
+            {
+                _discordService->Update();
+            }
+#endif
 
             twitch_update();
             chat_update();

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -32,7 +32,7 @@
   <Import Project="..\..\openrct2.common.props" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>__ENABLE_LIGHTFX__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__ENABLE_DISCORD__;__ENABLE_LIGHTFX__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Breakpad)'=='true'">USE_BREAKPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -17,18 +17,19 @@
 #ifdef __ENABLE_DISCORD__
 
 #include <discord-rpc.h>
+#include "../Context.h"
 #include "../core/Console.hpp"
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
 #include "../localisation/localisation.h"
 #include "../OpenRCT2.h"
-#include "../scenario/scenario.h"
 #include "../world/park.h"
 #include "DiscordService.h"
 #include "network.h"
 
 constexpr const char * APPLICATION_ID = "378612438200877056";
 constexpr const char * STEAM_APP_ID = nullptr;
+constexpr const uint32 REFRESH_INTERVAL = 5 * GAME_UPDATE_FPS; // 5 seconds
 
 static void OnReady()
 {
@@ -71,6 +72,19 @@ void DiscordService::Update()
 {
     Discord_RunCallbacks();
 
+    if (_ticksSinceLastRefresh >= REFRESH_INTERVAL)
+    {
+        _ticksSinceLastRefresh = 0;
+        RefreshPresence();
+    }
+    else
+    {
+        _ticksSinceLastRefresh++;
+    }
+}
+
+void DiscordService::RefreshPresence()
+{
     DiscordRichPresence discordPresence;
     Memory::Set(&discordPresence, 0, sizeof(discordPresence));
     discordPresence.largeImageKey = "logo";
@@ -110,7 +124,7 @@ void DiscordService::Update()
         details = "In Track Designer";
         break;
     case SCREEN_FLAGS_TRACK_MANAGER:
-        details = "In Track Manager";
+        details = "In Track Designs Manager";
         break;
     }
 

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -1,0 +1,123 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+*
+* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+* For more information, visit https://github.com/OpenRCT2/OpenRCT2
+*
+* OpenRCT2 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* A full copy of the GNU General Public License can be found in licence.txt
+*****************************************************************************/
+#pragma endregion
+
+#ifdef __ENABLE_DISCORD__
+
+#include <discord-rpc.h>
+#include "../core/Console.hpp"
+#include "../core/Memory.hpp"
+#include "../core/String.hpp"
+#include "../localisation/localisation.h"
+#include "../OpenRCT2.h"
+#include "../scenario/scenario.h"
+#include "../world/park.h"
+#include "DiscordService.h"
+#include "network.h"
+
+constexpr const char * APPLICATION_ID = "378612438200877056";
+constexpr const char * STEAM_APP_ID = nullptr;
+
+static void OnReady()
+{
+    log_verbose("DiscordService::OnReady()");
+}
+
+static void OnDisconnected(int errorCode, const char * message)
+{
+    Console::Error::WriteLine("DiscordService::OnDisconnected(%d, %s)", errorCode, message);
+}
+
+static void OnErrored(int errorCode, const char * message)
+{
+    Console::Error::WriteLine("DiscordService::OnErrored(%d, %s)", errorCode, message);
+}
+
+DiscordService::DiscordService()
+{
+    DiscordEventHandlers handlers;
+    Memory::Set(&handlers, 0, sizeof(handlers));
+    handlers.ready = OnReady;
+    handlers.disconnected = OnDisconnected;
+    handlers.errored = OnErrored;
+    Discord_Initialize(APPLICATION_ID, &handlers, 1, STEAM_APP_ID);
+}
+
+DiscordService::~DiscordService()
+{
+    Discord_Shutdown();
+}
+
+static std::string GetParkName()
+{
+    utf8 parkName[128];
+    format_string(parkName, sizeof(parkName), gParkName, &gParkNameArgs);
+    return std::string(parkName);
+}
+
+void DiscordService::Update()
+{
+    Discord_RunCallbacks();
+
+    DiscordRichPresence discordPresence;
+    Memory::Set(&discordPresence, 0, sizeof(discordPresence));
+    discordPresence.largeImageKey = "logo";
+
+    std::string state;
+    std::string details;
+    switch (gScreenFlags)
+    {
+    default:
+        details = GetParkName();
+        if (network_get_mode() == NETWORK_MODE_NONE)
+        {
+            state = "Playing Solo";
+        }
+        else
+        {
+            state = String::ToStd(network_get_server_name());
+
+            // NOTE: the party size is displayed next to state
+            discordPresence.partyId = network_get_server_name();
+            discordPresence.partySize = network_get_num_players();
+            discordPresence.partyMax = 256;
+
+            // TODO generate secrets for the server
+            discordPresence.matchSecret = nullptr;
+            discordPresence.spectateSecret = nullptr;
+            discordPresence.instance = 1;
+        }
+        break;
+    case SCREEN_FLAGS_TITLE_DEMO:
+        details = "In Menus";
+        break;
+    case SCREEN_FLAGS_SCENARIO_EDITOR:
+        details = "In Scenario Editor";
+        break;
+    case SCREEN_FLAGS_TRACK_DESIGNER:
+        details = "In Track Designer";
+        break;
+    case SCREEN_FLAGS_TRACK_MANAGER:
+        details = "In Track Manager";
+        break;
+    }
+
+    discordPresence.state = state.c_str();
+    discordPresence.details = details.c_str();
+
+    Discord_UpdatePresence(&discordPresence);
+}
+
+#endif

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -19,7 +19,6 @@
 #include <discord-rpc.h>
 #include "../Context.h"
 #include "../core/Console.hpp"
-#include "../core/Memory.hpp"
 #include "../core/String.hpp"
 #include "../localisation/localisation.h"
 #include "../OpenRCT2.h"
@@ -48,8 +47,7 @@ static void OnErrored(int errorCode, const char * message)
 
 DiscordService::DiscordService()
 {
-    DiscordEventHandlers handlers;
-    Memory::Set(&handlers, 0, sizeof(handlers));
+    DiscordEventHandlers handlers = {};
     handlers.ready = OnReady;
     handlers.disconnected = OnDisconnected;
     handlers.errored = OnErrored;
@@ -63,7 +61,7 @@ DiscordService::~DiscordService()
 
 static std::string GetParkName()
 {
-    utf8 parkName[128];
+    utf8 parkName[128] = {};
     format_string(parkName, sizeof(parkName), gParkName, &gParkNameArgs);
     return std::string(parkName);
 }
@@ -85,8 +83,7 @@ void DiscordService::Update()
 
 void DiscordService::RefreshPresence()
 {
-    DiscordRichPresence discordPresence;
-    Memory::Set(&discordPresence, 0, sizeof(discordPresence));
+    DiscordRichPresence discordPresence = {};
     discordPresence.largeImageKey = "logo";
 
     std::string state;

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -1,0 +1,30 @@
+#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+/*****************************************************************************
+* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+*
+* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+* For more information, visit https://github.com/OpenRCT2/OpenRCT2
+*
+* OpenRCT2 is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* A full copy of the GNU General Public License can be found in licence.txt
+*****************************************************************************/
+#pragma endregion
+
+#pragma once
+
+#ifdef __ENABLE_DISCORD__
+
+class DiscordService
+{
+public:
+    DiscordService();
+    ~DiscordService();
+
+    void Update();
+};
+
+#endif

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -18,13 +18,22 @@
 
 #ifdef __ENABLE_DISCORD__
 
+#include "../common.h"
+#include <limits>
+
 class DiscordService
 {
+private:
+    uint32 _ticksSinceLastRefresh = std::numeric_limits<uint32>::max();
+
 public:
     DiscordService();
     ~DiscordService();
 
     void Update();
+
+private:
+    void RefreshPresence();
 };
 
 #endif

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -21,7 +21,7 @@
 #include "../common.h"
 #include <limits>
 
-class DiscordService
+class DiscordService final
 {
 private:
     uint32 _ticksSinceLastRefresh = std::numeric_limits<uint32>::max();


### PR DESCRIPTION
Reports a basic status to Discord mentioning what mode the player is in, e.g. scenario editor, menus or the park name if in a game. If playing multiplayer, the server name is posted along with the number of players.

Further enhancements will come later with ability to join or spectate a server via Discord.

I have decided to not localise the strings as they will be displayed in Discord. The API does not offer multiple language strings.