### PR TITLE
Fix #6846: Ride overview window zoom level set too high

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -81,6 +81,7 @@
 - Fix: [#6657] Guest list is missing tracking icon after reopening.
 - Fix: [#6803] Symbolic links to directories are not descended by FileScanner.
 - Fix: [#6830] Crash when using mountain tool due to ride with no ride entry.
+- Fix: [#6846] Zoom level in some ride overview windows was erroneously set too high.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1486,7 +1486,8 @@ static void window_ride_update_overall_view(uint8 ride_index) {
 
     // Each farther zoom level shows twice as many tiles (log)
     // Appropriate zoom is lowered by one to fill the entire view with the ride
-    double zoom = ceil(log(size / 80)) - 1;
+    // Value clamped to a minimum of 0 to prevent underflow
+    sint32 zoom = Math::Max((sint32)ceil(log(size / 80)) - 1, 0);
     view->zoom = Math::Clamp<uint8>(0, zoom, 3);
 }
 


### PR DESCRIPTION
The zoom level calculation `ceil(log(size / 80)) - 1;` was ending up as `-1.0`, which was then 'underflowing' to 3 in the clamp on the next line (owing to the `uint8` cast).