### PR TITLE
multiplayer: Adds option to pause server

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -380,6 +380,7 @@ namespace Config
             model->known_keys_only = reader->GetBoolean("known_keys_only", false);
             model->log_chat = reader->GetBoolean("log_chat", false);
             model->log_server_actions = reader->GetBoolean("log_server_actions", false);
+            model->pause_server_if_no_clients = reader->GetBoolean("pause_server_if_no_clients", false);
         }
     }
 
@@ -404,6 +405,7 @@ namespace Config
         writer->WriteBoolean("known_keys_only", model->known_keys_only);
         writer->WriteBoolean("log_chat", model->log_chat);
         writer->WriteBoolean("log_server_actions", model->log_server_actions);
+        writer->WriteBoolean("pause_server_if_no_clients", model->pause_server_if_no_clients);
     }
 
     static void ReadNotifications(IIniReader * reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -152,6 +152,7 @@ typedef struct NetworkConfiguration
     bool        known_keys_only;
     bool        log_chat;
     bool        log_server_actions;
+    bool        pause_server_if_no_clients;
 } NetworkConfiguration;
 
 typedef struct NotificationConfiguration


### PR DESCRIPTION
OpenRCT2 does not provide a simple function to pause a server
while no client is connected. This patch adds a so called "pause_server_if_no_clients"
flag within network section of config.ini. By default this flag is set
to false to be backward compatible with running servers. After setting
this flag to true the game is paused on launch and gets unpaused on
first connection.
