### PR TITLE
Refactor and cleanup footpath-related code

### DIFF
--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -164,16 +164,16 @@ static const uint8 DefaultPathSlope[] = {
     0,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
-    TILE_ELEMENT_PATH_IS_SLOPED_FLAG | 2,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 2,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
-    TILE_ELEMENT_PATH_IS_SLOPED_FLAG | 3,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 3,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
-    TILE_ELEMENT_PATH_IS_SLOPED_FLAG | 1,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 1,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
-    TILE_ELEMENT_PATH_IS_SLOPED_FLAG | 0,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 0,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
@@ -815,7 +815,7 @@ static void window_footpath_set_provisional_path_at_point(sint32 x, sint32 y)
             slope = DefaultPathSlope[tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK];
             break;
         case VIEWPORT_INTERACTION_ITEM_FOOTPATH:
-            slope = tileElement->properties.path.type & (TILE_ELEMENT_PATH_IS_SLOPED_FLAG | TILE_ELEMENT_DIRECTION_MASK);
+            slope = tileElement->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK);
             break;
         }
         sint32 pathType = (gFootpathSelectedType << 7) + (gFootpathSelectedId & 0xFF);
@@ -909,7 +909,7 @@ static void window_footpath_place_path_at_point(sint32 x, sint32 y)
         presentType = DefaultPathSlope[tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK];
         break;
     case VIEWPORT_INTERACTION_ITEM_FOOTPATH:
-        presentType = tileElement->properties.path.type & (TILE_ELEMENT_PATH_IS_SLOPED_FLAG | TILE_ELEMENT_DIRECTION_MASK);
+        presentType = tileElement->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK);
         break;
     }
     z            = tileElement->base_height;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1377,10 +1377,10 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
         }
 
         *parameter_1 = 0;
-        *parameter_1 |= (tile_element->properties.path.type & (TILE_ELEMENT_PATH_IS_SLOPED_FLAG | TILE_ELEMENT_DIRECTION_MASK)) << 8;
+        *parameter_1 |= (tile_element->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)) << 8;
         *parameter_2 = tile_element->base_height;
         *parameter_2 |= ((footpath_element_get_type(tile_element)) << 8);
-        if (tile_element->type & TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG) {
+        if (footpath_element_has_queue_banner(tile_element)) {
             *parameter_2 |= LOCATION_NULL;
         }
         *parameter_3 = (selected_scenery & 0xFF) + 1;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1303,7 +1303,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
             }
 
             gSceneryPlaceZ = 0;
-            uint16 water_height = tile_element->properties.surface.terrain & TILE_ELEMENT_WATER_HEIGHT_MASK;
+            uint16 water_height = tile_element->properties.surface.terrain & TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
             if (water_height != 0) {
                 gSceneryPlaceZ = water_height * 16;
             }
@@ -1376,9 +1376,11 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
             return;
         }
 
-        *parameter_1 = 0 | ((tile_element->properties.path.type & 0x7) << 8);
-        *parameter_2 = tile_element->base_height | ((tile_element->properties.path.type >> 4) << 8);
-        if (tile_element->type & 1) {
+        *parameter_1 = 0;
+        *parameter_1 |= (tile_element->properties.path.type & (TILE_ELEMENT_PATH_IS_SLOPED_FLAG | TILE_ELEMENT_DIRECTION_MASK)) << 8;
+        *parameter_2 = tile_element->base_height;
+        *parameter_2 |= ((footpath_element_get_type(tile_element)) << 8);
+        if (tile_element->type & TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG) {
             *parameter_2 |= LOCATION_NULL;
         }
         *parameter_3 = (selected_scenery & 0xFF) + 1;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1303,7 +1303,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
             }
 
             gSceneryPlaceZ = 0;
-            uint16 water_height = tile_element->properties.surface.terrain & TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
+            uint16 water_height = map_get_water_height(tile_element);
             if (water_height != 0) {
                 gSceneryPlaceZ = water_height * 16;
             }

--- a/src/openrct2/interface/viewport_interaction.c
+++ b/src/openrct2/interface/viewport_interaction.c
@@ -466,7 +466,7 @@ static void viewport_interaction_remove_footpath_item(rct_tile_element *tileElem
 {
     sint32 type;
 
-    type = tileElement->properties.path.type >> 4;
+    type = footpath_element_get_type(tileElement);
     if (footpath_element_is_queue(tileElement))
         type |= 0x80;
 

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -388,7 +388,7 @@ bool wooden_a_supports_paint_setup(paint_session * session, sint32 supportType, 
         if (imageId == 0) {
             drawFlatPiece = true;
         } else {
-            imageId += word_97B3C4[slope & TILE_ELEMENT_SLOPE_MASK];
+            imageId += word_97B3C4[slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
             imageId |= imageColourFlags;
             sub_98197C(session, imageId, 0, 0, 32, 32, 11, z, 0, 0, z + 2, rotation);
 
@@ -411,7 +411,7 @@ bool wooden_a_supports_paint_setup(paint_session * session, sint32 supportType, 
         if (imageId == 0) {
             drawFlatPiece = true;
         } else {
-            imageId += word_97B3C4[slope & TILE_ELEMENT_SLOPE_MASK];
+            imageId += word_97B3C4[slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
             imageId |= imageColourFlags;
 
             sub_98197C(session, imageId, 0, 0, 32, 32, 11, z, 0, 0, z + 2, rotation);
@@ -528,7 +528,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
             baseHeight += 32;
             goTo662E8B = true;
         } else {
-            imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SLOPE_MASK];
+            imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
 
             sub_98197C(session, 
                 imageId | imageColourFlags,
@@ -564,7 +564,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
             baseHeight += 16;
             goTo662E8B = true;
         } else {
-            imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SLOPE_MASK];
+            imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
 
             sub_98197C(session, 
                 imageId | imageColourFlags,
@@ -746,7 +746,7 @@ bool metal_a_supports_paint_setup(paint_session * session, uint8 supportType, ui
         sint8 yOffset = loc_97AF20[segment].y;
 
         uint32 image_id = _97B15C[supportType].base_id;
-        image_id += metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SLOPE_MASK];
+        image_id += metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
         image_id |= imageColourFlags;
 
         sub_98196C(session, image_id, xOffset, yOffset, 0, 0, 5, supportSegments[segment].height, rotation);
@@ -931,7 +931,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
         || (_97B15C[supportType].base_id == 0)) {
         baseHeight = supportSegments[segment].height;
     } else {
-        uint32 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SLOPE_MASK];
+        uint32 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
         uint32 imageId = _97B15C[supportType].base_id + imageOffset;
 
         sub_98196C(session, 
@@ -1089,7 +1089,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
             return false;
         }
 
-        uint32 imageId = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SLOPE_MASK] + pathEntry->bridge_image;
+        uint32 imageId = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK] + pathEntry->bridge_image;
 
         sub_98197C(session, 
             imageId | imageColourFlags,
@@ -1120,7 +1120,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
             return false;
         }
 
-        uint32 ebx = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SLOPE_MASK] + pathEntry->bridge_image;
+        uint32 ebx = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK] + pathEntry->bridge_image;
 
         sub_98197C(session, 
             ebx | imageColourFlags,
@@ -1241,7 +1241,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
         || !(pathEntry->flags & FOOTPATH_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE)) {
         baseHeight = supportSegments[segment].height;
     } else {
-        uint8 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SLOPE_MASK];
+        uint8 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
         baseHeight = supportSegments[segment].height;
 
         sub_98196C(session, 

--- a/src/openrct2/paint/tile_element/Banner.cpp
+++ b/src/openrct2/paint/tile_element/Banner.cpp
@@ -24,6 +24,8 @@
 #include "../../world/scenery.h"
 
 /** rct2: 0x0098D884 */
+// BannerBoundBoxes[rotation][0] is for the pole in the back
+// BannerBoundBoxes[rotation][1] is for the pole and the banner in the front
 const LocationXY16 BannerBoundBoxes[][2] = {
     {{ 1,  2}, { 1, 29}},
     {{ 2, 32}, {29, 32}},

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -286,7 +286,8 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
     if (footpath_element_is_queue(tile_element)) {
         uint8 local_ebp = ebp & 0x0F;
         if (footpath_element_is_sloped(tile_element)) {
-            switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & TILE_ELEMENT_DIRECTION_MASK) {
+            switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)
+            {
                 case 0:
                     sub_98197C(session, 95 + base_image_id, 0, 4, 32, 1, 23, height, 0, 4, height + 2, get_current_rotation());
                     sub_98197C(session, 95 + base_image_id, 0, 28, 32, 1, 23, height, 0, 28, height + 2, get_current_rotation());
@@ -389,7 +390,7 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
 
         direction--;
         // If text shown
-        if (direction < 2 && tile_element->properties.path.ride_index != RIDE_ENTRY_INDEX_NULL && imageFlags == 0) {
+        if (direction < 2 && tile_element->properties.path.ride_index != RIDE_ID_NULL && imageFlags == 0) {
             uint16 scrollingMode = footpathEntry->scrolling_mode;
             scrollingMode += direction;
 
@@ -432,7 +433,8 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
     }
 
     if (footpath_element_is_sloped(tile_element)) {
-        switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & TILE_ELEMENT_DIRECTION_MASK) {
+        switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)
+        {
             case 0:
                 sub_98197C(session, 81 + base_image_id, 0, 4, 32, 1, 23, height, 0, 4, height + 2, get_current_rotation());
                 sub_98197C(session, 81 + base_image_id, 0, 28, 32, 1, 23, height, 0, 28, height + 2, get_current_rotation());
@@ -635,7 +637,7 @@ static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element,
     }
 
     // This is about tunnel drawing
-    uint8 direction = (footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & 0x03;
+    uint8 direction = (footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
     bool  sloped    = footpath_element_is_sloped(tile_element);
 
     if (connectedEdges & EDGE_SE) {
@@ -818,7 +820,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
 
     uint32 imageId;
     if (footpath_element_is_sloped(tileElement)) {
-        imageId = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + 16;
+        imageId = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK) + 16;
     } else {
         imageId = byte_98D6E0[edi];
     }
@@ -853,7 +855,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
     } else {
         uint32 image_id;
         if (footpath_element_is_sloped(tileElement)) {
-            image_id = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + footpathEntry->bridge_image + 51;
+            image_id = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK) + footpathEntry->bridge_image + 51;
         } else {
             image_id = byte_98D8A4[edges] + footpathEntry->bridge_image + 49;
         }
@@ -981,7 +983,7 @@ void path_paint_pole_support(paint_session * session, rct_tile_element* tileElem
     else {
         uint32 bridgeImage;
         if (footpath_element_is_sloped(tileElement)) {
-            bridgeImage = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + footpathEntry->bridge_image + 16;
+            bridgeImage = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK) + footpathEntry->bridge_image + 16;
         }
         else {
             bridgeImage = edges + footpathEntry->bridge_image;
@@ -1037,21 +1039,19 @@ void path_paint_pole_support(paint_session * session, rct_tile_element* tileElem
 
     paint_util_set_segment_support_height(session, SEGMENT_C4, 0xFFFF, 0);
 
-    if (edges & 1) {
+    if (edges & EDGE_NE) {
         paint_util_set_segment_support_height(session, SEGMENT_CC, 0xFFFF, 0);
     }
 
-    if (edges & 2) {
+    if (edges & EDGE_SE) {
         paint_util_set_segment_support_height(session, SEGMENT_D4, 0xFFFF, 0);
     }
 
-    if (edges & 4) {
+    if (edges & EDGE_SW) {
         paint_util_set_segment_support_height(session, SEGMENT_D0, 0xFFFF, 0);
     }
 
-    if (edges & 8) {
+    if (edges & EDGE_NW) {
         paint_util_set_segment_support_height(session, SEGMENT_C8, 0xFFFF, 0);
     }
 }
-
-

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -89,7 +89,7 @@ static void path_bit_lights_paint(paint_session * session, rct_scenery_entry* pa
 
     uint32 imageId;
 
-    if (!(edges & PATH_EDGE_FLAG_0)) {
+    if (!(edges & EDGE_NE)) {
         imageId = pathBitEntry->image + 1;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -99,7 +99,7 @@ static void path_bit_lights_paint(paint_session * session, rct_scenery_entry* pa
 
         sub_98197C(session, imageId, 2, 16, 1, 1, 23, height, 3, 16, height + 2, get_current_rotation());
     }
-    if (!(edges & PATH_EDGE_FLAG_1)) {
+    if (!(edges & EDGE_SE)) {
         imageId = pathBitEntry->image + 2;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -110,7 +110,7 @@ static void path_bit_lights_paint(paint_session * session, rct_scenery_entry* pa
         sub_98197C(session, imageId, 16, 30, 1, 0, 23, height, 16, 29, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_2)) {
+    if (!(edges & EDGE_SW)) {
         imageId = pathBitEntry->image + 3;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -121,7 +121,7 @@ static void path_bit_lights_paint(paint_session * session, rct_scenery_entry* pa
         sub_98197C(session, imageId, 30, 16, 0, 1, 23, height, 29, 16, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_3)) {
+    if (!(edges & EDGE_NW)) {
         imageId = pathBitEntry->image + 4;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -140,7 +140,7 @@ static void path_bit_bins_paint(paint_session * session, rct_scenery_entry* path
 
     uint32 imageId;
 
-    if (!(edges & PATH_EDGE_FLAG_0)) {
+    if (!(edges & EDGE_NE)) {
         imageId = pathBitEntry->image + 5;
 
         imageId |= pathBitImageFlags;
@@ -157,7 +157,7 @@ static void path_bit_bins_paint(paint_session * session, rct_scenery_entry* path
 
         sub_98197C(session, imageId, 7, 16, 1, 1, 7, height, 7, 16, height + 2, get_current_rotation());
     }
-    if (!(edges & PATH_EDGE_FLAG_1)) {
+    if (!(edges & EDGE_SE)) {
         imageId = pathBitEntry->image + 6;
 
         imageId |= pathBitImageFlags;
@@ -175,7 +175,7 @@ static void path_bit_bins_paint(paint_session * session, rct_scenery_entry* path
         sub_98197C(session, imageId, 16, 25, 1, 1, 7, height, 16, 25, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_2)) {
+    if (!(edges & EDGE_SW)) {
         imageId = pathBitEntry->image + 7;
 
         imageId |= pathBitImageFlags;
@@ -193,7 +193,7 @@ static void path_bit_bins_paint(paint_session * session, rct_scenery_entry* path
         sub_98197C(session, imageId, 25, 16, 1, 1, 7, height, 25, 16, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_3)) {
+    if (!(edges & EDGE_NW)) {
         imageId = pathBitEntry->image + 8;
 
         imageId |= pathBitImageFlags;
@@ -216,7 +216,7 @@ static void path_bit_bins_paint(paint_session * session, rct_scenery_entry* path
 static void path_bit_benches_paint(paint_session * session, rct_scenery_entry* pathBitEntry, rct_tile_element* tileElement, sint32 height, uint8 edges, uint32 pathBitImageFlags) {
     uint32 imageId;
 
-    if (!(edges & PATH_EDGE_FLAG_0)) {
+    if (!(edges & EDGE_NE)) {
         imageId = pathBitEntry->image + 1;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -226,7 +226,7 @@ static void path_bit_benches_paint(paint_session * session, rct_scenery_entry* p
 
         sub_98197C(session, imageId, 7, 16, 0, 16, 7, height, 6, 8, height + 2, get_current_rotation());
     }
-    if (!(edges & PATH_EDGE_FLAG_1)) {
+    if (!(edges & EDGE_SE)) {
         imageId = pathBitEntry->image + 2;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -237,7 +237,7 @@ static void path_bit_benches_paint(paint_session * session, rct_scenery_entry* p
         sub_98197C(session, imageId, 16, 25, 16, 0, 7, height, 8, 23, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_2)) {
+    if (!(edges & EDGE_SW)) {
         imageId = pathBitEntry->image + 3;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -248,7 +248,7 @@ static void path_bit_benches_paint(paint_session * session, rct_scenery_entry* p
         sub_98197C(session, imageId, 25, 16, 0, 16, 7, height, 23, 8, height + 2, get_current_rotation());
     }
 
-    if (!(edges & PATH_EDGE_FLAG_3)) {
+    if (!(edges & EDGE_NW)) {
         imageId = pathBitEntry->image + 4;
 
         if (tileElement->flags & TILE_ELEMENT_FLAG_BROKEN)
@@ -286,7 +286,7 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
     if (footpath_element_is_queue(tile_element)) {
         uint8 local_ebp = ebp & 0x0F;
         if (footpath_element_is_sloped(tile_element)) {
-            switch ((tile_element->properties.path.type + get_current_rotation()) & 0x03) {
+            switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & TILE_ELEMENT_DIRECTION_MASK) {
                 case 0:
                     sub_98197C(session, 95 + base_image_id, 0, 4, 32, 1, 23, height, 0, 4, height + 2, get_current_rotation());
                     sub_98197C(session, 95 + base_image_id, 0, 28, 32, 1, 23, height, 0, 28, height + 2, get_current_rotation());
@@ -356,7 +356,7 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
             }
         }
 
-        if (!(tile_element->properties.path.type & 0x08)) {
+        if (!footpath_element_has_queue_banner(tile_element)) {
             return;
         }
 
@@ -378,8 +378,10 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
 
         uint32 imageId = (direction << 1) + base_image_id + 101;
 
+        // Draw pole in the back
         sub_98197C(session, imageId, 0, 0, 1, 1, 21, height, boundBoxOffsets.x, boundBoxOffsets.y, boundBoxOffsets.z, get_current_rotation());
 
+        // Draw pole in the front and banner
         boundBoxOffsets.x = BannerBoundBoxes[direction][1].x;
         boundBoxOffsets.y = BannerBoundBoxes[direction][1].y;
         imageId++;
@@ -387,7 +389,7 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
 
         direction--;
         // If text shown
-        if (direction < 2 && tile_element->properties.path.ride_index != 255 && imageFlags == 0) {
+        if (direction < 2 && tile_element->properties.path.ride_index != RIDE_ENTRY_INDEX_NULL && imageFlags == 0) {
             uint16 scrollingMode = footpathEntry->scrolling_mode;
             scrollingMode += direction;
 
@@ -430,7 +432,7 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
     }
 
     if (footpath_element_is_sloped(tile_element)) {
-        switch ((tile_element->properties.path.type + get_current_rotation()) & 0x03) {
+        switch ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & TILE_ELEMENT_DIRECTION_MASK) {
             case 0:
                 sub_98197C(session, 81 + base_image_id, 0, 4, 32, 1, 23, height, 0, 4, height + 2, get_current_rotation());
                 sub_98197C(session, 81 + base_image_id, 0, 28, 32, 1, 23, height, 0, 28, height + 2, get_current_rotation());
@@ -573,13 +575,13 @@ static void sub_6A4101(paint_session * session, rct_tile_element * tile_element,
 /**
  * rct2: 0x006A3F61
  * @param tile_element (esp[0])
- * @param bp (bp)
+ * @param connectedEdges (bp) (relative to the camera's rotation)
  * @param height (dx)
  * @param footpathEntry (0x00F3EF6C)
  * @param imageFlags (0x00F3EF70)
  * @param sceneryImageFlags (0x00F3EF74)
  */
-static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element, uint16 bp, uint16 height, rct_footpath_entry * footpathEntry, uint32 imageFlags, uint32 sceneryImageFlags, bool word_F3F038)
+static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element, uint16 connectedEdges, uint16 height, rct_footpath_entry * footpathEntry, uint32 imageFlags, uint32 sceneryImageFlags, bool word_F3F038)
 {
     // eax --
     // ebx --
@@ -596,8 +598,7 @@ static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element,
 
     if (dpi->zoom_level <= 1) {
         if (!gTrackDesignSaveMode) {
-            uint8 additions = tile_element->properties.path.additions & 0xF;
-            if (additions != 0) {
+            if (footpath_element_has_path_scenery(tile_element)) {
                 session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM;
                 if (sceneryImageFlags != 0) {
                     session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
@@ -607,16 +608,16 @@ static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element,
                 rct_scenery_entry* sceneryEntry = get_footpath_item_entry(footpath_element_get_path_scenery_index(tile_element));
                 switch (sceneryEntry->path_bit.draw_type) {
                 case PATH_BIT_DRAW_TYPE_LIGHTS:
-                    path_bit_lights_paint(session, sceneryEntry, tile_element, height, (uint8)bp, sceneryImageFlags);
+                    path_bit_lights_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags);
                     break;
                 case PATH_BIT_DRAW_TYPE_BINS:
-                    path_bit_bins_paint(session, sceneryEntry, tile_element, height, (uint8)bp, sceneryImageFlags);
+                    path_bit_bins_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags);
                     break;
                 case PATH_BIT_DRAW_TYPE_BENCHES:
-                    path_bit_benches_paint(session, sceneryEntry, tile_element, height, (uint8)bp, sceneryImageFlags);
+                    path_bit_benches_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags);
                     break;
                 case PATH_BIT_DRAW_TYPE_JUMPING_FOUNTAINS:
-                    path_bit_jumping_fountains_paint(session, sceneryEntry, tile_element, height, (uint8)bp, sceneryImageFlags, dpi);
+                    path_bit_jumping_fountains_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags, dpi);
                     break;
                 }
 
@@ -630,35 +631,40 @@ static void sub_6A3F61(paint_session * session, rct_tile_element * tile_element,
 
         // Redundant zoom-level check removed
 
-        sub_6A4101(session, tile_element, height, bp, word_F3F038, footpathEntry, footpathEntry->image | imageFlags, imageFlags);
+        sub_6A4101(session, tile_element, height, connectedEdges, word_F3F038, footpathEntry, footpathEntry->image | imageFlags, imageFlags);
     }
 
     // This is about tunnel drawing
-    uint8 direction = (tile_element->properties.path.type + get_current_rotation()) & 0x03;
-    uint8 diagonal = tile_element->properties.path.type & 0x04;
-    uint8 bl = direction | diagonal;
+    uint8 direction = (footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & 0x03;
+    bool  sloped    = footpath_element_is_sloped(tile_element);
 
-    if (bp & 2) {
+    if (connectedEdges & EDGE_SE) {
         // Bottom right of tile is a tunnel
-        if (bl == 5) {
+        if (sloped && direction == EDGE_NE) {
+            // Path going down into the tunnel
             paint_util_push_tunnel_right(session, height + 16, TUNNEL_10);
-        } else if (bp & 1) {
+        } else if (connectedEdges & EDGE_NE) {
+            // Flat path with edge to the right (north-east)
             paint_util_push_tunnel_right(session, height, TUNNEL_11);
         } else {
+            // Path going up, or flat and not connected to the right
             paint_util_push_tunnel_right(session, height, TUNNEL_10);
         }
     }
 
-    if (!(bp & 4)) {
+    if (!(connectedEdges & EDGE_SW)) {
         return;
     }
 
     // Bottom left of the tile is a tunnel
-    if (bl == 6) {
+    if (sloped && direction == EDGE_SE) {
+        // Path going down into the tunnel
         paint_util_push_tunnel_left(session, height + 16, TUNNEL_10);
-    } else if (bp & 8) {
+    } else if (connectedEdges & EDGE_NW) {
+        // Flat path with edge to the left (north-west)
         paint_util_push_tunnel_left(session, height , TUNNEL_11);
     } else {
+        // Path going up, or flat and not connected to the left
         paint_util_push_tunnel_left(session, height , TUNNEL_10);
     }
 }
@@ -709,11 +715,11 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_til
         if (footpath_element_is_sloped(tile_element)) {
             // Diagonal path
 
-            if ((surface->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK) != byte_98D800[tile_element->properties.path.type & 0x03]) {
+            if ((surface->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK) != byte_98D800[footpath_element_get_slope_direction(tile_element)]) {
                 word_F3F038 = true;
             }
         } else {
-            if (surface->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK) {
+            if (surface->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK) {
                 word_F3F038 = true;
             }
         }
@@ -740,7 +746,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_til
             uint32 imageId = 2618;
             sint32 height2 = tile_element->base_height * 8;
             if (footpath_element_is_sloped(tile_element)) {
-                imageId = 2619 + ((tile_element->properties.path.type + get_current_rotation()) & 3);
+                imageId = 2619 + ((footpath_element_get_slope_direction(tile_element) + get_current_rotation()) & 3);
                 height2 += 16;
             }
 
@@ -760,7 +766,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_til
         sub_98196C(session, imageId, 16, 16, 1, 1, 0, height2, get_current_rotation());
     }
 
-    uint8 pathType = (tile_element->properties.path.type & 0xF0) >> 4;
+    uint8 pathType = footpath_element_get_type(tile_element);
     rct_footpath_entry * footpathEntry = get_footpath_entry(pathType);
 
     if (footpathEntry != NULL) {
@@ -777,16 +783,16 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, rct_til
         if (footpath_element_has_path_scenery(tile_element) && !(tile_element->flags & TILE_ELEMENT_FLAG_BROKEN)) {
             rct_scenery_entry *sceneryEntry = get_footpath_item_entry(footpath_element_get_path_scenery_index(tile_element));
             if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP) {
-                if (!(tile_element->properties.path.edges & PATH_EDGE_FLAG_0)) {
+                if (!(tile_element->properties.path.edges & EDGE_NE)) {
                     lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, -16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
-                if (!(tile_element->properties.path.edges & PATH_EDGE_FLAG_1)) {
+                if (!(tile_element->properties.path.edges & EDGE_SE)) {
                     lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, 16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
-                if (!(tile_element->properties.path.edges & PATH_EDGE_FLAG_2)) {
+                if (!(tile_element->properties.path.edges & EDGE_SW)) {
                     lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 16, 0, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
-                if (!(tile_element->properties.path.edges & PATH_EDGE_FLAG_3)) {
+                if (!(tile_element->properties.path.edges & EDGE_NW)) {
                     lightfx_add_3d_light_magic_from_drawing_tile(session->MapPosition, 0, -16, height + 23, LIGHTFX_LIGHT_TYPE_LANTERN_3);
                 }
             }
@@ -812,7 +818,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
 
     uint32 imageId;
     if (footpath_element_is_sloped(tileElement)) {
-        imageId = ((tileElement->properties.path.type + get_current_rotation()) & 3) + 16;
+        imageId = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + 16;
     } else {
         imageId = byte_98D6E0[edi];
     }
@@ -847,7 +853,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
     } else {
         uint32 image_id;
         if (footpath_element_is_sloped(tileElement)) {
-            image_id = ((tileElement->properties.path.type + get_current_rotation()) & 3) + footpathEntry->bridge_image + 51;
+            image_id = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + footpathEntry->bridge_image + 51;
         } else {
             image_id = byte_98D8A4[edges] + footpathEntry->bridge_image + 49;
         }
@@ -866,7 +872,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
 
     uint16 ax = 0;
     if (footpath_element_is_sloped(tileElement)) {
-        ax = ((tileElement->properties.path.type + get_current_rotation()) & 0x3) + 1;
+        ax = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 0x3) + 1;
     }
 
     if (byte_98D8A4[edges] == 0) {
@@ -936,7 +942,7 @@ void path_paint_pole_support(paint_session * session, rct_tile_element* tileElem
 
     uint32 imageId;
     if (footpath_element_is_sloped(tileElement)) {
-        imageId = ((tileElement->properties.path.type + get_current_rotation()) & 3) + 16;
+        imageId = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + 16;
     }
     else {
         imageId = byte_98D6E0[edi];
@@ -975,7 +981,7 @@ void path_paint_pole_support(paint_session * session, rct_tile_element* tileElem
     else {
         uint32 bridgeImage;
         if (footpath_element_is_sloped(tileElement)) {
-            bridgeImage = ((tileElement->properties.path.type + get_current_rotation()) & 3) + footpathEntry->bridge_image + 16;
+            bridgeImage = ((footpath_element_get_slope_direction(tileElement) + get_current_rotation()) & 3) + footpathEntry->bridge_image + 16;
         }
         else {
             bridgeImage = edges + footpathEntry->bridge_image;

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -1287,7 +1287,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
     if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_VERTICAL))
     {
         // loc_66122C:
-        const uint8 al_edgeStyle = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+        const uint8 al_edgeStyle = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
         const uint8 di_type = tileElement->type & 0x80;
 
         const uint32 eax = al_edgeStyle + di_type * 2;
@@ -1335,7 +1335,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, rct_
             paint_attach_to_previous_ps(session, SPR_WATER_OVERLAY + image_offset, 0, 0);
 
             // This wasn't in the original, but the code depended on globals that were only set in a different conditional
-            const uint8 al_edgeStyle = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+            const uint8 al_edgeStyle = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
             const uint8 di_type = tileElement->type & 0x80;
             const uint32 eax = al_edgeStyle + di_type * 2;
             assert(eax % 32 == 0);

--- a/src/openrct2/paint/tile_element/TileElement.h
+++ b/src/openrct2/paint/tile_element/TileElement.h
@@ -73,13 +73,6 @@ enum
     G141E9DB_FLAG_2 = 2,
 };
 
-enum {
-    PATH_EDGE_FLAG_0 = (1 << 0),
-    PATH_EDGE_FLAG_1 = (1 << 1),
-    PATH_EDGE_FLAG_2 = (1 << 2),
-    PATH_EDGE_FLAG_3 = (1 << 3)
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -8951,6 +8951,7 @@ static sint32 peep_interact_with_entrance(rct_peep * peep, sint16 x, sint16 y, r
         sint16 next_x = (x & 0xFFE0) + TileDirectionDelta[entranceDirection].x;
         sint16 next_y = (y & 0xFFE0) + TileDirectionDelta[entranceDirection].y;
 
+        // Make sure there is a path right behind the entrance, otherwise turn around
         uint8             found          = 0;
         rct_tile_element * nextTileElement = map_get_first_element_at(next_x / 32, next_y / 32);
         do

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1003,10 +1003,10 @@ static uint8 staff_handyman_direction_to_uncut_grass(rct_peep * peep, uint8 vali
 
         if (peep->next_var_29 & 0x4)
         {
-            if ((tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK) != byte_98D800[peep->next_var_29 & 0x3])
+            if ((tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK) != byte_98D800[peep->next_var_29 & 0x3])
                 return 0xFF;
         }
-        else if ((tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK) != 0)
+        else if ((tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK) != 0)
             return 0xFF;
     }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -462,7 +462,7 @@ private:
             case TILE_ELEMENT_TYPE_PATH:
             {
                 uint8 pathColour = tile_element_get_direction(tileElement);
-                uint8 pathType = (tileElement->properties.path.type & 0xF0) >> 4;
+                uint8 pathType   = footpath_element_get_type(tileElement);
 
                 pathType = (pathType << 2) | pathColour;
                 uint8 pathAdditionsType = tileElement->properties.path.additions & 0x0F;
@@ -2350,7 +2350,7 @@ private:
             {
                 // Type
                 uint8 pathColour = tileElement->type & 3;
-                uint8 pathType = (tileElement->properties.path.type & 0xF0) >> 4;
+                uint8 pathType   = footpath_element_get_type(tileElement);
 
                 pathType = (pathType << 2) | pathColour;
                 uint8 entryIndex = _pathTypeToEntryMap[pathType];

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -404,7 +404,7 @@ static bool mini_golf_paint_util_should_draw_fence(paint_session * session, rct_
         return true;
     }
 
-    if (surfaceElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK)
+    if (surfaceElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK)
     {
         return true;
     }

--- a/src/openrct2/ride/ride_ratings.c
+++ b/src/openrct2/ride/ride_ratings.c
@@ -18,6 +18,7 @@
 #include "../interface/window.h"
 #include "../localisation/date.h"
 #include "../OpenRCT2.h"
+#include "../world/footpath.h"
 #include "../world/map.h"
 #include "ride.h"
 #include "ride_data.h"
@@ -517,7 +518,7 @@ static void ride_ratings_score_close_proximity(rct_tile_element *inputTileElemen
             break;
         case TILE_ELEMENT_TYPE_PATH:
             // Bonus for normal path
-            if (tileElement->properties.path.type & 0xF0) {
+            if (footpath_element_get_type(tileElement) != 0) {
                 if (tileElement->clearance_height == inputTileElement->base_height) {
                     proximity_score_increment(PROXIMITY_PATH_TOUCH_ABOVE);
                 }

--- a/src/openrct2/ride/track_design_save.c
+++ b/src/openrct2/ride/track_design_save.c
@@ -24,6 +24,7 @@
 #include "../util/SawyerCoding.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"
+#include "../world/footpath.h"
 #include "../world/LargeScenery.h"
 #include "../world/scenery.h"
 #include "../world/SmallScenery.h"
@@ -354,10 +355,10 @@ static void track_design_save_add_footpath(sint32 x, sint32 y, rct_tile_element 
     rct_object_entry *entry = (rct_object_entry*)&object_entry_groups[OBJECT_TYPE_PATHS].entries[entryType];
 
     uint8 flags = 0;
-    flags |= tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK;
-    flags |= (tileElement->properties.path.type & TILE_ELEMENT_PATH_IS_SLOPED_FLAG) << 2;
+    flags |= tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
+    flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) << 2;
     flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
-    flags |= (tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) << 7;
+    flags |= (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) << 7;
 
     track_design_save_push_tile_element(x, y, tileElement);
     track_design_save_push_tile_element_desc(entry, x, y, tileElement->base_height, flags, 0, 0);
@@ -535,10 +536,10 @@ static void track_design_save_remove_footpath(sint32 x, sint32 y, rct_tile_eleme
     rct_object_entry *entry = (rct_object_entry*)&object_entry_groups[OBJECT_TYPE_PATHS].entries[entryType];
 
     uint8 flags = 0;
-    flags |= tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK;
-    flags |= (tileElement->properties.path.type & TILE_ELEMENT_PATH_IS_SLOPED_FLAG) << 2;
+    flags |= tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
+    flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) << 2;
     flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
-    flags |= (tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) << 7;
+    flags |= (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) << 7;
 
     track_design_save_pop_tile_element(x, y, tileElement);
     track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags, 0, 0);
@@ -570,7 +571,7 @@ static bool track_design_save_should_select_scenery_around(sint32 rideIndex, rct
 {
     switch (tile_element_get_type(tileElement)) {
     case TILE_ELEMENT_TYPE_PATH:
-        if ((tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) && tileElement->properties.path.addition_status == rideIndex)
+        if ((tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) && tileElement->properties.path.addition_status == rideIndex)
             return true;
         break;
     case TILE_ELEMENT_TYPE_TRACK:
@@ -600,7 +601,7 @@ static void track_design_save_select_nearby_scenery_for_tile(sint32 rideIndex, s
                 sint32 interactionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 switch (tile_element_get_type(tileElement)) {
                 case TILE_ELEMENT_TYPE_PATH:
-                    if (!(tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG))
+                    if (!(tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE))
                         interactionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
                     else if (tileElement->properties.path.addition_status == rideIndex)
                         interactionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;

--- a/src/openrct2/ride/track_design_save.c
+++ b/src/openrct2/ride/track_design_save.c
@@ -357,7 +357,7 @@ static void track_design_save_add_footpath(sint32 x, sint32 y, rct_tile_element 
     uint8 flags = 0;
     flags |= tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
     flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) << 2;
-    flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
+    flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK) << 5;
     flags |= (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) << 7;
 
     track_design_save_push_tile_element(x, y, tileElement);
@@ -538,7 +538,7 @@ static void track_design_save_remove_footpath(sint32 x, sint32 y, rct_tile_eleme
     uint8 flags = 0;
     flags |= tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
     flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) << 2;
-    flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
+    flags |= (tileElement->properties.path.type & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK) << 5;
     flags |= (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) << 7;
 
     track_design_save_pop_tile_element(x, y, tileElement);

--- a/src/openrct2/ride/track_design_save.c
+++ b/src/openrct2/ride/track_design_save.c
@@ -354,10 +354,10 @@ static void track_design_save_add_footpath(sint32 x, sint32 y, rct_tile_element 
     rct_object_entry *entry = (rct_object_entry*)&object_entry_groups[OBJECT_TYPE_PATHS].entries[entryType];
 
     uint8 flags = 0;
-    flags |= tileElement->properties.path.edges & 0x0F;
-    flags |= (tileElement->properties.path.type & 4) << 2;
-    flags |= (tileElement->properties.path.type & 3) << 5;
-    flags |= (tileElement->type & 1) << 7;
+    flags |= tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK;
+    flags |= (tileElement->properties.path.type & TILE_ELEMENT_PATH_IS_SLOPED_FLAG) << 2;
+    flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
+    flags |= (tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) << 7;
 
     track_design_save_push_tile_element(x, y, tileElement);
     track_design_save_push_tile_element_desc(entry, x, y, tileElement->base_height, flags, 0, 0);
@@ -535,10 +535,10 @@ static void track_design_save_remove_footpath(sint32 x, sint32 y, rct_tile_eleme
     rct_object_entry *entry = (rct_object_entry*)&object_entry_groups[OBJECT_TYPE_PATHS].entries[entryType];
 
     uint8 flags = 0;
-    flags |= tileElement->properties.path.edges & 0x0F;
-    flags |= (tileElement->properties.path.type & 4) << 2;
-    flags |= (tileElement->properties.path.type & 3) << 5;
-    flags |= (tileElement->type & 1) << 7;
+    flags |= tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK;
+    flags |= (tileElement->properties.path.type & TILE_ELEMENT_PATH_IS_SLOPED_FLAG) << 2;
+    flags |= (tileElement->properties.path.type & TILE_ELEMENT_DIRECTION_MASK) << 5;
+    flags |= (tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) << 7;
 
     track_design_save_pop_tile_element(x, y, tileElement);
     track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags, 0, 0);
@@ -570,7 +570,7 @@ static bool track_design_save_should_select_scenery_around(sint32 rideIndex, rct
 {
     switch (tile_element_get_type(tileElement)) {
     case TILE_ELEMENT_TYPE_PATH:
-        if ((tileElement->type & 1) && tileElement->properties.path.addition_status == rideIndex)
+        if ((tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) && tileElement->properties.path.addition_status == rideIndex)
             return true;
         break;
     case TILE_ELEMENT_TYPE_TRACK:
@@ -600,7 +600,7 @@ static void track_design_save_select_nearby_scenery_for_tile(sint32 rideIndex, s
                 sint32 interactionType = VIEWPORT_INTERACTION_ITEM_NONE;
                 switch (tile_element_get_type(tileElement)) {
                 case TILE_ELEMENT_TYPE_PATH:
-                    if (!(tileElement->type & 1))
+                    if (!(tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG))
                         interactionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
                     else if (tileElement->properties.path.addition_status == rideIndex)
                         interactionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -303,7 +303,7 @@ static money32 SmallSceneryPlace(sint16 x,
         !supportsRequired &&
         !isOnWater &&
         surfaceElement != nullptr &&
-        (surfaceElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK))
+        (surfaceElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK))
     {
 
         gGameCommandErrorText = STR_LEVEL_LAND_REQUIRED;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -459,7 +459,7 @@ sint32 tile_inspector_surface_toggle_corner(sint32 x, sint32 y, sint32 cornerInd
         // All corners are raised
         if ((surfaceElement->properties.surface.slope & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) == TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
         {
-            surfaceElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+            surfaceElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
 
             if (diagonal)
             {

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -355,7 +355,7 @@ static money32 WallPlace(uint8 wallType,
         }
         position.z = surfaceElement->base_height * 8;
 
-        uint8 slope = surfaceElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+        uint8 slope = surfaceElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
         edgeSlope = EdgeSlopes[slope][edge & 3];
         if (edgeSlope & EDGE_SLOPE_ELEVATED)
         {

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -141,7 +141,7 @@ static rct_tile_element *map_get_footpath_element_slope(sint32 x, sint32 y, sint
         if (
             tile_element_get_type(tileElement) == TILE_ELEMENT_TYPE_PATH &&
             tileElement->base_height == z &&
-            (tileElement->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | TILE_ELEMENT_DIRECTION_MASK)) == slope
+            (tileElement->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)) == slope
         ) {
             return tileElement;
         }
@@ -1187,7 +1187,7 @@ static bool sub_footpath_disconnect_queue_from_path(sint32 x, sint32 y, rct_tile
     sint32 z = tileElement->base_height;
     rct_tile_element *otherTileElement = footpath_get_element(x1, y1, z - 2, z, direction);
     if (otherTileElement != NULL && !footpath_element_is_queue(otherTileElement)) {
-        tileElement->properties.path.type &= ~TILE_ELEMENT_DIRECTION_MASK;
+        tileElement->properties.path.type &= ~FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
         if (action > 0) {
             tileElement->properties.path.edges &= ~(1 << direction);
             otherTileElement->properties.path.edges &= ~(1 << ((direction + 2) & 3));

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -1829,7 +1829,7 @@ void footpath_element_set_wide(rct_tile_element * tileElement, bool isWide)
 
 bool footpath_element_has_path_scenery(const rct_tile_element * tileElement)
 {
-    return footpath_element_get_path_scenery(tileElement) > 0;
+    return footpath_element_get_path_scenery(tileElement) != 0;
 }
 
 uint8 footpath_element_get_path_scenery(const rct_tile_element * tileElement)

--- a/src/openrct2/world/footpath.c
+++ b/src/openrct2/world/footpath.c
@@ -141,7 +141,7 @@ static rct_tile_element *map_get_footpath_element_slope(sint32 x, sint32 y, sint
         if (
             tile_element_get_type(tileElement) == TILE_ELEMENT_TYPE_PATH &&
             tileElement->base_height == z &&
-            (tileElement->properties.path.type & (TILE_ELEMENT_PATH_IS_SLOPED_FLAG | TILE_ELEMENT_DIRECTION_MASK)) == slope
+            (tileElement->properties.path.type & (FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | TILE_ELEMENT_DIRECTION_MASK)) == slope
         ) {
             return tileElement;
         }
@@ -191,7 +191,7 @@ static money32 footpath_element_insert(sint32 type, sint32 x, sint32 y, sint32 z
 
     bl = 15;
     zHigh = z + 4;
-    if (slope & TILE_ELEMENT_PATH_IS_SLOPED_FLAG) {
+    if (slope & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) {
         bl = byte_98D7EC[slope & TILE_ELEMENT_DIRECTION_MASK];
         zHigh += 2;
     }
@@ -270,7 +270,7 @@ static money32 footpath_element_insert(sint32 type, sint32 x, sint32 y, sint32 z
 
 static money32 footpath_element_update(sint32 x, sint32 y, rct_tile_element *tileElement, sint32 type, sint32 flags, uint8 pathItemType)
 {
-    if (footpath_element_get_type(tileElement) != (type & 0x0F) || (tileElement->type & TILE_ELEMENT_PATH_QUEUE_FLAG) != (type >> 7)) {
+    if (footpath_element_get_type(tileElement) != (type & 0x0F) || (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) != (type >> 7)) {
         gFootpathPrice += MONEY(6, 00);
     } else if (pathItemType != 0) {
         if (
@@ -299,7 +299,7 @@ static money32 footpath_element_update(sint32 x, sint32 y, rct_tile_element *til
             }
 
             if (!(unk6 & (PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER | PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW)) &&
-                (tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK) == 0x0F) {
+                (tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK) == 0x0F) {
                 gGameCommandErrorText = STR_NONE;
                 return MONEY32_UNDEFINED;
             }
@@ -657,7 +657,7 @@ static money32 footpath_place_from_track(sint32 type, sint32 x, sint32 y, sint32
             tileElement->type |= type >> 7;
             tileElement->properties.path.additions = 0;
             tileElement->properties.path.addition_status = 255;
-            tileElement->properties.path.edges = edges & TILE_ELEMENT_PATH_EDGES_MASK;
+            tileElement->properties.path.edges = edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
             tileElement->flags &= ~TILE_ELEMENT_FLAG_BROKEN;
             if (flags & (1 << 6))
                 tileElement->flags |= TILE_ELEMENT_FLAG_GHOST;
@@ -1208,7 +1208,7 @@ static bool footpath_disconnect_queue_from_path(sint32 x, sint32 y, rct_tile_ele
 
     if (footpath_element_is_sloped(tileElement)) return false;
 
-    uint8 c = connected_path_count[tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK];
+    uint8 c = connected_path_count[tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK];
     if ((action < 0) ? (c >= 2) : (c < 2)) return false;
 
     if (action < 0) {
@@ -1329,7 +1329,7 @@ static void loc_6A6D7E(
                 return;
             }
             if (footpath_element_is_queue(tileElement)) {
-                if (connected_path_count[tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK] < 2) {
+                if (connected_path_count[tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK] < 2) {
                     neighbour_list_push(neighbourList, 4, direction, tileElement->properties.path.ride_index, tileElement->properties.entrance.index);
                 } else {
                     if (tile_element_get_type(initialTileElement) == TILE_ELEMENT_TYPE_PATH &&
@@ -1524,11 +1524,11 @@ void footpath_chain_ride_queue(sint32 rideIndex, sint32 entranceIndex, sint32 x,
                 }
             }
 
-            tileElement->properties.path.type &= ~TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG;
+            tileElement->properties.path.type &= ~FOOTPATH_PROPERTIES_FLAG_HAS_QUEUE_BANNER;
             tileElement->properties.path.edges |= (1 << (direction ^ 2));
             tileElement->properties.path.ride_index = rideIndex;
-            tileElement->properties.path.additions &= ~TILE_ELEMENT_PATH_ADDITION_STATION_INDEX_MASK;
-            tileElement->properties.path.additions |= (entranceIndex << 4) & TILE_ELEMENT_PATH_ADDITION_STATION_INDEX_MASK;
+            tileElement->properties.path.additions &= ~FOOTPATH_PROPERTIES_ADDITIONS_STATION_INDEX_MASK;
+            tileElement->properties.path.additions |= (entranceIndex << 4) & FOOTPATH_PROPERTIES_ADDITIONS_STATION_INDEX_MASK;
 
             map_invalidate_element(x, y, tileElement);
 
@@ -1715,7 +1715,7 @@ static sint32 footpath_is_connected_to_map_edge_recurse(
         if (flags & (1 << 5)) {
             footpath_fix_ownership(x, y, tileElement);
         }
-        edges = tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK;
+        edges = tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
         direction ^= 2;
         if (!(flags & (1 << 7))) {
             if (tileElement[1].type == TILE_ELEMENT_TYPE_BANNER) {
@@ -1812,7 +1812,7 @@ bool footpath_element_is_queue(const rct_tile_element * tileElement)
 
 bool footpath_element_has_queue_banner(const rct_tile_element * tileElement)
 {
-    return (tileElement->properties.path.type & TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG) != 0;
+    return (tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_HAS_QUEUE_BANNER) != 0;
 }
 
 bool footpath_element_is_wide(const rct_tile_element * tileElement)
@@ -1834,12 +1834,12 @@ bool footpath_element_has_path_scenery(const rct_tile_element * tileElement)
 
 uint8 footpath_element_get_path_scenery(const rct_tile_element * tileElement)
 {
-    return tileElement->properties.path.additions & TILE_ELEMENT_PATH_ADDITION_TYPE_MASK;
+    return tileElement->properties.path.additions & FOOTPATH_PROPERTIES_ADDITIONS_TYPE_MASK;
 }
 
 void footpath_element_set_path_scenery(rct_tile_element * tileElement, uint8 pathSceneryType)
 {
-    tileElement->properties.path.additions &= ~TILE_ELEMENT_PATH_ADDITION_TYPE_MASK;
+    tileElement->properties.path.additions &= ~FOOTPATH_PROPERTIES_ADDITIONS_TYPE_MASK;
     tileElement->properties.path.additions |= pathSceneryType;
 }
 
@@ -1972,7 +1972,7 @@ void footpath_update_path_wide_flags(sint32 x, sint32 y)
         if (footpath_element_is_sloped(tileElement))
             continue;
 
-        if ((tileElement->properties.path.edges & TILE_ELEMENT_PATH_EDGES_MASK) == 0)
+        if ((tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK) == 0)
             continue;
 
         uint8 height = tileElement->base_height;

--- a/src/openrct2/world/footpath.h
+++ b/src/openrct2/world/footpath.h
@@ -83,6 +83,11 @@ enum
     FOOTPATH_CLEAR_DIRECTIONAL = (1 << 8),  // Flag set when direction is used.
 };
 
+enum
+{
+    SLOPE_IS_IRREGULAR_FLAG = (1 << 3), // Flag set in `defaultPathSlope[]` and checked in `footpath_place_real`
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -127,6 +132,7 @@ bool footpath_element_is_sloped(const rct_tile_element * tileElement);
 void footpath_element_set_sloped(rct_tile_element * tileElement, bool isSloped);
 uint8 footpath_element_get_slope_direction(const rct_tile_element * tileElement);
 bool footpath_element_is_queue(const rct_tile_element * tileElement);
+bool footpath_element_has_queue_banner(const rct_tile_element * tileElement);
 bool footpath_element_is_wide(const rct_tile_element * tileElement);
 uint8 footpath_element_get_type(const rct_tile_element * tileElement);
 void footpath_element_set_type(rct_tile_element * tileElement, uint8 type);

--- a/src/openrct2/world/footpath.h
+++ b/src/openrct2/world/footpath.h
@@ -21,10 +21,11 @@
 #include "../interface/viewport.h"
 #include "../object.h"
 
-enum {
+enum
+{
     PROVISIONAL_PATH_FLAG_SHOW_ARROW = (1 << 0),
-    PROVISIONAL_PATH_FLAG_1 = (1 << 1),
-    PROVISIONAL_PATH_FLAG_2 = (1 << 2),
+    PROVISIONAL_PATH_FLAG_1          = (1 << 1),
+    PROVISIONAL_PATH_FLAG_2          = (1 << 2),
 };
 
 #pragma pack(push, 1)
@@ -39,6 +40,7 @@ typedef struct rct_footpath_entry {
 assert_struct_size(rct_footpath_entry, 13);
 #pragma pack(pop)
 
+// Masks for value stored in rct_tile_element.type
 enum
 {
     FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE  = (1 << 0),
@@ -46,27 +48,47 @@ enum
     FOOTPATH_ELEMENT_TYPE_DIRECTION_MASK = (1 << 6) | (1 << 7),
 };
 
+// Masks and flags for values stored in rct_tile_element.properties.path.type
 enum
 {
-    FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK = (1 << 0) | (1 << 1),
-    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED = (1 << 2),
-
-    FOOTPATH_PROPERTIES_TYPE_MASK = (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7),
+    FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK  = (1 << 0) | (1 << 1),
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED        = (1 << 2),
+    FOOTPATH_PROPERTIES_FLAG_HAS_QUEUE_BANNER = (1 << 3),
+    FOOTPATH_PROPERTIES_TYPE_MASK             = (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7),
 };
 
-enum {
+// Masks and flags for values stored in in rct_tile_element.properties.path.edges
+enum
+{
+    FOOTPATH_PROPERTIES_EDGES_EDGES_MASK   = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3),
+    FOOTPATH_PROPERTIES_EDGES_CORNERS_MASK = (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7),
+};
+
+// Masks and flags for values stored in in rct_tile_element.properties.path.additions
+enum
+{
+    FOOTPATH_PROPERTIES_ADDITIONS_TYPE_MASK          = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3),
+    // The most significant bit in this mask will always be zero, since rides can only have 4 stations
+    FOOTPATH_PROPERTIES_ADDITIONS_STATION_INDEX_MASK = (1 << 4) | (1 << 5) | (1 << 6),
+    FOOTPATH_PROPERTIES_ADDITIONS_FLAG_GHOST         = (1 << 7),
+};
+
+enum
+{
     FOOTPATH_ENTRY_SUPPORT_TYPE_BOX = 0,
     FOOTPATH_ENTRY_SUPPORT_TYPE_POLE = 1,
     FOOTPATH_ENTRY_SUPPORT_TYPE_COUNT
 };
 
-enum {
-    FOOTPATH_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE = (1 << 0),
-    FOOTPATH_ENTRY_FLAG_HAS_PATH_BASE_SPRITE = (1 << 1), // When elevated
+enum
+{
+    FOOTPATH_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE      = (1 << 0),
+    FOOTPATH_ENTRY_FLAG_HAS_PATH_BASE_SPRITE         = (1 << 1), // When elevated
     FOOTPATH_ENTRY_FLAG_SHOW_ONLY_IN_SCENARIO_EDITOR = (1 << 2),
 };
 
-enum {
+enum
+{
     FOOTPATH_SEARCH_SUCCESS,
     FOOTPATH_SEARCH_NOT_FOUND,
     FOOTPATH_SEARCH_INCOMPLETE,

--- a/src/openrct2/world/footpath.h
+++ b/src/openrct2/world/footpath.h
@@ -40,7 +40,7 @@ typedef struct rct_footpath_entry {
 assert_struct_size(rct_footpath_entry, 13);
 #pragma pack(pop)
 
-// Masks for value stored in rct_tile_element.type
+// Masks for values stored in rct_tile_element.type
 enum
 {
     FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE  = (1 << 0),

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -1336,7 +1336,9 @@ static money32 map_change_surface_style(sint32 x0, sint32 y0, sint32 x1, sint32 
                         return MONEY32_UNDEFINED;
                     }
                     surfaceCost += TerrainPricing[style];
-                    if (flags & 1){
+
+                    if (flags & GAME_COMMAND_FLAG_APPLY)
+                    {
                         tileElement->properties.surface.terrain &= TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
                         tileElement->type &= TILE_ELEMENT_QUADRANT_MASK | TILE_ELEMENT_TYPE_MASK;
 

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -319,7 +319,7 @@ void tile_element_set_terrain_edge(rct_tile_element *element, sint32 terrain)
         element->type &= ~128;
 
     // Bits 0, 1, 2 for terrain are stored in element.slope bit 5, 6, 7
-    element->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+    element->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
     element->properties.surface.slope |= (terrain & 7) << 5;
 }
 
@@ -525,7 +525,7 @@ sint32 tile_element_height(sint32 x, sint32 y)
         (map_get_water_height(tileElement) << 20) |
         (tileElement->base_height << 3);
 
-    uint32 slope = (tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK);
+    uint32 slope = (tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK);
     uint8 extra_height = (slope & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT) >> 4; // 0x10 is the 5th bit - sets slope to double height
     // Remove the extra height bit
     slope &= TILE_ELEMENT_SLOPE_ALL_CORNERS_UP;
@@ -1337,7 +1337,7 @@ static money32 map_change_surface_style(sint32 x0, sint32 y0, sint32 x1, sint32 
                     }
                     surfaceCost += TerrainPricing[style];
                     if (flags & 1){
-                        tileElement->properties.surface.terrain &= TILE_ELEMENT_WATER_HEIGHT_MASK;
+                        tileElement->properties.surface.terrain &= TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
                         tileElement->type &= TILE_ELEMENT_QUADRANT_MASK | TILE_ELEMENT_TYPE_MASK;
 
                         //Save the new terrain
@@ -1361,7 +1361,7 @@ static money32 map_change_surface_style(sint32 x0, sint32 y0, sint32 x1, sint32 
                     edgeCost += 100;
 
                     if (flags & 1){
-                        tileElement->properties.surface.slope &= TILE_ELEMENT_SLOPE_MASK;
+                        tileElement->properties.surface.slope &= TILE_ELEMENT_SURFACE_SLOPE_MASK;
                         tileElement->type &= 0x7F;
 
                         //Save edge style
@@ -1492,7 +1492,7 @@ static sint32 map_get_corner_height(sint32 z, sint32 slope, sint32 direction)
 static sint32 tile_element_get_corner_height(rct_tile_element *tileElement, sint32 direction)
 {
     sint32 z = tileElement->base_height;
-    sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+    sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
     return map_get_corner_height(z, slope, direction);
 }
 
@@ -1677,7 +1677,7 @@ static money32 map_set_land_height(sint32 flags, sint32 x, sint32 y, sint32 heig
 
     for (sint32 i = 0; i < 4; i += 1) {
         sint32 cornerHeight = tile_element_get_corner_height(surfaceElement, i);
-        cornerHeight -= map_get_corner_height(height, style & TILE_ELEMENT_SLOPE_MASK, i);
+        cornerHeight -= map_get_corner_height(height, style & TILE_ELEMENT_SURFACE_SLOPE_MASK, i);
         cost += MONEY(abs(cornerHeight) * 5 / 2, 0);
     }
 
@@ -1694,9 +1694,9 @@ static money32 map_set_land_height(sint32 flags, sint32 x, sint32 y, sint32 heig
         surfaceElement = map_get_surface_element_at(x / 32, y / 32);
         surfaceElement->base_height = height;
         surfaceElement->clearance_height = height;
-        surfaceElement->properties.surface.slope &= TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+        surfaceElement->properties.surface.slope &= TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
         surfaceElement->properties.surface.slope |= style;
-        sint32 slope = surfaceElement->properties.surface.terrain & TILE_ELEMENT_SLOPE_MASK;
+        sint32 slope = surfaceElement->properties.surface.terrain & TILE_ELEMENT_SURFACE_SLOPE_MASK;
         if(slope != TILE_ELEMENT_SLOPE_FLAT && slope <= height / 2)
             surfaceElement->properties.surface.terrain &= TILE_ELEMENT_SURFACE_TERRAIN_MASK;
         map_invalidate_tile_full(x, y);
@@ -1834,7 +1834,7 @@ static money32 raise_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
             if (tile_element != NULL) {
                 uint8 height = tile_element->base_height;
                 if (height <= min_height){
-                    uint8 newStyle = tile_element_raise_styles[selectionType][tile_element->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK];
+                    uint8 newStyle = tile_element_raise_styles[selectionType][tile_element->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
                     if (newStyle & 0x20) { // needs to be raised
                         height += 2;
                         newStyle &= ~0x20;
@@ -1886,7 +1886,7 @@ static money32 lower_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
                     height += 2;
                 if (height >= max_height) {
                     height =  tile_element->base_height;
-                    uint8 newStyle = tile_element_lower_styles[selectionType][tile_element->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK];
+                    uint8 newStyle = tile_element_lower_styles[selectionType][tile_element->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
                     if (newStyle & 0x20) { // needs to be lowered
                         height -= 2;
                         newStyle &= ~0x20;
@@ -1913,7 +1913,7 @@ static money32 lower_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
 
 sint32 map_get_water_height(const rct_tile_element * tileElement)
 {
-    return tileElement->properties.surface.terrain & TILE_ELEMENT_WATER_HEIGHT_MASK;
+    return tileElement->properties.surface.terrain & TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
 }
 
 money32 raise_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags)
@@ -2114,7 +2114,7 @@ void game_command_lower_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx,
 static money32 smooth_land_tile(sint32 direction, uint8 flags, sint32 x, sint32 y, rct_tile_element * tileElement, bool raiseLand)
 {
     sint32 targetBaseZ = tileElement->base_height;
-    sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+    sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
     if (raiseLand) {
         slope = tile_element_raise_styles[direction][slope];
         if (slope & 0x20) {
@@ -2195,7 +2195,7 @@ static money32 smooth_land_row_by_edge(sint32 flags, sint32 x, sint32 y, sint32 
 
         // change land of current tile
         sint32 targetBaseZ = tileElement->base_height;
-        sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+        sint32 slope = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
         sint32 oldSlope = slope;
         if (raiseLand) {
             if (shouldContinue & 0x4) {
@@ -2375,7 +2375,7 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
     {
         // One corner tile selected
         newBaseZ = tileElement->base_height;
-        newSlope = tileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+        newSlope = tileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
         if (commandType == GAME_COMMAND_RAISE_LAND) {
             newSlope = tile_element_raise_styles[command & 0xFF][newSlope];
             if (newSlope & 0x20) {
@@ -3269,7 +3269,7 @@ sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 z
 
         // Only allow building crossings directly on a flat surface tile.
         if (tile_element_get_type(tile_element) == TILE_ELEMENT_TYPE_SURFACE &&
-            (tile_element->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK) == TILE_ELEMENT_SLOPE_FLAT &&
+            (tile_element->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK) == TILE_ELEMENT_SLOPE_FLAT &&
             tile_element->base_height == zLow)
         {
             canBuildCrossing = true;
@@ -3285,7 +3285,7 @@ sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 z
                 sint32 ah = al;
                 sint32 cl = al;
                 sint32 ch = al;
-                uint8 slope = tile_element->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+                uint8 slope = tile_element->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
                 if (slope & TILE_ELEMENT_SLOPE_N_CORNER_UP) {
                     al += 2;
                     if (slope == (TILE_ELEMENT_SLOPE_S_CORNER_DN | TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT))
@@ -3595,7 +3595,7 @@ void map_extend_boundary_surface()
         newTileElement = map_get_surface_element_at(x, y);
 
         newTileElement->type = (newTileElement->type & 0x7C) | (existingTileElement->type & 0x83);
-        newTileElement->properties.surface.slope = existingTileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+        newTileElement->properties.surface.slope = existingTileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
         newTileElement->properties.surface.terrain = existingTileElement->properties.surface.terrain;
         newTileElement->properties.surface.grass_length = existingTileElement->properties.surface.grass_length;
         newTileElement->properties.surface.ownership = 0;
@@ -3631,7 +3631,7 @@ void map_extend_boundary_surface()
         newTileElement = map_get_surface_element_at(x, y);
 
         newTileElement->type = (newTileElement->type & 0x7C) | (existingTileElement->type & 0x83);
-        newTileElement->properties.surface.slope = existingTileElement->properties.surface.slope & TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK;
+        newTileElement->properties.surface.slope = existingTileElement->properties.surface.slope & TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK;
         newTileElement->properties.surface.terrain = existingTileElement->properties.surface.terrain;
         newTileElement->properties.surface.grass_length = existingTileElement->properties.surface.grass_length;
         newTileElement->properties.surface.ownership = 0;

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -284,19 +284,6 @@ enum {
 #define TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK   0x1F // in rct_tile_element.properties.surface.terrain
 #define TILE_ELEMENT_SURFACE_TERRAIN_MASK        0xE0 // in rct_tile_element.properties.surface.terrain
 
-// Path
-#define TILE_ELEMENT_PATH_QUEUE_FLAG                    0x01 // in rct_tile_element.type
-#define TILE_ELEMENT_PATH_IS_WIDE_FLAG                  0x02 // in rct_tile_element.type
-#define TILE_ELEMENT_PATH_TYPE_MASK                     0xF0 // in rct_tile_element.properties.path.type
-#define TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG             0x08 // in rct_tile_element.properties.path.type
-#define TILE_ELEMENT_PATH_IS_SLOPED_FLAG                0x04 // in rct_tile_element.properties.path.type
-#define TILE_ELEMENT_PATH_EDGES_MASK                    0x0F // in rct_tile_element.properties.path.edges
-#define TILE_ELEMENT_PATH_CORNERS_MASK                  0xF0 // in rct_tile_element.properties.path.edges
-#define TILE_ELEMENT_PATH_ADDITION_TYPE_MASK            0x0F // in rct_tile_element.properties.path.additions
-// The most significant bit will always be zero, since only up to 4 stations are allowed per ride
-#define TILE_ELEMENT_PATH_ADDITION_STATION_INDEX_MASK   0x70 // in rct_tile_element.properties.path.additions
-#define TILE_ELEMENT_PATH_ADDITION_GHOST_FLAG           0x80 // in rct_tile_element.properties.path.additions
-
 #define MAP_ELEM_TRACK_SEQUENCE_STATION_INDEX_MASK 0x70
 #define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0x0F
 #define MAP_ELEM_TRACK_SEQUENCE_TAKING_PHOTO_MASK 0xF0

--- a/src/openrct2/world/map.h
+++ b/src/openrct2/world/map.h
@@ -218,19 +218,6 @@ enum {
 };
 
 enum {
-    PATH_QUEUE,
-    PATH_TARMAC,
-    PATH_DIRT,
-    PATH_CRAZY,
-    PATH_ROAD,
-    PATH_TILE
-};
-
-enum {
-    PATH_FLAG_QUEUE_BANNER = 1 << 3
-};
-
-enum {
     WALL_ANIMATION_FLAG_ACROSS_TRACK = (1 << 2),
     // 3 - 6 animation frame number
     WALL_ANIMATION_FLAG_DIRECTION_BACKWARD = (1 << 7),
@@ -287,15 +274,28 @@ enum {
 #define TILE_ELEMENT_TYPE_MASK 0x3C
 #define TILE_ELEMENT_DIRECTION_MASK 0x03
 
-#define TILE_ELEMENT_SLOPE_MASK 0x1F
-#define TILE_ELEMENT_PATH_TYPE_MASK 0x1F
-#define TILE_ELEMENT_SLOPE_EDGE_STYLE_MASK 0xE0
-
 #define TILE_ELEMENT_COLOUR_MASK 0x1F
 
-// Terrain
-#define TILE_ELEMENT_WATER_HEIGHT_MASK 0x1F
-#define TILE_ELEMENT_SURFACE_TERRAIN_MASK 0xE0
+// Surface
+#define TILE_ELEMENT_SURFACE_DIAGONAL_FLAG       0x10 // in rct_tile_element.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK 0x0F // in rct_tile_element.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_SLOPE_MASK          (TILE_ELEMENT_SURFACE_DIAGONAL_FLAG | TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK) // in rct_tile_element.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK     0xE0 // in rct_tile_element.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK   0x1F // in rct_tile_element.properties.surface.terrain
+#define TILE_ELEMENT_SURFACE_TERRAIN_MASK        0xE0 // in rct_tile_element.properties.surface.terrain
+
+// Path
+#define TILE_ELEMENT_PATH_QUEUE_FLAG                    0x01 // in rct_tile_element.type
+#define TILE_ELEMENT_PATH_IS_WIDE_FLAG                  0x02 // in rct_tile_element.type
+#define TILE_ELEMENT_PATH_TYPE_MASK                     0xF0 // in rct_tile_element.properties.path.type
+#define TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG             0x08 // in rct_tile_element.properties.path.type
+#define TILE_ELEMENT_PATH_IS_SLOPED_FLAG                0x04 // in rct_tile_element.properties.path.type
+#define TILE_ELEMENT_PATH_EDGES_MASK                    0x0F // in rct_tile_element.properties.path.edges
+#define TILE_ELEMENT_PATH_CORNERS_MASK                  0xF0 // in rct_tile_element.properties.path.edges
+#define TILE_ELEMENT_PATH_ADDITION_TYPE_MASK            0x0F // in rct_tile_element.properties.path.additions
+// The most significant bit will always be zero, since only up to 4 stations are allowed per ride
+#define TILE_ELEMENT_PATH_ADDITION_STATION_INDEX_MASK   0x70 // in rct_tile_element.properties.path.additions
+#define TILE_ELEMENT_PATH_ADDITION_GHOST_FLAG           0x80 // in rct_tile_element.properties.path.additions
 
 #define MAP_ELEM_TRACK_SEQUENCE_STATION_INDEX_MASK 0x70
 #define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0x0F

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -151,7 +151,7 @@ static bool map_animation_invalidate_queue_banner(sint32 x, sint32 y, sint32 bas
             continue;
         if (!(tileElement->flags & 1))
             continue;
-        if (!(tileElement->properties.path.type & TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG))
+        if (!(tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_HAS_QUEUE_BANNER))
             continue;
 
         sint32 direction = (footpath_element_get_direction(tileElement) + get_current_rotation()) & 3;

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -151,7 +151,7 @@ static bool map_animation_invalidate_queue_banner(sint32 x, sint32 y, sint32 bas
             continue;
         if (!(tileElement->flags & 1))
             continue;
-        if (!(tileElement->properties.path.type & FOOTPATH_PROPERTIES_FLAG_HAS_QUEUE_BANNER))
+        if (!footpath_element_has_queue_banner(tileElement))
             continue;
 
         sint32 direction = (footpath_element_get_direction(tileElement) + get_current_rotation()) & 3;

--- a/src/openrct2/world/map_animation.c
+++ b/src/openrct2/world/map_animation.c
@@ -151,7 +151,7 @@ static bool map_animation_invalidate_queue_banner(sint32 x, sint32 y, sint32 bas
             continue;
         if (!(tileElement->flags & 1))
             continue;
-        if (!(tileElement->properties.path.type & PATH_FLAG_QUEUE_BANNER))
+        if (!(tileElement->properties.path.type & TILE_ELEMENT_PATH_QUEUE_BANNER_FLAG))
             continue;
 
         sint32 direction = (footpath_element_get_direction(tileElement) + get_current_rotation()) & 3;

--- a/src/openrct2/world/map_helpers.c
+++ b/src/openrct2/world/map_helpers.c
@@ -27,7 +27,7 @@ sint32 map_smooth(sint32 l, sint32 t, sint32 r, sint32 b)
     for (y = t; y < b; y++) {
         for (x = l; x < r; x++) {
             tileElement = map_get_surface_element_at(x, y);
-            tileElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+            tileElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
 
             // Raise to edge height - 2
             highest = tileElement->base_height;
@@ -167,7 +167,7 @@ sint32 map_smooth(sint32 l, sint32 t, sint32 r, sint32 b)
                 // Raise
                 if (tileElement->properties.surface.slope == TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
                 {
-                    tileElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+                    tileElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
                     tileElement->base_height = tileElement->clearance_height += 2;
                 }
             }
@@ -216,7 +216,7 @@ static sint32 map_smooth_wavy(sint32 l, sint32 t, sint32 r, sint32 b)
         for (x = l; x < r; x++)
         {
             tileElement = map_get_surface_element_at(x, y);
-            tileElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+            tileElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
 
             // Raise to edge height - 2
             highest = tileElement->base_height;
@@ -315,7 +315,7 @@ static sint32 map_smooth_wavy(sint32 l, sint32 t, sint32 r, sint32 b)
                 // Raise
                 if (tileElement->properties.surface.slope == TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
                 {
-                    tileElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+                    tileElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
                     tileElement->base_height = tileElement->clearance_height += 2;
                 }
             }
@@ -402,14 +402,14 @@ sint32 tile_smooth(sint32 x, sint32 y)
     }
 
     // Check if the calculated slope is the same already
-    uint8 currentSlope = surfaceElement->properties.surface.slope & TILE_ELEMENT_SLOPE_MASK;
+    uint8 currentSlope = surfaceElement->properties.surface.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK;
     if (currentSlope == slope)
     {
         return 0;
     }
 
     // Remove old slope value
-    surfaceElement->properties.surface.slope &= ~TILE_ELEMENT_SLOPE_MASK;
+    surfaceElement->properties.surface.slope &= ~TILE_ELEMENT_SURFACE_SLOPE_MASK;
     if ((slope & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) == TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
     {
         // All corners are raised, raise the entire tile instead.
@@ -417,7 +417,7 @@ sint32 tile_smooth(sint32 x, sint32 y)
         uint8 waterHeight = map_get_water_height(surfaceElement) * 2;
         if (waterHeight <= surfaceElement->base_height)
         {
-            surfaceElement->properties.surface.terrain &= ~TILE_ELEMENT_WATER_HEIGHT_MASK;
+            surfaceElement->properties.surface.terrain &= ~TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
         }
     }
     else

--- a/test/testpaint/compat.c
+++ b/test/testpaint/compat.c
@@ -210,7 +210,7 @@ void tile_element_decrement_onride_photo_timout(rct_tile_element * tileElement)
 
 sint32 map_get_water_height(const rct_tile_element * tileElement)
 {
-    return tileElement->properties.surface.terrain & TILE_ELEMENT_WATER_HEIGHT_MASK;
+    return tileElement->properties.surface.terrain & TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK;
 }
 
 bool ride_type_has_flag(int rideType, int flag)


### PR DESCRIPTION
Mostly replacing harcoded values with defines, renaming some defines to make their purpose clear, and replacing wrongly used defines (and union names) with the correct ones. I've also added a few comments, a few new helper functions (for setting path type for example), and cleaned up some long lines of code.

The only change I made is that the array `DefaultPathSlope` has been cut in half. The last half of its entries were all set to invalid, which makes sense, since for those the diagonal surface flag will be set. Those could be removed, because paths also cannot be placed directly on surfaces with 3 corners raised, which is required for the diagonal flag to be set. (any surface elements that don't follow this format for whatever reason won't cause an issue, since they look funky already anyway).