### PR TITLE
Fix #6129: Guest List summary not updating after a ride rename

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6115] Random title screen music not random on launch.
 - Fix: [#6118, #6245, #6366] Tracked animated vehicles not animating.
+- Fix: [#6129] Guest List summary not updating after a ride rename.
 - Fix: [#6133] Construction rights not shown after selecting buy mode.
 - Fix: [#6188] Viewports not being clipped properly when zoomed out in OpenGL mode.
 - Fix: [#6193] All rings in Space Rings use the same secondary colour.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -267,9 +267,9 @@ public:
         }
     }
 
-    void BroadcastIntent(Intent * intent) override
+    void BroadcastIntent(const Intent &intent) override
     {
-        switch (intent->GetWindowClass())
+        switch (intent.GetWindowClass())
         {
         case INTENT_ACTION_MAP:
             window_map_reset();
@@ -316,6 +316,10 @@ public:
 
         case INTENT_ACTION_INVALIDATE_TICKER_NEWS:
             window_game_bottom_toolbar_invalidate_news_item();
+            break;
+
+        case INTENT_ACTION_REFRESH_GUEST_LIST:
+            window_guest_list_refresh_list();
             break;
         }
     }

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -106,10 +106,6 @@ static void window_ride_demolish_mouseup(rct_window *w, rct_widgetindex widgetIn
     case WIDX_DEMOLISH:
     {
         ride_demolish(w->number, GAME_COMMAND_FLAG_APPLY);
-
-        // Prevents demolished rides sticking around in the ride list window
-        auto intent = Intent(INTENT_ACTION_REFRESH_RIDE_LIST);
-        context_broadcast_intent(&intent);
         break;
     }
     case WIDX_CANCEL:

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -213,6 +213,13 @@ rct_window * window_guest_list_open()
     return window;
 }
 
+void window_guest_list_refresh_list()
+{
+    _window_guest_list_last_find_groups_wait = 0;
+    _window_guest_list_last_find_groups_tick = 0;
+    window_guest_list_find_groups();
+}
+
 /**
  *
  *  rct2: 0x006993BA

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -80,6 +80,7 @@ rct_window * window_new_campaign_open(sint16 campaignType);
 
 rct_window * window_install_track_open(const utf8* path);
 void window_guest_list_init_vars();
+void window_guest_list_refresh_list();
 rct_window * window_guest_list_open();
 rct_window * window_guest_list_open_with_filter(sint32 type, sint32 index);
 rct_window * window_staff_fire_prompt_open(rct_peep* peep);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1042,7 +1042,7 @@ extern "C"
     void context_broadcast_intent(Intent * intent)
     {
         auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
-        windowManager->BroadcastIntent(intent);
+        windowManager->BroadcastIntent(*intent);
     }
 
     void context_force_close_window_by_class(rct_windowclass windowClass)

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -16,14 +16,16 @@
 
 #pragma once
 
-#include "../core/MemoryStream.h"
-#include "GameAction.h"
-
 #include "../cheats.h"
+#include "../Context.h"
+#include "../core/MemoryStream.h"
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
 #include "../ride/ride.h"
+#include "../ui/UiContext.h"
+#include "../ui/WindowManager.h"
 #include "../world/park.h"
+#include "GameAction.h"
 
 struct RideDemolishAction : public GameActionBase<GAME_COMMAND_DEMOLISH_RIDE, GameActionResult>
 {
@@ -196,6 +198,7 @@ public:
             res->Position = { x, y, z };
         }
 
+        // Close windows related to the demolished ride
         if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED))
         {
             window_close_by_number(WC_RIDE_CONSTRUCTION, _rideIndex);
@@ -204,7 +207,10 @@ public:
         window_close_by_number(WC_DEMOLISH_RIDE_PROMPT, _rideIndex);
         window_close_by_class(WC_NEW_CAMPAIGN);
 
-        window_invalidate_by_class(WC_RIDE_LIST);
+        // Refresh windows that display the ride name
+        auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_GUEST_LIST));
 
         return res;
     }

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -16,14 +16,18 @@
 
 #pragma once
 
-#include "../core/MemoryStream.h"
-#include "../localisation/string_ids.h"
-#include "GameAction.h"
-
 #include "../cheats.h"
+#include "../Context.h"
+#include "../core/MemoryStream.h"
 #include "../interface/window.h"
 #include "../localisation/localisation.h"
+#include "../localisation/string_ids.h"
+#include "../ui/UiContext.h"
+#include "../ui/WindowManager.h"
 #include "../world/park.h"
+#include "GameAction.h"
+
+using namespace OpenRCT2;
 
 struct RideSetNameAction : public GameActionBase<GAME_COMMAND_SET_RIDE_NAME, GameActionResult>
 {
@@ -92,10 +96,10 @@ public:
 
         gfx_invalidate_screen();
 
-        // Force ride list window refresh
-        rct_window *w = window_find_by_class(WC_RIDE_LIST);
-        if (w != NULL)
-            w->no_list_items = 0;
+        // Refresh windows that display ride name
+        auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
+        windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_GUEST_LIST));
 
         auto res = std::make_unique<GameActionResult>();
         res->Position.x = ride->overall_view.x * 32 + 16;

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -26,7 +26,7 @@ namespace OpenRCT2 { namespace Ui
         rct_window * OpenDetails(uint8 type, sint32 id) override { return nullptr; }
         rct_window * ShowError(rct_string_id title, rct_string_id message) override { return nullptr; }
         rct_window * OpenIntent(Intent * intent) override { return nullptr; };
-        void BroadcastIntent(Intent * intent) override { }
+        void BroadcastIntent(const Intent &intent) override { }
         void ForceClose(rct_windowclass windowClass) override { }
         void UpdateMapTooltip() override { }
         void HandleKeyboard(bool isTitle) override { }

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -39,7 +39,7 @@ namespace OpenRCT2
             virtual rct_window * OpenView(uint8 view) abstract;
             virtual rct_window * OpenDetails(uint8 type, sint32 id) abstract;
             virtual rct_window * OpenIntent(Intent * intent) abstract;
-            virtual void BroadcastIntent(Intent * intent) abstract;
+            virtual void BroadcastIntent(const Intent &intent) abstract;
             virtual rct_window * ShowError(rct_string_id title, rct_string_id message) abstract;
             virtual void ForceClose(rct_windowclass windowClass) abstract;
             virtual void UpdateMapTooltip() abstract;

--- a/src/openrct2/windows/Intent.cpp
+++ b/src/openrct2/windows/Intent.cpp
@@ -62,7 +62,7 @@ Intent * Intent::putExtra(uint32 key, close_callback value)
     return this;
 }
 
-rct_windowclass Intent::GetWindowClass()
+rct_windowclass Intent::GetWindowClass() const
 {
     return this->_Class;
 }

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -30,7 +30,7 @@ private:
     std::map<uint32, IntentData> _Data;
 public:
     explicit Intent(rct_windowclass windowclass);
-    rct_windowclass GetWindowClass();
+    rct_windowclass GetWindowClass() const;
     void * GetPointerExtra(uint32 key);
     std::string GetStringExtra(uint32 key);
     uint32 GetUIntExtra(uint32 key);
@@ -82,6 +82,7 @@ extern "C" {
         INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG,
         INTENT_ACTION_REFRESH_SCENERY,
         INTENT_ACTION_INVALIDATE_TICKER_NEWS,
+        INTENT_ACTION_REFRESH_GUEST_LIST,
     };
 
     Intent *intent_create(rct_windowclass clss);


### PR DESCRIPTION
- Force refresh of ride list and guest list for both rename ride and demolish ride actions.