### PR TITLE
Reorganisation of the Options window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3966,7 +3966,7 @@ STR_5626    :Other Parks
 STR_5627    :Group scenario list by:
 STR_5628    :Source game
 STR_5629    :Difficulty level
-STR_5630    :Enable unlocking of scenarios
+STR_5630    :Enable progressive unlocking
 STR_5631    :Original DLC Parks
 STR_5632    :Build your own...
 STR_5633    :CMD + 
@@ -4149,7 +4149,7 @@ STR_5839    :{SMALLFONT}{BLACK}Show a separate button for the research and devel
 STR_5840    :{SMALLFONT}{BLACK}Show a separate button for the cheats window in the toolbar
 STR_5841    :{SMALLFONT}{BLACK}Show a separate button for the recent news window in the toolbar
 STR_5842    :{SMALLFONT}{BLACK}Sort scenarios into tabs by their difficulty (RCT2 behaviour) or their source game (RCT1 behaviour)
-STR_5843    :{SMALLFONT}{BLACK}Enable scenario unlocking (RCT1 behaviour)
+STR_5843    :{SMALLFONT}{BLACK}Enables progressive unlocking of scenarios (RCT1 behaviour)
 STR_5844    :{SMALLFONT}{BLACK}Stay connected to a multiplayer server{NEWLINE}even if a desync or error occurs
 STR_5845    :{SMALLFONT}{BLACK}Adds a button for{NEWLINE}debugging tools to the toolbar.{NEWLINE}Enables keyboard shortcut for developer console
 STR_5846    :{SMALLFONT}{BLACK}Set often OpenRCT2 automatically saves
@@ -4473,6 +4473,10 @@ STR_6163    :Mouse shaped cars speed through tight corners and short drops, gent
 STR_6164    :{WHITE}{CROSS}
 STR_6165    :Use vertical sync
 STR_6166    :{SMALLFONT}{BLACK}Synchronises each frame displayed to the monitor's refresh rate, preventing screen tearing.
+STR_6167    :{SMALLFONT}{BLACK}Advanced
+STR_6168    :Title Sequence
+STR_6169    :Scenario selection
+STR_6170    :Tweaks
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -55,6 +55,7 @@ enum WINDOW_OPTIONS_PAGE {
     WINDOW_OPTIONS_PAGE_AUDIO,
     WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
     WINDOW_OPTIONS_PAGE_MISC,
+    WINDOW_OPTIONS_PAGE_ADVANCED,
     WINDOW_OPTIONS_PAGE_TWITCH,
     WINDOW_OPTIONS_PAGE_COUNT
 };
@@ -73,6 +74,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_TAB_5,
     WIDX_TAB_6,
     WIDX_TAB_7,
+    WIDX_TAB_8,
 
     WIDX_PAGE_START,
 
@@ -154,13 +156,6 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
     // Misc
     WIDX_REAL_NAME_CHECKBOX = WIDX_PAGE_START,
-    WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,
-    WIDX_SAVE_PLUGIN_DATA_CHECKBOX,
-    WIDX_TEST_UNFINISHED_TRACKS,
-    WIDX_DEBUGGING_TOOLS,
-    WIDX_STAY_CONNECTED_AFTER_DESYNC,
-    WIDX_AUTOSAVE,
-    WIDX_AUTOSAVE_DROPDOWN,
     WIDX_TITLE_SEQUENCE,
     WIDX_TITLE_SEQUENCE_DROPDOWN,
     WIDX_TITLE_SEQUENCE_BUTTON,
@@ -168,6 +163,15 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_AUTO_OPEN_SHOPS,
     WIDX_DEFAULT_INSPECTION_INTERVAL,
     WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
+
+    // Advanced
+    WIDX_DEBUGGING_TOOLS = WIDX_PAGE_START,
+    WIDX_TEST_UNFINISHED_TRACKS,
+    WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,
+    WIDX_SAVE_PLUGIN_DATA_CHECKBOX,
+    WIDX_STAY_CONNECTED_AFTER_DESYNC,
+    WIDX_AUTOSAVE,
+    WIDX_AUTOSAVE_DROPDOWN,
     WIDX_PATH_TO_RCT1_TEXT,
     WIDX_PATH_TO_RCT1_BUTTON,
     WIDX_PATH_TO_RCT1_CLEAR,
@@ -203,7 +207,8 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     { WWT_TAB,              1,  96,     126,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_AUDIO_TIP }, \
     { WWT_TAB,              1,  127,    157,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP }, \
     { WWT_TAB,              1,  158,    188,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_MISCELLANEOUS_TIP }, \
-    { WWT_TAB,              TWITCH_TAB_COLOUR,  189,    219,    17,     43,     TWITCH_TAB_SPRITE,      STR_OPTIONS_TWITCH_TIP }
+    { WWT_TAB,              1,  189,    219,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_NONE }, \
+    { WWT_TAB,              TWITCH_TAB_COLOUR,  220,    250,    17,     43,     TWITCH_TAB_SPRITE,      STR_OPTIONS_TWITCH_TIP }
 
 static rct_widget window_options_display_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
@@ -310,20 +315,27 @@ static rct_widget window_options_controls_and_interface_widgets[] = {
 static rct_widget window_options_misc_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
     { WWT_CHECKBOX,         2,  10,     299,    54,     65,     STR_REAL_NAME,                              STR_REAL_NAME_TIP },                                // Show 'real' names of guests
-    { WWT_CHECKBOX,         2,  10,     299,    69,     80,     STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,  STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM_TIP },    // Allow loading with incorrect checksum
-    { WWT_CHECKBOX,         2,  10,     299,    84,     95,     STR_SAVE_PLUGIN_DATA,                       STR_SAVE_PLUGIN_DATA_TIP },                         // Export plug-in objects with saved games
-    { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_TEST_UNFINISHED_TRACKS,                 STR_TEST_UNFINISHED_TRACKS_TIP },                   // Test unfinished tracks
-    { WWT_CHECKBOX,         2,  10,     299,    114,    125,    STR_ENABLE_DEBUGGING_TOOLS,                 STR_ENABLE_DEBUGGING_TOOLS_TIP },                   // Enable debugging tools
-    { WWT_CHECKBOX,         2,  10,     299,    129,    140,    STR_STAY_CONNECTED_AFTER_DESYNC,            STR_STAY_CONNECTED_AFTER_DESYNC_TIP },              // Do not disconnect after the client desynchronises with the server
-    { WWT_DROPDOWN,         1,  155,    299,    144,    155,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    145,    154,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
     { WWT_DROPDOWN,         1,  155,    299,    159,    170,    STR_NONE,                                   STR_NONE },                                         // Title sequence dropdown
     { WWT_DROPDOWN_BUTTON,  1,  288,    298,    160,    169,    STR_DROPDOWN_GLYPH,                         STR_TITLE_SEQUENCE_TIP },                           // Title sequence dropdown button
     { WWT_DROPDOWN_BUTTON,  1,  155,    299,    174,    185,    STR_EDIT_TITLE_SEQUENCES_BUTTON,            STR_EDIT_TITLE_SEQUENCES_BUTTON_TIP },              // Edit title sequences button
     { WWT_CHECKBOX,         2,  10,     299,    189,    200,    STR_AUTO_STAFF_PLACEMENT,                   STR_AUTO_STAFF_PLACEMENT_TIP },                     // Auto staff placement
-    { WWT_CHECKBOX,         2,  10,     299,    209,    210,    STR_AUTO_OPEN_SHOPS,                        STR_AUTO_OPEN_SHOPS_TIP },                          // Automatically open shops & stalls
+    { WWT_CHECKBOX,         2,  10,     299,    201,    212,    STR_AUTO_OPEN_SHOPS,                        STR_AUTO_OPEN_SHOPS_TIP },                          // Automatically open shops & stalls
     { WWT_DROPDOWN,         1,  155,    299,    224,    235,    STR_NONE,                                   STR_NONE },                                         // Default inspection time dropdown
     { WWT_DROPDOWN_BUTTON,  1,  288,    298,    225,    234,    STR_DROPDOWN_GLYPH,                         STR_DEFAULT_INSPECTION_INTERVAL_TIP },              // Default inspection time dropdown button
+    { WIDGETS_END },
+};
+
+static rct_widget window_options_advanced_widgets[] = {
+    MAIN_OPTIONS_WIDGETS,
+    { WWT_CHECKBOX,         2,  10,     299,    114,    125,    STR_ENABLE_DEBUGGING_TOOLS,                 STR_ENABLE_DEBUGGING_TOOLS_TIP },                   // Enable debugging tools
+    { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_TEST_UNFINISHED_TRACKS,                 STR_TEST_UNFINISHED_TRACKS_TIP },                   // Test unfinished tracks
+    { WWT_CHECKBOX,         2,  10,     299,    69,     80,     STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,  STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM_TIP },    // Allow loading with incorrect checksum
+    { WWT_CHECKBOX,         2,  10,     299,    84,     95,     STR_SAVE_PLUGIN_DATA,                       STR_SAVE_PLUGIN_DATA_TIP },                         // Export plug-in objects with saved games
+    { WWT_CHECKBOX,         2,  10,     299,    129,    140,    STR_STAY_CONNECTED_AFTER_DESYNC,            STR_STAY_CONNECTED_AFTER_DESYNC_TIP },              // Do not disconnect after the client desynchronises with the server
+
+    { WWT_DROPDOWN,         1,  155,    299,    144,    155,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    145,    154,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
+
     { WWT_12,               1,  10,     298,    239,    250,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
     { WWT_DROPDOWN_BUTTON,  1,  10,     289,    254,    265,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
     { WWT_DROPDOWN_BUTTON,  1,  289,    299,    254,    265,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
@@ -348,6 +360,7 @@ static rct_widget *window_options_page_widgets[] = {
     window_options_audio_widgets,
     window_options_controls_and_interface_widgets,
     window_options_misc_widgets,
+    window_options_advanced_widgets,
     window_options_twitch_widgets
 };
 
@@ -380,8 +393,8 @@ static const rct_string_id window_options_fullscreen_mode_names[] = {
     STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
 };
 
-const sint32 window_options_tab_animation_divisor[] = { 4, 4, 8, 2, 2, 2, 1 };
-const sint32 window_options_tab_animation_frames[] = { 16, 8, 8, 16, 4, 16, 1 };
+const sint32 window_options_tab_animation_divisor[] = { 4, 4, 8, 2, 2, 2, 2, 1 };
+const sint32 window_options_tab_animation_frames[] = { 16, 8, 8, 16, 4, 16, 16, 1 };
 
 static void window_options_set_page(rct_window *w, sint32 page);
 static void window_options_set_pressed_tab(rct_window *w);
@@ -446,7 +459,8 @@ static rct_window_event_list window_options_events = {
     (1 << WIDX_TAB_4) | \
     (1 << WIDX_TAB_5) | \
     (1 << WIDX_TAB_6) | \
-    (1 << WIDX_TAB_7)
+    (1 << WIDX_TAB_7) | \
+    (1 << WIDX_TAB_8)
 
 static uint64 window_options_page_enabled_widgets[] = {
     MAIN_OPTIONS_ENABLED_WIDGETS |
@@ -522,22 +536,25 @@ static uint64 window_options_page_enabled_widgets[] = {
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_REAL_NAME_CHECKBOX) |
-    (1 << WIDX_SAVE_PLUGIN_DATA_CHECKBOX) |
-    (1 << WIDX_AUTOSAVE) |
-    (1 << WIDX_AUTOSAVE_DROPDOWN) |
-    (1 << WIDX_TEST_UNFINISHED_TRACKS) |
     (1 << WIDX_AUTO_STAFF_PLACEMENT) |
-    (1 << WIDX_DEBUGGING_TOOLS) |
     (1 << WIDX_TITLE_SEQUENCE) |
     (1 << WIDX_TITLE_SEQUENCE_DROPDOWN) |
     (1 << WIDX_TITLE_SEQUENCE_BUTTON) |
-    (1 << WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM) |
-    (1 << WIDX_STAY_CONNECTED_AFTER_DESYNC) |
     (1 << WIDX_AUTO_OPEN_SHOPS) |
     (1 << WIDX_DEFAULT_INSPECTION_INTERVAL) |
-    (1 << WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN) |
+    (1 << WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN),
+
+    MAIN_OPTIONS_ENABLED_WIDGETS |
+    (1 << WIDX_DEBUGGING_TOOLS) |
+    (1 << WIDX_TEST_UNFINISHED_TRACKS) |
+    (1 << WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM) |
+    (1 << WIDX_SAVE_PLUGIN_DATA_CHECKBOX) |
+    (1 << WIDX_STAY_CONNECTED_AFTER_DESYNC) |
+    (1 << WIDX_AUTOSAVE) |
+    (1 << WIDX_AUTOSAVE_DROPDOWN) |
+    (1 << WIDX_PATH_TO_RCT1_TEXT) |
     (1 << WIDX_PATH_TO_RCT1_BUTTON) |
-    (1ULL << WIDX_PATH_TO_RCT1_CLEAR),
+    (1 << WIDX_PATH_TO_RCT1_CLEAR),
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_CHANNEL_BUTTON) |
@@ -600,6 +617,7 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
     case WIDX_TAB_5:
     case WIDX_TAB_6:
     case WIDX_TAB_7:
+    case WIDX_TAB_8:
         window_options_set_page(w, widgetIndex - WIDX_TAB_1);
         break;
     }
@@ -788,6 +806,30 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
 
     case WINDOW_OPTIONS_PAGE_MISC:
         switch (widgetIndex) {
+        case WIDX_REAL_NAME_CHECKBOX:
+            gConfigGeneral.show_real_names_of_guests ^= 1;
+            config_save_default();
+            window_invalidate(w);
+            peep_update_names(gConfigGeneral.show_real_names_of_guests);
+            break;
+        case WIDX_AUTO_STAFF_PLACEMENT:
+            gConfigGeneral.auto_staff_placement ^= 1;
+            config_save_default();
+            window_invalidate(w);
+            break;
+        case WIDX_TITLE_SEQUENCE_BUTTON:
+            window_title_editor_open(0);
+            break;
+        case WIDX_AUTO_OPEN_SHOPS:
+            gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
+            config_save_default();
+            window_invalidate(w);
+            break;
+        }
+        break;
+
+    case WINDOW_OPTIONS_PAGE_ADVANCED:
+        switch (widgetIndex) {
         case WIDX_DEBUGGING_TOOLS:
             gConfigGeneral.debugging_tools ^= 1;
             config_save_default();
@@ -798,27 +840,13 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             config_save_default();
             window_invalidate(w);
             break;
-        case WIDX_REAL_NAME_CHECKBOX:
-            gConfigGeneral.show_real_names_of_guests ^= 1;
+        case WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM:
+            gConfigGeneral.allow_loading_with_incorrect_checksum = !gConfigGeneral.allow_loading_with_incorrect_checksum;
             config_save_default();
             window_invalidate(w);
-            peep_update_names(gConfigGeneral.show_real_names_of_guests);
             break;
         case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
             gConfigGeneral.save_plugin_data ^= 1;
-            config_save_default();
-            window_invalidate(w);
-            break;
-        case WIDX_AUTO_STAFF_PLACEMENT:
-            gConfigGeneral.auto_staff_placement ^= 1;
-            config_save_default();
-            window_invalidate(w);
-            break;
-        case WIDX_TITLE_SEQUENCE_BUTTON:
-            window_title_editor_open(0);
-            break;
-        case WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM:
-            gConfigGeneral.allow_loading_with_incorrect_checksum = !gConfigGeneral.allow_loading_with_incorrect_checksum;
             config_save_default();
             window_invalidate(w);
             break;
@@ -827,15 +855,11 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             config_save_default();
             window_invalidate(w);
             break;
-        case WIDX_AUTO_OPEN_SHOPS:
-            gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
-            config_save_default();
-            window_invalidate(w);
-            break;
         case WIDX_PATH_TO_RCT1_BUTTON:
         {
             utf8string rct1path = platform_open_directory_browser(language_get_string(STR_PATH_TO_RCT1_BROWSER));
-            if (rct1path) {
+            if (rct1path)
+            {
                 // Check if this directory actually contains RCT1
                 // The sprite file can be called either csg1.1 or csg1.dat, so check for both names.
                 utf8 checkpath[MAX_PATH];
@@ -843,18 +867,22 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
                 safe_strcat_path(checkpath, "Data", MAX_PATH);
                 safe_strcat_path(checkpath, "csg1.1", MAX_PATH);
 
-                if (!platform_file_exists(checkpath)) {
+                if (!platform_file_exists(checkpath))
+                {
                     safe_strcpy(checkpath, rct1path, MAX_PATH);
                     safe_strcat_path(checkpath, "Data", MAX_PATH);
                     safe_strcat_path(checkpath, "csg1.dat", MAX_PATH);
                 }
 
-                if (platform_file_exists(checkpath)) {
+                if (platform_file_exists(checkpath))
+                {
                     SafeFree(gConfigGeneral.rct1_path);
                     gConfigGeneral.rct1_path = rct1path;
                     config_save_default();
                     context_show_error(STR_RESTART_REQUIRED, STR_NONE);
-                } else {
+                }
+                else
+                {
                     SafeFree(rct1path);
                     context_show_error(STR_PATH_TO_RCT1_WRONG_ERROR, STR_NONE);
                 }
@@ -863,7 +891,8 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             break;
         }
         case WIDX_PATH_TO_RCT1_CLEAR:
-            if (!str_is_null_or_empty(gConfigGeneral.rct1_path)) {
+            if (!str_is_null_or_empty(gConfigGeneral.rct1_path))
+            {
                 SafeFree(gConfigGeneral.rct1_path);
                 config_save_default();
             }
@@ -1162,15 +1191,6 @@ static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex,
 
     case WINDOW_OPTIONS_PAGE_MISC:
         switch (widgetIndex) {
-        case WIDX_AUTOSAVE_DROPDOWN:
-            for (size_t i = AUTOSAVE_EVERY_MINUTE; i <= AUTOSAVE_NEVER; i++) {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = window_options_autosave_names[i];
-            }
-
-            window_options_show_dropdown(w, widget, AUTOSAVE_NEVER + 1);
-            dropdown_set_checked(gConfigGeneral.autosave_frequency, true);
-            break;
         case WIDX_TITLE_SEQUENCE_DROPDOWN:
             num_items = (sint32)title_sequence_manager_get_count();
             for (size_t i = 0; i < num_items; i++) {
@@ -1197,6 +1217,20 @@ static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex,
 
             window_options_show_dropdown(w, widget, 7);
             dropdown_set_checked(gConfigGeneral.default_inspection_interval, true);
+            break;
+        }
+        break;
+
+    case WINDOW_OPTIONS_PAGE_ADVANCED:
+        switch (widgetIndex) {
+        case WIDX_AUTOSAVE_DROPDOWN:
+            for (size_t i = AUTOSAVE_EVERY_MINUTE; i <= AUTOSAVE_NEVER; i++) {
+                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItemsArgs[i] = window_options_autosave_names[i];
+            }
+
+            window_options_show_dropdown(w, widget, AUTOSAVE_NEVER + 1);
+            dropdown_set_checked(gConfigGeneral.autosave_frequency, true);
             break;
         }
         break;
@@ -1393,13 +1427,6 @@ static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, 
 
     case WINDOW_OPTIONS_PAGE_MISC:
         switch (widgetIndex) {
-        case WIDX_AUTOSAVE_DROPDOWN:
-            if (dropdownIndex != gConfigGeneral.autosave_frequency) {
-                gConfigGeneral.autosave_frequency = (uint8)dropdownIndex;
-                config_save_default();
-                window_invalidate(w);
-            }
-            break;
         case WIDX_TITLE_SEQUENCE_DROPDOWN:
             if (dropdownIndex != (sint32)title_get_current_sequence()) {
                 title_sequence_change_preset((size_t)dropdownIndex);
@@ -1410,6 +1437,18 @@ static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, 
         case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
             if (dropdownIndex != gConfigGeneral.default_inspection_interval) {
                 gConfigGeneral.default_inspection_interval = (uint8)dropdownIndex;
+                config_save_default();
+                window_invalidate(w);
+            }
+            break;
+        }
+        break;
+
+    case WINDOW_OPTIONS_PAGE_ADVANCED:
+        switch (widgetIndex) {
+        case WIDX_AUTOSAVE_DROPDOWN:
+            if (dropdownIndex != gConfigGeneral.autosave_frequency) {
+                gConfigGeneral.autosave_frequency = (uint8)dropdownIndex;
                 config_save_default();
                 window_invalidate(w);
             }
@@ -1437,7 +1476,7 @@ static void window_options_invalidate(rct_window *w)
     window_options_set_pressed_tab(w);
 
 #ifdef DISABLE_TWITCH
-    w->disabled_widgets = (1 << WIDX_TAB_7);
+    w->disabled_widgets = (1 << WIDX_TAB_8);
 #else
     w->disabled_widgets = 0;
 #endif
@@ -1660,35 +1699,40 @@ static void window_options_invalidate(rct_window *w)
             window_options_misc_widgets[WIDX_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
         }
 
-        // save plugin data checkbox: visible or not
-        window_options_misc_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
-
         widget_set_checkbox_value(w, WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_guests);
-        widget_set_checkbox_value(w, WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
-        widget_set_checkbox_value(w, WIDX_TEST_UNFINISHED_TRACKS, gConfigGeneral.test_unfinished_tracks);
         widget_set_checkbox_value(w, WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.auto_staff_placement);
-        widget_set_checkbox_value(w, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
-        widget_set_checkbox_value(w, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
-        widget_set_checkbox_value(w, WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
         widget_set_checkbox_value(w, WIDX_AUTO_OPEN_SHOPS, gConfigGeneral.auto_open_shops);
 
         window_options_misc_widgets[WIDX_REAL_NAME_CHECKBOX].type = WWT_CHECKBOX;
-        window_options_misc_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
-        window_options_misc_widgets[WIDX_AUTOSAVE].type = WWT_DROPDOWN;
-        window_options_misc_widgets[WIDX_AUTOSAVE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
-        window_options_misc_widgets[WIDX_TEST_UNFINISHED_TRACKS].type = WWT_CHECKBOX;
         window_options_misc_widgets[WIDX_AUTO_STAFF_PLACEMENT].type = WWT_CHECKBOX;
-        window_options_misc_widgets[WIDX_DEBUGGING_TOOLS].type = WWT_CHECKBOX;
+        window_options_misc_widgets[WIDX_AUTO_OPEN_SHOPS].type = WWT_CHECKBOX;
+
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE].type = WWT_DROPDOWN;
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE_BUTTON].type = WWT_DROPDOWN_BUTTON;
-        window_options_misc_widgets[WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM].type = WWT_CHECKBOX;
-        window_options_misc_widgets[WIDX_STAY_CONNECTED_AFTER_DESYNC].type = WWT_CHECKBOX;
-        window_options_misc_widgets[WIDX_AUTO_OPEN_SHOPS].type = WWT_CHECKBOX;
+
         window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].type = WWT_DROPDOWN;
         window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
-        window_options_misc_widgets[WIDX_PATH_TO_RCT1_BUTTON].type = WWT_DROPDOWN_BUTTON;
-        window_options_misc_widgets[WIDX_PATH_TO_RCT1_CLEAR].type = WWT_DROPDOWN_BUTTON;
+        break;
+
+    case WINDOW_OPTIONS_PAGE_ADVANCED:
+        widget_set_checkbox_value(w, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
+        widget_set_checkbox_value(w, WIDX_TEST_UNFINISHED_TRACKS, gConfigGeneral.test_unfinished_tracks);
+        widget_set_checkbox_value(w, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
+        widget_set_checkbox_value(w, WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
+        widget_set_checkbox_value(w, WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
+
+        window_options_advanced_widgets[WIDX_DEBUGGING_TOOLS].type = WWT_CHECKBOX;
+        window_options_advanced_widgets[WIDX_TEST_UNFINISHED_TRACKS].type = WWT_CHECKBOX;
+        window_options_advanced_widgets[WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM].type = WWT_CHECKBOX;
+        window_options_advanced_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
+        window_options_advanced_widgets[WIDX_STAY_CONNECTED_AFTER_DESYNC].type = WWT_CHECKBOX;
+
+        window_options_advanced_widgets[WIDX_AUTOSAVE].type = WWT_DROPDOWN;
+        window_options_advanced_widgets[WIDX_AUTOSAVE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
+
+        window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON].type = WWT_DROPDOWN_BUTTON;
+        window_options_advanced_widgets[WIDX_PATH_TO_RCT1_CLEAR].type = WWT_DROPDOWN_BUTTON;
         break;
 
     case WINDOW_OPTIONS_PAGE_TWITCH:
@@ -1887,16 +1931,6 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
     case WINDOW_OPTIONS_PAGE_MISC:
     {
-        gfx_draw_string_left(dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_AUTOSAVE].top + 1);
-        gfx_draw_string_left(
-            dpi,
-            window_options_autosave_names[gConfigGeneral.autosave_frequency],
-            nullptr,
-            w->colours[1],
-            w->x + window_options_misc_widgets[WIDX_AUTOSAVE].left + 1,
-            w->y + window_options_misc_widgets[WIDX_AUTOSAVE].top
-        );
-
         const utf8 * name = title_sequence_manager_get_name(title_get_config_sequence());
         set_format_arg(0, uintptr_t, (uintptr_t)name);
         gfx_draw_string_left(dpi, STR_TITLE_SEQUENCE, w, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1);
@@ -1919,18 +1953,32 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
             w->x + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].left + 1,
             w->y + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top
         );
-        #ifdef __APPLE__
-            set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));
-        #else
-            set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
-        #endif
+        break;
+    }
+    case WINDOW_OPTIONS_PAGE_ADVANCED:
+    {
+        gfx_draw_string_left(dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->x + 10, w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1);
+        gfx_draw_string_left(
+            dpi,
+            window_options_autosave_names[gConfigGeneral.autosave_frequency],
+            nullptr,
+            w->colours[1],
+            w->x + window_options_advanced_widgets[WIDX_AUTOSAVE].left + 1,
+            w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top
+        );
+
+#ifdef __APPLE__
+        set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));
+#else
+        set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
+#endif
         gfx_draw_string_left_clipped(
             dpi,
             STR_STRING,
             gCommonFormatArgs,
             w->colours[1],
-            w->x + window_options_misc_widgets[WIDX_PATH_TO_RCT1_BUTTON].left + 1,
-            w->y + window_options_misc_widgets[WIDX_PATH_TO_RCT1_BUTTON].top,
+            w->x + window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON].left + 1,
+            w->y + window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON].top,
             277
         );
         break;
@@ -1980,11 +2028,15 @@ static void window_options_text_input(rct_window *w, rct_widgetindex widgetIndex
 
 static void window_options_tooltip(rct_window *w, rct_widgetindex widgetIndex, rct_string_id *stringid)
 {
-    if (widgetIndex == WIDX_PATH_TO_RCT1_BUTTON && w->page == WINDOW_OPTIONS_PAGE_MISC) {
-        if (str_is_null_or_empty(gConfigGeneral.rct1_path)) {
+    if (w->page == WINDOW_OPTIONS_PAGE_ADVANCED && widgetIndex == WIDX_PATH_TO_RCT1_BUTTON)
+    {
+        if (str_is_null_or_empty(gConfigGeneral.rct1_path))
+        {
             // No tooltip if the path is empty
             *stringid = STR_NONE;
-        } else {
+        }
+        else
+        {
             set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
         }
     }
@@ -2051,6 +2103,7 @@ static void window_options_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w
     window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
     window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE, SPR_TAB_GEARS_0);
     window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_WRENCH_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
     window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_TWITCH, SPR_G2_TAB_TWITCH);
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -293,23 +293,29 @@ static rct_widget window_options_audio_widgets[] = {
 
 static rct_widget window_options_controls_and_interface_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_GROUPBOX,         1,  5,      304,    53,         144,    STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
-    { WWT_CHECKBOX,         2,  10,     299,    68,         79,     STR_SCREEN_EDGE_SCROLLING,              STR_SCREEN_EDGE_SCROLLING_TIP },            // Edge scrolling
-    { WWT_CHECKBOX,         2,  10,     299,    83,         94,     STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
-    { WWT_CHECKBOX,         2,  10,     299,    98,         109,    STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
-    { WWT_CHECKBOX,         2,  10,     299,    113,        124,    STR_ZOOM_TO_CURSOR,                     STR_ZOOM_TO_CURSOR_TIP },           // Zoom to cursor
-    { WWT_DROPDOWN_BUTTON,  1,  155,    299,    128,        139,    STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
-    { WWT_GROUPBOX,         1,  5,      304,    148,        194,    STR_THEMES_GROUP,                       STR_NONE },                                 // Toolbar buttons group
-    { WWT_DROPDOWN,         1,  155,    299,    162,        173,    STR_NONE,                               STR_NONE },                                 // Themes
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    163,        172,    STR_DROPDOWN_GLYPH,                     STR_CURRENT_THEME_TIP },
-    { WWT_DROPDOWN_BUTTON,  1,  155,    299,    178,        189,    STR_EDIT_THEMES_BUTTON,                 STR_EDIT_THEMES_BUTTON_TIP },               // Themes button
-    { WWT_GROUPBOX,         1,  5,      304,    198,        273,    STR_TOOLBAR_BUTTONS_GROUP,              STR_NONE },                                 // Toolbar buttons group
-    { WWT_CHECKBOX,         2,  10,     145,    229,        240,    STR_FINANCES_BUTTON_ON_TOOLBAR,         STR_FINANCES_BUTTON_ON_TOOLBAR_TIP },       // Finances
-    { WWT_CHECKBOX,         2,  10,     145,    244,        255,    STR_RESEARCH_BUTTON_ON_TOOLBAR,         STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP },       // Research
-    { WWT_CHECKBOX,         2,  155,    299,    229,        240,    STR_CHEATS_BUTTON_ON_TOOLBAR,           STR_CHEATS_BUTTON_ON_TOOLBAR_TIP },         // Cheats
-    { WWT_CHECKBOX,         2,  155,    299,    244,        255,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP },  // Recent messages
-    { WWT_CHECKBOX,         2,  10,     185,    259,        270,    STR_MUTE_BUTTON_ON_TOOLBAR,             STR_MUTE_BUTTON_ON_TOOLBAR_TIP },           // Mute
+#define CONTROLS_GROUP_START 53
+    { WWT_GROUPBOX,         1,  5,      304,    CONTROLS_GROUP_START + 0,    CONTROLS_GROUP_START + 91,   STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 13,   CONTROLS_GROUP_START + 26,   STR_SCREEN_EDGE_SCROLLING,              STR_SCREEN_EDGE_SCROLLING_TIP },            // Edge scrolling
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 30,   CONTROLS_GROUP_START + 41,   STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 45,   CONTROLS_GROUP_START + 56,   STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 60,   CONTROLS_GROUP_START + 71,   STR_ZOOM_TO_CURSOR,                     STR_ZOOM_TO_CURSOR_TIP },                   // Zoom to cursor
+    { WWT_DROPDOWN_BUTTON,  1,  155,    299,    CONTROLS_GROUP_START + 75,   CONTROLS_GROUP_START + 87,   STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
+#undef CONTROLS_GROUP_START
+#define THEMES_GROUP_START 148
+    { WWT_GROUPBOX,         1,  5,      304,    THEMES_GROUP_START + 0,      THEMES_GROUP_START + 47,     STR_THEMES_GROUP,                       STR_NONE },                                 // Toolbar buttons group
+    { WWT_DROPDOWN,         1,  155,    299,    THEMES_GROUP_START + 14,     THEMES_GROUP_START + 25,     STR_NONE,                               STR_NONE },                                 // Themes
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    THEMES_GROUP_START + 15,     THEMES_GROUP_START + 24,     STR_DROPDOWN_GLYPH,                     STR_CURRENT_THEME_TIP },
+    { WWT_DROPDOWN_BUTTON,  1,  155,    299,    THEMES_GROUP_START + 30,     THEMES_GROUP_START + 42,     STR_EDIT_THEMES_BUTTON,                 STR_EDIT_THEMES_BUTTON_TIP },               // Themes button
+#undef THEMES_GROUP_START
+#define TOOLBAR_GROUP_START 200
+    { WWT_GROUPBOX,         1,  5,      304,    TOOLBAR_GROUP_START + 0,     TOOLBAR_GROUP_START + 75,    STR_TOOLBAR_BUTTONS_GROUP,              STR_NONE },                                 // Toolbar buttons group
+    { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 31,    TOOLBAR_GROUP_START + 42,    STR_FINANCES_BUTTON_ON_TOOLBAR,         STR_FINANCES_BUTTON_ON_TOOLBAR_TIP },       // Finances
+    { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 46,    TOOLBAR_GROUP_START + 57,    STR_RESEARCH_BUTTON_ON_TOOLBAR,         STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP },       // Research
+    { WWT_CHECKBOX,         2,  155,    299,    TOOLBAR_GROUP_START + 31,    TOOLBAR_GROUP_START + 42,    STR_CHEATS_BUTTON_ON_TOOLBAR,           STR_CHEATS_BUTTON_ON_TOOLBAR_TIP },         // Cheats
+    { WWT_CHECKBOX,         2,  155,    299,    TOOLBAR_GROUP_START + 46,    TOOLBAR_GROUP_START + 57,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP },  // Recent messages
+    { WWT_CHECKBOX,         2,  24,     185,    TOOLBAR_GROUP_START + 61,    TOOLBAR_GROUP_START + 72,    STR_MUTE_BUTTON_ON_TOOLBAR,             STR_MUTE_BUTTON_ON_TOOLBAR_TIP },           // Mute
     { WIDGETS_END },
+#undef TOOLBAR_GROUP_START
 };
 
 static rct_widget window_options_misc_widgets[] = {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -152,12 +152,15 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_TOOLBAR_SHOW_MUTE,
 
     // Misc
-    WIDX_TITLE_SEQUENCE = WIDX_PAGE_START,
+    WIDX_TITLE_SEQUENCE_GROUP = WIDX_PAGE_START,
+    WIDX_TITLE_SEQUENCE,
     WIDX_TITLE_SEQUENCE_DROPDOWN,
     WIDX_TITLE_SEQUENCE_BUTTON,
+    WIDX_SCENARIO_GROUP,
     WIDX_SCENARIO_GROUPING,
     WIDX_SCENARIO_GROUPING_DROPDOWN,
     WIDX_SCENARIO_UNLOCKING,
+    WIDX_TWEAKS_GROUP,
     WIDX_REAL_NAME_CHECKBOX,
     WIDX_AUTO_STAFF_PLACEMENT,
     WIDX_AUTO_OPEN_SHOPS,
@@ -207,7 +210,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     { WWT_TAB,              1,  96,     126,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_AUDIO_TIP }, \
     { WWT_TAB,              1,  127,    157,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_CONTROLS_AND_INTERFACE_TIP }, \
     { WWT_TAB,              1,  158,    188,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_MISCELLANEOUS_TIP }, \
-    { WWT_TAB,              1,  189,    219,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_NONE }, \
+    { WWT_TAB,              1,  189,    219,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,   STR_OPTIONS_ADVANCED }, \
     { WWT_TAB,              TWITCH_TAB_COLOUR,  220,    250,    17,     43,     TWITCH_TAB_SPRITE,      STR_OPTIONS_TWITCH_TIP }
 
 static rct_widget window_options_display_widgets[] = {
@@ -311,19 +314,26 @@ static rct_widget window_options_controls_and_interface_widgets[] = {
 
 static rct_widget window_options_misc_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_DROPDOWN,         1,  155,    299,    159,    170,    STR_NONE,                                   STR_NONE },                                         // Title sequence dropdown
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    160,    169,    STR_DROPDOWN_GLYPH,                         STR_TITLE_SEQUENCE_TIP },                           // Title sequence dropdown button
-    { WWT_DROPDOWN_BUTTON,  1,  155,    299,    174,    185,    STR_EDIT_TITLE_SEQUENCES_BUTTON,            STR_EDIT_TITLE_SEQUENCES_BUTTON_TIP },              // Edit title sequences button
-
-    { WWT_DROPDOWN,         1,  155,    299,    294,        305,    STR_NONE,                               STR_NONE },                                 // Scenario select mode
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    295,        304,    STR_DROPDOWN_GLYPH,                     STR_SCENARIO_GROUPING_TIP },
-    { WWT_CHECKBOX,         2,  18,     299,    309,        320,    STR_OPTIONS_SCENARIO_UNLOCKING,         STR_SCENARIO_UNLOCKING_TIP },               // Unlocking of scenarios
-
-    { WWT_CHECKBOX,         2,  10,     299,    54,     65,     STR_REAL_NAME,                              STR_REAL_NAME_TIP },                                // Show 'real' names of guests
-    { WWT_CHECKBOX,         2,  10,     299,    189,    200,    STR_AUTO_STAFF_PLACEMENT,                   STR_AUTO_STAFF_PLACEMENT_TIP },                     // Auto staff placement
-    { WWT_CHECKBOX,         2,  10,     299,    201,    212,    STR_AUTO_OPEN_SHOPS,                        STR_AUTO_OPEN_SHOPS_TIP },                          // Automatically open shops & stalls
-    { WWT_DROPDOWN,         1,  155,    299,    224,    235,    STR_NONE,                                   STR_NONE },                                         // Default inspection time dropdown
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    225,    234,    STR_DROPDOWN_GLYPH,                         STR_DEFAULT_INSPECTION_INTERVAL_TIP },              // Default inspection time dropdown button
+#define TITLE_SEQUENCE_START 53
+    { WWT_GROUPBOX,         1,  5,      304,    TITLE_SEQUENCE_START + 0,  TITLE_SEQUENCE_START + 49,  STR_OPTIONS_TITLE_SEQUENCE,       STR_NONE },
+    { WWT_DROPDOWN,         1,  135,    299,    TITLE_SEQUENCE_START + 15, TITLE_SEQUENCE_START + 26,  STR_NONE,                         STR_NONE },                             // Title sequence dropdown
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    TITLE_SEQUENCE_START + 16, TITLE_SEQUENCE_START + 25,  STR_DROPDOWN_GLYPH,               STR_TITLE_SEQUENCE_TIP },               // Title sequence dropdown button
+    { WWT_DROPDOWN_BUTTON,  1,  135,    299,    TITLE_SEQUENCE_START + 30, TITLE_SEQUENCE_START + 42,  STR_EDIT_TITLE_SEQUENCES_BUTTON,  STR_EDIT_TITLE_SEQUENCES_BUTTON_TIP },  // Edit title sequences button
+#undef TITLE_SEQUENCE_START
+#define SCENARIO_START 107
+    { WWT_GROUPBOX,         1,  5,      304,    SCENARIO_START + 0,        SCENARIO_START + 50,        STR_OPTIONS_SCENARIO_SELECTION,   STR_NONE },
+    { WWT_DROPDOWN,         1,  175,    299,    SCENARIO_START + 15,       SCENARIO_START + 26,        STR_NONE,                         STR_NONE },                             // Scenario select mode
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    SCENARIO_START + 16,       SCENARIO_START + 25,        STR_DROPDOWN_GLYPH,               STR_SCENARIO_GROUPING_TIP },
+    { WWT_CHECKBOX,         2,  25,     299,    SCENARIO_START + 30,       SCENARIO_START + 45,        STR_OPTIONS_SCENARIO_UNLOCKING,   STR_SCENARIO_UNLOCKING_TIP },           // Unlocking of scenarios
+#undef SCENARIO_START
+#define TWEAKS_START 162
+    { WWT_GROUPBOX,         1,  5,      304,    TWEAKS_START + 0,          TWEAKS_START + 80,          STR_OPTIONS_TWEAKS,               STR_NONE },
+    { WWT_CHECKBOX,         2,  10,     299,    TWEAKS_START + 15,         TWEAKS_START + 29,          STR_REAL_NAME,                    STR_REAL_NAME_TIP },                    // Show 'real' names of guests
+    { WWT_CHECKBOX,         2,  10,     299,    TWEAKS_START + 30,         TWEAKS_START + 44,          STR_AUTO_STAFF_PLACEMENT,         STR_AUTO_STAFF_PLACEMENT_TIP },         // Auto staff placement
+    { WWT_CHECKBOX,         2,  10,     299,    TWEAKS_START + 45,         TWEAKS_START + 59,          STR_AUTO_OPEN_SHOPS,              STR_AUTO_OPEN_SHOPS_TIP },              // Automatically open shops & stalls
+    { WWT_DROPDOWN,         1,  175,    299,    TWEAKS_START + 61,         TWEAKS_START + 72,          STR_NONE,                         STR_NONE },                             // Default inspection time dropdown
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    TWEAKS_START + 62,         TWEAKS_START + 71,          STR_DROPDOWN_GLYPH,               STR_DEFAULT_INSPECTION_INTERVAL_TIP },  // Default inspection time dropdown button
+#undef TWEAKS_START
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -327,18 +327,16 @@ static rct_widget window_options_misc_widgets[] = {
 
 static rct_widget window_options_advanced_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_CHECKBOX,         2,  10,     299,    114,    125,    STR_ENABLE_DEBUGGING_TOOLS,                 STR_ENABLE_DEBUGGING_TOOLS_TIP },                   // Enable debugging tools
-    { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_TEST_UNFINISHED_TRACKS,                 STR_TEST_UNFINISHED_TRACKS_TIP },                   // Test unfinished tracks
-    { WWT_CHECKBOX,         2,  10,     299,    69,     80,     STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,  STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM_TIP },    // Allow loading with incorrect checksum
-    { WWT_CHECKBOX,         2,  10,     299,    84,     95,     STR_SAVE_PLUGIN_DATA,                       STR_SAVE_PLUGIN_DATA_TIP },                         // Export plug-in objects with saved games
-    { WWT_CHECKBOX,         2,  10,     299,    129,    140,    STR_STAY_CONNECTED_AFTER_DESYNC,            STR_STAY_CONNECTED_AFTER_DESYNC_TIP },              // Do not disconnect after the client desynchronises with the server
-
-    { WWT_DROPDOWN,         1,  155,    299,    144,    155,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    145,    154,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
-
-    { WWT_12,               1,  10,     298,    239,    250,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
-    { WWT_DROPDOWN_BUTTON,  1,  10,     289,    254,    265,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
-    { WWT_DROPDOWN_BUTTON,  1,  289,    299,    254,    265,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
+    { WWT_CHECKBOX,         2,  10,     299,    54,      65,    STR_ENABLE_DEBUGGING_TOOLS,                 STR_ENABLE_DEBUGGING_TOOLS_TIP },                   // Enable debugging tools
+    { WWT_CHECKBOX,         2,  10,     299,    69,      80,    STR_TEST_UNFINISHED_TRACKS,                 STR_TEST_UNFINISHED_TRACKS_TIP },                   // Test unfinished tracks
+    { WWT_CHECKBOX,         2,  10,     299,    84,      95,    STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM,  STR_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM_TIP },    // Allow loading with incorrect checksum
+    { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_SAVE_PLUGIN_DATA,                       STR_SAVE_PLUGIN_DATA_TIP },                         // Export plug-in objects with saved games
+    { WWT_CHECKBOX,         2,  10,     299,    114,    125,    STR_STAY_CONNECTED_AFTER_DESYNC,            STR_STAY_CONNECTED_AFTER_DESYNC_TIP },              // Do not disconnect after the client desynchronises with the server
+    { WWT_DROPDOWN,         1,  165,    299,    130,    141,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    131,    140,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
+    { WWT_14,               1,  23,     298,    148,    159,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
+    { WWT_DROPDOWN_BUTTON,  1,  24,     289,    163,    176,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
+    { WWT_DROPDOWN_BUTTON,  1,  289,    299,    163,    176,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
     { WIDGETS_END },
 };
 
@@ -1957,7 +1955,7 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
     case WINDOW_OPTIONS_PAGE_ADVANCED:
     {
-        gfx_draw_string_left(dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->x + 10, w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1);
+        gfx_draw_string_left(dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->x + 24, w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1);
         gfx_draw_string_left(
             dpi,
             window_options_autosave_names[gConfigGeneral.autosave_frequency],
@@ -1972,13 +1970,21 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
 #else
         set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
 #endif
+
+        rct_widget pathWidget = window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON];
+
+        // Apply vertical alignment if appropriate.
+        sint32 widgetHeight = pathWidget.bottom - pathWidget.top;
+        sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+        uint32 padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
+
         gfx_draw_string_left_clipped(
             dpi,
             STR_STRING,
             gCommonFormatArgs,
             w->colours[1],
-            w->x + window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON].left + 1,
-            w->y + window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON].top,
+            w->x + pathWidget.left + 1,
+            w->y + pathWidget.top + padding,
             277
         );
         break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -237,7 +237,7 @@ static rct_widget window_options_display_widgets[] = {
 
     { WWT_CHECKBOX,         1,  11,     153,    161,    172,    STR_UNCAP_FPS,          STR_UNCAP_FPS_TIP },        // Uncap fps
     { WWT_CHECKBOX,         1,  155,    290,    161,    172,    STR_SHOW_FPS,           STR_SHOW_FPS_TIP },         // Show fps
-    { WWT_CHECKBOX,         1,  11 ,    290,    176,    187,    STR_USE_VSYNC,          STR_USE_VSYNC_TIP },        // Use vsync
+    { WWT_CHECKBOX,         1,  11,     290,    176,    187,    STR_USE_VSYNC,          STR_USE_VSYNC_TIP },        // Use vsync
     { WWT_CHECKBOX,         1,  11,     290,    191,    202,    STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS,  STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP },    // Minimise fullscreen focus loss
 
 
@@ -251,10 +251,10 @@ static rct_widget window_options_rendering_widgets[] = {
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 15,     FRAME_RENDERING_START + 26,     STR_TILE_SMOOTHING,             STR_TILE_SMOOTHING_TIP },               // Landscape smoothing
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 30,     FRAME_RENDERING_START + 41,     STR_GRIDLINES,                  STR_GRIDLINES_TIP },                    // Gridlines
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 45,     FRAME_RENDERING_START + 56,     STR_CYCLE_DAY_NIGHT,            STR_CYCLE_DAY_NIGHT_TIP },              // Cycle day-night
-    { WWT_CHECKBOX,         1,  31,     290,    FRAME_RENDERING_START + 60,     FRAME_RENDERING_START + 71,     STR_ENABLE_LIGHTING_EFFECTS,    STR_ENABLE_LIGHTING_EFFECTS_TIP },      // Enable light fx
+    { WWT_CHECKBOX,         1,  25,     290,    FRAME_RENDERING_START + 60,     FRAME_RENDERING_START + 71,     STR_ENABLE_LIGHTING_EFFECTS,    STR_ENABLE_LIGHTING_EFFECTS_TIP },      // Enable light fx
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 75,     FRAME_RENDERING_START + 86,     STR_UPPERCASE_BANNERS,          STR_UPPERCASE_BANNERS_TIP },            // Uppercase banners
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 90,     FRAME_RENDERING_START + 101,    STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
-    { WWT_CHECKBOX,         1,  31,     290,    FRAME_RENDERING_START + 101,    FRAME_RENDERING_START + 116,    STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
+    { WWT_CHECKBOX,         1,  25,     290,    FRAME_RENDERING_START + 105,    FRAME_RENDERING_START + 116,    STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_RENDERING_START + 120,    FRAME_RENDERING_START + 131,    STR_SHOW_GUEST_PURCHASES,       STR_SHOW_GUEST_PURCHASES_TIP },
 #undef FRAME_RENDERING_START
     { WIDGETS_END },

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -360,12 +360,12 @@ static rct_widget window_options_advanced_widgets[] = {
 
 static rct_widget window_options_twitch_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_DROPDOWN_BUTTON,  1,  10,     299,    54,     65,     STR_TWITCH_NAME,            STR_TWITCH_NAME_TIP },              // Twitch channel name
-    { WWT_CHECKBOX,         2,  10,     299,    69,     80,     STR_TWITCH_PEEP_FOLLOWERS,  STR_TWITCH_PEEP_FOLLOWERS_TIP },    // Twitch name peeps by follows
-    { WWT_CHECKBOX,         2,  10,     299,    84,     95,     STR_TWITCH_FOLLOWERS_TRACK, STR_TWITCH_FOLLOWERS_TRACK_TIP },   // Twitch information on for follows
-    { WWT_CHECKBOX,         2,  10,     299,    99,     110,    STR_TWITCH_PEEP_CHAT,       STR_TWITCH_PEEP_CHAT_TIP },         // Twitch name peeps by chat
-    { WWT_CHECKBOX,         2,  10,     299,    114,    125,    STR_TWITCH_CHAT_TRACK,      STR_TWITCH_CHAT_TRACK_TIP  },       // Twitch information on for chat
-    { WWT_CHECKBOX,         2,  10,     299,    129,    140,    STR_TWITCH_CHAT_NEWS,       STR_TWITCH_CHAT_NEWS_TIP },         // Twitch chat !news as notifications in game
+    { WWT_DROPDOWN_BUTTON,  1,  10,     299,    54,     66,     STR_TWITCH_NAME,            STR_TWITCH_NAME_TIP },              // Twitch channel name
+    { WWT_CHECKBOX,         2,  10,     299,    71,     86,     STR_TWITCH_PEEP_FOLLOWERS,  STR_TWITCH_PEEP_FOLLOWERS_TIP },    // Twitch name peeps by follows
+    { WWT_CHECKBOX,         2,  10,     299,    87,     102,    STR_TWITCH_FOLLOWERS_TRACK, STR_TWITCH_FOLLOWERS_TRACK_TIP },   // Twitch information on for follows
+    { WWT_CHECKBOX,         2,  10,     299,    103,    118,    STR_TWITCH_PEEP_CHAT,       STR_TWITCH_PEEP_CHAT_TIP },         // Twitch name peeps by chat
+    { WWT_CHECKBOX,         2,  10,     299,    119,    134,    STR_TWITCH_CHAT_TRACK,      STR_TWITCH_CHAT_TRACK_TIP  },       // Twitch information on for chat
+    { WWT_CHECKBOX,         2,  10,     299,    135,    150,    STR_TWITCH_CHAT_NEWS,       STR_TWITCH_CHAT_NEWS_TIP },         // Twitch chat !news as notifications in game
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -283,7 +283,7 @@ static rct_widget window_options_audio_widgets[] = {
     { WWT_DROPDOWN_BUTTON,  1,  288,    298,    54,     63,     STR_DROPDOWN_GLYPH,     STR_AUDIO_DEVICE_TIP },
     { WWT_CHECKBOX,         1,  10,     229,    69,     80,     STR_SOUND_EFFECTS,      STR_SOUND_EFFECTS_TIP },        // Enable / disable sound effects
     { WWT_CHECKBOX,         1,  10,     229,    84,     95,     STR_RIDE_MUSIC,         STR_RIDE_MUSIC_TIP },           // Enable / disable ride music
-    { WWT_CHECKBOX,         1,  10,     229,    98,     110,    STR_AUDIO_FOCUS,        STR_AUDIO_FOCUS_TIP },          // Enable / disable audio disabled on focus lost
+    { WWT_CHECKBOX,         1,  10,     299,    98,     110,    STR_AUDIO_FOCUS,        STR_AUDIO_FOCUS_TIP },          // Enable / disable audio disabled on focus lost
     { WWT_DROPDOWN,         1,  155,    299,    112,    124,    STR_NONE,               STR_NONE },                     // Title music
     { WWT_DROPDOWN_BUTTON,  1,  288,    298,    113,    123,    STR_DROPDOWN_GLYPH,     STR_TITLE_MUSIC_TIP },
     { WWT_SCROLL,           1,  155,    299,    68,     80,     SCROLL_HORIZONTAL,      STR_NONE },                     // Sound effect volume

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -403,8 +403,28 @@ static const rct_string_id window_options_fullscreen_mode_names[] = {
     STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
 };
 
-const sint32 window_options_tab_animation_divisor[] = { 4, 4, 8, 2, 2, 2, 2, 1 };
-const sint32 window_options_tab_animation_frames[] = { 16, 8, 8, 16, 4, 16, 16, 1 };
+const sint32 window_options_tab_animation_divisor[] =
+{
+    4, // WINDOW_OPTIONS_PAGE_DISPLAY,
+    1, // WINDOW_OPTIONS_PAGE_RENDERING,
+    8, // WINDOW_OPTIONS_PAGE_CULTURE,
+    2, // WINDOW_OPTIONS_PAGE_AUDIO,
+    2, // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
+    4, // WINDOW_OPTIONS_PAGE_MISC,
+    2, // WINDOW_OPTIONS_PAGE_ADVANCED,
+    1  // WINDOW_OPTIONS_PAGE_TWITCH,
+};
+const sint32 window_options_tab_animation_frames[] =
+{
+     8, // WINDOW_OPTIONS_PAGE_DISPLAY,
+     1, // WINDOW_OPTIONS_PAGE_RENDERING,
+     8, // WINDOW_OPTIONS_PAGE_CULTURE,
+    16, // WINDOW_OPTIONS_PAGE_AUDIO,
+     4, // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
+    16, // WINDOW_OPTIONS_PAGE_MISC,
+    16, // WINDOW_OPTIONS_PAGE_ADVANCED,
+     1  // WINDOW_OPTIONS_PAGE_TWITCH,
+};
 
 static void window_options_set_page(rct_window *w, sint32 page);
 static void window_options_set_pressed_tab(rct_window *w);
@@ -2116,14 +2136,14 @@ static void window_options_draw_tab_image(rct_drawpixelinfo *dpi, rct_window *w,
 
 static void window_options_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w)
 {
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_TAB_RIDE_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_RENDERING, SPR_TAB_PAINT_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CULTURE, SPR_TAB_TIMER_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_DISPLAY,                SPR_TAB_PAINT_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_RENDERING,              SPR_G2_TAB_TREE);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CULTURE,                SPR_TAB_TIMER_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_AUDIO,                  SPR_TAB_MUSIC_0);
     window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE, SPR_TAB_GEARS_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_WRENCH_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
-    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_TWITCH, SPR_G2_TAB_TWITCH);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_MISC,                   SPR_TAB_RIDE_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_ADVANCED,               SPR_TAB_WRENCH_0);
+    window_options_draw_tab_image(dpi, w, WINDOW_OPTIONS_PAGE_TWITCH,                 SPR_G2_TAB_TWITCH);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -150,15 +150,15 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_TOOLBAR_SHOW_CHEATS,
     WIDX_TOOLBAR_SHOW_NEWS,
     WIDX_TOOLBAR_SHOW_MUTE,
+
+    // Misc
+    WIDX_TITLE_SEQUENCE = WIDX_PAGE_START,
+    WIDX_TITLE_SEQUENCE_DROPDOWN,
+    WIDX_TITLE_SEQUENCE_BUTTON,
     WIDX_SCENARIO_GROUPING,
     WIDX_SCENARIO_GROUPING_DROPDOWN,
     WIDX_SCENARIO_UNLOCKING,
-
-    // Misc
-    WIDX_REAL_NAME_CHECKBOX = WIDX_PAGE_START,
-    WIDX_TITLE_SEQUENCE,
-    WIDX_TITLE_SEQUENCE_DROPDOWN,
-    WIDX_TITLE_SEQUENCE_BUTTON,
+    WIDX_REAL_NAME_CHECKBOX,
     WIDX_AUTO_STAFF_PLACEMENT,
     WIDX_AUTO_OPEN_SHOPS,
     WIDX_DEFAULT_INSPECTION_INTERVAL,
@@ -306,18 +306,20 @@ static rct_widget window_options_controls_and_interface_widgets[] = {
     { WWT_CHECKBOX,         2,  155,    299,    229,        240,    STR_CHEATS_BUTTON_ON_TOOLBAR,           STR_CHEATS_BUTTON_ON_TOOLBAR_TIP },         // Cheats
     { WWT_CHECKBOX,         2,  155,    299,    244,        255,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR,    STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP },  // Recent messages
     { WWT_CHECKBOX,         2,  10,     185,    259,        270,    STR_MUTE_BUTTON_ON_TOOLBAR,             STR_MUTE_BUTTON_ON_TOOLBAR_TIP },           // Mute
-    { WWT_DROPDOWN,         1,  155,    299,    294,        305,    STR_NONE,                               STR_NONE },                                 // Scenario select mode
-    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    295,        304,    STR_DROPDOWN_GLYPH,                     STR_SCENARIO_GROUPING_TIP },
-    { WWT_CHECKBOX,         2,  18,     299,    309,        320,    STR_OPTIONS_SCENARIO_UNLOCKING,         STR_SCENARIO_UNLOCKING_TIP },               // Unlocking of scenarios
     { WIDGETS_END },
 };
 
 static rct_widget window_options_misc_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
-    { WWT_CHECKBOX,         2,  10,     299,    54,     65,     STR_REAL_NAME,                              STR_REAL_NAME_TIP },                                // Show 'real' names of guests
     { WWT_DROPDOWN,         1,  155,    299,    159,    170,    STR_NONE,                                   STR_NONE },                                         // Title sequence dropdown
     { WWT_DROPDOWN_BUTTON,  1,  288,    298,    160,    169,    STR_DROPDOWN_GLYPH,                         STR_TITLE_SEQUENCE_TIP },                           // Title sequence dropdown button
     { WWT_DROPDOWN_BUTTON,  1,  155,    299,    174,    185,    STR_EDIT_TITLE_SEQUENCES_BUTTON,            STR_EDIT_TITLE_SEQUENCES_BUTTON_TIP },              // Edit title sequences button
+
+    { WWT_DROPDOWN,         1,  155,    299,    294,        305,    STR_NONE,                               STR_NONE },                                 // Scenario select mode
+    { WWT_DROPDOWN_BUTTON,  1,  288,    298,    295,        304,    STR_DROPDOWN_GLYPH,                     STR_SCENARIO_GROUPING_TIP },
+    { WWT_CHECKBOX,         2,  18,     299,    309,        320,    STR_OPTIONS_SCENARIO_UNLOCKING,         STR_SCENARIO_UNLOCKING_TIP },               // Unlocking of scenarios
+
+    { WWT_CHECKBOX,         2,  10,     299,    54,     65,     STR_REAL_NAME,                              STR_REAL_NAME_TIP },                                // Show 'real' names of guests
     { WWT_CHECKBOX,         2,  10,     299,    189,    200,    STR_AUTO_STAFF_PLACEMENT,                   STR_AUTO_STAFF_PLACEMENT_TIP },                     // Auto staff placement
     { WWT_CHECKBOX,         2,  10,     299,    201,    212,    STR_AUTO_OPEN_SHOPS,                        STR_AUTO_OPEN_SHOPS_TIP },                          // Automatically open shops & stalls
     { WWT_DROPDOWN,         1,  155,    299,    224,    235,    STR_NONE,                                   STR_NONE },                                         // Default inspection time dropdown
@@ -527,9 +529,6 @@ static uint64 window_options_page_enabled_widgets[] = {
     (1 << WIDX_THEMES) |
     (1 << WIDX_THEMES_DROPDOWN) |
     (1 << WIDX_THEMES_BUTTON) |
-    (1 << WIDX_SCENARIO_GROUPING) |
-    (1 << WIDX_SCENARIO_GROUPING_DROPDOWN) |
-    (1 << WIDX_SCENARIO_UNLOCKING) |
     (1 << WIDX_TOOLBAR_SHOW_MUTE),
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
@@ -538,6 +537,9 @@ static uint64 window_options_page_enabled_widgets[] = {
     (1 << WIDX_TITLE_SEQUENCE) |
     (1 << WIDX_TITLE_SEQUENCE_DROPDOWN) |
     (1 << WIDX_TITLE_SEQUENCE_BUTTON) |
+    (1 << WIDX_SCENARIO_GROUPING) |
+    (1 << WIDX_SCENARIO_GROUPING_DROPDOWN) |
+    (1 << WIDX_SCENARIO_UNLOCKING) |
     (1 << WIDX_AUTO_OPEN_SHOPS) |
     (1 << WIDX_DEFAULT_INSPECTION_INTERVAL) |
     (1 << WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN),
@@ -793,12 +795,6 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             context_open_window(WC_THEMES);
             window_invalidate(w);
             break;
-
-        case WIDX_SCENARIO_UNLOCKING:
-            gConfigGeneral.scenario_unlocking_enabled ^= 1;
-            config_save_default();
-            window_close_by_class(WC_SCENARIO_SELECT);
-            break;
         }
         break;
 
@@ -817,6 +813,11 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             break;
         case WIDX_TITLE_SEQUENCE_BUTTON:
             window_title_editor_open(0);
+            break;
+        case WIDX_SCENARIO_UNLOCKING:
+            gConfigGeneral.scenario_unlocking_enabled ^= 1;
+            config_save_default();
+            window_close_by_class(WC_SCENARIO_SELECT);
             break;
         case WIDX_AUTO_OPEN_SHOPS:
             gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
@@ -1162,28 +1163,6 @@ static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex,
             dropdown_set_checked((sint32)theme_manager_get_active_available_theme_index(), true);
             widget_invalidate(w, WIDX_THEMES_DROPDOWN);
             break;
-
-        case WIDX_SCENARIO_GROUPING_DROPDOWN:
-            num_items = 2;
-
-            gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[0] = STR_OPTIONS_SCENARIO_DIFFICULTY;
-            gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[1] = STR_OPTIONS_SCENARIO_ORIGIN;
-
-            window_dropdown_show_text_custom_width(
-                w->x + widget->left,
-                w->y + widget->top,
-                widget->bottom - widget->top + 1,
-                w->colours[1],
-                0,
-                DROPDOWN_FLAG_STAY_OPEN,
-                num_items,
-                widget->right - widget->left - 3
-            );
-
-            dropdown_set_checked(gConfigGeneral.scenario_select_mode, true);
-            break;
         }
         break;
 
@@ -1206,6 +1185,27 @@ static void window_options_mousedown(rct_window *w, rct_widgetindex widgetIndex,
             );
 
             dropdown_set_checked((sint32)title_get_current_sequence(), true);
+            break;
+        case WIDX_SCENARIO_GROUPING_DROPDOWN:
+            num_items = 2;
+
+            gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItemsArgs[0] = STR_OPTIONS_SCENARIO_DIFFICULTY;
+            gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItemsArgs[1] = STR_OPTIONS_SCENARIO_ORIGIN;
+
+            window_dropdown_show_text_custom_width(
+                w->x + widget->left,
+                w->y + widget->top,
+                widget->bottom - widget->top + 1,
+                w->colours[1],
+                0,
+                DROPDOWN_FLAG_STAY_OPEN,
+                num_items,
+                widget->right - widget->left - 3
+            );
+
+            dropdown_set_checked(gConfigGeneral.scenario_select_mode, true);
             break;
         case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
             for (size_t i = 0; i < 7; i++) {
@@ -1412,14 +1412,6 @@ static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, 
             }
             config_save_default();
             break;
-        case WIDX_SCENARIO_GROUPING_DROPDOWN:
-            if (dropdownIndex != gConfigGeneral.scenario_select_mode) {
-                gConfigGeneral.scenario_select_mode = dropdownIndex;
-                config_save_default();
-                window_invalidate(w);
-                window_close_by_class(WC_SCENARIO_SELECT);
-            }
-            break;
         }
         break;
 
@@ -1437,6 +1429,14 @@ static void window_options_dropdown(rct_window *w, rct_widgetindex widgetIndex, 
                 gConfigGeneral.default_inspection_interval = (uint8)dropdownIndex;
                 config_save_default();
                 window_invalidate(w);
+            }
+            break;
+        case WIDX_SCENARIO_GROUPING_DROPDOWN:
+            if (dropdownIndex != gConfigGeneral.scenario_select_mode) {
+                gConfigGeneral.scenario_select_mode = dropdownIndex;
+                config_save_default();
+                window_invalidate(w);
+                window_close_by_class(WC_SCENARIO_SELECT);
             }
             break;
         }
@@ -1666,13 +1666,6 @@ static void window_options_invalidate(rct_window *w)
         widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_CHEATS, gConfigInterface.toolbar_show_cheats);
         widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_NEWS, gConfigInterface.toolbar_show_news);
         widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_MUTE, gConfigInterface.toolbar_show_mute);
-        widget_set_checkbox_value(w, WIDX_SCENARIO_UNLOCKING, gConfigGeneral.scenario_unlocking_enabled);
-
-        if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN) {
-            w->disabled_widgets &= ~(1ULL << WIDX_SCENARIO_UNLOCKING);
-        } else {
-            w->disabled_widgets |= (1ULL << WIDX_SCENARIO_UNLOCKING);
-        }
 
         window_options_controls_and_interface_widgets[WIDX_THEMES].type = WWT_DROPDOWN;
         window_options_controls_and_interface_widgets[WIDX_THEMES_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
@@ -1685,8 +1678,6 @@ static void window_options_invalidate(rct_window *w)
         window_options_controls_and_interface_widgets[WIDX_TOOLBAR_SHOW_CHEATS].type = WWT_CHECKBOX;
         window_options_controls_and_interface_widgets[WIDX_TOOLBAR_SHOW_NEWS].type = WWT_CHECKBOX;
         window_options_controls_and_interface_widgets[WIDX_TOOLBAR_SHOW_MUTE].type = WWT_CHECKBOX;
-        window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].type = WWT_DROPDOWN;
-        window_options_controls_and_interface_widgets[WIDX_SCENARIO_UNLOCKING].type = WWT_CHECKBOX;
         break;
 
     case WINDOW_OPTIONS_PAGE_MISC:
@@ -1708,6 +1699,17 @@ static void window_options_invalidate(rct_window *w)
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE].type = WWT_DROPDOWN;
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
         window_options_misc_widgets[WIDX_TITLE_SEQUENCE_BUTTON].type = WWT_DROPDOWN_BUTTON;
+
+        widget_set_checkbox_value(w, WIDX_SCENARIO_UNLOCKING, gConfigGeneral.scenario_unlocking_enabled);
+
+        if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN) {
+            w->disabled_widgets &= ~(1ULL << WIDX_SCENARIO_UNLOCKING);
+        } else {
+            w->disabled_widgets |= (1ULL << WIDX_SCENARIO_UNLOCKING);
+        }
+
+        window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].type = WWT_DROPDOWN;
+        window_options_controls_and_interface_widgets[WIDX_SCENARIO_UNLOCKING].type = WWT_CHECKBOX;
 
         window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].type = WWT_DROPDOWN;
         window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
@@ -1913,18 +1915,6 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
             w->y + window_options_controls_and_interface_widgets[WIDX_THEMES].top,
             window_options_controls_and_interface_widgets[WIDX_THEMES_DROPDOWN].left - window_options_controls_and_interface_widgets[WIDX_THEMES].left - 4
         );
-        gfx_draw_string_left(dpi, STR_OPTIONS_SCENARIO_GROUPING, nullptr, w->colours[1], w->x + 10, w->y + window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].top + 1);
-        gfx_draw_string_left_clipped(
-            dpi,
-            gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_DIFFICULTY ?
-                STR_OPTIONS_SCENARIO_DIFFICULTY :
-                STR_OPTIONS_SCENARIO_ORIGIN,
-            nullptr,
-            w->colours[1],
-            w->x + window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].left + 1,
-            w->y + window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].top,
-            window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING_DROPDOWN].left - window_options_controls_and_interface_widgets[WIDX_SCENARIO_GROUPING].left - 4
-        );
         break;
     }
     case WINDOW_OPTIONS_PAGE_MISC:
@@ -1940,6 +1930,19 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi)
             w->x + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].left + 1,
             w->y + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top,
             window_options_misc_widgets[WIDX_TITLE_SEQUENCE_DROPDOWN].left - window_options_misc_widgets[WIDX_TITLE_SEQUENCE].left - 4
+        );
+
+        gfx_draw_string_left(dpi, STR_OPTIONS_SCENARIO_GROUPING, nullptr, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top + 1);
+        gfx_draw_string_left_clipped(
+            dpi,
+            gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_DIFFICULTY ?
+                STR_OPTIONS_SCENARIO_DIFFICULTY :
+                STR_OPTIONS_SCENARIO_ORIGIN,
+            nullptr,
+            w->colours[1],
+            w->x + window_options_misc_widgets[WIDX_SCENARIO_GROUPING].left + 1,
+            w->y + window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top,
+            window_options_misc_widgets[WIDX_SCENARIO_GROUPING_DROPDOWN].left - window_options_misc_widgets[WIDX_SCENARIO_GROUPING].left - 4
         );
 
         gfx_draw_string_left(dpi, STR_DEFAULT_INSPECTION_INTERVAL, w, w->colours[1], w->x + 10, w->y + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1);

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3813,6 +3813,11 @@ enum {
     STR_USE_VSYNC = 6165,
     STR_USE_VSYNC_TIP = 6166,
             
+    STR_OPTIONS_ADVANCED = 6167,
+    STR_OPTIONS_TITLE_SEQUENCE = 6168,
+    STR_OPTIONS_SCENARIO_SELECTION = 6169,
+    STR_OPTIONS_TWEAKS = 6170,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
As mentioned in #6773, I have been meaning to clean up the Options window. The 'Miscellaneous' tab in particular was getting really cluttered, with it having had widgets added over time.

This PR aims to reorganise the widgets in a more logical manner.

## Brief overview of the changes

* Introducing a new tab, 'Advanced', split off from 'Miscellaneous'. Contains e.g. debug options. (Suggestions for a better name are welcome.)
* ~~~Title music has been moved to the 'Miscellaneous' tab, grouping it together with the title sequence options. Widened dropdowns for localisation.~~~ (Reverted)
* Scenario grouping options have been moved to the 'Miscellaneous' tab, too, also grouping them together.
* Some tabs have had their icon changed. (Could be improved upon, still.)
* ~~~Screen resolution option is now disabled in windowed mode, too.~~~ (Merged separately.)
* ~~~Buttons are right-aligned uniformly. This disassociates them from unrelated options.~~~ (Merged separately.)

## Screenshots

Here are a few screenshots of the changed tabs:

![screenshot_20171217_174459](https://user-images.githubusercontent.com/604665/34081726-0ad49cec-e352-11e7-9630-5b13d7c6fc1f.png)
![screenshot_20171218_133900](https://user-images.githubusercontent.com/604665/34106543-e6425fac-e3f8-11e7-868c-1af932f8788a.png)
![screenshot_20171217_174441](https://user-images.githubusercontent.com/604665/34081725-0abb7ac8-e352-11e7-9ab2-9d7ca5d486bf.png)


