### PR TITLE
Fix potential access violation when setting park name

### DIFF
--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -656,7 +656,7 @@ static void window_park_entrance_mouseup(rct_window *w, rct_widgetindex widgetIn
         break;
     case WIDX_RENAME:
         set_format_arg(16, uint32, gParkNameArgs);
-        window_text_input_open(w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, gParkName, 0, 32);
+        window_text_input_open(w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, gParkName, 0, USER_STRING_MAX_LENGTH);
         break;
     case WIDX_CLOSE_LIGHT:
         park_set_open(0);

--- a/src/openrct2/world/park.c
+++ b/src/openrct2/world/park.c
@@ -764,10 +764,16 @@ void update_park_fences_around_tile(sint32 x, sint32 y)
 
 void park_set_name(const char *name)
 {
+    // Required else the pointer arithmetic in the game commands below could cause an access violation
+    char* newName = malloc(USER_STRING_MAX_LENGTH + 1);
+    strncpy(newName, name, USER_STRING_MAX_LENGTH);
+
     gGameCommandErrorTitle = STR_CANT_RENAME_PARK;
-    game_do_command(1, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(name + 0)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(name + 8)), *((sint32*)(name + 4)));
-    game_do_command(2, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(name + 12)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(name + 20)), *((sint32*)(name + 16)));
-    game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(name + 24)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(name + 32)), *((sint32*)(name + 28)));
+    game_do_command(1, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(newName + 0)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(newName + 8)), *((sint32*)(newName + 4)));
+    game_do_command(2, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(newName + 12)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(newName + 20)), *((sint32*)(newName + 16)));
+    game_do_command(0, GAME_COMMAND_FLAG_APPLY, 0, *((sint32*)(newName + 24)), GAME_COMMAND_SET_PARK_NAME, *((sint32*)(newName + 32)), *((sint32*)(newName + 28)));
+
+    free(newName);
 }
 
 /**


### PR DESCRIPTION
Following the changes in #6800 the pointer arithmetic in `park_set_name()` could cause an access violation (on Windows at least - didn't seem to happen on macOS).

There may well be a better way to fix this, but I think rewriting the 'rename park' game command is beyond me at the moment!