### PR TITLE
Ability to Change View Scroll Speed

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1596,8 +1596,10 @@ void input_scroll_viewport(sint32 scrollX, sint32 scrollY)
     rct_window * mainWindow = window_get_main();
     rct_viewport * viewport = mainWindow->viewport;
 
-    sint32 dx = scrollX * (12 << viewport->zoom);
-    sint32 dy = scrollY * (12 << viewport->zoom);
+    const sint32 speed = gConfigGeneral.edge_scrolling_speed;
+
+    sint32 dx = scrollX * (speed << viewport->zoom);
+    sint32 dy = scrollY * (speed << viewport->zoom);
 
     if (scrollX != 0)
     {

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -148,6 +148,7 @@ namespace Config
             model->custom_currency_affix = reader->GetEnum<sint32>("custom_currency_affix", CURRENCY_SUFFIX, Enum_CurrencySymbolAffix);
             model->custom_currency_symbol = reader->GetCString("custom_currency_symbol", "Ctm");
             model->edge_scrolling = reader->GetBoolean("edge_scrolling", true);
+            model->edge_scrolling_speed = reader->GetSint32("edge_scrolling_speed", 12);
             model->fullscreen_mode = reader->GetSint32("fullscreen_mode", 0);
             model->fullscreen_height = reader->GetSint32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetSint32("fullscreen_width", -1);
@@ -224,6 +225,7 @@ namespace Config
         writer->WriteEnum<sint32>("custom_currency_affix", model->custom_currency_affix, Enum_CurrencySymbolAffix);
         writer->WriteString("custom_currency_symbol", model->custom_currency_symbol);
         writer->WriteBoolean("edge_scrolling", model->edge_scrolling);
+        writer->WriteSint32("edge_scrolling_speed", model->edge_scrolling_speed);
         writer->WriteSint32("fullscreen_mode", model->fullscreen_mode);
         writer->WriteSint32("fullscreen_height", model->fullscreen_height);
         writer->WriteSint32("fullscreen_width", model->fullscreen_width);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -64,6 +64,7 @@ typedef struct GeneralConfiguration
 
     // Controls
     bool        edge_scrolling;
+    sint32      edge_scrolling_speed;
     bool        trap_cursor;
     bool        invert_viewport_drag;
     bool        zoom_to_cursor;


### PR DESCRIPTION
This pull request implements feature #1355: Ability to Change View Scroll Speed

**Details:**
- Possible internal scroll speed values are ranged 1 to 435 inclusive (default=12) which are the results from an exponential growth equation where `x` is an integer between 1 and 100 inclusive. `x` is set via a scroll bar in the "Options" window. The equation was selected based on local gameplay testing, personal preferences, and scrolling behavior personally experienced playing other games.
- The equations used are `y = |(6/5)^(x/3)|` and `x = 3log(y) / log(6/5)`. Suggestions on equation alternatives are welcome.

**Comments:**
I am personally fairly satisfied with the result. However, because of the exponential nature of the equation, there is a visual awkwardness with very low values (see screenshots) which I dislike. In the attached screenshots, both scroll bar positions produce the internal value of 1. If the window is closed as seen in screenshot (1), it will be opened appearing as screenshot (2). The internal value is still correctly loaded/saved as 1, but it is not visually represented accurately as it is with higher values.

Thoughts/comments/suggestions/criticism welcome.

**Screenshots**:
1)
![inaccurate1](https://user-images.githubusercontent.com/22711643/34801275-69147b22-f62d-11e7-96ae-67508745d9a8.png)
2)
![inaccurate2](https://user-images.githubusercontent.com/22711643/34801276-6974eb7e-f62d-11e7-98a0-bd1d00fe156c.png)
