### PR TITLE
Use min/max instead of clamp for limiting tree count in RMG

### DIFF
--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -346,7 +346,7 @@ static void mapgen_place_trees()
 
     // Place trees
     float  treeToLandRatio = (10 + (util_rand() % 30)) / 100.0f;
-    sint32 numTrees        = Math::Clamp(4, (sint32) (availablePositions.size() * treeToLandRatio), (sint32)availablePositions.size());
+    sint32 numTrees        = std::min(std::max(4, (sint32) (availablePositions.size() * treeToLandRatio)), (sint32)availablePositions.size());
 
     for (sint32 i = 0; i < numTrees; i++)
     {


### PR DESCRIPTION
Call to `clamp` may not guarantee correct result when `high` < `low`,
use calls to `max()` and `min()` explicitly instead.

See b47a0f7cb57b514cbf7f93f154630c3f7f435e36