### PR TITLE
Fix #6388: Construction rights wrongly shown as available on some RCT1 parks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -68,6 +68,7 @@
 - Fix: [#6331] Scenery costs nothing in track designs.
 - Fix: [#6360] Off-by-one filenames when exporting all sprites.
 - Fix: [#6358] HTTP requests can point to invalid URL string.
+- Fix: [#6388] Construction rights tool erroneously enabled in some RCT1 scenarios even when no rights available.
 - Fix: [#6413] Maze previews only showing scenery.
 - Fix: [#6423] Importing parks containing names with Polish characters.
 - Fix: [#6423] Polish characters now correctly drawn when using the sprite font.

--- a/src/openrct2/world/map.c
+++ b/src/openrct2/world/map.c
@@ -434,20 +434,31 @@ void map_count_remaining_land_rights()
     gLandRemainingOwnershipSales = 0;
     gLandRemainingConstructionSales = 0;
 
-    for (sint32 x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++) {
-        for (sint32 y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++) {
+    for (sint32 x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+    {
+        for (sint32 y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+        {
             rct_tile_element *element = map_get_surface_element_at(x, y);
             // Surface elements are sometimes hacked out to save some space for other map elements
-            if (element == NULL) {
+            if (element == NULL)
+            {
                 continue;
             }
 
             uint8 flags = element->properties.surface.ownership;
 
-            if ((flags & OWNERSHIP_AVAILABLE) && (flags & OWNERSHIP_OWNED) == 0) {
-                gLandRemainingOwnershipSales++;
-            } else if ((flags & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) && (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED) == 0) {
-                gLandRemainingConstructionSales++;
+            // Do not combine this condition with (flags & OWNERSHIP_AVAILABLE)
+            // As some RCT1 parks have owned tiles with the 'construction rights available' flag also set
+            if (!(flags & OWNERSHIP_OWNED))
+            {
+                if (flags & OWNERSHIP_AVAILABLE)
+                {
+                    gLandRemainingOwnershipSales++;
+                }
+                else if ((flags & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) && (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED) == 0)
+                {
+                    gLandRemainingConstructionSales++;
+                }
             }
         }
     }


### PR DESCRIPTION
Some RCT1 parks seemingly have owned tiles with the 'construction rights available' flag set, which led to the behaviour in #6388. This PR tweaks the conditions to check for ownership first.