### PR TITLE
Overall view: small rides and shops, general centring

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1473,9 +1473,9 @@ static void window_ride_update_overall_view(uint8 ride_index) {
     }
 
     ride_overall_view *view = &ride_overall_views[ride_index];
-    view->x = (minx + maxx) / 2;
-    view->y = (miny + maxy) / 2;
-    view->z = (minz + maxz) / 2 + 8;
+    view->x = (minx + maxx) / 2 + 16;
+    view->y = (miny + maxy) / 2 + 16;
+    view->z = (minz + maxz) / 2 - 8;
 
     // Calculate size to determine from how far away to view the ride
     sint32 dx = maxx - minx;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1484,11 +1484,17 @@ static void window_ride_update_overall_view(uint8 ride_index) {
 
     sint32 size = (sint32) sqrt(dx*dx + dy*dy + dz*dz);
 
-    // Each farther zoom level shows twice as many tiles (log)
-    // Appropriate zoom is lowered by one to fill the entire view with the ride
-    // Value clamped to a minimum of 0 to prevent underflow
-    sint32 zoom = Math::Max((sint32)ceil(log(size / 80)) - 1, 0);
-    view->zoom = Math::Clamp<uint8>(0, zoom, 3);
+    if (size >= 80)
+    {
+        // Each farther zoom level shows twice as many tiles (log)
+        // Appropriate zoom is lowered by one to fill the entire view with the ride
+        view->zoom = Math::Clamp(0, (sint32) ceil(log(size / 80)) - 1, 3);
+    }
+    else
+    {
+        // Small rides or stalls are zoomed in all the way.
+        view->zoom = 0;
+    }
 }
 
 /**


### PR DESCRIPTION
This explicitly sets the overall view for small rides and shops to be zoomed in all the way. Previously, it would be set zoomed out all the way due to the algorithm taking the `log(size / 80)`, while the size for most shops is 48 or 64. Hence, the log quickly flies off into infinity, which is clamped to 3 — the outermost zoom.

In testing, I also noticed the overall views weren't centred properly. I've changed the viewport assignments slightly to be in line with the geometric centre.

Before:
![](https://user-images.githubusercontent.com/604665/34521429-fd0f9424-f08d-11e7-88b2-34c276966bd2.png)

After:
![screenshot_20180104_005813](https://user-images.githubusercontent.com/604665/34545053-641f9734-f0ea-11e7-8cac-700b433d9a3a.png)
