### PR TITLE
Fix scenery group assignment race conditions

### DIFF
--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -47,11 +47,11 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
     const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
+    static const rct_object_entry scgPathX = Object::GetScgPathXHeader();
 
-    if (objectEntry != nullptr && scgPathX != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
+    if (objectEntry != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
     {
-        SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
+        SetPrimarySceneryGroup(&scgPathX);
     }
 }
 

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -48,11 +48,11 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stre
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
     const std::string identifier = GetIdentifier();
     const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    static const rct_object_entry * scgPathX = object_list_find_by_name("SCGPATHX");
+    static const rct_object_entry scgPathX = Object::GetScgPathXHeader();
 
-    if (objectEntry != nullptr && scgPathX != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
+    if (objectEntry != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
     {
-        SetPrimarySceneryGroup((rct_object_entry *)scgPathX);
+        SetPrimarySceneryGroup(&scgPathX);
     }
 }
 

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -64,6 +64,24 @@ const utf8 * Object::GetString(uint8 index) const
     return sz != nullptr ? sz : "";
 }
 
+rct_object_entry Object::GetScgWallsHeader()
+{
+    rct_object_entry scgWalls = { 0 };
+    scgWalls.flags = 207140231;
+    Memory::Copy(scgWalls.name, "SCGWALLS", 8);
+    scgWalls.checksum = 3518650219;
+    return scgWalls;
+}
+
+rct_object_entry Object::GetScgPathXHeader()
+{
+    rct_object_entry scgPathX = { 0 };
+    scgPathX.flags = 207140231;
+    Memory::Copy(scgPathX.name, "SCGPATHX", 8);
+    scgPathX.checksum = 890227440;
+    return scgPathX;
+}
+
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wsuggest-final-methods"

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -66,21 +66,23 @@ const utf8 * Object::GetString(uint8 index) const
 
 rct_object_entry Object::GetScgWallsHeader()
 {
-    rct_object_entry scgWalls = { 0 };
-    scgWalls.flags = 207140231;
-    Memory::Copy(scgWalls.name, "SCGWALLS", 8);
-    scgWalls.checksum = 3518650219;
-    return scgWalls;
+    return Object::CreateHeader("SCGWALLS", 207140231, 3518650219);
 }
 
 rct_object_entry Object::GetScgPathXHeader()
 {
-    rct_object_entry scgPathX = { 0 };
-    scgPathX.flags = 207140231;
-    Memory::Copy(scgPathX.name, "SCGPATHX", 8);
-    scgPathX.checksum = 890227440;
-    return scgPathX;
+    return Object::CreateHeader("SCGPATHX", 207140231, 890227440);
 }
+
+rct_object_entry Object::CreateHeader(const char name[9], uint32 flags, uint32 checksum)
+{
+    rct_object_entry header = { 0 };
+    header.flags = flags;
+    Memory::Copy(header.name, name, 8);
+    header.checksum = checksum;
+    return header;
+}
+
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
     #pragma GCC diagnostic push

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -90,6 +90,7 @@ public:
 
     rct_object_entry GetScgWallsHeader();
     rct_object_entry GetScgPathXHeader();
+    rct_object_entry CreateHeader(const char name[9], uint32 flags, uint32 checksum);
 
 };
 #ifdef __WARN_SUGGEST_FINAL_TYPES__

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -87,6 +87,10 @@ public:
     virtual const utf8 *    GetName() const;
 
     virtual void SetRepositoryItem(ObjectRepositoryItem * item) const { }
+
+    rct_object_entry GetScgWallsHeader();
+    rct_object_entry GetScgPathXHeader();
+
 };
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
     #pragma GCC diagnostic pop

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -158,7 +158,7 @@ uint8 * SmallSceneryObject::ReadFrameOffsets(IStream * stream)
 void SmallSceneryObject::PerformFixes()
 {
     std::string identifier = GetIdentifier();
-    static const rct_object_entry * scgWalls = object_list_find_by_name("SCGWALLS");
+    static const rct_object_entry scgWalls = Object::GetScgWallsHeader();
 
     // ToonTowner's base blocks. Make them allow supports on top and put them in the Walls and Roofs group.
     if (String::Equals(identifier, "XXBBCL01") ||
@@ -166,10 +166,7 @@ void SmallSceneryObject::PerformFixes()
         String::Equals(identifier, "XXBBBR01") ||
         String::Equals(identifier, "ARBASE2 "))
     {
-        if (scgWalls != nullptr)
-        {
-            SetPrimarySceneryGroup((rct_object_entry *)scgWalls);
-        }
+        SetPrimarySceneryGroup(&scgWalls);
 
         _legacyType.small_scenery.flags |= SMALL_SCENERY_FLAG_BUILD_DIRECTLY_ONTOP;
     }
@@ -181,10 +178,7 @@ void SmallSceneryObject::PerformFixes()
         String::Equals(identifier, "TTRFTL07") ||
         String::Equals(identifier, "TTRFTL08"))
     {
-        if (scgWalls != nullptr)
-        {
-            SetPrimarySceneryGroup((rct_object_entry *)scgWalls);
-        }
+        SetPrimarySceneryGroup(&scgWalls);
     }
 
     // ToonTowner's Pirate roofs. Make them show up in the Pirate Theming.
@@ -198,11 +192,8 @@ void SmallSceneryObject::PerformFixes()
         String::Equals(identifier, "TTPRF10 ") ||
         String::Equals(identifier, "TTPRF11 "))
     {
-        static const rct_object_entry * scgPirat = object_list_find_by_name("SCGPIRAT");
-        if (scgPirat != nullptr)
-        {
-            SetPrimarySceneryGroup((rct_object_entry *)scgPirat);
-        }
+        static const rct_object_entry scgPirat = GetScgPiratHeader();
+        SetPrimarySceneryGroup(&scgPirat);
     }
 
     // ToonTowner's wooden roofs. Make them show up in the Mine Theming.
@@ -215,11 +206,8 @@ void SmallSceneryObject::PerformFixes()
         String::Equals(identifier, "TTRFWD07") ||
         String::Equals(identifier, "TTRFWD08"))
     {
-        static const rct_object_entry * scgMine = object_list_find_by_name("SCGMINE ");
-        if (scgMine != nullptr)
-        {
-            SetPrimarySceneryGroup((rct_object_entry *)scgMine);
-        }
+        static const rct_object_entry scgMine = GetScgMineHeader();
+        SetPrimarySceneryGroup(&scgMine);
     }
 
     // ToonTowner's glass roofs. Make them show up in the Abstract Theming.
@@ -227,10 +215,34 @@ void SmallSceneryObject::PerformFixes()
         String::Equals(identifier, "TTRFGL02") ||
         String::Equals(identifier, "TTRFGL03"))
     {
-        static const rct_object_entry * scgAbstr = object_list_find_by_name("SCGABSTR");
-        if (scgAbstr != nullptr)
-        {
-            SetPrimarySceneryGroup((rct_object_entry *)scgAbstr);
-        }
+        static const rct_object_entry scgAbstr = GetScgAbstrHeader();
+        SetPrimarySceneryGroup(&scgAbstr);
     }
+}
+
+rct_object_entry SmallSceneryObject::GetScgPiratHeader()
+{
+    static rct_object_entry scgPirat = { 0 };
+    scgPirat.flags = 207140231;
+    Memory::Copy(scgPirat.name, "SCGPIRAT", 8);
+    scgPirat.checksum = 21592567;
+    return scgPirat;
+}
+
+rct_object_entry SmallSceneryObject::GetScgMineHeader()
+{
+    static rct_object_entry scgMine = { 0 };
+    scgMine.flags = 207140231;
+    Memory::Copy(scgMine.name, "SCGMINE ", 8);
+    scgMine.checksum = 3638141733;
+    return scgMine;
+}
+
+rct_object_entry SmallSceneryObject::GetScgAbstrHeader()
+{
+    static rct_object_entry scgAbstr = { 0 };
+    scgAbstr.flags = 207140231;
+    Memory::Copy(scgAbstr.name, "SCGABSTR", 8);
+    scgAbstr.checksum = 932253451;
+    return scgAbstr;
 }

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -222,27 +222,15 @@ void SmallSceneryObject::PerformFixes()
 
 rct_object_entry SmallSceneryObject::GetScgPiratHeader()
 {
-    static rct_object_entry scgPirat = { 0 };
-    scgPirat.flags = 207140231;
-    Memory::Copy(scgPirat.name, "SCGPIRAT", 8);
-    scgPirat.checksum = 21592567;
-    return scgPirat;
+    return Object::CreateHeader("SCGPATHX", 207140231, 21592567);
 }
 
 rct_object_entry SmallSceneryObject::GetScgMineHeader()
 {
-    static rct_object_entry scgMine = { 0 };
-    scgMine.flags = 207140231;
-    Memory::Copy(scgMine.name, "SCGMINE ", 8);
-    scgMine.checksum = 3638141733;
-    return scgMine;
+    return Object::CreateHeader("SCGMINE ", 207140231, 3638141733);
 }
 
 rct_object_entry SmallSceneryObject::GetScgAbstrHeader()
 {
-    static rct_object_entry scgAbstr = { 0 };
-    scgAbstr.flags = 207140231;
-    Memory::Copy(scgAbstr.name, "SCGABSTR", 8);
-    scgAbstr.checksum = 932253451;
-    return scgAbstr;
+    return Object::CreateHeader("SCGABSTR", 207140231, 932253451);
 }

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -43,6 +43,9 @@ public:
 private:
     static uint8 * ReadFrameOffsets(IStream * stream);
     void PerformFixes();
+    rct_object_entry GetScgPiratHeader();
+    rct_object_entry GetScgMineHeader();
+    rct_object_entry GetScgAbstrHeader();
 };
 
 #endif


### PR DESCRIPTION
When adding entries to scenery groups by hand, like we do for a lot of ToonTowner's stuff, it currently tries to get the loaded scenery group. If this happens not to be loaded at that time, this will fail.
Instead, hardcode the headers - that's how object .DATs do this anyway.