### PR TITLE
Command line server password bugfix

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -95,6 +95,7 @@ The following people are not part of the project team, but have been contributin
 * Robbin Voortman (rvoortman)
 * (telk5093)
 * Ethan Smith (ethanhs) - Refactoring.
+* Robert Lewicki (rlewicki)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1673,10 +1673,10 @@ void Network::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& 
     // when process dump gets collected at some point in future.
     _key.Unload();
 
-	const char* password = String::IsNullOrEmpty(gCustomPassword) ?
-		"" :
-		gCustomPassword;
-	Client_Send_AUTH(gConfigNetwork.player_name, password, pubkey.c_str(), signature, sigsize);
+    const char* password = String::IsNullOrEmpty(gCustomPassword) ?
+        "" :
+        gCustomPassword;
+    Client_Send_AUTH(gConfigNetwork.player_name, password, pubkey.c_str(), signature, sigsize);
 
     delete [] signature;
 }
@@ -1714,7 +1714,7 @@ void Network::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
         connection.Socket->Disconnect();
         break;
     case NETWORK_AUTH_REQUIREPASSWORD:
-		context_open_window_view(WV_NETWORK_PASSWORD);
+        context_open_window_view(WV_NETWORK_PASSWORD);
         break;
     case NETWORK_AUTH_UNKNOWN_KEY_DISALLOWED:
         connection.SetLastDisconnectReason(STR_MULTIPLAYER_UNKNOWN_KEY_DISALLOWED);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1672,7 +1672,12 @@ void Network::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& 
     // Don't keep private key in memory. There's no need and it may get leaked
     // when process dump gets collected at some point in future.
     _key.Unload();
-    Client_Send_AUTH(gConfigNetwork.player_name, "", pubkey.c_str(), signature, sigsize);
+
+	const char* password = String::IsNullOrEmpty(gCustomPassword) ?
+		"" :
+		gCustomPassword;
+	Client_Send_AUTH(gConfigNetwork.player_name, password, pubkey.c_str(), signature, sigsize);
+
     delete [] signature;
 }
 
@@ -1709,7 +1714,7 @@ void Network::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
         connection.Socket->Disconnect();
         break;
     case NETWORK_AUTH_REQUIREPASSWORD:
-        context_open_window_view(WV_NETWORK_PASSWORD);
+		context_open_window_view(WV_NETWORK_PASSWORD);
         break;
     case NETWORK_AUTH_UNKNOWN_KEY_DISALLOWED:
         connection.SetLastDisconnectReason(STR_MULTIPLAYER_UNKNOWN_KEY_DISALLOWED);


### PR DESCRIPTION
When launching game using as argument password, given password was never used when trying to connect to server as mentioned in issue #6848.

Now it is checked before first attempt if there was any given while launching, if yes, client  is trying to connect using it.