### PR TITLE
Fix #6625: Not to try to open a ride window when it crashes in headless server

### DIFF
--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -7685,9 +7685,6 @@ void ride_set_to_default_inspection_interval(sint32 rideIndex)
  */
 void ride_crash(uint8 rideIndex, uint8 vehicleIndex)
 {
-    // It is unnecessary to deal with ride crash in headless server
-    if (gOpenRCT2Headless) return;
-
     Ride *ride = get_ride(rideIndex);
     rct_vehicle *vehicle = GET_VEHICLE(ride->vehicles[vehicleIndex]);
 
@@ -7698,7 +7695,7 @@ void ride_crash(uint8 rideIndex, uint8 vehicleIndex)
         rct_window * w = context_open_intent(intent);
         intent_release(intent);
 
-        if (w->viewport != NULL) {
+        if (w != NULL && w->viewport != NULL) {
             w->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
         }
     }

--- a/src/openrct2/ride/ride.c
+++ b/src/openrct2/ride/ride.c
@@ -7685,6 +7685,9 @@ void ride_set_to_default_inspection_interval(sint32 rideIndex)
  */
 void ride_crash(uint8 rideIndex, uint8 vehicleIndex)
 {
+    // It is unnecessary to deal with ride crash in headless server
+    if (gOpenRCT2Headless) return;
+
     Ride *ride = get_ride(rideIndex);
     rct_vehicle *vehicle = GET_VEHICLE(ride->vehicles[vehicleIndex]);
 


### PR DESCRIPTION
It might not be theoretical solution, but I request pulling this.
It fixes #6625 by not trying to open a ride window when it crashes in headless server.
And there is no reason to show a ride window in headless server since there is no graphical displays.

Also I will appreciate if something is wrong with my codes, or this PR since I'm not good at git and C++. Thanks.