### PR TITLE
Fix #6097: String::Trim wasn't taking multibyte chars into account

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -469,7 +469,10 @@ namespace String
         if (firstNonWhitespace != nullptr &&
             firstNonWhitespace != str)
         {
-            size_t newStringSize = ch - firstNonWhitespace;
+            // Take multibyte characters into account: use the last byte of the
+            // current character.
+            size_t newStringSize = (nextCh - 1) - firstNonWhitespace;
+
 #ifdef DEBUG
             size_t currentStringSize = String::SizeOf(str);
             Guard::Assert(newStringSize < currentStringSize, GUARD_LINE);
@@ -523,7 +526,10 @@ namespace String
                 {
                     startSubstr = ch;
                 }
-                endSubstr = ch;
+
+                // Take multibyte characters into account: move pointer towards
+                // the last byte of the current character.
+                endSubstr = nextCh - 1;
             }
             ch = nextCh;
         }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -508,12 +508,19 @@ namespace String
             }
             ch = nextCh;
         }
-        return str;
+        // String is all whitespace
+        return ch;
     }
 
     utf8 * TrimStart(utf8 * buffer, size_t bufferSize, const utf8 * src)
     {
         return String::Set(buffer, bufferSize, TrimStart(src));
+    }
+
+    std::string TrimStart(const std::string &s)
+    {
+        const utf8 * trimmed = TrimStart(s.c_str());
+        return std::string(trimmed);
     }
 
     std::string Trim(const std::string &s)

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -447,6 +447,12 @@ namespace String
         return utf8_write_codepoint(dst, codepoint);
     }
 
+    bool IsWhiteSpace(codepoint_t codepoint)
+    {
+        // 0x3000 is the 'ideographic space', a 'fullwidth' character used in CJK languages.
+        return iswspace((wchar_t)codepoint) || codepoint == 0x3000;
+    }
+
     utf8 * Trim(utf8 * str)
     {
         utf8 * firstNonWhitespace = nullptr;
@@ -456,7 +462,7 @@ namespace String
         utf8 * nextCh;
         while ((codepoint = GetNextCodepoint(ch, &nextCh)) != '\0')
         {
-            if (codepoint <= WCHAR_MAX && !iswspace((wchar_t)codepoint))
+            if (codepoint <= WCHAR_MAX && !IsWhiteSpace(codepoint))
             {
                 if (firstNonWhitespace == nullptr)
                 {
@@ -496,7 +502,7 @@ namespace String
         const utf8 * nextCh;
         while ((codepoint = GetNextCodepoint(ch, &nextCh)) != '\0')
         {
-            if (codepoint <= WCHAR_MAX && !iswspace((wchar_t)codepoint))
+            if (codepoint <= WCHAR_MAX && !IsWhiteSpace(codepoint))
             {
                 return ch;
             }
@@ -519,7 +525,7 @@ namespace String
         const utf8 * endSubstr = nullptr;
         while ((codepoint = GetNextCodepoint(ch, &nextCh)) != '\0')
         {
-            bool isWhiteSpace = codepoint <= WCHAR_MAX && iswspace((wchar_t)codepoint);
+            bool isWhiteSpace = codepoint <= WCHAR_MAX && IsWhiteSpace(codepoint);
             if (!isWhiteSpace)
             {
                 if (startSubstr == nullptr)

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -98,5 +98,6 @@ namespace String
     utf8 *          Trim(utf8 * str);
     const utf8 *    TrimStart(const utf8 * str);
     utf8 *          TrimStart(utf8 * buffer, size_t bufferSize, const utf8 * src);
+    std::string     TrimStart(const std::string &s);
     std::string     Trim(const std::string &s);
 }

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -94,6 +94,7 @@ namespace String
     codepoint_t GetNextCodepoint(const utf8 * ptr, const utf8 * * nextPtr = nullptr);
     utf8 *      WriteCodepoint(utf8 * dst, codepoint_t codepoint);
 
+    bool            IsWhiteSpace(codepoint_t codepoint);
     utf8 *          Trim(utf8 * str);
     const utf8 *    TrimStart(const utf8 * str);
     utf8 *          TrimStart(utf8 * buffer, size_t bufferSize, const utf8 * src);

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -18,6 +18,8 @@ INSTANTIATE_TEST_CASE_P(TrimData, StringTest, testing::Values(
     TCase("      ", ""),
     TCase(" ストリング", "ストリング"),
     TCase("ストリング ", "ストリング"),
+    TCase("　ストリング　", "ストリング"),
+    TCase("　　　　", ""),
     TCase("", ""),
     TCase("\n", ""),
     TCase("\n\n\n\r\n", ""),

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -16,6 +16,8 @@ INSTANTIATE_TEST_CASE_P(TrimData, StringTest, testing::Values(
     TCase("string  ", "string"),
     TCase("   some   string  ", "some   string"),
     TCase("      ", ""),
+    TCase(" ストリング", "ストリング"),
+    TCase("ストリング ", "ストリング"),
     TCase("", ""),
     TCase("\n", ""),
     TCase("\n\n\n\r\n", ""),

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -1,29 +1,31 @@
 #include <string>
 #include <tuple>
+#include <utility>
 #include <gtest/gtest.h>
 #include <openrct2/core/String.hpp>
 #include "AssertHelpers.hpp"
 
-using TCase = std::tuple<std::string, std::string>;
+using TCase = std::tuple<std::string, std::string, std::string>;
 
 class StringTest : public testing::TestWithParam<TCase>
 {
 };
 
 INSTANTIATE_TEST_CASE_P(TrimData, StringTest, testing::Values(
-    TCase("string", "string"),
-    TCase("  string", "string"),
-    TCase("string  ", "string"),
-    TCase("   some   string  ", "some   string"),
-    TCase("      ", ""),
-    TCase(" ストリング", "ストリング"),
-    TCase("ストリング ", "ストリング"),
-    TCase("　ストリング　", "ストリング"),
-    TCase("　　　　", ""),
-    TCase("", ""),
-    TCase("\n", ""),
-    TCase("\n\n\n\r\n", ""),
-    TCase("\n\n\n\r\nstring\n\n", "string")
+    // input                      after Trim       after TrimStart
+    TCase("string",               "string",        "string"),
+    TCase("  string",             "string",        "string"),
+    TCase("string  ",             "string",        "string  "),
+    TCase("   some   string  ",   "some   string", "some   string  "),
+    TCase("      ",               "",              ""),
+    TCase(" ストリング",         "ストリング",   "ストリング"),
+    TCase("ストリング ",         "ストリング",   "ストリング "),
+    TCase("　ストリング　",      "ストリング",   "ストリング　"),
+    TCase("　　　　",            "",              ""),
+    TCase("",                     "",              ""),
+    TCase("\n",                   "",              ""),
+    TCase("\n\n\n\r\n",           "",              ""),
+    TCase("\n\n\n\r\nstring\n\n", "string",        "string\n\n")
 ));
 TEST_P(StringTest, Trim)
 {
@@ -31,6 +33,15 @@ TEST_P(StringTest, Trim)
     std::string input = std::get<0>(testCase);
     std::string expected = std::get<1>(testCase);
     std::string actual = String::Trim(input);
+    ASSERT_EQ(expected, actual);
+}
+
+TEST_P(StringTest, TrimStart)
+{
+    auto testCase = GetParam();
+    std::string input = std::get<0>(testCase);
+    std::string expected = std::get<2>(testCase);
+    std::string actual = String::TrimStart(input);
     ASSERT_EQ(expected, actual);
 }
 


### PR DESCRIPTION
String::Trim wasn't taking multibyte chars into account, leading to corruption in e.g. the player name if multibyte characters were used.

Fixes #6097; supersedes #6691.