### PR TITLE
Fix #6803: Symlinks to directories are not descended by FileScanner

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -78,6 +78,7 @@
 - Fix: [#6547] The server log is not logged if the server name contains CJK
 - Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
 - Fix: [#6657] Guest list is missing tracking icon after reopening.
+- Fix: [#6803] Symbolic links to directories are not descended by FileScanner.
 - Fix: [#6830] Crash when using mountain tool due to ride with no ride entry.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -325,7 +325,7 @@ private:
     {
         DirectoryChild result;
         result.Name = std::string(node->d_name);
-        if (node->d_type & DT_DIR)
+        if (node->d_type == DT_DIR)
         {
             result.Type = DIRECTORY_CHILD_TYPE::DC_DIRECTORY;
         }
@@ -345,6 +345,11 @@ private:
             {
                 result.Size = statInfo.st_size;
                 result.LastModified = statInfo.st_mtime;
+
+                if (S_ISDIR(statInfo.st_mode))
+                {
+                    result.Type = DIRECTORY_CHILD_TYPE::DC_DIRECTORY;
+                }
             }
 
             Memory::Free(path);


### PR DESCRIPTION
Backported from json-objects.