### PR TITLE
Reduce console verbosity for TTF loading

### DIFF
--- a/src/openrct2/drawing/ttf.c
+++ b/src/openrct2/drawing/ttf.c
@@ -78,13 +78,13 @@ bool ttf_initialise()
 
             utf8 fontPath[MAX_PATH];
             if (!platform_get_font_path(fontDesc, fontPath, sizeof(fontPath))) {
-                log_error("Unable to load font '%s'", fontDesc->font_name);
+                log_verbose("Unable to load font '%s'", fontDesc->font_name);
                 return false;
             }
 
             fontDesc->font = ttf_open_font(fontPath, fontDesc->ptSize);
             if (fontDesc->font == NULL) {
-                log_error("Unable to load '%s'", fontPath);
+                log_verbose("Unable to load '%s'", fontPath);
                 return false;
             }
 

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -155,7 +155,7 @@ void TryLoadFonts()
             {
                 return;
             }
-            Console::Error::WriteLine("Unable to initialise configured TrueType font -- falling back to the language's default.");
+            log_verbose("Unable to initialise configured TrueType font -- falling back to the language's default.");
         }
 
         for (auto &font : *fontFamily)
@@ -166,12 +166,12 @@ void TryLoadFonts()
             }
 
             TTFFontDescriptor smallFont = font->size[FONT_SIZE_SMALL];
-            Console::Error::WriteLine("Unable to load TrueType font '%s' -- trying the next font in the family.", smallFont.font_name);
+            log_verbose("Unable to load TrueType font '%s' -- trying the next font in the family.", smallFont.font_name);
         }
 
         if (fontFamily != &TTFFamilySansSerif)
         {
-            Console::Error::WriteLine("Unable to initialise any of the preferred TrueType fonts -- falling back to sans serif fonts.");
+            log_verbose("Unable to initialise any of the preferred TrueType fonts -- falling back to sans serif fonts.");
 
             for (auto &font : TTFFamilySansSerif)
             {
@@ -181,10 +181,10 @@ void TryLoadFonts()
                 }
 
                 TTFFontDescriptor smallFont = font->size[FONT_SIZE_SMALL];
-                Console::Error::WriteLine("Unable to load TrueType font '%s' -- trying the next font in the family.", smallFont.font_name);
+                log_verbose("Unable to load TrueType font '%s' -- trying the next font in the family.", smallFont.font_name);
             }
 
-            Console::Error::WriteLine("Unable to initialise any of the preferred TrueType fonts -- falling back to sprite font.");
+            log_verbose("Unable to initialise any of the preferred TrueType fonts -- falling back to sprite font.");
         }
     }
 #endif // NO_TTF


### PR DESCRIPTION
With #6571 merged, OpenRCT2 is capable of recognising more than just one TrueType font as suitable for a particular language. However, inherent to the way the approach works, some fonts may fail to be loaded along the way.

This PR reduces the output verbosity for functions related to TTF loading by hiding related console log messages unless verbose logging is activated.

Originally, this was part of #6583, but I split off the changes to focus discussion in that PR.