### PR TITLE
Screenshot options

### DIFF
--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -21,9 +21,15 @@ static ScreenshotOptions options;
 
 static const CommandLineOptionDefinition ScreenshotOptionsDef[]
 {
-    { CMDLINE_TYPE_INTEGER, &options.weather,       NAC, "weather",     "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
-    { CMDLINE_TYPE_SWITCH,  &options.hide_guests,   NAC, "no-peeps",    "hide peeps" },
-    { CMDLINE_TYPE_SWITCH,  &options.hide_sprites,  NAC, "no-sprites",  "hide all sprites (e.g. balloons, vehicles, guests)" },
+    { CMDLINE_TYPE_INTEGER, &options.weather,       NAC, "weather",       "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_SWITCH,  &options.hide_guests,   NAC, "no-peeps",      "hide peeps" },
+    { CMDLINE_TYPE_SWITCH,  &options.hide_sprites,  NAC, "no-sprites",    "hide all sprites (e.g. balloons, vehicles, guests)" },
+    { CMDLINE_TYPE_SWITCH,  &options.clear_grass,   NAC, "clear-grass",   "set all grass to be clear of weeds" },
+    { CMDLINE_TYPE_SWITCH,  &options.mowed_grass,   NAC, "mowed-grass",   "set all grass to be mowed" },
+    { CMDLINE_TYPE_SWITCH,  &options.water_plants,  NAC, "water-plants",  "water plants for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &options.fix_vandalism, NAC, "fix vandalism", "fix vandalism" },
+    { CMDLINE_TYPE_SWITCH,  &options.remove_litter, NAC, "remove litter", "remove litter" },
+    { CMDLINE_TYPE_SWITCH,  &options.tidy_up_park,  NAC, "tidy-up-park",  "clear grass, water plants, fix vandalism and remove litter" },
     OptionTableEnd
 };
 

--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -21,7 +21,9 @@ static ScreenshotOptions options;
 
 static const CommandLineOptionDefinition ScreenshotOptionsDef[]
 {
-    { CMDLINE_TYPE_INTEGER, &options.weather,     NAC, "weather",   "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_INTEGER, &options.weather,       NAC, "weather",     "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_SWITCH,  &options.hide_guests,   NAC, "no-peeps",    "hide peeps" },
+    { CMDLINE_TYPE_SWITCH,  &options.hide_sprites,  NAC, "no-sprites",  "hide all sprites (e.g. balloons, vehicles, guests)" },
     OptionTableEnd
 };
 

--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -17,16 +17,11 @@
 #include "../interface/Screenshot.h"
 #include "CommandLine.hpp"
 
-extern "C"
-{
-    sint32 gScreenshotWeather = 0;
-}
+static ScreenshotOptions options;
 
-static uint32 _weather = 0;
-
-static const CommandLineOptionDefinition ScreenshotOptions[]
+static const CommandLineOptionDefinition ScreenshotOptionsDef[]
 {
-    { CMDLINE_TYPE_INTEGER, &_weather, NAC, "weather", "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_INTEGER, &options.weather,     NAC, "weather",   "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
     OptionTableEnd
 };
 
@@ -35,18 +30,16 @@ static exitcode_t HandleScreenshot(CommandLineArgEnumerator *argEnumerator);
 const CommandLineCommand CommandLine::ScreenshotCommands[]
 {
     // Main commands
-    DefineCommand("", "<file> <output_image> <width> <height> [<x> <y> <zoom> <rotation>]", ScreenshotOptions, HandleScreenshot),
-    DefineCommand("", "<file> <output_image> giant <zoom> <rotation>",                      ScreenshotOptions, HandleScreenshot),
+    DefineCommand("", "<file> <output_image> <width> <height> [<x> <y> <zoom> <rotation>]", ScreenshotOptionsDef, HandleScreenshot),
+    DefineCommand("", "<file> <output_image> giant <zoom> <rotation>",                      ScreenshotOptionsDef, HandleScreenshot),
     CommandTableEnd
 };
 
 static exitcode_t HandleScreenshot(CommandLineArgEnumerator *argEnumerator)
 {
-    gScreenshotWeather = _weather;
-
     const char * * argv = (const char * *)argEnumerator->GetArguments() + argEnumerator->GetIndex();
     sint32 argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
-    sint32 result = cmdline_for_screenshot(argv, argc);
+    sint32 result = cmdline_for_screenshot(argv, argc, &options);
     if (result < 0) {
         return EXITCODE_FAIL;
     }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -532,6 +532,31 @@ sint32 cmdline_for_screenshot(const char * * argv, sint32 argc, ScreenshotOption
             viewport.flags |= VIEWPORT_FLAG_INVISIBLE_SPRITES;
         }
 
+        if (options->mowed_grass)
+        {
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_SETGRASSLENGTH, GRASS_LENGTH_MOWED, GAME_COMMAND_CHEAT, 0, 0);
+        }
+
+        if (options->clear_grass || options->tidy_up_park)
+        {
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_SETGRASSLENGTH, GRASS_LENGTH_CLEAR_0, GAME_COMMAND_CHEAT, 0, 0);
+        }
+
+        if (options->water_plants || options->tidy_up_park)
+        {
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_WATERPLANTS, 0, GAME_COMMAND_CHEAT, 0, 0);
+        }
+
+        if (options->fix_vandalism || options->tidy_up_park)
+        {
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_FIXVANDALISM, 0, GAME_COMMAND_CHEAT, 0, 0);
+        }
+
+        if (options->remove_litter || options->tidy_up_park)
+        {
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_REMOVELITTER, 0, GAME_COMMAND_CHEAT, 0, 0);
+        }
+
         viewport_render(&dpi, &viewport, 0, 0, viewport.width, viewport.height);
 
         rct_palette renderedPalette;

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -355,7 +355,7 @@ sint32 cmdline_for_gfxbench(const char **argv, sint32 argc)
     return 1;
 }
 
-sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
+sint32 cmdline_for_screenshot(const char * * argv, sint32 argc, ScreenshotOptions * options)
 {
     // Don't include options in the count (they have been handled by CommandLine::ParseOptions already)
     for (sint32 i = 0; i < argc; i++)
@@ -496,9 +496,9 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
             gCurrentRotation = gSavedViewRotation;
         }
 
-        if (gScreenshotWeather != 0)
+        if (options->weather != 0)
         {
-            if (gScreenshotWeather < 1 || gScreenshotWeather > 6)
+            if (options->weather < 1 || options->weather > 6)
             {
                 std::printf("Weather can only be set to an integer value from 1 till 6.");
                 drawing_engine_dispose();
@@ -506,7 +506,7 @@ sint32 cmdline_for_screenshot(const char **argv, sint32 argc)
                 return -1;
             }
 
-            uint8 customWeather = gScreenshotWeather - 1;
+            uint8 customWeather = options->weather - 1;
             climate_force_weather(customWeather);
         }
 

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -522,6 +522,16 @@ sint32 cmdline_for_screenshot(const char * * argv, sint32 argc, ScreenshotOption
         dpi.zoom_level = 0;
         dpi.bits = (uint8 *)malloc(dpi.width * dpi.height);
 
+        if (options->hide_guests)
+        {
+            viewport.flags |= VIEWPORT_FLAG_INVISIBLE_PEEPS;
+        }
+
+        if (options->hide_sprites)
+        {
+            viewport.flags |= VIEWPORT_FLAG_INVISIBLE_SPRITES;
+        }
+
         viewport_render(&dpi, &viewport, 0, 0, viewport.width, viewport.height);
 
         rct_palette renderedPalette;

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -28,9 +28,15 @@ extern "C"
 
     struct ScreenshotOptions
     {
-        sint32 weather = 0;
-        bool hide_guests = false;
-        bool hide_sprites = false;
+        sint32 weather     = 0;
+        bool hide_guests   = false;
+        bool hide_sprites  = false;
+        bool clear_grass   = false;
+        bool mowed_grass   = false;
+        bool water_plants  = false;
+        bool fix_vandalism = false;
+        bool remove_litter = false;
+        bool tidy_up_park  = false;
     };
 
     void screenshot_check();

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -29,6 +29,8 @@ extern "C"
     struct ScreenshotOptions
     {
         sint32 weather = 0;
+        bool hide_guests = false;
+        bool hide_sprites = false;
     };
 
     void screenshot_check();

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -25,7 +25,11 @@ extern "C"
 {
 #endif
     extern uint8 gScreenshotCountdown;
-    extern sint32 gScreenshotWeather;
+
+    struct ScreenshotOptions
+    {
+        sint32 weather = 0;
+    };
 
     void screenshot_check();
     sint32 screenshot_dump();
@@ -33,7 +37,7 @@ extern "C"
     sint32 screenshot_dump_png_32bpp(sint32 width, sint32 height, const void *pixels);
 
     void screenshot_giant();
-    sint32 cmdline_for_screenshot(const char **argv, sint32 argc);
+    sint32 cmdline_for_screenshot(const char * * argv, sint32 argc, ScreenshotOptions * options);
     sint32 cmdline_for_gfxbench(const char **argv, sint32 argc);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR is basically a continuation of #6715. The first commit refactors the way options are handled, so that the settings are stored inside a struct that gets passed to the screenshot function, rather than storing them in a global variable.
The latter commits add new options. those being the peep and sprite visibility, and some visible cheats (like clearing litter) before the screenshot gets taken.

```
----------
screenshot
----------
usage: openrct2  <file> <output_image> <width> <height> [<x> <y> <zoom> <rotation>] [options]
                 <file> <output_image> giant <zoom> <rotation>                      [options]

    --weather=<int>    weather to be used (0 = default, 1 = sunny, ..., 6 = thunder).
    --no-peeps         hide peeps
    --no-sprites       hide all sprites (e.g. balloons, vehicles, guests)
    --clear-grass      set all grass to be clear of weeds
    --mowed-grass      set all grass to be mowed
    --water-plants     water plants for the screenshot
    --fix vandalism    fix vandalism
    --remove litter    remove litter
    --tidy-up-park     clear grass, water plants, fix vandalism and remove litter
```