### PR TITLE
docs: adds code style reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ important that you create an issue as this can be more easily overlooked.
 
 When coding, please also add a string constant for your strings to ```./src/localisation/string_ids.h```.
 
-### Coding style / language
-OpenRCT2 currently does not have a strict coding style. This will be implemented after the entire game is implemented and
-undergoes heavy refactoring. For now, it is recommended that you only write C files as the majority of the game is currently in
-C. Exceptions are to modules that have no direct relationship to original code such as the new software audio mixer, the
-HTTP integration and the Twitch integration.
+### Coding style
+Use [this](https://github.com/OpenRCT2/OpenRCT2/wiki/Coding-Style) code style as a reference for new or changed code.
+
+### Language
+For now, it is recommended that you only write C++ files as the majority of the game is currently in
+C++. Exceptions are to modules that have direct relationship to original code.


### PR DESCRIPTION
The contribution guideline is outdated and needs a
reference to coding style.

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>