### PR TITLE
Automatically add all path bits and signs to the designated group

### DIFF
--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -20,6 +20,7 @@
 #include "../drawing/drawing.h"
 #include "../localisation/language.h"
 #include "../object.h"
+#include "../object_list.h"
 
 void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
@@ -45,11 +46,11 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     // Add banners to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
-    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    uint8 source = (objectEntry->flags & 0xF0) >> 4;
+    uint8 source = object_entry_get_source_game(object_list_find_by_name(identifier.c_str()));
+
     static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
 
-    if (scgPathX != nullptr && source != 8)
+    if (scgPathX != nullptr && source != OBJECT_SOURCE_RCT2)
     {
         SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -46,11 +46,10 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     // Add banners to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
-    uint8 source = object_entry_get_source_game(object_list_find_by_name(identifier.c_str()));
-
+    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
     static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
 
-    if (scgPathX != nullptr && source != OBJECT_SOURCE_RCT2)
+    if (objectEntry != nullptr && scgPathX != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
     {
         SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -19,6 +19,7 @@
 
 #include "../drawing/drawing.h"
 #include "../localisation/language.h"
+#include "../object.h"
 
 void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
@@ -39,6 +40,18 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     if (_legacyType.large_scenery.price <= 0)
     {
         context->LogError(OBJECT_ERROR_INVALID_PROPERTY, "Price can not be free or negative.");
+    }
+
+    // Add banners to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
+    // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
+    const std::string identifier = GetIdentifier();
+    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
+    uint8 source = (objectEntry->flags & 0xF0) >> 4;
+    static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
+
+    if (scgPathX != nullptr && source != 8)
+    {
+        SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }
 }
 

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -20,6 +20,7 @@
 #include "../drawing/drawing.h"
 #include "../localisation/localisation.h"
 #include "../object.h"
+#include "../object_list.h"
 
 void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
@@ -46,11 +47,11 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stre
     // Add path bits to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
-    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    uint8 source = (objectEntry->flags & 0xF0) >> 4;
+    uint8 source = object_entry_get_source_game(object_list_find_by_name(identifier.c_str()));
+
     static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
 
-    if (scgPathX != nullptr && source != 8)
+    if (scgPathX != nullptr && source != OBJECT_SOURCE_RCT2)
     {
         SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -47,11 +47,10 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stre
     // Add path bits to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
-    uint8 source = object_entry_get_source_game(object_list_find_by_name(identifier.c_str()));
-
+    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
     static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
 
-    if (scgPathX != nullptr && source != OBJECT_SOURCE_RCT2)
+    if (objectEntry != nullptr && scgPathX != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
     {
         SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -19,6 +19,7 @@
 
 #include "../drawing/drawing.h"
 #include "../localisation/localisation.h"
+#include "../object.h"
 
 void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
@@ -40,6 +41,18 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stre
     if (_legacyType.large_scenery.price <= 0)
     {
         context->LogError(OBJECT_ERROR_INVALID_PROPERTY, "Price can not be free or negative.");
+    }
+
+    // Add path bits to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
+    // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
+    const std::string identifier = GetIdentifier();
+    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
+    uint8 source = (objectEntry->flags & 0xF0) >> 4;
+    static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
+
+    if (scgPathX != nullptr && source != 8)
+    {
+        SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
     }
 }
 

--- a/src/openrct2/object_list.c
+++ b/src/openrct2/object_list.c
@@ -118,6 +118,11 @@ bool object_entry_is_empty(const rct_object_entry *entry)
     return false;
 }
 
+uint8 object_entry_get_source_game(const rct_object_entry * objectEntry)
+{
+    return (objectEntry->flags & 0xF0) >> 4;
+}
+
 /**
  *
  *  rct2: 0x006AB344

--- a/src/openrct2/object_list.h
+++ b/src/openrct2/object_list.h
@@ -55,6 +55,7 @@ extern "C" {
 void get_type_entry_index(size_t index, uint8 * outObjectType, uint8 * outEntryIndex);
 const rct_object_entry * get_loaded_object_entry(size_t index);
 void * get_loaded_object_chunk(size_t index);
+uint8 object_entry_get_source_game(const rct_object_entry * objectEntry);
 
 #ifdef __cplusplus
 }

--- a/src/openrct2/windows/EditorObjectSelection.cpp
+++ b/src/openrct2/windows/EditorObjectSelection.cpp
@@ -1803,8 +1803,11 @@ static bool filter_source(const ObjectRepositoryItem * item)
     if (_FILTER_ALL)
         return true;
 
-    uint8 source = (item->ObjectEntry.flags & 0xF0) >> 4;
-    return (_FILTER_RCT2 && source == 8) || (_FILTER_WW && source == 1) || (_FILTER_TT && source == 2) || (_FILTER_CUSTOM && source != 8 && source != 1 && source != 2);
+    uint8 source = object_entry_get_source_game(&item->ObjectEntry);
+    return (_FILTER_RCT2 && source == OBJECT_SOURCE_RCT2) ||
+           (_FILTER_WW && source == OBJECT_SOURCE_WACKY_WORLDS) ||
+           (_FILTER_TT && source == OBJECT_SOURCE_TIME_TWISTER) ||
+           (_FILTER_CUSTOM && source != OBJECT_SOURCE_RCT2 && source != OBJECT_SOURCE_WACKY_WORLDS && source != OBJECT_SOURCE_TIME_TWISTER);
 }
 
 static bool filter_chunks(const ObjectRepositoryItem * item)


### PR DESCRIPTION
There are two ways scenery can added to groups. One can create a scenery group and and add the items to those (which is the best-known manner), but it is also possible to set a scenery group on individual items. This allows custom items to appear in original groups, like Signs and Items for Footpaths, rather than them being lumped together with everything else in the Miscellaneous tabs.

This PR sets the 'Signs and Items for Footpaths' group for every WW/TT/custom path bit and sign.