### PR TITLE
Fix #5562: fix continous reopening of log files

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -63,6 +63,7 @@ typedef struct GameAction GameAction;
 #include <string>
 #include <vector>
 #include <functional>
+#include <fstream>
 #include <map>
 #include <openssl/evp.h>
 #include "../actions/GameAction.h"
@@ -128,7 +129,7 @@ public:
     void LoadGroups();
 
     std::string BeginLog(const std::string &directory, const std::string &midName, const std::string &filenameFormat);
-    void AppendLog(const std::string &logPath, const std::string &s);
+    void AppendLog(std::ostream &fs, const std::string &s);
 
     void BeginChatLog();
     void AppendChatLog(const std::string &s);
@@ -290,6 +291,9 @@ private:
     void Server_Handle_OBJECTS(NetworkConnection& connection, NetworkPacket& packet);
 
     uint8 * save_for_network(size_t &out_size, const std::vector<const ObjectRepositoryItem *> &objects) const;
+
+    std::ofstream _chat_log_fs;
+    std::ofstream _server_log_fs;
 };
 
 #endif // __cplusplus


### PR DESCRIPTION
Every logging opens a new file handle which should be avoided
for performance reasons.

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>

Supersedes #5680 

 I've assumed that FileStream is from C style OpenRCT2 and should be replaced by C++ streams for a good codebase.