### PR TITLE
Show formatted dates in load/save window

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -62,8 +62,8 @@ static rct_widget window_loadsave_widgets[] = {
     { WWT_BUTTON,       0,      86,                 167,            36,         49,         STR_FILEBROWSER_ACTION_UP,          STR_NONE},                  // Up
     { WWT_BUTTON,       0,      168,                251,            36,         49,         STR_FILEBROWSER_ACTION_NEW_FOLDER,  STR_NONE },                 // New
     { WWT_BUTTON,       0,      252,                334,            36,         49,         STR_FILEBROWSER_ACTION_NEW_FILE,    STR_NONE },                 // New
-    { WWT_BUTTON,       0,      4,                  (WW - 5) / 2,   55,         68,         STR_NONE,                           STR_NONE },                 // Name
-    { WWT_BUTTON,       0,      (WW - 5) / 2 + 1,   WW - 5 - 1,     55,         68,         STR_NONE,                           STR_NONE },                 // Date
+    { WWT_TABLE_HEADER, 0,      4,                  (WW - 5) / 2,   55,         68,         STR_NONE,                           STR_NONE },                 // Name
+    { WWT_TABLE_HEADER, 0,      (WW - 5) / 2 + 1,   WW - 5 - 1,     55,         68,         STR_NONE,                           STR_NONE },                 // Date
     { WWT_SCROLL,       0,      4,                  WW - 5,         68,         WH - 30,    SCROLL_VERTICAL,                    STR_NONE },                 // File list
     { WWT_BUTTON,       0,      4,                  200,            WH - 24,    WH - 6,     STR_FILEBROWSER_USE_SYSTEM_WINDOW,  STR_NONE },                 // Use native browser
     { WIDGETS_END }
@@ -590,8 +590,8 @@ static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     // Draw name button indicator.
     rct_widget sort_name_widget = window_loadsave_widgets[WIDX_SORT_NAME];
-    gfx_draw_string_centred_clipped(dpi, STR_NAME, &id, COLOUR_GREY, w->x + 4 + sort_name_widget.left + (sort_name_widget.right - sort_name_widget.left) / 2,
-        w->y + sort_name_widget.top + 1, (sort_name_widget.right - sort_name_widget.left) / 2);
+    gfx_draw_string_left(dpi, STR_NAME, &id, COLOUR_GREY, w->x + sort_name_widget.left + 11,
+        w->y + sort_name_widget.top + 1);
 
     // Date button text
     if (gConfigGeneral.load_save_sort == SORT_DATE_ASCENDING)
@@ -602,8 +602,8 @@ static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi)
         id = STR_NONE;
 
     rct_widget sort_date_widget = window_loadsave_widgets[WIDX_SORT_DATE];
-    gfx_draw_string_centred_clipped(dpi, STR_DATE, &id, COLOUR_GREY, w->x + 4 + sort_date_widget.left + (sort_date_widget.right - sort_date_widget.left) / 2,
-        w->y + sort_date_widget.top + 1, (sort_date_widget.right - sort_date_widget.left) / 2);
+    gfx_draw_string_left(dpi, STR_DATE, &id, COLOUR_GREY, w->x + sort_date_widget.left + 5,
+        w->y + sort_date_widget.top + 1);
 }
 
 static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 scrollIndex)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -14,31 +14,30 @@
  *****************************************************************************/
 #pragma endregion
 
-#include <string>
-
-#include <openrct2/config/Config.h>
-#include <openrct2/title/TitleScreen.h>
-#include <openrct2/core/Memory.hpp>
-#include <openrct2/Context.h>
-#include <openrct2/windows/Intent.h>
-#include <openrct2-ui/windows/Window.h>
-
 #include <ctime>
+#include <openrct2-ui/windows/Window.h>
+#include <openrct2/config/Config.h>
+#include <openrct2/Context.h>
 #include <openrct2/core/Guard.hpp>
+#include <openrct2/core/Memory.hpp>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>
 #include <openrct2/interface/Widget.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/platform/platform.h>
 #include <openrct2/platform/Platform2.h>
+#include <openrct2/title/TitleScreen.h>
 #include <openrct2/util/Util.h>
+#include <openrct2/windows/Intent.h>
+#include <string>
 
 #pragma region Widgets
 
 #define WW 340
 #define WH 400
 
-enum {
+enum
+{
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,
@@ -54,7 +53,8 @@ enum {
 };
 
 // 0x9DE48C
-static rct_widget window_loadsave_widgets[] = {
+static rct_widget window_loadsave_widgets[] =
+{
     { WWT_FRAME,        0,      0,                  WW - 1,         0,          WH - 1,     STR_NONE,                           STR_NONE },
     { WWT_CAPTION,      0,      1,                  WW - 2,         1,          14,         STR_NONE,                           STR_WINDOW_TITLE_TIP },
     { WWT_CLOSEBOX,     0,      WW - 13,            WW - 3,         2,          13,         STR_CLOSE_X,                        STR_CLOSE_WINDOW_TIP },     //Window close button
@@ -87,7 +87,8 @@ static void window_loadsave_invalidate(rct_window *w);
 static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 scrollIndex);
 
-static rct_window_event_list window_loadsave_events = {
+static rct_window_event_list window_loadsave_events =
+{
     window_loadsave_close,
     window_loadsave_mouseup,
     window_loadsave_resize,
@@ -120,12 +121,14 @@ static rct_window_event_list window_loadsave_events = {
 
 #pragma endregion
 
-enum {
+enum
+{
     TYPE_DIRECTORY,
     TYPE_FILE,
 };
 
-typedef struct loadsave_list_item {
+typedef struct loadsave_list_item
+{
     char name[256];
     char path[MAX_PATH];
     time_t date_modified;
@@ -167,10 +170,12 @@ static sint32 window_loadsave_get_dir(utf8 *last_save, char *path, const char *s
     else
         platform_get_user_directory(path, subdir, pathSize);
 
-    if (!platform_ensure_directory_exists(path)) {
+    if (!platform_ensure_directory_exists(path))
+    {
         log_error("Unable to create save directory.");
         return 0;
     }
+
     return 1;
 }
 
@@ -180,15 +185,25 @@ rct_window *window_loadsave_open(sint32 type, const char *defaultName)
     _type = type;
     _defaultName[0] = '\0';
 
-    if (!str_is_null_or_empty(defaultName)) {
+    if (!str_is_null_or_empty(defaultName))
+    {
         safe_strcpy(_defaultName, defaultName, sizeof(_defaultName));
     }
 
     rct_window *w = window_bring_to_front_by_class(WC_LOADSAVE);
-    if (w == nullptr) {
+    if (w == nullptr)
+    {
         w = window_create_centred(WW, WH, &window_loadsave_events, WC_LOADSAVE, WF_STICK_TO_FRONT | WF_RESIZABLE);
         w->widgets = window_loadsave_widgets;
-        w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_UP) | (1 << WIDX_NEW_FOLDER) | (1 << WIDX_NEW_FILE) | (1 << WIDX_SORT_NAME) | (1 << WIDX_SORT_DATE) | (1 << WIDX_BROWSE) | (1 << WIDX_DEFAULT);
+        w->enabled_widgets =
+            (1 << WIDX_CLOSE) |
+            (1 << WIDX_UP) |
+            (1 << WIDX_NEW_FOLDER) |
+            (1 << WIDX_NEW_FILE) |
+            (1 << WIDX_SORT_NAME) |
+            (1 << WIDX_SORT_DATE) |
+            (1 << WIDX_BROWSE) |
+            (1 << WIDX_DEFAULT);
 
         w->min_width = WW;
         w->min_height = WH / 2;
@@ -203,48 +218,60 @@ rct_window *window_loadsave_open(sint32 type, const char *defaultName)
     bool success = false;
     char path[MAX_PATH];
 
-    switch (type & 0x0E) {
+    switch (type & 0x0E)
+    {
     case LOADSAVETYPE_GAME:
         w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
-        if (window_loadsave_get_dir(gConfigGeneral.last_save_game_directory, path, "save", sizeof(path))) {
+        if (window_loadsave_get_dir(gConfigGeneral.last_save_game_directory, path, "save", sizeof(path)))
+        {
             window_loadsave_populate_list(w, isSave, path, isSave ? ".sv6" : ".sv6;.sc6;.sv4;.sc4");
             success = true;
         }
         break;
+
     case LOADSAVETYPE_LANDSCAPE:
         w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
-        if (window_loadsave_get_dir(gConfigGeneral.last_save_landscape_directory, path, "landscape", sizeof(path))) {
+        if (window_loadsave_get_dir(gConfigGeneral.last_save_landscape_directory, path, "landscape", sizeof(path)))
+        {
             window_loadsave_populate_list(w, isSave, path, isSave ? ".sc6" : ".sc6;.sv6;.sc4;.sv4");
             success = true;
         }
         break;
+
     case LOADSAVETYPE_SCENARIO:
         w->widgets[WIDX_TITLE].text = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
-        if (window_loadsave_get_dir(gConfigGeneral.last_save_scenario_directory, path, "scenario", sizeof(path))) {
+        if (window_loadsave_get_dir(gConfigGeneral.last_save_scenario_directory, path, "scenario", sizeof(path)))
+        {
             window_loadsave_populate_list(w, isSave, path, ".sc6");
             success = true;
         }
         break;
+
     case LOADSAVETYPE_TRACK:
         w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
-        if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "track", sizeof(path))) {
+        if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "track", sizeof(path)))
+        {
             window_loadsave_populate_list(w, isSave, path, isSave ? ".td6" : ".td6;.td4");
             success = true;
         }
         break;
+
     case LOADSAVETYPE_IMAGE:
         openrct2_assert(!isSave, "Cannot save images through loadsave window");
         w->widgets[WIDX_TITLE].text = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
-        if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "", sizeof(path))) {
+        if (window_loadsave_get_dir(gConfigGeneral.last_save_track_directory, path, "", sizeof(path)))
+        {
             window_loadsave_populate_list(w, false, path, ".bmp;.png");
             success = true;
         }
         break;
+
     default:
         log_error("Unsupported load/save type: %d", type & 0x0F);
     }
 
-    if (!success) {
+    if (!success)
+    {
         window_close(w);
         return nullptr;
     }
@@ -258,7 +285,8 @@ rct_window *window_loadsave_open(sint32 type, const char *defaultName)
 
 static void window_loadsave_close(rct_window *w)
 {
-    if (_listItems != nullptr) {
+    if (_listItems != nullptr)
+    {
         free(_listItems);
         _listItems = nullptr;
     }
@@ -268,11 +296,13 @@ static void window_loadsave_close(rct_window *w)
 
 static void window_loadsave_resize(rct_window *w)
 {
-    if (w->width < w->min_width) {
+    if (w->width < w->min_width)
+    {
         window_invalidate(w);
         w->width = w->min_width;
     }
-    if (w->height < w->min_height) {
+    if (w->height < w->min_height)
+    {
         window_invalidate(w);
         w->height = w->min_height;
     }
@@ -290,27 +320,32 @@ static bool browse(bool isSave, char *path, size_t pathSize)
     desc.default_filename = isSave ? path : nullptr;
 
     rct_string_id title = STR_NONE;
-    switch (_type & 0x0E) {
+    switch (_type & 0x0E)
+    {
     case LOADSAVETYPE_GAME:
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_SAVED_GAME);
         desc.filters[0].pattern = isSave ? "*.sv6" : "*.sv6;*.sc6;*.sv4;*.sc4";
         break;
+
     case LOADSAVETYPE_LANDSCAPE:
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_LANDSCAPE_FILE);
         desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4";
         break;
+
     case LOADSAVETYPE_SCENARIO:
         title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_SCENARIO_FILE);
         desc.filters[0].pattern = "*.sc6";
         break;
+
     case LOADSAVETYPE_TRACK:
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_TRACK_DESIGN_FILE);
         desc.filters[0].pattern = isSave ? "*.td6" : "*.td6;*.td4";
         break;
+
     case LOADSAVETYPE_IMAGE:
         title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_HEIGHTMAP_FILE);
@@ -331,22 +366,27 @@ static void window_loadsave_mouseup(rct_window *w, rct_widgetindex widgetIndex)
     char path[MAX_PATH];
 
     bool isSave = (_type & 0x01) == LOADSAVETYPE_SAVE;
-    switch (widgetIndex){
+    switch (widgetIndex)
+    {
     case WIDX_CLOSE:
         window_close(w);
         break;
+
     case WIDX_UP:
         safe_strcpy(path, _parentDirectory, sizeof(path));
         window_loadsave_populate_list(w, isSave, path, _extension);
         window_init_scroll_widgets(w);
         w->no_list_items = _listItemsCount;
         break;
+
     case WIDX_NEW_FILE:
         window_text_input_open(w, WIDX_NEW_FILE, STR_NONE, STR_FILEBROWSER_FILE_NAME_PROMPT, STR_STRING, (uintptr_t)&_defaultName, 64);
         break;
+
     case WIDX_NEW_FOLDER:
         window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, nullptr, 64);
         break;
+
     case WIDX_BROWSE:
         if (browse(isSave, path, sizeof(path)))
         {
@@ -361,28 +401,38 @@ static void window_loadsave_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             w->no_list_items = _listItemsCount;
         }
         break;
+
     case WIDX_SORT_NAME:
-        if (gConfigGeneral.load_save_sort == SORT_NAME_ASCENDING){
+        if (gConfigGeneral.load_save_sort == SORT_NAME_ASCENDING)
+        {
             gConfigGeneral.load_save_sort = SORT_NAME_DESCENDING;
-        } else {
+        }
+        else
+        {
             gConfigGeneral.load_save_sort = SORT_NAME_ASCENDING;
         }
         config_save_default();
         window_loadsave_sort_list(0, _listItemsCount - 1);
         window_invalidate(w);
         break;
+
     case WIDX_SORT_DATE:
-        if (gConfigGeneral.load_save_sort == SORT_DATE_DESCENDING){
+        if (gConfigGeneral.load_save_sort == SORT_DATE_DESCENDING)
+        {
             gConfigGeneral.load_save_sort = SORT_DATE_ASCENDING;
-        } else {
+        }
+        else
+        {
             gConfigGeneral.load_save_sort = SORT_DATE_DESCENDING;
         }
         config_save_default();
         window_loadsave_sort_list(0, _listItemsCount - 1);
         window_invalidate(w);
         break;
+
     case WIDX_DEFAULT:
-        switch (_type & 0x0E) {
+        switch (_type & 0x0E)
+        {
         case LOADSAVETYPE_GAME:
             platform_get_user_directory(path, "save", sizeof(path));
             break;
@@ -416,7 +466,9 @@ static void window_loadsave_scrollmousedown(rct_window *w, sint32 scrollIndex, s
     selectedItem = y / SCROLLABLE_ROW_HEIGHT;
     if (selectedItem >= w->no_list_items)
         return;
-    if (_listItems[selectedItem].type == TYPE_DIRECTORY){
+
+    if (_listItems[selectedItem].type == TYPE_DIRECTORY)
+    {
         // The selected item is a folder
         sint32 includeNewItem;
 
@@ -431,7 +483,9 @@ static void window_loadsave_scrollmousedown(rct_window *w, sint32 scrollIndex, s
         window_init_scroll_widgets(w);
 
         w->no_list_items = _listItemsCount;
-    } else {
+    }
+    else
+    {
         // TYPE_FILE
         // Load or overwrite
         if ((_type & 0x01) == LOADSAVETYPE_SAVE)
@@ -462,9 +516,11 @@ static void window_loadsave_textinput(rct_window *w, rct_widgetindex widgetIndex
     if (text == nullptr || text[0] == 0)
         return;
 
-    switch (widgetIndex) {
+    switch (widgetIndex)
+    {
         case WIDX_NEW_FOLDER:
-            if (!filename_valid_characters(text)) {
+            if (!filename_valid_characters(text))
+            {
                 context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE);
                 return;
             }
@@ -472,10 +528,12 @@ static void window_loadsave_textinput(rct_window *w, rct_widgetindex widgetIndex
             safe_strcpy(path, _directory, sizeof(path));
             safe_strcat_path(path, text, sizeof(path));
 
-            if (!platform_ensure_directory_exists(path)) {
+            if (!platform_ensure_directory_exists(path))
+            {
                 context_show_error(STR_UNABLE_TO_CREATE_FOLDER, STR_NONE);
                 return;
             }
+
             w->no_list_items = 0;
             w->selected_list_item = -1;
 
@@ -485,14 +543,17 @@ static void window_loadsave_textinput(rct_window *w, rct_widgetindex widgetIndex
             w->no_list_items = _listItemsCount;
             window_invalidate(w);
             break;
+
         case WIDX_NEW_FILE:
             safe_strcpy(path, _directory, sizeof(path));
             safe_strcat_path(path, text, sizeof(path));
             path_append_extension(path, _extension, sizeof(path));
 
             overwrite = 0;
-            for (i = 0; i < _listItemsCount; i++) {
-                if (_stricmp(_listItems[i].path, path) == 0) {
+            for (i = 0; i < _listItemsCount; i++)
+            {
+                if (_stricmp(_listItems[i].path, path) == 0)
+                {
                     overwrite = 1;
                     break;
                 }
@@ -562,7 +623,8 @@ static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi)
 {
     window_draw_widgets(w, dpi);
 
-    if (_shortenedDirectory[0] == '\0') {
+    if (_shortenedDirectory[0] == '\0')
+    {
         shorten_path(_shortenedDirectory, sizeof(_shortenedDirectory), _directory, w->width - 8);
     }
 
@@ -612,7 +674,8 @@ static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, s
     gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1, ColourMapA[w->colours[1]].mid_light);
     const sint32 listWidth = w->widgets[WIDX_SCROLL].right - w->widgets[WIDX_SCROLL].left;
 
-    for (sint32 i = 0; i < w->no_list_items; i++) {
+    for (sint32 i = 0; i < w->no_list_items; i++)
+    {
         sint32 y = i * SCROLLABLE_ROW_HEIGHT;
         if (y > dpi->y + dpi->height)
             break;
@@ -623,12 +686,14 @@ static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, s
         rct_string_id stringId = STR_BLACK_STRING;
 
         // If hovering over item, change the color and fill the backdrop.
-        if (i == w->selected_list_item) {
+        if (i == w->selected_list_item)
+        {
             stringId = STR_WINDOW_COLOUR_2_STRINGID;
             gfx_filter_rect(dpi, 0, y, listWidth, y + SCROLLABLE_ROW_HEIGHT, PALETTE_DARKEN_1);
         }
         // display a marker next to the currently loaded game file
-        if (_listItems[i].loaded) {
+        if (_listItems[i].loaded)
+        {
             set_format_arg(0, rct_string_id, STR_RIGHTGUILLEMET);
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y);
         }
@@ -662,7 +727,8 @@ static sint32 list_item_sort(const void *a, const void *b)
     if (itemA->type != itemB->type)
         return itemA->type - itemB->type;
 
-    switch (gConfigGeneral.load_save_sort){
+    switch (gConfigGeneral.load_save_sort)
+    {
     case SORT_NAME_ASCENDING:
         return strcicmp(itemA->name, itemB->name);
     case SORT_NAME_DESCENDING:
@@ -688,7 +754,8 @@ static void window_loadsave_sort_list(sint32 index, sint32 endIndex)
 static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, const char *directory, const char *extension)
 {
     safe_strcpy(_directory, directory, sizeof(_directory));
-    if (_extension != extension) {
+    if (_extension != extension)
+    {
         safe_strcpy(_extension, extension, sizeof(_extension));
     }
     _shortenedDirectory[0] = '\0';
@@ -705,11 +772,14 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
     window_loadsave_widgets[WIDX_NEW_FOLDER].type = includeNewItem ? WWT_BUTTON : WWT_EMPTY;
 
     sint32 drives = platform_get_drives();
-    if (str_is_null_or_empty(directory) && drives) {
+    if (str_is_null_or_empty(directory) && drives)
+    {
         // List Windows drives
         w->disabled_widgets |= (1 << WIDX_NEW_FILE) | (1 << WIDX_NEW_FOLDER) | (1 << WIDX_UP);
-        for (sint32 x = 0; x < 26; x++){
-            if (listItemCapacity <= _listItemsCount) {
+        for (sint32 x = 0; x < 26; x++)
+        {
+            if (listItemCapacity <= _listItemsCount)
+            {
                 listItemCapacity *= 2;
                 void *new_memory = realloc(_listItems, listItemCapacity * sizeof(loadsave_list_item));
                 if (new_memory == nullptr) {
@@ -719,7 +789,8 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
                 _listItems = (loadsave_list_item*)new_memory;
             }
 
-            if (drives & (1 << x)){
+            if (drives & (1 << x))
+            {
                 // If the drive exists, list it
                 loadsave_list_item *listItem = &_listItems[_listItemsCount];
 
@@ -731,8 +802,8 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
             }
         }
     }
-    else {
-
+    else
+    {
         // Remove the separator at the end of the path, if present
         safe_strcpy(_parentDirectory, directory, sizeof(_parentDirectory));
         if (_parentDirectory[strlen(_parentDirectory) - 1] == *PATH_SEPARATOR
@@ -743,12 +814,17 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
         char *ch = strrchr(_parentDirectory, *PATH_SEPARATOR);
         char *posix_ch = strrchr(_parentDirectory, '/');
         ch = ch < posix_ch ? posix_ch : ch;
-        if (ch != nullptr) {
+        if (ch != nullptr)
+        {
             *(ch + 1) = '\0';
-        } else if (drives) {
+        }
+        else if (drives)
+        {
             // If on Windows, clear the entire path to show the drives
             _parentDirectory[0] = '\0';
-        } else {
+        }
+        else
+        {
             // Else, go to the root directory
             snprintf(_parentDirectory, MAX_PATH, "%c", *PATH_SEPARATOR);
         }
@@ -766,8 +842,10 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
         // List all directories
         char subDir[MAX_PATH];
         sint32 fileEnumHandle = platform_enumerate_directories_begin(directory);
-        while (platform_enumerate_directories_next(fileEnumHandle, subDir)) {
-            if (listItemCapacity <= _listItemsCount) {
+        while (platform_enumerate_directories_next(fileEnumHandle, subDir))
+        {
+            if (listItemCapacity <= _listItemsCount)
+            {
                 listItemCapacity *= 2;
                 _listItems = Memory::ReallocateArray(_listItems, listItemCapacity);
             }
@@ -790,15 +868,18 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
         char * extToken;
         bool showExtension = false;
         extToken = strtok(extCopy, ";");
-        while (extToken != nullptr) {
+        while (extToken != nullptr)
+        {
             safe_strcpy(filter, directory, sizeof(filter));
             safe_strcat_path(filter, "*", sizeof(filter));
             path_append_extension(filter, extToken, sizeof(filter));
 
             file_info fileInfo;
             fileEnumHandle = platform_enumerate_files_begin(filter);
-            while (platform_enumerate_files_next(fileEnumHandle, &fileInfo)) {
-                if (listItemCapacity <= _listItemsCount) {
+            while (platform_enumerate_files_next(fileEnumHandle, &fileInfo))
+            {
+                if (listItemCapacity <= _listItemsCount)
+                {
                     listItemCapacity *= 2;
                     _listItems = Memory::ReallocateArray(_listItems, listItemCapacity);
                 }
@@ -836,7 +917,8 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
 
 static void window_loadsave_invoke_callback(sint32 result, const utf8 * path)
 {
-    if (_loadSaveCallback != nullptr) {
+    if (_loadSaveCallback != nullptr)
+    {
         _loadSaveCallback(result, path);
     }
 }
@@ -863,7 +945,8 @@ static bool is_valid_path(const char * path)
 
 static void window_loadsave_select(rct_window *w, const char *path)
 {
-    if (!is_valid_path(path)) {
+    if (!is_valid_path(path))
+    {
         context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE);
         return;
     }
@@ -872,7 +955,7 @@ static void window_loadsave_select(rct_window *w, const char *path)
     safe_strcpy(pathBuffer, path, sizeof(pathBuffer));
 
     switch (_type & 0x0F) {
-    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME) :
+    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME):
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
         safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
         safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
@@ -881,9 +964,11 @@ static void window_loadsave_select(rct_window *w, const char *path)
         window_close_by_class(WC_LOADSAVE);
         gfx_invalidate_screen();
         break;
-    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME) :
+
+    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME):
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
-        if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 1 : 0)) {
+        if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 1 : 0))
+        {
             safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
             safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             gFirstTimeSaving = false;
@@ -892,37 +977,48 @@ static void window_loadsave_select(rct_window *w, const char *path)
             gfx_invalidate_screen();
 
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
-        } else {
+        }
+        else
+        {
             context_show_error(STR_SAVE_GAME, STR_GAME_SAVE_FAILED);
             window_loadsave_invoke_callback(MODAL_RESULT_FAIL, pathBuffer);
         }
         break;
-    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_LANDSCAPE) :
+
+    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_LANDSCAPE):
         save_path(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
-        if (Editor::LoadLandscape(pathBuffer)) {
+        if (Editor::LoadLandscape(pathBuffer))
+        {
             safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             gfx_invalidate_screen();
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
-        } else {
+        }
+        else
+        {
             // Not the best message...
             context_show_error(STR_LOAD_LANDSCAPE, STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA);
             window_loadsave_invoke_callback(MODAL_RESULT_FAIL, pathBuffer);
         }
         break;
-    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE) :
+
+    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE):
         save_path(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
         safe_strcpy(gScenarioFileName, pathBuffer, sizeof(gScenarioFileName));
-        if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 3 : 2)) {
+        if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 3 : 2))
+        {
             safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
             window_close_by_class(WC_LOADSAVE);
             gfx_invalidate_screen();
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
-        } else {
+        }
+        else
+        {
             context_show_error(STR_SAVE_LANDSCAPE, STR_LANDSCAPE_SAVE_FAILED);
             window_loadsave_invoke_callback(MODAL_RESULT_FAIL, pathBuffer);
         }
         break;
-    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO) :
+
+    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO):
     {
         save_path(&gConfigGeneral.last_save_scenario_directory, pathBuffer);
         sint32 parkFlagsBackup = gParkFlags;
@@ -932,18 +1028,22 @@ static void window_loadsave_select(rct_window *w, const char *path)
         sint32 success = scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 3 : 2);
         gParkFlags = parkFlagsBackup;
 
-        if (success) {
+        if (success)
+        {
             window_close_by_class(WC_LOADSAVE);
             window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
             title_load();
-        } else {
+        }
+        else
+        {
             context_show_error(STR_FILE_DIALOG_TITLE_SAVE_SCENARIO, STR_SCENARIO_SAVE_FAILED);
             gS6Info.editor_step = EDITOR_STEP_OBJECTIVE_SELECTION;
             window_loadsave_invoke_callback(MODAL_RESULT_FAIL, pathBuffer);
         }
         break;
     }
-    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK) :
+
+    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK):
     {
         save_path(&gConfigGeneral.last_save_track_directory, pathBuffer);
         auto intent = Intent(WC_INSTALL_TRACK);
@@ -953,22 +1053,27 @@ static void window_loadsave_select(rct_window *w, const char *path)
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         break;
     }
-    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK) :
+
+    case (LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK):
     {
         path_set_extension(pathBuffer, "td6", sizeof(pathBuffer));
         sint32 success = track_design_save_to_file(pathBuffer);
 
-        if (success) {
+        if (success)
+        {
             window_close_by_class(WC_LOADSAVE);
             window_ride_measurements_design_cancel();
             window_loadsave_invoke_callback(MODAL_RESULT_OK, path);
-        } else {
+        }
+        else
+        {
             context_show_error(STR_FILE_DIALOG_TITLE_SAVE_TRACK, STR_TRACK_SAVE_FAILED);
             window_loadsave_invoke_callback(MODAL_RESULT_FAIL, path);
         }
         break;
     }
-    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_IMAGE) :
+
+    case (LOADSAVETYPE_LOAD | LOADSAVETYPE_IMAGE):
         window_close_by_class(WC_LOADSAVE);
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         break;
@@ -988,7 +1093,8 @@ enum {
     WIDX_OVERWRITE_CANCEL
 };
 
-static rct_widget window_overwrite_prompt_widgets[] = {
+static rct_widget window_overwrite_prompt_widgets[] =
+{
     { WWT_FRAME,            0, 0,                   OVERWRITE_WW - 1,   0,                  OVERWRITE_WH - 1,   STR_NONE,                           STR_NONE },
     { WWT_CAPTION,          0, 1,                   OVERWRITE_WW - 2,   1,                  14,                 STR_FILEBROWSER_OVERWRITE_TITLE,    STR_WINDOW_TITLE_TIP },
     { WWT_CLOSEBOX,         0, OVERWRITE_WW - 13,   OVERWRITE_WW - 3,   2,                  13,                 STR_CLOSE_X,                        STR_CLOSE_WINDOW_TIP },
@@ -1000,7 +1106,8 @@ static rct_widget window_overwrite_prompt_widgets[] = {
 static void window_overwrite_prompt_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_overwrite_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_overwrite_prompt_events = {
+static rct_window_event_list window_overwrite_prompt_events =
+{
     nullptr,
     window_overwrite_prompt_mouseup,
     nullptr,
@@ -1042,8 +1149,13 @@ static rct_window *window_overwrite_prompt_open(const char *name, const char *pa
 
     w = window_create_centred(OVERWRITE_WW, OVERWRITE_WH, &window_overwrite_prompt_events, WC_LOADSAVE_OVERWRITE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_overwrite_prompt_widgets;
-    w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_OVERWRITE_CANCEL) | (1 << WIDX_OVERWRITE_OVERWRITE);
+    w->enabled_widgets =
+        (1 << WIDX_CLOSE) |
+        (1 << WIDX_OVERWRITE_CANCEL) |
+        (1 << WIDX_OVERWRITE_OVERWRITE);
+
     window_init_scroll_widgets(w);
+
     w->flags |= WF_TRANSPARENT;
     w->colours[0] = TRANSLUCENT(COLOUR_BORDEAUX_RED);
 
@@ -1057,7 +1169,8 @@ static void window_overwrite_prompt_mouseup(rct_window *w, rct_widgetindex widge
 {
     rct_window *loadsaveWindow;
 
-    switch (widgetIndex) {
+    switch (widgetIndex)
+    {
     case WIDX_OVERWRITE_OVERWRITE:
         loadsaveWindow = window_find_by_class(WC_LOADSAVE);
         if (loadsaveWindow != nullptr)
@@ -1066,6 +1179,7 @@ static void window_overwrite_prompt_mouseup(rct_window *w, rct_widgetindex widge
         // windows we can't use window_close(w).
         window_close_by_class(WC_LOADSAVE_OVERWRITE_PROMPT);
         break;
+
     case WIDX_OVERWRITE_CANCEL:
     case WIDX_OVERWRITE_CLOSE:
         window_close(w);
@@ -1084,6 +1198,5 @@ static void window_overwrite_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi)
     sint32 y = w->y + (w->height / 2) - 3;
     gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
 }
-
 
 #pragma endregion

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -123,6 +123,7 @@ typedef struct loadsave_list_item {
     char name[256];
     char path[MAX_PATH];
     time_t date_modified;
+    char date_formatted[30];
     uint8 type;
     bool loaded;
 } loadsave_list_item;
@@ -550,9 +551,18 @@ static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, s
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y);
         }
 
+        // Print filename
         set_format_arg(0, rct_string_id, STR_STRING);
         set_format_arg(2, char*, _listItems[i].name);
-        gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, SCROLLABLE_ROW_HEIGHT, y);
+        gfx_draw_string_left_clipped(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 10, y, (WW - 5) / 2 - 5);
+
+        // Print formatted modified date, if this is a file
+        if (_listItems[i].type == TYPE_FILE)
+        {
+            set_format_arg(0, rct_string_id, STR_STRING);
+            set_format_arg(2, char*, _listItems[i].date_formatted);
+            gfx_draw_string_left_clipped(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, (WW - 5) / 2 + 5, y, (WW - 5) / 2);
+        }
     }
 }
 
@@ -711,6 +721,10 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
                 safe_strcat_path(listItem->path, fileInfo.path, sizeof(listItem->path));
                 listItem->type = TYPE_FILE;
                 listItem->date_modified = platform_file_get_modified_time(listItem->path);
+
+                // Cache a human-readable version of the modified date.
+                std::strftime(listItem->date_formatted, sizeof(listItem->date_formatted), "%x %X", std::localtime(&listItem->date_modified));
+
                 // Mark if file is the currently loaded game
                 listItem->loaded = strcmp(listItem->path, gCurrentLoadedPath) == 0;
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -598,6 +598,7 @@ static void window_loadsave_invalidate(rct_window *w)
     window_loadsave_widgets[WIDX_CLOSE].right = w->width - 3;
     window_loadsave_widgets[WIDX_BACKGROUND].right = w->width - 1;
     window_loadsave_widgets[WIDX_BACKGROUND].bottom = w->height - 1;
+    window_loadsave_widgets[WIDX_RESIZE].top = w->height - 1;
     window_loadsave_widgets[WIDX_RESIZE].right = w->width - 1;
     window_loadsave_widgets[WIDX_RESIZE].bottom = w->height - 1;
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -333,6 +333,7 @@ void draw_string_right_underline(rct_drawpixelinfo *dpi, rct_string_id format, v
 
 void gfx_draw_string_left_clipped(rct_drawpixelinfo *dpi, rct_string_id format, void *args, uint8 colour, sint32 x, sint32 y, sint32 width);
 void gfx_draw_string_centred_clipped(rct_drawpixelinfo *dpi, rct_string_id format, void *args, uint8 colour, sint32 x, sint32 y, sint32 width);
+void gfx_draw_string_right_clipped(rct_drawpixelinfo *dpi, rct_string_id format, void *args, uint8 colour, sint32 x, sint32 y, sint32 width);
 
 sint32 gfx_draw_string_left_wrapped(rct_drawpixelinfo *dpi, void *args, sint32 x, sint32 y, sint32 width, rct_string_id format, uint8 colour);
 sint32 gfx_draw_string_centred_wrapped(rct_drawpixelinfo *dpi, void *args, sint32 x, sint32 y, sint32 width, rct_string_id format, uint8 colour);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -198,6 +198,11 @@ extern "C"
         DrawTextEllipsisedCompat(dpi, x, y, width, format, args, colour, TextAlignment::CENTRE);
     }
 
+    void gfx_draw_string_right_clipped(rct_drawpixelinfo * dpi, rct_string_id format, void * args, uint8 colour, sint32 x, sint32 y, sint32 width)
+    {
+        DrawTextEllipsisedCompat(dpi, x, y, width, format, args, colour, TextAlignment::RIGHT);
+    }
+
     // Wrapping
     sint32 gfx_draw_string_left_wrapped(rct_drawpixelinfo * dpi, void * args, sint32 x, sint32 y, sint32 width, rct_string_id format, uint8 colour)
     {

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <pwd.h>
 #include <cstdlib>
+#include <ctime>
 #include "../core/String.hpp"
 #include "Platform2.h"
 #include "platform.h"
@@ -81,6 +82,20 @@ namespace Platform
         platform_resolve_openrct_data_path();
         platform_get_openrct_data_path(path, sizeof(path));
         return path;
+    }
+
+    std::string FormatShortDate(std::time_t timestamp)
+    {
+        char date[20];
+        std::strftime(date, sizeof(date), "%x", std::gmtime(&timestamp));
+        return std::string(date);
+    }
+
+    std::string FormatTime(std::time_t timestamp)
+    {
+        char time[20];
+        std::strftime(time, sizeof(time), "%X", std::gmtime(&timestamp));
+        return std::string(time);
     }
 }
 

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -24,6 +24,7 @@
 
 #if !defined(__MINGW32__) && ((NTDDI_VERSION >= NTDDI_VISTA) && !defined(_USING_V110_SDK71_) && !defined(_ATL_XP_TARGETING))
     #define __USE_SHGETKNOWNFOLDERPATH__
+    #define __USE_GETDATEFORMATEX__
 #endif
 
 #include "../core/Path.hpp"
@@ -146,7 +147,7 @@ namespace Platform
         return path;
     }
 
-    SYSTEMTIME TimeToSystemTime(std::time_t timestamp)
+    static SYSTEMTIME TimeToSystemTime(std::time_t timestamp)
     {
         LONGLONG ll = Int32x32To64(timestamp, 10000000) + 116444736000000000;
 
@@ -163,9 +164,16 @@ namespace Platform
     {
         SYSTEMTIME st = TimeToSystemTime(timestamp);
 
+#ifdef __USE_GETDATEFORMATEX__
         wchar_t date[20];
         GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, &st, nullptr, date, sizeof(date), nullptr);
         std::string result = String::ToUtf8(std::wstring(date));
+#else
+        char date[20];
+        GetDateFormat(LOCALE_USER_DEFAULT, DATE_SHORTDATE, &st, nullptr, date, sizeof(date));
+        std::string result(date);
+#endif
+
         return result;
     }
 
@@ -173,9 +181,16 @@ namespace Platform
     {
         SYSTEMTIME st = TimeToSystemTime(timestamp);
 
+#ifdef __USE_GETDATEFORMATEX__
         wchar_t time[20];
         GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, nullptr, time, sizeof(time));
         std::string result = String::ToUtf8(std::wstring(time));
+#else
+        char time[20];
+        GetTimeFormat(LOCALE_USER_DEFAULT, 0, &st, nullptr, time, sizeof(time));
+        std::string result(time);
+#endif
+
         return result;
     }
 }

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -18,6 +18,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <datetimeapi.h>
 #include <shlobj.h>
 #undef GetEnvironmentVariable
 
@@ -143,6 +144,37 @@ namespace Platform
         platform_resolve_openrct_data_path();
         platform_get_openrct_data_path(path, sizeof(path));
         return path;
+    }
+
+    SYSTEMTIME * TimeToSystemTime(std::time_t timestamp)
+    {
+        LONGLONG ll = Int32x32To64(timestamp, 10000000) + 116444736000000000;
+
+        FILETIME ft;
+        ft.dwLowDateTime = (DWORD) ll;
+        ft.dwHighDateTime = ll >> 32;
+
+        SYSTEMTIME st;
+        FileTimeToSystemTime(&ft, &st);
+        return &st;
+    }
+
+    std::string FormatShortDate(std::time_t timestamp)
+    {
+        SYSTEMTIME * st = TimeToSystemTime(timestamp);
+
+        wchar_t date[20];
+        GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, st, nullptr, &date, sizeof(date), nullptr);
+        return String::ToUtf8(std::wstring(date));
+    }
+
+    std::string FormatTime(std::time_t timestamp)
+    {
+        SYSTEMTIME * st = TimeToSystemTime(timestamp);
+
+        wchar_t time[20];
+        GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, st, nullptr, &time, sizeof(time));
+        return String::ToUtf8(std::wstring(time));
     }
 }
 

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -146,7 +146,7 @@ namespace Platform
         return path;
     }
 
-    SYSTEMTIME * TimeToSystemTime(std::time_t timestamp)
+    SYSTEMTIME TimeToSystemTime(std::time_t timestamp)
     {
         LONGLONG ll = Int32x32To64(timestamp, 10000000) + 116444736000000000;
 
@@ -156,25 +156,27 @@ namespace Platform
 
         SYSTEMTIME st;
         FileTimeToSystemTime(&ft, &st);
-        return &st;
+        return st;
     }
 
     std::string FormatShortDate(std::time_t timestamp)
     {
-        SYSTEMTIME * st = TimeToSystemTime(timestamp);
+        SYSTEMTIME st = TimeToSystemTime(timestamp);
 
         wchar_t date[20];
-        GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, st, nullptr, &date, sizeof(date), nullptr);
-        return String::ToUtf8(std::wstring(date));
+        GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, &st, nullptr, date, sizeof(date), nullptr);
+        std::string result = String::ToUtf8(std::wstring(date));
+        return result;
     }
 
     std::string FormatTime(std::time_t timestamp)
     {
-        SYSTEMTIME * st = TimeToSystemTime(timestamp);
+        SYSTEMTIME st = TimeToSystemTime(timestamp);
 
         wchar_t time[20];
-        GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, st, nullptr, &time, sizeof(time));
-        return String::ToUtf8(std::wstring(time));
+        GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, nullptr, time, sizeof(time));
+        std::string result = String::ToUtf8(std::wstring(time));
+        return result;
     }
 }
 

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -18,6 +18,7 @@
 
 #ifdef __cplusplus
 
+#include <ctime>
 #include <string>
 #include "../common.h"
 
@@ -40,6 +41,9 @@ namespace Platform
     std::string GetEnvironmentPath(const char * name);
     std::string GetHomePath();
 #endif
+
+    std::string FormatShortDate(std::time_t timestamp);
+    std::string FormatTime(std::time_t timestamp);
 }
 
 #endif


### PR DESCRIPTION
The load/save window has had the ability to sort by date since its inception, but it has never actually _shown_ the dates. This PR aims to change that.

The date format used is the one provided by the system locale settings. Hence, it looks different when comparing e.g. English to Japanese:

![2018-01-06 01 17 00](https://user-images.githubusercontent.com/604665/34633919-b37ccc98-f27f-11e7-9e8a-93df424ad2ac.png)  ![2018-01-06 01 22 54_](https://user-images.githubusercontent.com/604665/34634006-5eef2184-f280-11e7-8842-2a4e436bc640.png)

I'm not sure what to do about the date alignment. As the sprite font, like many Latin fonts, uses variable-width characters, it's a bit of a mess. A solution to this would be to possibly paint using two virtual columns, rendering the date right-aligned and the time left-aligned next to it?

Another question to ask is: does this make the window too small? Should we widen it a little?