### PR TITLE
Fix build in clang

### DIFF
--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -656,27 +656,15 @@ static void window_editor_scenario_options_financial_mousedown(rct_window *w, rc
         break;
     case WIDX_INTEREST_RATE_INCREASE:
         if (gBankLoanInterestRate < 80) {
-            if (gBankLoanInterestRate < 0) {
-                game_do_command(
-                    0,
-                    GAME_COMMAND_FLAG_APPLY,
-                    EDIT_SCENARIOOPTIONS_SETANNUALINTERESTRATE,
-                    0,
-                    GAME_COMMAND_EDIT_SCENARIO_OPTIONS,
-                    0,
-                    0
-                );
-            } else {
-                game_do_command(
-                    0,
-                    GAME_COMMAND_FLAG_APPLY,
-                    EDIT_SCENARIOOPTIONS_SETANNUALINTERESTRATE,
-                    gBankLoanInterestRate + 1,
-                    GAME_COMMAND_EDIT_SCENARIO_OPTIONS,
-                    0,
-                    0
-                );
-            }
+            game_do_command(
+                0,
+                GAME_COMMAND_FLAG_APPLY,
+                EDIT_SCENARIOOPTIONS_SETANNUALINTERESTRATE,
+                gBankLoanInterestRate + 1,
+                GAME_COMMAND_EDIT_SCENARIO_OPTIONS,
+                0,
+                0
+            );
         } else {
             context_show_error(STR_CANT_INCREASE_INTEREST_RATE, STR_NONE);
         }

--- a/src/openrct2/game.c
+++ b/src/openrct2/game.c
@@ -1202,14 +1202,8 @@ void game_load_init()
         mainWindow->viewport->zoom = gSavedViewZoom;
         gCurrentRotation = gSavedViewRotation;
         if (zoomDifference != 0) {
-            if (zoomDifference < 0) {
-                zoomDifference = -zoomDifference;
-                mainWindow->viewport->view_width >>= zoomDifference;
-                mainWindow->viewport->view_height >>= zoomDifference;
-            } else {
-                mainWindow->viewport->view_width <<= zoomDifference;
-                mainWindow->viewport->view_height <<= zoomDifference;
-            }
+            mainWindow->viewport->view_width <<= zoomDifference;
+            mainWindow->viewport->view_height <<= zoomDifference;
         }
         mainWindow->saved_view_x -= mainWindow->viewport->view_width >> 1;
         mainWindow->saved_view_y -= mainWindow->viewport->view_height >> 1;

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -62,7 +62,7 @@ namespace RCT1
             COLOUR_BRIGHT_YELLOW,
             COLOUR_ICY_BLUE
         };
-        if (colour < 0 || colour >= Util::CountOf(map))
+        if (colour >= Util::CountOf(map))
         {
             log_warning("Unsupported RCT1 colour.");
             return COLOUR_BLACK;
@@ -110,7 +110,7 @@ namespace RCT1
             PEEP_SPRITE_TYPE_CHICKEN, // 0x21
             PEEP_SPRITE_TYPE_LEMONADE, // 0x22
         };
-        if (rct1SpriteType < 0 || rct1SpriteType >= Util::CountOf(map))
+        if (rct1SpriteType >= Util::CountOf(map))
         {
             log_warning("Unsupported RCT1 peep sprite type: %d.", rct1SpriteType);
             return PEEP_SPRITE_TYPE_NORMAL;


### PR DESCRIPTION
Fixes a few build errors in clang:

```
OpenRCT2/src/openrct2/game.c:1205:32: error: comparison of unsigned expression < 0 is always false [-Werror,-Wtautological-unsigned-zero-compare]
            if (zoomDifference < 0) {
                ~~~~~~~~~~~~~~ ^ ~
OpenRCT2/src/openrct2/rct1/Tables.cpp:65:20: error: comparison of unsigned expression < 0 is always false [-Werror,-Wtautological-unsigned-zero-compare]
        if (colour < 0 || colour >= Util::CountOf(map))
            ~~~~~~ ^ ~
OpenRCT2/src/openrct2/rct1/Tables.cpp:113:28: error: comparison of unsigned expression < 0 is always false [-Werror,-Wtautological-unsigned-zero-compare]
        if (rct1SpriteType < 0 || rct1SpriteType >= Util::CountOf(map))
            ~~~~~~~~~~~~~~ ^ ~
OpenRCT2/src/openrct2-ui/windows/EditorScenarioOptions.cpp:659:39: error: comparison of unsigned expression < 0 is always false [-Werror,-Wtautological-unsigned-zero-compare]
            if (gBankLoanInterestRate < 0) {
                ~~~~~~~~~~~~~~~~~~~~~ ^ ~
```