### PR TITLE
When there is one guest, make UI say "1 guest" instead of "1 guests"

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4499,6 +4499,9 @@ STR_6189    :Duck
 STR_6190    :{SMALLFONT}{BLACK}You cannot select a sprite while the main title screen is active.
 STR_6191    :Surface
 STR_6192    :Wall
+STR_6193    :{COMMA16} guest
+STR_6194    :{INLINE_SPRITE}{11}{20}{00}{00}{COMMA16} guest
+STR_6195    :{INLINE_SPRITE}{10}{20}{00}{00}{COMMA16} guest
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -471,6 +471,13 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE,
     };
 
+	static const rct_string_id guestCountFormatsSingular[] =
+	{
+		STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE_SINGULAR,
+		STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE_SINGULAR,
+		STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE_SINGULAR,
+	};
+
     // Draw guests
     {
         rct_widget widget = window_game_bottom_toolbar_widgets[WIDX_GUESTS];
@@ -479,7 +486,7 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
 
         gfx_draw_string_centred(
             dpi,
-            guestCountFormats[gGuestChangeModifier],
+            gNumGuestsInPark == 1 ? guestCountFormatsSingular[gGuestChangeModifier] : guestCountFormats[gGuestChangeModifier],
             x,
             y,
             (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_GUESTS ? COLOUR_WHITE : NOT_TRANSLUCENT(w->colours[0])),

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -471,12 +471,12 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE,
     };
 
-	static const rct_string_id guestCountFormatsSingular[] =
-	{
-		STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE_SINGULAR,
-		STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE_SINGULAR,
-		STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE_SINGULAR,
-	};
+    static const rct_string_id guestCountFormatsSingular[] =
+    {
+        STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE_SINGULAR,
+        STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE_SINGULAR,
+        STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE_SINGULAR,
+    };
 
     // Draw guests
     {

--- a/src/openrct2/localisation/string_ids.h
+++ b/src/openrct2/localisation/string_ids.h
@@ -3844,6 +3844,9 @@ enum {
     STR_TILE_INSPECTOR_SURFACE = 6191,
     STR_TILE_INSPECTOR_WALL = 6192,
 
+    STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE_SINGULAR = 6193,
+    STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE_SINGULAR = 6194,
+    STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE_SINGULAR = 6195,
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
When there is one guest, make UI say "1 guest" instead of "1 guests"

To test:

Start a new Evergreen Gardens (it starts with one guest). Wait for a second guest to show up to ensure that it changes back to "guests".
  