### PR TITLE
Improve TODO note in widget_text

### DIFF
--- a/src/openrct2/interface/widget.c
+++ b/src/openrct2/interface/widget.c
@@ -456,8 +456,9 @@ static void widget_text(rct_drawpixelinfo *dpi, rct_window *w, rct_widgetindex w
     sint32 t = w->y + widget->top;
     sint32 r = w->x + widget->right;
 
-    // TODO: -2 seems odd
-    if (widget->text == (rct_string_id)-2 || widget->text == STR_NONE)
+    // TODO -2 seems to link to the string id for [TBR].
+    const rct_string_id strTbr = (rct_string_id)-2;
+    if (widget->text == strTbr || widget->text == STR_NONE)
         return;
 
     if (widget_is_disabled(w, widgetIndex))


### PR DESCRIPTION
I can't seem to find out how to simply comment on a line of code on github anymore, so I had to adjust the code. If I should rename `strTbr` to something else, like `unknownStr`, and just keep the Tbr assumption in the comment, let me know. It's merely speculation by looking for the second to last line in en-GB.txt