### PR TITLE
Fix #5398: Attempting to place Mini Maze.TD4 results in weird behaviour and crashes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -45,6 +45,7 @@
 - Fix: [#4991] Inverted helices can be built on the Lay Down RC, but are not drawn.
 - Fix: [#5190] Cannot build Wild Mouse - Flying Dutchman Gold Mine.
 - Fix: [#5224] Multiplayer window is not closed when server shuts down.
+- Fix: [#5398] Attempting to place Mini Maze.TD4 results in weird behaviour and crashes.
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.
 - Fix: [#5585] Inconsistent zooming with mouse wheel.


### PR DESCRIPTION
This fixes both the crash and the spurious 'Includes unavailable scenery message'. The first was caused by padding out the file with 1's, while mazes are padded out with zeros. The second problem was caused by junk at the end, because original RCT1 TD4's are slightly smaller than AA/LL TD4's.