### PR TITLE
Fix garbage in buffer

### DIFF
--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -102,7 +102,7 @@ static sint32 _maxInputLength;
 void window_text_input_open(rct_window* call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description, rct_string_id existing_text, uintptr_t existing_args, sint32 maxLength)
 {
     // Get the raw string
-    utf8 buffer[Util::CountOf(text_input)];
+    utf8 buffer[Util::CountOf(text_input)]{};
     if (existing_text != STR_NONE)
         format_string(buffer, maxLength, existing_text, &existing_args);
 


### PR DESCRIPTION
This fixes an oversight made in #6867. When `STR_NONE` is passed, the buffer was not initialized.