### PR TITLE
Add optional screenshot argument to set weather

### DIFF
--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -17,18 +17,33 @@
 #include "../interface/Screenshot.h"
 #include "CommandLine.hpp"
 
+extern "C"
+{
+    sint32 gScreenshotWeather = 0;
+}
+
+static uint32 _weather = 0;
+
+static const CommandLineOptionDefinition ScreenshotOptions[]
+{
+    { CMDLINE_TYPE_INTEGER, &_weather, NAC, "weather", "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    OptionTableEnd
+};
+
 static exitcode_t HandleScreenshot(CommandLineArgEnumerator *argEnumerator);
 
 const CommandLineCommand CommandLine::ScreenshotCommands[]
 {
     // Main commands
-    DefineCommand("", "<file> <output_image> <width> <height> [<x> <y> <zoom> <rotation>]", nullptr, HandleScreenshot),
-    DefineCommand("", "<file> <output_image> giant <zoom> <rotation>",                      nullptr, HandleScreenshot),
+    DefineCommand("", "<file> <output_image> <width> <height> [<x> <y> <zoom> <rotation>]", ScreenshotOptions, HandleScreenshot),
+    DefineCommand("", "<file> <output_image> giant <zoom> <rotation>",                      ScreenshotOptions, HandleScreenshot),
     CommandTableEnd
 };
 
 static exitcode_t HandleScreenshot(CommandLineArgEnumerator *argEnumerator)
 {
+    gScreenshotWeather = _weather;
+
     const char * * argv = (const char * *)argEnumerator->GetArguments() + argEnumerator->GetIndex();
     sint32 argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
     sint32 result = cmdline_for_screenshot(argv, argc);

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -348,17 +348,28 @@ sint32 cmdline_for_gfxbench(const char **argv, sint32 argc)
 
 sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
 {
-    bool giantScreenshot = (argc == 5 || argc == 6) && _stricmp(argv[2], "giant") == 0;
-    if (argc != 4 && argc != 5 && argc != 8 && argc != 9 && !giantScreenshot) {
-        printf("Usage: openrct2 screenshot <file> <ouput_image> <width> <height> [<x> <y> <zoom> <rotation>] [<weather>]\n");
-        printf("Usage: openrct2 screenshot <file> <ouput_image> giant <zoom> <rotation> [<weather>]\n");
+    // Don't include options in the count (they have been handled by CommandLine::ParseOptions already)
+    for (sint32 i = 0; i < argc; i++)
+    {
+        if (argv[i][0] == '-')
+        {
+            // Setting argc to i works, because options can only be at the end of the command
+            argc = i;
+            break;
+        }
+    }
+
+    bool giantScreenshot = (argc == 5) && _stricmp(argv[2], "giant") == 0;
+    if (argc != 4 && argc != 8 && !giantScreenshot) {
+        std::printf("Usage: openrct2 screenshot <file> <ouput_image> <width> <height> [<x> <y> <zoom> <rotation>]\n");
+        std::printf("Usage: openrct2 screenshot <file> <ouput_image> giant <zoom> <rotation>\n");
         return -1;
     }
 
     bool customLocation = false;
     bool centreMapX = false;
     bool centreMapY = false;
-    sint32 resolutionWidth, resolutionHeight, customX = 0, customY = 0, customZoom, customRotation = 0, customWeather = -1;
+    sint32 resolutionWidth, resolutionHeight, customX = 0, customY = 0, customZoom, customRotation = 0;
 
     const char *inputPath = argv[0];
     const char *outputPath = argv[1];
@@ -371,20 +382,19 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
         centreMapY = true;
         customZoom = atoi(argv[3]);
         customRotation = atoi(argv[4]) & 3;
-        if (argc == 6)
-            customWeather = atoi(argv[5]);
     }
     else
     {
         resolutionWidth = atoi(argv[2]);
         resolutionHeight = atoi(argv[3]);
-        if (argc >= 8)
+        if (argc == 8)
         {
             customLocation = true;
             if (argv[4][0] == 'c')
                 centreMapX = true;
             else
                 customX = atoi(argv[4]);
+
             if (argv[5][0] == 'c')
                 centreMapY = true;
             else
@@ -392,14 +402,10 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
 
             customZoom = atoi(argv[6]);
             customRotation = atoi(argv[7]) & 3;
-            if (argc == 9)
-                customWeather = atoi(argv[8]);
         }
         else
         {
             customZoom = 0;
-            if (argc == 5)
-                customWeather = atoi(argv[4]);
         }
     }
 
@@ -408,7 +414,18 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
     if (context->Initialise())
     {
         drawing_engine_init();
-        context->LoadParkFromFile(inputPath);
+
+        try
+        {
+            context->LoadParkFromFile(inputPath);
+        }
+        catch (const std::exception &e)
+        {
+            std::printf("%s", e.what());
+            drawing_engine_dispose();
+            delete context;
+            return -1;
+        }
 
         gIntroState = INTRO_STATE_NONE;
         gScreenFlags = SCREEN_FLAGS_PLAYING;
@@ -470,14 +487,15 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
             gCurrentRotation = gSavedViewRotation;
         }
 
-        if (customWeather != -1)
+        if (gScreenshotWeather != 0)
         {
-            if (customWeather < -1 || customWeather >= 6)
+            if (gScreenshotWeather < 1 || gScreenshotWeather > 6)
             {
-                printf("Weather can only be set to an integer value from 0 till 5.");
+                printf("Weather can only be set to an integer value from 1 till 6.");
                 return -1;
             }
 
+            uint8 customWeather = gScreenshotWeather - 1;
             climate_force_weather(customWeather);
         }
 

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <chrono>
+#include <cstdlib>
 #include "../audio/audio.h"
 #include "../Context.h"
 #include "../core/Console.hpp"
@@ -380,28 +381,28 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
         customLocation = true;
         centreMapX = true;
         centreMapY = true;
-        customZoom = atoi(argv[3]);
-        customRotation = atoi(argv[4]) & 3;
+        customZoom = std::atoi(argv[3]);
+        customRotation = std::atoi(argv[4]) & 3;
     }
     else
     {
-        resolutionWidth = atoi(argv[2]);
-        resolutionHeight = atoi(argv[3]);
+        resolutionWidth = std::atoi(argv[2]);
+        resolutionHeight = std::atoi(argv[3]);
         if (argc == 8)
         {
             customLocation = true;
             if (argv[4][0] == 'c')
                 centreMapX = true;
             else
-                customX = atoi(argv[4]);
+                customX = std::atoi(argv[4]);
 
             if (argv[5][0] == 'c')
                 centreMapY = true;
             else
-                customY = atoi(argv[5]);
+                customY = std::atoi(argv[5]);
 
-            customZoom = atoi(argv[6]);
-            customRotation = atoi(argv[7]) & 3;
+            customZoom = std::atoi(argv[6]);
+            customRotation = std::atoi(argv[7]) & 3;
         }
         else
         {
@@ -421,7 +422,7 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
         }
         catch (const std::exception &e)
         {
-            std::printf("%s", e.what());
+            std::printf("%s\n", e.what());
             drawing_engine_dispose();
             delete context;
             return -1;
@@ -491,7 +492,9 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
         {
             if (gScreenshotWeather < 1 || gScreenshotWeather > 6)
             {
-                printf("Weather can only be set to an integer value from 1 till 6.");
+                std::printf("Weather can only be set to an integer value from 1 till 6.");
+                drawing_engine_dispose();
+                delete context;
                 return -1;
             }
 

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -25,6 +25,7 @@ extern "C"
 {
 #endif
     extern uint8 gScreenshotCountdown;
+    extern sint32 gScreenshotWeather;
 
     void screenshot_check();
     sint32 screenshot_dump();


### PR DESCRIPTION
This does not change the weather of the saved game, it only sets it for the screenshot. I figured this would be useful when automatically screenshotting parks.

0 = default (saved game weather)
1 = sunny
6 = thunderstorm

Here's a simple example of two screenshots made with the folling commands:

```
openrct2.com screenshot _DEBUGGING.sv6 _DEBUGGING0.png 400 280 --weather=1
openrct2.com screenshot _DEBUGGING.sv6 _DEBUGGING4.png 400 280 --weather=5
```

![](https://i.imgur.com/ie1o9g1.png)
![](https://i.imgur.com/sa8c3dk.png)