### PR TITLE
Take font line height into account for bottom toolbar

### DIFF
--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -130,7 +130,7 @@ rct_window * window_game_bottom_toolbar_open()
     sint32 screenHeight = context_get_height();
 
     // Figure out how much line height we have to work with.
-    uint32 line_height = font_get_line_height(gCurrentFontSpriteBase);
+    uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     rct_window * window = window_create(
         0,
@@ -255,7 +255,7 @@ static void window_game_bottom_toolbar_tooltip(rct_window* w, rct_widgetindex wi
 static void window_game_bottom_toolbar_invalidate(rct_window *w)
 {
     // Figure out how much line height we have to work with.
-    uint32 line_height = font_get_line_height(gCurrentFontSpriteBase);
+    uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Reset dimensions as appropriate -- in case we're switching languages.
     w->height = line_height * 3 + 2;
@@ -447,7 +447,7 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
     sint32 y = window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].top + w->y + 4;
 
     // Figure out how much line height we have to work with.
-    uint32 line_height = font_get_line_height(gCurrentFontSpriteBase);
+    uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Draw money
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -546,7 +546,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, 
     );
 
     // Figure out how much line height we have to work with.
-    uint32 line_height = font_get_line_height(gCurrentFontSpriteBase);
+    uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Temperature
     x = w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 15;
@@ -699,7 +699,7 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi,
     );
 
     // Figure out how much line height we have to work with.
-    uint32 line_height = font_get_line_height(gCurrentFontSpriteBase);
+    uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     sint32 x = w->x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
     sint32 y = w->y + middleOutsetWidget->top + line_height + 1;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -131,12 +131,13 @@ rct_window * window_game_bottom_toolbar_open()
 
     // Figure out how much line height we have to work with.
     uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32 toolbar_height = line_height * 2 + 12;
 
     rct_window * window = window_create(
         0,
-        screenHeight - line_height * 3 + 2,
+        screenHeight - toolbar_height,
         screenWidth,
-        line_height * 3 + 2,
+        toolbar_height,
         &window_game_bottom_toolbar_events,
         WC_BOTTOM_TOOLBAR,
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND
@@ -258,7 +259,7 @@ static void window_game_bottom_toolbar_invalidate(rct_window *w)
     uint32 line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Reset dimensions as appropriate -- in case we're switching languages.
-    w->height = line_height * 3 + 2;
+    w->height = line_height * 2 + 12;
     w->y = context_get_height() - w->height;
 
     // Change height of widgets in accordance with line height.

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -270,10 +270,9 @@ static void window_game_bottom_toolbar_invalidate(rct_window *w)
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
     {
         w->widgets[WIDX_MONEY].type         = WWT_EMPTY;
-        w->widgets[WIDX_MONEY].bottom       = w->widgets[WIDX_MONEY].top + line_height;
         w->widgets[WIDX_GUESTS].top         = 1;
-        w->widgets[WIDX_GUESTS].bottom      = 17;
-        w->widgets[WIDX_PARK_RATING].top    = 18;
+        w->widgets[WIDX_GUESTS].bottom      = line_height + 7;
+        w->widgets[WIDX_PARK_RATING].top    = line_height + 8;
         w->widgets[WIDX_PARK_RATING].bottom = w->height - 1;
     }
     else


### PR DESCRIPTION
Currently, the bottom toolbar assumes a line height of 10 pixels, equal to the sprite font. This is troublesome for the languages using TrueType fonts, which require and use a bigger line height. In practice, this means most of the text overlaps.

This PR aims to change the bottom toolbar's window and widget heights depending on the actual line height required.

## Screenshots

Japanese: [before](https://user-images.githubusercontent.com/604665/34084476-894a8ecc-e381-11e7-800b-f2e1762e5336.png), [after](https://user-images.githubusercontent.com/604665/34084473-89014b9a-e381-11e7-9eff-05cda28e1fd9.png)
Korean: [before](https://user-images.githubusercontent.com/604665/34084477-89630a42-e381-11e7-8a15-349bd966749b.png), [after](https://user-images.githubusercontent.com/604665/34084474-89192238-e381-11e7-8942-39a90b31fa04.png) 
English: [unaffected](https://user-images.githubusercontent.com/604665/34084475-8932a898-e381-11e7-845a-e3ada0db923e.png)