### PR TITLE
Fix #5224: Close multiplayer window when server closes 

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -548,6 +548,7 @@ void Network::UpdateClient()
                 intent.putExtra(INTENT_EXTRA_MESSAGE, std::string { str_disconnected });
                 context_open_intent(&intent);
             }
+            window_close_by_class(WC_MULTIPLAYER);
             Close();
         }
         break;


### PR DESCRIPTION
Fixes #5224

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>