### PR TITLE
Clang-format guards for static data

### DIFF
--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -174,6 +174,7 @@ IPlatformEnvironment * OpenRCT2::CreatePlatformEnvironment()
     return env;
 }
 
+// clang-format off
 const char * PlatformEnvironment::DirectoryNamesRCT2[] =
 {
     "Data",                 // DATA
@@ -225,3 +226,4 @@ const char * PlatformEnvironment::FileNames[] =
     "scores.dat",           // SCORES (LEGACY)
     "Saved Games" PATH_SEPARATOR "scores.dat",  // SCORES (RCT2)
 };
+// clang-format on

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -61,6 +61,7 @@ rct_vehicle_sound           gVehicleSoundList[AUDIO_MAX_VEHICLE_SOUNDS];
 rct_vehicle_sound_params    gVehicleSoundParamsList[AUDIO_MAX_VEHICLE_SOUNDS];
 rct_vehicle_sound_params *  gVehicleSoundParamsListEnd;
 
+// clang-format off
 static sint32 SoundVolumeAdjust[SOUND_MAXID] =
 {
     0,      // SOUND_LIFT_1
@@ -127,6 +128,7 @@ static sint32 SoundVolumeAdjust[SOUND_MAXID] =
     -2700,  // SOUND_DOOR_CLOSE
     -700    // SOUND_62
 };
+// clang-format on
 
 AudioParams audio_get_params_from_location(sint32 soundId, const LocationXYZ16 *location);
 

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -63,6 +63,7 @@ static utf8 * _openrctDataPath = nullptr;
 static utf8 * _rct2DataPath    = nullptr;
 static bool   _silentBreakpad  = false;
 
+// clang-format off
 static const CommandLineOptionDefinition StandardOptions[]
 {
     { CMDLINE_TYPE_SWITCH,  &_help,            'h', "help",              "show this help message and exit"                            },
@@ -156,6 +157,7 @@ const CommandLineExample CommandLine::RootExamples[]
 #endif
     ExampleTableEnd
 };
+// clang-format on
 
 exitcode_t CommandLine::HandleCommandDefault()
 {

--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -19,6 +19,7 @@
 
 static ScreenshotOptions options;
 
+// clang-format off
 static const CommandLineOptionDefinition ScreenshotOptionsDef[]
 {
     { CMDLINE_TYPE_INTEGER, &options.weather,       NAC, "weather",       "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
@@ -42,6 +43,7 @@ const CommandLineCommand CommandLine::ScreenshotCommands[]
     DefineCommand("", "<file> <output_image> giant <zoom> <rotation>",                      ScreenshotOptionsDef, HandleScreenshot),
     CommandTableEnd
 };
+// clang-format on
 
 static exitcode_t HandleScreenshot(CommandLineArgEnumerator *argEnumerator)
 {

--- a/src/openrct2/cmdline/SpriteCommands.cpp
+++ b/src/openrct2/cmdline/SpriteCommands.cpp
@@ -30,6 +30,7 @@ sint32 gSpriteMode = 0;
 
 static const char * _mode;
 
+// clang-format off
 static const CommandLineOptionDefinition SpriteOptions[]
 {
     { CMDLINE_TYPE_STRING, &_mode, 'm', "mode", "the type of sprite conversion <" SZ_DEFAULT "|" SZ_CLOSEST "|" SZ_DITHERING ">" },
@@ -49,6 +50,7 @@ const CommandLineCommand CommandLine::SpriteCommands[]
     DefineCommand("exportall", "<spritefile> <output directory>",          SpriteOptions, HandleSprite),
     CommandTableEnd
 };
+// clang-format on
 
 static exitcode_t HandleSprite(CommandLineArgEnumerator *argEnumerator)
 {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -48,6 +48,7 @@ sint32 gPickupPeepY;
  *
  * rct2: 0x0009ABE0C
  */
+// clang-format off
 uint8 gPeepPalette[256] = {
     0x00, 0xF3, 0xF4, 0xF5, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
@@ -473,6 +474,7 @@ const translucent_window_palette TranslucentWindowPalettes[COLOUR_COUNT] = {
     WINDOW_PALETTE_BRIGHT_PINK,             // COLOUR_BRIGHT_PINK
     {PALETTE_TRANSLUCENT_LIGHT_PINK,        PALETTE_TRANSLUCENT_LIGHT_PINK_HIGHLIGHT,       PALETTE_TRANSLUCENT_LIGHT_PINK_SHADOW},
 };
+// clang-format on
 
 void (*mask_fn)(sint32 width, sint32 height, const uint8 * RESTRICT maskSrc, const uint8 * RESTRICT colourSrc,
                 uint8 * RESTRICT dst, sint32 maskWrap, sint32 colourWrap, sint32 dstWrap) = nullptr;

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -159,6 +159,7 @@ extern bool TempForScrollText;
 
 #define SCROLL_POS(x, y)    ((y * 64) + x)
 
+// clang-format off
 static const sint16 _scrollpos0[] = {
     SCROLL_POS( 35, 12 ),
     SCROLL_POS( 36, 12 ),
@@ -1418,6 +1419,7 @@ static const sint16* _scrollPositions[MAX_SCROLLING_TEXT_MODES] = {
     _scrollpos36,
     _scrollpos37,
 };
+// clang-format on
 
 extern "C"
 {

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -496,6 +496,7 @@ void X8DrawingContext::Clear(uint8 paletteIndex)
 }
 
 /** rct2: 0x0097FF04 */
+// clang-format off
 static const uint16 Pattern[] = {
     0b0111111110000000,
     0b0011111111000000,
@@ -540,6 +541,7 @@ static const uint16 * Patterns[] = {
     Pattern,
     PatternInverse
 };
+// clang-format on
 
 void X8DrawingContext::FillRect(uint32 colour, sint32 left, sint32 top, sint32 right, sint32 bottom)
 {

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -29,6 +29,7 @@
 uint8 const HINTING_THRESHOLD_LOW    = 40;
 uint8 const HINTING_THRESHOLD_MEDIUM = 60;
 
+// clang-format off
 TTFFontSetDescriptor TTFFontMSGothic = { {
     { "msgothic.ttc", "MS PGothic",  9, 1, -1, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "msgothic.ttc", "MS PGothic", 12, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
@@ -98,6 +99,7 @@ TTFFontSetDescriptor TTFFontArialUnicode = { {
     { "arialuni.ttf", "Arial Unicode MS", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arialuni.ttf", "Arial Unicode MS", 12, 0, -1, 14, HINTING_THRESHOLD_LOW, nullptr },
 } };
+// clang-format on
 #endif // NO_TTF
 
 static void LoadSpriteFont()

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -99,6 +99,7 @@ struct WindowThemeDesc
 
 #pragma region Window Theme Descriptors
 
+// clang-format off
 #define COLOURS_1(c0) 1, { { (c0), 0, 0, 0, 0, 0 } }
 #define COLOURS_2(c0, c1) 2, { { (c0), (c1), 0, 0, 0, 0 } }
 #define COLOURS_3(c0, c1, c2) 3, { { (c0), (c1), (c2), 0, 0, 0 } }
@@ -230,6 +231,7 @@ static const PredefinedTheme PredefinedThemes[] = {
     { &PredefinedThemeRCT1, STR_TITLE_SEQUENCE_RCT1 },
     { &PredefinedThemeRCT2, STR_TITLE_SEQUENCE_RCT2 }
 };
+// clang-format on
 
 #pragma endregion
 

--- a/src/openrct2/localisation/ConversionTables.cpp
+++ b/src/openrct2/localisation/ConversionTables.cpp
@@ -17,6 +17,7 @@
 #include "ConversionTables.h"
 #include "FormatCodes.h"
 
+// clang-format off
 const encoding_convert_entry RCT2ToUnicodeTable[256] =
 {
     { 0, 0 },
@@ -46293,3 +46294,4 @@ const encoding_convert_entry CP949ToUnicodeTable[17176] =
     { 0xFDFD, 0x7FB2 }, // CJK UNIFIED IDEOGRAPH
     { 0xFDFE, 0x8A70 }, // CJK UNIFIED IDEOGRAPH
 };
+//clang-format on

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -19,6 +19,7 @@
 #include "Currency.h"
 #include "StringIds.h"
 
+// clang-format off
 currency_descriptor CurrencyDescriptors[CURRENCY_END] = {
     {   "GBP",  10,     CURRENCY_PREFIX,    "\xC2\xA3",     CURRENCY_SUFFIX,    "GBP",  STR_POUNDS          },  // British Pound
     {   "USD",  10,     CURRENCY_PREFIX,    "$",            CURRENCY_PREFIX,    "$",    STR_DOLLARS         },  // US Dollar
@@ -38,6 +39,7 @@ currency_descriptor CurrencyDescriptors[CURRENCY_END] = {
     {   "CNY",  100,    CURRENCY_PREFIX,    "CN\xC2\xA5",   CURRENCY_PREFIX,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
     {   "CTM",  10,     CURRENCY_PREFIX,    "Ctm",          CURRENCY_PREFIX,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
 };
+// clang-format on
 
 void currency_load_custom_currency_config()
 {

--- a/src/openrct2/localisation/Date.cpp
+++ b/src/openrct2/localisation/Date.cpp
@@ -26,6 +26,7 @@ uint16 gDateMonthsElapsed;
 // rct2: 0x00993988
 const sint16 days_in_month[MONTH_COUNT] = { 31, 30, 31, 30, 31, 31, 30, 31 };
 
+// clang-format off
 const rct_string_id DateFormatStringIds[] = {
     STR_DATE_FORMAT_DAY_MONTH_YEAR,
     STR_DATE_FORMAT_MONTH_DAY_YEAR,
@@ -39,6 +40,7 @@ const rct_string_id DateFormatStringFormatIds[] = {
     STR_DATE_FORMAT_YMD,
     STR_DATE_FORMAT_YDM
 };
+// clang-format on
 
 openrct_timeofday gRealTimeOfDay;
 

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -26,6 +26,7 @@ typedef struct format_code_token {
     const char *token;
 } format_code_token;
 
+// clang-format off
 static const format_code_token format_code_tokens[] = {
     { FORMAT_MOVE_X,                    "MOVE_X"                },
     { FORMAT_ADJUST_PALETTE,            "ADJUST_PALETTE"        },
@@ -99,6 +100,7 @@ static const format_code_token format_code_tokens[] = {
     { FORMAT_INVERTEDQUESTION,          "INVERTEDQUESTION"      },
     { FORMAT_COMMA1DP16,                "COMMA1DP16"            }
 };
+// clang-format on
 
 uint32 format_get_code(const char *token)
 {

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -26,6 +26,7 @@
 #include "../platform/platform.h"
 #include "Localisation.h"
 
+// clang-format off
 const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] =
 {
     { "",       "",                     "",                      FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_UNDEFINED
@@ -51,6 +52,7 @@ const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] =
     { "fi-FI", "Finnish",               "Suomi",                 FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_ENGLISH_UK },          // LANGUAGE_FINNISH
     { "sv-SE", "Swedish",               "Svenska",               FAMILY_OPENRCT2_SPRITE,                RCT2_LANGUAGE_ID_SWEDISH },             // LANGUAGE_SWEDISH
 };
+// clang-format on
 
 extern "C" {
 
@@ -60,11 +62,13 @@ bool gUseTrueTypeFont = false;
 static ILanguagePack * _languageFallback = nullptr;
 static ILanguagePack * _languageCurrent = nullptr;
 
+// clang-format off
 const utf8 BlackUpArrowString[] =       { (utf8)(uint8)0xC2, (utf8)(uint8)0x8E, (utf8)(uint8)0xE2, (utf8)(uint8)0x96, (utf8)(uint8)0xB2, (utf8)(uint8)0x00 };
 const utf8 BlackDownArrowString[] =     { (utf8)(uint8)0xC2, (utf8)(uint8)0x8E, (utf8)(uint8)0xE2, (utf8)(uint8)0x96, (utf8)(uint8)0xBC, (utf8)(uint8)0x00 };
 const utf8 BlackLeftArrowString[] =     { (utf8)(uint8)0xC2, (utf8)(uint8)0x8E, (utf8)(uint8)0xE2, (utf8)(uint8)0x97, (utf8)(uint8)0x80, (utf8)(uint8)0x00 };
 const utf8 BlackRightArrowString[] =    { (utf8)(uint8)0xC2, (utf8)(uint8)0x8E, (utf8)(uint8)0xE2, (utf8)(uint8)0x96, (utf8)(uint8)0xB6, (utf8)(uint8)0x00 };
 const utf8 CheckBoxMarkString[] =       { (utf8)(uint8)0xE2, (utf8)(uint8)0x9C, (utf8)(uint8)0x93, (utf8)(uint8)0x00 };
+// clang-format on
 
 void utf8_remove_format_codes(utf8 * text, bool allowcolours)
 {

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -48,6 +48,7 @@ uint8 gMapTooltipFormatArgs[40];
     bool gDebugStringFormatting = false;
 #endif
 
+// clang-format off
 const rct_string_id SpeedNames[] = {
     STR_SPEED_NORMAL,
     STR_SPEED_QUICK,
@@ -330,6 +331,7 @@ const rct_string_id DateGameShortMonthNames[MONTH_COUNT] = {
     STR_MONTH_SHORT_SEP,
     STR_MONTH_SHORT_OCT,
 };
+// clang-format on
 
 #define format_push_char_safe(C) { *(*dest)++ = (C); --(*size); }
 #define format_handle_overflow(X) if ((*size) <= (X)) { *(*dest) = '\0'; (*size) = 0; return; }

--- a/src/openrct2/localisation/RealNames.cpp
+++ b/src/openrct2/localisation/RealNames.cpp
@@ -16,6 +16,7 @@
 
 #include "Localisation.h"
 
+// clang-format off
 const char real_name_initials[] = {
     'B', 'C', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'W'
 };
@@ -1047,3 +1048,4 @@ const char *real_names[] = {
     "Zachery",
     "Zola"
 };
+// clang-format on

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -55,6 +55,7 @@ sint32 NetworkActions::FindCommandByPermissionName(const std::string &permission
     return -1;
 }
 
+// clang-format off
 const std::vector<NetworkAction> NetworkActions::Actions =
 {
     {
@@ -226,5 +227,6 @@ const std::vector<NetworkAction> NetworkActions::Actions =
         }
     }
 };
+// clang-format on
 
 #endif

--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <thread>
 
+// clang-format off
 #ifdef _WIN32
     // winsock2 must be included before windows.h
     #include <winsock2.h>
@@ -58,6 +59,7 @@
         #define FLAG_NO_PIPE 0
     #endif // defined(__linux__)
 #endif // _WIN32
+// clang-format on
 
 #include "TcpSocket.h"
 

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -24,6 +24,7 @@
 #include "../util/Util.h"
 
 // 98DA00
+// clang-format off
 sint32 object_entry_group_counts[] = {
     MAX_RIDE_OBJECTS,          // rides
     MAX_SMALL_SCENERY_OBJECTS, // small scenery
@@ -92,6 +93,7 @@ const rct_object_entry_group object_entry_groups[] = {
     (void**)(gWaterEntries              ), _objectEntriesWaters,    // water            0x009ADAE0, 0xF42868
     (void**)(gStexEntries               ), _objectEntriesStexs, // scenario text    0x009ADAE4, 0xF4287C
 };
+// clang-format on
 
 bool object_entry_is_empty(const rct_object_entry *entry)
 {

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -155,6 +155,7 @@ uint8 * SmallSceneryObject::ReadFrameOffsets(IStream * stream)
     return Memory::Duplicate(data.data(), data.size());
 }
 
+// clang-format off
 void SmallSceneryObject::PerformFixes()
 {
     std::string identifier = GetIdentifier();
@@ -219,6 +220,7 @@ void SmallSceneryObject::PerformFixes()
         SetPrimarySceneryGroup(&scgAbstr);
     }
 }
+// clang-format on
 
 rct_object_entry SmallSceneryObject::GetScgPiratHeader()
 {

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -20,6 +20,7 @@
 #include "tile_element/TileElement.h"
 
 /** rct2: 0x0097AF20, 0x0097AF21 */
+// clang-format off
 static const LocationXY8 loc_97AF20[] = {
     {4,  4},
     {28, 4},
@@ -328,6 +329,7 @@ static const uint16 word_97B3C4[] = {
     15,
     0,
 };
+// clang-format on
 
 extern bool gUseOriginalRidePaint;
 

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -31,6 +31,7 @@
 #include "../../world/Map.h"
 #include "../../drawing/LightFX.h"
 
+// clang-format off
 const uint8 byte_98D800[] = {
     12, 9, 3, 6
 };
@@ -76,6 +77,7 @@ static const sint16 stru_98D804[][4] = {
 static const uint8 byte_98D8A4[] = {
     0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0
 };
+// clang-format on
 
 void path_paint_box_support(paint_session * session, rct_tile_element * tileElement, sint32 height, rct_footpath_entry * footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);
 void path_paint_pole_support(paint_session * session, rct_tile_element* tileElement, sint16 height, rct_footpath_entry* footpathEntry, bool hasFences, uint32 imageFlags, uint32 sceneryImageFlags);

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -25,6 +25,7 @@
 #include "Surface.h"
 #include "TileElement.h"
 
+// clang-format off
 static constexpr const uint8 byte_97B444[] =
 {
     0, 2, 1, 3, 8, 10, 9, 11, 4, 6,
@@ -420,6 +421,7 @@ static constexpr const tile_surface_boundary_data _tileSurfaceBoundaries[4] =
         { 1,  30 }
     },
 };
+// clang-format on
 
 static uint8 viewport_surface_paint_setup_get_relative_slope(rct_tile_element * tileElement, sint32 rotation)
 {

--- a/src/openrct2/peep/PeepData.cpp
+++ b/src/openrct2/peep/PeepData.cpp
@@ -17,6 +17,7 @@
 #include "../core/Util.hpp"
 #include "../world/sprite.h"
 
+// clang-format off
 static const uint8 PeepSpriteImage_Normal_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
 static const uint8 PeepSpriteImage_Normal_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
 static const uint8 PeepSpriteImage_Normal_02_sequence[] = { 0 };
@@ -5455,3 +5456,4 @@ rct_peep_animation_entry g_peep_animation_entries[] =
     { PeepSpriteImage_Soup, PeepSpriteBounds_Soup },
     { PeepSpriteImage_Sandwich, PeepSpriteBounds_Sandwich },
 };
+// clang-format on

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -23,6 +23,7 @@
 #include "RCT1.h"
 #include "../ride/Ride.h"
 
+// clang-format off
 namespace RCT1
 {
     colour_t GetColour(colour_t colour)
@@ -1426,3 +1427,4 @@ namespace RCT1
         return map[sceneryType];
     }
 }
+// clang-format on

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -62,6 +62,7 @@
 #pragma region Ride classification table
 
 /** rct2: 0x0097C3AF */
+// clang-format off
 const uint8 gRideClassifications[255] = {
     RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE,
     RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE,
@@ -128,6 +129,7 @@ const uint8 gRideClassifications[255] = {
     RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE,
     RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE, RIDE_CLASS_RIDE
 };
+// clang-format on
 
 uint8 gTypeToRideEntryIndexMap[TYPE_TO_RIDE_ENTRY_SLOTS];
 

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -212,6 +212,7 @@ bool RideGroupManager::RideGroupIsInvented(const RideGroup * rideGroup)
 
 const std::vector<const char *> RideGroupManager::GetPreferredRideEntryOrder(const uint8 rideType)
 {
+    // clang-format off
     static const std::vector<const char *> preferredRideEntryOrder[] =
     {
         { "SPDRCR  " },                                                             // RIDE_TYPE_SPIRAL_ROLLER_COASTER
@@ -305,7 +306,8 @@ const std::vector<const char *> RideGroupManager::GetPreferredRideEntryOrder(con
         { "PMT1    " },                                                             // RIDE_TYPE_MINE_RIDE
         { },                                                                        // RIDE_TYPE_59
         { "PREMT1  " },                                                             // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER
-   };
+    };
+    // clang-format on
     return preferredRideEntryOrder[rideType];
 }
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -42,6 +42,7 @@
 uint8 gTrackGroundFlags;
 
 /**  rct2: 0x00997C9D */
+// clang-format off
 const rct_trackdefinition TrackDefinitions[256] =
 {
     // TYPE                         VANGLE END                  VANGLE START                BANK END                BANK START              PREVIEW Z OFFSET
@@ -563,6 +564,7 @@ const rct_trackdefinition FlatRideTrackDefinitions[256] =
     { TRACK_QUARTER_LOOP_UNINVERTED,TRACK_SLOPE_NONE,           TRACK_SLOPE_UP_90,          TRACK_BANK_UPSIDE_DOWN, TRACK_BANK_NONE,        0                           },  // 253
     { TRACK_QUARTER_LOOP_UNINVERTED,TRACK_SLOPE_DOWN_90,        TRACK_SLOPE_NONE,           TRACK_BANK_UPSIDE_DOWN, TRACK_BANK_NONE,        0                           },  // 254
 };
+// clang-format on
 
 /**
  * Helper method to determine if a connects to b by its bank and angle, not location.

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -19,6 +19,7 @@
 #include "TrackData.h"
 #include "track_paint.h"
 
+// clang-format off
 const rct_track_coordinates FlatTrackCoordinates[] = {
     {    0,    0,    0,    0,    0,    0 },
     {    0,    0,    0,    0,    0,    0 },
@@ -32310,3 +32311,4 @@ const uint16 TrackFlags[] = {
     /* TRACK_ELEM_MULTIDIM_FLAT_TO_90_DEG_DOWN_QUARTER_LOOP            */   TRACK_ELEM_FLAG_DOWN | TRACK_ELEM_FLAG_INVERSION_TO_NORMAL,
     /*                                                                 */   TRACK_ELEM_FLAG_UP | TRACK_ELEM_FLAG_NORMAL_TO_INVERSION | TRACK_ELEM_FLAG_INVERSION_TO_NORMAL,
 };
+// clang-format on

--- a/src/openrct2/ride/TrackDataOld.cpp
+++ b/src/openrct2/ride/TrackDataOld.cpp
@@ -17,6 +17,7 @@
 #include "TrackData.h"
 
 /** rct2: 0x008A42F4 */
+// clang-format off
 static const uint32 _OldSpiralRollerCoasterTrackPaintFunctions[256] = {
     0x008A4ABC, // TRACK_ELEM_FLAT
     0x008A4D0C, // TRACK_ELEM_END_STATION
@@ -19359,3 +19360,4 @@ const uint32 * RideTypeTrackPaintFunctionsOld[RIDE_TYPE_COUNT] = {
     _null,                                                  // RIDE_TYPE_59
     _OldLimLaunchedRollerCoasterTrackPaintFunctions,        // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER
 };
+//clang-format on

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -873,6 +873,7 @@ static const uint32 junior_rc_track_pieces_left_quarter_turn_5_tiles_25_deg_up[2
       } }
 };
 
+// clang-format off
 const LocationXY16 junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets[4][5] = { {
                                                                                    { 0, 6 },
                                                                                    { 0, 0 },
@@ -1621,6 +1622,7 @@ static const uint32 junior_rc_track_pieces_diag_60_deg_down_to_25_deg_down[2][4]
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_CHAIN_N_S,
     },
 };
+// clang-format on
 
 void junior_rc_paint_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction, uint16 height,
                                 rct_tile_element * tileElement, JUNIOR_RC_CHAINTYPE chainType)

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -793,6 +793,7 @@ static void paint_miniature_railway_track_25_deg_down_to_flat(paint_session * se
     paint_miniature_railway_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
+// clang-format off
 const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_offsets[4][5] = { {
                                                                                   { 0, 2 },
                                                                                   { 0, 16 },
@@ -879,6 +880,7 @@ const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_bound_lengths[4]
                                                                                         { 32, 16 },
                                                                                         { 32, 32 },
                                                                                     } };
+// clang-format on
 
 static const uint32 miniature_railway_right_quarter_turn_5_tiles_track_floor[4][5] = {
     { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_S_SEGMENT, SPR_FLOOR_PLANKS_N_SEGMENT, SPR_FLOOR_PLANKS_S_SEGMENT,

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -38,6 +38,7 @@ namespace ScenarioSources
 
     #pragma region Scenario Data
 
+    // clang-format off
     static const ScenarioAlias ScenarioAliases[] =
     {
         // UK - US differences:
@@ -257,6 +258,7 @@ namespace ScenarioSources
         DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesRealParks),
         DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesOtherParks),
     };
+    // clang-format on
 
     #pragma endregion
 

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -250,6 +250,7 @@ static bool WallCheckObstruction(rct_scenery_entry * wall,
 
 #pragma region Edge Slopes Table
 
+// clang-format off
 enum EDGE_SLOPE
 {
     EDGE_SLOPE_ELEVATED     = (1 << 0), // 0x01
@@ -296,6 +297,7 @@ static const uint8 EdgeSlopes[][4] = {
     { EDGE_SLOPE_DOWNWARDS_ELEVATED, EDGE_SLOPE_DOWNWARDS,          EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_UPWARDS_ELEVATED   },
     { 0,                             0,                             0,                             0                             },
 };
+// clang-format on
 
 #pragma endregion
 


### PR DESCRIPTION
This guards most of the hardcoded data from clang-format.

[ci skip]