### PR TITLE
Fix #5761: Mini coaster doesn't appear despite being selected

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -52,6 +52,7 @@
 - Fix: [#5636] Pausing the game shows mute button as active.
 - Fix: [#5741] Land rights indicators disappear when switching views.
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list.
+- Fix: [#5761] Mini coaster doesn't appear despite being selected.
 - Fix: [#5838] Crash when saving very large track designs.
 - Fix: [#6101] Rides remain in ride list window briefly after demolition.
 - Fix: [#6114] Crash when using a non-LL CSG1.DAT.

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -371,7 +371,7 @@ void window_research_development_page_paint(rct_window *w, rct_drawpixelinfo *dp
 
         // Expected
         set_format_arg(0, rct_string_id, STR_RESEARCH_STAGE_UNKNOWN);
-        if (gResearchProgressStage != 0) {
+        if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH) {
             uint16 expectedDay = gResearchExpectedDay;
             if (expectedDay != 255) {
                 // TODO: Should probably use game date format setting
@@ -505,7 +505,6 @@ static void window_research_funding_invalidate(rct_window *w)
 
     if ((gParkFlags & PARK_FLAGS_NO_MONEY) ||
         (gResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)) {
-        //window_research_funding_widgets[WIDX_FUNDING_GROUP].type = WWT_EMPTY;
         window_research_funding_widgets[WIDX_RESEARCH_FUNDING].type = WWT_EMPTY;
         window_research_funding_widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON].type = WWT_EMPTY;
     } else {

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -62,6 +62,7 @@
 #include "world/scenery.h"
 #include "world/sprite.h"
 #include "world/water.h"
+#include "ObjectList.h"
 
 #define NUMBER_OF_AUTOSAVES_TO_KEEP 9
 
@@ -1238,44 +1239,7 @@ void game_fix_save_vars()
         }
     }
 
-    // Fix invalid research items
-    for (sint32 i = 0; i < MAX_RESEARCH_ITEMS; i++)
-    {
-        rct_research_item * researchItem = &gResearchItems[i];
-        if (researchItem->entryIndex == RESEARCHED_ITEMS_SEPARATOR)
-            continue;
-        if (researchItem->entryIndex == RESEARCHED_ITEMS_END)
-        {
-            if (i == MAX_RESEARCH_ITEMS - 1)
-            {
-                (--researchItem)->entryIndex = RESEARCHED_ITEMS_END;
-            }
-            (++researchItem)->entryIndex = RESEARCHED_ITEMS_END_2;
-            break;
-        }
-        if (researchItem->entryIndex == RESEARCHED_ITEMS_END_2)
-            break;
-        if (researchItem->entryIndex & RESEARCH_ENTRY_RIDE_MASK)
-        {
-            uint8          entryIndex  = researchItem->entryIndex & 0xFF;
-            rct_ride_entry * rideEntry = get_ride_entry(entryIndex);
-            if (rideEntry == nullptr)
-            {
-                research_remove(researchItem->entryIndex);
-                i--;
-            }
-        }
-        else
-        {
-            uint8                   entryIndex          = researchItem->entryIndex;
-            rct_scenery_group_entry * sceneryGroupEntry = get_scenery_group_entry(entryIndex);
-            if (sceneryGroupEntry == nullptr)
-            {
-                research_remove(researchItem->entryIndex);
-                i--;
-            }
-        }
-    }
+    research_fix();
 
     // Fix banner list pointing to NULL map elements
     banner_reset_broken_index();

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -126,6 +126,7 @@ rct_string_id research_item_get_name(uint32 researchItem);
 uint8 research_get_ride_base_type(sint32 researchItem);
 rct_string_id research_get_friendly_base_ride_type_name(uint8 trackType, rct_ride_entry * rideEntry);
 void research_remove_flags();
+void research_fix();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR tackles two research corruption issues:
- Everything is researched, but the status is not set to 'All research completed'
- Everything is researched, but some ride entries are still marked as unavailable

This is enough to fix #5761.