### PR TITLE
Reduce vertical spacing of vehicle info in ride window

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2919,7 +2919,7 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     // Description
     y += gfx_draw_string_left_wrapped(dpi, &rideEntry->naming.description, x, y, 300, STR_BLACK_STRING, COLOUR_BLACK);
-    y += 5;
+    y += 2;
 
     // Capacity
     void * loadedObject = object_manager_get_loaded_object_by_index(ride->subtype);
@@ -2930,7 +2930,7 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
         set_format_arg(2, utf8 *, capacity);
         gfx_draw_string_left(dpi, STR_CAPACITY, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
-    y += 5;
+    y += 2;
 
     if (!(rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE) || rideTypeShouldLoseSeparateFlag(rideEntry)) {
         // Excitement Factor


### PR DESCRIPTION
This fixes an original bug where the 'E/I/N factor: +X%' text would overlap the vehicle preview if all three factors were displayed under a three-line vehicle description.

**Before**
![chrome_2017-11-20_18-34-00](https://user-images.githubusercontent.com/16639257/33034968-6eb8ed62-ce21-11e7-8b50-b7f043e21c20.png)

**After**
![openrct2_2017-11-20_18-31-33](https://user-images.githubusercontent.com/16639257/33034973-72ce63dc-ce21-11e7-9ec6-8917d468d91f.png)
