### PR TITLE
Use range-based for loops

### DIFF
--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -160,11 +160,11 @@ void audio_populate_devices()
     std::vector<std::string> devices = audioContext->GetOutputDevices();
 
     // Replace blanks with localised unknown string
-    for (size_t i = 0; i < devices.size(); i++)
+    for (auto &device : devices)
     {
-        if (devices[i].empty())
+        if (device.empty())
         {
-            devices[i] = language_get_string(STR_OPTIONS_SOUND_VALUE_DEFAULT);
+            device = language_get_string(STR_OPTIONS_SOUND_VALUE_DEFAULT);
         }
     }
 

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -337,12 +337,11 @@ void UITheme::SetName(const utf8 * name)
 
 const UIThemeWindowEntry * UITheme::GetEntry(rct_windowclass windowClass) const
 {
-    for (size_t i = 0; i < Entries.size(); i++)
+    for (const auto &entry : Entries)
     {
-        const UIThemeWindowEntry * entry = &Entries[i];
-        if (entry->WindowClass == windowClass)
+        if (entry.WindowClass == windowClass)
         {
-            return entry;
+            return &entry;
         }
     }
     return nullptr;
@@ -351,12 +350,11 @@ const UIThemeWindowEntry * UITheme::GetEntry(rct_windowclass windowClass) const
 void UITheme::SetEntry(const UIThemeWindowEntry * newEntry)
 {
     // Try to replace existing entry
-    for (size_t i = 0; i < Entries.size(); i++)
+    for (auto &entry : Entries)
     {
-        UIThemeWindowEntry * entry = &Entries[i];
-        if (entry->WindowClass == newEntry->WindowClass)
+        if (entry.WindowClass == newEntry->WindowClass)
         {
-            *entry = *newEntry;
+            entry = *newEntry;
             return;
         }
     }

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -135,29 +135,29 @@ public:
         _stringData = _stringDataSB.GetString();
 
         size_t stringDataBaseAddress = (size_t)_stringData;
-        for (size_t i = 0; i < _strings.size(); i++)
+        for (auto &string : _strings)
         {
-            if (_strings[i] != nullptr)
+            if (string != nullptr)
             {
-                _strings[i] = (utf8*)(stringDataBaseAddress + (size_t)_strings[i]);
+                string = (utf8*)(stringDataBaseAddress + (size_t)string);
             }
         }
-        for (size_t i = 0; i < _objectOverrides.size(); i++)
+        for (auto &objectOverride : _objectOverrides)
         {
             for (sint32 j = 0; j < ObjectOverrideMaxStringCount; j++)
             {
-                const utf8 * * strPtr = &(_objectOverrides[i].strings[j]);
+                const utf8 * * strPtr = &(objectOverride.strings[j]);
                 if (*strPtr != nullptr)
                 {
                     *strPtr = (utf8*)(stringDataBaseAddress + (size_t)*strPtr);
                 }
             }
         }
-        for (size_t i = 0; i < _scenarioOverrides.size(); i++)
+        for (auto &scenarioOverride : _scenarioOverrides)
         {
             for (sint32 j = 0; j < ScenarioOverrideMaxStringCount; j++)
             {
-                const utf8 **strPtr = &(_scenarioOverrides[i].strings[j]);
+                const utf8 * * strPtr = &(scenarioOverride.strings[j]);
                 if (*strPtr != nullptr)
                 {
                     *strPtr = (utf8*)(stringDataBaseAddress + (size_t)*strPtr);
@@ -291,12 +291,11 @@ public:
     {
         Guard::ArgumentNotNull(objectIdentifier);
 
-        for (size_t i = 0; i < _objectOverrides.size(); i++)
+        for (auto &oo : _objectOverrides)
         {
-            ObjectOverride *oo = &_objectOverrides[i];
-            if (strncmp(oo->name, objectIdentifier, 8) == 0)
+            if (strncmp(oo.name, objectIdentifier, 8) == 0)
             {
-                return oo;
+                return &oo;
             }
         }
         return nullptr;
@@ -306,15 +305,14 @@ public:
     {
         Guard::ArgumentNotNull(scenarioIdentifier);
 
-        for (size_t i = 0; i < _scenarioOverrides.size(); i++)
+        for (auto &so : _scenarioOverrides)
         {
-            ScenarioOverride *so = &_scenarioOverrides[i];
             // At this point ScenarioOverrides were not yet rewritten to point at
             // strings, but rather still hold offsets from base.
-            const utf8 *name = _stringDataSB.GetBuffer() + (size_t)so->name;
+            const utf8 *name = _stringDataSB.GetBuffer() + (size_t)so.name;
             if (_stricmp(name, scenarioIdentifier) == 0)
             {
-                return so;
+                return &so;
             }
         }
         return nullptr;
@@ -621,9 +619,9 @@ public:
         if (_currentGroup == nullptr)
         {
             // Make sure the list is big enough to contain this string id
-            while (_strings.size() <= (size_t)stringId)
+            if ((size_t)stringId >= _strings.size())
             {
-                _strings.push_back(nullptr);
+                _strings.resize(stringId + 1);
             }
 
             _strings[stringId] = relativeOffset;

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -33,19 +33,24 @@ NetworkGroup::~NetworkGroup()
 NetworkGroup NetworkGroup::FromJson(const json_t * json)
 {
     NetworkGroup group;
-    json_t * jsonId = json_object_get(json, "id");
-    json_t * jsonName = json_object_get(json, "name");
+    json_t * jsonId          = json_object_get(json, "id");
+    json_t * jsonName        = json_object_get(json, "name");
     json_t * jsonPermissions = json_object_get(json, "permissions");
+
     if (jsonId == nullptr || jsonName == nullptr || jsonPermissions == nullptr)
     {
         throw Exception("Missing group data");
     }
-    group.Id = (uint8)json_integer_value(jsonId);
+
+    group.Id    = (uint8)json_integer_value(jsonId);
     group._name = std::string(json_string_value(jsonName));
-    for (size_t i = 0; i < group.ActionsAllowed.size(); i++) {
-        group.ActionsAllowed[i] = 0;
+    for (auto &action : group.ActionsAllowed)
+    {
+        action = 0;
     }
-    for (size_t i = 0; i < json_array_size(jsonPermissions); i++) {
+
+    for (size_t i = 0; i < json_array_size(jsonPermissions); i++)
+    {
         json_t * jsonPermissionValue = json_array_get(jsonPermissions, i);
         const char * perm_name = json_string_value(jsonPermissionValue);
         if (perm_name == nullptr) {
@@ -91,9 +96,9 @@ void NetworkGroup::Read(NetworkPacket &packet)
 {
     packet >> Id;
     SetName(packet.ReadString());
-    for (size_t i = 0; i < ActionsAllowed.size(); i++)
+    for (auto action : ActionsAllowed)
     {
-        packet >> ActionsAllowed[i];
+        packet >> action;
     }
 }
 

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -44,10 +44,7 @@ NetworkGroup NetworkGroup::FromJson(const json_t * json)
 
     group.Id    = (uint8)json_integer_value(jsonId);
     group._name = std::string(json_string_value(jsonName));
-    for (auto &action : group.ActionsAllowed)
-    {
-        action = 0;
-    }
+    std::fill(group.ActionsAllowed.begin(), group.ActionsAllowed.end(), 0);
 
     for (size_t i = 0; i < json_array_size(jsonPermissions); i++)
     {

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -350,9 +350,9 @@ public:
 private:
     void ClearItems()
     {
-        for (uint32 i = 0; i < _items.size(); i++)
+        for (auto &item : _items)
         {
-            FreeItem(&_items[i]);
+            FreeItem(&item);
         }
         _items.clear();
         _itemMap.clear();

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -367,15 +367,14 @@ public:
 
     const scenario_index_entry * GetByFilename(const utf8 * filename) const override
     {
-        for (size_t i = 0; i < _scenarios.size(); i++)
+        for (const auto &scenario : _scenarios)
         {
-            const scenario_index_entry * scenario = &_scenarios[i];
-            const utf8 * scenarioFilename = Path::GetFileName(scenario->path);
+            const utf8 * scenarioFilename = Path::GetFileName(scenario.path);
 
             // Note: this is always case insensitive search for cross platform consistency
             if (String::Equals(filename, scenarioFilename, true))
             {
-                return &_scenarios[i];
+                return &scenario;
             }
         }
         return nullptr;
@@ -383,12 +382,11 @@ public:
 
     const scenario_index_entry * GetByPath(const utf8 * path) const override
     {
-        for (size_t i = 0; i < _scenarios.size(); i++)
+        for (const auto &scenario : _scenarios)
         {
-            const scenario_index_entry * scenario = &_scenarios[i];
-            if (Path::Equals(path, scenario->path))
+            if (Path::Equals(path, scenario.path))
             {
-                return scenario;
+                return &scenario;
             }
         }
         return nullptr;
@@ -616,9 +614,8 @@ private:
                 if (scBasic.Flags & SCENARIO_FLAGS_COMPLETED)
                 {
                     bool notFound = true;
-                    for (size_t j = 0; j < _highscores.size(); j++)
+                    for (auto &highscore : _highscores)
                     {
-                        scenario_highscore_entry * highscore = _highscores[j];
                         if (String::Equals(scBasic.Path, highscore->fileName, true))
                         {
                             notFound = false;
@@ -675,9 +672,8 @@ private:
 
     void AttachHighscores()
     {
-        for (size_t i = 0; i < _highscores.size(); i++)
+        for (auto &highscore : _highscores)
         {
-            scenario_highscore_entry * highscore = _highscores[i];
             scenario_index_entry * scenerio = GetByFilename(highscore->fileName);
             if (scenerio != nullptr)
             {


### PR DESCRIPTION
This PR tries to clean up the code a little bit by using range-based for loops instead of standard for loops, where the index was only being used for random access in the array it looped over. It uses `auto` for types, and `auto &` for instances.