### PR TITLE
Fix consecutive thoughts removal on ride demolish

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -98,6 +98,7 @@ The following people are not part of the project team, but have been contributin
 * (telk5093)
 * Ethan Smith (ethanhs) - Refactoring.
 * Robert Lewicki (rlewicki)
+* Tyler Ruckinger (TyPR124)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,4 +1,4 @@
-0.1.2 (in development)
+﻿0.1.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#3510] Auto-append extension if none is specified.
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
@@ -100,6 +100,7 @@
 - Fix: RCT1 mazes with wooden fences not imported correctly.
 - Fix: Title sequence editor now gracefully fails to preview a title sequence and lets the user know with an error message.
 - Fix: When preset title sequence fails to load, the preset will forcibly be changed to the first sequence to successfully load.
+- Fix: Remove consecutive thoughts about a ride being demolished
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,4 +1,4 @@
-﻿0.1.2 (in development)
+0.1.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#3510] Auto-append extension if none is specified.
 - Feature: [#3994] Show bottom toolbar with map tooltip (theme option).
@@ -100,7 +100,6 @@
 - Fix: RCT1 mazes with wooden fences not imported correctly.
 - Fix: Title sequence editor now gracefully fails to preview a title sequence and lets the user know with an error message.
 - Fix: When preset title sequence fails to load, the preset will forcibly be changed to the first sequence to successfully load.
-- Fix: Remove consecutive thoughts about a ride being demolished
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -100,6 +100,7 @@
 - Fix: RCT1 mazes with wooden fences not imported correctly.
 - Fix: Title sequence editor now gracefully fails to preview a title sequence and lets the user know with an error message.
 - Fix: When preset title sequence fails to load, the preset will forcibly be changed to the first sequence to successfully load.
+- Fix: Remove consecutive thoughts about a ride being demolished
 - Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
 - Improved: [#6218] Speed up game start up time by saving scenario index to file.
 - Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -176,6 +176,7 @@ public:
                     // Clear top thought, push others up
                     memmove(&peep->thoughts[i], &peep->thoughts[i + 1], sizeof(rct_peep_thought)*(PEEP_MAX_THOUGHTS - i - 1));
                     peep->thoughts[PEEP_MAX_THOUGHTS - 1].type = PEEP_THOUGHT_TYPE_NONE;
+                    i--; //Next iteration, check the new thought at this index
                 }
             }
         }

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -176,7 +176,8 @@ public:
                     // Clear top thought, push others up
                     memmove(&peep->thoughts[i], &peep->thoughts[i + 1], sizeof(rct_peep_thought)*(PEEP_MAX_THOUGHTS - i - 1));
                     peep->thoughts[PEEP_MAX_THOUGHTS - 1].type = PEEP_THOUGHT_TYPE_NONE;
-                    i--; //Next iteration, check the new thought at this index
+                    //Next iteration, check the new thought at this index
+                    i--;
                 }
             }
         }

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -176,8 +176,7 @@ public:
                     // Clear top thought, push others up
                     memmove(&peep->thoughts[i], &peep->thoughts[i + 1], sizeof(rct_peep_thought)*(PEEP_MAX_THOUGHTS - i - 1));
                     peep->thoughts[PEEP_MAX_THOUGHTS - 1].type = PEEP_THOUGHT_TYPE_NONE;
-                    //Next iteration, check the new thought at this index
-                    i--;
+                    i--; //Next iteration, check the new thought at this index
                 }
             }
         }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -51,7 +51,7 @@ typedef struct GameAction GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "25"
+#define NETWORK_STREAM_VERSION "26"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #ifdef __cplusplus


### PR DESCRIPTION
Previously, if a peep had two consecutive thoughts about the same ride, only the first would be removed, leaving the 2nd thought about a non-existing ride.