### PR TITLE
Add ability to search object by filename

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,10 +17,10 @@
 - Feature: [#6411] Add command to remove the park fence.
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
 - Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
+- Feature: [#6516] Ability to search by filename in the object selection window.
 - Feature: [#6530] Land rights tool no longer blocks when a tile is not for purchase.
 - Feature: [#6568] Add smooth nearest neighbour scaling.
 - Feature: [#6651, #6658] Integrate Discord Rich Presence.
-- Feature: [#6713] Add ability to search object by filename.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Feature: [#6530] Land rights tool no longer blocks when a tile is not for purchase.
 - Feature: [#6568] Add smooth nearest neighbour scaling.
 - Feature: [#6651, #6658] Integrate Discord Rich Presence.
+- Feature: [#6713] Add ability to search object by filename.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).

--- a/src/openrct2/windows/EditorObjectSelection.cpp
+++ b/src/openrct2/windows/EditorObjectSelection.cpp
@@ -824,7 +824,6 @@ static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetinde
         break;
     }
     case WIDX_FILTER_STRING_BUTTON:
-        //window_text_input_open(w, widgetIndex, STR_OBJECT_SEARCH, STR_OBJECT_SEARCH_DESC, STR_STRING, (uint32)_filter_string, 40);
         window_start_textbox(w, widgetIndex, STR_STRING, _filter_string, sizeof(_filter_string));
         break;
     case WIDX_FILTER_CLEAR_BUTTON:
@@ -1734,13 +1733,7 @@ static void window_editor_object_selection_textinput(rct_window *w, rct_widgetin
     if (strcmp(_filter_string, text) == 0)
         return;
 
-    if (strlen(text) == 0) {
-        memset(_filter_string, 0, sizeof(_filter_string));
-    }
-    else {
-        memset(_filter_string, 0, sizeof(_filter_string));
-        safe_strcpy(_filter_string, text, sizeof(_filter_string));
-    }
+    safe_strcpy(_filter_string, text, sizeof(_filter_string));
 
     filter_update_counts();
 

--- a/src/openrct2/windows/EditorObjectSelection.cpp
+++ b/src/openrct2/windows/EditorObjectSelection.cpp
@@ -61,7 +61,7 @@ enum {
 static uint32 _filter_flags;
 static uint16 _filter_object_counts[11];
 
-static char _filter_string[41];
+static char _filter_string[MAX_PATH];
 
 #define _FILTER_ALL ((_filter_flags & FILTER_ALL) == FILTER_ALL)
 #define _FILTER_RCT2 (_filter_flags & FILTER_RCT2)
@@ -825,7 +825,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetinde
     }
     case WIDX_FILTER_STRING_BUTTON:
         //window_text_input_open(w, widgetIndex, STR_OBJECT_SEARCH, STR_OBJECT_SEARCH_DESC, STR_STRING, (uint32)_filter_string, 40);
-        window_start_textbox(w, widgetIndex, STR_STRING, _filter_string, 40);
+        window_start_textbox(w, widgetIndex, STR_STRING, _filter_string, sizeof(_filter_string));
         break;
     case WIDX_FILTER_CLEAR_BUTTON:
         memset(_filter_string, 0, sizeof(_filter_string));
@@ -1783,9 +1783,11 @@ static bool filter_string(const ObjectRepositoryItem * item)
     // Get object name (ride/vehicle for rides) and type name (rides only)
     char name_lower[MAX_PATH];
     char type_lower[MAX_PATH];
+    char object_path[MAX_PATH];
     char filter_lower[sizeof(_filter_string)];
     safe_strcpy(name_lower, name, MAX_PATH);
     safe_strcpy(type_lower, rideTypeName, MAX_PATH);
+    safe_strcpy(object_path, item->Path, MAX_PATH);
     safe_strcpy(filter_lower, _filter_string, sizeof(_filter_string));
 
     // Make use of lowercase characters only
@@ -1793,10 +1795,17 @@ static bool filter_string(const ObjectRepositoryItem * item)
         name_lower[i] = (char)tolower(name_lower[i]);
     for (sint32 i = 0; type_lower[i] != '\0'; i++)
         type_lower[i] = (char)tolower(type_lower[i]);
+    for (sint32 i = 0; object_path[i] != '\0'; i++)
+        object_path[i] = (char)tolower(object_path[i]);
     for (sint32 i = 0; filter_lower[i] != '\0'; i++)
         filter_lower[i] = (char)tolower(filter_lower[i]);
 
-    return strstr(name_lower, filter_lower) != nullptr || (((item->ObjectEntry.flags & 0x0F) == OBJECT_TYPE_RIDE) && strstr(type_lower, filter_lower) != nullptr);
+    // Check if the searched string exists in the name, ride type, or filename
+    bool inName = strstr(name_lower, filter_lower) != nullptr;
+    bool inRideType = ((item->ObjectEntry.flags & 0x0F) == OBJECT_TYPE_RIDE) && strstr(type_lower, filter_lower) != nullptr;
+    bool inPath = strstr(object_path, filter_lower) != nullptr;
+
+    return inName || inRideType || inPath;
 }
 
 static bool filter_source(const ObjectRepositoryItem * item)


### PR DESCRIPTION
This PR also increases the max length of the filter string from 40 to `MAX_PATH`, so that entire paths can be pasted inside the search box.