### PR TITLE
Refactor entertainer invented logic

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -33,6 +33,7 @@
 #define WINDOW_SCENERY_HEIGHT   180
 #define SCENERY_BUTTON_WIDTH    66
 #define SCENERY_BUTTON_HEIGHT   80
+#define SCENERY_WINDOW_TABS     (MAX_SCENERY_GROUP_OBJECTS + 1) // The + 1 is for the 'Miscellaneous' tab
 
 enum {
     WINDOW_SCENERY_TAB_1,
@@ -179,6 +180,9 @@ static rct_widget window_scenery_widgets[] = {
 };
 
 void window_scenery_update_scroll(rct_window *w);
+
+// rct2: 0x00F64F2C
+static sint16 window_scenery_tab_entries[SCENERY_WINDOW_TABS][SCENERY_ENTRIES_BY_TAB + 1];
 
 /**
  * Was part of 0x006DFA00

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -817,6 +817,32 @@ bool scenery_is_invented(uint16 sceneryItem)
     return invented;
 }
 
+bool scenery_set_is_invented(sint32 scenerySetIndex)
+{
+    auto invented = false;
+    const auto scenerySetEntry = get_scenery_group_entry(scenerySetIndex);
+    if (scenerySetEntry != nullptr && scenerySetEntry->entry_count > 0)
+    {
+        if (gCheatsIgnoreResearchStatus)
+        {
+            invented = true;
+        }
+        else
+        {
+            for (auto i = 0; i < scenerySetEntry->entry_count; i++)
+            {
+                auto sceneryEntryIndex = scenerySetEntry->scenery_entries[i];
+                if (scenery_is_invented(sceneryEntryIndex))
+                {
+                    invented = true;
+                    break;
+                }
+            }
+        }
+    }
+    return invented;
+}
+
 void reset_researched_scenery_items()
 {
     for (sint32 i = 0; i < MAX_RESEARCHED_SCENERY_ITEMS; i++)

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -817,11 +817,11 @@ bool scenery_is_invented(uint16 sceneryItem)
     return invented;
 }
 
-bool scenery_set_is_invented(sint32 scenerySetIndex)
+bool scenery_group_is_invented(sint32 sgIndex)
 {
     auto invented = false;
-    const auto scenerySetEntry = get_scenery_group_entry(scenerySetIndex);
-    if (scenerySetEntry != nullptr && scenerySetEntry->entry_count > 0)
+    const auto sgEntry = get_scenery_group_entry(sgIndex);
+    if (sgEntry != nullptr && sgEntry->entry_count > 0)
     {
         if (gCheatsIgnoreResearchStatus)
         {
@@ -829,9 +829,9 @@ bool scenery_set_is_invented(sint32 scenerySetIndex)
         }
         else
         {
-            for (auto i = 0; i < scenerySetEntry->entry_count; i++)
+            for (auto i = 0; i < sgEntry->entry_count; i++)
             {
-                auto sceneryEntryIndex = scenerySetEntry->scenery_entries[i];
+                auto sceneryEntryIndex = sgEntry->scenery_entries[i];
                 if (scenery_is_invented(sceneryEntryIndex))
                 {
                     invented = true;

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -118,6 +118,7 @@ void research_insert_scenery_group_entry(uint8 entryIndex, bool researched);
 bool ride_type_is_invented(sint32 rideType);
 bool ride_entry_is_invented(sint32 rideEntryIndex);
 bool track_piece_is_available_for_ride_type(uint8 rideType, sint32 trackType);
+bool scenery_set_is_invented(sint32 scenerySetIndex);
 bool scenery_is_invented(uint16 sceneryItem);
 void reset_researched_scenery_items();
 void reset_researched_ride_types_and_entries();

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -118,7 +118,7 @@ void research_insert_scenery_group_entry(uint8 entryIndex, bool researched);
 bool ride_type_is_invented(sint32 rideType);
 bool ride_entry_is_invented(sint32 rideEntryIndex);
 bool track_piece_is_available_for_ride_type(uint8 rideType, sint32 trackType);
-bool scenery_set_is_invented(sint32 scenerySetIndex);
+bool scenery_group_is_invented(sint32 sgIndex);
 bool scenery_is_invented(uint16 sceneryItem);
 void reset_researched_scenery_items();
 void reset_researched_ride_types_and_entries();

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1659,10 +1659,10 @@ uint32 staff_get_available_entertainer_costumes()
     uint32 entertainerCostumes = 0;
     for (sint32 i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
-        if (scenery_set_is_invented(i))
+        if (scenery_group_is_invented(i))
         {
-            rct_scenery_set_entry * scenery_entry = get_scenery_group_entry(i);
-            entertainerCostumes |= scenery_entry->entertainer_costumes;
+            const auto sgEntry = get_scenery_group_entry(i);
+            entertainerCostumes |= sgEntry->entertainer_costumes;
         }
     }
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1656,12 +1656,10 @@ bool staff_set_colour(uint8 staffType, colour_t value)
 
 uint32 staff_get_available_entertainer_costumes()
 {
-    init_scenery();
-
     uint32 entertainerCostumes = 0;
     for (sint32 i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
-        if (window_scenery_tab_entries[i][0] != -1)
+        if (scenery_set_is_invented(i))
         {
             rct_scenery_set_entry * scenery_entry = get_scenery_group_entry(i);
             entertainerCostumes |= scenery_entry->entertainer_costumes;

--- a/src/openrct2/windows/_legacy.c
+++ b/src/openrct2/windows/_legacy.c
@@ -77,9 +77,6 @@ const rct_object_entry DefaultSelectedObjects[26] = {
         { 0x00000087, { "SCGWATER" }, 0 }       // Water Feature Theming
 };
 
-// rct2: 0x00F64F2C
-sint16 window_scenery_tab_entries[SCENERY_WINDOW_TABS][SCENERY_ENTRIES_BY_TAB + 1];
-
 void game_command_callback_pickup_guest(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
 {
     switch (ecx)

--- a/src/openrct2/world/scenery.h
+++ b/src/openrct2/world/scenery.h
@@ -32,8 +32,6 @@
 #define SCENERY_PATH_SCENERY_ID_MIN  0x100
 #define SCENERY_PATH_SCENERY_ID_MAX  0x10F
 
-#define SCENERY_WINDOW_TABS 20 // (MAX_SCENERY_GROUP_OBJECTS + 1). The + 1 is for the 'Miscellaneous' tab
-
 #pragma pack(push, 1)
 typedef struct rct_small_scenery_entry {
     uint32 flags;           // 0x06
@@ -296,8 +294,6 @@ extern sint16 gSceneryCtrlPressZ;
 extern uint8 gSceneryGroundFlags;
 
 extern const LocationXY8 ScenerySubTileOffsets[];
-
-extern sint16 window_scenery_tab_entries[SCENERY_WINDOW_TABS][SCENERY_ENTRIES_BY_TAB + 1];
 
 extern money32 gClearSceneryCost;
 


### PR DESCRIPTION
This fixes the `#define` issue in #6674, ultimately it has now been moved to the scenery window reducing the hard dependency on the scenery tabs altogether.

> Remove hard dependency on scenery window by calling a new is scenery set invented function. I don't think this the performance is any worse as it called init_scenery anyway for every call to get_available_entertainers.