### PR TITLE
Set DPI scaling on first launch

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -19,8 +19,8 @@
 #include <cstdlib>
 #include <cmath>
 #include <memory>
-#include <vector>
 #include <SDL2/SDL.h>
+#include <openrct2/PlatformEnvironment.h>
 #include <openrct2/audio/AudioMixer.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/Context.h>
@@ -33,6 +33,7 @@
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/Version.h>
+#include <vector>
 #include "CursorRepository.h"
 #include "drawing/engines/DrawingEngineFactory.hpp"
 #include "input/KeyboardShortcuts.h"
@@ -103,6 +104,24 @@ public:
         {
             SDLException::Throw("SDL_Init(SDL_INIT_VIDEO)");
         }
+
+        if (gConfigGeneral.window_scale == -1)
+        {
+#ifndef __MINGW32__
+            float ddpi, hdpi, vdpi;
+            if (SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi))
+            {
+                SDLException::Throw("SDL_GetDisplayDPI(...)");
+            }
+            // divide acutal dpi by default (96.0f) dpi
+            gConfigGeneral.window_scale = ddpi / 96.0f;
+#else
+            gConfigGeneral.window_scale = 1.0f;
+#endif
+            auto configPath = env->GetFilePath(PATHID::CONFIG);
+            config_save(configPath.c_str());
+        }
+
         _cursorRepository.LoadCursors();
         _keyboardShortcuts.Reset();
         _keyboardShortcuts.Load();

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -192,7 +192,7 @@ namespace Config
             model->disable_lightning_effect = reader->GetBoolean("disable_lightning_effect", false);
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);
             model->steam_overlay_pause = reader->GetBoolean("steam_overlay_pause", true);
-            model->window_scale = reader->GetFloat("window_scale", platform_get_default_scale());
+            model->window_scale = reader->GetFloat("window_scale", -1);
             model->scale_quality = reader->GetEnum<sint32>("scale_quality", SCALE_QUALITY_SMOOTH_NN, Enum_ScaleQuality);
             model->show_fps = reader->GetBoolean("show_fps", false);
             model->trap_cursor = reader->GetBoolean("trap_cursor", false);

--- a/src/openrct2/platform/Android.cpp
+++ b/src/openrct2/platform/Android.cpp
@@ -59,6 +59,11 @@ float platform_get_default_scale() {
     return displayScale;
 }
 
+void platform_get_changelog_path(utf8 *outPath, size_t outSize)
+{
+    STUB();
+}
+
 bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 {
     return false;

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -206,13 +206,6 @@ uint8 platform_get_currency_value(const char * currCode)
     return CURRENCY_POUNDS;
 }
 
-#ifndef __ANDROID__
-float platform_get_default_scale()
-{
-    return 1;
-}
-#endif
-
 void core_init()
 {
     static bool initialised = false;


### PR DESCRIPTION
When OpenRCT2 is first launched every setting gets defaulted.
DPI default is set to 1.0 which is to small for high dpi monitors.
It's not a big issue as a scaling is already supported but hitting
the tremendous small upwards icon is hard. After this patch
on first launch the monitor scaling is checked and set to a more
appropriate value.
