### PR TITLE
Change failing test to expect nullptr rather than "".

### DIFF
--- a/test/tests/LanguagePackTest.cpp
+++ b/test/tests/LanguagePackTest.cpp
@@ -22,7 +22,7 @@ TEST_F(LanguagePackTest, create_mutable_id_1)
     ILanguagePack * lang = LanguagePackFactory::FromText(1, "STR_0000:\n");
     ASSERT_EQ(lang->GetId(), 1);
     ASSERT_EQ(lang->GetCount(), 1);
-    ASSERT_STREQ(lang->GetString(0), "");
+    ASSERT_STREQ(lang->GetString(0), nullptr);
     lang->SetString(0, "xx");
     ASSERT_EQ(lang->GetCount(), 1);
     ASSERT_STREQ(lang->GetString(0), "xx");


### PR DESCRIPTION
As of 2a509c2, a nullptr is returned rather than an empty string. The language pack unit test has not been updated to reflect this.

Whichever it should return, the failing test is currently preventing builds from being uploaded to OpenRCT2.org, while most strings in the interface are currently not showing up as the result of a bug that has been fixed since. This is a quick patch to address this.