### PR TITLE
Add missing header include for std::ceil call

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -16,6 +16,7 @@
 
 #ifndef DISABLE_OPENGL
 
+#include <cmath>
 #include <unordered_map>
 #include <SDL.h>
 


### PR DESCRIPTION
OpenGLDrawingEngine::ConfigureCanvas calls std::ceil which is defined by
the cmath include. Adding the include directive resolves a compilation
failure to due std::ceil being otherwise undefined.