### PR TITLE
Remove duplicated code in text window

### DIFF
--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -131,7 +131,7 @@ void window_network_status_close();
 
 void window_text_input_key(rct_window * w, char keychar);
 void window_text_input_open(rct_window * call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description, rct_string_id existing_text, uintptr_t existing_args, sint32 maxLength);
-void window_text_input_raw_open(rct_window * call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description, utf8string existing_text, sint32 maxLength);
+void window_text_input_raw_open(rct_window * call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description, const_utf8string existing_text, sint32 maxLength);
 
 rct_window * window_object_load_error_open(utf8 * path, size_t numMissingObjects, const rct_object_entry * missingObjects);
 


### PR DESCRIPTION
The two functions for opening the window were almost identical, the only difference being how the initial string was passed. The one taking a string ID now converts it to a raw string, and then calls the nearly identical function taking the raw string.

This also makes the passed string const and replaces a memset with `String::Set`