### PR TITLE
Make GCC aware Object class is not final

### DIFF
--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -64,7 +64,16 @@ const utf8 * Object::GetString(uint8 index) const
     return sz != nullptr ? sz : "";
 }
 
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
+#endif
+
 const utf8 * Object::GetName() const
 {
     return GetString(OBJ_STRING_ID_NAME);
 }
+
+#ifdef __WARN_SUGGEST_FINAL_METHODS__
+    #pragma GCC diagnostic pop
+#endif

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -47,6 +47,10 @@ interface IReadObjectContext
     virtual void LogError(uint32 code, const utf8 * text) abstract;
 };
 
+#ifdef __WARN_SUGGEST_FINAL_TYPES__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#endif
 class Object
 {
 private:
@@ -83,6 +87,9 @@ public:
 
     virtual void SetRepositoryItem(ObjectRepositoryItem * item) const { }
 };
+#ifdef __WARN_SUGGEST_FINAL_TYPES__
+    #pragma GCC diagnostic pop
+#endif
 
 enum OBJECT_ERROR : uint32
 {

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -50,6 +50,7 @@ interface IReadObjectContext
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wsuggest-final-types"
+    #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #endif
 class Object
 {


### PR DESCRIPTION
GCC suddenly decided `Object` should be marked as `final`, however it is
used as a base class for more specific types that inherit from it.