### PR TITLE
Fix #6657: Reset tracking icon status when opening guest list

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -62,6 +62,7 @@
 - Fix: [#6481] Can't take screenshots of parks with colons in the name.
 - Fix: [#6500] Failure to load resources when config file is missing.
 - Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
+- Fix: [#6657] Guest list is missing tracking icon after reopening.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -201,6 +201,7 @@ rct_window * window_guest_list_open()
     _window_guest_list_selected_page = 0;
     _window_guest_list_num_pages = 1;
     _window_guest_list_tracking_only = false;
+    window_guest_list_widgets[WIDX_TRACKING].type = WWT_FLATBTN;
     window_guest_list_widgets[WIDX_PAGE_DROPDOWN].type = WWT_EMPTY;
     window_guest_list_widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WWT_EMPTY;
     window->var_492 = 0;


### PR DESCRIPTION
The guest tracking icon is hidden on the guest list if it's in
PAGE_SUMMARISED mode. Closing then reopening the window reset it back to
INDIVIDUAL mode but did not restore the icon state.