### PR TITLE
Add extra padding to label text in guest window

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1245,7 +1245,7 @@ void window_guest_mouse_up(rct_window *w, rct_widgetindex widgetIndex)
  */
 void window_guest_stats_resize(rct_window *w)
 {
-    window_set_resize(w, 192, 162, 192, 162);
+    window_set_resize(w, 192, 180, 192, 180);
 }
 
 /**
@@ -1307,24 +1307,28 @@ void window_guest_stats_invalidate(rct_window *w)
 *
 *  ebp: colour, contains flag BAR_BLINK for blinking
 */
-static void window_guest_stats_bars_paint(sint32 value, sint32 x, sint32 y, rct_window *w, rct_drawpixelinfo *dpi, sint32 colour){
-    value *= 0x76;
-    value >>= 8;
+static void window_guest_stats_bars_paint(sint32 value, sint32 x, sint32 y, rct_window *w, rct_drawpixelinfo *dpi, sint32 colour)
+{
+    if (font_get_line_height(gCurrentFontSpriteBase) > 10)
+    {
+        y += 1;
+    }
 
-    gfx_fill_rect_inset(dpi, x + 0x3A, y + 1, x + 0x3A + 0x79, y + 9, w->colours[1], INSET_RECT_F_30);
+    gfx_fill_rect_inset(dpi, x + 61, y + 1, x + 61 + 121, y + 9, w->colours[1], INSET_RECT_F_30);
 
     sint32 blink_flag = colour & BAR_BLINK;
     colour &= ~BAR_BLINK;
 
-    if (!blink_flag ||
-        game_is_paused() ||
-        (gCurrentTicks & 8) == 0)
+    if (!blink_flag || game_is_paused() || (gCurrentTicks & 8) == 0)
     {
+        value *= 118;
+        value >>= 8;
+
         if (value <= 2)
             return;
-        gfx_fill_rect_inset(dpi, x + 0x3C, y + 2, x + 0x3C + value - 1, y + 8, colour, 0);
-    }
 
+        gfx_fill_rect_inset(dpi, x + 63, y + 2, x + 63 + value - 1, y + 8, colour, 0);
+    }
 }
 
 /**
@@ -1362,7 +1366,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(happiness, x, y, w, dpi, ebp);
 
     // Energy
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_ENERGY_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     sint32 energy = ((peep->energy - PEEP_MIN_ENERGY) * 255) / (PEEP_MAX_ENERGY - PEEP_MIN_ENERGY);
@@ -1374,7 +1378,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(energy, x, y, w, dpi, ebp);
 
     // Hunger
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_HUNGER_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     sint32 hunger = peep->hunger;
@@ -1393,7 +1397,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(hunger, x, y, w, dpi, ebp);
 
     // Thirst
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_THIRST_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     sint32 thirst = peep->thirst;
@@ -1412,7 +1416,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(thirst, x, y, w, dpi, ebp);
 
     // Nausea
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     sint32 nausea = peep->nausea - 32;
@@ -1428,7 +1432,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(nausea, x, y, w, dpi, ebp);
 
     // Bathroom
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     gfx_draw_string_left(dpi, STR_GUEST_STAT_TOILET_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     sint32 bathroom = peep->bathroom - 32;
@@ -1446,7 +1450,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_guest_stats_bars_paint(bathroom, x, y, w, dpi, ebp);
 
     // Time in park
-    y += 11;
+    y += LIST_ROW_HEIGHT + 1;
     if (peep->time_in_park != -1){
         sint32 eax = gScenarioTicks;
         eax -= peep->time_in_park;
@@ -1455,12 +1459,12 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
         gfx_draw_string_left(dpi, STR_GUEST_STAT_TIME_IN_PARK, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
 
-    y += 19;
+    y += LIST_ROW_HEIGHT + 9;
     gfx_fill_rect_inset(dpi, x, y - 6, x + 179, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
     // Preferred Ride
     gfx_draw_string_left(dpi, STR_GUEST_STAT_PREFERRED_RIDE, nullptr, COLOUR_BLACK, x, y);
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     // Intensity
     sint32 intensity = peep->intensity / 16;
@@ -1482,7 +1486,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
         STR_PEEP_STAT_NAUSEA_TOLERANCE_AVERAGE,
         STR_PEEP_STAT_NAUSEA_TOLERANCE_HIGH,
     };
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     sint32 nausea_tolerance = peep->nausea_tolerance & 0x3;
     set_format_arg(0, rct_string_id, nauseaTolerances[nausea_tolerance]);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_TOLERANCE, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -1711,7 +1715,7 @@ void window_guest_rides_scroll_paint(rct_window *w, rct_drawpixelinfo *dpi, sint
  */
 void window_guest_finance_resize(rct_window *w)
 {
-    window_set_resize(w, 210, 134, 210, 134);
+    window_set_resize(w, 210, 148, 210, 148);
 }
 
 /**
@@ -1784,11 +1788,11 @@ void window_guest_finance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_IN_POCKET, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     // Cash spent
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->cash_spent);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_SPENT, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
-    y += 20;
+    y += LIST_ROW_HEIGHT * 2;
     gfx_fill_rect_inset(dpi, x, y - 6, x + 179, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
     // Paid to enter
@@ -1796,7 +1800,7 @@ void window_guest_finance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_ENTRANCE_FEE, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     // Paid on rides
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_rides);
     set_format_arg(4, uint16, peep->no_of_rides);
     if (peep->no_of_rides != 1){
@@ -1807,7 +1811,7 @@ void window_guest_finance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
 
     // Paid on food
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_food);
     set_format_arg(4, uint16, peep->no_of_food);
     if (peep->no_of_food != 1){
@@ -1818,7 +1822,7 @@ void window_guest_finance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
 
     // Paid on drinks
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_drink);
     set_format_arg(4, uint16, peep->no_of_drinks);
     if (peep->no_of_drinks != 1){
@@ -1829,7 +1833,7 @@ void window_guest_finance_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
 
     // Paid on souvenirs
-    y += 10;
+    y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_souvenirs);
     set_format_arg(4, uint16, peep->no_of_souvenirs);
     if (peep->no_of_souvenirs != 1){


### PR DESCRIPTION
This changes the appearance of the guest window slightly, increasing the distance between items in the status and finance tab, thereby reducing textual overlap in CJK languages. (While the sprite font is optimised for 10px, the CJK languages are using 12px.)

### Screenshots

For comparison, screenshots of the affected tabs:

**Status tab**
English: [before](https://user-images.githubusercontent.com/604665/34503863-21d3d66c-f01b-11e7-9124-fcd3618c17f4.png), [after](https://user-images.githubusercontent.com/604665/34503862-21b48e4c-f01b-11e7-95f5-287c356680e2.png)
Japanese: [before](https://user-images.githubusercontent.com/604665/34503868-224b25be-f01b-11e7-84c3-220414db9ab5.png), [after](https://user-images.githubusercontent.com/604665/34503866-221ff57e-f01b-11e7-9b31-55fdee540532.png)
Korean: [before](https://user-images.githubusercontent.com/604665/34503872-22c1c390-f01b-11e7-9702-278504ff2354.png), [after](https://user-images.githubusercontent.com/604665/34503871-22a42baa-f01b-11e7-80f0-694120c90618.png)

**Finance tab**
English: [before](https://user-images.githubusercontent.com/604665/34503855-13e95568-f01b-11e7-8691-4db03fa876c5.png), [after](https://user-images.githubusercontent.com/604665/34503854-13c64104-f01b-11e7-9289-112a3f04b604.png)
Japanese: [before](https://user-images.githubusercontent.com/604665/34503865-220741b4-f01b-11e7-84c3-fa3cd3d57b9e.png), [after](https://user-images.githubusercontent.com/604665/34503864-21ef18fa-f01b-11e7-855d-1e23031df636.png)
Korean: [before](https://user-images.githubusercontent.com/604665/34503870-2286ec5c-f01b-11e7-8695-f848e542d106.png), [after](https://user-images.githubusercontent.com/604665/34503869-226c70b6-f01b-11e7-870e-0455547c28a4.png)

