### PR TITLE
Trim object names when copying the missing objects list

### DIFF
--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -182,7 +182,7 @@ static void copy_object_names_to_clipboard(rct_window *w)
     }
 
     platform_place_string_on_clipboard(buffer);
-    delete buffer;
+    delete[] buffer;
 }
 
 rct_window * window_object_load_error_open(utf8 * path, size_t numMissingObjects, const rct_object_entry * missingObjects)

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -162,8 +162,8 @@ static void copy_object_names_to_clipboard(rct_window *w)
 
     // No system has a newline over 2 characters
     size_t line_sep_len = strnlen(PLATFORM_NEWLINE, 2);
-    size_t buffer_len = (w->no_list_items * (8 + line_sep_len)) + 1;
-    utf8* buffer = new utf8[buffer_len]{};
+    size_t buffer_len   = (w->no_list_items * (8 + line_sep_len)) + 1;
+    utf8 * buffer       = new utf8[buffer_len]{};
 
     size_t cur_len = 0;
     for (uint16 i = 0; i < w->no_list_items; i++) {


### PR DESCRIPTION
Before adding a name to the clipboard buffer, it checks for spaces at the end of the name, to prevent copying those.

It also moves some logic from the `mouseup` function, and moved memory deallocation within the same function where it got allocated.

Because it's a cpp file, I changed `malloc` and `SafeFree` to `new` and `delete` respectively. I wasn't sure if I should also make use of `std::string`, or leave it.