### PR TITLE
Performance improvements.

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -634,7 +634,7 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
     right += _clipLeft;
     bottom += _clipTop;
 
-    auto texture = _textureCache->GetOrLoadImageTexture(image);
+    const auto texture = _textureCache->GetOrLoadImageTexture(image);
 
     int paletteCount;
     ivec3 palettes{};
@@ -673,10 +673,10 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
         DrawRectCommand& command = _commandBuffers.transparent.allocate();
 
         command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
-        command.texColourAtlas = texture->index;
-        command.texColourBounds = texture->normalizedBounds;
-        command.texMaskAtlas = texture->index;
-        command.texMaskBounds = texture->normalizedBounds;
+        command.texColourAtlas = texture.index;
+        command.texColourBounds = texture.normalizedBounds;
+        command.texMaskAtlas = texture.index;
+        command.texMaskBounds = texture.normalizedBounds;
         command.palettes = palettes;
         command.colour = palettes.x - (special ? 1 : 0);
         command.bounds = { left, top, right, bottom };
@@ -688,8 +688,8 @@ void OpenGLDrawingContext::DrawSprite(uint32 image, sint32 x, sint32 y, uint32 t
         DrawRectCommand& command = _commandBuffers.rects.allocate();
 
         command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
-        command.texColourAtlas = texture->index;
-        command.texColourBounds = texture->normalizedBounds;
+        command.texColourAtlas = texture.index;
+        command.texColourBounds = texture.normalizedBounds;
         command.texMaskAtlas = 0;
         command.texMaskBounds = { 0.0f, 0.0f, 0.0f, 0.0f };
         command.palettes = palettes;
@@ -709,8 +709,8 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(sint32 x, sint32 y, uint32 maskIm
         return;
     }
 
-    auto textureMask = _textureCache->GetOrLoadImageTexture(maskImage);
-    auto textureColour = _textureCache->GetOrLoadImageTexture(colourImage);
+    const auto textureMask = _textureCache->GetOrLoadImageTexture(maskImage);
+    const auto textureColour = _textureCache->GetOrLoadImageTexture(colourImage);
 
     uint8 zoomLevel = (1 << _dpi->zoom_level);
 
@@ -751,10 +751,10 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(sint32 x, sint32 y, uint32 maskIm
     DrawRectCommand& command = _commandBuffers.rects.allocate();
 
     command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
-    command.texColourAtlas = textureColour->index;
-    command.texColourBounds = textureColour->normalizedBounds;
-    command.texMaskAtlas = textureMask->index;
-    command.texMaskBounds = textureMask->normalizedBounds;
+    command.texColourAtlas = textureColour.index;
+    command.texColourBounds = textureColour.normalizedBounds;
+    command.texMaskAtlas = textureMask.index;
+    command.texMaskBounds = textureMask.normalizedBounds;
     command.palettes = { 0, 0, 0 };
     command.flags = DrawRectCommand::FLAG_MASK;
     command.colour = 0;
@@ -773,7 +773,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(uint32 image, sint32 x, sint32 y, uin
         return;
     }
 
-    auto texture = _textureCache->GetOrLoadImageTexture(image);
+    const auto texture = _textureCache->GetOrLoadImageTexture(image);
 
     sint32 drawOffsetX = g1Element->x_offset;
     sint32 drawOffsetY = g1Element->y_offset;
@@ -804,8 +804,8 @@ void OpenGLDrawingContext::DrawSpriteSolid(uint32 image, sint32 x, sint32 y, uin
     command.clip = { _clipLeft, _clipTop, _clipRight, _clipBottom };
     command.texColourAtlas = 0;
     command.texColourBounds = { 0.0f, 0.0f, 0.0f, 0.0f };
-    command.texMaskAtlas = texture->index;
-    command.texMaskBounds = texture->normalizedBounds;
+    command.texMaskAtlas = texture.index;
+    command.texMaskBounds = texture.normalizedBounds;
     command.palettes = { 0, 0, 0 };
     command.flags = DrawRectCommand::FLAG_NO_TEXTURE | DrawRectCommand::FLAG_MASK;
     command.colour = colour & 0xFF;
@@ -821,7 +821,7 @@ void OpenGLDrawingContext::DrawGlyph(uint32 image, sint32 x, sint32 y, uint8 * p
         return;
     }
 
-    auto texture = _textureCache->GetOrLoadGlyphTexture(image, palette);
+    const auto texture = _textureCache->GetOrLoadGlyphTexture(image, palette);
 
     sint32 drawOffsetX = g1Element->x_offset;
     sint32 drawOffsetY = g1Element->y_offset;

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -23,6 +23,13 @@
 
 #include <openrct2/drawing/Drawing.h>
 
+constexpr uint32 UNUSED_INDEX = 0xFFFFFFFF;
+
+TextureCache::TextureCache()
+{
+    std::fill(_indexMap.begin(), _indexMap.end(), UNUSED_INDEX);
+}
+
 TextureCache::~TextureCache()
 {
     FreeTextures();
@@ -30,31 +37,61 @@ TextureCache::~TextureCache()
 
 void TextureCache::InvalidateImage(uint32 image)
 {
-    auto kvp = _imageTextureMap.find(image);
-    if (kvp != _imageTextureMap.end())
+    uint32 index = _indexMap[image];
+    if (index == UNUSED_INDEX)
+        return;
+
+    AtlasTextureInfo& elem = _textureCache.at(index);
+
+    _atlases[elem.index].Free(elem);
+    _indexMap[image] = UNUSED_INDEX;
+
+    if (index == _textureCache.size() - 1)
     {
-        _atlases[kvp->second.index].Free(kvp->second);
-        _imageTextureMap.erase(kvp);
+        // Last element can be popped back.
+        _textureCache.pop_back();
+    }
+    else
+    {
+        // Swap last element with element to erase and then pop back.
+        AtlasTextureInfo& last = _textureCache.back();
+
+        // Move last to current.
+        elem = last;
+
+        // Change index for moved element.
+        _indexMap[last.image] = index;
+
+        _textureCache.pop_back();
     }
 }
 
-const CachedTextureInfo* TextureCache::GetOrLoadImageTexture(uint32 image)
+BasicTextureInfo TextureCache::GetOrLoadImageTexture(uint32 image)
 {
     image &= 0x7FFFF;
 
-    auto kvp = _imageTextureMap.find(image);
-    if (kvp != _imageTextureMap.end())
+    uint32 index = _indexMap[image];
+    if (index != UNUSED_INDEX)
     {
-        return &kvp->second;
+        const auto& info = _textureCache[index];
+        return
+        {
+            info.index,
+            info.normalizedBounds,
+        };
     }
 
-    auto cacheInfo = LoadImageTexture(image);
-    auto cacheItr = _imageTextureMap.insert(std::make_pair(image, cacheInfo));
+    index = (uint32)_textureCache.size();
 
-    return &(cacheItr.first->second);
+    AtlasTextureInfo info = LoadImageTexture(image);
+
+    _textureCache.push_back(info);
+    _indexMap[image] = index;
+
+    return info;
 }
 
-CachedTextureInfo TextureCache::GetOrLoadGlyphTexture(uint32 image, uint8 * palette)
+BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(uint32 image, uint8 * palette)
 {
     GlyphId glyphId;
     glyphId.Image = image;
@@ -63,13 +100,18 @@ CachedTextureInfo TextureCache::GetOrLoadGlyphTexture(uint32 image, uint8 * pale
     auto kvp = _glyphTextureMap.find(glyphId);
     if (kvp != _glyphTextureMap.end())
     {
-        return kvp->second;
+        const auto& info = kvp->second;
+        return
+        {
+            info.index,
+            info.normalizedBounds,
+        };
     }
 
     auto cacheInfo = LoadGlyphTexture(image, palette);
-    _glyphTextureMap[glyphId] = cacheInfo;
+    auto it = _glyphTextureMap.insert(std::make_pair(glyphId, cacheInfo));
 
-    return cacheInfo;
+    return (*it.first).second;
 }
 
 void TextureCache::CreateTextures()
@@ -149,33 +191,27 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
     _atlasesTextureIndices = newIndices;
 }
 
-CachedTextureInfo TextureCache::LoadImageTexture(uint32 image)
+AtlasTextureInfo TextureCache::LoadImageTexture(uint32 image)
 {
     rct_drawpixelinfo dpi = GetImageAsDPI(image, 0);
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
+    cacheInfo.image = image;
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
     glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, dpi.width, dpi.height, 1, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
 
     DeleteDPI(dpi);
 
-    cacheInfo.computedBounds = 
-    {
-        cacheInfo.normalizedBounds.x,
-        cacheInfo.normalizedBounds.y,
-        (cacheInfo.normalizedBounds.z - cacheInfo.normalizedBounds.x) / (float)(cacheInfo.bounds.z - cacheInfo.bounds.x),
-        (cacheInfo.normalizedBounds.w - cacheInfo.normalizedBounds.y) / (float)(cacheInfo.bounds.w - cacheInfo.bounds.y)
-    };
-
     return cacheInfo;
 }
 
-CachedTextureInfo TextureCache::LoadGlyphTexture(uint32 image, uint8 * palette)
+AtlasTextureInfo TextureCache::LoadGlyphTexture(uint32 image, uint8 * palette)
 {
     rct_drawpixelinfo dpi = GetGlyphAsDPI(image, palette);
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
+    cacheInfo.image = image;
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
     glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, cacheInfo.bounds.x, cacheInfo.bounds.y, cacheInfo.index, dpi.width, dpi.height, 1, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
@@ -185,7 +221,7 @@ CachedTextureInfo TextureCache::LoadGlyphTexture(uint32 image, uint8 * palette)
     return cacheInfo;
 }
 
-CachedTextureInfo TextureCache::AllocateImage(sint32 imageWidth, sint32 imageHeight)
+AtlasTextureInfo TextureCache::AllocateImage(sint32 imageWidth, sint32 imageHeight)
 {
     CreateTextures();
 
@@ -247,7 +283,8 @@ void TextureCache::FreeTextures()
 {
     // Free array texture
     glDeleteTextures(1, &_atlasesTexture);
-    _imageTextureMap.clear();
+    _textureCache.clear();
+    std::fill(_indexMap.begin(), _indexMap.end(), UNUSED_INDEX);
 }
 
 rct_drawpixelinfo TextureCache::CreateDPI(sint32 width, sint32 height)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -164,13 +164,13 @@ static paint_struct * sub_9819_c(paint_session * session, uint32 image_id, Locat
         break;
     }
 
-    ps->bound_box_x_end = boundBoxSize.x + boundBoxOffset.x + session->SpritePosition.x;
-    ps->bound_box_z = boundBoxOffset.z;
-    ps->bound_box_z_end = boundBoxOffset.z + boundBoxSize.z;
-    ps->bound_box_y_end = boundBoxSize.y + boundBoxOffset.y + session->SpritePosition.y;
+    ps->bounds.x_end = boundBoxSize.x + boundBoxOffset.x + session->SpritePosition.x;
+    ps->bounds.z = boundBoxOffset.z;
+    ps->bounds.z_end = boundBoxOffset.z + boundBoxSize.z;
+    ps->bounds.y_end = boundBoxSize.y + boundBoxOffset.y + session->SpritePosition.y;
     ps->flags = 0;
-    ps->bound_box_x = boundBoxOffset.x + session->SpritePosition.x;
-    ps->bound_box_y = boundBoxOffset.y + session->SpritePosition.y;
+    ps->bounds.x = boundBoxOffset.x + session->SpritePosition.x;
+    ps->bounds.y = boundBoxOffset.y + session->SpritePosition.y;
     ps->attached_ps = nullptr;
     ps->var_20 = nullptr;
     ps->sprite_type = session->InteractionType;
@@ -294,36 +294,58 @@ void paint_session_generate(paint_session * session)
     }
 }
 
-static bool is_bbox_intersecting(uint8 rotation, const paint_struct_bound_box& initialBBox,
+template<uint8_t> static bool check_bounding_box(const paint_struct_bound_box& initialBBox,
     const paint_struct_bound_box& currentBBox)
 {
-    bool result = false;
-    switch (rotation) {
-    case 0:
-        if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end >= currentBBox.x
-            && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x < currentBBox.x_end))
-            result = true;
-        break;
-    case 1:
-        if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end < currentBBox.x
-            && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
-            result = true;
-        break;
-    case 2:
-        if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end < currentBBox.x
-            && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
-            result = true;
-        break;
-    case 3:
-        if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end >= currentBBox.x
-            && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x < currentBBox.x_end))
-            result = true;
-        break;
-    }
-    return result;
+    return false;
 }
 
-paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadrantIndex, uint8 flag)
+template<> bool check_bounding_box<0>(const paint_struct_bound_box& initialBBox,
+    const paint_struct_bound_box& currentBBox)
+{
+    if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end >= currentBBox.x
+        && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x < currentBBox.x_end))
+    {
+        return true;
+    }
+    return false;
+}
+
+template<> bool check_bounding_box<1>(const paint_struct_bound_box& initialBBox,
+    const paint_struct_bound_box& currentBBox)
+{
+    if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end < currentBBox.x
+        && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
+    {
+        return true;
+    }
+    return false;
+}
+
+template<> bool check_bounding_box<2>(const paint_struct_bound_box& initialBBox,
+    const paint_struct_bound_box& currentBBox)
+{
+    if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end < currentBBox.x
+        && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
+    {
+        return true;
+    }
+    return false;
+}
+
+template<> bool check_bounding_box<3>(const paint_struct_bound_box& initialBBox,
+    const paint_struct_bound_box& currentBBox)
+{
+    if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end >= currentBBox.x
+        && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x < currentBBox.x_end))
+    {
+        return true;
+    }
+    return false;
+}
+
+template<uint8 _TRotation>
+static paint_struct * paint_arrange_structs_helper_rotation(paint_struct * ps_next, uint16 quadrantIndex, uint8 flag)
 {
     paint_struct * ps;
     paint_struct * ps_temp;
@@ -357,7 +379,6 @@ paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadr
     } while (ps->quadrant_index <= quadrantIndex + 1);
     ps = ps_temp;
 
-    uint8 rotation = get_current_rotation();
     while (true)
     {
         while (true)
@@ -372,16 +393,7 @@ paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadr
         ps_next->quadrant_flags &= ~PAINT_QUADRANT_FLAG_IDENTICAL;
         ps_temp = ps;
 
-        const paint_struct_bound_box initialBBox =
-        {
-            ps_next->bound_box_x,
-            ps_next->bound_box_y,
-            ps_next->bound_box_z,
-            ps_next->bound_box_x_end,
-            ps_next->bound_box_y_end,
-            ps_next->bound_box_z_end
-        };
-
+        const paint_struct_bound_box& initialBBox = ps_next->bounds;
 
         while (true)
         {
@@ -391,17 +403,9 @@ paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadr
             if (ps_next->quadrant_flags & PAINT_QUADRANT_FLAG_BIGGER) break;
             if (!(ps_next->quadrant_flags & PAINT_QUADRANT_FLAG_NEXT)) continue;
 
-            const paint_struct_bound_box currentBBox =
-            {
-                ps_next->bound_box_x,
-                ps_next->bound_box_y,
-                ps_next->bound_box_z,
-                ps_next->bound_box_x_end,
-                ps_next->bound_box_y_end,
-                ps_next->bound_box_z_end
-            };
+            const paint_struct_bound_box& currentBBox = ps_next->bounds;
 
-            bool compareResult = is_bbox_intersecting(rotation, initialBBox, currentBBox);
+            const bool compareResult = check_bounding_box<_TRotation>(initialBBox, currentBBox);
 
             if (compareResult)
             {
@@ -417,6 +421,22 @@ paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadr
     }
 }
 
+paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadrantIndex, uint8 flag, uint8 rotation)
+{
+    switch (rotation)
+    {
+    case 0:
+        return paint_arrange_structs_helper_rotation<0>(ps_next, quadrantIndex, flag);
+    case 1:
+        return paint_arrange_structs_helper_rotation<1>(ps_next, quadrantIndex, flag);
+    case 2:
+        return paint_arrange_structs_helper_rotation<2>(ps_next, quadrantIndex, flag);
+    case 3:
+        return paint_arrange_structs_helper_rotation<3>(ps_next, quadrantIndex, flag);
+    }
+    return nullptr;
+}
+
 /**
 *
 *  rct2: 0x00688217
@@ -427,6 +447,7 @@ paint_struct paint_session_arrange(paint_session * session)
     paint_struct * ps = &psHead;
     ps->next_quadrant_ps = nullptr;
     uint32 quadrantIndex = session->QuadrantBackIndex;
+    const uint8 rotation = get_current_rotation();
     if (quadrantIndex != UINT32_MAX)
     {
         do
@@ -439,18 +460,20 @@ paint_struct paint_session_arrange(paint_session * session)
                 {
                     ps = ps_next;
                     ps_next = ps_next->next_quadrant_ps;
+
                 } while (ps_next != nullptr);
             }
         } while (++quadrantIndex <= session->QuadrantFrontIndex);
 
-        paint_struct * ps_cache = paint_arrange_structs_helper(&psHead, session->QuadrantBackIndex & 0xFFFF, PAINT_QUADRANT_FLAG_NEXT);
+        paint_struct * ps_cache = paint_arrange_structs_helper(&psHead, session->QuadrantBackIndex & 0xFFFF, PAINT_QUADRANT_FLAG_NEXT, rotation);
 
         quadrantIndex = session->QuadrantBackIndex;
         while (++quadrantIndex < session->QuadrantFrontIndex)
         {
-            ps_cache = paint_arrange_structs_helper(ps_cache, quadrantIndex & 0xFFFF, 0);
+            ps_cache = paint_arrange_structs_helper(ps_cache, quadrantIndex & 0xFFFF, 0, rotation);
         }
     }
+
     return psHead;
 }
 
@@ -535,65 +558,65 @@ static void paint_ps_image_with_bounding_boxes(rct_drawpixelinfo * dpi, paint_st
 
     const LocationXYZ16 frontTop =
     {
-        (sint16)ps->bound_box_x_end,
-        (sint16)ps->bound_box_y_end,
-        (sint16)ps->bound_box_z_end
+        (sint16)ps->bounds.x_end,
+        (sint16)ps->bounds.y_end,
+        (sint16)ps->bounds.z_end
     };
     const LocationXY16 screenCoordFrontTop = coordinate_3d_to_2d(&frontTop, rotation);
 
     const LocationXYZ16 frontBottom =
     {
-        (sint16)ps->bound_box_x_end,
-        (sint16)ps->bound_box_y_end,
-        (sint16)ps->bound_box_z
+        (sint16)ps->bounds.x_end,
+        (sint16)ps->bounds.y_end,
+        (sint16)ps->bounds.z
     };
     const LocationXY16 screenCoordFrontBottom = coordinate_3d_to_2d(&frontBottom, rotation);
 
     const LocationXYZ16 leftTop =
     {
-        (sint16)ps->bound_box_x,
-        (sint16)ps->bound_box_y_end,
-        (sint16)ps->bound_box_z_end
+        (sint16)ps->bounds.x,
+        (sint16)ps->bounds.y_end,
+        (sint16)ps->bounds.z_end
     };
     const LocationXY16 screenCoordLeftTop = coordinate_3d_to_2d(&leftTop, rotation);
 
     const LocationXYZ16 leftBottom =
     {
-        (sint16)ps->bound_box_x,
-        (sint16)ps->bound_box_y_end,
-        (sint16)ps->bound_box_z
+        (sint16)ps->bounds.x,
+        (sint16)ps->bounds.y_end,
+        (sint16)ps->bounds.z
     };
     const LocationXY16 screenCoordLeftBottom = coordinate_3d_to_2d(&leftBottom, rotation);
 
     const LocationXYZ16 rightTop =
     {
-        (sint16)ps->bound_box_x_end,
-        (sint16)ps->bound_box_y,
-        (sint16)ps->bound_box_z_end
+        (sint16)ps->bounds.x_end,
+        (sint16)ps->bounds.y,
+        (sint16)ps->bounds.z_end
     };
     const LocationXY16 screenCoordRightTop = coordinate_3d_to_2d(&rightTop, rotation);
 
     const LocationXYZ16 rightBottom =
     {
-        (sint16)ps->bound_box_x_end,
-        (sint16)ps->bound_box_y,
-        (sint16)ps->bound_box_z
+        (sint16)ps->bounds.x_end,
+        (sint16)ps->bounds.y,
+        (sint16)ps->bounds.z
     };
     const LocationXY16 screenCoordRightBottom = coordinate_3d_to_2d(&rightBottom, rotation);
 
     const LocationXYZ16 backTop =
     {
-        (sint16)ps->bound_box_x,
-        (sint16)ps->bound_box_y,
-        (sint16)ps->bound_box_z_end
+        (sint16)ps->bounds.x,
+        (sint16)ps->bounds.y,
+        (sint16)ps->bounds.z_end
     };
     const LocationXY16 screenCoordBackTop = coordinate_3d_to_2d(&backTop, rotation);
 
     const LocationXYZ16 backBottom =
     {
-        (sint16)ps->bound_box_x,
-        (sint16)ps->bound_box_y,
-        (sint16)ps->bound_box_z
+        (sint16)ps->bounds.x,
+        (sint16)ps->bounds.y,
+        (sint16)ps->bounds.z
     };
     const LocationXY16 screenCoordBackBottom = coordinate_3d_to_2d(&backBottom, rotation);
 
@@ -805,12 +828,12 @@ extern "C"
         coord_3d.x += session->SpritePosition.x;
         coord_3d.y += session->SpritePosition.y;
 
-        ps->bound_box_x_end = coord_3d.x + boundBox.x;
-        ps->bound_box_y_end = coord_3d.y + boundBox.y;
+        ps->bounds.x_end = coord_3d.x + boundBox.x;
+        ps->bounds.y_end = coord_3d.y + boundBox.y;
 
         // TODO: check whether this is right. edx is ((bound_box_length_z + z_offset) << 16 | z_offset)
-        ps->bound_box_z = coord_3d.z;
-        ps->bound_box_z_end = (boundBox.z + coord_3d.z);
+        ps->bounds.z = coord_3d.z;
+        ps->bounds.z_end = (boundBox.z + coord_3d.z);
 
         LocationXY16 map = coordinate_3d_to_2d(&coord_3d, rotation);
 
@@ -831,8 +854,8 @@ extern "C"
         if (bottom >= (dpi->y + dpi->height)) return nullptr;
 
         ps->flags = 0;
-        ps->bound_box_x = coord_3d.x;
-        ps->bound_box_y = coord_3d.y;
+        ps->bounds.x = coord_3d.x;
+        ps->bounds.y = coord_3d.y;
         ps->attached_ps = nullptr;
         ps->var_20 = nullptr;
         ps->sprite_type = session->InteractionType;
@@ -907,8 +930,8 @@ extern "C"
 
         LocationXY16 attach =
         {
-            (sint16)ps->bound_box_x,
-            (sint16)ps->bound_box_y
+            (sint16)ps->bounds.x,
+            (sint16)ps->bounds.y
         };
 
         rotate_map_coordinates(&attach.x, &attach.y, rotation);

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -51,6 +51,15 @@ enum PAINT_QUADRANT_FLAGS {
     PAINT_QUADRANT_FLAG_NEXT = (1 << 1),
 };
 
+typedef struct paint_struct_bound_box {
+    uint16 x;
+    uint16 y;
+    uint16 z;
+    uint16 x_end;
+    uint16 y_end;
+    uint16 z_end;
+} paint_struct_bound_box;
+
 /* size 0x34 */
 struct paint_struct {
     uint32 image_id;        // 0x00
@@ -59,12 +68,7 @@ struct paint_struct {
         // If masked image_id is masked_id
         uint32 colour_image_id; // 0x04
     };
-    uint16 bound_box_x;     // 0x08
-    uint16 bound_box_y;     // 0x0A
-    uint16 bound_box_z; // 0x0C
-    uint16 bound_box_z_end; // 0x0E
-    uint16 bound_box_x_end; // 0x10
-    uint16 bound_box_y_end; // 0x12
+    paint_struct_bound_box bounds; // 0x08
     uint16 x;               // 0x14
     uint16 y;               // 0x16
     uint16 quadrant_index;
@@ -113,15 +117,6 @@ typedef struct sprite_bb {
     LocationXYZ16 bb_offset;
     LocationXYZ16 bb_size;
 } sprite_bb;
-
-typedef struct paint_struct_bound_box {
-    uint16 x;
-    uint16 y;
-    uint16 z;
-    uint16 x_end;
-    uint16 y_end;
-    uint16 z_end;
-} paint_struct_bound_box;
 
 enum PAINT_STRUCT_FLAGS {
     PAINT_STRUCT_FLAG_IS_MASKED = (1 << 0)
@@ -209,7 +204,7 @@ paint_session * paint_session_alloc(rct_drawpixelinfo * dpi);
 void paint_session_free(paint_session *);
 void paint_session_generate(paint_session * session);
 paint_struct paint_session_arrange(paint_session * session);
-paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadrantIndex, uint8 flag);
+paint_struct * paint_arrange_structs_helper(paint_struct * ps_next, uint16 quadrantIndex, uint8 flag, uint8 rotation);
 void paint_draw_structs(rct_drawpixelinfo * dpi, paint_struct * ps, uint32 viewFlags);
 void paint_draw_money_structs(rct_drawpixelinfo * dpi, paint_string_struct * ps);
 


### PR DESCRIPTION
In this PR we eliminate the unordered_map from the texture cache, we have a fixed space of possible images so we just use a fixed array. As for the bounding box test, I made it decide how to perform the bbox test before sorting which eliminates a lot of branching.

It would help if someone could test this on relatively old hardware where branch misses are quite impacting. I have a few other concepts planned but it would help if I could obtain some empirical evidence first. 

Consider this as a WIP 