### PR TITLE
Use const and constexpr whenever possible.

### DIFF
--- a/src/openrct2-ui/CursorData.cpp
+++ b/src/openrct2-ui/CursorData.cpp
@@ -19,12 +19,12 @@
 
 namespace OpenRCT2 { namespace Ui
 {
-    static const CursorData BlankCursorData =
+    static constexpr const CursorData BlankCursorData =
     {
         { 0, 0 }, { 0 }, { 0 }
     };
 
-    static const CursorData UpArrowCursorData =
+    static constexpr const CursorData UpArrowCursorData =
     {
         { 15, 0 },
         {
@@ -49,7 +49,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData UpDownArrowCursorData =
+    static constexpr const CursorData UpDownArrowCursorData =
     {
         { 7, 31 },
         {
@@ -74,7 +74,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData ZZZCursorData =
+    static constexpr const CursorData ZZZCursorData =
     {
         { 0, 0 },
         {
@@ -99,7 +99,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData DiagonalArrowCursorData =
+    static constexpr const CursorData DiagonalArrowCursorData =
     {
         { 0, 0 },
         {
@@ -124,7 +124,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData PickerArrowCursorData =
+    static constexpr const CursorData PickerArrowCursorData =
     {
         { 15, 31 },
         {
@@ -149,7 +149,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData TreeDownCursorData =
+    static constexpr const CursorData TreeDownCursorData =
     {
         { 7, 31 },
         {
@@ -174,7 +174,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData FountainDownCursorData =
+    static constexpr const CursorData FountainDownCursorData =
     {
         { 7, 31 },
         {
@@ -199,7 +199,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData StatueDownCursorData =
+    static constexpr const CursorData StatueDownCursorData =
     {
         { 7, 31 },
         {
@@ -224,7 +224,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData BenchDownCursorData =
+    static constexpr const CursorData BenchDownCursorData =
     {
         { 7, 31 },
         {
@@ -249,7 +249,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData CrossHairCursorData =
+    static constexpr const CursorData CrossHairCursorData =
     {
         { 15, 15 },
         {
@@ -274,7 +274,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData BinDownCursorData =
+    static constexpr const CursorData BinDownCursorData =
     {
         { 7, 31 },
         {
@@ -299,7 +299,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData LampPostDownCursorData =
+    static constexpr const CursorData LampPostDownCursorData =
     {
         { 7, 31 },
         {
@@ -324,7 +324,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData FenceDownCursorData =
+    static constexpr const CursorData FenceDownCursorData =
     {
         { 7, 31 },
         {
@@ -349,7 +349,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData FlowerDownCursorData =
+    static constexpr const CursorData FlowerDownCursorData =
     {
         { 7, 31 },
         {
@@ -374,7 +374,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData FootpathDownCursorData =
+    static constexpr const CursorData FootpathDownCursorData =
     {
         { 7, 31 },
         {
@@ -399,7 +399,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData DigDownCursorData =
+    static constexpr const CursorData DigDownCursorData =
     {
         { 7, 31 },
         {
@@ -424,7 +424,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData WaterDownCursorData =
+    static constexpr const CursorData WaterDownCursorData =
     {
         { 7, 31 },
         {
@@ -449,7 +449,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData HouseDownCursorData =
+    static constexpr const CursorData HouseDownCursorData =
     {
         { 7, 31 },
         {
@@ -474,7 +474,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData VolcanoDownCursorData =
+    static constexpr const CursorData VolcanoDownCursorData =
     {
         { 7, 31 },
         {
@@ -499,7 +499,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData WalkDownCursorData =
+    static constexpr const CursorData WalkDownCursorData =
     {
         { 7, 31 },
         {
@@ -524,7 +524,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData PaintDownCursorData =
+    static constexpr const CursorData PaintDownCursorData =
     {
         { 8, 30 },
         {
@@ -549,7 +549,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData EntranceDownCursorData =
+    static constexpr const CursorData EntranceDownCursorData =
     {
         { 7, 31 },
         {
@@ -574,7 +574,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData HandOpenDownCursorData =
+    static constexpr const CursorData HandOpenDownCursorData =
     {
         { 5, 1 },
         {
@@ -599,7 +599,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData HandClosedDownCursorData =
+    static constexpr const CursorData HandClosedDownCursorData =
     {
         { 5, 1 },
         {
@@ -624,7 +624,7 @@ namespace OpenRCT2 { namespace Ui
         }
     };
 
-    static const CursorData * RawCursorData[] =
+    static constexpr const CursorData * RawCursorData[] =
     {
         nullptr,                    // CURSOR_ARROW
         &BlankCursorData,           // CURSOR_BLANK

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -132,7 +132,7 @@ public:
 
     void SetFullscreenMode(FULLSCREEN_MODE mode) override
     {
-        static const sint32 SDLFSFlags[] = { 0, SDL_WINDOW_FULLSCREEN, SDL_WINDOW_FULLSCREEN_DESKTOP };
+        static constexpr const sint32 SDLFSFlags[] = { 0, SDL_WINDOW_FULLSCREEN, SDL_WINDOW_FULLSCREEN_DESKTOP };
         uint32 windowFlags = SDLFSFlags[(sint32)mode];
 
         // HACK Changing window size when in fullscreen usually has no effect

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1389,7 +1389,7 @@ void input_state_widget_pressed(sint32 x, sint32 y, sint32 state, rct_widgetinde
             gDropdownLastColourHover = dropdown_index;
             window_tooltip_close();
 
-            static const rct_string_id colourTooltips[] = {
+            static constexpr const rct_string_id colourTooltips[] = {
                 STR_COLOUR_BLACK_TIP,
                 STR_COLOUR_GREY_TIP,
                 STR_COLOUR_WHITE_TIP,

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -41,7 +41,7 @@ enum WINDOW_BANNER_WIDGET_IDX {
     WIDX_TEXT_COLOUR_DROPDOWN_BUTTON
 };
 
-static const rct_string_id BannerColouredTextFormats[] = {
+static constexpr const rct_string_id BannerColouredTextFormats[] = {
     STR_TEXT_COLOR_BLACK,
     STR_TEXT_COLOR_GREY,
     STR_TEXT_COLOR_WHITE,

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -40,7 +40,7 @@ enum {
     WINDOW_CHEATS_PAGE_RIDES,
 };
 
-static const rct_string_id WeatherTypes[] = {
+static constexpr const rct_string_id WeatherTypes[] = {
     STR_SUNNY,
     STR_PARTIALLY_CLOUDY,
     STR_CLOUDY,

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -114,7 +114,7 @@ static EMPTY_ARGS_VOID_POINTER *next_button_mouseup_events[] = {
     nullptr
 };
 
-static const rct_string_id EditorStepNames[] = {
+static constexpr const rct_string_id EditorStepNames[] = {
     STR_EDITOR_STEP_OBJECT_SELECTION,
     STR_EDITOR_STEP_LANDSCAPE_EDITOR,
     STR_EDITOR_STEP_INVENTIONS_LIST_SET_UP,

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -155,7 +155,7 @@ static rct_window_event_list window_editor_inventions_list_drag_events = {
 
 static rct_research_item *_editorInventionsListDraggedItem;
 
-static const rct_string_id EditorInventionsResearchCategories[] = {
+static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
     STR_RESEARCH_NEW_TRANSPORT_RIDES,
     STR_RESEARCH_NEW_GENTLE_RIDES,
     STR_RESEARCH_NEW_ROLLER_COASTERS,

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -89,7 +89,7 @@ enum {
     WINDOW_OBJECT_SELECTION_PAGE_COUNT
 };
 
-static const rct_string_id ObjectSelectionPageNames[WINDOW_OBJECT_SELECTION_PAGE_COUNT] = {
+static constexpr const rct_string_id ObjectSelectionPageNames[WINDOW_OBJECT_SELECTION_PAGE_COUNT] = {
     STR_OBJECT_SELECTION_RIDE_VEHICLES_ATTRACTIONS,
     STR_OBJECT_SELECTION_SMALL_SCENERY,
     STR_OBJECT_SELECTION_LARGE_SCENERY,
@@ -230,8 +230,8 @@ static rct_window_event_list window_editor_object_selection_events = {
 
 #pragma endregion
 
-const sint32 window_editor_object_selection_animation_loops[] = { 20, 32, 10, 72, 24, 28, 16 };
-const sint32 window_editor_object_selection_animation_divisor[] = { 4, 8, 2, 4, 4, 4, 2 };
+static constexpr const sint32 window_editor_object_selection_animation_loops[] = { 20, 32, 10, 72, 24, 28, 16 };
+static constexpr const sint32 window_editor_object_selection_animation_divisor[] = { 4, 8, 2, 4, 4, 4, 2 };
 
 static void window_editor_object_set_page(rct_window *w, sint32 page);
 static void window_editor_object_selection_set_pressed_tab(rct_window *w);

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -36,14 +36,14 @@ enum {
     WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_COUNT
 };
 
-static const rct_string_id ClimateNames[] = {
+static constexpr const rct_string_id ClimateNames[] = {
     STR_CLIMATE_COOL_AND_WET,
     STR_CLIMATE_WARM,
     STR_CLIMATE_HOT_AND_DRY,
     STR_CLIMATE_COLD,
 };
 
-static const rct_string_id ObjectiveDropdownOptionNames[] = {
+static constexpr const rct_string_id ObjectiveDropdownOptionNames[] = {
     STR_OBJECTIVE_DROPDOWN_NONE,
     STR_OBJECTIVE_DROPDOWN_NUMBER_OF_GUESTS_AT_A_GIVEN_DATE,
     STR_OBJECTIVE_DROPDOWN_PARK_VALUE_AT_A_GIVEN_DATE,

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -435,7 +435,7 @@ static rct_window_event_list *const _windowFinancesPageEvents[] =
     (1ULL << WIDX_TAB_5) | \
     (1ULL << WIDX_TAB_6))
 
-static const uint32 WindowFinancesPageEnabledWidgets[] =
+static constexpr const uint32 WindowFinancesPageEnabledWidgets[] =
 {
     ALWAYS_ENABLED_WIDGETS |
     (1ULL << WIDX_LOAN_INCREASE) |
@@ -467,7 +467,7 @@ static const uint32 WindowFinancesPageEnabledWidgets[] =
     (1ULL << WIDX_SCENERY_AND_THEMING)
 };
 
-static const uint32 WindowFinancesPageHoldDownWidgets[] =
+static constexpr const uint32 WindowFinancesPageHoldDownWidgets[] =
 {
     (1ULL << WIDX_LOAN_INCREASE) |
     (1ULL << WIDX_LOAN_DECREASE),
@@ -481,12 +481,12 @@ static const uint32 WindowFinancesPageHoldDownWidgets[] =
 
 #pragma endregion
 
-static const sint32 WindowFinancesTabAnimationLoops[] =
+static constexpr const sint32 WindowFinancesTabAnimationLoops[] =
 {
     16, 32, 32, 32, 38, 16
 };
 
-static const rct_string_id window_finances_summary_row_labels[RCT_EXPENDITURE_TYPE_COUNT] = {
+static constexpr const rct_string_id window_finances_summary_row_labels[RCT_EXPENDITURE_TYPE_COUNT] = {
     STR_FINANCES_SUMMARY_RIDE_CONSTRUCTION,
     STR_FINANCES_SUMMARY_RIDE_RUNNING_COSTS,
     STR_FINANCES_SUMMARY_LAND_PURCHASE,

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -160,7 +160,7 @@ static uint8   _lastUpdatedCameraRotation           = UINT8_MAX;
 static bool    _footpathErrorOccured;
 
 /** rct2: 0x0098D8B4 */
-static const uint8 DefaultPathSlope[] = {
+static constexpr const uint8 DefaultPathSlope[] = {
     0,
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
@@ -180,7 +180,7 @@ static const uint8 DefaultPathSlope[] = {
 };
 
 /** rct2: 0x0098D7E0 */
-static const uint8 ConstructionPreviewImages[][4] = {
+static constexpr const uint8 ConstructionPreviewImages[][4] = {
     {5,  10, 5,  10}, // Flat
     {16, 17, 18, 19}, // Upwards
     {18, 19, 16, 17}, // Downwards

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -464,14 +464,14 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, r
             );
     }
 
-    static const rct_string_id guestCountFormats[] =
+    static constexpr const rct_string_id guestCountFormats[] =
     {
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE,
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE,
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_INCREASE,
     };
 
-    static const rct_string_id guestCountFormatsSingular[] =
+    static constexpr const rct_string_id guestCountFormatsSingular[] =
     {
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_STABLE_SINGULAR,
         STR_BOTTOM_TOOLBAR_NUM_GUESTS_DECREASE_SINGULAR,

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -418,7 +418,7 @@ static rct_window_event_list *window_guest_page_events[] = {
 void window_guest_set_colours();
 
 // 0x981D3C
-static const uint32 window_guest_page_enabled_widgets[] = {
+static constexpr const uint32 window_guest_page_enabled_widgets[] = {
     (1 << WIDX_CLOSE) |
     (1 << WIDX_TAB_1) |
     (1 << WIDX_TAB_2) |
@@ -1480,7 +1480,7 @@ void window_guest_stats_paint(rct_window *w, rct_drawpixelinfo *dpi)
     gfx_draw_string_left(dpi, string_id, gCommonFormatArgs, COLOUR_BLACK, x + 4, y);
 
     // Nausea tolerance
-    static const rct_string_id nauseaTolerances[] = {
+    static constexpr const rct_string_id nauseaTolerances[] = {
         STR_PEEP_STAT_NAUSEA_TOLERANCE_NONE,
         STR_PEEP_STAT_NAUSEA_TOLERANCE_LOW,
         STR_PEEP_STAT_NAUSEA_TOLERANCE_AVERAGE,

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -53,7 +53,7 @@ enum {
     VIEW_COUNT
 };
 
-static const rct_string_id pageNames[] = {
+static constexpr const rct_string_id pageNames[] = {
     STR_PAGE_1,
     STR_PAGE_2,
     STR_PAGE_3,
@@ -61,13 +61,13 @@ static const rct_string_id pageNames[] = {
     STR_PAGE_5,
 };
 
-static const rct_string_id filterNames[] = {
+static constexpr const rct_string_id filterNames[] = {
     STR_GUESTS_FILTER,
     STR_GUESTS_FILTER_THINKING,
     STR_GUESTS_FILTER_THINKING_ABOUT,
 };
 
-static const rct_string_id viewNames[VIEW_COUNT] = {
+static constexpr const rct_string_id viewNames[VIEW_COUNT] = {
     STR_ACTIONS,
     STR_THOUGHTS,
 };
@@ -90,7 +90,7 @@ static rct_widget window_guest_list_widgets[] = {
     { WIDGETS_END },
 };
 
-static const uint8 SUMMARISED_GUEST_ROW_HEIGHT = SCROLLABLE_ROW_HEIGHT + 11;
+static constexpr const uint8 SUMMARISED_GUEST_ROW_HEIGHT = SCROLLABLE_ROW_HEIGHT + 11;
 
 static void window_guest_list_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_guest_list_resize(rct_window *w);

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -101,7 +101,7 @@ static rct_widget window_map_widgets[] = {
 
 // used in transforming viewport view coordinates to minimap coordinates
 // rct2: 0x00981BBC
-const LocationXY16 MiniMapOffsets[] = {
+static constexpr const LocationXY16 MiniMapOffsets[] = {
     { 256 - 8,   0 },
     { 512 - 8, 256 },
     { 256 - 8, 512 },
@@ -109,7 +109,7 @@ const LocationXY16 MiniMapOffsets[] = {
 };
 
 /** rct2: 0x00981BCC */
-static const uint16 RideKeyColours[] = {
+static constexpr const uint16 RideKeyColours[] = {
     MAP_COLOUR(PALETTE_INDEX_61),   // COLOUR_KEY_RIDE
     MAP_COLOUR(PALETTE_INDEX_42),   // COLOUR_KEY_FOOD
     MAP_COLOUR(PALETTE_INDEX_20),   // COLOUR_KEY_DRINK
@@ -1434,8 +1434,8 @@ static void map_window_decrease_map_size()
     gfx_invalidate_screen();
 }
 
-static const uint16 WaterColour = MAP_COLOUR(PALETTE_INDEX_195);
-static const uint16 TerrainColour[] = {
+static constexpr const uint16 WaterColour = MAP_COLOUR(PALETTE_INDEX_195);
+static constexpr const uint16 TerrainColour[] = {
     MAP_COLOUR(PALETTE_INDEX_73),                       // TERRAIN_GRASS
     MAP_COLOUR(PALETTE_INDEX_40),                       // TERRAIN_SAND
     MAP_COLOUR(PALETTE_INDEX_108),                      // TERRAIN_DIRT
@@ -1452,7 +1452,7 @@ static const uint16 TerrainColour[] = {
     MAP_COLOUR(PALETTE_INDEX_222),                      // TERRAIN_SAND_LIGHT
 };
 
-static const uint16 ElementTypeMaskColour[] = {
+static constexpr const uint16 ElementTypeMaskColour[] = {
     0xFFFF,         // TILE_ELEMENT_TYPE_SURFACE
     0x0000,         // TILE_ELEMENT_TYPE_PATH
     0x00FF,         // TILE_ELEMENT_TYPE_TRACK
@@ -1464,7 +1464,7 @@ static const uint16 ElementTypeMaskColour[] = {
     0x0000,         // TILE_ELEMENT_TYPE_CORRUPT
 };
 
-static const uint16 ElementTypeAddColour[] = {
+static constexpr const uint16 ElementTypeAddColour[] = {
     MAP_COLOUR(PALETTE_INDEX_0),                        // TILE_ELEMENT_TYPE_SURFACE
     MAP_COLOUR(PALETTE_INDEX_17),                       // TILE_ELEMENT_TYPE_PATH
     MAP_COLOUR_2(PALETTE_INDEX_183, PALETTE_INDEX_0),   // TILE_ELEMENT_TYPE_TRACK
@@ -1487,7 +1487,7 @@ enum {
     COLOUR_KEY_TOILETS
 };
 
-static const uint8 RideColourKey[] = {
+static constexpr const uint8 RideColourKey[] = {
     COLOUR_KEY_RIDE,                // RIDE_TYPE_SPIRAL_ROLLER_COASTER
     COLOUR_KEY_RIDE,                // RIDE_TYPE_STAND_UP_ROLLER_COASTER
     COLOUR_KEY_RIDE,                // RIDE_TYPE_SUSPENDED_SWINGING_COASTER

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -528,13 +528,13 @@ static uint64 PressedWidgets[WINDOW_MAPGEN_PAGE_COUNT] = {
 
 #pragma endregion
 
-static const sint32 TabAnimationDivisor[WINDOW_MAPGEN_PAGE_COUNT] = {
+static constexpr const sint32 TabAnimationDivisor[WINDOW_MAPGEN_PAGE_COUNT] = {
     1, 1, 1, 1
 };
-static const sint32 TabAnimationFrames[WINDOW_MAPGEN_PAGE_COUNT] = {
+static constexpr const sint32 TabAnimationFrames[WINDOW_MAPGEN_PAGE_COUNT] = {
     1, 1, 1, 1
 };
-static const sint32 TabAnimationLoops[WINDOW_MAPGEN_PAGE_COUNT] = {
+static constexpr const sint32 TabAnimationLoops[WINDOW_MAPGEN_PAGE_COUNT] = {
     16, 16, 16, 0
 };
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -106,7 +106,7 @@ static rct_widget *window_multiplayer_page_widgets[] = {
     window_multiplayer_options_widgets
 };
 
-const uint64 window_multiplayer_page_enabled_widgets[] = {
+static constexpr const uint64 window_multiplayer_page_enabled_widgets[] = {
     (1 << WIDX_CLOSE) | (1 << WIDX_TAB1) | (1 << WIDX_TAB2) | (1 << WIDX_TAB3) | (1 << WIDX_TAB4),
     (1 << WIDX_CLOSE) | (1 << WIDX_TAB1) | (1 << WIDX_TAB2) | (1 << WIDX_TAB3) | (1 << WIDX_TAB4),
     (1 << WIDX_CLOSE) | (1 << WIDX_TAB1) | (1 << WIDX_TAB2) | (1 << WIDX_TAB3) | (1 << WIDX_TAB4) | (1 << WIDX_DEFAULT_GROUP) | (1 << WIDX_DEFAULT_GROUP_DROPDOWN) | (1 << WIDX_ADD_GROUP) | (1 << WIDX_REMOVE_GROUP) | (1 << WIDX_RENAME_GROUP) | (1 << WIDX_SELECTED_GROUP) | (1 << WIDX_SELECTED_GROUP_DROPDOWN),
@@ -281,8 +281,8 @@ static rct_window_event_list *window_multiplayer_page_events[] = {
     &window_multiplayer_options_events
 };
 
-static const sint32 window_multiplayer_animation_divisor[] = { 4, 4, 2, 2 };
-static const sint32 window_multiplayer_animation_frames[] = { 8, 8, 7, 4 };
+static constexpr const sint32 window_multiplayer_animation_divisor[] = { 4, 4, 2, 2 };
+static constexpr const sint32 window_multiplayer_animation_frames[] = { 8, 8, 7, 4 };
 
 static void window_multiplayer_draw_tab_images(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_multiplayer_set_page(rct_window* w, sint32 page);

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -35,7 +35,7 @@ static rct_widget window_music_credits_widgets[] = {
     { WIDGETS_END },
 };
 
-static const rct_string_id music_credits[] = {
+static constexpr const rct_string_id music_credits[] = {
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_MARCH_CHILDREN_OF_THE_REGIMENT,
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_HEYKENS_SERENADE,
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_IN_CONTINENTAL_MOOD,
@@ -49,7 +49,7 @@ static const rct_string_id music_credits[] = {
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_BELLA_BELLA_BIMBA,
 };
 
-static const rct_string_id music_credits_rct2[] = {
+static constexpr const rct_string_id music_credits_rct2[] = {
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_RCT2_TITLE_MUSIC,
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_DODGEMS_BEAT,
     STR_MUSIC_ACKNOWLEDGEMENTS_TRACK_MIS_SUMMERS_HEAT,

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -53,7 +53,7 @@ static ride_list_item _windowNewRideListItems[384];
  * The order of ride types shown in the new ride window so that the order stays consistent across games and rides of the same
  * type are kept together.
  */
-const char RideTypeViewOrder[] = {
+static constexpr const char RideTypeViewOrder[] = {
     // Transport rides
     RIDE_TYPE_MINIATURE_RAILWAY,
     RIDE_TYPE_MONORAIL,
@@ -254,7 +254,7 @@ static rct_window_event_list window_new_ride_events = {
 
 #pragma endregion
 
-static const rct_string_id window_new_ride_titles[WINDOW_NEW_RIDE_PAGE_COUNT] = {
+static constexpr const rct_string_id window_new_ride_titles[WINDOW_NEW_RIDE_PAGE_COUNT] = {
     STR_NEW_TRANSPORT_RIDES,
     STR_NEW_GENTLE_RIDES,
     STR_NEW_ROLLER_COASTERS,
@@ -264,8 +264,8 @@ static const rct_string_id window_new_ride_titles[WINDOW_NEW_RIDE_PAGE_COUNT] = 
     STR_RESEARCH_AND_DEVELOPMENT,
 };
 
-const sint32 window_new_ride_tab_animation_loops[] = { 20, 32, 10, 72, 24, 28, 16 };
-const sint32 window_new_ride_tab_animation_divisor[] = { 4, 8, 2, 4, 4, 4, 2 };
+static constexpr const sint32 window_new_ride_tab_animation_loops[] = { 20, 32, 10, 72, 24, 28, 16 };
+static constexpr const sint32 window_new_ride_tab_animation_divisor[] = { 4, 8, 2, 4, 4, 4, 2 };
 
 static void window_new_ride_set_page(rct_window *w, sint32 page);
 static void window_new_ride_refresh_widget_sizing(rct_window *w);
@@ -642,7 +642,7 @@ static void window_new_ride_set_pressed_tab(rct_window *w)
     w->pressed_widgets |= 1LL << (WIDX_TAB_1 + _windowNewRideCurrentTab);
 }
 
-const sint32 ThrillRidesTabAnimationSequence[] = {
+static constexpr const sint32 ThrillRidesTabAnimationSequence[] = {
     5, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0
 };
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -34,7 +34,7 @@ typedef struct notification_def {
     size_t config_offset;
 } notification_def;
 
-static const notification_def NewsItemOptionDefinitions[] = {
+static constexpr const notification_def NewsItemOptionDefinitions[] = {
     { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_AWARD,                        offsetof(NotificationConfiguration, park_award)                         },
     { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_MARKETING_CAMPAIGN_FINISHED,  offsetof(NotificationConfiguration, park_marketing_campaign_finished)   },
     { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_WARNINGS,                     offsetof(NotificationConfiguration, park_warnings)                      },

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -384,7 +384,7 @@ static rct_widget *window_options_page_widgets[] = {
 
 #pragma endregion
 
-static const rct_string_id window_options_autosave_names[6] = {
+static constexpr const rct_string_id window_options_autosave_names[6] = {
     STR_SAVE_EVERY_MINUTE,
     STR_SAVE_EVERY_5MINUTES,
     STR_SAVE_EVERY_15MINUTES,
@@ -393,19 +393,19 @@ static const rct_string_id window_options_autosave_names[6] = {
     STR_SAVE_NEVER,
 };
 
-static const rct_string_id window_options_title_music_names[] = {
+static constexpr const rct_string_id window_options_title_music_names[] = {
     STR_OPTIONS_MUSIC_VALUE_NONE ,
     STR_ROLLERCOASTER_TYCOON_1_DROPDOWN ,
     STR_ROLLERCOASTER_TYCOON_2_DROPDOWN ,
     STR_OPTIONS_MUSIC_VALUE_RANDOM,
 };
 
-static const rct_string_id window_options_scale_quality_names[] = {
+static constexpr const rct_string_id window_options_scale_quality_names[] = {
     STR_SCALING_QUALITY_LINEAR,
     STR_SCALING_QUALITY_SMOOTH_NN
 };
 
-static const rct_string_id window_options_fullscreen_mode_names[] = {
+static constexpr const rct_string_id window_options_fullscreen_mode_names[] = {
     STR_OPTIONS_DISPLAY_WINDOWED,
     STR_OPTIONS_DISPLAY_FULLSCREEN,
     STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -523,7 +523,7 @@ typedef struct window_park_award {
     uint32 sprite;
 } window_park_award;
 
-static const window_park_award ParkAwards[] = {
+static constexpr const window_park_award ParkAwards[] = {
     { STR_AWARD_MOST_UNTIDY,                SPR_AWARD_MOST_UNTIDY },
     { STR_AWARD_MOST_TIDY,                  SPR_AWARD_MOST_TIDY },
     { STR_AWARD_BEST_ROLLERCOASTERS,        SPR_AWARD_BEST_ROLLERCOASTERS },

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -210,7 +210,7 @@ static uint32 window_research_page_enabled_widgets[] = {
 
 const sint32 window_research_tab_animation_loops[] = { 16, 16 };
 
-static const rct_string_id ResearchCategoryNames[] = {
+static constexpr const rct_string_id ResearchCategoryNames[] = {
     STR_RESEARCH_CATEGORY_TRANSPORT,
     STR_RESEARCH_CATEGORY_GENTLE,
     STR_RESEARCH_CATEGORY_ROLLERCOASTER,
@@ -220,7 +220,7 @@ static const rct_string_id ResearchCategoryNames[] = {
     STR_RESEARCH_CATEGORY_SCENERYSET,
 };
 
-static const rct_string_id ResearchStageNames[] = {
+static constexpr const rct_string_id ResearchStageNames[] = {
     STR_RESEARCH_STAGE_INITIAL_RESEARCH,
     STR_RESEARCH_STAGE_DESIGNING,
     STR_RESEARCH_STAGE_COMPLETING_DESIGN,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -399,7 +399,7 @@ static rct_widget *window_ride_page_widgets[] = {
     (1ULL << WIDX_TAB_9) | \
     (1ULL << WIDX_TAB_10)
 
-const uint64 window_ride_page_enabled_widgets[] = {
+static constexpr const uint64 window_ride_page_enabled_widgets[] = {
     MAIN_RIDE_ENABLED_WIDGETS |
         (1ULL << WIDX_VIEW) |
         (1ULL << WIDX_VIEW_DROPDOWN) |
@@ -493,7 +493,7 @@ const uint64 window_ride_page_enabled_widgets[] = {
         (1ULL << WIDX_SHOW_GUESTS_QUEUING),
 };
 
-const uint64 window_ride_page_hold_down_widgets[] = {
+static constexpr const uint64 window_ride_page_hold_down_widgets[] = {
     (1ULL << WIDX_RIDE_TYPE_INCREASE) |
         (1ULL << WIDX_RIDE_TYPE_DECREASE),
     (1ULL << WIDX_VEHICLE_TRAINS_INCREASE) |
@@ -971,10 +971,10 @@ typedef struct ride_overall_view_t {
 
 static ride_overall_view ride_overall_views[MAX_RIDES] = {0};
 
-const sint32 window_ride_tab_animation_divisor[] = { 0, 0, 2, 2, 4, 2, 8, 8, 2, 0 };
-const sint32 window_ride_tab_animation_frames[] = { 0, 0, 4, 16, 8, 16, 8, 8, 8, 0 };
+static constexpr const sint32 window_ride_tab_animation_divisor[] = { 0, 0, 2, 2, 4, 2, 8, 8, 2, 0 };
+static constexpr const sint32 window_ride_tab_animation_frames[] = { 0, 0, 4, 16, 8, 16, 8, 8, 8, 0 };
 
-static const rct_string_id RatingNames[] = {
+static constexpr const rct_string_id RatingNames[] = {
     STR_RATING_LOW,
     STR_RATING_MEDIUM,
     STR_RATING_HIGH,
@@ -983,7 +983,7 @@ static const rct_string_id RatingNames[] = {
     STR_RATING_ULTRA_EXTREME,
 };
 
-static const rct_string_id RideBreakdownReasonNames[] = {
+static constexpr const rct_string_id RideBreakdownReasonNames[] = {
     STR_RIDE_BREAKDOWN_SAFETY_CUT_OUT ,
     STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_CLOSED,
     STR_RIDE_BREAKDOWN_RESTRAINTS_STUCK_OPEN,
@@ -994,14 +994,14 @@ static const rct_string_id RideBreakdownReasonNames[] = {
     STR_RIDE_BREAKDOWN_CONTROL_FAILURE
 };
 
-static const rct_string_id ColourSchemeNames[] = {
+static constexpr const rct_string_id ColourSchemeNames[] = {
     STR_MAIN_COLOUR_SCHEME,
     STR_ALTERNATIVE_COLOUR_SCHEME_1,
     STR_ALTERNATIVE_COLOUR_SCHEME_2,
     STR_ALTERNATIVE_COLOUR_SCHEME_3,
 };
 
-static const rct_string_id VehicleLoadNames[] = {
+static constexpr const rct_string_id VehicleLoadNames[] = {
     STR_QUARTER_LOAD,
     STR_HALF_LOAD,
     STR_THREE_QUARTER_LOAD,
@@ -1009,13 +1009,13 @@ static const rct_string_id VehicleLoadNames[] = {
     STR_ANY_LOAD,
 };
 
-static const rct_string_id VehicleColourSchemeNames[] = {
+static constexpr const rct_string_id VehicleColourSchemeNames[] = {
     STR_ALL_VEHICLES_IN_SAME_COLOURS ,
     STR_DIFFERENT_COLOURS_PER ,
     STR_DIFFERENT_COLOURS_PER_VEHICLE ,
 };
 
-static const rct_string_id VehicleStatusNames[] = {
+static constexpr const rct_string_id VehicleStatusNames[] = {
     STR_MOVING_TO_END_OF,           // VEHICLE_STATUS_MOVING_TO_END_OF_STATION
     STR_WAITING_FOR_PASSENGERS_AT,  // VEHICLE_STATUS_WAITING_FOR_PASSENGERS
     STR_WAITING_TO_DEPART,          // VEHICLE_STATUS_WAITING_TO_DEPART
@@ -1049,7 +1049,7 @@ static const rct_string_id VehicleStatusNames[] = {
     STR_STOPPED_BY_BLOCK_BRAKES,    // VEHICLE_STATUS_STOPPED_BY_BLOCK_BRAKES
 };
 
-static const rct_string_id SingleSessionVehicleStatusNames[] = {
+static constexpr const rct_string_id SingleSessionVehicleStatusNames[] = {
     STR_STOPPING_0,                 // VEHICLE_STATUS_MOVING_TO_END_OF_STATION
     STR_WAITING_FOR_PASSENGERS,     // VEHICLE_STATUS_WAITING_FOR_PASSENGERS
     STR_WAITING_TO_START,           // VEHICLE_STATUS_WAITING_TO_DEPART
@@ -1059,7 +1059,7 @@ static const rct_string_id SingleSessionVehicleStatusNames[] = {
     STR_UNLOADING_PASSENGERS,       // VEHICLE_STATUS_UNLOADING_PASSENGERS
 };
 
-static const rct_string_id MusicStyleNames[] = {
+static constexpr const rct_string_id MusicStyleNames[] = {
     STR_MUSIC_STYLE_DODGEMS_BEAT,
     STR_MUSIC_STYLE_FAIRGROUND_ORGAN,
     STR_MUSIC_STYLE_ROMAN_FANFARE,
@@ -1100,7 +1100,7 @@ typedef struct window_ride_maze_design_option {
     uint32 sprite;
 } window_ride_maze_design_option;
 
-static const window_ride_maze_design_option MazeOptions[] = {
+static constexpr const window_ride_maze_design_option MazeOptions[] = {
     { STR_RIDE_DESIGN_MAZE_BRICK_WALLS,     SPR_RIDE_DESIGN_PREVIEW_MAZE_BRICK_WALLS },
     { STR_RIDE_DESIGN_MAZE_HEDGES,          SPR_RIDE_DESIGN_PREVIEW_MAZE_HEDGES },
     { STR_RIDE_DESIGN_MAZE_ICE_BLOCKS,      SPR_RIDE_DESIGN_PREVIEW_MAZE_ICE_BLOCKS },
@@ -1113,7 +1113,7 @@ typedef struct window_ride_colour_preview
     uint32 supports;
 } window_ride_colour_preview;
 
-static const window_ride_colour_preview TrackColourPreviews[] = {
+static constexpr const window_ride_colour_preview TrackColourPreviews[] = {
     { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK,          SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS},
     { SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_TRACK,        SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_SUPPORTS},
     { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_TRACK,     SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_SUPPORTS},
@@ -1215,7 +1215,7 @@ typedef struct rct_window_graphs_y_axis {
 } rct_window_graphs_y_axis;
 
 /** rct2: 0x0098DD98 */
-static const rct_window_graphs_y_axis window_graphs_y_axi[] = {
+static constexpr const rct_window_graphs_y_axis window_graphs_y_axi[] = {
     {11, 0,  10, STR_RIDE_STATS_VELOCITY_FORMAT},   // GRAPH_VELOCITY
     {10, 0,  15, STR_RIDE_STATS_ALTITUDE_FORMAT},   // GRAPH_ALTITUDE
     {13, -3, 1,  STR_RIDE_STATS_G_FORCE_FORMAT},    // GRAPH_VERTICAL
@@ -4039,7 +4039,7 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
 #pragma region Colour
 
-const uint8 window_ride_entrance_style_list[] = {
+static constexpr const uint8 window_ride_entrance_style_list[] = {
     RIDE_ENTRANCE_STYLE_PLAIN,
     RIDE_ENTRANCE_STYLE_CANVAS_TENT,
     RIDE_ENTRANCE_STYLE_WOODEN,
@@ -4705,7 +4705,7 @@ static void window_ride_colour_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
 
 #pragma region Music
 
-const uint8 MusicStyleOrder[] = {
+static constexpr const uint8 MusicStyleOrder[] = {
     MUSIC_STYLE_GENTLE,
     MUSIC_STYLE_SUMMER,
     MUSIC_STYLE_WATER,

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -183,7 +183,7 @@ static rct_window_event_list window_ride_construction_events = {
 #pragma region RideConfigurationStringIds
 
 // rct2: 0x00999492
-static const rct_string_id RideConfigurationStringIds[] = {
+static constexpr const rct_string_id RideConfigurationStringIds[] = {
     0,                                      // 0
     STR_STATION_PLATFORM,                   // 1
     0,                                      // 2
@@ -486,7 +486,7 @@ static void ride_construction_tooldown_entrance_exit(sint32 screenX, sint32 scre
 
 static uint8 _currentPossibleRideConfigurations[32];
 
-static const rct_string_id RideConstructionSeatAngleRotationStrings[] = {
+static constexpr const rct_string_id RideConstructionSeatAngleRotationStrings[] = {
     STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_NEG_180,
     STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_NEG_135,
     STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_NEG_90,

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -137,7 +137,7 @@ enum {
     DROPDOWN_LIST_COUNT
 };
 
-static const rct_string_id ride_info_type_string_mapping[DROPDOWN_LIST_COUNT] = {
+static constexpr const rct_string_id ride_info_type_string_mapping[DROPDOWN_LIST_COUNT] = {
     STR_STATUS,
     STR_POPULARITY,
     STR_SATISFACTION,
@@ -155,13 +155,13 @@ static const rct_string_id ride_info_type_string_mapping[DROPDOWN_LIST_COUNT] = 
     STR_GUESTS_FAVOURITE
 };
 
-static const rct_string_id ride_list_statusbar_count_strings[PAGE_COUNT] = {
+static constexpr const rct_string_id ride_list_statusbar_count_strings[PAGE_COUNT] = {
     STR_NUMBER_RIDES,
     STR_NUMBER_SHOPS_AND_STALLS,
     STR_NUMBER_RESTROOMS_AND_INFORMATION_KIOSKS,
 };
 
-static const bool ride_info_type_money_mapping[DROPDOWN_LIST_COUNT] = {
+static constexpr const bool ride_info_type_money_mapping[DROPDOWN_LIST_COUNT] = {
     false,
     false,
     false,
@@ -179,7 +179,7 @@ static const bool ride_info_type_money_mapping[DROPDOWN_LIST_COUNT] = {
     false
 };
 
-static const rct_string_id page_names[] = {
+static constexpr const rct_string_id page_names[] = {
     STR_RIDES,
     STR_SHOPS_AND_STALLS,
     STR_RESTROOMS_AND_INFORMATION_KIOSKS,

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -64,7 +64,7 @@ static rct_widget window_quit_prompt_widgets[] = {
     { WIDGETS_END },
 };
 
-static const rct_string_id window_save_prompt_labels[][2] = {
+static constexpr const rct_string_id window_save_prompt_labels[][2] = {
     { STR_LOAD_GAME_PROMPT_TITLE,   STR_SAVE_BEFORE_LOADING },
     { STR_QUIT_GAME_PROMPT_TITLE,   STR_SAVE_BEFORE_QUITTING },
     { STR_QUIT_GAME_2_PROMPT_TITLE, STR_SAVE_BEFORE_QUITTING_2 },

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -264,7 +264,7 @@ static rct_window_event_list *window_staff_page_events[] = {
     &window_staff_stats_events
 };
 
-static const uint32 window_staff_page_enabled_widgets[] = {
+static constexpr const uint32 window_staff_page_enabled_widgets[] = {
     (1 << WIDX_CLOSE) |
     (1 << WIDX_TAB_1) |
     (1 << WIDX_TAB_2) |

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -141,7 +141,7 @@ typedef struct staff_naming_convention
     rct_string_id action_hire;
 } staff_naming_convention;
 
-static const staff_naming_convention StaffNamingConvention[] = {
+static constexpr const staff_naming_convention StaffNamingConvention[] = {
     { STR_HANDYMAN_PLURAL,          STR_HANDYMAN_SINGULAR,          STR_HIRE_HANDYMAN },
     { STR_MECHANIC_PLURAL,          STR_MECHANIC_SINGULAR,          STR_HIRE_MECHANIC },
     { STR_SECURITY_GUARD_PLURAL,    STR_SECURITY_GUARD_SINGULAR,    STR_HIRE_SECURITY_GUARD },
@@ -616,14 +616,14 @@ void window_staff_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
 }
 
 /** rct2: 0x00992A08 */
-static const uint32 staffOrderBaseSprites[] = {
+static constexpr const uint32 staffOrderBaseSprites[] = {
     SPR_STAFF_ORDERS_SWEEPING,
     SPR_STAFF_ORDERS_INSPECT_RIDES,
     0,
     0,
 };
 
-static const uint32 staffCostumeSprites[] = {
+static constexpr const uint32 staffCostumeSprites[] = {
     SPR_STAFF_COSTUME_PANDA,
     SPR_STAFF_COSTUME_TIGER,
     SPR_STAFF_COSTUME_ELEPHANT,

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -270,10 +270,10 @@ static rct_windowclass *window_themes_tab_classes[] = {
 static uint8 _selected_tab = 0;
 static sint16 _colour_index_1 = -1;
 static sint8 _colour_index_2 = -1;
-static const uint8 _row_height = 32;
-static const uint8 _button_offset_x = 220;
-static const uint8 _button_offset_y = 3;
-static const uint8 _check_offset_y = 3 + 12 + 2;
+static constexpr const uint8 _row_height = 32;
+static constexpr const uint8 _button_offset_x = 220;
+static constexpr const uint8 _button_offset_y = 3;
+static constexpr const uint8 _check_offset_y = 3 + 12 + 2;
 
 static void window_themes_init_vars()
 {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -36,7 +36,7 @@
 #include <openrct2/world/SmallScenery.h>
 #include <openrct2/world/TileInspector.h>
 
-static const rct_string_id TerrainTypeStringIds[] = {
+static constexpr const rct_string_id TerrainTypeStringIds[] = {
     STR_TILE_INSPECTOR_TERRAIN_GRASS,
     STR_TILE_INSPECTOR_TERRAIN_SAND,
     STR_TILE_INSPECTOR_TERRAIN_DIRT,
@@ -55,7 +55,7 @@ static const rct_string_id TerrainTypeStringIds[] = {
     STR_TILE_INSPECTOR_TERRAIN_UNDERGROUND_VIEW,
 };
 
-static const rct_string_id TerrainEdgeTypeStringIds[] = {
+static constexpr const rct_string_id TerrainEdgeTypeStringIds[] = {
     STR_TILE_INSPECTOR_TERRAIN_EDGE_ROCK,
     STR_TILE_INSPECTOR_TERRAIN_EDGE_WOOD_RED,
     STR_TILE_INSPECTOR_TERRAIN_EDGE_WOOD_BLACK,
@@ -63,19 +63,19 @@ static const rct_string_id TerrainEdgeTypeStringIds[] = {
 
 };
 
-static const rct_string_id EntranceTypeStringIds[] = {
+static constexpr const rct_string_id EntranceTypeStringIds[] = {
     STR_TILE_INSPECTOR_ENTRANCE_TYPE_RIDE_ENTRANCE,
     STR_TILE_INSPECTOR_ENTRANCE_TYPE_RIDE_EXIT,
     STR_TILE_INSPECTOR_ENTRANCE_TYPE_PARK_ENTRANC,
 };
 
-static const rct_string_id ParkEntrancePartStringIds[] = {
+static constexpr const rct_string_id ParkEntrancePartStringIds[] = {
     STR_TILE_INSPECTOR_ENTRANCE_MIDDLE,
     STR_TILE_INSPECTOR_ENTRANCE_LEFT,
     STR_TILE_INSPECTOR_ENTRANCE_RIGHT
 };
 
-static const rct_string_id WallSlopeStringIds[] = {
+static constexpr const rct_string_id WallSlopeStringIds[] = {
     STR_TILE_INSPECTOR_WALL_FLAT,
     STR_TILE_INSPECTOR_WALL_SLOPED_LEFT,
     STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -84,7 +84,7 @@ static rct_widget window_scenarioselect_widgets[] = {
     { WIDGETS_END },
 };
 
-static const rct_string_id ScenarioOriginStringIds[] = {
+static constexpr const rct_string_id ScenarioOriginStringIds[] = {
     STR_SCENARIO_CATEGORY_RCT1,
     STR_SCENARIO_CATEGORY_RCT1_AA,
     STR_SCENARIO_CATEGORY_RCT1_LL,
@@ -721,6 +721,6 @@ static bool is_locking_enabled(rct_window *w)
         return false;
     if (_titleEditor)
         return false;
-    
+
     return true;
 }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -153,7 +153,7 @@ enum {
 #pragma region Toolbar_widget_ordering
 
 // from left to right
-static const sint32 left_aligned_widgets_order[] = {
+static constexpr const sint32 left_aligned_widgets_order[] = {
     WIDX_PAUSE,
     WIDX_FASTFORWARD,
     WIDX_FILE_MENU,
@@ -173,7 +173,7 @@ static const sint32 left_aligned_widgets_order[] = {
 };
 
 // from right to left
-static const sint32 right_aligned_widgets_order[] = {
+static constexpr const sint32 right_aligned_widgets_order[] = {
     WIDX_NEWS,
     WIDX_GUESTS,
     WIDX_STAFF,

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -187,7 +187,7 @@ namespace OpenRCT2
 
         std::string GetPathLegacy(sint32 pathId) override
         {
-            static const char * const LegacyFileNames[PATH_ID_END] =
+            static constexpr const char * const LegacyFileNames[PATH_ID_END] =
             {
                 nullptr,
                 nullptr,

--- a/src/openrct2/Diagnostic.cpp
+++ b/src/openrct2/Diagnostic.cpp
@@ -71,7 +71,7 @@ void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *f
 
 #else
 
-static const char * _level_strings[] = {
+static constexpr const char * _level_strings[] = {
     "FATAL",
     "ERROR",
     "WARNING",

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -45,14 +45,14 @@ namespace Config
 {
     #pragma region Enums
 
-    static auto Enum_MeasurementFormat = ConfigEnum<sint32>(
+    static const auto Enum_MeasurementFormat = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("IMPERIAL", MEASUREMENT_FORMAT_IMPERIAL),
         ConfigEnumEntry<sint32>("METRIC", MEASUREMENT_FORMAT_METRIC),
         ConfigEnumEntry<sint32>("SI", MEASUREMENT_FORMAT_SI),
     });
 
-    static auto Enum_Currency = ConfigEnum<sint32>(
+    static const auto Enum_Currency = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("GBP", CURRENCY_POUNDS),
         ConfigEnumEntry<sint32>("USD", CURRENCY_DOLLARS),
@@ -73,13 +73,13 @@ namespace Config
         ConfigEnumEntry<sint32>("CUSTOM", CURRENCY_CUSTOM),
     });
 
-    static auto Enum_CurrencySymbolAffix = ConfigEnum<sint32>(
+    static const auto Enum_CurrencySymbolAffix = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("PREFIX", CURRENCY_PREFIX),
         ConfigEnumEntry<sint32>("SUFFIX", CURRENCY_SUFFIX),
     });
 
-    static auto Enum_DateFormat = ConfigEnum<sint32>(
+    static const auto Enum_DateFormat = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("DD/MM/YY", DATE_FORMAT_DAY_MONTH_YEAR),
         ConfigEnumEntry<sint32>("MM/DD/YY", DATE_FORMAT_MONTH_DAY_YEAR),
@@ -87,20 +87,20 @@ namespace Config
         ConfigEnumEntry<sint32>("YY/DD/MM", DATE_FORMAT_YEAR_DAY_MONTH),
     });
 
-    static auto Enum_DrawingEngine = ConfigEnum<sint32>(
+    static const auto Enum_DrawingEngine = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("SOFTWARE", DRAWING_ENGINE_SOFTWARE),
         ConfigEnumEntry<sint32>("SOFTWARE_HWD", DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY),
         ConfigEnumEntry<sint32>("OPENGL", DRAWING_ENGINE_OPENGL),
     });
 
-    static auto Enum_Temperature = ConfigEnum<sint32>(
+    static const auto Enum_Temperature = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("CELSIUS", TEMPERATURE_FORMAT_C),
         ConfigEnumEntry<sint32>("FAHRENHEIT", TEMPERATURE_FORMAT_F),
     });
-    
-    static auto Enum_ScaleQuality = ConfigEnum<sint32>(
+
+    static const auto Enum_ScaleQuality = ConfigEnum<sint32>(
     {
         ConfigEnumEntry<sint32>("NEAREST_NEIGHBOUR", SCALE_QUALITY_NN),
         ConfigEnumEntry<sint32>("LINEAR", SCALE_QUALITY_LINEAR),
@@ -599,7 +599,7 @@ namespace Config
     {
         log_verbose("config_find_rct2_path(...)");
 
-        static const utf8 * searchLocations[] =
+        static constexpr const utf8 * searchLocations[] =
         {
             R"(C:\GOG Games\RollerCoaster Tycoon 2 Triple Thrill Pack)",
             R"(C:\Program Files\Atari\RollerCoaster Tycoon 2)",

--- a/src/openrct2/config/ConfigEnum.hpp
+++ b/src/openrct2/config/ConfigEnum.hpp
@@ -46,12 +46,12 @@ template<typename T>
 class ConfigEnum final : public IConfigEnum<T>
 {
 private:
-    std::vector<ConfigEnumEntry<T>> _entries;
+    const std::vector<ConfigEnumEntry<T>> _entries;
 
 public:
-    ConfigEnum(std::initializer_list<ConfigEnumEntry<T>> entries)
+    ConfigEnum(const std::initializer_list<ConfigEnumEntry<T>>& entries)
+        : _entries(entries)
     {
-        _entries = entries;
     }
 
     std::string GetName(T value) const override

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -54,7 +54,7 @@ void X8RainDrawer::SetDPI(rct_drawpixelinfo * dpi)
 
 void X8RainDrawer::Draw(sint32 x, sint32 y, sint32 width, sint32 height, sint32 xStart, sint32 yStart)
 {
-    static const uint8 RainPattern[] =
+    static constexpr const uint8 RainPattern[] =
     {
         32, 32, 0, 12, 0, 14, 0, 16, 255, 0, 255, 0, 255, 0, 255, 0, 255,
         0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0,
@@ -497,7 +497,7 @@ void X8DrawingContext::Clear(uint8 paletteIndex)
 
 /** rct2: 0x0097FF04 */
 // clang-format off
-static const uint16 Pattern[] = {
+static constexpr const uint16 Pattern[] = {
     0b0111111110000000,
     0b0011111111000000,
     0b0001111111100000,
@@ -517,7 +517,7 @@ static const uint16 Pattern[] = {
 };
 
 /** rct2: 0x0097FF14 */
-static const uint16 PatternInverse[] = {
+static constexpr const uint16 PatternInverse[] = {
     0b1000000001111111,
     0b1100000000111111,
     0b1110000000011111,
@@ -537,7 +537,7 @@ static const uint16 PatternInverse[] = {
 };
 
 /** rct2: 0x0097FEFC */
-static const uint16 * Patterns[] = {
+static constexpr const uint16 * Patterns[] = {
     Pattern,
     PatternInverse
 };

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -113,7 +113,7 @@ struct WindowThemeDesc
 
 #define THEME_WC(wc) wc, #wc
 
-static const WindowThemeDesc WindowThemeDescriptors[] =
+static constexpr const WindowThemeDesc WindowThemeDescriptors[] =
 {
     // WindowClass, WindowClassSZ                  WindowName                                        NumColours, DefaultTheme
     { THEME_WC(WC_TOP_TOOLBAR),                    STR_THEMES_WINDOW_TOP_TOOLBAR,                    COLOURS_4(COLOUR_LIGHT_BLUE,               COLOUR_DARK_GREEN,               COLOUR_DARK_BROWN,             COLOUR_GREY         ) },
@@ -184,7 +184,7 @@ static const WindowThemeDesc WindowThemeDescriptors[] =
 
 #define COLOURS_RCT1(c0, c1, c2, c3, c4, c5) { { (c0), (c1), (c2), (c3), (c4), (c5) } }
 
-static const UIThemeWindowEntry PredefinedThemeRCT1_Entries[] =
+static constexpr const UIThemeWindowEntry PredefinedThemeRCT1_Entries[] =
 {
     { WC_TOP_TOOLBAR,              COLOURS_RCT1(COLOUR_GREY,               COLOUR_GREY,                COLOUR_GREY,                COLOUR_GREY,     COLOUR_BLACK,    COLOUR_BLACK)    },
     { WC_BOTTOM_TOOLBAR,           COLOURS_RCT1(TRANSLUCENT(COLOUR_GREY),  TRANSLUCENT(COLOUR_GREY),   COLOUR_BLACK,               COLOUR_YELLOW,   COLOUR_BLACK,    COLOUR_BLACK)    },
@@ -207,7 +207,7 @@ static const UIThemeWindowEntry PredefinedThemeRCT1_Entries[] =
     THEME_DEF_END
 };
 
-static const UIThemeWindowEntry PredefinedThemeRCT2_Entries[] =
+static constexpr const UIThemeWindowEntry PredefinedThemeRCT2_Entries[] =
 {
     THEME_DEF_END
 };
@@ -227,7 +227,7 @@ struct PredefinedTheme
     rct_string_id Name;
 };
 
-static const PredefinedTheme PredefinedThemes[] = {
+static constexpr const PredefinedTheme PredefinedThemes[] = {
     { &PredefinedThemeRCT1, STR_TITLE_SEQUENCE_RCT1 },
     { &PredefinedThemeRCT2, STR_TITLE_SEQUENCE_RCT2 }
 };

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -27,7 +27,7 @@
 #define NEGATIVE 0
 #define POSITIVE 1
 
-static const uint8 AwardPositiveMap[] =
+static constexpr const uint8 AwardPositiveMap[] =
 {
     NEGATIVE, // PARK_AWARD_MOST_UNTIDY
     POSITIVE, // PARK_AWARD_MOST_TIDY
@@ -48,7 +48,7 @@ static const uint8 AwardPositiveMap[] =
     POSITIVE, // PARK_AWARD_BEST_GENTLE_RIDES
 };
 
-static const rct_string_id AwardNewsStrings[] =
+static constexpr const rct_string_id AwardNewsStrings[] =
 {
     STR_NEWS_ITEM_AWARD_MOST_UNTIDY,
     STR_NEWS_ITEM_MOST_TIDY,
@@ -552,7 +552,7 @@ static bool award_is_deserved_best_custom_designed_rides(sint32 awardType, sint3
 }
 
 /** At least 5 colourful rides and more than half of the rides are colourful. */
-static const uint8 dazzling_ride_colours[] = {5, 14, 20, 30};
+static constexpr const uint8 dazzling_ride_colours[] = {5, 14, 20, 30};
 
 static bool award_is_deserved_most_dazzling_ride_colours(sint32 awardType, sint32 activeAwardTypes)
 {
@@ -642,7 +642,7 @@ static bool award_is_deserved_best_gentle_rides(sint32 awardType, sint32 activeA
 
 typedef bool (* award_deserved_check)(sint32, sint32);
 
-static const award_deserved_check _awardChecks[] =
+static constexpr const award_deserved_check _awardChecks[] =
 {
     award_is_deserved_most_untidy,
     award_is_deserved_most_tidy,

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -48,7 +48,7 @@ const money32 research_cost_table[RESEARCH_FUNDING_COUNT] =
     MONEY(400, 00)       // Maximum funding
 };
 
-static const sint32 dword_988E60[RCT_EXPENDITURE_TYPE_COUNT] = {1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0};
+static constexpr const sint32 dword_988E60[RCT_EXPENDITURE_TYPE_COUNT] = {1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0};
 
 money32 gInitialCash;
 money32 gCash;

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -36,7 +36,7 @@ const money16 AdvertisingCampaignPricePerWeek[] =
     MONEY(200, 00)   // RIDE
 };
 
-static const sint32 AdvertisingCampaignGuestGenerationProbabilities[] = {400, 300, 200, 200, 250, 200};
+static constexpr const sint32 AdvertisingCampaignGuestGenerationProbabilities[] = {400, 300, 200, 200, 250, 200};
 
 uint8 gMarketingCampaignDaysLeft[20];
 uint8 gMarketingCampaignRideIndex[22];

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -37,7 +37,7 @@
 #include "../core/Memory.hpp"
 #include "../util/Util.h"
 
-const sint32 _researchRate[] = {0, 160, 250, 400};
+static constexpr const sint32 _researchRate[] = {0, 160, 250, 400};
 
 uint8  gResearchFundingLevel;
 uint8  gResearchPriorities;

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -229,7 +229,7 @@ private:
     static std::string GenerateAdvertiseKey()
     {
         // Generate a string of 16 random hex characters (64-integer key as a hex formatted string)
-        static const char hexChars[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        static constexpr const char hexChars[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
         char key[17];
         for (sint32 i = 0; i < 16; i++)
         {

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -22,7 +22,7 @@
 #include "Object.h"
 #include "StringTable.h"
 
-static const uint8 RCT2ToOpenRCT2LanguageId[] =
+static constexpr const uint8 RCT2ToOpenRCT2LanguageId[] =
 {
     LANGUAGE_ENGLISH_UK,
     LANGUAGE_ENGLISH_US,

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -30,7 +30,7 @@ uint8 gClipHeight = 128; // Default to middle value
 paint_session gPaintSession;
 static bool _paintSessionInUse;
 
-static const uint8 BoundBoxDebugColours[] =
+static constexpr const uint8 BoundBoxDebugColours[] =
 {
     0,   // NONE
     102, // TERRAIN

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x0097AF20, 0x0097AF21 */
 // clang-format off
-static const LocationXY8 loc_97AF20[] = {
+static constexpr const LocationXY8 loc_97AF20[] = {
     {4,  4},
     {28, 4},
     {4,  28},
@@ -34,7 +34,7 @@ static const LocationXY8 loc_97AF20[] = {
 };
 
 /** rct2: 0x0097AF32 */
-static const uint8 _97AF32[] = {
+static constexpr const uint8 _97AF32[] = {
     5, 2, 5, 2, 5, 2, 5, 2,
     7, 1, 7, 1, 7, 1, 7, 1,
     6, 3, 6, 3, 6, 3, 6, 3,
@@ -77,7 +77,7 @@ static const uint8 _97AF32[] = {
 };
 
 /** rct2: 0x0097B052, 0x0097B053 */
-static const LocationXY16 loc_97B052[] = {
+static constexpr const LocationXY16 loc_97B052[] = {
     {-15, -1},
     {0,   -2},
     {-2,  -1},
@@ -89,7 +89,7 @@ static const LocationXY16 loc_97B052[] = {
 };
 
 /** rct2: 0x0097B062, 0x0097B063 */
-static const LocationXY8 _97B062[] = {
+static constexpr const LocationXY8 _97B062[] = {
     { 18,  3 },
     {  3, 18 },
     { 18,  3 },
@@ -101,7 +101,7 @@ static const LocationXY8 _97B062[] = {
 };
 
 /** rct2: 0x0097B072 */
-static const uint32 _metalSupportTypeToCrossbeamImages[][8] = {
+static constexpr const uint32 _metalSupportTypeToCrossbeamImages[][8] = {
     { 3370, 3371, 3370, 3371, 3372, 3373, 3372, 3373 }, // METAL_SUPPORTS_TUBES
     { 3374, 3375, 3374, 3375, 3376, 3377, 3376, 3377 }, // METAL_SUPPORTS_FORK
     { 3374, 3375, 3374, 3375, 3376, 3377, 3376, 3377 }, // METAL_SUPPORTS_FORK_ALT
@@ -118,7 +118,7 @@ static const uint32 _metalSupportTypeToCrossbeamImages[][8] = {
 };
 
 /** rct2: 0x0097B142 */
-static const uint8 supportTypeToHeight[] = {
+static constexpr const uint8 supportTypeToHeight[] = {
     6,
     3,
     3,
@@ -140,7 +140,7 @@ typedef struct metal_supports_images {
 } metal_supports_images;
 
 /** rct2: 0x0097B15C */
-static const metal_supports_images _97B15C[] = {
+static constexpr const metal_supports_images _97B15C[] = {
     { 3243, 3209 },
     { 3279, 3262 },
     { 3298, 3262 },
@@ -157,7 +157,7 @@ static const metal_supports_images _97B15C[] = {
 };
 
 /** rct2: 0x0097B190 */
-static const metal_supports_images _97B190[] = {
+static constexpr const metal_supports_images _97B190[] = {
     { 3243, 3226 }, // 3209
     { 3279, 3262 },
     { 3298, 3262 },
@@ -174,7 +174,7 @@ static const metal_supports_images _97B190[] = {
 };
 
 /** rct2: 0x0097B404 */
-static const uint8 metal_supports_slope_image_map[] = {
+static constexpr const uint8 metal_supports_slope_image_map[] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  0,
      0,  0,  0,  0,  0,  0,  0, 15,  0,  0,  0, 16,  0, 17, 18,  0,
 };
@@ -187,7 +187,7 @@ typedef struct supports_id_desc {
 } supports_id_desc;
 
 /* 0x0097B1C4 */
-static const supports_id_desc WoodenSupportImageIds[] = {
+static constexpr const supports_id_desc WoodenSupportImageIds[] = {
     { 3392, 3393, 3394, 3536 },
     { 3390, 3391, 3394, 3514 },
     { 3558, 3559, 3560, 3570 },
@@ -203,7 +203,7 @@ static const supports_id_desc WoodenSupportImageIds[] = {
 };
 
 /* 0x0097B224 */
-static const uint16 WoodenCurveSupportImageIds[] = {
+static constexpr const uint16 WoodenCurveSupportImageIds[] = {
     3465,
     3465,
     0,
@@ -234,7 +234,7 @@ typedef struct unk_supports_desc {
 } unk_supports_desc;
 
 /* 0x0097B23C */
-static const unk_supports_desc byte_97B23C[] = {
+static constexpr const unk_supports_desc byte_97B23C[] = {
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
     {{{0,  0,  0}, {1,  1,  8}},  0, 1},
@@ -287,7 +287,7 @@ static const unk_supports_desc byte_97B23C[] = {
 };
 
 /* 0x0098D8D4 */
-static const unk_supports_desc byte_98D8D4[] = {
+static constexpr const unk_supports_desc byte_98D8D4[] = {
     {{{0, 0, 0}, {1, 1, 4}}, 0, 1},
     {{{0, 0, 0}, {1, 1, 4}}, 0, 1},
     {{{0, 0, 0}, {1, 1, 4}}, 0, 1},
@@ -295,7 +295,7 @@ static const unk_supports_desc byte_98D8D4[] = {
 };
 
 /* 0x0097B3C4 */
-static const uint16 word_97B3C4[] = {
+static constexpr const uint16 word_97B3C4[] = {
     0,
     0,
     1,
@@ -532,7 +532,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
         } else {
             imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
 
-            sub_98197C(session, 
+            sub_98197C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 32, 32, 11,
@@ -542,7 +542,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
             );
             baseHeight += 16;
 
-            sub_98197C(session, 
+            sub_98197C(session,
                 (imageId + 4) | imageColourFlags,
                 0, 0,
                 32, 32, 3,
@@ -568,7 +568,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
         } else {
             imageId += word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
 
-            sub_98197C(session, 
+            sub_98197C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 32, 32, 3,
@@ -587,7 +587,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
         if (heightSteps == 0) {
             skipTo663004 = true;
         } else {
-            sub_98196C(session, 
+            sub_98196C(session,
                 WoodenSupportImageIds[supportType].flat | imageColourFlags,
                 0, 0,
                 32, 32, 0,
@@ -601,7 +601,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
     if (!skipTo663004) {
         while (heightSteps > 0) {
             if (baseHeight & 0x10 || heightSteps == 1 || baseHeight + 16 == session->Unk141E9DC) {
-                sub_98196C(session, 
+                sub_98196C(session,
                     WoodenSupportImageIds[supportType].half | imageColourFlags,
                     0, 0,
                     32, 32, ((heightSteps == 1) ? 7 : 12),
@@ -612,7 +612,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
                 baseHeight += 16;
                 _9E32B1 = true;
             } else {
-                sub_98196C(session, 
+                sub_98196C(session,
                     WoodenSupportImageIds[supportType].full | imageColourFlags,
                     0, 0,
                     32, 32, ((heightSteps == 2) ? 23 : 28),
@@ -638,7 +638,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
             unk_supports_desc_bound_box boundBox = supportsDesc.bounding_box;
 
             if (supportsDesc.var_6 == 0 || session->WoodenSupportsPrependTo == nullptr) {
-                sub_98197C(session, 
+                sub_98197C(session,
                     imageId | imageColourFlags,
                     0, 0,
                     boundBox.length.x, boundBox.length.y, boundBox.length.z,
@@ -648,7 +648,7 @@ bool wooden_b_supports_paint_setup(paint_session * session, sint32 supportType, 
                 );
                 _9E32B1 = true;
             } else {
-                paint_struct * paintStruct = sub_98198C(session, 
+                paint_struct * paintStruct = sub_98198C(session,
                     imageId | imageColourFlags,
                     0, 0,
                     boundBox.length.x, boundBox.length.y, boundBox.length.z,
@@ -917,7 +917,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
             return true; // STC
         }
 
-        sub_98196C(session, 
+        sub_98196C(session,
             _metalSupportTypeToCrossbeamImages[supportType][ebp] | imageColourFlags,
             loc_97AF20[originalSegment].x + loc_97B052[ebp].x, loc_97AF20[originalSegment].y + loc_97B052[ebp].y,
             _97B062[ebp].x, _97B062[ebp].y, 1,
@@ -936,7 +936,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
         uint32 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
         uint32 imageId = _97B15C[supportType].base_id + imageOffset;
 
-        sub_98196C(session, 
+        sub_98196C(session,
             imageId | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, 5,
@@ -954,7 +954,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
 
     heightDiff -= baseHeight;
     if (heightDiff > 0) {
-        sub_98196C(session, 
+        sub_98196C(session,
             (_97B15C[supportType].beam_id + (heightDiff - 1)) | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, heightDiff - 1,
@@ -991,7 +991,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
             }
         }
 
-        sub_98196C(session, 
+        sub_98196C(session,
             imageId | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, beamLength - 1,
@@ -1021,7 +1021,7 @@ bool metal_b_supports_paint_setup(paint_session * session, uint8 supportType, ui
             }
 
             uint32 imageId = _97B15C[supportType].beam_id + (beamLength - 1);
-            sub_98197C(session, 
+            sub_98197C(session,
                 imageId | imageColourFlags,
                 loc_97AF20[originalSegment].x, loc_97AF20[originalSegment].y,
                 0, 0, 0,
@@ -1076,7 +1076,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
 
     if (session->Support.slope & 0x20) {
         //save dx2
-        sub_98196C(session, 
+        sub_98196C(session,
             (pathEntry->bridge_image + 48) | imageColourFlags,
             0, 0,
             32, 32, 0,
@@ -1093,7 +1093,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
 
         uint32 imageId = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK] + pathEntry->bridge_image;
 
-        sub_98197C(session, 
+        sub_98197C(session,
             imageId | imageColourFlags,
             0, 0,
             32, 32, 11,
@@ -1103,7 +1103,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
         );
         baseHeight += 16;
 
-        sub_98197C(session, 
+        sub_98197C(session,
             (imageId + 4) | imageColourFlags,
             0, 0,
             32, 32, 11,
@@ -1124,7 +1124,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
 
         uint32 ebx = (supportType * 24) + word_97B3C4[session->Support.slope & TILE_ELEMENT_SURFACE_SLOPE_MASK] + pathEntry->bridge_image;
 
-        sub_98197C(session, 
+        sub_98197C(session,
             ebx | imageColourFlags,
             0, 0,
             32, 32, 11,
@@ -1142,7 +1142,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
 
             uint32 imageId = (supportType * 24) + pathEntry->bridge_image + 23;
 
-            sub_98196C(session, 
+            sub_98196C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 32, 32, ((heightSteps == 1) ? 7 : 12),
@@ -1155,7 +1155,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
         } else {
             uint32 imageId = (supportType * 24) + pathEntry->bridge_image + 22;
 
-            sub_98196C(session, 
+            sub_98196C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 32, 32, ((heightSteps == 2) ? 23 : 28),
@@ -1177,7 +1177,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
         unk_supports_desc_bound_box boundBox = supportsDesc.bounding_box;
 
         if (supportsDesc.var_6 == 0 || session->WoodenSupportsPrependTo == nullptr) {
-            sub_98197C(session, 
+            sub_98197C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 boundBox.length.y, boundBox.length.x, boundBox.length.z,
@@ -1187,7 +1187,7 @@ bool path_a_supports_paint_setup(paint_session * session, sint32 supportType, si
             );
             hasSupports = true;
         } else {
-            paint_struct * paintStruct = sub_98198C(session, 
+            paint_struct * paintStruct = sub_98198C(session,
                 imageId | imageColourFlags,
                 0, 0,
                 boundBox.length.y, boundBox.length.x, boundBox.length.z,
@@ -1246,7 +1246,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
         uint8 imageOffset = metal_supports_slope_image_map[supportSegments[segment].slope & TILE_ELEMENT_SURFACE_SLOPE_MASK];
         baseHeight = supportSegments[segment].height;
 
-        sub_98196C(session, 
+        sub_98196C(session,
             (pathEntry->bridge_image + 37 + imageOffset) | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, 5,
@@ -1267,7 +1267,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
     heightDiff -= baseHeight;
 
     if (heightDiff > 0) {
-        sub_98196C(session, 
+        sub_98196C(session,
             (pathEntry->bridge_image + 20 + (heightDiff - 1)) | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, heightDiff - 1,
@@ -1299,7 +1299,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
                 break;
             }
 
-            sub_98196C(session, 
+            sub_98196C(session,
                 (pathEntry->bridge_image + 20 + (z - 1)) | imageColourFlags,
                 loc_97AF20[segment].x, loc_97AF20[segment].y,
                 0, 0, (z - 1),
@@ -1319,7 +1319,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
             imageId += 1;
         }
 
-        sub_98196C(session, 
+        sub_98196C(session,
             imageId | imageColourFlags,
             loc_97AF20[segment].x, loc_97AF20[segment].y,
             0, 0, (z - 1),
@@ -1349,7 +1349,7 @@ bool path_b_supports_paint_setup(paint_session * session, sint32 segment, sint32
             }
 
             uint32 imageId = pathEntry->bridge_image + 20 + (z - 1);
-            sub_98197C(session, 
+            sub_98197C(session,
                 imageId | imageColourFlags,
                 loc_97AF20[segment].x, loc_97AF20[segment].y,
                 0, 0, 0,

--- a/src/openrct2/paint/sprite/Litter.cpp
+++ b/src/openrct2/paint/sprite/Litter.cpp
@@ -51,7 +51,7 @@ typedef struct litter_sprite {
 } litter_sprite;
 
 /** rct2: 0x0097EF6C */
-static const litter_sprite litter_sprites[] = {
+static constexpr const litter_sprite litter_sprites[] = {
     { SPR_LITTER_SICK,              0x1 },
     { SPR_LITTER_SICK_ALT,          0x1 },
     { SPR_LITTER_EMPTY_CAN,         0x1 },
@@ -84,7 +84,7 @@ void litter_paint(paint_session * session, rct_litter *litter, sint32 imageDirec
     imageDirection &= litter_sprites[litter->type].direction_mask;
 
     uint32 image_id = imageDirection + litter_sprites[litter->type].base_id;
-    
+
     // In the following call to sub_98197C, we add 4 (instead of 2) to the
     //  bound_box_offset_z to make sure litter is drawn on top of railways
     sub_98197C(session, image_id, 0, 0, 4, 4, -1, litter->z, -4, -4, litter->z + 4, get_current_rotation());

--- a/src/openrct2/paint/sprite/Misc.cpp
+++ b/src/openrct2/paint/sprite/Misc.cpp
@@ -22,7 +22,7 @@
 #include "../../localisation/StringIds.h"
 
 /** rct2: 0x0097EDA4 */
-static const sint8 money_wave[] = {
+static constexpr const sint8 money_wave[] = {
     0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -3, -3, -2, -2, -1,
     0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -3, -3, -2, -2, -1
 };

--- a/src/openrct2/paint/tile_element/Fence.cpp
+++ b/src/openrct2/paint/tile_element/Fence.cpp
@@ -28,22 +28,22 @@
 #include "../Paint.h"
 #include "TileElement.h"
 
-static const uint8 byte_9A406C[] = {
+static constexpr const uint8 byte_9A406C[] = {
     2, 2, 22, 26, 30, 34, 34, 34, 34, 34, 30, 26, 22, 2, 6, 2,
     2, 2, 6, 10, 14, 18, 18, 18, 18, 18, 14, 10, 6, 2, 22, 2
 };
 
-static const uint8 byte_9A408C[] = {
+static constexpr const uint8 byte_9A408C[] = {
     0, 0, 4, 8, 12, 16, 16, 16, 16, 16, 12, 8, 4, 0, 20, 0,
     0, 0, 20, 24, 28, 32, 32, 32, 32, 32, 28, 24, 20, 0, 4, 0
 };
 
-static const uint8 byte_9A40AC[] = {
+static constexpr const uint8 byte_9A40AC[] = {
     2, 2, 6, 10, 14, 18, 18, 18, 18, 18, 14, 10, 6, 2, 22, 2,
     2, 2, 22, 26, 30, 34, 34, 34, 34, 34, 30, 26, 22, 2, 6, 2
 };
 
-static const uint8 byte_9A40CC[] = {
+static constexpr const uint8 byte_9A40CC[] = {
     0, 0, 20, 24, 28, 32, 32, 32, 32, 32, 28, 24, 20, 0, 4, 0,
     0, 0, 4, 8, 12, 16, 16, 16, 16, 16, 12, 8, 4, 0, 20, 0
 };

--- a/src/openrct2/paint/tile_element/LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/LargeScenery.cpp
@@ -161,7 +161,7 @@ typedef struct boundbox {
     LocationXY16 length;
 } boundbox;
 
-static const boundbox s98E3C4[] = {
+static constexpr const boundbox s98E3C4[] = {
     { 3,   3, 26, 26 },
     { 17, 17, 12, 12 },
     { 17,  3, 12, 12 },

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -36,7 +36,7 @@ const uint8 byte_98D800[] = {
     12, 9, 3, 6
 };
 
-static const uint8 byte_98D6E0[] = {
+static constexpr const uint8 byte_98D6E0[] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     0, 1, 2, 20, 4, 5, 6, 22, 8, 9, 10, 26, 12, 13, 14, 36,
     0, 1, 2, 3, 4, 5, 21, 23, 8, 9, 10, 11, 12, 13, 33, 37,
@@ -55,7 +55,7 @@ static const uint8 byte_98D6E0[] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 50
 };
 
-static const sint16 stru_98D804[][4] = {
+static constexpr const sint16 stru_98D804[][4] = {
     {3, 3, 26, 26},
     {0, 3, 29, 26},
     {3, 3, 26, 29},
@@ -74,7 +74,7 @@ static const sint16 stru_98D804[][4] = {
     {0, 0, 32, 32},
 };
 
-static const uint8 byte_98D8A4[] = {
+static constexpr const uint8 byte_98D8A4[] = {
     0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0
 };
 // clang-format on
@@ -842,7 +842,7 @@ void path_paint_box_support(paint_session * session, rct_tile_element * tileElem
     // By default, add 1 to the z bounding box to always clip above the surface
     uint8 boundingBoxZOffset = 1;
 
-    // If we are on the same tile as a straight track, add the offset 2 so we 
+    // If we are on the same tile as a straight track, add the offset 2 so we
     //  can clip above gravel part of the track sprite
     if (session->TrackElementOnSameHeight)
     {
@@ -969,7 +969,7 @@ void path_paint_pole_support(paint_session * session, rct_tile_element* tileElem
     // By default, add 1 to the z bounding box to always clip above the surface
     uint8 boundingBoxZOffset = 1;
 
-    // If we are on the same tile as a straight track, add the offset 2 so we 
+    // If we are on the same tile as a straight track, add the offset 2 so we
     //  can clip above gravel part of the track sprite
     if (session->TrackElementOnSameHeight)
     {

--- a/src/openrct2/paint/tile_element/SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/SmallScenery.cpp
@@ -25,14 +25,14 @@
 #include "../../world/scenery.h"
 #include "../../world/SmallScenery.h"
 
-static const LocationXY16 offsets[] = {
+static constexpr const LocationXY16 offsets[] = {
     {  3,  3 },
     {  3, 17 },
     { 17,  3 },
     {  3,  3 }
 };
 
-static const LocationXY16 lengths[] = {
+static constexpr const LocationXY16 lengths[] = {
     { 12, 26 },
     { 26, 12 },
     { 12, 26 },

--- a/src/openrct2/paint/tile_element/TileElement.cpp
+++ b/src/openrct2/paint/tile_element/TileElement.cpp
@@ -349,7 +349,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
         return;
     }
 
-    static const sint32 segmentPositions[][3] = {
+    static constexpr const sint32 segmentPositions[][3] = {
         {0, 6, 2},
         {5, 4, 8},
         {1, 7, 3},

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -184,7 +184,7 @@ bool loc_690FD0(rct_peep * peep, uint8 * rideToView, uint8 * rideSeatToView, rct
 #endif
 
 // clang-format off
-static const char *gPeepEasterEggNames[] = {
+static constexpr const char *gPeepEasterEggNames[] = {
     "MICHAEL SCHUMACHER",
     "JACQUES VILLENEUVE",
     "DAMON HILL",
@@ -433,7 +433,7 @@ static uint8 PeepActionToSpriteTypeMap[] = {
     PEEP_ACTION_SPRITE_TYPE_WITHDRAW_MONEY
 };
 
-static const bool SpriteTypeToSlowWalkMap[] = {
+static constexpr const bool SpriteTypeToSlowWalkMap[] = {
     false, false, false, false, false, false, false, false,
     false, false, false, true,  false, false, true,  true,
     true,  true,  true,  false, true,  false, true,  true,
@@ -443,18 +443,18 @@ static const bool SpriteTypeToSlowWalkMap[] = {
 };
 
 // These arrays contain the base minimum and maximum nausea ratings for peeps, based on their nausea tolerance level.
-static const ride_rating NauseaMinimumThresholds[] = {
+static constexpr const ride_rating NauseaMinimumThresholds[] = {
     0, 0, 200, 400
 };
 
-static const ride_rating NauseaMaximumThresholds[] = {
+static constexpr const ride_rating NauseaMaximumThresholds[] = {
     300, 600, 800, 1000
 };
 
 // Locations of the spiral slide platform that a peep walks from the entrance of the ride to the
 // entrance of the slide. Up to 4 locations for each 4 sides that an ride entrance can be located
 // and 4 different rotations of the ride. 4 * 4 * 4 = 64 locations.
-static const LocationXY16 SpiralSlideWalkingPath[64] = {
+static constexpr const LocationXY16 SpiralSlideWalkingPath[64] = {
     {  56,   8 },
     {   8,   8 },
     {   8,  32 },
@@ -800,7 +800,7 @@ static void peep_decide_whether_to_leave_park(rct_peep * peep)
 
 // clang-format off
 /** rct2: 0x009822F4, 0x00982310 */
-static const uint8 byte_9822F4[] = {
+static constexpr const uint8 byte_9822F4[] = {
     0,      // SHOP_ITEM_BALLOON
     0,      // SHOP_ITEM_TOY
     0,      // SHOP_ITEM_MAP
@@ -858,7 +858,7 @@ static const uint8 byte_9822F4[] = {
 };
 
 /** rct2: 009823AC */
-static const uint8 crowded_thoughts[] = {
+static constexpr const uint8 crowded_thoughts[] = {
     PEEP_THOUGHT_TYPE_LOST,
     PEEP_THOUGHT_TYPE_TIRED,
     PEEP_THOUGHT_TYPE_BAD_LITTER,
@@ -878,7 +878,7 @@ static const uint8 crowded_thoughts[] = {
 };
 
 /** rct2: 0x00982326 */
-static const uint8 peep_item_containers[] = {
+static constexpr const uint8 peep_item_containers[] = {
     0xFF,                           // PEEP_ITEM_BALLOON
     0xFF,                           // PEEP_ITEM_TOY
     0xFF,                           // PEEP_ITEM_MAP
@@ -910,7 +910,7 @@ static const uint8 peep_item_containers[] = {
 };
 
 /** rct2: 0x00982342 */
-static const uint8 peep_extra_item_containers[] = {
+static constexpr const uint8 peep_extra_item_containers[] = {
     0xFF,                           // PEEP_ITEM_PHOTO2
     0xFF,                           // PEEP_ITEM_PHOTO3
     0xFF,                           // PEEP_ITEM_PHOTO4
@@ -1646,7 +1646,7 @@ static void peep_check_cant_find_ride(rct_peep * peep)
  *
  *  rct2: 0x69C2D0
  * Check if cant find exit.
- */ 
+ */
 static void peep_check_cant_find_exit(rct_peep * peep)
 {
     if (!(peep->peep_flags & PEEP_FLAGS_LEAVING_PARK))
@@ -1664,7 +1664,7 @@ static void peep_check_cant_find_exit(rct_peep * peep)
 }
 
 /** rct2: 0x00981D7C, 0x00981D7E */
-static const LocationXY16 word_981D7C[4] = { { -2, 0 }, { 0, 2 }, { 2, 0 }, { 0, -2 } };
+static constexpr const LocationXY16 word_981D7C[4] = { { -2, 0 }, { 0, 2 }, { 2, 0 }, { 0, -2 } };
 
 /**
  *
@@ -2404,7 +2404,7 @@ static void peep_try_get_up_from_sitting(rct_peep * peep)
 }
 
 /** rct2: 0x00981F2C, 0x00981F2E */
-static const LocationXY16 _981F2C[] = {
+static constexpr const LocationXY16 _981F2C[] = {
     { 7, 12 }, { 12, 25 }, { 25, 20 }, { 20, 7 }, { 7, 20 }, { 20, 25 }, { 25, 12 }, { 12, 7 },
 };
 
@@ -2852,7 +2852,7 @@ static void peep_update_ride_sub_state_0(rct_peep * peep)
 }
 
 /** rct2: 0x00981FD4, 0x00981FD6 */
-static const LocationXY16 _981FD4[] = {
+static constexpr const LocationXY16 _981FD4[] = {
     { 8, 8 },
     { 8, 24 },
     { 24, 24 },
@@ -3989,7 +3989,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
 }
 
 /** rct2: 0x00981F0C, 0x00981F0E */
-static const LocationXY16 _981F0C[] = {
+static constexpr const LocationXY16 _981F0C[] = {
     { 25, 56 },
     { 56, 7 },
     { 7, -24 },
@@ -3997,7 +3997,7 @@ static const LocationXY16 _981F0C[] = {
 };
 
 /** rct2: 0x00981F1C, 0x00981F1E */
-static const LocationXY16 _981F1C[] = {
+static constexpr const LocationXY16 _981F1C[] = {
     { 8, 56 },
     { 56, 24 },
     { 24, -24 },
@@ -4173,7 +4173,7 @@ static void peep_update_ride_sub_state_16(rct_peep * peep)
 }
 
 /** rct2: 0x00981FE4 */
-static const uint8 _981FE4[][4] = {
+static constexpr const uint8 _981FE4[][4] = {
     { 15, 7, 15, 7 },
     { 11, 3, 11, 3 },
     { 7, 15, 7, 15 },
@@ -4181,7 +4181,7 @@ static const uint8 _981FE4[][4] = {
 };
 
 /** rct2: 0x00981FF4 */
-static const uint8 _981FF4[][4] = {
+static constexpr const uint8 _981FF4[][4] = {
     { 1, 2, 14, 0 },
     { 4, 5, 6, 2 },
     { 6, 8, 9, 10 },
@@ -4606,7 +4606,7 @@ static void peep_update_ride(rct_peep * peep)
     }
 }
 
-static const uint32 loc_992A18[9] = {
+static constexpr const uint32 loc_992A18[9] = {
     (1 << 14) | (1 << 13) | (1 << 12) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 7),
     (1 << 14) | (1 << 13) | (1 << 12) | (1 << 2) | (1 << 1),
     (1 << 14) | (1 << 13) | (1 << 12) | (1 << 4) | (1 << 1),
@@ -4874,7 +4874,7 @@ static bool peep_update_fixing_sub_state_6(bool firstRun, rct_peep * peep, Ride 
 }
 
 /** rct2: 0x00992A3C */
-static const LocationXY16 _992A3C[] = {
+static constexpr const LocationXY16 _992A3C[] = {
     { -12, 0 },
     { 0, 12 },
     { 12, 0 },
@@ -5427,7 +5427,7 @@ static void peep_update_queuing(rct_peep * peep)
 }
 
 /** rct2: 0x009929C8 */
-static const LocationXY16 _9929C8[] = {
+static constexpr const LocationXY16 _9929C8[] = {
     { 28, 28 }, { 28, 4 }, { 20, 4 }, { 20, 28 }, { 12, 28 }, { 12, 4 }, { 4, 4 }, { 4, 28 },
 };
 
@@ -5985,7 +5985,7 @@ static sint32 peep_update_walking_find_bench(rct_peep * peep)
 }
 
 /** rct2: 0x00992A4C */
-static const LocationXY16 _992A4C[] = {
+static constexpr const LocationXY16 _992A4C[] = {
     { 11, 16 },
     { 16, 21 },
     { 21, 16 },
@@ -6293,7 +6293,7 @@ static void peep_update_buying(rct_peep * peep)
 }
 
 /** rct2: 0x0097EFCC */
-static const uint8 item_standard_litter[32] = {
+static constexpr const uint8 item_standard_litter[32] = {
     LITTER_TYPE_RUBBISH,          // PEEP_ITEM_BALLOON
     LITTER_TYPE_RUBBISH,          // PEEP_ITEM_TOY
     LITTER_TYPE_RUBBISH,          // PEEP_ITEM_MAP
@@ -6325,7 +6325,7 @@ static const uint8 item_standard_litter[32] = {
 };
 
 /** rct2: 0x0097EFE8 */
-static const uint8 item_extra_litter[32] = {
+static constexpr const uint8 item_extra_litter[32] = {
     LITTER_TYPE_RUBBISH,            // PEEP_ITEM_PHOTO2
     LITTER_TYPE_RUBBISH,            // PEEP_ITEM_PHOTO3
     LITTER_TYPE_RUBBISH,            // PEEP_ITEM_PHOTO4
@@ -6755,7 +6755,7 @@ static void peep_update_answering(rct_peep * peep)
 }
 
 /** rct2: 0x00992A5C */
-static const LocationXY16 _992A5C[] = {
+static constexpr const LocationXY16 _992A5C[] = {
     { 3, 16 }, { 16, 29 }, { 29, 16 }, { 16, 3 }, { 3, 29 }, { 29, 29 }, { 29, 3 }, { 3, 3 },
 };
 
@@ -7024,7 +7024,7 @@ static void peep_update_patrolling(rct_peep * peep)
 
 // clang-format off
 /** rct2: 0x00981F4C, 0x00981F4E */
-static const LocationXY16 _981F4C[] = {
+static constexpr const LocationXY16 _981F4C[] = {
     {  7,  5 },
     {  5, 25 },
     { 25,  5 },
@@ -7129,7 +7129,7 @@ static void peep_update_walking(rct_peep * peep)
         {
             if ((0xFFFF & peep_rand()) <= 4096)
             {
-                static const uint8 litter_types[] = {
+                static constexpr const uint8 litter_types[] = {
                     LITTER_TYPE_EMPTY_CAN,
                     LITTER_TYPE_RUBBISH,
                     LITTER_TYPE_EMPTY_BURGER_BOX,
@@ -7833,7 +7833,7 @@ void peep_update_days_in_queue()
 
 // clang-format off
 /** rct2: 0x009823A0 */
-static const enum PEEP_NAUSEA_TOLERANCE nausea_tolerance_distribution[] = {
+static constexpr const enum PEEP_NAUSEA_TOLERANCE nausea_tolerance_distribution[] = {
     PEEP_NAUSEA_TOLERANCE_NONE,
     PEEP_NAUSEA_TOLERANCE_LOW, PEEP_NAUSEA_TOLERANCE_LOW,
     PEEP_NAUSEA_TOLERANCE_AVERAGE, PEEP_NAUSEA_TOLERANCE_AVERAGE, PEEP_NAUSEA_TOLERANCE_AVERAGE,
@@ -7841,7 +7841,7 @@ static const enum PEEP_NAUSEA_TOLERANCE nausea_tolerance_distribution[] = {
 };
 
 /** rct2: 0x009823BC */
-static const uint8 trouser_colours[] = {
+static constexpr const uint8 trouser_colours[] = {
     COLOUR_BLACK,
     COLOUR_GREY,
     COLOUR_LIGHT_BROWN,
@@ -7870,7 +7870,7 @@ static const uint8 trouser_colours[] = {
 };
 
 /** rct2: 0x009823D5 */
-static const uint8 tshirt_colours[] = {
+static constexpr const uint8 tshirt_colours[] = {
     COLOUR_BLACK,
     COLOUR_GREY,
     COLOUR_LIGHT_BROWN,
@@ -8260,7 +8260,7 @@ void peep_thought_set_format_args(rct_peep_thought * thought)
 }
 
 /** rct2: 0x00982004 */
-static const bool peep_allow_pick_up[] = {
+static constexpr const bool peep_allow_pick_up[] = {
     true,  // PEEP_STATE_FALLING
     false, // PEEP_STATE_1
     false, // PEEP_STATE_QUEUING_FRONT
@@ -8314,7 +8314,7 @@ enum
     PEEP_FACE_OFFSET_VERY_VERY_HAPPY,
 };
 
-static const sint32 face_sprite_small[] = {
+static constexpr const sint32 face_sprite_small[] = {
     SPR_PEEP_SMALL_FACE_ANGRY,
     SPR_PEEP_SMALL_FACE_VERY_VERY_SICK,
     SPR_PEEP_SMALL_FACE_VERY_SICK,
@@ -8330,7 +8330,7 @@ static const sint32 face_sprite_small[] = {
     SPR_PEEP_SMALL_FACE_VERY_VERY_HAPPY,
 };
 
-static const sint32 face_sprite_large[] = {
+static constexpr const sint32 face_sprite_large[] = {
     SPR_PEEP_LARGE_FACE_ANGRY_0,
     SPR_PEEP_LARGE_FACE_VERY_VERY_SICK_0,
     SPR_PEEP_LARGE_FACE_VERY_SICK_0,

--- a/src/openrct2/peep/PeepData.cpp
+++ b/src/openrct2/peep/PeepData.cpp
@@ -18,1832 +18,1832 @@
 #include "../world/sprite.h"
 
 // clang-format off
-static const uint8 PeepSpriteImage_Normal_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Normal_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Normal_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Normal_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Normal_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Normal_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Normal_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Normal_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Normal_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Normal_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Normal_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Normal_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Normal_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Normal_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Normal_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Normal_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Normal_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Normal_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Normal_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Normal_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Normal_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Normal_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Normal_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Normal_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Normal_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Normal_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Normal_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Normal_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Normal_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Normal_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Normal_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Normal_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Normal_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Normal_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Normal_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Normal_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Normal_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Normal_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Handyman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Handyman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Handyman_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Handyman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Handyman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Handyman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Handyman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Handyman_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Handyman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Handyman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Handyman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Handyman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Handyman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Handyman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Handyman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Handyman_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Handyman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Handyman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Handyman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Handyman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Handyman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Handyman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Handyman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Handyman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Handyman_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Handyman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Handyman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Handyman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Handyman_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Handyman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Handyman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Handyman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Handyman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Handyman_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Handyman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Handyman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Handyman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Handyman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Mechanic_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Mechanic_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Mechanic_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Mechanic_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Mechanic_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Mechanic_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Mechanic_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Mechanic_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Mechanic_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Mechanic_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Mechanic_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Mechanic_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Mechanic_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Mechanic_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Mechanic_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Mechanic_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Mechanic_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Mechanic_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Mechanic_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Mechanic_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Mechanic_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Mechanic_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Mechanic_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Security_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Security_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Security_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Security_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Security_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Security_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Security_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Security_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Security_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Security_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Security_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Security_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Security_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Security_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Security_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Security_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Security_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
-static const uint8 PeepSpriteImage_Security_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Security_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Security_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Security_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Security_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Security_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Security_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Security_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Security_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Security_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Security_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Security_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Security_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Security_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Security_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Security_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Security_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Security_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Security_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Security_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
+static constexpr const uint8 PeepSpriteImage_Security_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Security_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Security_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Security_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerPanda_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPanda_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerPanda_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_03_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerPanda_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerPanda_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPanda_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerPanda_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPanda_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerPanda_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerPanda_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerPanda_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
-static const uint8 PeepSpriteImage_EntertainerPanda_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-static const uint8 PeepSpriteImage_EntertainerPanda_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_30_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPanda_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerPanda_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_03_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_30_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPanda_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerTiger_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerTiger_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerTiger_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_03_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerTiger_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerTiger_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerTiger_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerTiger_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerTiger_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerTiger_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerTiger_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerTiger_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
-static const uint8 PeepSpriteImage_EntertainerTiger_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 25, 25, 25, 25 };
-static const uint8 PeepSpriteImage_EntertainerTiger_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_30_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerTiger_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerTiger_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_03_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 25, 25, 25, 25 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_30_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 4, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerTiger_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerElephant_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerElephant_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerElephant_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerElephant_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerElephant_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerElephant_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerElephant_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerElephant_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerElephant_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerElephant_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerElephant_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7, 8, 9 };
-static const uint8 PeepSpriteImage_EntertainerElephant_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27 };
-static const uint8 PeepSpriteImage_EntertainerElephant_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerElephant_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerElephant_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6, 7, 8, 9 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerElephant_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerRoman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerRoman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerRoman_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerRoman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerRoman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerRoman_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerRoman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerRoman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerRoman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerRoman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerRoman_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerRoman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_26_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 16, 16, 16, 16, 16, 17, 18, 19, 20, 21, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 23, 24, 25, 26, 27, 28, 28, 28, 29, 30, 31, 32, 32, 32, 32, 32, 33, 34, 35, 36, 37, 38 };
-static const uint8 PeepSpriteImage_EntertainerRoman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerRoman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerRoman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_26_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 14, 13, 12, 11, 10, 11, 12, 13, 14, 15, 16, 16, 16, 16, 16, 17, 18, 19, 20, 21, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 23, 24, 25, 26, 27, 28, 28, 28, 29, 30, 31, 32, 32, 32, 32, 32, 33, 34, 35, 36, 37, 38 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerRoman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerGorilla_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_17_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerGorilla_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_17_sequence[] = { 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerGorilla_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerSnowman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7, 8, 9 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerSnowman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7, 8, 9 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 33 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSnowman_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerKnight_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerKnight_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerKnight_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
-static const uint8 PeepSpriteImage_EntertainerKnight_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerKnight_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerKnight_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerKnight_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerKnight_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerKnight_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerKnight_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerKnight_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerKnight_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerKnight_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
-static const uint8 PeepSpriteImage_EntertainerKnight_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
-static const uint8 PeepSpriteImage_EntertainerKnight_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerKnight_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerKnight_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 12, 12, 12, 12, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 23, 23, 23, 23, 23, 24, 25, 26, 27 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerKnight_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerAstronaut_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_03_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_26_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_30_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerAstronaut_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_03_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_26_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_30_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 9, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerAstronaut_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerBandit_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerBandit_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerBandit_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
-static const uint8 PeepSpriteImage_EntertainerBandit_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerBandit_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerBandit_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerBandit_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerBandit_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerBandit_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerBandit_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerBandit_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerBandit_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-static const uint8 PeepSpriteImage_EntertainerBandit_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
-static const uint8 PeepSpriteImage_EntertainerBandit_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
-static const uint8 PeepSpriteImage_EntertainerBandit_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerBandit_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerBandit_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 14, 15, 16, 17, 17, 17, 17, 17, 18, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 21, 20, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerBandit_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerSheriff_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerSheriff_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8, 9, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 10, 11, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerSheriff_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_EntertainerPirate_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPirate_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_EntertainerPirate_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
-static const uint8 PeepSpriteImage_EntertainerPirate_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_EntertainerPirate_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_EntertainerPirate_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPirate_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_EntertainerPirate_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_EntertainerPirate_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_EntertainerPirate_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_EntertainerPirate_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_EntertainerPirate_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-static const uint8 PeepSpriteImage_EntertainerPirate_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
-static const uint8 PeepSpriteImage_EntertainerPirate_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
-static const uint8 PeepSpriteImage_EntertainerPirate_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_EntertainerPirate_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_EntertainerPirate_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_17_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 21, 21, 21, 21, 21, 22, 23, 23, 23, 23, 24, 25, 26, 27, 27, 27, 27, 28, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_EntertainerPirate_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_IceCream_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_IceCream_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_IceCream_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_IceCream_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_IceCream_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_IceCream_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_IceCream_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_IceCream_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_IceCream_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_IceCream_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_IceCream_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_IceCream_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_IceCream_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_IceCream_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_IceCream_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_IceCream_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_IceCream_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_IceCream_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_IceCream_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_IceCream_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_IceCream_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_IceCream_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_IceCream_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_IceCream_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_IceCream_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_IceCream_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_IceCream_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_IceCream_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_IceCream_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_IceCream_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_IceCream_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_IceCream_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_IceCream_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_IceCream_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_IceCream_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_IceCream_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_IceCream_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_IceCream_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_IceCream_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_IceCream_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Chips_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Chips_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Chips_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Chips_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chips_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Chips_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Chips_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Chips_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Chips_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chips_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Chips_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Chips_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chips_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Chips_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Chips_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Chips_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Chips_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Chips_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Chips_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Chips_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Chips_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chips_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Chips_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Chips_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Chips_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Chips_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chips_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Chips_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Chips_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Chips_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chips_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chips_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Chips_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Chips_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Chips_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Chips_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Chips_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Chips_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chips_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Chips_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Burger_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Burger_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Burger_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Burger_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Burger_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Burger_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Burger_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Burger_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Burger_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Burger_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Burger_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Burger_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Burger_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Burger_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Burger_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Burger_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Burger_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Burger_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Burger_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Burger_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Burger_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Burger_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Burger_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Burger_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Burger_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Burger_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Burger_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Burger_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Burger_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Burger_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Burger_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Burger_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Burger_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Burger_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Burger_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Burger_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Burger_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Burger_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Burger_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Burger_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Drink_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Drink_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Drink_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Drink_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Drink_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Drink_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Drink_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Drink_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Drink_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Drink_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Drink_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Drink_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Drink_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Drink_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Drink_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Drink_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Drink_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Drink_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Drink_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Drink_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Drink_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Drink_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Drink_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Drink_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Drink_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Drink_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Drink_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Drink_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Drink_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Drink_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Drink_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Drink_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Drink_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Drink_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Drink_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Drink_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Drink_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Drink_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Drink_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Drink_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Balloon_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Balloon_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Balloon_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Balloon_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Balloon_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Balloon_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Balloon_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Balloon_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Balloon_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Balloon_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Balloon_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Balloon_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Balloon_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Balloon_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Balloon_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Balloon_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Balloon_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Balloon_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Balloon_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Balloon_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Balloon_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Balloon_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Balloon_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Balloon_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Balloon_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Balloon_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Balloon_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Balloon_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Balloon_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Balloon_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Balloon_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Balloon_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Balloon_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Balloon_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Balloon_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Balloon_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Balloon_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Balloon_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Candyfloss_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Candyfloss_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Candyfloss_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Candyfloss_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Candyfloss_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Candyfloss_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Candyfloss_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Candyfloss_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Candyfloss_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Candyfloss_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Candyfloss_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Candyfloss_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Candyfloss_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Candyfloss_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Candyfloss_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Candyfloss_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Candyfloss_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Candyfloss_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Candyfloss_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Candyfloss_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Umbrella_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Umbrella_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Umbrella_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Umbrella_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Umbrella_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Umbrella_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Umbrella_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Umbrella_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Umbrella_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Umbrella_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Umbrella_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Umbrella_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Umbrella_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Umbrella_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Umbrella_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Umbrella_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Umbrella_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Umbrella_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_24_sequence[] = {  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Umbrella_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Umbrella_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Umbrella_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Umbrella_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_24_sequence[] = {  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Umbrella_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Pizza_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Pizza_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Pizza_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Pizza_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pizza_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Pizza_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Pizza_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pizza_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Pizza_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pizza_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Pizza_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Pizza_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Pizza_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pizza_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Pizza_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Pizza_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Pizza_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Pizza_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Pizza_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Pizza_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Pizza_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pizza_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Pizza_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Pizza_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Pizza_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Pizza_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pizza_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Pizza_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Pizza_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pizza_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pizza_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Pizza_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pizza_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Pizza_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Pizza_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Pizza_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Pizza_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Pizza_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pizza_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Pizza_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_SecurityAlt_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_SecurityAlt_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_SecurityAlt_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_SecurityAlt_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_SecurityAlt_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_SecurityAlt_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_SecurityAlt_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_SecurityAlt_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_SecurityAlt_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_SecurityAlt_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_SecurityAlt_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_SecurityAlt_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
-static const uint8 PeepSpriteImage_SecurityAlt_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_SecurityAlt_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SecurityAlt_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_SecurityAlt_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_17_sequence[] = { 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1, 0, 4, 5, 6 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_SecurityAlt_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Popcorn_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Popcorn_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Popcorn_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Popcorn_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Popcorn_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Popcorn_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Popcorn_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Popcorn_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Popcorn_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Popcorn_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Popcorn_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Popcorn_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Popcorn_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Popcorn_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Popcorn_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Popcorn_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Popcorn_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Popcorn_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Popcorn_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Popcorn_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Popcorn_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Popcorn_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Popcorn_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Popcorn_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_ArmsCrossed_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ArmsCrossed_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_ArmsCrossed_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_ArmsCrossed_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_ArmsCrossed_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_ArmsCrossed_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ArmsCrossed_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_ArmsCrossed_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ArmsCrossed_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_ArmsCrossed_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_ArmsCrossed_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_ArmsCrossed_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_ArmsCrossed_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_ArmsCrossed_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ArmsCrossed_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_ArmsCrossed_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_ArmsCrossed_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_HeadDown_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_HeadDown_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_HeadDown_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_HeadDown_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_HeadDown_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_HeadDown_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_HeadDown_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_HeadDown_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_HeadDown_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_HeadDown_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_HeadDown_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_HeadDown_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_HeadDown_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_HeadDown_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_HeadDown_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_HeadDown_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_HeadDown_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_HeadDown_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_HeadDown_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_HeadDown_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HeadDown_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_HeadDown_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_HeadDown_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Nauseous_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Nauseous_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Nauseous_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Nauseous_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Nauseous_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Nauseous_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Nauseous_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Nauseous_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Nauseous_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Nauseous_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Nauseous_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Nauseous_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Nauseous_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Nauseous_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Nauseous_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Nauseous_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Nauseous_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Nauseous_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Nauseous_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Nauseous_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Nauseous_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Nauseous_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Nauseous_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_VeryNauseous_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_VeryNauseous_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_VeryNauseous_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_VeryNauseous_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_VeryNauseous_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_VeryNauseous_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_VeryNauseous_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_VeryNauseous_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_VeryNauseous_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_VeryNauseous_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_VeryNauseous_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_VeryNauseous_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_VeryNauseous_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_VeryNauseous_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_VeryNauseous_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_VeryNauseous_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_VeryNauseous_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_RequireBathroom_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_RequireBathroom_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_RequireBathroom_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_RequireBathroom_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_RequireBathroom_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_RequireBathroom_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_RequireBathroom_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_RequireBathroom_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_RequireBathroom_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_RequireBathroom_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_RequireBathroom_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_RequireBathroom_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_RequireBathroom_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_RequireBathroom_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_RequireBathroom_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_RequireBathroom_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_RequireBathroom_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Hat_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Hat_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Hat_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Hat_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Hat_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Hat_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Hat_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Hat_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Hat_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Hat_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Hat_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Hat_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Hat_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Hat_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Hat_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Hat_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Hat_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Hat_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Hat_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Hat_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Hat_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Hat_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Hat_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Hat_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Hat_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Hat_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Hat_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Hat_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Hat_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Hat_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Hat_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Hat_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Hat_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Hat_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Hat_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Hat_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Hat_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Hat_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_HotDog_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_HotDog_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_HotDog_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_HotDog_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_HotDog_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_HotDog_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_HotDog_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_HotDog_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_HotDog_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_HotDog_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_HotDog_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_HotDog_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_HotDog_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_HotDog_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_HotDog_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_HotDog_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_HotDog_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_HotDog_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_HotDog_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_HotDog_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_HotDog_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_HotDog_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_HotDog_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_HotDog_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_HotDog_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_HotDog_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_HotDog_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_HotDog_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_HotDog_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_HotDog_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_HotDog_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_HotDog_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_HotDog_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_HotDog_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_HotDog_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_HotDog_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_HotDog_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_HotDog_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_HotDog_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_HotDog_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Tentacle_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29 };
-static const uint8 PeepSpriteImage_Tentacle_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Tentacle_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Tentacle_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
-static const uint8 PeepSpriteImage_Tentacle_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Tentacle_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Tentacle_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Tentacle_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Tentacle_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
-static const uint8 PeepSpriteImage_Tentacle_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Tentacle_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Tentacle_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Tentacle_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Tentacle_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Tentacle_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Tentacle_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Tentacle_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Tentacle_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Tentacle_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Tentacle_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Tentacle_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Tentacle_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Tentacle_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Tentacle_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_ToffeeApple_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_ToffeeApple_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_ToffeeApple_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ToffeeApple_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_ToffeeApple_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_ToffeeApple_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ToffeeApple_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ToffeeApple_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_ToffeeApple_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_ToffeeApple_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_ToffeeApple_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_ToffeeApple_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_ToffeeApple_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_ToffeeApple_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_ToffeeApple_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_ToffeeApple_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_ToffeeApple_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_03_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_08_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_ToffeeApple_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Donut_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Donut_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Donut_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Donut_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Donut_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Donut_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Donut_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Donut_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Donut_08_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Donut_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Donut_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Donut_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Donut_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Donut_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Donut_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Donut_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Donut_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Donut_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Donut_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Donut_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Donut_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Donut_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Donut_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Donut_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Donut_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Donut_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Donut_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Donut_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Donut_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Donut_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_08_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Donut_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Donut_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Donut_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Donut_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Donut_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Donut_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Donut_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Donut_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Donut_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Donut_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Coffee_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Coffee_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Coffee_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Coffee_03_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 2, 1 };
-static const uint8 PeepSpriteImage_Coffee_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Coffee_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Coffee_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Coffee_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Coffee_08_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 2, 1 };
-static const uint8 PeepSpriteImage_Coffee_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Coffee_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Coffee_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Coffee_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Coffee_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Coffee_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Coffee_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Coffee_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Coffee_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Coffee_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Coffee_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Coffee_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Coffee_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Coffee_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Coffee_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Coffee_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Coffee_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_03_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 2, 1 };
+static constexpr const uint8 PeepSpriteImage_Coffee_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Coffee_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Coffee_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Coffee_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_08_sequence[] = { 0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 2, 1 };
+static constexpr const uint8 PeepSpriteImage_Coffee_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Coffee_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Coffee_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Coffee_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Coffee_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Coffee_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Coffee_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Coffee_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Coffee_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Coffee_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Chicken_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Chicken_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Chicken_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Chicken_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chicken_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Chicken_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Chicken_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Chicken_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Chicken_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chicken_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Chicken_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Chicken_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Chicken_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Chicken_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Chicken_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Chicken_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Chicken_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Chicken_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Chicken_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Chicken_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Chicken_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Chicken_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Chicken_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Chicken_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Chicken_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Chicken_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chicken_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Chicken_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Chicken_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Chicken_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chicken_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Chicken_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Chicken_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Chicken_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Chicken_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Chicken_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Chicken_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Chicken_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Chicken_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Chicken_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Lemonade_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Lemonade_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Lemonade_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Lemonade_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Lemonade_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Lemonade_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Lemonade_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Lemonade_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Lemonade_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Lemonade_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Lemonade_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Lemonade_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Lemonade_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Lemonade_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Lemonade_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Lemonade_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Lemonade_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Lemonade_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Lemonade_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Lemonade_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Lemonade_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Lemonade_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Lemonade_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Lemonade_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Watching_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Watching_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Watching_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Watching_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Watching_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Watching_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Watching_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Watching_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Watching_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Watching_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Watching_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Watching_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Watching_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Watching_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Watching_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Watching_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Watching_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Watching_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Watching_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Watching_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Watching_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Watching_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Watching_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Watching_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Watching_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Watching_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Watching_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Watching_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Watching_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Watching_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Watching_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Watching_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Watching_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Watching_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Watching_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Watching_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Watching_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Watching_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Pretzel_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Pretzel_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Pretzel_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Pretzel_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Pretzel_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Pretzel_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Pretzel_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pretzel_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Pretzel_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Pretzel_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Pretzel_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Pretzel_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Pretzel_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Pretzel_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Pretzel_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Pretzel_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Pretzel_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Pretzel_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Pretzel_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Pretzel_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Pretzel_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Pretzel_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Pretzel_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Pretzel_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Sunglasses_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sunglasses_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Sunglasses_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sunglasses_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
-static const uint8 PeepSpriteImage_Sunglasses_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Sunglasses_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Sunglasses_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sunglasses_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sunglasses_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sunglasses_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sunglasses_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Sunglasses_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Sunglasses_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Sunglasses_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Sunglasses_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Sunglasses_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sunglasses_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Sunglasses_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_00_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_08_sequence[] = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Sunglasses_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_SuJongkwa_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_SuJongkwa_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_SuJongkwa_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_SuJongkwa_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_SuJongkwa_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_SuJongkwa_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_SuJongkwa_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_SuJongkwa_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_SuJongkwa_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_SuJongkwa_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_SuJongkwa_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_SuJongkwa_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_SuJongkwa_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_SuJongkwa_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_SuJongkwa_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_SuJongkwa_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_SuJongkwa_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_SuJongkwa_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Juice_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Juice_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Juice_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Juice_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Juice_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Juice_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Juice_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Juice_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Juice_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Juice_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Juice_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Juice_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Juice_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Juice_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Juice_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Juice_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Juice_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Juice_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Juice_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Juice_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Juice_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Juice_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Juice_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Juice_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Juice_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Juice_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Juice_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Juice_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Juice_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Juice_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Juice_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Juice_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Juice_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Juice_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Juice_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Juice_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Juice_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Juice_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Juice_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Juice_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_FunnelCake_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_FunnelCake_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_FunnelCake_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_FunnelCake_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_FunnelCake_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_FunnelCake_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_FunnelCake_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_FunnelCake_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_FunnelCake_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_FunnelCake_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_FunnelCake_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_FunnelCake_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_FunnelCake_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_FunnelCake_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_FunnelCake_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_FunnelCake_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_FunnelCake_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_FunnelCake_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_FunnelCake_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_FunnelCake_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Noodles_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Noodles_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Noodles_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Noodles_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Noodles_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Noodles_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Noodles_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Noodles_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Noodles_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Noodles_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Noodles_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Noodles_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Noodles_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Noodles_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Noodles_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Noodles_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Noodles_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Noodles_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Noodles_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Noodles_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Noodles_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Noodles_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Noodles_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Noodles_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Noodles_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Noodles_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Noodles_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Noodles_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Noodles_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Noodles_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Noodles_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Noodles_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Noodles_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Noodles_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Noodles_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Noodles_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Noodles_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Noodles_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Noodles_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Noodles_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Sausage_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Sausage_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Sausage_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sausage_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sausage_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Sausage_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Sausage_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sausage_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sausage_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sausage_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sausage_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sausage_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sausage_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sausage_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Sausage_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Sausage_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Sausage_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Sausage_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Sausage_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Sausage_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Sausage_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sausage_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Sausage_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Sausage_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Sausage_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Sausage_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sausage_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Sausage_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Sausage_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sausage_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sausage_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sausage_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sausage_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Sausage_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Sausage_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Sausage_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Sausage_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Sausage_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sausage_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Sausage_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Soup_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Soup_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Soup_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Soup_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Soup_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Soup_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Soup_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Soup_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Soup_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Soup_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Soup_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Soup_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Soup_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Soup_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Soup_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Soup_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Soup_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Soup_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Soup_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Soup_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Soup_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Soup_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Soup_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Soup_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Soup_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Soup_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Soup_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Soup_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Soup_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Soup_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Soup_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Soup_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Soup_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Soup_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Soup_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Soup_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Soup_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Soup_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Soup_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Soup_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
-static const uint8 PeepSpriteImage_Sandwich_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-static const uint8 PeepSpriteImage_Sandwich_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
-static const uint8 PeepSpriteImage_Sandwich_02_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sandwich_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sandwich_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
-static const uint8 PeepSpriteImage_Sandwich_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
-static const uint8 PeepSpriteImage_Sandwich_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sandwich_07_sequence[] = { 0 };
-static const uint8 PeepSpriteImage_Sandwich_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sandwich_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sandwich_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
-static const uint8 PeepSpriteImage_Sandwich_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-static const uint8 PeepSpriteImage_Sandwich_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
-static const uint8 PeepSpriteImage_Sandwich_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
-static const uint8 PeepSpriteImage_Sandwich_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
-static const uint8 PeepSpriteImage_Sandwich_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
-static const uint8 PeepSpriteImage_Sandwich_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
-static const uint8 PeepSpriteImage_Sandwich_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
-static const uint8 PeepSpriteImage_Sandwich_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
-static const uint8 PeepSpriteImage_Sandwich_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-static const uint8 PeepSpriteImage_Sandwich_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
-static const uint8 PeepSpriteImage_Sandwich_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
-static const uint8 PeepSpriteImage_Sandwich_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_00_sequence[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_01_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_02_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_03_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_04_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_05_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_06_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_07_sequence[] = { 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_08_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_09_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_10_sequence[] = { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_11_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_12_sequence[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_13_sequence[] = { 0, 1, 2, 3, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_14_sequence[] = { 8, 8, 9, 9, 10, 10, 9, 9, 8, 8, 11, 12, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 8, 8, 9, 9, 8, 8 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_15_sequence[] = { 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_16_sequence[] = { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_17_sequence[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0, 5, 6, 7 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_18_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 17, 18, 18, 18, 18, 18, 18, 18, 17, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 15, 16, 15, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_19_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 16, 15, 14, 14, 14, 14, 14, 14, 19, 20, 20, 20, 19, 14, 14, 14, 14, 14, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_20_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 9, 8, 14, 15, 15, 15, 16, 17, 17, 17, 14, 11, 12, 13, 12, 13, 12, 11, 9, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_21_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_22_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 21, 22, 21, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 29, 30, 31, 32, 31, 30, 31, 32, 31, 30, 31, 32, 31, 30, 29, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_23_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 16, 17, 18, 19, 18, 17, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_24_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 11, 12, 13, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 15, 16, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 18, 19, 20, 21, 22, 21, 20, 21, 22, 21, 20, 21, 22, 20, 19, 18, 0, 0, 23, 24, 25, 26, 27, 28, 28, 26, 24, 0, 0, 0, 0, 0, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_25_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_26_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_27_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 11, 12, 11, 10, 10, 10, 13, 14, 14, 14, 13, 10, 10, 10, 11, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_28_sequence[] = { 0, 1, 2, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 3, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_29_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_30_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 5, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_31_sequence[] = { 0, 1, 2, 3, 4, 5, 5, 5, 5, 6, 7, 6, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_32_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_33_sequence[] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_34_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 8, 9, 10, 11, 12, 13, 8, 9, 10, 11, 12, 13, 7, 6, 5, 4, 3, 2, 1, 0 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_35_sequence[] = { 0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4 };
+static constexpr const uint8 PeepSpriteImage_Sandwich_36_sequence[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10, 11, 12, 11, 12, 11, 12, 11, 12, 11, 11, 11, 11, 11, 13, 14, 15 };
 
 
-static const rct_peep_animation PeepSpriteImage_Normal[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Normal[] = {
     { 6409,  Util::CountOf(PeepSpriteImage_Normal_00_sequence), PeepSpriteImage_Normal_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Normal_01_sequence), PeepSpriteImage_Normal_01_sequence },
     { 6621,  Util::CountOf(PeepSpriteImage_Normal_02_sequence), PeepSpriteImage_Normal_02_sequence },
@@ -1883,7 +1883,7 @@ static const rct_peep_animation PeepSpriteImage_Normal[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Normal_36_sequence), PeepSpriteImage_Normal_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Handyman[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Handyman[] = {
     { 11261, Util::CountOf(PeepSpriteImage_Handyman_00_sequence), PeepSpriteImage_Handyman_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Handyman_01_sequence), PeepSpriteImage_Handyman_01_sequence },
     { 11285, Util::CountOf(PeepSpriteImage_Handyman_02_sequence), PeepSpriteImage_Handyman_02_sequence },
@@ -1923,7 +1923,7 @@ static const rct_peep_animation PeepSpriteImage_Handyman[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Handyman_36_sequence), PeepSpriteImage_Handyman_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Mechanic[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Mechanic[] = {
     { 11441, Util::CountOf(PeepSpriteImage_Mechanic_00_sequence), PeepSpriteImage_Mechanic_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Mechanic_01_sequence), PeepSpriteImage_Mechanic_01_sequence },
     { 11465, Util::CountOf(PeepSpriteImage_Mechanic_02_sequence), PeepSpriteImage_Mechanic_02_sequence },
@@ -1963,7 +1963,7 @@ static const rct_peep_animation PeepSpriteImage_Mechanic[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Mechanic_36_sequence), PeepSpriteImage_Mechanic_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Security[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Security[] = {
     { 11881, Util::CountOf(PeepSpriteImage_Security_00_sequence), PeepSpriteImage_Security_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Security_01_sequence), PeepSpriteImage_Security_01_sequence },
     { 11905, Util::CountOf(PeepSpriteImage_Security_02_sequence), PeepSpriteImage_Security_02_sequence },
@@ -2003,7 +2003,7 @@ static const rct_peep_animation PeepSpriteImage_Security[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Security_36_sequence), PeepSpriteImage_Security_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerPanda[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerPanda[] = {
     { 11973, Util::CountOf(PeepSpriteImage_EntertainerPanda_00_sequence), PeepSpriteImage_EntertainerPanda_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerPanda_01_sequence), PeepSpriteImage_EntertainerPanda_01_sequence },
     { 11997, Util::CountOf(PeepSpriteImage_EntertainerPanda_02_sequence), PeepSpriteImage_EntertainerPanda_02_sequence },
@@ -2043,7 +2043,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerPanda[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerPanda_36_sequence), PeepSpriteImage_EntertainerPanda_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerTiger[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerTiger[] = {
     { 12129, Util::CountOf(PeepSpriteImage_EntertainerTiger_00_sequence), PeepSpriteImage_EntertainerTiger_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerTiger_01_sequence), PeepSpriteImage_EntertainerTiger_01_sequence },
     { 12153, Util::CountOf(PeepSpriteImage_EntertainerTiger_02_sequence), PeepSpriteImage_EntertainerTiger_02_sequence },
@@ -2083,7 +2083,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerTiger[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerTiger_36_sequence), PeepSpriteImage_EntertainerTiger_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerElephant[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerElephant[] = {
     { 12325, Util::CountOf(PeepSpriteImage_EntertainerElephant_00_sequence), PeepSpriteImage_EntertainerElephant_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerElephant_01_sequence), PeepSpriteImage_EntertainerElephant_01_sequence },
     { 12349, Util::CountOf(PeepSpriteImage_EntertainerElephant_02_sequence), PeepSpriteImage_EntertainerElephant_02_sequence },
@@ -2123,7 +2123,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerElephant[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerElephant_36_sequence), PeepSpriteImage_EntertainerElephant_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerRoman[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerRoman[] = {
     { 13897, Util::CountOf(PeepSpriteImage_EntertainerRoman_00_sequence), PeepSpriteImage_EntertainerRoman_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerRoman_01_sequence), PeepSpriteImage_EntertainerRoman_01_sequence },
     { 13921, Util::CountOf(PeepSpriteImage_EntertainerRoman_02_sequence), PeepSpriteImage_EntertainerRoman_02_sequence },
@@ -2163,7 +2163,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerRoman[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerRoman_36_sequence), PeepSpriteImage_EntertainerRoman_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerGorilla[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerGorilla[] = {
     { 12549, Util::CountOf(PeepSpriteImage_EntertainerGorilla_00_sequence), PeepSpriteImage_EntertainerGorilla_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerGorilla_01_sequence), PeepSpriteImage_EntertainerGorilla_01_sequence },
     { 12545, Util::CountOf(PeepSpriteImage_EntertainerGorilla_02_sequence), PeepSpriteImage_EntertainerGorilla_02_sequence },
@@ -2203,7 +2203,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerGorilla[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerGorilla_36_sequence), PeepSpriteImage_EntertainerGorilla_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerSnowman[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerSnowman[] = {
     { 12681, Util::CountOf(PeepSpriteImage_EntertainerSnowman_00_sequence), PeepSpriteImage_EntertainerSnowman_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerSnowman_01_sequence), PeepSpriteImage_EntertainerSnowman_01_sequence },
     { 12677, Util::CountOf(PeepSpriteImage_EntertainerSnowman_02_sequence), PeepSpriteImage_EntertainerSnowman_02_sequence },
@@ -2243,7 +2243,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerSnowman[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerSnowman_36_sequence), PeepSpriteImage_EntertainerSnowman_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerKnight[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerKnight[] = {
     { 12897, Util::CountOf(PeepSpriteImage_EntertainerKnight_00_sequence), PeepSpriteImage_EntertainerKnight_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerKnight_01_sequence), PeepSpriteImage_EntertainerKnight_01_sequence },
     { 12893, Util::CountOf(PeepSpriteImage_EntertainerKnight_02_sequence), PeepSpriteImage_EntertainerKnight_02_sequence },
@@ -2283,7 +2283,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerKnight[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerKnight_36_sequence), PeepSpriteImage_EntertainerKnight_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerAstronaut[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerAstronaut[] = {
     { 13769, Util::CountOf(PeepSpriteImage_EntertainerAstronaut_00_sequence), PeepSpriteImage_EntertainerAstronaut_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerAstronaut_01_sequence), PeepSpriteImage_EntertainerAstronaut_01_sequence },
     { 13765, Util::CountOf(PeepSpriteImage_EntertainerAstronaut_02_sequence), PeepSpriteImage_EntertainerAstronaut_02_sequence },
@@ -2323,7 +2323,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerAstronaut[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerAstronaut_36_sequence), PeepSpriteImage_EntertainerAstronaut_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerBandit[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerBandit[] = {
     { 13109, Util::CountOf(PeepSpriteImage_EntertainerBandit_00_sequence), PeepSpriteImage_EntertainerBandit_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerBandit_01_sequence), PeepSpriteImage_EntertainerBandit_01_sequence },
     { 13105, Util::CountOf(PeepSpriteImage_EntertainerBandit_02_sequence), PeepSpriteImage_EntertainerBandit_02_sequence },
@@ -2363,7 +2363,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerBandit[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerBandit_36_sequence), PeepSpriteImage_EntertainerBandit_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerSheriff[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerSheriff[] = {
     { 13613, Util::CountOf(PeepSpriteImage_EntertainerSheriff_00_sequence), PeepSpriteImage_EntertainerSheriff_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerSheriff_01_sequence), PeepSpriteImage_EntertainerSheriff_01_sequence },
     { 13609, Util::CountOf(PeepSpriteImage_EntertainerSheriff_02_sequence), PeepSpriteImage_EntertainerSheriff_02_sequence },
@@ -2403,7 +2403,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerSheriff[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerSheriff_36_sequence), PeepSpriteImage_EntertainerSheriff_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_EntertainerPirate[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_EntertainerPirate[] = {
     { 13381, Util::CountOf(PeepSpriteImage_EntertainerPirate_00_sequence), PeepSpriteImage_EntertainerPirate_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_EntertainerPirate_01_sequence), PeepSpriteImage_EntertainerPirate_01_sequence },
     { 13377, Util::CountOf(PeepSpriteImage_EntertainerPirate_02_sequence), PeepSpriteImage_EntertainerPirate_02_sequence },
@@ -2443,7 +2443,7 @@ static const rct_peep_animation PeepSpriteImage_EntertainerPirate[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_EntertainerPirate_36_sequence), PeepSpriteImage_EntertainerPirate_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_IceCream[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_IceCream[] = {
     { 7505,  Util::CountOf(PeepSpriteImage_IceCream_00_sequence), PeepSpriteImage_IceCream_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_IceCream_01_sequence), PeepSpriteImage_IceCream_01_sequence },
     { 7501,  Util::CountOf(PeepSpriteImage_IceCream_02_sequence), PeepSpriteImage_IceCream_02_sequence },
@@ -2483,7 +2483,7 @@ static const rct_peep_animation PeepSpriteImage_IceCream[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_IceCream_36_sequence), PeepSpriteImage_IceCream_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Chips[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Chips[] = {
     { 7609,  Util::CountOf(PeepSpriteImage_Chips_00_sequence), PeepSpriteImage_Chips_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Chips_01_sequence), PeepSpriteImage_Chips_01_sequence },
     { 7605,  Util::CountOf(PeepSpriteImage_Chips_02_sequence), PeepSpriteImage_Chips_02_sequence },
@@ -2523,7 +2523,7 @@ static const rct_peep_animation PeepSpriteImage_Chips[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Chips_36_sequence), PeepSpriteImage_Chips_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Burger[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Burger[] = {
     { 8385,  Util::CountOf(PeepSpriteImage_Burger_00_sequence), PeepSpriteImage_Burger_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Burger_01_sequence), PeepSpriteImage_Burger_01_sequence },
     { 8381,  Util::CountOf(PeepSpriteImage_Burger_02_sequence), PeepSpriteImage_Burger_02_sequence },
@@ -2563,7 +2563,7 @@ static const rct_peep_animation PeepSpriteImage_Burger[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Burger_36_sequence), PeepSpriteImage_Burger_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Drink[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Drink[] = {
     { 8713,  Util::CountOf(PeepSpriteImage_Drink_00_sequence), PeepSpriteImage_Drink_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Drink_01_sequence), PeepSpriteImage_Drink_01_sequence },
     { 8709,  Util::CountOf(PeepSpriteImage_Drink_02_sequence), PeepSpriteImage_Drink_02_sequence },
@@ -2603,7 +2603,7 @@ static const rct_peep_animation PeepSpriteImage_Drink[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Drink_36_sequence), PeepSpriteImage_Drink_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Balloon[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Balloon[] = {
     { 10785, Util::CountOf(PeepSpriteImage_Balloon_00_sequence), PeepSpriteImage_Balloon_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Balloon_01_sequence), PeepSpriteImage_Balloon_01_sequence },
     { 10781, Util::CountOf(PeepSpriteImage_Balloon_02_sequence), PeepSpriteImage_Balloon_02_sequence },
@@ -2643,7 +2643,7 @@ static const rct_peep_animation PeepSpriteImage_Balloon[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Balloon_36_sequence), PeepSpriteImage_Balloon_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Candyfloss[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Candyfloss[] = {
     { 10849, Util::CountOf(PeepSpriteImage_Candyfloss_00_sequence), PeepSpriteImage_Candyfloss_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Candyfloss_01_sequence), PeepSpriteImage_Candyfloss_01_sequence },
     { 10845, Util::CountOf(PeepSpriteImage_Candyfloss_02_sequence), PeepSpriteImage_Candyfloss_02_sequence },
@@ -2683,7 +2683,7 @@ static const rct_peep_animation PeepSpriteImage_Candyfloss[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Candyfloss_36_sequence), PeepSpriteImage_Candyfloss_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Umbrella[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Umbrella[] = {
     { 11197, Util::CountOf(PeepSpriteImage_Umbrella_00_sequence), PeepSpriteImage_Umbrella_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Umbrella_01_sequence), PeepSpriteImage_Umbrella_01_sequence },
     { 11221, Util::CountOf(PeepSpriteImage_Umbrella_02_sequence), PeepSpriteImage_Umbrella_02_sequence },
@@ -2723,7 +2723,7 @@ static const rct_peep_animation PeepSpriteImage_Umbrella[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Umbrella_36_sequence), PeepSpriteImage_Umbrella_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Pizza[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Pizza[] = {
     { 7785,  Util::CountOf(PeepSpriteImage_Pizza_00_sequence), PeepSpriteImage_Pizza_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Pizza_01_sequence), PeepSpriteImage_Pizza_01_sequence },
     { 7781,  Util::CountOf(PeepSpriteImage_Pizza_02_sequence), PeepSpriteImage_Pizza_02_sequence },
@@ -2763,7 +2763,7 @@ static const rct_peep_animation PeepSpriteImage_Pizza[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Pizza_36_sequence), PeepSpriteImage_Pizza_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_SecurityAlt[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_SecurityAlt[] = {
     { 11949, Util::CountOf(PeepSpriteImage_SecurityAlt_00_sequence),PeepSpriteImage_SecurityAlt_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_SecurityAlt_01_sequence),PeepSpriteImage_SecurityAlt_01_sequence },
     { 11905, Util::CountOf(PeepSpriteImage_SecurityAlt_02_sequence),PeepSpriteImage_SecurityAlt_02_sequence },
@@ -2803,7 +2803,7 @@ static const rct_peep_animation PeepSpriteImage_SecurityAlt[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_SecurityAlt_36_sequence),PeepSpriteImage_SecurityAlt_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Popcorn[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Popcorn[] = {
     { 11025, Util::CountOf(PeepSpriteImage_Popcorn_00_sequence), PeepSpriteImage_Popcorn_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Popcorn_01_sequence), PeepSpriteImage_Popcorn_01_sequence },
     { 11021, Util::CountOf(PeepSpriteImage_Popcorn_02_sequence), PeepSpriteImage_Popcorn_02_sequence },
@@ -2843,7 +2843,7 @@ static const rct_peep_animation PeepSpriteImage_Popcorn[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Popcorn_36_sequence), PeepSpriteImage_Popcorn_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_ArmsCrossed[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_ArmsCrossed[] = {
     { 6433,  Util::CountOf(PeepSpriteImage_ArmsCrossed_00_sequence), PeepSpriteImage_ArmsCrossed_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_ArmsCrossed_01_sequence), PeepSpriteImage_ArmsCrossed_01_sequence },
     { 6621,  Util::CountOf(PeepSpriteImage_ArmsCrossed_02_sequence), PeepSpriteImage_ArmsCrossed_02_sequence },
@@ -2883,7 +2883,7 @@ static const rct_peep_animation PeepSpriteImage_ArmsCrossed[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_ArmsCrossed_36_sequence), PeepSpriteImage_ArmsCrossed_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_HeadDown[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_HeadDown[] = {
     { 6457,  Util::CountOf(PeepSpriteImage_HeadDown_00_sequence), PeepSpriteImage_HeadDown_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_HeadDown_01_sequence), PeepSpriteImage_HeadDown_01_sequence },
     { 6621,  Util::CountOf(PeepSpriteImage_HeadDown_02_sequence), PeepSpriteImage_HeadDown_02_sequence },
@@ -2923,7 +2923,7 @@ static const rct_peep_animation PeepSpriteImage_HeadDown[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_HeadDown_36_sequence), PeepSpriteImage_HeadDown_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Nauseous[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Nauseous[] = {
     { 6481,  Util::CountOf(PeepSpriteImage_Nauseous_00_sequence), PeepSpriteImage_Nauseous_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Nauseous_01_sequence), PeepSpriteImage_Nauseous_01_sequence },
     { 6621,  Util::CountOf(PeepSpriteImage_Nauseous_02_sequence), PeepSpriteImage_Nauseous_02_sequence },
@@ -2963,7 +2963,7 @@ static const rct_peep_animation PeepSpriteImage_Nauseous[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Nauseous_36_sequence), PeepSpriteImage_Nauseous_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_VeryNauseous[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_VeryNauseous[] = {
     { 6505,  Util::CountOf(PeepSpriteImage_VeryNauseous_00_sequence), PeepSpriteImage_VeryNauseous_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_VeryNauseous_01_sequence), PeepSpriteImage_VeryNauseous_01_sequence },
     { 6529,  Util::CountOf(PeepSpriteImage_VeryNauseous_02_sequence), PeepSpriteImage_VeryNauseous_02_sequence },
@@ -3003,7 +3003,7 @@ static const rct_peep_animation PeepSpriteImage_VeryNauseous[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_VeryNauseous_36_sequence), PeepSpriteImage_VeryNauseous_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_RequireBathroom[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_RequireBathroom[] = {
     { 6537,  Util::CountOf(PeepSpriteImage_RequireBathroom_00_sequence), PeepSpriteImage_RequireBathroom_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_RequireBathroom_01_sequence), PeepSpriteImage_RequireBathroom_01_sequence },
     { 6621,  Util::CountOf(PeepSpriteImage_RequireBathroom_02_sequence), PeepSpriteImage_RequireBathroom_02_sequence },
@@ -3043,7 +3043,7 @@ static const rct_peep_animation PeepSpriteImage_RequireBathroom[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_RequireBathroom_36_sequence), PeepSpriteImage_RequireBathroom_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Hat[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Hat[] = {
     { 10721, Util::CountOf(PeepSpriteImage_Hat_00_sequence), PeepSpriteImage_Hat_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Hat_01_sequence), PeepSpriteImage_Hat_01_sequence },
     { 10717, Util::CountOf(PeepSpriteImage_Hat_02_sequence), PeepSpriteImage_Hat_02_sequence },
@@ -3083,7 +3083,7 @@ static const rct_peep_animation PeepSpriteImage_Hat[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Hat_36_sequence), PeepSpriteImage_Hat_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_HotDog[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_HotDog[] = {
     { 7889,  Util::CountOf(PeepSpriteImage_HotDog_00_sequence), PeepSpriteImage_HotDog_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_HotDog_01_sequence), PeepSpriteImage_HotDog_01_sequence },
     { 7885,  Util::CountOf(PeepSpriteImage_HotDog_02_sequence), PeepSpriteImage_HotDog_02_sequence },
@@ -3123,7 +3123,7 @@ static const rct_peep_animation PeepSpriteImage_HotDog[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_HotDog_36_sequence), PeepSpriteImage_HotDog_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Tentacle[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Tentacle[] = {
     { 8065,  Util::CountOf(PeepSpriteImage_Tentacle_00_sequence), PeepSpriteImage_Tentacle_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Tentacle_01_sequence), PeepSpriteImage_Tentacle_01_sequence },
     { 8061,  Util::CountOf(PeepSpriteImage_Tentacle_02_sequence), PeepSpriteImage_Tentacle_02_sequence },
@@ -3163,7 +3163,7 @@ static const rct_peep_animation PeepSpriteImage_Tentacle[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Tentacle_36_sequence), PeepSpriteImage_Tentacle_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_ToffeeApple[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_ToffeeApple[] = {
     { 7401,  Util::CountOf(PeepSpriteImage_ToffeeApple_00_sequence), PeepSpriteImage_ToffeeApple_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_ToffeeApple_01_sequence), PeepSpriteImage_ToffeeApple_01_sequence },
     { 7397,  Util::CountOf(PeepSpriteImage_ToffeeApple_02_sequence), PeepSpriteImage_ToffeeApple_02_sequence },
@@ -3203,7 +3203,7 @@ static const rct_peep_animation PeepSpriteImage_ToffeeApple[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_ToffeeApple_36_sequence), PeepSpriteImage_ToffeeApple_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Donut[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Donut[] = {
     { 8561,  Util::CountOf(PeepSpriteImage_Donut_00_sequence), PeepSpriteImage_Donut_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Donut_01_sequence), PeepSpriteImage_Donut_01_sequence },
     { 8557,  Util::CountOf(PeepSpriteImage_Donut_02_sequence), PeepSpriteImage_Donut_02_sequence },
@@ -3243,7 +3243,7 @@ static const rct_peep_animation PeepSpriteImage_Donut[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Donut_36_sequence), PeepSpriteImage_Donut_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Coffee[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Coffee[] = {
     { 8885,  Util::CountOf(PeepSpriteImage_Coffee_00_sequence), PeepSpriteImage_Coffee_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Coffee_01_sequence), PeepSpriteImage_Coffee_01_sequence },
     { 8981,  Util::CountOf(PeepSpriteImage_Coffee_02_sequence), PeepSpriteImage_Coffee_02_sequence },
@@ -3283,7 +3283,7 @@ static const rct_peep_animation PeepSpriteImage_Coffee[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Coffee_36_sequence), PeepSpriteImage_Coffee_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Chicken[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Chicken[] = {
     { 9005,  Util::CountOf(PeepSpriteImage_Chicken_00_sequence), PeepSpriteImage_Chicken_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Chicken_01_sequence), PeepSpriteImage_Chicken_01_sequence },
     { 9125,  Util::CountOf(PeepSpriteImage_Chicken_02_sequence), PeepSpriteImage_Chicken_02_sequence },
@@ -3323,7 +3323,7 @@ static const rct_peep_animation PeepSpriteImage_Chicken[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Chicken_36_sequence), PeepSpriteImage_Chicken_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Lemonade[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Lemonade[] = {
     { 9173,  Util::CountOf(PeepSpriteImage_Lemonade_00_sequence), PeepSpriteImage_Lemonade_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Lemonade_01_sequence), PeepSpriteImage_Lemonade_01_sequence },
     { 9293,  Util::CountOf(PeepSpriteImage_Lemonade_02_sequence), PeepSpriteImage_Lemonade_02_sequence },
@@ -3363,7 +3363,7 @@ static const rct_peep_animation PeepSpriteImage_Lemonade[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Lemonade_36_sequence), PeepSpriteImage_Lemonade_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Watching[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Watching[] = {
     { 6409,  Util::CountOf(PeepSpriteImage_Watching_00_sequence), PeepSpriteImage_Watching_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Watching_01_sequence), PeepSpriteImage_Watching_01_sequence },
     { 7245,  Util::CountOf(PeepSpriteImage_Watching_02_sequence), PeepSpriteImage_Watching_02_sequence },
@@ -3403,7 +3403,7 @@ static const rct_peep_animation PeepSpriteImage_Watching[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Watching_36_sequence), PeepSpriteImage_Watching_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Pretzel[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Pretzel[] = {
     { 9341,  Util::CountOf(PeepSpriteImage_Pretzel_00_sequence), PeepSpriteImage_Pretzel_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Pretzel_01_sequence), PeepSpriteImage_Pretzel_01_sequence },
     { 9461,  Util::CountOf(PeepSpriteImage_Pretzel_02_sequence), PeepSpriteImage_Pretzel_02_sequence },
@@ -3443,7 +3443,7 @@ static const rct_peep_animation PeepSpriteImage_Pretzel[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Pretzel_36_sequence), PeepSpriteImage_Pretzel_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Sunglasses[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Sunglasses[] = {
     { 10685, Util::CountOf(PeepSpriteImage_Sunglasses_00_sequence), PeepSpriteImage_Sunglasses_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Sunglasses_01_sequence), PeepSpriteImage_Sunglasses_01_sequence },
     { 10713, Util::CountOf(PeepSpriteImage_Sunglasses_02_sequence), PeepSpriteImage_Sunglasses_02_sequence },
@@ -3483,7 +3483,7 @@ static const rct_peep_animation PeepSpriteImage_Sunglasses[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Sunglasses_36_sequence), PeepSpriteImage_Sunglasses_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_SuJongkwa[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_SuJongkwa[] = {
     { 9509,  Util::CountOf(PeepSpriteImage_SuJongkwa_00_sequence), PeepSpriteImage_SuJongkwa_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_SuJongkwa_01_sequence), PeepSpriteImage_SuJongkwa_01_sequence },
     { 9629,  Util::CountOf(PeepSpriteImage_SuJongkwa_02_sequence), PeepSpriteImage_SuJongkwa_02_sequence },
@@ -3523,7 +3523,7 @@ static const rct_peep_animation PeepSpriteImage_SuJongkwa[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_SuJongkwa_36_sequence), PeepSpriteImage_SuJongkwa_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Juice[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Juice[] = {
     { 9677,  Util::CountOf(PeepSpriteImage_Juice_00_sequence), PeepSpriteImage_Juice_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Juice_01_sequence), PeepSpriteImage_Juice_01_sequence },
     { 9797,  Util::CountOf(PeepSpriteImage_Juice_02_sequence), PeepSpriteImage_Juice_02_sequence },
@@ -3563,7 +3563,7 @@ static const rct_peep_animation PeepSpriteImage_Juice[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Juice_36_sequence), PeepSpriteImage_Juice_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_FunnelCake[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_FunnelCake[] = {
     { 9845,  Util::CountOf(PeepSpriteImage_FunnelCake_00_sequence), PeepSpriteImage_FunnelCake_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_FunnelCake_01_sequence), PeepSpriteImage_FunnelCake_01_sequence },
     { 9965,  Util::CountOf(PeepSpriteImage_FunnelCake_02_sequence), PeepSpriteImage_FunnelCake_02_sequence },
@@ -3603,7 +3603,7 @@ static const rct_peep_animation PeepSpriteImage_FunnelCake[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_FunnelCake_36_sequence), PeepSpriteImage_FunnelCake_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Noodles[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Noodles[] = {
     { 10013, Util::CountOf(PeepSpriteImage_Noodles_00_sequence), PeepSpriteImage_Noodles_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Noodles_01_sequence), PeepSpriteImage_Noodles_01_sequence },
     { 10133, Util::CountOf(PeepSpriteImage_Noodles_02_sequence), PeepSpriteImage_Noodles_02_sequence },
@@ -3643,7 +3643,7 @@ static const rct_peep_animation PeepSpriteImage_Noodles[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Noodles_36_sequence), PeepSpriteImage_Noodles_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Sausage[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Sausage[] = {
     { 10181, Util::CountOf(PeepSpriteImage_Sausage_00_sequence), PeepSpriteImage_Sausage_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Sausage_01_sequence), PeepSpriteImage_Sausage_01_sequence },
     { 10301, Util::CountOf(PeepSpriteImage_Sausage_02_sequence), PeepSpriteImage_Sausage_02_sequence },
@@ -3683,7 +3683,7 @@ static const rct_peep_animation PeepSpriteImage_Sausage[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Sausage_36_sequence), PeepSpriteImage_Sausage_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Soup[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Soup[] = {
     { 10349, Util::CountOf(PeepSpriteImage_Soup_00_sequence), PeepSpriteImage_Soup_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Soup_01_sequence), PeepSpriteImage_Soup_01_sequence },
     { 10469, Util::CountOf(PeepSpriteImage_Soup_02_sequence), PeepSpriteImage_Soup_02_sequence },
@@ -3723,7 +3723,7 @@ static const rct_peep_animation PeepSpriteImage_Soup[] = {
     { 7181,  Util::CountOf(PeepSpriteImage_Soup_36_sequence), PeepSpriteImage_Soup_36_sequence },
 };
 
-static const rct_peep_animation PeepSpriteImage_Sandwich[] = {
+static constexpr const rct_peep_animation PeepSpriteImage_Sandwich[] = {
     { 10517, Util::CountOf(PeepSpriteImage_Sandwich_00_sequence), PeepSpriteImage_Sandwich_00_sequence },
     { 6585,  Util::CountOf(PeepSpriteImage_Sandwich_01_sequence), PeepSpriteImage_Sandwich_01_sequence },
     { 10637, Util::CountOf(PeepSpriteImage_Sandwich_02_sequence), PeepSpriteImage_Sandwich_02_sequence },
@@ -3764,7 +3764,7 @@ static const rct_peep_animation PeepSpriteImage_Sandwich[] = {
 };
 
 
-static const rct_sprite_bounds PeepSpriteBounds_Normal[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Normal[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -3804,7 +3804,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Normal[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Handyman[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Handyman[] = {
     { 12, 16, 6 },
     { 8, 16, 5 },
     { 9, 16, 6 },
@@ -3844,7 +3844,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Handyman[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Mechanic[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Mechanic[] = {
     { 10, 16, 5 },
     { 8, 16, 5 },
     { 10, 16, 5 },
@@ -3884,7 +3884,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Mechanic[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Security[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Security[] = {
     { 8, 18, 5 },
     { 8, 16, 5 },
     { 8, 17, 5 },
@@ -3924,7 +3924,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Security[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerPanda[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerPanda[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -3964,7 +3964,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerPanda[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerTiger[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerTiger[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4004,7 +4004,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerTiger[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerElephant[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerElephant[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4044,7 +4044,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerElephant[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerRoman[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerRoman[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4084,7 +4084,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerRoman[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerGorilla[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerGorilla[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4124,7 +4124,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerGorilla[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerSnowman[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerSnowman[] = {
     { 13, 24, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4164,7 +4164,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerSnowman[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerKnight[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerKnight[] = {
     { 16, 32, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4204,7 +4204,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerKnight[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerAstronaut[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerAstronaut[] = {
     { 16, 32, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4244,7 +4244,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerAstronaut[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerBandit[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerBandit[] = {
     { 16, 32, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4284,7 +4284,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerBandit[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerSheriff[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerSheriff[] = {
     { 16, 32, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4324,7 +4324,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerSheriff[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_EntertainerPirate[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_EntertainerPirate[] = {
     { 16, 32, 8 },
     { 8, 16, 5 },
     { 10, 23, 7 },
@@ -4364,7 +4364,7 @@ static const rct_sprite_bounds PeepSpriteBounds_EntertainerPirate[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_IceCream[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_IceCream[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4404,7 +4404,7 @@ static const rct_sprite_bounds PeepSpriteBounds_IceCream[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Chips[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Chips[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4444,7 +4444,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Chips[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Burger[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Burger[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4484,7 +4484,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Burger[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Drink[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Drink[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4524,7 +4524,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Drink[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Balloon[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Balloon[] = {
     { 11, 28, 5 },
     { 8, 16, 5 },
     { 11, 28, 5 },
@@ -4564,7 +4564,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Balloon[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Candyfloss[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Candyfloss[] = {
     { 11, 19, 5 },
     { 8, 16, 5 },
     { 11, 19, 5 },
@@ -4604,7 +4604,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Candyfloss[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Umbrella[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Umbrella[] = {
     { 14, 21, 5 },
     { 8, 16, 5 },
     { 14, 21, 5 },
@@ -4644,7 +4644,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Umbrella[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Pizza[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Pizza[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4684,7 +4684,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Pizza[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_SecurityAlt[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_SecurityAlt[] = {
     { 8, 18, 5 },
     { 8, 16, 5 },
     { 8, 17, 5 },
@@ -4724,7 +4724,7 @@ static const rct_sprite_bounds PeepSpriteBounds_SecurityAlt[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Popcorn[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Popcorn[] = {
     { 11, 19, 5 },
     { 8, 16, 5 },
     { 11, 19, 5 },
@@ -4764,7 +4764,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Popcorn[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Hat[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Hat[] = {
     { 12, 32, 5 },
     { 8, 16, 5 },
     { 12, 32, 5 },
@@ -4804,7 +4804,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Hat[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_HotDog[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_HotDog[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4844,7 +4844,7 @@ static const rct_sprite_bounds PeepSpriteBounds_HotDog[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Tentacle[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Tentacle[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4884,7 +4884,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Tentacle[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_ToffeeApple[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_ToffeeApple[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4924,7 +4924,7 @@ static const rct_sprite_bounds PeepSpriteBounds_ToffeeApple[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Donut[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Donut[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -4964,7 +4964,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Donut[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Coffee[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Coffee[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5004,7 +5004,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Coffee[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Chicken[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Chicken[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5044,7 +5044,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Chicken[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Lemonade[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Lemonade[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5084,7 +5084,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Lemonade[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Pretzel[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Pretzel[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5124,7 +5124,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Pretzel[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_SuJongkwa[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_SuJongkwa[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5164,7 +5164,7 @@ static const rct_sprite_bounds PeepSpriteBounds_SuJongkwa[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Juice[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Juice[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5204,7 +5204,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Juice[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_FunnelCake[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_FunnelCake[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5244,7 +5244,7 @@ static const rct_sprite_bounds PeepSpriteBounds_FunnelCake[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Noodles[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Noodles[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5284,7 +5284,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Noodles[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Sausage[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Sausage[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5324,7 +5324,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Sausage[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Soup[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Soup[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },
@@ -5364,7 +5364,7 @@ static const rct_sprite_bounds PeepSpriteBounds_Soup[] = {
     { 9, 22, 7 },
 };
 
-static const rct_sprite_bounds PeepSpriteBounds_Sandwich[] = {
+static constexpr const rct_sprite_bounds PeepSpriteBounds_Sandwich[] = {
     { 8, 16, 5 },
     { 8, 16, 5 },
     { 8, 16, 5 },

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -315,7 +315,7 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
             newPeep->id         = newStaffIndex;
             newPeep->staff_type = staff_type;
 
-            static const rct_string_id staffNames[] = {
+            static constexpr const rct_string_id staffNames[] = {
                 STR_HANDYMAN_X,
                 STR_MECHANIC_X,
                 STR_SECURITY_GUARD_X,
@@ -323,7 +323,7 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
             };
 
             /* rct2: 0x009929FC */
-            static const uint8 spriteTypes[] = {
+            static constexpr const uint8 spriteTypes[] = {
                 PEEP_SPRITE_TYPE_HANDYMAN,
                 PEEP_SPRITE_TYPE_MECHANIC,
                 PEEP_SPRITE_TYPE_SECURITY,
@@ -399,7 +399,7 @@ void game_command_hire_new_staff_member(sint32 * eax, sint32 * ebx, sint32 * ecx
 }
 
 /** rct2: 0x00982134 */
-static const bool peep_slow_walking_types[] = {
+static constexpr const bool peep_slow_walking_types[] = {
     false, // PEEP_SPRITE_TYPE_NORMAL
     false, // PEEP_SPRITE_TYPE_HANDYMAN
     false, // PEEP_SPRITE_TYPE_MECHANIC

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -135,7 +135,7 @@ uint8 gTypeToRideEntryIndexMap[TYPE_TO_RIDE_ENTRY_SLOTS];
 
 #pragma endregion
 
-static const sint32 RideInspectionInterval[] = {
+static constexpr const sint32 RideInspectionInterval[] = {
     10, 20, 30, 45, 60, 120, 0, 0
 };
 
@@ -2145,7 +2145,7 @@ void ride_update_popularity(Ride* ride, uint8 pop_amount){
 }
 
 /** rct2: 0x0098DDB8, 0x0098DDBA */
-static const LocationXY16 ride_spiral_slide_main_tile_offset[][4] = {
+static constexpr const LocationXY16 ride_spiral_slide_main_tile_offset[][4] = {
     {
         {  32,  32 },
         {   0,  32 },
@@ -4439,14 +4439,14 @@ static sint32 count_free_misc_sprite_slots()
     return Math::Max(0, miscSpriteCount + remainingSpriteCount - 300);
 }
 
-static const LocationXY16 word_9A3AB4[4] = {
+static constexpr const LocationXY16 word_9A3AB4[4] = {
     {   0,   0 },
     {   0, -96 },
     { -96, -96 },
     { -96,   0 },
 };
 
-static const LocationXY16 word_9A2A60[] = {
+static constexpr const LocationXY16 word_9A2A60[] = {
     {   0,  16 },
     {  16,  31 },
     {  31,  16 },
@@ -5487,7 +5487,7 @@ sint32 ride_get_refund_price(sint32 ride_id)
             GAME_COMMAND_SET_MAZE_TRACK,
             z,
             0);
-        // Above gamecommand may remove the tile element which will cause the next game command to 
+        // Above gamecommand may remove the tile element which will cause the next game command to
         // return MONEY32_UNDEFINED as it does not need to be called.
 
         money32 removePrice = game_do_command(
@@ -7937,7 +7937,7 @@ bool ride_has_ratings(const Ride * ride)
 
 const char * ride_type_get_enum_name(sint32 rideType)
 {
-    static const char * RideTypeEnumNames[RIDE_TYPE_COUNT] =
+    static constexpr const char * RideTypeEnumNames[RIDE_TYPE_COUNT] =
     {
         nameof(RIDE_TYPE_SPIRAL_ROLLER_COASTER),
         nameof(RIDE_TYPE_STAND_UP_ROLLER_COASTER),

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -27,70 +27,70 @@
 #include "Track.h"
 #include "TrackData.h"
 
-static const RideGroup ride_group_corkscrew_rc = {
+static constexpr const RideGroup ride_group_corkscrew_rc = {
     /*.RideType =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
     /*.MaximumHeight =*/ 28,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
     /*.Naming =*/ { STR_CORKSCREW_RC_GROUP, STR_CORKSCREW_RC_GROUP_DESC },
 };
 
-static const RideGroup ride_group_hypercoaster = {
+static constexpr const RideGroup ride_group_hypercoaster = {
     /*.RideType =*/ RIDE_TYPE_CORKSCREW_ROLLER_COASTER,
     /*.MaximumHeight =*/ 45,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_STEEP_LONG),
     /*.Naming =*/ { STR_HYPERCOASTER_GROUP, STR_HYPERCOASTER_GROUP_DESC },
 };
 
-static const RideGroup ride_group_car_ride = {
+static constexpr const RideGroup ride_group_car_ride = {
     /*.RideType =*/ RIDE_TYPE_CAR_RIDE,
     /*.MaximumHeight =*/ 6,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_SPINNING_TUNNEL),
     /*.Naming =*/ { STR_CAR_RIDE_GROUP, STR_CAR_RIDE_GROUP_DESC },
 };
 
-static const RideGroup ride_group_monster_trucks = {
+static constexpr const RideGroup ride_group_monster_trucks = {
     /*.RideType =*/ RIDE_TYPE_CAR_RIDE,
     /*.MaximumHeight =*/ 18,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_RAPIDS),
     /*.Naming =*/ { STR_MONSTER_TRUCKS_GROUP, STR_MONSTER_TRUCKS_GROUP_DESC },
 };
 
-static const RideGroup ride_group_steel_twister_rc = {
+static constexpr const RideGroup ride_group_steel_twister_rc = {
     /*.RideType =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
     /*.MaximumHeight =*/ 40,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_VERTICAL_LOOP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HALF_LOOP) | (1ULL << TRACK_CORKSCREW) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_SLOPE_VERTICAL) | (1ULL << TRACK_BARREL_ROLL) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_HALF_LOOP_LARGE) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG) | (1ULL << TRACK_CURVE_VERTICAL) | (1ULL << TRACK_QUARTER_LOOP) | (1ULL << TRACK_BOOSTER),
     /*.Naming =*/ { STR_STEEL_TWISTER_GROUP, STR_STEEL_TWISTER_GROUP_DESC },
 };
 
-static const RideGroup ride_group_hyper_twister = {
+static constexpr const RideGroup ride_group_hyper_twister = {
     /*.RideType =*/ RIDE_TYPE_TWISTER_ROLLER_COASTER,
     /*.MaximumHeight =*/ 54,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_FLAT) | (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_SLOPE_CURVE_STEEP) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_POWERED_LIFT) | (1ULL << TRACK_SLOPE_CURVE_BANKED) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_SLOPE_ROLL_BANKING) | (1ULL << TRACK_SLOPE_STEEP_LONG),
     /*.Naming =*/ { STR_HYPER_TWISTER_GROUP, STR_HYPER_TWISTER_GROUP_DESC },
 };
 
-static const RideGroup ride_group_junior_rc = {
+static constexpr const RideGroup ride_group_junior_rc = {
     /*.RideType =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
     /*.MaximumHeight =*/ 12,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
     /*.Naming =*/ { STR_JUNIOR_RC_GROUP, STR_JUNIOR_RC_GROUP_DESC },
 };
 
-static const RideGroup ride_group_classic_mini_coaster = {
+static constexpr const RideGroup ride_group_classic_mini_coaster = {
     /*.RideType =*/ RIDE_TYPE_JUNIOR_ROLLER_COASTER,
     /*.MaximumHeight =*/ 15,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_CURVE) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER),
     /*.Naming =*/ { STR_CLASSIC_MINI_COASTER_GROUP, STR_CLASSIC_MINI_COASTER_GROUP_DESC },
 };
 
-static const RideGroup ride_group_steel_wild_mouse = {
+static constexpr const RideGroup ride_group_steel_wild_mouse = {
     /*.RideType =*/ RIDE_TYPE_STEEL_WILD_MOUSE,
     /*.MaximumHeight =*/ 16,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_LIFT_HILL_STEEP) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES),
     /*.Naming =*/ { STR_RIDE_NAME_WILD_MOUSE, STR_RIDE_DESCRIPTION_WILD_MOUSE },
 };
 
-static const RideGroup ride_group_spinning_wild_mouse = {
+static constexpr const RideGroup ride_group_spinning_wild_mouse = {
     /*.RideType =*/ RIDE_TYPE_STEEL_WILD_MOUSE,
     /*.MaximumHeight =*/ 16,
     /*.AvailableTrackPieces =*/ (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1971,7 +1971,7 @@ static uint8 maze_element_get_segment_bit(uint16 x, uint16 y)
 }
 
 /** rct2: 0x00993CE9 */
-static const uint8 byte_993CE9[] = {
+static constexpr const uint8 byte_993CE9[] = {
     0xFF, 0xE0, 0xFF,
     14, 0, 1, 2,
     6, 2, 4, 5,
@@ -1980,12 +1980,12 @@ static const uint8 byte_993CE9[] = {
 };
 
 /** rct2: 0x00993CFC */
-static const uint8 byte_993CFC[] = {
+static constexpr const uint8 byte_993CFC[] = {
     5, 12, 0xFF, 0xFF, 9, 0, 0xFF, 0xFF, 13, 4, 0xFF, 0xFF, 1, 8, 0xFF, 0xFF
 };
 
 /** rct2: 0x00993D0C */
-static const uint8 byte_993D0C[] = {
+static constexpr const uint8 byte_993D0C[] = {
     3, 0, 0xFF, 0xFF, 0, 1, 0xFF, 0xFF, 1, 2, 0xFF, 0xFF, 2, 3, 0xFF, 0xFF
 };
 

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -6487,8 +6487,8 @@ const track_descriptor gTrackDescriptors[142] = {
 };
 
 #define CREATE_VEHICLE_INFO(VAR, ...) \
-    static const rct_vehicle_info VAR##_data [] = __VA_ARGS__ ; \
-    static const rct_vehicle_info_list VAR = { static_cast<uint16>(Util::CountOf(VAR##_data)), VAR##_data };
+    static constexpr const rct_vehicle_info VAR##_data [] = __VA_ARGS__ ; \
+    static constexpr const rct_vehicle_info_list VAR = { static_cast<uint16>(Util::CountOf(VAR##_data)), VAR##_data };
 
 CREATE_VEHICLE_INFO(TrackVehicleInfo_8BE57A, {
     {     31,   16,    0,  0,  0,  0 }, {     30,   16,    0,  0,  0,  0 }, {     29,   16,    0,  0,  0,  0 }, {     28,   16,    0,  0,  0,  0 }, {     27,   16,    0,  0,  0,  0 },

--- a/src/openrct2/ride/TrackDataOld.cpp
+++ b/src/openrct2/ride/TrackDataOld.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x008A42F4 */
 // clang-format off
-static const uint32 _OldSpiralRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSpiralRollerCoasterTrackPaintFunctions[256] = {
     0x008A4ABC, // TRACK_ELEM_FLAT
     0x008A4D0C, // TRACK_ELEM_END_STATION
     0x008A4D1C, // TRACK_ELEM_BEGIN_STATION
@@ -278,7 +278,7 @@ static const uint32 _OldSpiralRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A6DB0 */
-static const uint32 _OldStandUpRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldStandUpRollerCoasterTrackPaintFunctions[256] = {
     0x008A7114, // TRACK_ELEM_FLAT
     0x008A7384, // TRACK_ELEM_END_STATION
     0x008A7394, // TRACK_ELEM_BEGIN_STATION
@@ -538,7 +538,7 @@ static const uint32 _OldStandUpRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A85E4 */
-static const uint32 _OldSuspendedSwingingCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSuspendedSwingingCoasterTrackPaintFunctions[256] = {
     0x008A8958, // TRACK_ELEM_FLAT
     0x008A8AA8, // TRACK_ELEM_END_STATION
     0x008A8AB8, // TRACK_ELEM_BEGIN_STATION
@@ -798,7 +798,7 @@ static const uint32 _OldSuspendedSwingingCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A8EE4 */
-static const uint32 _OldInvertedRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldInvertedRollerCoasterTrackPaintFunctions[256] = {
     0x008A92E8, // TRACK_ELEM_FLAT
     0x008A9558, // TRACK_ELEM_END_STATION
     0x008A9568, // TRACK_ELEM_BEGIN_STATION
@@ -1058,7 +1058,7 @@ static const uint32 _OldInvertedRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AAA0C */
-static const uint32 _OldJuniorRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldJuniorRollerCoasterTrackPaintFunctions[256] = {
     0x008AAD80, // TRACK_ELEM_FLAT
     0x008AAE70, // TRACK_ELEM_END_STATION
     0x008AAE80, // TRACK_ELEM_BEGIN_STATION
@@ -1318,7 +1318,7 @@ static const uint32 _OldJuniorRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008ACE48 */
-static const uint32 _OldMiniatureRailwayTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMiniatureRailwayTrackPaintFunctions[256] = {
     0x008AD0C0, // TRACK_ELEM_FLAT
     0x008AD170, // TRACK_ELEM_END_STATION
     0x008AD180, // TRACK_ELEM_BEGIN_STATION
@@ -1578,7 +1578,7 @@ static const uint32 _OldMiniatureRailwayTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008ADF34 */
-static const uint32 _OldMonorailTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMonorailTrackPaintFunctions[256] = {
     0x008AE1AC, // TRACK_ELEM_FLAT
     0x008AE25C, // TRACK_ELEM_END_STATION
     0x008AE26C, // TRACK_ELEM_BEGIN_STATION
@@ -1838,7 +1838,7 @@ static const uint32 _OldMonorailTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AFC24 */
-static const uint32 _OldMiniSuspendedCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMiniSuspendedCoasterTrackPaintFunctions[256] = {
     0x008AFE9C, // TRACK_ELEM_FLAT
     0x008AFF4C, // TRACK_ELEM_END_STATION
     0x008AFF5C, // TRACK_ELEM_BEGIN_STATION
@@ -2098,7 +2098,7 @@ static const uint32 _OldMiniSuspendedCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008B0D60 */
-static const uint32 _OldBoatHireTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldBoatHireTrackPaintFunctions[256] = {
     0x008B0E40, // TRACK_ELEM_FLAT
     0x008B0E50, // TRACK_ELEM_END_STATION
     0x008B0E60, // TRACK_ELEM_BEGIN_STATION
@@ -2358,7 +2358,7 @@ static const uint32 _OldBoatHireTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A534C */
-static const uint32 _OldWoodenWildMouseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldWoodenWildMouseTrackPaintFunctions[256] = {
     0x008A5464, // TRACK_ELEM_FLAT
     0x008A5534, // TRACK_ELEM_END_STATION
     0x008A5544, // TRACK_ELEM_BEGIN_STATION
@@ -2618,7 +2618,7 @@ static const uint32 _OldWoodenWildMouseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A5634 */
-static const uint32 _OldSteeplechaseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSteeplechaseTrackPaintFunctions[256] = {
     0x008A59A8, // TRACK_ELEM_FLAT
     0x008A5A58, // TRACK_ELEM_END_STATION
     0x008A5A68, // TRACK_ELEM_BEGIN_STATION
@@ -2878,7 +2878,7 @@ static const uint32 _OldSteeplechaseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x006F7000 */
-static const uint32 _OldCarRideTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldCarRideTrackPaintFunctions[256] = {
     0x006F72C8, // TRACK_ELEM_FLAT
     0x006F7338, // TRACK_ELEM_END_STATION
     0x006F7348, // TRACK_ELEM_BEGIN_STATION
@@ -3138,7 +3138,7 @@ static const uint32 _OldCarRideTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x006FD0E8 */
-static const uint32 _OldLaunchedFreefallTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLaunchedFreefallTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -3398,7 +3398,7 @@ static const uint32 _OldLaunchedFreefallTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x006FE240 */
-static const uint32 _OldBobsleighCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldBobsleighCoasterTrackPaintFunctions[256] = {
     0x006FE5B4, // TRACK_ELEM_FLAT
     0x006FE764, // TRACK_ELEM_END_STATION
     0x006FE774, // TRACK_ELEM_BEGIN_STATION
@@ -3658,7 +3658,7 @@ static const uint32 _OldBobsleighCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0070DC5C */
-static const uint32 _OldObservationTowerTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldObservationTowerTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -3918,7 +3918,7 @@ static const uint32 _OldObservationTowerTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A5B88 */
-static const uint32 _OldLoopingRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLoopingRollerCoasterTrackPaintFunctions[256] = {
     0x008A6370, // TRACK_ELEM_FLAT
     0x008A6600, // TRACK_ELEM_END_STATION
     0x008A6610, // TRACK_ELEM_BEGIN_STATION
@@ -4178,7 +4178,7 @@ static const uint32 _OldLoopingRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0070EDB4 */
-static const uint32 _OldDinghySlideTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldDinghySlideTrackPaintFunctions[256] = {
     0x0070EF20, // TRACK_ELEM_FLAT
     0x0070F030, // TRACK_ELEM_END_STATION
     0x0070F040, // TRACK_ELEM_BEGIN_STATION
@@ -4438,7 +4438,7 @@ static const uint32 _OldDinghySlideTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0071BC40 */
-static const uint32 _OldMineTrainCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMineTrainCoasterTrackPaintFunctions[256] = {
     0x0071BFA4, // TRACK_ELEM_FLAT
     0x0071C154, // TRACK_ELEM_END_STATION
     0x0071C164, // TRACK_ELEM_BEGIN_STATION
@@ -4698,7 +4698,7 @@ static const uint32 _OldMineTrainCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00743EC8 */
-static const uint32 _OldChairliftTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldChairliftTrackPaintFunctions[256] = {
     0x00743FC8, // TRACK_ELEM_FLAT
     0x00743F98, // TRACK_ELEM_END_STATION
     0x00743FA8, // TRACK_ELEM_BEGIN_STATION
@@ -4958,7 +4958,7 @@ static const uint32 _OldChairliftTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A7784 */
-static const uint32 _OldCorkscrewRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldCorkscrewRollerCoasterTrackPaintFunctions[256] = {
     0x008A7AF8, // TRACK_ELEM_FLAT
     0x008A7D68, // TRACK_ELEM_END_STATION
     0x008A7D78, // TRACK_ELEM_BEGIN_STATION
@@ -5218,7 +5218,7 @@ static const uint32 _OldCorkscrewRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A81E8 */
-static const uint32 _OldMazeTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMazeTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -5478,7 +5478,7 @@ static const uint32 _OldMazeTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0074840C */
-static const uint32 _OldSpiralSlideTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSpiralSlideTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -5738,7 +5738,7 @@ static const uint32 _OldSpiralSlideTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0074A668 */
-static const uint32 _OldGoKartsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldGoKartsTrackPaintFunctions[256] = {
     0x0074A748, // TRACK_ELEM_FLAT
     0x0074A7B8, // TRACK_ELEM_END_STATION
     0x0074A7C8, // TRACK_ELEM_BEGIN_STATION
@@ -5998,7 +5998,7 @@ static const uint32 _OldGoKartsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0074DDEC */
-static const uint32 _OldLogFlumeTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLogFlumeTrackPaintFunctions[256] = {
     0x0074E0B0, // TRACK_ELEM_FLAT
     0x0074E140, // TRACK_ELEM_END_STATION
     0x0074E150, // TRACK_ELEM_BEGIN_STATION
@@ -6258,7 +6258,7 @@ static const uint32 _OldLogFlumeTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0075745C */
-static const uint32 _OldRiverRapidsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldRiverRapidsTrackPaintFunctions[256] = {
     0x00757650, // TRACK_ELEM_FLAT
     0x007576C0, // TRACK_ELEM_END_STATION
     0x007576D0, // TRACK_ELEM_BEGIN_STATION
@@ -6518,7 +6518,7 @@ static const uint32 _OldRiverRapidsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0075C9D0 */
-static const uint32 _OldDodgemsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldDodgemsTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -6778,7 +6778,7 @@ static const uint32 _OldDodgemsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A83E0 */
-static const uint32 _OldPirateShipTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldPirateShipTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -7038,7 +7038,7 @@ static const uint32 _OldPirateShipTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00760070 */
-static const uint32 _OldSwingingInverterShipTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSwingingInverterShipTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -7302,7 +7302,7 @@ static const uint32 _OldSwingingInverterShipTrackPaintFunctions[256] = {
  *
  * rct2: 0x00761160
  */
-static const uint32 _OldShopTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldShopTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -7562,7 +7562,7 @@ static const uint32 _OldShopTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076190C */
-static const uint32 _OldMerryGoRoundTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMerryGoRoundTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -7826,7 +7826,7 @@ static const uint32 _OldMerryGoRoundTrackPaintFunctions[256] = {
  *
  * rct2: 0x00762D44
  */
-static const uint32 _OldFacilityTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldFacilityTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -8086,7 +8086,7 @@ static const uint32 _OldFacilityTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A8CC8 */
-static const uint32 _OldFerrisWheelTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldFerrisWheelTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -8346,7 +8346,7 @@ static const uint32 _OldFerrisWheelTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00763520 */
-static const uint32 _OldMotionSimulatorTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMotionSimulatorTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -8606,7 +8606,7 @@ static const uint32 _OldMotionSimulatorTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076554C */
-static const uint32 _Old3DCinemaTrackPaintFunctions[256] = {
+static constexpr const uint32 _Old3DCinemaTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -8866,7 +8866,7 @@ static const uint32 _Old3DCinemaTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076659C */
-static const uint32 _OldTopSpinTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldTopSpinTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -9126,7 +9126,7 @@ static const uint32 _OldTopSpinTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00767A40 */
-static const uint32 _OldSpaceRingsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSpaceRingsTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -9386,7 +9386,7 @@ static const uint32 _OldSpaceRingsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00768BAC */
-static const uint32 _OldReverseFreefallCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldReverseFreefallCoasterTrackPaintFunctions[256] = {
     0x00768DB4, // TRACK_ELEM_FLAT
     0x00768DC4, // TRACK_ELEM_END_STATION
     0x00768DD4, // TRACK_ELEM_BEGIN_STATION
@@ -9646,7 +9646,7 @@ static const uint32 _OldReverseFreefallCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076C5BC */
-static const uint32 _OldLiftTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLiftTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -9906,7 +9906,7 @@ static const uint32 _OldLiftTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A9C08 */
-static const uint32 _OldVerticalDropRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldVerticalDropRollerCoasterTrackPaintFunctions[256] = {
     0x008AA00C, // TRACK_ELEM_FLAT
     0x008AA25C, // TRACK_ELEM_END_STATION
     0x008AA26C, // TRACK_ELEM_BEGIN_STATION
@@ -10166,7 +10166,7 @@ static const uint32 _OldVerticalDropRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076D658 */
-static const uint32 _OldTwistTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldTwistTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -10426,7 +10426,7 @@ static const uint32 _OldTwistTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076E7B0 */
-static const uint32 _OldHauntedHouseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldHauntedHouseTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -10686,7 +10686,7 @@ static const uint32 _OldHauntedHouseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0076F8D4 */
-static const uint32 _OldCircusShowTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldCircusShowTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -10946,7 +10946,7 @@ static const uint32 _OldCircusShowTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00770924 */
-static const uint32 _OldGhostTrainTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldGhostTrainTrackPaintFunctions[256] = {
     0x00770BEC, // TRACK_ELEM_FLAT
     0x00770C5C, // TRACK_ELEM_END_STATION
     0x00770C6C, // TRACK_ELEM_BEGIN_STATION
@@ -11206,7 +11206,7 @@ static const uint32 _OldGhostTrainTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AB2A0 */
-static const uint32 _OldTwisterRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldTwisterRollerCoasterTrackPaintFunctions[256] = {
     0x008AB6A4, // TRACK_ELEM_FLAT
     0x008AB8F4, // TRACK_ELEM_END_STATION
     0x008AB904, // TRACK_ELEM_BEGIN_STATION
@@ -11466,7 +11466,7 @@ static const uint32 _OldTwisterRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AC164 */
-static const uint32 _OldWoodenRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldWoodenRollerCoasterTrackPaintFunctions[256] = {
     0x008AC568, // TRACK_ELEM_FLAT
     0x008AC7B8, // TRACK_ELEM_END_STATION
     0x008AC7C8, // TRACK_ELEM_BEGIN_STATION
@@ -11726,7 +11726,7 @@ static const uint32 _OldWoodenRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00778124 */
-static const uint32 _OldSideFrictionRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSideFrictionRollerCoasterTrackPaintFunctions[256] = {
     0x0077839C, // TRACK_ELEM_FLAT
     0x007784AC, // TRACK_ELEM_END_STATION
     0x007784BC, // TRACK_ELEM_BEGIN_STATION
@@ -11986,7 +11986,7 @@ static const uint32 _OldSideFrictionRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0078AE80 */
-static const uint32 _OldWildMouseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldWildMouseTrackPaintFunctions[256] = {
     0x0078B1E4, // TRACK_ELEM_FLAT
     0x0078B2B4, // TRACK_ELEM_END_STATION
     0x0078B2C4, // TRACK_ELEM_BEGIN_STATION
@@ -12246,7 +12246,7 @@ static const uint32 _OldWildMouseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00792978 */
-static const uint32 _OldMultiDimensionRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMultiDimensionRollerCoasterTrackPaintFunctions[256] = {
     0x00792D88, // TRACK_ELEM_FLAT
     0x00792F98, // TRACK_ELEM_END_STATION
     0x00792FA8, // TRACK_ELEM_BEGIN_STATION
@@ -12506,7 +12506,7 @@ static const uint32 _OldMultiDimensionRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x007C6C00 */
-static const uint32 _OldFlyingRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldFlyingRollerCoasterTrackPaintFunctions[256] = {
     0x007C6FF4, // TRACK_ELEM_FLAT
     0x007C7244, // TRACK_ELEM_END_STATION
     0x007C7254, // TRACK_ELEM_BEGIN_STATION
@@ -12766,7 +12766,7 @@ static const uint32 _OldFlyingRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00811184 */
-static const uint32 _OldVirginiaReelTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldVirginiaReelTrackPaintFunctions[256] = {
     0x00811264, // TRACK_ELEM_FLAT
     0x008112D4, // TRACK_ELEM_END_STATION
     0x008112E4, // TRACK_ELEM_BEGIN_STATION
@@ -13026,7 +13026,7 @@ static const uint32 _OldVirginiaReelTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008164AC */
-static const uint32 _OldSplashBoatsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSplashBoatsTrackPaintFunctions[256] = {
     0x00816584, // TRACK_ELEM_FLAT
     0x00816614, // TRACK_ELEM_END_STATION
     0x00816624, // TRACK_ELEM_BEGIN_STATION
@@ -13286,7 +13286,7 @@ static const uint32 _OldSplashBoatsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0081F268 */
-static const uint32 _OldMiniHelicoptersTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMiniHelicoptersTrackPaintFunctions[256] = {
     0x0081F348, // TRACK_ELEM_FLAT
     0x0081F3B8, // TRACK_ELEM_END_STATION
     0x0081F3C8, // TRACK_ELEM_BEGIN_STATION
@@ -13546,7 +13546,7 @@ static const uint32 _OldMiniHelicoptersTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008245A8 */
-static const uint32 _OldLayDownRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLayDownRollerCoasterTrackPaintFunctions[256] = {
     0x0082491C, // TRACK_ELEM_FLAT
     0x00824B8C, // TRACK_ELEM_END_STATION
     0x00824B9C, // TRACK_ELEM_BEGIN_STATION
@@ -13806,7 +13806,7 @@ static const uint32 _OldLayDownRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0086347C */
-static const uint32 _OldSuspendedMonorailTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSuspendedMonorailTrackPaintFunctions[256] = {
     0x008636F4, // TRACK_ELEM_FLAT
     0x008637A4, // TRACK_ELEM_END_STATION
     0x008637B4, // TRACK_ELEM_BEGIN_STATION
@@ -14066,7 +14066,7 @@ static const uint32 _OldSuspendedMonorailTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0086E2F8 */
-static const uint32 _OldReverserRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldReverserRollerCoasterTrackPaintFunctions[256] = {
     0x0086E65C, // TRACK_ELEM_FLAT
     0x0086E70C, // TRACK_ELEM_END_STATION
     0x0086E71C, // TRACK_ELEM_BEGIN_STATION
@@ -14326,7 +14326,7 @@ static const uint32 _OldReverserRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00876618 */
-static const uint32 _OldHeartlineTwisterCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldHeartlineTwisterCoasterTrackPaintFunctions[256] = {
     0x0087694C, // TRACK_ELEM_FLAT
     0x00876A1C, // TRACK_ELEM_END_STATION
     0x00876A2C, // TRACK_ELEM_BEGIN_STATION
@@ -14586,7 +14586,7 @@ static const uint32 _OldHeartlineTwisterCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0087EDC4 */
-static const uint32 _OldMiniGolfTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMiniGolfTrackPaintFunctions[256] = {
     0x0087F10C, // TRACK_ELEM_FLAT
     0x0087F17C, // TRACK_ELEM_END_STATION
     0x0087F18C, // TRACK_ELEM_BEGIN_STATION
@@ -14846,7 +14846,7 @@ static const uint32 _OldMiniGolfTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AD280 */
-static const uint32 _OldGigaCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldGigaCoasterTrackPaintFunctions[256] = {
     0x008AD674, // TRACK_ELEM_FLAT
     0x008AD8C4, // TRACK_ELEM_END_STATION
     0x008AD8D4, // TRACK_ELEM_BEGIN_STATION
@@ -15106,7 +15106,7 @@ static const uint32 _OldGigaCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00886074 */
-static const uint32 _OldRoToDropTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldRoToDropTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -15366,7 +15366,7 @@ static const uint32 _OldRoToDropTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00887208 */
-static const uint32 _OldFlyingSaucersTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldFlyingSaucersTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -15626,7 +15626,7 @@ static const uint32 _OldFlyingSaucersTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00889C28 */
-static const uint32 _OldCrookedHouseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldCrookedHouseTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -15886,7 +15886,7 @@ static const uint32 _OldCrookedHouseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0088AC88 */
-static const uint32 _OldMonorailCyclesTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMonorailCyclesTrackPaintFunctions[256] = {
     0x0088AD48, // TRACK_ELEM_FLAT
     0x0088AD58, // TRACK_ELEM_END_STATION
     0x0088AD68, // TRACK_ELEM_BEGIN_STATION
@@ -16146,7 +16146,7 @@ static const uint32 _OldMonorailCyclesTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AE36C */
-static const uint32 _OldCompactInvertedCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldCompactInvertedCoasterTrackPaintFunctions[256] = {
     0x008AE6E0, // TRACK_ELEM_FLAT
     0x008AE950, // TRACK_ELEM_END_STATION
     0x008AE960, // TRACK_ELEM_BEGIN_STATION
@@ -16406,7 +16406,7 @@ static const uint32 _OldCompactInvertedCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AEDE0 */
-static const uint32 _OldWaterCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldWaterCoasterTrackPaintFunctions[256] = {
     0x008AF154, // TRACK_ELEM_FLAT
     0x008AF2A4, // TRACK_ELEM_END_STATION
     0x008AF2B4, // TRACK_ELEM_BEGIN_STATION
@@ -16666,7 +16666,7 @@ static const uint32 _OldWaterCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008AF764 */
-static const uint32 _OldAirPoweredVerticalCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldAirPoweredVerticalCoasterTrackPaintFunctions[256] = {
     0x008AFAD4, // TRACK_ELEM_FLAT
     0x008AFAE4, // TRACK_ELEM_END_STATION
     0x008AFAF4, // TRACK_ELEM_BEGIN_STATION
@@ -16926,7 +16926,7 @@ static const uint32 _OldAirPoweredVerticalCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00890940 */
-static const uint32 _OldInvertedHairpinCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldInvertedHairpinCoasterTrackPaintFunctions[256] = {
     0x00890CB4, // TRACK_ELEM_FLAT
     0x00890D84, // TRACK_ELEM_END_STATION
     0x00890D94, // TRACK_ELEM_BEGIN_STATION
@@ -17186,7 +17186,7 @@ static const uint32 _OldInvertedHairpinCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x00898384 */
-static const uint32 _OldMagicCarpetTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMagicCarpetTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -17446,7 +17446,7 @@ static const uint32 _OldMagicCarpetTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008995D4 */
-static const uint32 _OldSubmarineRideTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldSubmarineRideTrackPaintFunctions[256] = {
     0x008996B4, // TRACK_ELEM_FLAT
     0x008996C4, // TRACK_ELEM_END_STATION
     0x008996D4, // TRACK_ELEM_BEGIN_STATION
@@ -17706,7 +17706,7 @@ static const uint32 _OldSubmarineRideTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x0089B0C0 */
-static const uint32 _OldRiverRaftsTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldRiverRaftsTrackPaintFunctions[256] = {
     0x0089B170, // TRACK_ELEM_FLAT
     0x0089B1A0, // TRACK_ELEM_END_STATION
     0x0089B1B0, // TRACK_ELEM_BEGIN_STATION
@@ -17966,7 +17966,7 @@ static const uint32 _OldRiverRaftsTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A13B4 */
-static const uint32 _OldEnterpriseTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldEnterpriseTrackPaintFunctions[256] = {
     0,
     0,
     0,
@@ -18226,7 +18226,7 @@ static const uint32 _OldEnterpriseTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008B005C */
-static const uint32 _OldInvertedImpulseCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldInvertedImpulseCoasterTrackPaintFunctions[256] = {
     0x008B0460, // TRACK_ELEM_FLAT
     0x008B0470, // TRACK_ELEM_END_STATION
     0x008B0480, // TRACK_ELEM_BEGIN_STATION
@@ -18486,7 +18486,7 @@ static const uint32 _OldInvertedImpulseCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A46D8 */
-static const uint32 _OldMiniRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMiniRollerCoasterTrackPaintFunctions[256] = {
     0x008A4ABC, // TRACK_ELEM_FLAT
     0x008A4D0C, // TRACK_ELEM_END_STATION
     0x008A4D1C, // TRACK_ELEM_BEGIN_STATION
@@ -18746,7 +18746,7 @@ static const uint32 _OldMiniRollerCoasterTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008B0610 */
-static const uint32 _OldMineRideTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldMineRideTrackPaintFunctions[256] = {
     0x008B08D0, // TRACK_ELEM_FLAT
     0x008B0A80, // TRACK_ELEM_END_STATION
     0x008B0A90, // TRACK_ELEM_BEGIN_STATION
@@ -19006,7 +19006,7 @@ static const uint32 _OldMineRideTrackPaintFunctions[256] = {
 };
 
 /** rct2: 0x008A5F6C */
-static const uint32 _OldLimLaunchedRollerCoasterTrackPaintFunctions[256] = {
+static constexpr const uint32 _OldLimLaunchedRollerCoasterTrackPaintFunctions[256] = {
     0x008A6370, // TRACK_ELEM_FLAT
     0x008A6D50, // TRACK_ELEM_END_STATION
     0x008A6D60, // TRACK_ELEM_BEGIN_STATION
@@ -19265,7 +19265,7 @@ static const uint32 _OldLimLaunchedRollerCoasterTrackPaintFunctions[256] = {
     0,
 };
 
-static const uint32 _null[256] = {0};
+static constexpr const uint32 _null[256] = {0};
 
 const uint32 * RideTypeTrackPaintFunctionsOld[RIDE_TYPE_COUNT] = {
     _OldSpiralRollerCoasterTrackPaintFunctions,             // RIDE_TYPE_SPIRAL_ROLLER_COASTER

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -608,7 +608,7 @@ static void track_design_mirror_ride(rct_track_td6 * td6)
 }
 
 /** rct2: 0x00993EDC */
-static const uint8 maze_segment_mirror_map[] = {
+static constexpr const uint8 maze_segment_mirror_map[] = {
     5, 4, 2, 7, 1, 0, 14, 3, 13, 12, 10, 15, 9, 8, 6, 11
 };
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -103,13 +103,13 @@ rct_vehicle * _vehicleFrontVehicle;
 LocationXYZ16 unk_F64E20;
 
 // clang-format off
-static const uint8 byte_9A3A14[] = { SOUND_SCREAM_8, SOUND_SCREAM_1 };
-static const uint8 byte_9A3A16[] = { SOUND_SCREAM_1, SOUND_SCREAM_6 };
-static const uint8 byte_9A3A18[] = {
+static constexpr const uint8 byte_9A3A14[] = { SOUND_SCREAM_8, SOUND_SCREAM_1 };
+static constexpr const uint8 byte_9A3A16[] = { SOUND_SCREAM_1, SOUND_SCREAM_6 };
+static constexpr const uint8 byte_9A3A18[] = {
     SOUND_SCREAM_3, SOUND_SCREAM_1, SOUND_SCREAM_5, SOUND_SCREAM_6,
     SOUND_SCREAM_7, SOUND_SCREAM_2, SOUND_SCREAM_4
 };
-static const uint8 _soundParams[SOUND_MAXID][2] =
+static constexpr const uint8 _soundParams[SOUND_MAXID][2] =
 {
     { 1, 0 },   // SOUND_LIFT_1
     { 1, 0 },   // SOUND_TRACK_FRICTION_1
@@ -176,7 +176,7 @@ static const uint8 _soundParams[SOUND_MAXID][2] =
     { 0, 0 }    // SOUND_62
 };
 
-static const uint8 SpaceRingsTimeToSpriteMap[] =
+static constexpr const uint8 SpaceRingsTimeToSpriteMap[] =
 {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
     1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4,
@@ -310,7 +310,7 @@ static const uint8 SpaceRingsTimeToSpriteMap[] =
     255
 };
 
-static const sint8 SwingingTimeToSpriteMap_0[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_0[] =
 {
     0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
@@ -318,7 +318,7 @@ static const sint8 SwingingTimeToSpriteMap_0[] =
     -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -3, -2, -2, -2, -2, -2, -2, -2, -2, -2,
     -2, -2, -1, -1, -1, -1, -1, -1, -1, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_1[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_1[] =
 {
     0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 1, 1, 1, 1,
@@ -326,7 +326,7 @@ static const sint8 SwingingTimeToSpriteMap_1[] =
     -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -4, -4, -4, -4, -4, -4,
     -4, -4, -4, -3, -3, -3, -3, -3, -3, -2, -2, -2, -2, -2, -1, -1, -1, -1, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_2[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_2[] =
 {
     0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7,
     7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4, 4, 3, 3, 3, 3, 2,
@@ -335,7 +335,7 @@ static const sint8 SwingingTimeToSpriteMap_2[] =
     -6, -6, -6, -6, -6, -6, -5, -5, -5, -5, -5, -5, -4, -4, -4, -4, -4, -3, -3, -3, -3, -2, -2, -2, -1, -1,
     -1, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_3[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_3[] =
 {
     0, 1, 1, 2, 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9,
     9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 8, 8, 8, 8, 8, 8, 8, 8, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 6, 5, 5, 5, 5, 4,
@@ -344,7 +344,7 @@ static const sint8 SwingingTimeToSpriteMap_3[] =
     -9, -8, -8, -8, -8, -8, -8, -8, -8, -7, -7, -7, -7, -7, -7, -6, -6, -6, -6, -6, -5, -5, -5, -5, -4, -4,
     -4, -3, -3, -2, -2, -1, -1, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_4[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_4[] =
 {
     0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
     6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6,
@@ -355,7 +355,7 @@ static const sint8 SwingingTimeToSpriteMap_4[] =
     -6, -6, -6, -5, -5, -5, -5, -5, -5, -5, -4, -4, -4, -4, -4, -3, -3, -3, -3, -3, -2, -2, -2, -2, -2, -1,
     -1, -1, -1, -1, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_5[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_5[] =
 {
     0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9,
     9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14,
@@ -370,7 +370,7 @@ static const sint8 SwingingTimeToSpriteMap_5[] =
     -11, -11, -11, -10, -10, -10, -10, -9, -9, -9, -9, -8, -8, -8, -8, -7, -7, -7, -7, -6, -6, -6, -6, -5,
     -5, -5, -5, -4, -4, -4, -4, -3, -3, -3, -3, -2, -2, -2, -2, -1, -1, -1, -1, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_6[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_6[] =
 {
     0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10, 11, 11,
     11, 12, 12, 12, 13, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 20,
@@ -388,7 +388,7 @@ static const sint8 SwingingTimeToSpriteMap_6[] =
     -13, -13, -12, -12, -12, -11, -11, -11, -10, -10, -10, -9, -9, -9, -8, -8, -8, -7, -7, -7, -6, -6, -6,
     -5, -5, -5, -4, -4, -4, -3, -3, -3, -2, -2, -2, -1, -1, -1, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_7[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_7[] =
 {
     0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10, 11, 11,
     11, 12, 12, 12, 13, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 20,
@@ -400,7 +400,7 @@ static const sint8 SwingingTimeToSpriteMap_7[] =
     -14, -14, -13, -13, -13, -12, -12, -12, -11, -11, -11, -10, -10, -10, -9, -9, -9, -8, -8, -8, -7, -7,
     -7, -6, -6, -6, -5, -5, -5, -4, -4, -4, -3, -3, -3, -2, -2, -2, -1, -1, -1, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_8[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_8[] =
 {
     0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
     6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6,
@@ -411,7 +411,7 @@ static const sint8 SwingingTimeToSpriteMap_8[] =
     26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 30, 30, 30, 30, 30, 31,
     31, 31, 31, 31, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_9[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_9[] =
 {
     0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
     6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6,
@@ -422,7 +422,7 @@ static const sint8 SwingingTimeToSpriteMap_9[] =
     26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 30, 30, 30, 30, 30, 31,
     31, 31, 31, 31, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_10[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_10[] =
 {
     0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9,
     9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 15, 15,
@@ -438,7 +438,7 @@ static const sint8 SwingingTimeToSpriteMap_10[] =
     19, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25, 25, 25, 25, 26,
     26, 26, 26, 27, 27, 27, 27, 28, 28, 28, 28, 29, 29, 29, 29, 30, 30, 30, 30, 31, 31, 31, 31, 0, 0, -128
 };
-static const sint8 SwingingTimeToSpriteMap_11[] =
+static constexpr const sint8 SwingingTimeToSpriteMap_11[] =
 {
     0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9,
     10, 10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16,
@@ -448,7 +448,7 @@ static const sint8 SwingingTimeToSpriteMap_11[] =
 };
 
 /** rct2: 0x0099F9D0 */
-static const sint8 * SwingingTimeToSpriteMaps[] = {
+static constexpr const sint8 * SwingingTimeToSpriteMaps[] = {
     SwingingTimeToSpriteMap_0,
     SwingingTimeToSpriteMap_1,
     SwingingTimeToSpriteMap_2,
@@ -471,7 +471,7 @@ typedef struct
 } unk_9a36c4;
 
 /** rct2: 0x009A36C4 */
-static const unk_9a36c4 Unk9A36C4[] =
+static constexpr const unk_9a36c4 Unk9A36C4[] =
 {
     {-1, 0, 8716},
     {-1, 0, 8716},
@@ -508,7 +508,7 @@ static const unk_9a36c4 Unk9A36C4[] =
 };
 
 /** rct2: 0x009A37C4 */
-static const LocationXY16 Unk9A37C4[] =
+static constexpr const LocationXY16 Unk9A37C4[] =
 {
     { 0,  0},
     { 0, +1},
@@ -522,7 +522,7 @@ static const LocationXY16 Unk9A37C4[] =
 };
 
 /** rct2: 0x009A37E4 */
-static const sint32 Unk9A37E4[] =
+static constexpr const sint32 Unk9A37E4[] =
 {
     2147483647,
     2106585154,
@@ -587,7 +587,7 @@ static const sint32 Unk9A37E4[] =
 };
 
 /** rct2: 0x009A38D4 */
-static const sint32 Unk9A38D4[] =
+static constexpr const sint32 Unk9A38D4[] =
 {
     0,
     417115092,
@@ -652,7 +652,7 @@ static const sint32 Unk9A38D4[] =
 };
 
 /** rct2: 0x009A39C4 */
-static const sint32 Unk9A39C4[] =
+static constexpr const sint32 Unk9A39C4[] =
 {
     2147483647,
     2096579710,
@@ -676,7 +676,7 @@ static const sint32 Unk9A39C4[] =
     1946281152,
 };
 
-static const LocationXY16 AvoidCollisionMoveOffset[] =
+static constexpr const LocationXY16 AvoidCollisionMoveOffset[] =
 {
     { -1,  0 },
     {  0,  1 },
@@ -685,13 +685,13 @@ static const LocationXY16 AvoidCollisionMoveOffset[] =
 };
 
 
-static const uint8 DoorOpenSoundIds[] =
+static constexpr const uint8 DoorOpenSoundIds[] =
 {
     SOUND_DOOR_OPEN,
     SOUND_62
 };
 
-static const uint8 DoorCloseSoundIds[] =
+static constexpr const uint8 DoorCloseSoundIds[] =
 {
     SOUND_DOOR_CLOSE,
     SOUND_62
@@ -808,7 +808,7 @@ const rct_vehicle_info * vehicle_get_move_info(sint32 cd, sint32 typeAndDirectio
 {
     if (!vehicle_move_info_valid(cd, typeAndDirection, offset))
     {
-        static const rct_vehicle_info zero = { 0 };
+        static constexpr const rct_vehicle_info zero = { 0 };
         return &zero;
     }
     return &gTrackVehicleInfo[cd][typeAndDirection]->info[offset];
@@ -3596,7 +3596,7 @@ static void vehicle_update_collision_setup(rct_vehicle * vehicle)
 }
 
 /** rct2: 0x009A3AC4, 0x009A3AC6 */
-static const LocationXY16 stru_9A3AC4[] = {
+static constexpr const LocationXY16 stru_9A3AC4[] = {
     { -256, 0 }, { -236, 98 }, { -181, 181 }, { -98, 236 }, { 0, 256 },  { 98, 236 },   { 181, 181 },   { 236, 98 },
     { 256, 0 },  { 236, -98 }, { 181, -181 }, { 98, -236 }, { 0, -256 }, { -98, -236 }, { -181, -181 }, { -236, -98 },
 };
@@ -4637,7 +4637,7 @@ static void vehicle_update_boat_location(rct_vehicle * vehicle)
         }
     }
 
-    static const sint8 rotations[] = { 0, 1, -1, 2 };
+    static constexpr const sint8 rotations[] = { 0, 1, -1, 2 };
     for (auto rotation : rotations)
     {
         if (randDirection + rotation == curDirection)
@@ -7093,7 +7093,7 @@ enum
     loc_6D6718
 };
 
-static const uint8 off_9A2E84[256] = {
+static constexpr const uint8 off_9A2E84[256] = {
     loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C,
     loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D66F0, loc_6D672B, loc_6D673C, loc_6D673C,
     loc_6D673C, loc_6D673C, loc_6D66F0, loc_6D672B, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C, loc_6D673C,

--- a/src/openrct2/ride/VehicleData.cpp
+++ b/src/openrct2/ride/VehicleData.cpp
@@ -19,7 +19,7 @@
 
 // clang-format off
 /** rct2: 0x0099F100 */
-static const uint8 Rotation1TimeToSpriteMap_0[] = {
+static constexpr const uint8 Rotation1TimeToSpriteMap_0[] = {
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,
     1,   1,   1,   1,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
@@ -72,7 +72,7 @@ static const uint8 Rotation1TimeToSpriteMap_0[] = {
 };
 
 /** rct2: 0x0099F422 */
-static const uint8 Rotation1TimeToSpriteMap_1[] = {
+static constexpr const uint8 Rotation1TimeToSpriteMap_1[] = {
     0,   0,   0,   1,   1,   1,   2,   2,   2,   3,   3,   3,   4,   4,   4,   5,   5,
     5,   6,   6,   6,   7,   7,   7,   8,   8,   8,   9,   9,   9,  10,  10,  10,  11,
     11,  11,  12,  12,  12,  13,  13,  13,  14,  14,  14,  15,  15,  15,  16,  16,  16,
@@ -116,7 +116,7 @@ static const uint8 Rotation1TimeToSpriteMap_1[] = {
 };
 
 /** rct2: 0x0099F6AB */
-static const uint8 Rotation1TimeToSpriteMap_2[] = {
+static constexpr const uint8 Rotation1TimeToSpriteMap_2[] = {
     0,   0,   0,   1,   1,   1,   2,   2,   2,   3,   3,   3,   4,   4,   4,   5,   5,
     5,   6,   6,   6,   7,   7,   7,   8,   8,   8,   9,   9,   9,  10,  10,  10,  11,
     11,  11,  12,  12,  12,  13,  13,  13,  14,  14,  14,  15,  15,  15,  16,  16,  16,
@@ -176,7 +176,7 @@ const uint8 * Rotation1TimeToSpriteMaps[] = {
 };
 
 /** rct2: 0x009A2434 */
-static const uint8 Rotation2TimeToSpriteMap_0[] = {
+static constexpr const uint8 Rotation2TimeToSpriteMap_0[] = {
     0,   0,   0,   0,   0,   0,   0,   0,   1,   1,   1,   1,   1,   1,   1,   1,   2,
     2,   2,   2,   2,   2,   2,   2,   3,   3,   3,   3,   3,   3,   3,   3,   4,   4,
     4,   4,   4,   4,   4,   4,   5,   5,   5,   5,   5,   5,   5,   5,   6,   6,   6,
@@ -218,7 +218,7 @@ static const uint8 Rotation2TimeToSpriteMap_0[] = {
 };
 
 /** rct2: 0x009A26A6 */
-static const uint8 Rotation2TimeToSpriteMap_1[] = {
+static constexpr const uint8 Rotation2TimeToSpriteMap_1[] = {
     46,  46,  47,  47,  48,  48,  46,  46,  47,  47,  48,  48,  46,  46,  47,  47,  48,
     48,  46,  46,  47,  47,  48,  48,  46,  46,  47,  47,  48,  48,  46,  46,  47,  47,
     48,  48,  46,  46,  47,  47,  48,  48,  46,  46,  47,  47,  48,  48,  46,  46,  47,
@@ -229,7 +229,7 @@ static const uint8 Rotation2TimeToSpriteMap_1[] = {
 };
 
 /** rct2: 0x009A270E */
-static const uint8 Rotation2TimeToSpriteMap_2[] = {
+static constexpr const uint8 Rotation2TimeToSpriteMap_2[] = {
     43,  43,  44,  44,  45,  45,  43,  43,  44,  44,  45,  45,  43,  43,  44,  44,  45,
     45,  40,  40,  41,  41,  42,  42,  40,  40,  41,  41,  42,  42,  40,  40,  41,  41,
     42,  42,  37,  37,  38,  38,  39,  39,  37,  37,  38,  38,  39,  39,  37,  37,  38,
@@ -269,7 +269,7 @@ const uint8 * Rotation2TimeToSpriteMaps[] = {
 };
 
 /** rct2: 0x0099EB28 */
-static const uint8 Rotation3TimeToSpriteMap_0[] = {
+static constexpr const uint8 Rotation3TimeToSpriteMap_0[] = {
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,
     1,   1,   1,   1,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
@@ -306,7 +306,7 @@ static const uint8 Rotation3TimeToSpriteMap_0[] = {
 };
 
 /** rct2: 0x0099ED49 */
-static const uint8 Rotation3TimeToSpriteMap_1[] = {
+static constexpr const uint8 Rotation3TimeToSpriteMap_1[] = {
     0,   0,   0,   1,   1,   1,   2,   2,   2,   3,   3,   3,   4,   4,   4,   5,   5,
     5,   6,   6,   6,   7,   7,   7,   8,   8,   8,   9,   9,   9,  10,  10,  10,  11,
     11,  11,  12,  12,  12,  13,  13,  13,  14,  14,  14,  15,  15,  15,  16,  16,  16,
@@ -334,7 +334,7 @@ static const uint8 Rotation3TimeToSpriteMap_1[] = {
 };
 
 /** rct2: 0x0099EED1 */
-static const uint8 Rotation3TimeToSpriteMap_2[] = {
+static constexpr const uint8 Rotation3TimeToSpriteMap_2[] = {
     0,   0,   0,   1,   1,   1,   2,   2,   2,   3,   3,   3,   4,   4,   4,   5,   5,
     5,   6,   6,   6,   7,   7,   7,   8,   8,   8,   9,   9,   9,  10,  10,  10,  11,
     11,  11,  12,  12,  12,  13,  13,  13,  14,  14,  14,  15,  15,  15,  16,  16,  16,
@@ -378,7 +378,7 @@ const uint8 * Rotation3TimeToSpriteMaps[] = {
 };
 
 /** rct2: 0x009A12EC */
-static const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_0[] = {
+static constexpr const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_0[] = {
     {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 },
     {  0,  0 }, {  0,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 },
     {  1,  0 }, {  1,  0 }, {  1,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 },
@@ -464,7 +464,7 @@ static const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_0[] = {
 };
 
 /** rct2: 0x009A1751 */
-static const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_1[] = {
+static constexpr const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_1[] = {
     {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 },
     {  0,  0 }, {  0,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 },
     {  1,  0 }, {  1,  0 }, {  1,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 },
@@ -569,7 +569,7 @@ static const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_1[] = {
 };
 
 /** rct2: 0x009A1CC6 */
-static const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_2[] = {
+static constexpr const top_spin_time_to_sprite_map TopSpinTimeToSpriteMap_2[] = {
     {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 }, {  0,  0 },
     {  0,  0 }, {  0,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 }, {  1,  0 },
     {  1,  0 }, {  1,  0 }, {  1,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 }, {  2,  0 },

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -184,7 +184,7 @@ static uint32 air_powered_vertical_rc_get_support_colour(paint_session * session
 static void air_powered_vertical_rc_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_AIR_POWERED_VERTICAL_RC_FLAT_SW_NE,
         SPR_AIR_POWERED_VERTICAL_RC_FLAT_NW_SE,
         SPR_AIR_POWERED_VERTICAL_RC_FLAT_SW_NE,
@@ -205,7 +205,7 @@ static void air_powered_vertical_rc_track_flat(paint_session * session, uint8 ri
 static void air_powered_vertical_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                   uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_AIR_POWERED_VERTICAL_RC_STATION_SW_NE, SPR_STATION_BASE_B_SW_NE },
         { SPR_AIR_POWERED_VERTICAL_RC_STATION_NW_SE, SPR_STATION_BASE_B_NW_SE },
         { SPR_AIR_POWERED_VERTICAL_RC_STATION_SW_NE, SPR_STATION_BASE_B_SW_NE },
@@ -231,7 +231,7 @@ static void air_powered_vertical_rc_track_station(paint_session * session, uint8
 static void air_powered_vertical_rc_track_right_quarter_turn_5(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                                uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][5] = {
+    static constexpr const sprite_bb imageIds[4][5] = {
         {
             { SPR_AIR_POWERED_VERTICAL_RC_QUARTER_TURN_5_SW_SE_PART_0, { 0, 2, 0 }, { 0, 0, 0 }, { 32, 32, 2 } },
             { SPR_AIR_POWERED_VERTICAL_RC_QUARTER_TURN_5_SW_SE_PART_1, { 0, 16, 0 }, { 0, 0, 0 }, { 32, 16, 2 } },
@@ -319,7 +319,7 @@ static void air_powered_vertical_rc_track_left_quarter_turn_5(paint_session * se
 static void air_powered_vertical_rc_track_flat_to_left_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_SW_NE, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_SW_NE },
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_NW_SE, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_NW_SE },
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_NE_SW, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_NE_SW },
@@ -347,7 +347,7 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(paint_session * sess
 static void air_powered_vertical_rc_track_flat_to_right_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                              uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_RIGHT_BANK_SW_NE, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_SW_NE },
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_RIGHT_BANK_NW_SE, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_NW_SE },
         { SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_RIGHT_BANK_NE_SW, SPR_AIR_POWERED_VERTICAL_RC_FLAT_TO_LEFT_BANK_FRONT_NE_SW },
@@ -389,7 +389,7 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(paint_sess
                                                                       uint8 trackSequence, uint8 direction, sint32 height,
                                                                       rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][5] = {
+    static constexpr const sprite_bb imageIds[4][5] = {
         {
             { SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 3 } },
             { SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 3 } },
@@ -492,7 +492,7 @@ static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(paint_sessi
 static void air_powered_vertical_rc_track_left_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_AIR_POWERED_VERTICAL_RC_LEFT_BANK_SW_NE,
         SPR_AIR_POWERED_VERTICAL_RC_LEFT_BANK_NW_SE,
         SPR_AIR_POWERED_VERTICAL_RC_LEFT_BANK_NE_SW,
@@ -526,7 +526,7 @@ static void air_powered_vertical_rc_track_right_bank(paint_session * session, ui
 static void air_powered_vertical_rc_track_brakes(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_AIR_POWERED_VERTICAL_RC_BRAKES_NW_SE,
         SPR_AIR_POWERED_VERTICAL_RC_BRAKES_SW_NE,
         SPR_AIR_POWERED_VERTICAL_RC_BRAKES_NW_SE,
@@ -547,7 +547,7 @@ static void air_powered_vertical_rc_track_brakes(paint_session * session, uint8 
 static void air_powered_vertical_rc_track_vertical_slope_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 trackImageIds[7][4] = {
+    static constexpr const uint32 trackImageIds[7][4] = {
         {
             SPR_AIR_POWERED_VERTICAL_RC_SLOPE_SW_NE_0,
             SPR_AIR_POWERED_VERTICAL_RC_SLOPE_NW_SE_0,
@@ -587,7 +587,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(paint_session * sess
         },
     };
 
-    static const uint32 supportImageIds[7][4] = {
+    static constexpr const uint32 supportImageIds[7][4] = {
         {
             22264,
             SPR_AIR_POWERED_VERTICAL_RC_SLOPE_SUPPORTS_NW_SE_0,
@@ -632,9 +632,9 @@ static void air_powered_vertical_rc_track_vertical_slope_up(paint_session * sess
         },
     };
 
-    static const sint8  bbHeights03[]    = { 1, 6, 14, 37, 76 };
-    static const sint8  bbHeights12[]    = { 1, 6, 14, 27, 59 };
-    static const sint32 supportHeights[] = { 48, 64, 128, 176, 208, 240, 240 };
+    static constexpr const sint8  bbHeights03[]    = { 1, 6, 14, 37, 76 };
+    static constexpr const sint8  bbHeights12[]    = { 1, 6, 14, 27, 59 };
+    static constexpr const sint32 supportHeights[] = { 48, 64, 128, 176, 208, 240, 240 };
 
     uint32 supportsImageId = supportImageIds[trackSequence][direction] | air_powered_vertical_rc_get_support_colour(session);
     uint32 trackImageId    = trackImageIds[trackSequence][direction] | session->TrackColours[SCHEME_TRACK];
@@ -749,7 +749,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(paint_session * sess
 static void air_powered_vertical_rc_track_vertical_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_SW_NE_SEQ_0, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_SW_NE_SEQ_1 },
         { SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_NW_SE_SEQ_0, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_NW_SE_SEQ_1 },
         { SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_NE_SW_SEQ_0, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_UP_NE_SW_SEQ_1 },
@@ -792,7 +792,7 @@ static void air_powered_vertical_rc_track_vertical_top(paint_session * session, 
         return;
     }
 
-    static const uint32 imageIds[4][6] = {
+    static constexpr const uint32 imageIds[4][6] = {
         { SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_TOP_SUPPORT_SW_NE, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_TOP_TRACK_SW_NE_SEQ_0,
           SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_TOP_TRACK_SW_NE_SEQ_1,
           SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_TOP_TRACK_SW_NE_SEQ_2, SPR_AIR_POWERED_VERTICAL_RC_VERTICAL_TOP_SUPPORT_NE_SW,

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -87,7 +87,7 @@ static void bobsleigh_rc_track_flat(paint_session * session, uint8 rideIndex, ui
 static void bobsleigh_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { 14580, SPR_STATION_BASE_B_SW_NE },
         { 14581, SPR_STATION_BASE_B_NW_SE },
         { 14580, SPR_STATION_BASE_B_SW_NE },

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.cpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.cpp
@@ -85,7 +85,7 @@ void bolliger_mabillard_track_flat(paint_session * session, uint8 rideIndex, uin
 void bolliger_mabillard_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement, sint32 supportType)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 17154, 17150, SPR_STATION_BASE_A_SW_NE },
         { 17155, 17151, SPR_STATION_BASE_A_NW_SE },
         { 17154, 17150, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -79,7 +79,7 @@ static void compact_inverted_rc_track_flat(paint_session * session, uint8 rideIn
 static void compact_inverted_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 26557, SPR_STATION_INVERTED_BAR_A_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 26558, SPR_STATION_INVERTED_BAR_A_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 26557, SPR_STATION_INVERTED_BAR_A_SW_NE },

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -86,7 +86,7 @@ static void corkscrew_rc_track_flat(paint_session * session, uint8 rideIndex, ui
 static void corkscrew_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 16236, 16232, SPR_STATION_BASE_A_SW_NE },
         { 16237, 16233, SPR_STATION_BASE_A_NW_SE },
         { 16236, 16232, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -139,7 +139,7 @@ static void flying_rc_track_station(paint_session * session, uint8 rideIndex, ui
 {
     if (track_element_is_inverted(tileElement))
     {
-        static const uint32 imageIds[4][3] = {
+        static constexpr const uint32 imageIds[4][3] = {
             { SPR_STATION_BASE_C_SW_NE, 27131, SPR_STATION_INVERTED_BAR_C_SW_NE },
             { SPR_STATION_BASE_C_NW_SE, 27132, SPR_STATION_INVERTED_BAR_C_NW_SE },
             { SPR_STATION_BASE_C_SW_NE, 27131, SPR_STATION_INVERTED_BAR_C_SW_NE },
@@ -157,7 +157,7 @@ static void flying_rc_track_station(paint_session * session, uint8 rideIndex, ui
     }
     else
     {
-        static const uint32 imageIds[4][3] = {
+        static constexpr const uint32 imageIds[4][3] = {
             { 17154, 17150, SPR_STATION_BASE_A_SW_NE },
             { 17155, 17151, SPR_STATION_BASE_A_NW_SE },
             { 17154, 17150, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -105,7 +105,7 @@ static void giga_rc_track_flat(paint_session * session, uint8 rideIndex, uint8 t
 static void giga_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height,
                                   rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 18084, 18076, SPR_STATION_BASE_A_SW_NE },
         { 18085, 18077, SPR_STATION_BASE_A_NW_SE },
         { 18084, 18076, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -94,7 +94,7 @@ static void heartline_twister_rc_track_flat(paint_session * session, uint8 rideI
 static void heartline_twister_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 19732, SPR_STATION_BASE_B_SW_NE },
         { 19733, SPR_STATION_BASE_B_NW_SE },
         { 19732, SPR_STATION_BASE_B_SW_NE },

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -85,7 +85,7 @@ static void inverted_hairpin_rc_track_flat(paint_session * session, uint8 rideIn
 static void inverted_hairpin_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 17028, SPR_STATION_INVERTED_BAR_0_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 17029, SPR_STATION_INVERTED_BAR_0_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 17028, SPR_STATION_INVERTED_BAR_0_SW_NE },

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -60,7 +60,7 @@ static void inverted_impulse_rc_track_flat(paint_session * session, uint8 rideIn
 static void inverted_impulse_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 19662, SPR_STATION_INVERTED_BAR_B_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 19663, SPR_STATION_INVERTED_BAR_B_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 19662, SPR_STATION_INVERTED_BAR_B_SW_NE },

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -78,7 +78,7 @@ static void inverted_rc_track_flat(paint_session * session, uint8 rideIndex, uin
 static void inverted_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 27131, SPR_STATION_INVERTED_BAR_C_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 27132, SPR_STATION_INVERTED_BAR_C_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 27131, SPR_STATION_INVERTED_BAR_C_SW_NE },

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -644,7 +644,7 @@ enum
     SPR_JUNIOR_RC_BOOSTER_NE_SW = SPR_G2_BEGIN + 86,
 };
 
-static const uint32 junior_rc_track_pieces_flat[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_flat[3][4] = {
     { SPR_JUNIOR_RC_FLAT_SW_NE, SPR_JUNIOR_RC_FLAT_NW_SE, SPR_JUNIOR_RC_FLAT_SW_NE, SPR_JUNIOR_RC_FLAT_NW_SE },
     { SPR_JUNIOR_RC_FLAT_CHAIN_SW_NE, SPR_JUNIOR_RC_FLAT_CHAIN_NW_SE, SPR_JUNIOR_RC_FLAT_CHAIN_SW_NE,
       SPR_JUNIOR_RC_FLAT_CHAIN_NW_SE },
@@ -656,20 +656,20 @@ static const uint32 junior_rc_track_pieces_flat[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_block_brake[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_block_brake[2][4] = {
     { SPR_JUNIOR_RC_FLAT_BLOCK_SW_NE, SPR_JUNIOR_RC_FLAT_BLOCK_NW_SE, SPR_JUNIOR_RC_FLAT_BLOCK_SW_NE,
       SPR_JUNIOR_RC_FLAT_BLOCK_NW_SE },
     { SPR_JUNIOR_RC_FLAT_BLOCK_SW_NE_BRAKED, SPR_JUNIOR_RC_FLAT_BLOCK_NW_SE_BRAKED, SPR_JUNIOR_RC_FLAT_BLOCK_SW_NE_BRAKED,
       SPR_JUNIOR_RC_FLAT_BLOCK_NW_SE_BRAKED },
 };
 
-static const uint32 junior_rc_track_pieces_station[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_station[2][4] = {
     { SPR_JUNIOR_RC_STATION_SW_NE, SPR_JUNIOR_RC_STATION_NW_SE, SPR_JUNIOR_RC_STATION_SW_NE, SPR_JUNIOR_RC_STATION_NW_SE },
     { SPR_JUNIOR_RC_FLAT_SW_NE_BRAKED, SPR_JUNIOR_RC_FLAT_NW_SE_BRAKED, SPR_JUNIOR_RC_FLAT_SW_NE_BRAKED,
       SPR_JUNIOR_RC_FLAT_NW_SE_BRAKED },
 };
 
-static const uint32 junior_rc_track_pieces_25_deg_up[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_25_deg_up[3][4] = {
     { SPR_JUNIOR_RC_25_DEG_SW_NE, SPR_JUNIOR_RC_25_DEG_NW_SE, SPR_JUNIOR_RC_25_DEG_NE_SW, SPR_JUNIOR_RC_25_DEG_SE_NW },
     { SPR_JUNIOR_RC_25_DEG_CHAIN_SW_NE, SPR_JUNIOR_RC_25_DEG_CHAIN_NW_SE, SPR_JUNIOR_RC_25_DEG_CHAIN_NE_SW,
       SPR_JUNIOR_RC_25_DEG_CHAIN_SE_NW },
@@ -681,7 +681,7 @@ static const uint32 junior_rc_track_pieces_25_deg_up[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_flat_to_25_deg_up[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_to_25_deg_up[3][4] = {
     { SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_SW_NE, SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_NW_SE, SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_NE_SW,
       SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_SE_NW },
     { SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_CHAIN_SW_NE, SPR_JUNIOR_RC_FLAT_TO_25_DEG_UP_CHAIN_NW_SE,
@@ -694,7 +694,7 @@ static const uint32 junior_rc_track_pieces_flat_to_25_deg_up[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_25_deg_up_to_flat[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_25_deg_up_to_flat[3][4] = {
     { SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_SW_NE, SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_NW_SE, SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_NE_SW,
       SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_SE_NW },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_CHAIN_SW_NE, SPR_JUNIOR_RC_25_DEG_UP_TO_FLAT_CHAIN_NW_SE,
@@ -707,21 +707,21 @@ static const uint32 junior_rc_track_pieces_25_deg_up_to_flat[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_flat_to_left_bank[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_to_left_bank[4][2] = {
     { SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_SW_NE, SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_SW_NE_FRONT },
     { SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_NW_SE, SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_NW_SE_FRONT },
     { SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_NE_SW, 0 },
     { SPR_JUNIOR_RC_FLAT_TO_LEFT_BANK_SE_NW, 0 }
 };
 
-static const uint32 junior_rc_track_pieces_flat_to_right_bank[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_to_right_bank[4][2] = {
     { SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_SW_NE, 0 },
     { SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_NW_SE, 0 },
     { SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_NE_SW, SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_NE_SW_FRONT },
     { SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_SE_NW, SPR_JUNIOR_RC_FLAT_TO_RIGHT_BANK_SE_NW_FRONT }
 };
 
-static const uint32 junior_rc_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     {
         SPR_JUNIOR_RC_FLAT_QUARTER_TURN_5_TILES_SW_SE_PART_0,
         SPR_JUNIOR_RC_FLAT_QUARTER_TURN_5_TILES_SW_SE_PART_1,
@@ -752,7 +752,7 @@ static const uint32 junior_rc_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     }
 };
 
-static const uint32 junior_rc_track_pieces_banked_quarter_turn_5_tiles[4][5] = {
+static constexpr const uint32 junior_rc_track_pieces_banked_quarter_turn_5_tiles[4][5] = {
     {
         SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_SW_SE_PART_0,
         SPR_JUNIOR_RC_BANKED_QUARTER_TURN_5_TILES_SW_SE_PART_1,
@@ -783,38 +783,38 @@ static const uint32 junior_rc_track_pieces_banked_quarter_turn_5_tiles[4][5] = {
     }
 };
 
-static const uint32 junior_rc_track_pieces_left_banked_to_25_deg_up[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_left_banked_to_25_deg_up[4][2] = {
     { SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_SW_NE, SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_SW_NE_FRONT },
     { SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_NW_SE, SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_NW_SE_FRONT },
     { SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_NE_SW, 0 },
     { SPR_JUNIOR_RC_LEFT_BANK_TO_25_DEG_UP_SE_NW, 0 }
 };
 
-static const uint32 junior_rc_track_pieces_right_banked_to_25_deg_up[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_banked_to_25_deg_up[4][2] = {
     { SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_SW_NE, 0 },
     { SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_NW_SE, 0 },
     { SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_NE_SW, SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_NE_SW_FRONT },
     { SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_SE_NW, SPR_JUNIOR_RC_RIGHT_BANK_TO_25_DEG_UP_SE_NW_FRONT }
 };
 
-static const uint32 junior_rc_track_pieces_25_deg_up_to_left_bank[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_25_deg_up_to_left_bank[4][2] = {
     { SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_SW_NE, SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_SW_NE_FRONT },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_NW_SE, SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_NW_SE_FRONT },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_NE_SW, 0 },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_LEFT_BANK_SE_NW, 0 }
 };
 
-static const uint32 junior_rc_track_pieces_25_deg_up_to_right_bank[4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_25_deg_up_to_right_bank[4][2] = {
     { SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_SW_NE, 0 },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_NW_SE, 0 },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_NE_SW, SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_NE_SW_FRONT },
     { SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_SE_NW, SPR_JUNIOR_RC_25_DEG_UP_TO_RIGHT_BANK_SE_NW_FRONT }
 };
 
-static const uint32 junior_rc_track_pieces_left_bank[4] = { SPR_JUNIOR_RC_LEFT_BANK_SW_NE, SPR_JUNIOR_RC_LEFT_BANK_NW_SE,
+static constexpr const uint32 junior_rc_track_pieces_left_bank[4] = { SPR_JUNIOR_RC_LEFT_BANK_SW_NE, SPR_JUNIOR_RC_LEFT_BANK_NW_SE,
                                                             SPR_JUNIOR_RC_LEFT_BANK_NE_SW, SPR_JUNIOR_RC_LEFT_BANK_SE_NW };
 
-static const uint32 junior_rc_track_pieces_left_quarter_turn_5_tiles_25_deg_up[2][4][5] = {
+static constexpr const uint32 junior_rc_track_pieces_left_quarter_turn_5_tiles_25_deg_up[2][4][5] = {
     { {
           SPR_JUNIOR_RC_LEFT_QUARTER_TURN_5_TILES_25_DEG_UP_SW_SE_PART_0,
           SPR_JUNIOR_RC_LEFT_QUARTER_TURN_5_TILES_25_DEG_UP_SW_SE_PART_1,
@@ -874,7 +874,7 @@ static const uint32 junior_rc_track_pieces_left_quarter_turn_5_tiles_25_deg_up[2
 };
 
 // clang-format off
-const LocationXY16 junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets[4][5] = { {
+static constexpr const LocationXY16 junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets[4][5] = { {
                                                                                    { 0, 6 },
                                                                                    { 0, 0 },
                                                                                    { 0, 16 },
@@ -903,7 +903,7 @@ const LocationXY16 junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets[4][5] =
                                                                                    { 0, 6 },
                                                                                } };
 
-static const uint32 junior_rc_track_pieces_right_quarter_turn_5_tiles_25_deg_up[2][4][5] = {
+static constexpr const uint32 junior_rc_track_pieces_right_quarter_turn_5_tiles_25_deg_up[2][4][5] = {
     { {
           SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_5_TILES_25_DEG_UP_SW_SE_PART_0,
           SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_5_TILES_25_DEG_UP_SW_SE_PART_1,
@@ -962,7 +962,7 @@ static const uint32 junior_rc_track_pieces_right_quarter_turn_5_tiles_25_deg_up[
       } }
 };
 
-static const uint32 junior_rc_track_pieces_s_bend_left[2][4] = { {
+static constexpr const uint32 junior_rc_track_pieces_s_bend_left[2][4] = { {
                                                                      SPR_JUNIOR_RC_S_BEND_LEFT_SW_NE_PART_0,
                                                                      SPR_JUNIOR_RC_S_BEND_LEFT_SW_NE_PART_1,
                                                                      SPR_JUNIOR_RC_S_BEND_LEFT_SW_NE_PART_2,
@@ -975,7 +975,7 @@ static const uint32 junior_rc_track_pieces_s_bend_left[2][4] = { {
                                                                      SPR_JUNIOR_RC_S_BEND_LEFT_SE_NW_PART_0,
                                                                  } };
 
-static const uint32 junior_rc_track_pieces_s_bend_right[2][4] = { {
+static constexpr const uint32 junior_rc_track_pieces_s_bend_right[2][4] = { {
                                                                       SPR_JUNIOR_RC_S_BEND_RIGHT_SW_NE_PART_0,
                                                                       SPR_JUNIOR_RC_S_BEND_RIGHT_SW_NE_PART_1,
                                                                       SPR_JUNIOR_RC_S_BEND_RIGHT_SW_NE_PART_2,
@@ -988,7 +988,7 @@ static const uint32 junior_rc_track_pieces_s_bend_right[2][4] = { {
                                                                       SPR_JUNIOR_RC_S_BEND_RIGHT_SE_NW_PART_0,
                                                                   } };
 
-static const uint32 junior_rc_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
     { SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -999,7 +999,7 @@ static const uint32 junior_rc_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
       SPR_JUNIOR_RC_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 junior_rc_track_pieces_banked_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 junior_rc_track_pieces_banked_quarter_turn_3_tiles[4][3] = {
     { SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -1010,7 +1010,7 @@ static const uint32 junior_rc_track_pieces_banked_quarter_turn_3_tiles[4][3] = {
       SPR_JUNIOR_RC_BANKED_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[2][4][2] = {
     { { SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_UP_SW_SE_PART_0,
         SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_UP_SW_SE_PART_1 },
       { SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_UP_NW_SW_PART_0,
@@ -1029,7 +1029,7 @@ static const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_up[
         SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_UP_CHAIN_SE_NE_PART_1 } }
 };
 
-static const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_down[2][4][2] = {
     { { SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_DOWN_SW_SE_PART_0,
         SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_DOWN_SW_SE_PART_1 },
       { SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_DOWN_NW_SW_PART_0,
@@ -1048,7 +1048,7 @@ static const uint32 junior_rc_track_pieces_right_quarter_turn_3_tiles_25_deg_dow
         SPR_JUNIOR_RC_RIGHT_QUARTER_TURN_3_TILES_25_DEG_DOWN_CHAIN_SE_NE_PART_1 } }
 };
 
-static const uint32 junior_rc_track_pieces_right_half_banked_helix_up_small_quarter_tiles[4][3][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_half_banked_helix_up_small_quarter_tiles[4][3][2] = {
     {
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_SMALL_SW_SE_PART_0 },
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_SMALL_SW_SE_PART_1 },
@@ -1067,7 +1067,7 @@ static const uint32 junior_rc_track_pieces_right_half_banked_helix_up_small_quar
       { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_SMALL_SE_NE_PART_2 } }
 };
 
-static const uint32 junior_rc_track_pieces_right_half_banked_helix_down_small_quarter_tiles[4][3][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_half_banked_helix_down_small_quarter_tiles[4][3][2] = {
     {
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_SMALL_SW_SE_PART_0 },
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_SMALL_SW_SE_PART_1 },
@@ -1086,7 +1086,7 @@ static const uint32 junior_rc_track_pieces_right_half_banked_helix_down_small_qu
       { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_SMALL_SE_NE_PART_2 } }
 };
 
-static const uint32 junior_rc_track_pieces_right_half_banked_helix_up_large_quarter_tiles[4][5][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_half_banked_helix_up_large_quarter_tiles[4][5][2] = {
     {
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_LARGE_SW_SE_PART_0 },
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_LARGE_SW_SE_PART_1 },
@@ -1113,7 +1113,7 @@ static const uint32 junior_rc_track_pieces_right_half_banked_helix_up_large_quar
       { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_UP_LARGE_SE_NE_PART_4 } }
 };
 
-static const uint32 junior_rc_track_pieces_right_half_banked_helix_down_large_quarter_tiles[4][5][2] = {
+static constexpr const uint32 junior_rc_track_pieces_right_half_banked_helix_down_large_quarter_tiles[4][5][2] = {
     {
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_LARGE_SW_SE_PART_0 },
         { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_LARGE_SW_SE_PART_1 },
@@ -1140,10 +1140,10 @@ static const uint32 junior_rc_track_pieces_right_half_banked_helix_down_large_qu
       { SPR_JUNIOR_RC_RIGHT_HALF_BANKED_HELIX_DOWN_LARGE_SE_NE_PART_4 } }
 };
 
-static const uint32 junior_rc_track_pieces_brake[4] = { SPR_JUNIOR_RC_FLAT_SW_NE_BRAKED, SPR_JUNIOR_RC_FLAT_NW_SE_BRAKED,
+static constexpr const uint32 junior_rc_track_pieces_brake[4] = { SPR_JUNIOR_RC_FLAT_SW_NE_BRAKED, SPR_JUNIOR_RC_FLAT_NW_SE_BRAKED,
                                                         SPR_JUNIOR_RC_FLAT_SW_NE_BRAKED, SPR_JUNIOR_RC_FLAT_NW_SE_BRAKED };
 
-static const uint32 junior_rc_track_pieces_left_eight_to_diag[4][4] = {
+static constexpr const uint32 junior_rc_track_pieces_left_eight_to_diag[4][4] = {
     {
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_SW_N_PART_0,
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_SW_N_PART_1,
@@ -1170,7 +1170,7 @@ static const uint32 junior_rc_track_pieces_left_eight_to_diag[4][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_right_eight_to_diag[4][4] = {
+static constexpr const uint32 junior_rc_track_pieces_right_eight_to_diag[4][4] = {
     {
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_SW_E_PART_0,
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_SW_E_PART_1,
@@ -1197,7 +1197,7 @@ static const uint32 junior_rc_track_pieces_right_eight_to_diag[4][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_left_eight_to_diag_bank[4][4] = {
+static constexpr const uint32 junior_rc_track_pieces_left_eight_to_diag_bank[4][4] = {
     {
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_BANK_SW_N_PART_0,
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_BANK_SW_N_PART_1,
@@ -1224,7 +1224,7 @@ static const uint32 junior_rc_track_pieces_left_eight_to_diag_bank[4][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_right_eight_to_diag_bank[4][4] = {
+static constexpr const uint32 junior_rc_track_pieces_right_eight_to_diag_bank[4][4] = {
     {
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_BANK_SW_E_PART_0,
         SPR_JUNIOR_RC_EIGHT_TO_DIAG_BANK_SW_E_PART_1,
@@ -1251,7 +1251,7 @@ static const uint32 junior_rc_track_pieces_right_eight_to_diag_bank[4][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat[3][4] = {
     { SPR_JUNIOR_RC_DIAG_FLAT_W_E, SPR_JUNIOR_RC_DIAG_FLAT_N_S, SPR_JUNIOR_RC_DIAG_FLAT_E_W, SPR_JUNIOR_RC_DIAG_FLAT_S_N },
     { SPR_JUNIOR_RC_DIAG_FLAT_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_FLAT_CHAIN_N_S, SPR_JUNIOR_RC_DIAG_FLAT_CHAIN_E_W,
       SPR_JUNIOR_RC_DIAG_FLAT_CHAIN_S_N },
@@ -1259,7 +1259,7 @@ static const uint32 junior_rc_track_pieces_diag_flat[3][4] = {
       SPR_WATER_RC_DIAG_FLAT_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_up[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_up[3][4] = {
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_N_S, SPR_JUNIOR_RC_DIAG_25_DEG_UP_E_W,
       SPR_JUNIOR_RC_DIAG_25_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_CHAIN_N_S, SPR_JUNIOR_RC_DIAG_25_DEG_UP_CHAIN_E_W,
@@ -1268,7 +1268,7 @@ static const uint32 junior_rc_track_pieces_diag_25_deg_up[3][4] = {
       SPR_WATER_RC_DIAG_25_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_up[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_up[3][4] = {
     { SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_N_S,
       SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_E_W, SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_CHAIN_N_S,
@@ -1277,14 +1277,14 @@ static const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_up[3][4] = {
       SPR_WATER_RC_DIAG_FLAT_TO_25_DEG_UP_CHAIN_E_W, SPR_WATER_RC_DIAG_FLAT_TO_25_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_60_deg_up[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_60_deg_up[2][4] = {
     { SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_N_S,
       SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_E_W, SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_CHAIN_N_S,
       SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_CHAIN_E_W, SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_up_to_flat[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_up_to_flat[3][4] = {
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_N_S,
       SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_E_W, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_S_N },
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_CHAIN_N_S,
@@ -1293,14 +1293,14 @@ static const uint32 junior_rc_track_pieces_diag_25_deg_up_to_flat[3][4] = {
       SPR_WATER_RC_DIAG_25_DEG_UP_TO_FLAT_CHAIN_E_W, SPR_WATER_RC_DIAG_25_DEG_UP_TO_FLAT_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_up_to_flat[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_up_to_flat[2][4] = {
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_N_S,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_E_W, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_S_N },
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_CHAIN_N_S,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_CHAIN_E_W, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_down[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_down[3][4] = {
     {
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_S_N,
@@ -1321,7 +1321,7 @@ static const uint32 junior_rc_track_pieces_diag_25_deg_down[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_down[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_down[3][4] = {
     {
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_E_W,
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_FLAT_S_N,
@@ -1342,7 +1342,7 @@ static const uint32 junior_rc_track_pieces_diag_flat_to_25_deg_down[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_60_deg_down[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_60_deg_down[2][4] = {
     {
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_E_W,
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_FLAT_S_N,
@@ -1357,7 +1357,7 @@ static const uint32 junior_rc_track_pieces_diag_flat_to_60_deg_down[2][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_flat[3][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_down_to_flat[3][4] = {
     {
         SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_FLAT_TO_25_DEG_UP_S_N,
@@ -1378,7 +1378,7 @@ static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_flat[3][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_down_to_flat[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_down_to_flat[2][4] = {
     {
         SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_FLAT_TO_60_DEG_UP_S_N,
@@ -1393,105 +1393,105 @@ static const uint32 junior_rc_track_pieces_diag_60_deg_down_to_flat[2][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_left_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_left_bank[4] = {
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_N_S,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_flat_to_right_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_flat_to_right_bank[4] = {
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_N_S,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_right_bank_to_flat[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_right_bank_to_flat[4] = {
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_S_N,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_LEFT_BANK_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_left_bank_to_flat[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_left_bank_to_flat[4] = {
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_S_N,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_FLAT_TO_RIGHT_BANK_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_left_bank_to_25_deg_up[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_left_bank_to_25_deg_up[4] = {
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_N_S,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_E_W,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_right_bank_to_25_deg_up[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_right_bank_to_25_deg_up[4] = {
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_W_E,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_N_S,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_up_to_left_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_up_to_left_bank[4] = {
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_N_S,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_up_to_right_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_up_to_right_bank[4] = {
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_N_S,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_right_bank_to_25_deg_down[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_right_bank_to_25_deg_down[4] = {
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_S_N,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_LEFT_BANK_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_left_bank_to_25_deg_down[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_left_bank_to_25_deg_down[4] = {
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_S_N,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_RIGHT_BANK_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_right_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_down_to_right_bank[4] = {
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_E_W,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_S_N,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_W_E,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_TO_25_DEG_UP_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_left_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_down_to_left_bank[4] = {
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_E_W,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_S_N,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_W_E,
     SPR_JUNIOR_RC_DIAG_RIGHT_BANK_TO_25_DEG_UP_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_diag_left_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_left_bank[4] = {
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_N_S,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_S_N,
 };
 
-static const uint32 junior_rc_track_pieces_diag_right_bank[4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_right_bank[4] = {
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_E_W,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_S_N,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_W_E,
     SPR_JUNIOR_RC_DIAG_LEFT_BANK_N_S,
 };
 
-static const uint32 junior_rc_track_pieces_flat_to_60_deg_up[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_flat_to_60_deg_up[2][4][2] = {
     {
         { SPR_JUNIOR_RC_FLAT_TO_60_DEG_UP_SW_NE, 0 },
         { SPR_JUNIOR_RC_FLAT_TO_60_DEG_UP_NW_SE, SPR_JUNIOR_RC_FLAT_TO_60_DEG_UP_NW_SE_PART_0_2 },
@@ -1506,7 +1506,7 @@ static const uint32 junior_rc_track_pieces_flat_to_60_deg_up[2][4][2] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_60_deg_up_to_flat[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_60_deg_up_to_flat[2][4][2] = {
     {
         { SPR_JUNIOR_RC_60_DEG_UP_TO_FLAT_SW_NE, 0 },
         { SPR_JUNIOR_RC_60_DEG_UP_TO_FLAT_NW_SE, SPR_JUNIOR_RC_60_DEG_UP_TO_FLAT_NW_SE_PART_0_2 },
@@ -1521,13 +1521,13 @@ static const uint32 junior_rc_track_pieces_60_deg_up_to_flat[2][4][2] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_60_deg_up[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_60_deg_up[2][4] = {
     { SPR_JUNIOR_RC_60_DEG_SW_NE, SPR_JUNIOR_RC_60_DEG_NW_SE, SPR_JUNIOR_RC_60_DEG_NE_SW, SPR_JUNIOR_RC_60_DEG_SE_NW },
     { SPR_JUNIOR_RC_60_DEG_CHAIN_SW_NE, SPR_JUNIOR_RC_60_DEG_CHAIN_NW_SE, SPR_JUNIOR_RC_60_DEG_CHAIN_NE_SW,
       SPR_JUNIOR_RC_60_DEG_CHAIN_SE_NW },
 };
 
-static const uint32 junior_rc_track_pieces_25_deg_up_to_60_deg_up[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_25_deg_up_to_60_deg_up[2][4][2] = {
     {
         { SPR_JUNIOR_RC_25_DEG_TO_60_DEG_UP_SW_NE, 0 },
         { SPR_JUNIOR_RC_25_DEG_TO_60_DEG_UP_NW_SE, SPR_JUNIOR_RC_25_DEG_TO_60_DEG_UP_NW_SE_PART_0_2 },
@@ -1542,7 +1542,7 @@ static const uint32 junior_rc_track_pieces_25_deg_up_to_60_deg_up[2][4][2] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_60_deg_up_to_25_deg_up[2][4][2] = {
+static constexpr const uint32 junior_rc_track_pieces_60_deg_up_to_25_deg_up[2][4][2] = {
     {
         { SPR_JUNIOR_RC_60_DEG_TO_25_DEG_UP_SW_NE, 0 },
         { SPR_JUNIOR_RC_60_DEG_TO_25_DEG_UP_NW_SE, SPR_JUNIOR_RC_60_DEG_TO_25_DEG_UP_NW_SE_PART_0_2 },
@@ -1557,14 +1557,14 @@ static const uint32 junior_rc_track_pieces_60_deg_up_to_25_deg_up[2][4][2] = {
     }
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_up[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_up[2][4] = {
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_N_S, SPR_JUNIOR_RC_DIAG_60_DEG_UP_E_W,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_CHAIN_N_S, SPR_JUNIOR_RC_DIAG_60_DEG_UP_CHAIN_E_W,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_down[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_down[2][4] = {
     {
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_S_N,
@@ -1579,21 +1579,21 @@ static const uint32 junior_rc_track_pieces_diag_60_deg_down[2][4] = {
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_up_to_60_deg_up[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_up_to_60_deg_up[2][4] = {
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_N_S,
       SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_E_W, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_CHAIN_N_S,
       SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_CHAIN_E_W, SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_up_to_25_deg_up[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_up_to_25_deg_up[2][4] = {
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_N_S,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_E_W, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_S_N },
     { SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_CHAIN_W_E, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_CHAIN_N_S,
       SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_CHAIN_E_W, SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_CHAIN_S_N },
 };
 
-static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[2][4] = {
     {
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_60_DEG_UP_TO_25_DEG_UP_S_N,
@@ -1608,7 +1608,7 @@ static const uint32 junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[2][4]
     },
 };
 
-static const uint32 junior_rc_track_pieces_diag_60_deg_down_to_25_deg_down[2][4] = {
+static constexpr const uint32 junior_rc_track_pieces_diag_60_deg_down_to_25_deg_down[2][4] = {
     {
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_E_W,
         SPR_JUNIOR_RC_DIAG_25_DEG_UP_TO_60_DEG_UP_S_N,
@@ -1786,7 +1786,7 @@ void junior_rc_paint_track_25_deg_up_to_flat(paint_session * session, uint8 ride
     paint_util_set_general_support_height(session, height + 40, 0x20);
 }
 
-static const sint8 junior_rc_track_right_quarter_turn_5_tiles_support_height_offset[][7] = {
+static constexpr const sint8 junior_rc_track_right_quarter_turn_5_tiles_support_height_offset[][7] = {
     { 0, 0, 0, 0, 0, 0, -1 },
     { -1, 0, 0, 0, 0, 0, 0 },
     { 0 },
@@ -1984,7 +1984,7 @@ static void junior_rc_right_bank_to_flat_paint_setup(paint_session * session, ui
     junior_rc_flat_to_left_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
-const LocationXY16 junior_rc_banked_right_quarter_turn_5_tiles_bound_lengths[4][5] = { {
+static constexpr const LocationXY16 junior_rc_banked_right_quarter_turn_5_tiles_bound_lengths[4][5] = { {
                                                                                        { 32, 20 },
                                                                                        { 32, 16 },
                                                                                        { 16, 16 },
@@ -2013,7 +2013,7 @@ const LocationXY16 junior_rc_banked_right_quarter_turn_5_tiles_bound_lengths[4][
                                                                                        { 32, 20 },
                                                                                    } };
 
-const LocationXYZ16 junior_rc_banked_right_quarter_turn_5_tiles_bound_offsets[4][5] = { {
+static constexpr const LocationXYZ16 junior_rc_banked_right_quarter_turn_5_tiles_bound_offsets[4][5] = { {
                                                                                         { 0, 6 },
                                                                                         { 0, 16 },
                                                                                         { 0, 0 },
@@ -2420,14 +2420,14 @@ static void junior_rc_25_deg_down_to_right_bank_paint_setup(paint_session * sess
     junior_rc_left_bank_to_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
-static const LocationXYZ16 junior_rc_left_bank_bound_lengths[4] = {
+static constexpr const LocationXYZ16 junior_rc_left_bank_bound_lengths[4] = {
     { 32, 1, 26 },
     { 1, 32, 26 },
     { 32, 20, 1 },
     { 20, 32, 1 },
 };
 
-static const LocationXY16 junior_rc_left_bank_bound_offsets[4] = {
+static constexpr const LocationXY16 junior_rc_left_bank_bound_offsets[4] = {
     { 0, 27 },
     { 27, 0 },
     { 0, 6 },
@@ -2921,7 +2921,7 @@ static void junior_rc_left_quarter_turn_3_tiles_paint_setup(paint_session * sess
                                                      tileElement);
 }
 
-const LocationXY16 junior_rc_right_quarter_turn_3_tiles_bank_bound_lengths[4][3] = { {
+static constexpr const LocationXY16 junior_rc_right_quarter_turn_3_tiles_bank_bound_lengths[4][3] = { {
                                                                                      { 32, 20 },
                                                                                      { 16, 16 },
                                                                                      { 20, 32 },
@@ -2942,7 +2942,7 @@ const LocationXY16 junior_rc_right_quarter_turn_3_tiles_bank_bound_lengths[4][3]
                                                                                      { 32, 20 },
                                                                                  } };
 
-const LocationXYZ16 junior_rc_right_quarter_turn_3_tiles_bank_offsets[4][3] = { {
+static constexpr const LocationXYZ16 junior_rc_right_quarter_turn_3_tiles_bank_offsets[4][3] = { {
                                                                                 { 0, 6 },
                                                                                 { 16, 16 },
                                                                                 { 6, 0 },
@@ -3201,7 +3201,7 @@ static void junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(paint_s
         isChained ? JUNIOR_RC_CHAIN_FRICTION_WHEELS : JUNIOR_RC_CHAIN_NONE);
 }
 
-static const uint8 junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[] = { 3, 1, 2, 0 };
 
 /** rct2: 0x008AAEC0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(paint_session * session, uint8 rideIndex,
@@ -3793,7 +3793,7 @@ static void junior_rc_right_eighth_to_orthogonal_paint_setup(paint_session * ses
     junior_rc_left_eighth_to_diag_paint_setup(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
-static const LocationXY16 junior_rc_left_eighth_to_diag_bank_bound_lengths[4][4] = {
+static constexpr const LocationXY16 junior_rc_left_eighth_to_diag_bank_bound_lengths[4][4] = {
     {
         { 32, 1 },
         { 32, 16 },
@@ -3820,7 +3820,7 @@ static const LocationXY16 junior_rc_left_eighth_to_diag_bank_bound_lengths[4][4]
     },
 };
 
-static const LocationXYZ16 junior_rc_left_eighth_to_diag_bank_bound_offsets[4][4] = {
+static constexpr const LocationXYZ16 junior_rc_left_eighth_to_diag_bank_bound_offsets[4][4] = {
     {
         { 0, 27 },
         { 0, 0 },
@@ -3847,7 +3847,7 @@ static const LocationXYZ16 junior_rc_left_eighth_to_diag_bank_bound_offsets[4][4
     },
 };
 
-static const sint8 junior_rc_left_eighth_to_diag_bank_thickness[4][4] = {
+static constexpr const sint8 junior_rc_left_eighth_to_diag_bank_thickness[4][4] = {
     {
         26,
         1,
@@ -3937,7 +3937,7 @@ static void junior_rc_left_eighth_to_diag_bank_paint_setup(paint_session * sessi
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const LocationXY16 junior_rc_right_eighth_to_diag_bank_bound_lengths[4][4] = {
+static constexpr const LocationXY16 junior_rc_right_eighth_to_diag_bank_bound_lengths[4][4] = {
     {
         { 32, 20 },
         { 16, 16 },
@@ -3964,7 +3964,7 @@ static const LocationXY16 junior_rc_right_eighth_to_diag_bank_bound_lengths[4][4
     },
 };
 
-static const LocationXYZ16 junior_rc_right_eighth_to_diag_bank_bound_offsets[4][4] = {
+static constexpr const LocationXYZ16 junior_rc_right_eighth_to_diag_bank_bound_offsets[4][4] = {
     {
         { 0, 6 },
         { 0, 0 },
@@ -3991,7 +3991,7 @@ static const LocationXYZ16 junior_rc_right_eighth_to_diag_bank_bound_offsets[4][
     },
 };
 
-static const sint8 junior_rc_right_eighth_to_diag_bank_thickness[4][4] = {
+static constexpr const sint8 junior_rc_right_eighth_to_diag_bank_thickness[4][4] = {
     {
         1,
         1,
@@ -4099,12 +4099,12 @@ static void junior_rc_right_eighth_to_orthogonal_bank_paint_setup(paint_session 
     junior_rc_left_eighth_to_diag_bank_paint_setup(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
-static const sint32 junior_rc_diag_blocked_segments[] = { SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4 | SEGMENT_BC,
+static constexpr const sint32 junior_rc_diag_blocked_segments[] = { SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4 | SEGMENT_BC,
                                                           SEGMENT_C4 | SEGMENT_CC | SEGMENT_C8 | SEGMENT_B4,
                                                           SEGMENT_D0 | SEGMENT_C4 | SEGMENT_C0 | SEGMENT_D4,
                                                           SEGMENT_D0 | SEGMENT_C4 | SEGMENT_B8 | SEGMENT_C8 };
 
-static const uint8 junior_rc_diag_support_segment[] = { 1, 0, 2, 3 };
+static constexpr const uint8 junior_rc_diag_support_segment[] = { 1, 0, 2, 3 };
 
 void junior_rc_paint_track_diag_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                      uint16 height, rct_tile_element * tileElement, JUNIOR_RC_CHAINTYPE chainType)
@@ -4725,14 +4725,14 @@ static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(paint_session *
     paint_util_set_general_support_height(session, height + 48, 0x20);
 }
 
-const LocationXYZ16 junior_rc_diag_left_bank_bound_offsets[4] = {
+static constexpr const LocationXYZ16 junior_rc_diag_left_bank_bound_offsets[4] = {
     { -16, -16, 27 },
     { -16, -16 },
     { -16, -16 },
     { -16, -16 },
 };
 
-const LocationXYZ16 junior_rc_diag_right_bank_bound_offsets[4] = {
+static constexpr const LocationXYZ16 junior_rc_diag_right_bank_bound_offsets[4] = {
     { -16, -16 },
     { -16, -16 },
     { -16, -16, 27 },
@@ -4781,23 +4781,23 @@ static void junior_rc_diag_right_bank_paint_setup(paint_session * session, uint8
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const LocationXY16 junior_rc_60_deg_up_bound_offsets[4] = {
+static constexpr const LocationXY16 junior_rc_60_deg_up_bound_offsets[4] = {
     { 0, 6 },
     { 10, 29 },
     { 29, 10 },
     { 6, 0 },
 };
 
-static const LocationXY16 junior_rc_60_deg_up_tile_offsets[4] = {
+static constexpr const LocationXY16 junior_rc_60_deg_up_tile_offsets[4] = {
     { 0, 6 },
     { 6, 0 },
     { 0, 6 },
     { 6, 0 },
 };
 
-static const sint8 junior_rc_60_deg_up_bound_thickness[4] = { 1, 75, 75, 1 };
+static constexpr const sint8 junior_rc_60_deg_up_bound_thickness[4] = { 1, 75, 75, 1 };
 
-static const LocationXY16 junior_rc_60_deg_up_bound_lengths[4] = {
+static constexpr const LocationXY16 junior_rc_60_deg_up_bound_lengths[4] = {
     { 32, 20 },
     { 10, 1 },
     { 1, 10 },
@@ -4861,16 +4861,16 @@ static void junior_rc_60_deg_down_paint_setup(paint_session * session, uint8 rid
     junior_rc_60_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
-static const LocationXY16 junior_rc_25_deg_up_to_60_deg_up_bound_lengths[4][2] = {
+static constexpr const LocationXY16 junior_rc_25_deg_up_to_60_deg_up_bound_lengths[4][2] = {
     { { 32, 20 }, { 0 } },
     { { 10, 32 }, { 2, 32 } },
     { { 32, 10 }, { 32, 2 } },
     { { 20, 32 }, { 0 } },
 };
 
-static const sint8 junior_rc_25_deg_up_to_60_deg_up_bound_thickness[4] = { 1, 43, 43, 1 };
+static constexpr const sint8 junior_rc_25_deg_up_to_60_deg_up_bound_thickness[4] = { 1, 43, 43, 1 };
 
-static const LocationXY16 junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4][2] = {
+static constexpr const LocationXY16 junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4][2] = {
     { { 0, 6 }, { 0 } },
     { { 10, 0 }, { 4, 0 } },
     { { 0, 10 }, { 0, 4 } },
@@ -5206,27 +5206,27 @@ static void junior_rc_diag_60_deg_down_to_25_deg_down_paint_setup(paint_session 
                                                           isChained ? JUNIOR_RC_CHAIN_FRICTION_WHEELS : JUNIOR_RC_CHAIN_NONE);
 }
 
-static const LocationXY16 junior_rc_flat_to_60_deg_up_bound_lengths[4][2] = {
+static constexpr const LocationXY16 junior_rc_flat_to_60_deg_up_bound_lengths[4][2] = {
     { { 32, 24 }, { 0 } },
     { { 10, 1 }, { 2, 32 } },
     { { 1, 10 }, { 32, 2 } },
     { { 24, 32 }, { 0 } },
 };
 
-static const sint8 junior_rc_flat_to_60_deg_up_bound_thickness[4] = { 1, 43, 43, 1 };
+static constexpr const sint8 junior_rc_flat_to_60_deg_up_bound_thickness[4] = { 1, 43, 43, 1 };
 
-static const LocationXY16 junior_rc_flat_to_60_deg_up_bound_offsets[4][2] = {
+static constexpr const LocationXY16 junior_rc_flat_to_60_deg_up_bound_offsets[4][2] = {
     { { 0, 4 }, { 0 } },
     { { 10, 0 }, { 4, 0 } },
     { { 0, 10 }, { 0, 4 } },
     { { 4, 0 }, { 0 } },
 };
 
-static const LocationXY16 junior_rc_flat_to_60_deg_up_tile_offsets[4][2] = {
+static constexpr const LocationXY16 junior_rc_flat_to_60_deg_up_tile_offsets[4][2] = {
     { { 12, -10 }, { 0 } }, { { 22, 9 }, { 12, -11 } }, { { 30, 7 }, { 5, 0 } }, { { 12, -12 }, { 0 } }
 };
 
-static const LocationXY16 junior_rc_60_deg_up_to_flat_tile_offsets[4][2] = {
+static constexpr const LocationXY16 junior_rc_60_deg_up_to_flat_tile_offsets[4][2] = {
     { { 13, -9 }, { 0 } }, { { 32, 9 }, { -7, -11 } }, { { 22, 18 }, { 2, -19 } }, { { 13, -9 }, { 0 } }
 };
 

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -139,7 +139,7 @@ static void lay_down_rc_track_station(paint_session * session, uint8 rideIndex, 
 {
     if (track_element_is_inverted(tileElement))
     {
-        static const uint32 imageIds[4][3] = {
+        static constexpr const uint32 imageIds[4][3] = {
             { SPR_STATION_BASE_C_SW_NE, 26557, SPR_STATION_INVERTED_BAR_A_SW_NE },
             { SPR_STATION_BASE_C_NW_SE, 26558, SPR_STATION_INVERTED_BAR_A_NW_SE },
             { SPR_STATION_BASE_C_SW_NE, 26557, SPR_STATION_INVERTED_BAR_A_SW_NE },
@@ -159,7 +159,7 @@ static void lay_down_rc_track_station(paint_session * session, uint8 rideIndex, 
     }
     else
     {
-        static const uint32 imageIds[4][3] = {
+        static constexpr const uint32 imageIds[4][3] = {
             { 16236, 16232, SPR_STATION_BASE_A_SW_NE },
             { 16237, 16233, SPR_STATION_BASE_A_NW_SE },
             { 16236, 16232, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -30,7 +30,7 @@
 static void lim_launched_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                           sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 15018, 15020, SPR_STATION_BASE_B_SW_NE },
         { 15019, 15021, SPR_STATION_BASE_B_NW_SE },
         { 15018, 15020, SPR_STATION_BASE_B_SW_NE },

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -61,7 +61,7 @@ static void mine_ride_track_flat(paint_session * session, uint8 rideIndex, uint8
 static void mine_ride_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                     sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 19338, SPR_STATION_BASE_A_SW_NE },
         { 19339, SPR_STATION_BASE_A_NW_SE },
         { 19338, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -83,7 +83,7 @@ static void mine_train_rc_track_flat(paint_session * session, uint8 rideIndex, u
 static void mine_train_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                         sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 20064, 20060, SPR_STATION_BASE_B_SW_NE },
         { 20065, 20061, SPR_STATION_BASE_B_NW_SE },
         { 20064, 20060, SPR_STATION_BASE_B_SW_NE },

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -86,7 +86,7 @@ static void mini_suspended_rc_track_flat(paint_session * session, uint8 rideInde
 static void mini_suspended_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                             sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 28433, SPR_STATION_INVERTED_BAR_E_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 28434, SPR_STATION_INVERTED_BAR_E_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 28433, SPR_STATION_INVERTED_BAR_E_SW_NE },

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -111,7 +111,7 @@ static void multi_dimension_rc_track_flat(paint_session * session, uint8 rideInd
 static void multi_dimension_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                              sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 15810, 15812, SPR_STATION_INVERTED_BAR_A_SW_NE },
         { 15811, 15813, SPR_STATION_INVERTED_BAR_A_NW_SE },
         { 15810, 15812, SPR_STATION_INVERTED_BAR_A_SW_NE },

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -94,14 +94,14 @@ enum
     SPR_REVERSE_FREEFALL_RC_SLOPE_SUPPORTS_SE_NW_5  = 22225,
 };
 
-static const uint32 reverse_freefall_rc_track_pieces_station[4] = {
+static constexpr const uint32 reverse_freefall_rc_track_pieces_station[4] = {
     SPR_REVERSE_FREEFALL_RC_STATION_SW_NE,
     SPR_REVERSE_FREEFALL_RC_STATION_NW_SE,
     SPR_REVERSE_FREEFALL_RC_STATION_SW_NE,
     SPR_REVERSE_FREEFALL_RC_STATION_NW_SE,
 };
 
-static const uint32 reverse_freefall_rc_track_pieces_slope[7][4] = {
+static constexpr const uint32 reverse_freefall_rc_track_pieces_slope[7][4] = {
     {
         SPR_REVERSE_FREEFALL_RC_SLOPE_SW_NE_0,
         SPR_REVERSE_FREEFALL_RC_SLOPE_NW_SE_0,
@@ -141,7 +141,7 @@ static const uint32 reverse_freefall_rc_track_pieces_slope[7][4] = {
     },
 };
 
-static const uint32 reverse_freefall_rc_track_pieces_slope_supports[7][4] = {
+static constexpr const uint32 reverse_freefall_rc_track_pieces_slope_supports[7][4] = {
     {
         SPR_REVERSE_FREEFALL_RC_SLOPE_SUPPORTS_SW_NE_0,
         SPR_REVERSE_FREEFALL_RC_SLOPE_SUPPORTS_NW_SE_0,
@@ -186,14 +186,14 @@ static const uint32 reverse_freefall_rc_track_pieces_slope_supports[7][4] = {
     },
 };
 
-static const uint32 reverse_freefall_rc_track_pieces_vertical[4] = {
+static constexpr const uint32 reverse_freefall_rc_track_pieces_vertical[4] = {
     SPR_REVERSE_FREEFALL_RC_VERTICAL_SW_NE,
     SPR_REVERSE_FREEFALL_RC_VERTICAL_NW_SE,
     SPR_REVERSE_FREEFALL_RC_VERTICAL_NE_SW,
     SPR_REVERSE_FREEFALL_RC_VERTICAL_SE_NW,
 };
 
-static const uint32 reverse_freefall_rc_track_pieces_vertical_supports[4] = {
+static constexpr const uint32 reverse_freefall_rc_track_pieces_vertical_supports[4] = {
     SPR_REVERSE_FREEFALL_RC_VERTICAL_SUPPORTS_SW_NE,
     SPR_REVERSE_FREEFALL_RC_VERTICAL_SUPPORTS_NW_SE,
     SPR_REVERSE_FREEFALL_RC_VERTICAL_SUPPORTS_NE_SW,
@@ -267,10 +267,10 @@ static void paint_reverse_freefall_rc_slope(paint_session * session, uint8 rideI
 {
     TESTPAINT_IGNORE_ALL();
 
-    static const sint8  bbHeights03[]     = { 1, 6, 14, 37, 64 };
-    static const sint8  bbHeights12[]     = { 1, 6, 14, 27, 59 };
-    static const sint32 supportHeights[]  = { 48, 64, 128, 176, 208, 240, 240 };
-    static const sint32 tunnelOffsets03[] = { 0, 0, 0, 16, 64 };
+    static constexpr const sint8  bbHeights03[]     = { 1, 6, 14, 37, 64 };
+    static constexpr const sint8  bbHeights12[]     = { 1, 6, 14, 27, 59 };
+    static constexpr const sint32 supportHeights[]  = { 48, 64, 128, 176, 208, 240, 240 };
+    static constexpr const sint32 tunnelOffsets03[] = { 0, 0, 0, 16, 64 };
 
     uint32 supportsImageId =
         reverse_freefall_rc_track_pieces_slope_supports[trackSequence][direction] | session->TrackColours[SCHEME_SUPPORTS];

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -94,7 +94,7 @@ static void reverser_rc_track_flat(paint_session * session, uint8 rideIndex, uin
 static void reverser_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 21506, SPR_STATION_BASE_A_SW_NE },
         { 21507, SPR_STATION_BASE_A_NW_SE },
         { 21506, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -95,7 +95,7 @@ static void side_friction_rc_track_flat(paint_session * session, uint8 rideIndex
 static void side_friction_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                            sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         21610,
         21611,
         21610,

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -80,7 +80,7 @@ static void stand_up_rc_track_flat(paint_session * session, uint8 rideIndex, uin
 static void stand_up_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 25567, 25571, SPR_STATION_BASE_A_SW_NE },
         { 25568, 25572, SPR_STATION_BASE_A_NW_SE },
         { 25567, 25571, SPR_STATION_BASE_A_SW_NE },

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -73,7 +73,7 @@ static void steeplechase_track_flat(paint_session * session, uint8 rideIndex, ui
 static void steeplechase_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { 28635, SPR_STATION_BASE_B_SW_NE },
         { 28636, SPR_STATION_BASE_B_NW_SE },
         { 28635, SPR_STATION_BASE_B_SW_NE },

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -78,7 +78,7 @@ static void suspended_swinging_rc_track_flat(paint_session * session, uint8 ride
 static void suspended_swinging_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                 sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 25963, SPR_STATION_INVERTED_BAR_D_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 25964, SPR_STATION_INVERTED_BAR_D_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 25963, SPR_STATION_INVERTED_BAR_D_SW_NE },

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -24,7 +24,7 @@
 #include "../VehiclePaint.h"
 
 // 0x009927E6:
-static const vehicle_boundbox _virginiaReelBoundbox[] = {
+static constexpr const vehicle_boundbox _virginiaReelBoundbox[] = {
     { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 },
     { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 },
     { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 }, { -11, -11, 1, 22, 22, 13 },
@@ -80,63 +80,63 @@ enum
     SPR_VIRGINIA_REEL_25_DEG_UP_LIFT_HILL_SE_NW              = 21503,
 };
 
-static const uint32 virginia_reel_track_pieces_flat[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat[4] = {
     SPR_VIRGINIA_REEL_FLAT_SW_NE,
     SPR_VIRGINIA_REEL_FLAT_NW_SE,
     SPR_VIRGINIA_REEL_FLAT_SW_NE,
     SPR_VIRGINIA_REEL_FLAT_NW_SE,
 };
 
-static const uint32 virginia_reel_track_pieces_flat_lift_hill[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat_lift_hill[4] = {
     SPR_VIRGINIA_REEL_FLAT_LIFT_HILL_SW_NE,
     SPR_VIRGINIA_REEL_FLAT_LIFT_HILL_NW_SE,
     SPR_VIRGINIA_REEL_FLAT_LIFT_HILL_NE_SW,
     SPR_VIRGINIA_REEL_FLAT_LIFT_HILL_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_flat_to_25_deg_up[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat_to_25_deg_up[4] = {
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_SW_NE,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_NW_SE,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_NE_SW,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_flat_to_25_deg_up_lift_hill[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat_to_25_deg_up_lift_hill[4] = {
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_LIFT_HILL_SW_NE,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_LIFT_HILL_NW_SE,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_LIFT_HILL_NE_SW,
     SPR_VIRGINIA_REEL_FLAT_TO_25_DEG_UP_LIFT_HILL_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_25_deg_up_to_flat[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_25_deg_up_to_flat[4] = {
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_SW_NE,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_NW_SE,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_NE_SW,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_25_deg_up_to_flat_lift_hill[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_25_deg_up_to_flat_lift_hill[4] = {
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_LIFT_HILL_SW_NE,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_LIFT_HILL_NW_SE,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_LIFT_HILL_NE_SW,
     SPR_VIRGINIA_REEL_25_DEG_UP_TO_FLAT_LIFT_HILL_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_25_deg_up[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_25_deg_up[4] = {
     SPR_VIRGINIA_REEL_25_DEG_UP_SW_NE,
     SPR_VIRGINIA_REEL_25_DEG_UP_NW_SE,
     SPR_VIRGINIA_REEL_25_DEG_UP_NE_SW,
     SPR_VIRGINIA_REEL_25_DEG_UP_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_25_deg_up_lift_hill[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_25_deg_up_lift_hill[4] = {
     SPR_VIRGINIA_REEL_25_DEG_UP_LIFT_HILL_SW_NE,
     SPR_VIRGINIA_REEL_25_DEG_UP_LIFT_HILL_NW_SE,
     SPR_VIRGINIA_REEL_25_DEG_UP_LIFT_HILL_NE_SW,
     SPR_VIRGINIA_REEL_25_DEG_UP_LIFT_HILL_SE_NW,
 };
 
-static const uint32 virginia_reel_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
     { SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -147,7 +147,7 @@ static const uint32 virginia_reel_track_pieces_flat_quarter_turn_3_tiles[4][3] =
       SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 virginia_reel_track_pieces_flat_quarter_turn_1_tile[4] = {
+static constexpr const uint32 virginia_reel_track_pieces_flat_quarter_turn_1_tile[4] = {
     SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_1_TILE_SW_NW,
     SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_1_TILE_NW_NE,
     SPR_VIRGINIA_REEL_FLAT_QUARTER_TURN_1_TILE_NE_SE,
@@ -460,7 +460,7 @@ static void paint_virginia_reel_station(paint_session * session, uint8 rideIndex
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint8 virginia_reel_left_quarter_turn_supports[] = { 5, 2, 3, 4 };
+static constexpr const uint8 virginia_reel_left_quarter_turn_supports[] = { 5, 2, 3, 4 };
 
 /** rct2: 0x00811304 */
 static void paint_virginia_reel_track_left_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex, uint8 trackSequence,
@@ -488,7 +488,7 @@ static void paint_virginia_reel_track_left_quarter_turn_3_tiles(paint_session * 
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint8 virginia_reel_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 virginia_reel_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
 
 /** rct2: 0x00811314 */
 static void paint_virginia_reel_track_right_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex, uint8 trackSequence,

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -155,14 +155,14 @@ enum
     SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SE_NE_PART_1 = 17025,
 };
 
-static const uint32 _wild_mouse_brakes_image_ids[4] = {
+static constexpr const uint32 _wild_mouse_brakes_image_ids[4] = {
     SPR_WILD_MOUSE_BRAKES_SW_NE,
     SPR_WILD_MOUSE_BRAKES_NW_SE,
     SPR_WILD_MOUSE_BRAKES_SW_NE,
     SPR_WILD_MOUSE_BRAKES_NW_SE,
 };
 
-static const uint32 _wild_mouse_block_brakes_image_ids[4] = {
+static constexpr const uint32 _wild_mouse_block_brakes_image_ids[4] = {
     SPR_WILD_MOUSE_BLOCK_BRAKES_SW_NE,
     SPR_WILD_MOUSE_BLOCK_BRAKES_NW_SE,
     SPR_WILD_MOUSE_BLOCK_BRAKES_SW_NE,
@@ -173,7 +173,7 @@ static const uint32 _wild_mouse_block_brakes_image_ids[4] = {
 static void wild_mouse_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height,
                                   rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_FLAT_SW_NE, SPR_WILD_MOUSE_FLAT_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_FLAT_NW_SE, SPR_WILD_MOUSE_FLAT_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_FLAT_SW_NE, SPR_WILD_MOUSE_FLAT_CHAIN_NE_SW },
@@ -196,7 +196,7 @@ static void wild_mouse_track_flat(paint_session * session, uint8 rideIndex, uint
 static void wild_mouse_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                      sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 baseImageIds[4] = {
+    static constexpr const uint32 baseImageIds[4] = {
         SPR_STATION_BASE_B_SW_NE,
         SPR_STATION_BASE_B_NW_SE,
         SPR_STATION_BASE_B_SW_NE,
@@ -228,7 +228,7 @@ static void wild_mouse_track_station(paint_session * session, uint8 rideIndex, u
 static void wild_mouse_track_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_25_DEG_SW_NE, SPR_WILD_MOUSE_25_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_25_DEG_NW_SE, SPR_WILD_MOUSE_25_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_25_DEG_NE_SW, SPR_WILD_MOUSE_25_DEG_CHAIN_NE_SW },
@@ -259,7 +259,7 @@ static void wild_mouse_track_25_deg_up(paint_session * session, uint8 rideIndex,
 static void wild_mouse_track_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_60_DEG_SW_NE, SPR_WILD_MOUSE_60_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_60_DEG_NW_SE, SPR_WILD_MOUSE_60_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_60_DEG_NE_SW, SPR_WILD_MOUSE_60_DEG_CHAIN_NE_SW },
@@ -304,7 +304,7 @@ static void wild_mouse_track_60_deg_up(paint_session * session, uint8 rideIndex,
 static void wild_mouse_track_flat_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_FLAT_TO_25_DEG_SW_NE, SPR_WILD_MOUSE_FLAT_TO_25_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_FLAT_TO_25_DEG_NW_SE, SPR_WILD_MOUSE_FLAT_TO_25_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_FLAT_TO_25_DEG_NE_SW, SPR_WILD_MOUSE_FLAT_TO_25_DEG_CHAIN_NE_SW },
@@ -335,13 +335,13 @@ static void wild_mouse_track_flat_to_25_deg_up(paint_session * session, uint8 ri
 static void wild_mouse_track_25_deg_up_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_SW_NE, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_NW_SE, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_NE_SW, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_NE_SW },
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_SE_NW, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_SE_NW },
     };
-    static const uint32 frontImageIds[4][2] = {
+    static constexpr const uint32 frontImageIds[4][2] = {
         { 0, 0 },
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_FRONT_NW_SE, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_FRONT_NW_SE },
         { SPR_WILD_MOUSE_25_DEG_TO_60_DEG_FRONT_NE_SW, SPR_WILD_MOUSE_25_DEG_TO_60_DEG_CHAIN_FRONT_NE_SW },
@@ -381,13 +381,13 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(paint_session * session, uin
 static void wild_mouse_track_60_deg_up_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_SW_NE, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_NW_SE, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_NE_SW, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_NE_SW },
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_SE_NW, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_SE_NW },
     };
-    static const uint32 frontImageIds[4][2] = {
+    static constexpr const uint32 frontImageIds[4][2] = {
         { 0, 0 },
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_FRONT_NW_SE, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_FRONT_NW_SE },
         { SPR_WILD_MOUSE_60_DEG_TO_25_DEG_FRONT_NE_SW, SPR_WILD_MOUSE_60_DEG_TO_25_DEG_CHAIN_FRONT_NE_SW },
@@ -427,7 +427,7 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(paint_session * session, uin
 static void wild_mouse_track_25_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_25_DEG_TO_FLAT_SW_NE, SPR_WILD_MOUSE_25_DEG_TO_FLAT_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_25_DEG_TO_FLAT_NW_SE, SPR_WILD_MOUSE_25_DEG_TO_FLAT_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_25_DEG_TO_FLAT_NE_SW, SPR_WILD_MOUSE_25_DEG_TO_FLAT_CHAIN_NE_SW },
@@ -499,7 +499,7 @@ static void wild_mouse_track_25_deg_down_to_flat(paint_session * session, uint8 
 static void wild_mouse_track_right_quarter_turn_3(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                   uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][3] = {
+    static constexpr const sprite_bb imageIds[4][3] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 3 } },
@@ -554,7 +554,7 @@ static void wild_mouse_track_right_quarter_turn_3(paint_session * session, uint8
 static void wild_mouse_track_right_quarter_turn_3_25_deg_down(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                               uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][2] = {
+    static constexpr const sprite_bb imageIds[4][2] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SW_SE_PART_1, { 6, 0, 0 }, { 0, 0, 0 }, { 20, 32, 3 } },
@@ -572,7 +572,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(paint_session * se
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SE_NE_PART_1, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
         }
     };
-    static const sint16 generalSupportHeights[] = { 72, 56, 56, 72 };
+    static constexpr const sint16 generalSupportHeights[] = { 72, 56, 56, 72 };
 
     if (trackSequence == 0 || trackSequence == 3)
     {
@@ -620,7 +620,7 @@ static void wild_mouse_track_left_quarter_turn_3_25_deg_up(paint_session * sessi
 static void wild_mouse_track_right_quarter_turn_3_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][2] = {
+    static constexpr const sprite_bb imageIds[4][2] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_UP_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_UP_SW_SE_PART_1, { 6, 0, 0 }, { 0, 0, 0 }, { 20, 32, 3 } },
@@ -638,7 +638,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(paint_session * sess
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_UP_SE_NE_PART_1, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
         }
     };
-    static const sint16 generalSupportHeights[] = { 72, 56, 56, 72 };
+    static constexpr const sint16 generalSupportHeights[] = { 72, 56, 56, 72 };
 
     if (trackSequence == 0 || trackSequence == 3)
     {
@@ -742,13 +742,13 @@ static void wild_mouse_track_right_quarter_turn_1(paint_session * session, uint8
 static void wild_mouse_track_flat_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_SW_NE, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_NW_SE, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_NE_SW, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_NE_SW },
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_SE_NW, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_SE_NW },
     };
-    static const uint32 frontImageIds[4][2] = {
+    static constexpr const uint32 frontImageIds[4][2] = {
         { 0, 0 },
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_FRONT_NW_SE, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_FRONT_NW_SE },
         { SPR_WILD_MOUSE_FLAT_TO_60_DEG_FRONT_NE_SW, SPR_WILD_MOUSE_FLAT_TO_60_DEG_CHAIN_FRONT_NE_SW },
@@ -788,13 +788,13 @@ static void wild_mouse_track_flat_to_60_deg_up(paint_session * session, uint8 ri
 static void wild_mouse_track_60_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_SW_NE, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_SW_NE },
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_NW_SE, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_NW_SE },
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_NE_SW, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_NE_SW },
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_SE_NW, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_SE_NW },
     };
-    static const uint32 frontImageIds[4][2] = {
+    static constexpr const uint32 frontImageIds[4][2] = {
         { 0, 0 },
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_FRONT_NW_SE, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_FRONT_NW_SE },
         { SPR_WILD_MOUSE_60_DEG_TO_FLAT_FRONT_NE_SW, SPR_WILD_MOUSE_60_DEG_TO_FLAT_CHAIN_FRONT_NE_SW },
@@ -871,7 +871,7 @@ static void wild_mouse_track_brakes(paint_session * session, uint8 rideIndex, ui
 static void wild_mouse_track_rotation_control_toggle(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                      uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_WILD_MOUSE_ROTATION_CONTROL_TOGGLE_SW_NE,
         SPR_WILD_MOUSE_ROTATION_CONTROL_TOGGLE_NW_SE,
         SPR_WILD_MOUSE_ROTATION_CONTROL_TOGGLE_SW_NE,

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -390,7 +390,7 @@ enum
     SPR_WOODEN_RC_STATION_RAILS_NW_SE = 24840,
 };
 
-static const uint32 _wooden_rc_block_brakes_image_ids[4][2] = {
+static constexpr const uint32 _wooden_rc_block_brakes_image_ids[4][2] = {
     { SPR_WOODEN_RC_BLOCK_BRAKES_SW_NE, SPR_WOODEN_RC_BLOCK_BRAKES_RAILS_SW_NE },
     { SPR_WOODEN_RC_BLOCK_BRAKES_NW_SE, SPR_WOODEN_RC_BLOCK_BRAKES_RAILS_NW_SE },
     { SPR_WOODEN_RC_BLOCK_BRAKES_SW_NE, SPR_WOODEN_RC_BLOCK_BRAKES_RAILS_SW_NE },
@@ -440,13 +440,13 @@ static void wooden_rc_track_paint_bb(paint_session * session, const sprite_bb_2 
 static void wooden_rc_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction, sint32 height,
                                  rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WOODEN_RC_FLAT_SW_NE, SPR_WOODEN_RC_FLAT_CHAIN_SW_NE },
         { SPR_WOODEN_RC_FLAT_NW_SE, SPR_WOODEN_RC_FLAT_CHAIN_NW_SE },
         { SPR_WOODEN_RC_FLAT_SW_NE, SPR_WOODEN_RC_FLAT_CHAIN_NE_SW },
         { SPR_WOODEN_RC_FLAT_NW_SE, SPR_WOODEN_RC_FLAT_CHAIN_SE_NW },
     };
-    static const uint32 railsImageIds[4][2] = {
+    static constexpr const uint32 railsImageIds[4][2] = {
         { SPR_WOODEN_RC_FLAT_RAILS_SW_NE, SPR_WOODEN_RC_FLAT_CHAIN_RAILS_SW_NE },
         { SPR_WOODEN_RC_FLAT_RAILS_NW_SE, SPR_WOODEN_RC_FLAT_CHAIN_RAILS_NW_SE },
         { SPR_WOODEN_RC_FLAT_RAILS_SW_NE, SPR_WOODEN_RC_FLAT_CHAIN_RAILS_NE_SW },
@@ -465,7 +465,7 @@ static void wooden_rc_track_flat(paint_session * session, uint8 rideIndex, uint8
 static void wooden_rc_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                     sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 stationImageIds[4][2] = {
+    static constexpr const uint32 stationImageIds[4][2] = {
         { SPR_WOODEN_RC_STATION_SW_NE, SPR_WOODEN_RC_STATION_RAILS_SW_NE },
         { SPR_WOODEN_RC_STATION_NW_SE, SPR_WOODEN_RC_STATION_RAILS_NW_SE },
         { SPR_WOODEN_RC_STATION_SW_NE, SPR_WOODEN_RC_STATION_RAILS_SW_NE },
@@ -495,7 +495,7 @@ static void wooden_rc_track_station(paint_session * session, uint8 rideIndex, ui
 static void wooden_rc_track_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][4] = {
+    static constexpr const uint32 imageIds[2][4][4] = {
         {
             { SPR_WOODEN_RC_25_DEG_SW_NE, SPR_WOODEN_RC_25_DEG_RAILS_SW_NE, 0, 0 },
             { SPR_WOODEN_RC_25_DEG_NW_SE, SPR_WOODEN_RC_25_DEG_RAILS_NW_SE, SPR_WOODEN_RC_25_DEG_FRONT_NW_SE,
@@ -541,7 +541,7 @@ static void wooden_rc_track_25_deg_up(paint_session * session, uint8 rideIndex, 
 static void wooden_rc_track_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WOODEN_RC_60_DEG_SW_NE, SPR_WOODEN_RC_60_DEG_RAILS_SW_NE },
         { SPR_WOODEN_RC_60_DEG_NW_SE, SPR_WOODEN_RC_60_DEG_RAILS_NW_SE },
         { SPR_WOODEN_RC_60_DEG_NE_SW, SPR_WOODEN_RC_60_DEG_RAILS_NE_SW },
@@ -577,7 +577,7 @@ static void wooden_rc_track_60_deg_up(paint_session * session, uint8 rideIndex, 
 static void wooden_rc_track_flat_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][4] = {
+    static constexpr const uint32 imageIds[2][4][4] = {
         {
             { SPR_WOODEN_RC_FLAT_TO_25_DEG_SW_NE, SPR_WOODEN_RC_FLAT_TO_25_DEG_RAILS_SW_NE, 0, 0 },
             { SPR_WOODEN_RC_FLAT_TO_25_DEG_NW_SE, SPR_WOODEN_RC_FLAT_TO_25_DEG_RAILS_NW_SE,
@@ -623,7 +623,7 @@ static void wooden_rc_track_flat_to_25_deg_up(paint_session * session, uint8 rid
 static void wooden_rc_track_25_deg_up_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                    uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_25_DEG_TO_60_DEG_SW_NE, SPR_WOODEN_RC_25_DEG_TO_60_DEG_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_25_DEG_TO_60_DEG_NW_SE, SPR_WOODEN_RC_25_DEG_TO_60_DEG_RAILS_NW_SE,
           SPR_WOODEN_RC_25_DEG_TO_60_DEG_FRONT_NW_SE, SPR_WOODEN_RC_25_DEG_TO_60_DEG_RAILS_FRONT_NW_SE },
@@ -663,7 +663,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(paint_session * session, uint
 static void wooden_rc_track_60_deg_up_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                    uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_60_DEG_TO_25_DEG_SW_NE, SPR_WOODEN_RC_60_DEG_TO_25_DEG_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_60_DEG_TO_25_DEG_NW_SE, SPR_WOODEN_RC_60_DEG_TO_25_DEG_RAILS_NW_SE,
           SPR_WOODEN_RC_60_DEG_TO_25_DEG_FRONT_NW_SE, SPR_WOODEN_RC_60_DEG_TO_25_DEG_RAILS_FRONT_NW_SE },
@@ -703,7 +703,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(paint_session * session, uint
 static void wooden_rc_track_25_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][4] = {
+    static constexpr const uint32 imageIds[2][4][4] = {
         {
             { SPR_WOODEN_RC_25_DEG_TO_FLAT_SW_NE, SPR_WOODEN_RC_25_DEG_TO_FLAT_RAILS_SW_NE, 0, 0 },
             { SPR_WOODEN_RC_25_DEG_TO_FLAT_NW_SE, SPR_WOODEN_RC_25_DEG_TO_FLAT_RAILS_NW_SE,
@@ -790,7 +790,7 @@ static void wooden_rc_track_25_deg_down_to_flat(paint_session * session, uint8 r
 static void wooden_rc_track_right_quarter_turn_5(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb_2 imageIds[2][4][7] = {
+    static constexpr const sprite_bb_2 imageIds[2][4][7] = {
         { {
               { SPR_WOODEN_RC_QUARTER_TURN_5_SW_SE_SEQ_0,
                 SPR_WOODEN_RC_QUARTER_TURN_5_RAILS_SW_SE_SEQ_0,
@@ -1042,7 +1042,7 @@ static void wooden_rc_track_left_quarter_turn_5(paint_session * session, uint8 r
 static void wooden_rc_track_flat_to_left_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_FLAT_TO_LEFT_BANK_SW_NE, SPR_WOODEN_RC_FLAT_TO_LEFT_BANK_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_FLAT_TO_LEFT_BANK_NW_SE, SPR_WOODEN_RC_FLAT_TO_LEFT_BANK_RAILS_NW_SE,
           SPR_WOODEN_RC_RC_FLAT_TO_LEFT_BANK_FRONT_NW_SE, SPR_WOODEN_RC_RC_FLAT_TO_LEFT_BANK_RAILS_FRONT_NW_SE },
@@ -1068,7 +1068,7 @@ static void wooden_rc_track_flat_to_left_bank(paint_session * session, uint8 rid
 static void wooden_rc_track_flat_to_right_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_FLAT_TO_RIGHT_BANK_SW_NE, SPR_WOODEN_RC_FLAT_TO_RIGHT_BANK_RAILS_SW_NE,
           SPR_WOODEN_RC_RC_FLAT_TO_RIGHT_BANK_FRONT_SW_NE, SPR_WOODEN_RC_RC_FLAT_TO_RIGHT_BANK_RAILS_FRONT_SW_NE },
         { SPR_WOODEN_RC_FLAT_TO_RIGHT_BANK_NW_SE, SPR_WOODEN_RC_FLAT_TO_RIGHT_BANK_RAILS_NW_SE, 0, 0 },
@@ -1107,7 +1107,7 @@ static void wooden_rc_track_right_bank_to_flat(paint_session * session, uint8 ri
 static void wooden_rc_track_banked_right_quarter_turn_5(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                         uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb_2 imageIds[2][4][7] = {
+    static constexpr const sprite_bb_2 imageIds[2][4][7] = {
         { {
               { SPR_WOODEN_RC_BANKED_QUARTER_TURN_5_SW_SE_SEQ_0,
                 SPR_WOODEN_RC_BANKED_QUARTER_TURN_5_RAILS_SW_SE_SEQ_0,
@@ -1359,7 +1359,7 @@ static void wooden_rc_track_banked_left_quarter_turn_5(paint_session * session, 
 static void wooden_rc_track_left_bank_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                    uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_SW_NE, SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_NW_SE, SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_RAILS_NW_SE,
           SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_FRONT_NW_SE, SPR_WOODEN_RC_LEFT_BANK_TO_25_DEG_RAILS_FRONT_NW_SE },
@@ -1392,7 +1392,7 @@ static void wooden_rc_track_left_bank_to_25_deg_up(paint_session * session, uint
 static void wooden_rc_track_right_bank_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_SW_NE, SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_NW_SE, SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_RAILS_NW_SE,
           SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_FRONT_NW_SE, SPR_WOODEN_RC_RIGHT_BANK_TO_25_DEG_RAILS_FRONT_NW_SE },
@@ -1425,7 +1425,7 @@ static void wooden_rc_track_right_bank_to_25_deg_up(paint_session * session, uin
 static void wooden_rc_track_25_deg_up_to_left_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                    uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_SW_NE, SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_NW_SE, SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_RAILS_NW_SE,
           SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_FRONT_NW_SE, SPR_WOODEN_RC_25_DEG_TO_LEFT_BANK_RAILS_FRONT_NW_SE },
@@ -1458,7 +1458,7 @@ static void wooden_rc_track_25_deg_up_to_left_bank(paint_session * session, uint
 static void wooden_rc_track_25_deg_up_to_right_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4] = {
+    static constexpr const uint32 imageIds[4][4] = {
         { SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_SW_NE, SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_RAILS_SW_NE, 0, 0 },
         { SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_NW_SE, SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_RAILS_NW_SE,
           SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_FRONT_NW_SE, SPR_WOODEN_RC_25_DEG_TO_RIGHT_BANK_RAILS_FRONT_NW_SE },
@@ -1519,7 +1519,7 @@ static void wooden_rc_track_25_deg_down_to_right_bank(paint_session * session, u
 static void wooden_rc_track_left_bank(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                       sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WOODEN_RC_LEFT_BANK_SW_NE, SPR_WOODEN_RC_LEFT_BANK_RAILS_SW_NE },
         { SPR_WOODEN_RC_LEFT_BANK_NW_SE, SPR_WOODEN_RC_LEFT_BANK_RAILS_NW_SE },
         { SPR_WOODEN_RC_LEFT_BANK_NE_SW, SPR_WOODEN_RC_LEFT_BANK_RAILS_NE_SW },
@@ -5339,7 +5339,7 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_down(paint_session * ses
 static void wooden_rc_track_brakes(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                    sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WOODEN_RC_BRAKES_SW_NE, SPR_WOODEN_RC_BRAKES_RAILS_SW_NE },
         { SPR_WOODEN_RC_BRAKES_NW_SE, SPR_WOODEN_RC_BRAKES_RAILS_NW_SE },
         { SPR_WOODEN_RC_BRAKES_SW_NE, SPR_WOODEN_RC_BRAKES_RAILS_SW_NE },

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -132,7 +132,7 @@ enum
 static void wooden_wild_mouse_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                          sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_WOODEN_WILD_MOUSE_FLAT_SW_NE,
         SPR_WOODEN_WILD_MOUSE_FLAT_NW_SE,
         SPR_WOODEN_WILD_MOUSE_FLAT_SW_NE,
@@ -155,7 +155,7 @@ static void wooden_wild_mouse_track_flat(paint_session * session, uint8 rideInde
 static void wooden_wild_mouse_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                             sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_WOODEN_WILD_MOUSE_FLAT_SW_NE, SPR_STATION_BASE_B_SW_NE },
         { SPR_WOODEN_WILD_MOUSE_FLAT_NW_SE, SPR_STATION_BASE_B_NW_SE },
         { SPR_WOODEN_WILD_MOUSE_FLAT_SW_NE, SPR_STATION_BASE_B_SW_NE },
@@ -177,7 +177,7 @@ static void wooden_wild_mouse_track_station(paint_session * session, uint8 rideI
 static void wooden_wild_mouse_track_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4] = {
+    static constexpr const uint32 imageIds[2][4] = {
         {
             SPR_WOODEN_WILD_MOUSE_25_DEG_SW_NE,
             SPR_WOODEN_WILD_MOUSE_25_DEG_NW_SE,
@@ -215,7 +215,7 @@ static void wooden_wild_mouse_track_25_deg_up(paint_session * session, uint8 rid
 static void wooden_wild_mouse_track_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4] = {
+    static constexpr const uint32 imageIds[2][4] = {
         {
             SPR_WOODEN_WILD_MOUSE_60_DEG_SW_NE,
             SPR_WOODEN_WILD_MOUSE_60_DEG_NW_SE,
@@ -261,7 +261,7 @@ static void wooden_wild_mouse_track_60_deg_up(paint_session * session, uint8 rid
 static void wooden_wild_mouse_track_flat_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4] = {
+    static constexpr const uint32 imageIds[2][4] = {
         {
             SPR_WOODEN_WILD_MOUSE_FLAT_TO_25_DEG_SW_NE,
             SPR_WOODEN_WILD_MOUSE_FLAT_TO_25_DEG_NW_SE,
@@ -299,7 +299,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(paint_session * session, u
 static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                            uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_WOODEN_WILD_MOUSE_25_DEG_TO_60_DEG_SW_NE, 0 },
             { SPR_WOODEN_WILD_MOUSE_25_DEG_TO_60_DEG_NW_SE, SPR_WOODEN_WILD_MOUSE_25_DEG_TO_60_DEG_FRONT_NW_SE },
@@ -348,7 +348,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(paint_session * sessi
 static void wooden_wild_mouse_track_60_deg_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                         uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_WOODEN_WILD_MOUSE_60_DEG_TO_25_DEG_SW_NE, 0 },
             { SPR_WOODEN_WILD_MOUSE_60_DEG_TO_25_DEG_NW_SE, SPR_WOODEN_WILD_MOUSE_60_DEG_TO_25_DEG_FRONT_NW_SE },
@@ -398,7 +398,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(paint_session * session,
 static void wooden_wild_mouse_track_25_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4] = {
+    static constexpr  const uint32 imageIds[2][4] = {
         {
             SPR_WOODEN_WILD_MOUSE_25_DEG_TO_FLAT_SW_NE,
             SPR_WOODEN_WILD_MOUSE_25_DEG_TO_FLAT_NW_SE,
@@ -477,7 +477,7 @@ static void wooden_wild_mouse_track_25_deg_down_to_flat(paint_session * session,
 static void wooden_wild_mouse_track_right_quarter_turn_3(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                          uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][3] = {
+    static constexpr const sprite_bb imageIds[4][3] = {
         {
             { SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 1 } },
             { SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_1, { 16, 16, 0 }, { 0, 0, 0 }, { 16, 16, 1 } },
@@ -540,7 +540,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_3(paint_session * session,
 static void wooden_wild_mouse_track_left_quarter_turn_1(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                         uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4] = {
+    static constexpr const uint32 imageIds[4] = {
         SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_1_SW_NE,
         SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_1_NW_SE,
         SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_1_NE_SW,
@@ -581,7 +581,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_1(paint_session * session
 static void wooden_wild_mouse_track_flat_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_WOODEN_WILD_MOUSE_FLAT_TO_60_DEG_SW_NE, 0 },
             { SPR_WOODEN_WILD_MOUSE_FLAT_TO_60_DEG_NW_SE, SPR_WOODEN_WILD_MOUSE_FLAT_TO_60_DEG_FRONT_NW_SE },
@@ -630,7 +630,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(paint_session * session, u
 static void wooden_wild_mouse_track_60_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_WOODEN_WILD_MOUSE_60_DEG_TO_FLAT_SW_NE, 0 },
             { SPR_WOODEN_WILD_MOUSE_60_DEG_TO_FLAT_NW_SE, SPR_WOODEN_WILD_MOUSE_60_DEG_TO_FLAT_FRONT_NW_SE },

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -76,70 +76,70 @@ enum
     SPR_CAR_RIDE_QUARTER_TURN_3_TILES_SE_NE_PART_2  = 28820,
 };
 
-static const uint32 car_ride_track_pieces_flat[4] = {
+static constexpr const uint32 car_ride_track_pieces_flat[4] = {
     SPR_CAR_RIDE_FLAT_SW_NE,
     SPR_CAR_RIDE_FLAT_NW_SE,
     SPR_CAR_RIDE_FLAT_SW_NE,
     SPR_CAR_RIDE_FLAT_NW_SE,
 };
 
-static const uint32 car_ride_track_pieces_log_bumps[4] = {
+static constexpr const uint32 car_ride_track_pieces_log_bumps[4] = {
     SPR_CAR_RIDE_LOG_BUMPS_SW_NE,
     SPR_CAR_RIDE_LOG_BUMPS_NW_SE,
     SPR_CAR_RIDE_LOG_BUMPS_SW_NE,
     SPR_CAR_RIDE_LOG_BUMPS_NW_SE,
 };
 
-static const uint32 car_ride_track_pieces_25_deg_up[4] = {
+static constexpr const uint32 car_ride_track_pieces_25_deg_up[4] = {
     SPR_CAR_RIDE_25_DEG_UP_SW_NE,
     SPR_CAR_RIDE_25_DEG_UP_NW_SE,
     SPR_CAR_RIDE_25_DEG_UP_NE_SW,
     SPR_CAR_RIDE_25_DEG_UP_SE_NW,
 };
 
-static const uint32 car_ride_track_pieces_flat_to_25_deg_up[4] = {
+static constexpr const uint32 car_ride_track_pieces_flat_to_25_deg_up[4] = {
     SPR_CAR_RIDE_FLAT_TO_25_DEG_UP_SW_NE,
     SPR_CAR_RIDE_FLAT_TO_25_DEG_UP_NW_SE,
     SPR_CAR_RIDE_FLAT_TO_25_DEG_UP_NE_SW,
     SPR_CAR_RIDE_FLAT_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 car_ride_track_pieces_25_deg_up_to_flat[4] = {
+static constexpr const uint32 car_ride_track_pieces_25_deg_up_to_flat[4] = {
     SPR_CAR_RIDE_DEG_UP_TO_FLAT_SW_NE,
     SPR_CAR_RIDE_DEG_UP_TO_FLAT_NW_SE,
     SPR_CAR_RIDE_DEG_UP_TO_FLAT_NE_SW,
     SPR_CAR_RIDE_DEG_UP_TO_FLAT_SE_NW,
 };
 
-static const uint32 car_ride_track_pieces_60_deg_up[4] = {
+static constexpr const uint32 car_ride_track_pieces_60_deg_up[4] = {
     SPR_CAR_RIDE_60_DEG_UP_SW_NE,
     SPR_CAR_RIDE_60_DEG_UP_NW_SE,
     SPR_CAR_RIDE_60_DEG_UP_NE_SW,
     SPR_CAR_RIDE_60_DEG_UP_SE_NW,
 };
 
-static const uint32 car_ride_track_pieces_25_deg_up_to_60_deg_up[4][2] = {
+static constexpr const uint32 car_ride_track_pieces_25_deg_up_to_60_deg_up[4][2] = {
     { SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_SW_NE, 0 },
     { SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_NW_SE, SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_FRONT_NW_SE },
     { SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_NE_SW, SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_FRONT_NE_SW },
     { SPR_CAR_RIDE_25_DEG_UP_TO_60_DEG_UP_SE_NW, 0 },
 };
 
-static const uint32 car_ride_track_pieces_60_deg_up_to_25_deg_up[4][2] = {
+static constexpr const uint32 car_ride_track_pieces_60_deg_up_to_25_deg_up[4][2] = {
     { SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_SW_NE, 0 },
     { SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_NW_SE, SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_FRONT_NW_SE },
     { SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_NE_SW, SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_FRONT_NE_SW },
     { SPR_CAR_RIDE_60_DEG_UP_TO_25_DEG_UP_SE_NW, 0 },
 };
 
-static const uint32 car_ride_track_pieces_left_quarter_turn_1_tile[4] = {
+static constexpr const uint32 car_ride_track_pieces_left_quarter_turn_1_tile[4] = {
     SPR_CAR_RIDE_QUARTER_TURN_1_TILE_SW_NW,
     SPR_CAR_RIDE_QUARTER_TURN_1_TILE_NW_NE,
     SPR_CAR_RIDE_QUARTER_TURN_1_TILE_NE_SE,
     SPR_CAR_RIDE_QUARTER_TURN_1_TILE_SE_SW,
 };
 
-static const uint32 car_ride_track_pieces_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 car_ride_track_pieces_quarter_turn_3_tiles[4][3] = {
     { SPR_CAR_RIDE_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_CAR_RIDE_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_CAR_RIDE_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_CAR_RIDE_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_CAR_RIDE_QUARTER_TURN_3_TILES_NW_SW_PART_1,

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -28,7 +28,7 @@ typedef struct rct_crooked_house_bound_box
     sint16 length_y;
 } rct_crooked_house_bound_box;
 
-static const rct_crooked_house_bound_box crooked_house_data[] = { { 6, 0, 42, 24 },
+static constexpr const rct_crooked_house_bound_box crooked_house_data[] = { { 6, 0, 42, 24 },
                                                      { 0, 0, 0, 0 },
                                                      { -16, -16, 32, 32 },
                                                      { 0, 0, 0, 0 }, // Unused

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -31,7 +31,7 @@ enum
     SPR_DODGEMS_FENCE_TOP_LEFT     = 21937
 };
 
-const uint32 dodgems_fence_sprites[] = { SPR_DODGEMS_FENCE_TOP_RIGHT, SPR_DODGEMS_FENCE_BOTTOM_RIGHT,
+static constexpr const uint32 dodgems_fence_sprites[] = { SPR_DODGEMS_FENCE_TOP_RIGHT, SPR_DODGEMS_FENCE_BOTTOM_RIGHT,
                                          SPR_DODGEMS_FENCE_BOTTOM_LEFT, SPR_DODGEMS_FENCE_TOP_LEFT };
 
 static void paint_dodgems_roof(paint_session * session, sint32 height, sint32 offset)

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -20,14 +20,14 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-static const uint8 edges_1x4_ne_sw[] = {
+static constexpr const uint8 edges_1x4_ne_sw[] = {
     EDGE_NW | EDGE_SE,
     EDGE_NW | EDGE_SE | EDGE_NE,
     EDGE_NW | EDGE_SE,
     EDGE_NW | EDGE_SE | EDGE_SW,
 };
 
-static const uint8 edges_1x4_nw_se[] = {
+static constexpr const uint8 edges_1x4_nw_se[] = {
     EDGE_NE | EDGE_SW,
     EDGE_NE | EDGE_SW | EDGE_NW,
     EDGE_NE | EDGE_SW,

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -29,7 +29,7 @@ enum
     SPR_FLYING_SAUCERS_FENCE_NW = 21924,
 };
 
-static const uint32 flying_saucers_fence_sprites[] = {
+static constexpr const uint32 flying_saucers_fence_sprites[] = {
     SPR_FLYING_SAUCERS_FENCE_NE,
     SPR_FLYING_SAUCERS_FENCE_SE,
     SPR_FLYING_SAUCERS_FENCE_SW,

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -74,42 +74,42 @@ enum
     SPR_GHOST_TRAIN_TRACK_BRAKES_NW_SE = 28882
 };
 
-static const uint32 ghost_train_track_pieces_flat[4] = {
+static constexpr const uint32 ghost_train_track_pieces_flat[4] = {
     SPR_GHOST_TRAIN_TRACK_FLAT_SW_NE,
     SPR_GHOST_TRAIN_TRACK_FLAT_NW_SE,
     SPR_GHOST_TRAIN_TRACK_FLAT_SW_NE,
     SPR_GHOST_TRAIN_TRACK_FLAT_NW_SE,
 };
 
-static const uint32 ghost_train_track_pieces_flat_to_25_deg_up[4][2] = {
+static constexpr const uint32 ghost_train_track_pieces_flat_to_25_deg_up[4][2] = {
     { SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_SW_NE, SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_FRONT_SW_NE },
     { SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_NW_SE, SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_FRONT_NW_SE },
     { SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_NE_SW, SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_FRONT_NE_SW },
     { SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_SE_NW, SPR_GHOST_TRAIN_TRACK_FLAT_TO_25_DEG_UP_FRONT_SE_NW },
 };
 
-static const uint32 ghost_train_track_pieces_25_deg_up_to_flat[4][2] = {
+static constexpr const uint32 ghost_train_track_pieces_25_deg_up_to_flat[4][2] = {
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_SW_NE, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_FRONT_SW_NE },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_NW_SE, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_FRONT_NW_SE },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_NE_SW, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_FRONT_NE_SW },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_SE_NW, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_TO_FLAT_FRONT_SE_NW },
 };
 
-static const uint32 ghost_train_track_pieces_25_deg_up[4][2] = {
+static constexpr const uint32 ghost_train_track_pieces_25_deg_up[4][2] = {
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_SW_NE, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_FRONT_SW_NE },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_NW_SE, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_FRONT_NW_SE },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_NE_SW, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_FRONT_NE_SW },
     { SPR_GHOST_TRAIN_TRACK_25_DEG_UP_SE_NW, SPR_GHOST_TRAIN_TRACK_25_DEG_UP_FRONT_SE_NW },
 };
 
-static const uint32 ghost_train_track_pieces_quarter_turn_1_tile[4] = {
+static constexpr const uint32 ghost_train_track_pieces_quarter_turn_1_tile[4] = {
     SPR_GHOST_TRAIN_QUARTER_TURN_1_TILE_SW_NW,
     SPR_GHOST_TRAIN_QUARTER_TURN_1_TILE_NW_NE,
     SPR_GHOST_TRAIN_QUARTER_TURN_1_TILE_NE_SE,
     SPR_GHOST_TRAIN_QUARTER_TURN_1_TILE_SE_SW,
 };
 
-static const uint32 ghost_train_track_pieces_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 ghost_train_track_pieces_quarter_turn_3_tiles[4][3] = {
     { SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -120,14 +120,14 @@ static const uint32 ghost_train_track_pieces_quarter_turn_3_tiles[4][3] = {
       SPR_GHOST_TRAIN_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 ghost_train_track_pieces_spinning_tunnel_track[4] = {
+static constexpr const uint32 ghost_train_track_pieces_spinning_tunnel_track[4] = {
     SPR_GHOST_TRAIN_SPINNING_TUNNEL_TRACK_SW_NE,
     SPR_GHOST_TRAIN_SPINNING_TUNNEL_TRACK_NW_SE,
     SPR_GHOST_TRAIN_SPINNING_TUNNEL_TRACK_SW_NE,
     SPR_GHOST_TRAIN_SPINNING_TUNNEL_TRACK_NW_SE,
 };
 
-static const uint32 ghost_train_track_pieces_brakes[4] = {
+static constexpr const uint32 ghost_train_track_pieces_brakes[4] = {
     SPR_GHOST_TRAIN_TRACK_BRAKES_SW_NE,
     SPR_GHOST_TRAIN_TRACK_BRAKES_NW_SE,
     SPR_GHOST_TRAIN_TRACK_BRAKES_SW_NE,

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -21,10 +21,10 @@
 #include "../TrackPaint.h"
 
 /** rct2: 0x0142805C */
-static const uint32 merry_go_round_rider_offsets[] = { 0, 32, 64, 96, 16, 48, 80, 112 };
+static constexpr const uint32 merry_go_round_rider_offsets[] = { 0, 32, 64, 96, 16, 48, 80, 112 };
 
 /** rct2: 0x0142807C */
-static const uint16 merry_go_round_breakdown_vibration[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 0 };
+static constexpr const uint16 merry_go_round_breakdown_vibration[] = { 0, 1, 2, 3, 4, 3, 2, 1, 0, 0 };
 
 /**
  * rct2: 0x0076287D

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -250,21 +250,21 @@ static const uint32 mini_golf_track_sprites_25_deg_up_to_flat[][3] = { {
                                                                            SPR_MINI_GOLF_25_DEG_UP_TO_FLAT_FENCE_FRONT_SE_NW,
                                                                        } };
 
-static const uint32 mini_golf_track_sprites_quarter_turn_1_tile[] = {
+static constexpr const uint32 mini_golf_track_sprites_quarter_turn_1_tile[] = {
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_SW_NW,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_NW_NE,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_NE_SE,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_SE_SW,
 };
 
-static const uint32 mini_golf_track_sprites_quarter_turn_1_tile_fence_front[] = {
+static constexpr const uint32 mini_golf_track_sprites_quarter_turn_1_tile_fence_front[] = {
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_FRONT_SW_NW,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_FRONT_NW_NE,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_FRONT_NE_SE,
     SPR_MINI_GOLF_QUARTER_TURN_1_TILE_FENCE_FRONT_SE_SW,
 };
 
-static const uint32 mini_golf_track_sprites_hole_a[4][2][2] = {
+static constexpr const uint32 mini_golf_track_sprites_hole_a[4][2][2] = {
     { { SPR_MINI_GOLF_HOLE_A_BASE_PART_1_SW_NE, SPR_MINI_GOLF_HOLE_A_TRIM_PART_1_SW_NE },
       { SPR_MINI_GOLF_HOLE_A_BASE_PART_2_SW_NE, SPR_MINI_GOLF_HOLE_A_TRIM_PART_2_SW_NE } },
     { { SPR_MINI_GOLF_HOLE_A_BASE_PART_1_NW_SE, SPR_MINI_GOLF_HOLE_A_TRIM_PART_1_NW_SE },
@@ -275,7 +275,7 @@ static const uint32 mini_golf_track_sprites_hole_a[4][2][2] = {
       { SPR_MINI_GOLF_HOLE_A_BASE_PART_2_SE_NW, SPR_MINI_GOLF_HOLE_A_TRIM_PART_2_SE_NW } },
 };
 
-static const uint32 mini_golf_track_sprites_hole_b[4][2][2] = {
+static constexpr const uint32 mini_golf_track_sprites_hole_b[4][2][2] = {
     { { SPR_MINI_GOLF_HOLE_B_BASE_PART_1_SW_NE, SPR_MINI_GOLF_HOLE_B_TRIM_PART_1_SW_NE },
       { SPR_MINI_GOLF_HOLE_B_BASE_PART_2_SW_NE, SPR_MINI_GOLF_HOLE_B_TRIM_PART_2_SW_NE } },
     { { SPR_MINI_GOLF_HOLE_B_BASE_PART_1_NW_SE, SPR_MINI_GOLF_HOLE_B_TRIM_PART_1_NW_SE },
@@ -286,7 +286,7 @@ static const uint32 mini_golf_track_sprites_hole_b[4][2][2] = {
       { SPR_MINI_GOLF_HOLE_B_BASE_PART_2_SE_NW, SPR_MINI_GOLF_HOLE_B_TRIM_PART_2_SE_NW } },
 };
 
-static const uint32 mini_golf_track_sprites_hole_c[][2][2] = {
+static constexpr const uint32 mini_golf_track_sprites_hole_c[][2][2] = {
     { { SPR_MINI_GOLF_HOLE_C_BASE_PART_1_SW_NE, SPR_MINI_GOLF_HOLE_C_TRIM_PART_1_SW_NE },
       { SPR_MINI_GOLF_HOLE_C_BASE_PART_2_SW_NE, SPR_MINI_GOLF_HOLE_C_TRIM_PART_2_SW_NE } },
     { { SPR_MINI_GOLF_HOLE_C_BASE_PART_1_NW_SE, SPR_MINI_GOLF_HOLE_C_TRIM_PART_1_NW_SE },
@@ -297,7 +297,7 @@ static const uint32 mini_golf_track_sprites_hole_c[][2][2] = {
       { SPR_MINI_GOLF_HOLE_C_BASE_PART_2_SE_NW, SPR_MINI_GOLF_HOLE_C_TRIM_PART_2_SE_NW } },
 };
 
-static const uint32 mini_golf_track_sprites_hole_d[][3][2] = {
+static constexpr const uint32 mini_golf_track_sprites_hole_d[][3][2] = {
     { { SPR_MINI_GOLF_HOLE_D_BASE_PART_1_SW_SE, SPR_MINI_GOLF_HOLE_D_TRIM_PART_1_SW_SE },
       { SPR_MINI_GOLF_HOLE_D_BASE_PART_2_SW_SE, SPR_MINI_GOLF_HOLE_D_TRIM_PART_2_SW_SE },
       { SPR_MINI_GOLF_HOLE_D_BASE_PART_3_SW_SE, SPR_MINI_GOLF_HOLE_D_TRIM_PART_3_SW_SE } },
@@ -312,7 +312,7 @@ static const uint32 mini_golf_track_sprites_hole_d[][3][2] = {
       { SPR_MINI_GOLF_HOLE_D_BASE_PART_3_SE_NE, SPR_MINI_GOLF_HOLE_D_TRIM_PART_3_SE_NE } },
 };
 
-static const uint32 mini_golf_track_sprites_hole_e[][3][2] = {
+static constexpr const uint32 mini_golf_track_sprites_hole_e[][3][2] = {
     { { SPR_MINI_GOLF_HOLE_E_BASE_PART_1_SW_NW, SPR_MINI_GOLF_HOLE_E_TRIM_PART_1_SW_NW },
       { SPR_MINI_GOLF_HOLE_E_BASE_PART_2_SW_NW, SPR_MINI_GOLF_HOLE_E_TRIM_PART_2_SW_NW },
       { SPR_MINI_GOLF_HOLE_E_BASE_PART_3_SW_NW, SPR_MINI_GOLF_HOLE_E_TRIM_PART_3_SW_NW } },
@@ -328,34 +328,34 @@ static const uint32 mini_golf_track_sprites_hole_e[][3][2] = {
 };
 
 /** rct2: 0x00933471 */
-static const uint8 mini_golf_peep_animation_frames_walk[] = { 0, 1, 2, 3, 4, 5 };
+static constexpr const uint8 mini_golf_peep_animation_frames_walk[] = { 0, 1, 2, 3, 4, 5 };
 
 /** rct2: 0x00933478 */
-static const uint8 mini_golf_peep_animation_frames_place_ball_downwards[] = { 12, 13, 14, 15 };
+static constexpr const uint8 mini_golf_peep_animation_frames_place_ball_downwards[] = { 12, 13, 14, 15 };
 
 /** rct2: 0x009334B5 */
-static const uint8 mini_golf_peep_animation_frames_swing[] = { 31, 31, 31, 31, 31, 31, 31, 31, 31, 32, 33, 33, 33, 33, 34 };
+static constexpr const uint8 mini_golf_peep_animation_frames_swing[] = { 31, 31, 31, 31, 31, 31, 31, 31, 31, 32, 33, 33, 33, 33, 34 };
 
 /** rct2: 0x0093347D */
-static const uint8 mini_golf_peep_animation_frames_swing_left[] = { 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 8, 8, 8, 9 };
+static constexpr const uint8 mini_golf_peep_animation_frames_swing_left[] = { 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 8, 8, 8, 8, 9 };
 
 /** rct2: 0x0093348D */
-static const uint8 mini_golf_peep_animation_frames_place_ball_upwards[] = { 12, 13, 14, 15, 14, 13, 12 };
+static constexpr const uint8 mini_golf_peep_animation_frames_place_ball_upwards[] = { 12, 13, 14, 15, 14, 13, 12 };
 
 /** rct2: 0x00933495 */
-static const uint8 mini_golf_peep_animation_frames_jump[] = { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 };
+static constexpr const uint8 mini_golf_peep_animation_frames_jump[] = { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 };
 
 /** rct2: 0x009334A5 */
-static const uint8 mini_golf_peep_animation_frames_pickup_ball[] = { 15, 14, 13, 12 };
+static constexpr const uint8 mini_golf_peep_animation_frames_pickup_ball[] = { 15, 14, 13, 12 };
 
 /** rct2: 0x009334C5 */
-static const uint8 mini_golf_peep_animation_frames_put[] = { 35, 36, 36, 36, 36, 36, 35, 35, 35, 35 };
+static constexpr const uint8 mini_golf_peep_animation_frames_put[] = { 35, 36, 36, 36, 36, 36, 35, 35, 35, 35 };
 
 /** rct2: 0x009334AA */
-static const uint8 mini_golf_peep_animation_frames_put_left[] = { 10, 11, 11, 11, 11, 11, 10, 10, 10, 10 };
+static constexpr const uint8 mini_golf_peep_animation_frames_put_left[] = { 10, 11, 11, 11, 11, 11, 10, 10, 10, 10 };
 
 /** rct2: 0x008B8F74 */
-static const uint8 * mini_golf_peep_animation_frames[] = {
+static constexpr const uint8 * mini_golf_peep_animation_frames[] = {
     mini_golf_peep_animation_frames_walk,       mini_golf_peep_animation_frames_place_ball_downwards,
     mini_golf_peep_animation_frames_swing_left, mini_golf_peep_animation_frames_place_ball_upwards,
     mini_golf_peep_animation_frames_jump,       mini_golf_peep_animation_frames_pickup_ball,

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -266,7 +266,7 @@ static void paint_mini_helicopters_track_left_quarter_turn_3_tiles(paint_session
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint8 mini_helicopters_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 mini_helicopters_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
 
 /** rct2: 0x0081F3F8 */
 static void paint_mini_helicopters_track_right_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex,

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -77,9 +77,9 @@ enum
     SPR_MONORAIL_CYCLES_S_BEND_RIGHT_NW_SE_PART_3              = 16869,
 };
 
-static const uint32 monorail_cycles_track_pieces_flat[4] = { SPR_MONORAIL_CYCLES_FLAT_SW_NE, SPR_MONORAIL_CYCLES_FLAT_NW_SE };
+static constexpr const uint32 monorail_cycles_track_pieces_flat[4] = { SPR_MONORAIL_CYCLES_FLAT_SW_NE, SPR_MONORAIL_CYCLES_FLAT_NW_SE };
 
-static const uint32 monorail_cycles_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
+static constexpr const uint32 monorail_cycles_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     {
         SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_5_TILES_SW_SE_PART_0,
         SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_5_TILES_SW_SE_PART_1,
@@ -110,7 +110,7 @@ static const uint32 monorail_cycles_track_pieces_flat_quarter_turn_5_tiles[4][5]
     }
 };
 
-static const uint32 monorail_cycles_track_pieces_s_bend_left[2][4] = { {
+static constexpr const uint32 monorail_cycles_track_pieces_s_bend_left[2][4] = { {
                                                                            SPR_MONORAIL_CYCLES_S_BEND_LEFT_SW_NE_PART_0,
                                                                            SPR_MONORAIL_CYCLES_S_BEND_LEFT_SW_NE_PART_1,
                                                                            SPR_MONORAIL_CYCLES_S_BEND_LEFT_SW_NE_PART_2,
@@ -123,7 +123,7 @@ static const uint32 monorail_cycles_track_pieces_s_bend_left[2][4] = { {
                                                                            SPR_MONORAIL_CYCLES_S_BEND_LEFT_NW_SE_PART_3,
                                                                        } };
 
-static const uint32 monorail_cycles_track_pieces_s_bend_right[2][4] = { {
+static constexpr const uint32 monorail_cycles_track_pieces_s_bend_right[2][4] = { {
                                                                             SPR_MONORAIL_CYCLES_S_BEND_RIGHT_SW_NE_PART_0,
                                                                             SPR_MONORAIL_CYCLES_S_BEND_RIGHT_SW_NE_PART_1,
                                                                             SPR_MONORAIL_CYCLES_S_BEND_RIGHT_SW_NE_PART_2,
@@ -136,7 +136,7 @@ static const uint32 monorail_cycles_track_pieces_s_bend_right[2][4] = { {
                                                                             SPR_MONORAIL_CYCLES_S_BEND_RIGHT_NW_SE_PART_3,
                                                                         } };
 
-static const uint32 monorail_cycles_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 monorail_cycles_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
     { SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_MONORAIL_CYCLES_FLAT_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -254,7 +254,7 @@ static void paint_monorail_cycles_track_left_quarter_turn_3_tiles(paint_session 
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint8 monorail_cycles_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 monorail_cycles_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
 
 /** rct2: 0x0088AD98 */
 static void paint_monorail_cycles_track_right_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex,
@@ -266,14 +266,14 @@ static void paint_monorail_cycles_track_right_quarter_turn_3_tiles(paint_session
                                                           tileElement);
 }
 
-static const sint8 monorail_cycles_track_right_quarter_turn_5_tiles_support_height_offset[][7] = {
+static constexpr const sint8 monorail_cycles_track_right_quarter_turn_5_tiles_support_height_offset[][7] = {
     { -2, 0, -2, 0, 0, -3, -1 },
     { -3, 0, 0, 0, 0, 0, 0 },
     { 0 },
     { 0, 0, 0, 0, 0, -2, -3 },
 };
 
-static const sint8 monorail_cycles_track_right_quarter_turn_5_tiles_support_special[][7] = {
+static constexpr const sint8 monorail_cycles_track_right_quarter_turn_5_tiles_support_special[][7] = {
     { 0, 0, 0, 0, 0, 0, 0 },
     { 0, 0, 0, 0, 0, 0, 1 },
     { 0, 0, 1, 0, 0, 1, 1 },

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -29,7 +29,7 @@ enum
     SPR_SPACE_RINGS_FENCE_NW = 22149,
 };
 
-static const uint32 space_rings_fence_sprites[] = {
+static constexpr const uint32 space_rings_fence_sprites[] = {
     SPR_SPACE_RINGS_FENCE_NE,
     SPR_SPACE_RINGS_FENCE_SE,
     SPR_SPACE_RINGS_FENCE_SW,

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -183,7 +183,7 @@ static void spiral_slide_paint_tile_front(paint_session * session, uint8 rideInd
     }
 }
 
-static const uint32 spiral_slide_fence_sprites[] = {
+static constexpr const uint32 spiral_slide_fence_sprites[] = {
     SPIRAL_SLIDE_FENCE_TOP_RIGHT,
     SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT,
     SPIRAL_SLIDE_FENCE_BOTTOM_LEFT,

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -109,21 +109,21 @@ static const uint32 go_karts_track_pieces_starting_grid[4][2] = {
     { SPR_GO_KARTS_STARTING_GRID_SE_NW, SPR_GO_KARTS_STARTING_GRID_FRONT_SE_NW },
 };
 
-static const uint32 go_karts_track_pieces_25_deg_up[4][2] = {
+static constexpr const uint32 go_karts_track_pieces_25_deg_up[4][2] = {
     { SPR_GO_KARTS_25_DEG_UP_SW_NE, SPR_GO_KARTS_25_DEG_UP_FRONT_SW_NE },
     { SPR_GO_KARTS_25_DEG_UP_NW_SE, SPR_GO_KARTS_25_DEG_UP_FRONT_NW_SE },
     { SPR_GO_KARTS_25_DEG_UP_NE_SW, SPR_GO_KARTS_25_DEG_UP_FRONT_NE_SW },
     { SPR_GO_KARTS_25_DEG_UP_SE_NW, SPR_GO_KARTS_25_DEG_UP_FRONT_SE_NW },
 };
 
-static const uint32 go_karts_track_pieces_flat_to_25_deg_up[4][2] = {
+static constexpr const uint32 go_karts_track_pieces_flat_to_25_deg_up[4][2] = {
     { SPR_GO_KARTS_FLAT_TO_25_DEG_UP_SW_NE, SPR_GO_KARTS_FLAT_TO_25_DEG_UP_FRONT_SW_NE },
     { SPR_GO_KARTS_FLAT_TO_25_DEG_UP_NW_SE, SPR_GO_KARTS_FLAT_TO_25_DEG_UP_FRONT_NW_SE },
     { SPR_GO_KARTS_FLAT_TO_25_DEG_UP_NE_SW, SPR_GO_KARTS_FLAT_TO_25_DEG_UP_FRONT_NE_SW },
     { SPR_GO_KARTS_FLAT_TO_25_DEG_UP_SE_NW, SPR_GO_KARTS_FLAT_TO_25_DEG_UP_FRONT_SE_NW },
 };
 
-static const uint32 go_karts_track_pieces_25_deg_up_to_flat[4][2] = {
+static constexpr const uint32 go_karts_track_pieces_25_deg_up_to_flat[4][2] = {
     { SPR_GO_KARTS_25_DEG_UP_TO_FLAT_SW_NE, SPR_GO_KARTS_25_DEG_UP_TO_FLAT_FRONT_SW_NE },
     { SPR_GO_KARTS_25_DEG_UP_TO_FLAT_NW_SE, SPR_GO_KARTS_25_DEG_UP_TO_FLAT_FRONT_NW_SE },
     { SPR_GO_KARTS_25_DEG_UP_TO_FLAT_NE_SW, SPR_GO_KARTS_25_DEG_UP_TO_FLAT_FRONT_NE_SW },

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -47,15 +47,15 @@ typedef struct bound_box
 } bound_box;
 
 /** rct2: 0x01428220 */
-static const sint16 MagicCarpetOscillationZ[] = { -2, -1, 1,  5,  10, 16, 23, 30, 37, 45, 52, 59, 65, 70, 74, 76,
+static constexpr const sint16 MagicCarpetOscillationZ[] = { -2, -1, 1,  5,  10, 16, 23, 30, 37, 45, 52, 59, 65, 70, 74, 76,
                                                   77, 76, 74, 70, 65, 59, 52, 45, 37, 30, 23, 16, 10, 5,  1,  -1 };
 
 /** rct2: 0x01428260 */
-static const sint8 MagicCarpetOscillationXY[] = { 0, 6,  12,  18,  23,  27,  30,  31,  32,  31,  30,  27,  23,  18,  12,  6,
+static constexpr const sint8 MagicCarpetOscillationXY[] = { 0, 6,  12,  18,  23,  27,  30,  31,  32,  31,  30,  27,  23,  18,  12,  6,
                                                   0, -5, -11, -17, -22, -26, -29, -30, -31, -30, -29, -26, -22, -17, -11, -5 };
 
 /** rct2: 0x014281F0 */
-static const bound_box MagicCarpetBounds[] = { { 0, 8, 32, 16 }, { 8, 0, 16, 32 }, { 0, 8, 32, 16 }, { 8, 0, 16, 32 } };
+static constexpr const bound_box MagicCarpetBounds[] = { { 0, 8, 32, 16 }, { 8, 0, 16, 32 }, { 0, 8, 32, 16 }, { 8, 0, 16, 32 } };
 
 static rct_vehicle * get_first_vehicle(Ride * ride)
 {

--- a/src/openrct2/ride/thrill/PirateShip.cpp
+++ b/src/openrct2/ride/thrill/PirateShip.cpp
@@ -21,7 +21,7 @@
 #include "../TrackPaint.h"
 
 // 1 2 0 3 4
-static const uint8 track_map_1x5[][5] = {
+static constexpr const uint8 track_map_1x5[][5] = {
     { 0, 1, 2, 3, 4 },
     { 0, 4, 3, 2, 1 },
     { 0, 4, 3, 2, 1 },
@@ -37,10 +37,10 @@ typedef struct pirate_ship_bound_box
 } pirate_ship_bound_box;
 
 /** rct2: 0x008A83B0 */
-static const uint32 pirate_ship_base_sprite_offset[] = { 0, 9, 0, 9 };
+static constexpr const uint32 pirate_ship_base_sprite_offset[] = { 0, 9, 0, 9 };
 
 /** rct2: 0x008A83C0 */
-static const pirate_ship_bound_box pirate_ship_data[] = {
+static constexpr const pirate_ship_bound_box pirate_ship_data[] = {
     { 31, 16, 1, 8 },
     { 16, 31, 8, 1 },
     { 31, 16, 1, 8 },
@@ -55,7 +55,7 @@ enum
     SPR_PIRATE_SHIP_FRAME_FRONT_NW_SE = 21997,
 };
 
-static const uint32 pirate_ship_frame_sprites[][2] = {
+static constexpr const uint32 pirate_ship_frame_sprites[][2] = {
     { SPR_PIRATE_SHIP_FRAME_SW_NE, SPR_PIRATE_SHIP_FRAME_FRONT_SW_NE },
     { SPR_PIRATE_SHIP_FRAME_NW_SE, SPR_PIRATE_SHIP_FRAME_FRONT_NW_SE },
 };

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -21,10 +21,10 @@
 #include "../TrackPaint.h"
 
 /** rct2: 0x01428010 */
-static const uint32 swinging_inverter_ship_base_sprite_offset[] = { 0, 16, 0, 16 };
+static constexpr const uint32 swinging_inverter_ship_base_sprite_offset[] = { 0, 16, 0, 16 };
 
 /** rct2: 0x01428020 */
-static const uint32 swinging_inverter_ship_animating_base_sprite_offset[] = { 32, 33, 32, 33 };
+static constexpr const uint32 swinging_inverter_ship_animating_base_sprite_offset[] = { 32, 33, 32, 33 };
 
 typedef struct swinging_inverter_ship_bound_box
 {
@@ -35,7 +35,7 @@ typedef struct swinging_inverter_ship_bound_box
 } swinging_inverter_ship_bound_box;
 
 /** rct2: 0x01428020 */
-static const swinging_inverter_ship_bound_box swinging_inverter_ship_bounds[] = {
+static constexpr const swinging_inverter_ship_bound_box swinging_inverter_ship_bounds[] = {
     { 32, 16, 0, 8 }, { 16, 32, 8, 0 }, { 32, 16, 0, 8 }, { 16, 32, 8, 0 }
 };
 
@@ -47,7 +47,7 @@ enum
     SPR_SWINGING_INVERTER_SHIP_FRAME_3 = 22001,
 };
 
-static const uint32 swinging_inverter_ship_frame_sprites[] = { SPR_SWINGING_INVERTER_SHIP_FRAME_0,
+static constexpr const uint32 swinging_inverter_ship_frame_sprites[] = { SPR_SWINGING_INVERTER_SHIP_FRAME_0,
                                                                SPR_SWINGING_INVERTER_SHIP_FRAME_1,
                                                                SPR_SWINGING_INVERTER_SHIP_FRAME_2,
                                                                SPR_SWINGING_INVERTER_SHIP_FRAME_3 };

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -35,7 +35,7 @@ enum
     SPR_LIFT_CAGE_NW_FRONT = 15003,
 };
 
-static const uint32 lift_cage_sprites[][2] = {
+static constexpr const uint32 lift_cage_sprites[][2] = {
     { SPR_LIFT_CAGE_BACK, SPR_LIFT_CAGE_FRONT },       { SPR_LIFT_CAGE_NE_BACK, SPR_LIFT_CAGE_NE_FRONT },
     { SPR_LIFT_CAGE_SE_BACK, SPR_LIFT_CAGE_SE_FRONT }, { SPR_LIFT_CAGE_SW_BACK, SPR_LIFT_CAGE_SW_FRONT },
     { SPR_LIFT_CAGE_NW_BACK, SPR_LIFT_CAGE_NW_FRONT },

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -144,24 +144,24 @@ enum
 static const uint32 miniature_railway_track_floor[4] = { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS,
                                                          SPR_FLOOR_PLANKS_90_DEG };
 
-static const uint32 miniature_railway_track_pieces_flat[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_flat[4] = {
     SPR_MINIATURE_RAILWAY_FLAT_SW_NE,
     SPR_MINIATURE_RAILWAY_FLAT_NW_SE,
     SPR_MINIATURE_RAILWAY_FLAT_SW_NE,
     SPR_MINIATURE_RAILWAY_FLAT_NW_SE,
 };
 
-static const uint32 miniature_railway_station_floor[4] = { SPR_STATION_BASE_A_SW_NE, SPR_STATION_BASE_A_NW_SE,
+static constexpr const uint32 miniature_railway_station_floor[4] = { SPR_STATION_BASE_A_SW_NE, SPR_STATION_BASE_A_NW_SE,
                                                            SPR_STATION_BASE_A_SW_NE, SPR_STATION_BASE_A_NW_SE };
 
-static const uint32 miniature_railway_track_pieces_flat_station[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_flat_station[4] = {
     SPR_MINIATURE_RAILWAY_FLAT_NO_BASE_SW_NE,
     SPR_MINIATURE_RAILWAY_FLAT_NO_BASE_NW_SE,
     SPR_MINIATURE_RAILWAY_FLAT_NO_BASE_SW_NE,
     SPR_MINIATURE_RAILWAY_FLAT_NO_BASE_NW_SE,
 };
 
-static const uint32 miniature_railway_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
+static constexpr const uint32 miniature_railway_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     {
         SPR_MINIATURE_RAILWAY_QUARTER_TURN_5_TILES_SW_SE_PART_0,
         SPR_MINIATURE_RAILWAY_QUARTER_TURN_5_TILES_SW_SE_PART_1,
@@ -192,28 +192,28 @@ static const uint32 miniature_railway_track_pieces_flat_quarter_turn_5_tiles[4][
     }
 };
 
-static const uint32 miniature_railway_track_pieces_25_deg_up[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_25_deg_up[4] = {
     SPR_MINIATURE_RAILWAY_25_DEG_UP_SW_NE,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_NW_SE,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_NE_SW,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_SE_NW,
 };
 
-static const uint32 miniature_railway_track_pieces_flat_to_25_deg_up[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_flat_to_25_deg_up[4] = {
     SPR_MINIATURE_RAILWAY_FLAT_TO_25_DEG_UP_SW_NE,
     SPR_MINIATURE_RAILWAY_FLAT_TO_25_DEG_UP_NW_SE,
     SPR_MINIATURE_RAILWAY_FLAT_TO_25_DEG_UP_NE_SW,
     SPR_MINIATURE_RAILWAY_FLAT_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 miniature_railway_track_pieces_25_deg_up_to_flat[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_25_deg_up_to_flat[4] = {
     SPR_MINIATURE_RAILWAY_25_DEG_UP_TO_FLAT_SW_NE,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_TO_FLAT_NW_SE,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_TO_FLAT_NE_SW,
     SPR_MINIATURE_RAILWAY_25_DEG_UP_TO_FLAT_SE_NW,
 };
 
-static const uint32 miniature_railway_track_pieces_s_bend_left[2][4] = { {
+static constexpr const uint32 miniature_railway_track_pieces_s_bend_left[2][4] = { {
                                                                              SPR_MINIATURE_RAILWAY_S_BEND_LEFT_SW_NE_PART_0,
                                                                              SPR_MINIATURE_RAILWAY_S_BEND_LEFT_SW_NE_PART_1,
                                                                              SPR_MINIATURE_RAILWAY_S_BEND_LEFT_SW_NE_PART_2,
@@ -226,7 +226,7 @@ static const uint32 miniature_railway_track_pieces_s_bend_left[2][4] = { {
                                                                              SPR_MINIATURE_RAILWAY_S_BEND_LEFT_SE_NW_PART_0,
                                                                          } };
 
-static const uint32 miniature_railway_track_pieces_s_bend_right[2][4] = { {
+static constexpr const uint32 miniature_railway_track_pieces_s_bend_right[2][4] = { {
                                                                               SPR_MINIATURE_RAILWAY_S_BEND_RIGHT_SW_NE_PART_0,
                                                                               SPR_MINIATURE_RAILWAY_S_BEND_RIGHT_SW_NE_PART_1,
                                                                               SPR_MINIATURE_RAILWAY_S_BEND_RIGHT_SW_NE_PART_2,
@@ -239,7 +239,7 @@ static const uint32 miniature_railway_track_pieces_s_bend_right[2][4] = { {
                                                                               SPR_MINIATURE_RAILWAY_S_BEND_RIGHT_SE_NW_PART_0,
                                                                           } };
 
-static const uint32 miniature_railway_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 miniature_railway_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
     { SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -250,7 +250,7 @@ static const uint32 miniature_railway_track_pieces_flat_quarter_turn_3_tiles[4][
       SPR_MINIATURE_RAILWAY_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 miniature_railway_track_pieces_right_eight_to_diag[4][4] = {
+static constexpr const uint32 miniature_railway_track_pieces_right_eight_to_diag[4][4] = {
     {
         SPR_MINIATURE_RAILWAY_EIGHT_TO_DIAG_SW_E_PART_0,
         SPR_MINIATURE_RAILWAY_EIGHT_TO_DIAG_SW_E_PART_1,
@@ -277,7 +277,7 @@ static const uint32 miniature_railway_track_pieces_right_eight_to_diag[4][4] = {
     },
 };
 
-static const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_diag_bounds[4][4] = {
+static constexpr const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_diag_bounds[4][4] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -304,7 +304,7 @@ static const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_diag_bo
     },
 };
 
-static const LocationXY16 miniature_railway_track_pieces_right_eight_to_diag_offset[4][4] = {
+static constexpr const LocationXY16 miniature_railway_track_pieces_right_eight_to_diag_offset[4][4] = {
     {
         { 0, 0 },
         { 0, 16 },
@@ -331,7 +331,7 @@ static const LocationXY16 miniature_railway_track_pieces_right_eight_to_diag_off
     },
 };
 
-static const uint32 miniature_railway_track_pieces_left_eight_to_diag[4][4] = {
+static constexpr const uint32 miniature_railway_track_pieces_left_eight_to_diag[4][4] = {
     {
         SPR_MINIATURE_RAILWAY_EIGHT_TO_DIAG_SW_N_PART_0,
         SPR_MINIATURE_RAILWAY_EIGHT_TO_DIAG_SW_N_PART_1,
@@ -358,7 +358,7 @@ static const uint32 miniature_railway_track_pieces_left_eight_to_diag[4][4] = {
     },
 };
 
-static const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_diag_bounds[4][4] = {
+static constexpr const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_diag_bounds[4][4] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -385,7 +385,7 @@ static const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_diag_bou
     },
 };
 
-static const LocationXY16 miniature_railway_track_pieces_left_eight_to_diag_offset[4][4] = {
+static constexpr const LocationXY16 miniature_railway_track_pieces_left_eight_to_diag_offset[4][4] = {
     {
         { 0, 0 },
         { 0, 0 },
@@ -412,7 +412,7 @@ static const LocationXY16 miniature_railway_track_pieces_left_eight_to_diag_offs
     },
 };
 
-static const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_orthog_bounds[4][4] = {
+static constexpr const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_orthog_bounds[4][4] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -439,7 +439,7 @@ static const LocationXYZ16 miniature_railway_track_pieces_right_eight_to_orthog_
     },
 };
 
-static const LocationXY16 miniature_railway_track_pieces_right_eight_to_orthog_offset[4][4] = {
+static constexpr const LocationXY16 miniature_railway_track_pieces_right_eight_to_orthog_offset[4][4] = {
     {
         { 0, 0 },
         { 0, 0 },
@@ -466,7 +466,7 @@ static const LocationXY16 miniature_railway_track_pieces_right_eight_to_orthog_o
     },
 };
 
-static const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_orthog_bounds[4][4] = {
+static constexpr const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_orthog_bounds[4][4] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -493,7 +493,7 @@ static const LocationXYZ16 miniature_railway_track_pieces_left_eight_to_orthog_b
     },
 };
 
-static const LocationXY16 miniature_railway_track_pieces_left_eight_to_orthog_offset[4][4] = {
+static constexpr const LocationXY16 miniature_railway_track_pieces_left_eight_to_orthog_offset[4][4] = {
     {
         { 0, 0 },
         { 0, 16 },
@@ -527,21 +527,21 @@ static const uint32 miniature_railway_track_pieces_diag_flat[4] = {
     SPR_MINIATURE_RAILWAY_DIAG_FLAT_S_N,
 };
 
-static const uint32 miniature_railway_track_pieces_diag_flat_to_25_deg_up[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_diag_flat_to_25_deg_up[4] = {
     SPR_MINIATURE_RAILWAY_DIAG_FLAT_TO_25_DEG_UP_W_E,
     SPR_MINIATURE_RAILWAY_DIAG_FLAT_TO_25_DEG_UP_N_S,
     SPR_MINIATURE_RAILWAY_DIAG_FLAT_TO_25_DEG_UP_E_W,
     SPR_MINIATURE_RAILWAY_DIAG_FLAT_TO_25_DEG_UP_S_N,
 };
 
-static const uint32 miniature_railway_track_pieces_diag_25_deg_up_to_flat[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_diag_25_deg_up_to_flat[4] = {
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_TO_FLAT_W_E,
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_TO_FLAT_N_S,
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_TO_FLAT_E_W,
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_TO_FLAT_S_N,
 };
 
-static const uint32 miniature_railway_track_pieces_diag_25_deg_up[4] = {
+static constexpr const uint32 miniature_railway_track_pieces_diag_25_deg_up[4] = {
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_W_E,
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_N_S,
     SPR_MINIATURE_RAILWAY_DIAG_25_DEG_UP_E_W,
@@ -794,7 +794,7 @@ static void paint_miniature_railway_track_25_deg_down_to_flat(paint_session * se
 }
 
 // clang-format off
-const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_offsets[4][5] = { {
+static constexpr const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_offsets[4][5] = { {
                                                                                   { 0, 2 },
                                                                                   { 0, 16 },
                                                                                   { 0, 0 },
@@ -823,7 +823,7 @@ const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_offsets[4][5] = 
                                                                                   { 0, 2 },
                                                                               } };
 
-const LocationXYZ16 miniature_railway_right_quarter_turn_5_tiles_bound_offsets[4][5] = { {
+static constexpr const LocationXYZ16 miniature_railway_right_quarter_turn_5_tiles_bound_offsets[4][5] = { {
                                                                                          { 0, 2, 0 },
                                                                                          { 0, 16, 0 },
                                                                                          { 0, 0, 0 },
@@ -852,7 +852,7 @@ const LocationXYZ16 miniature_railway_right_quarter_turn_5_tiles_bound_offsets[4
                                                                                          { 0, 2, 0 },
                                                                                      } };
 
-const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_bound_lengths[4][5] = { {
+static constexpr const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_bound_lengths[4][5] = { {
                                                                                         { 32, 32 },
                                                                                         { 32, 16 },
                                                                                         { 16, 16 },
@@ -882,7 +882,7 @@ const LocationXY16 miniature_railway_right_quarter_turn_5_tiles_bound_lengths[4]
                                                                                     } };
 // clang-format on
 
-static const uint32 miniature_railway_right_quarter_turn_5_tiles_track_floor[4][5] = {
+static constexpr const uint32 miniature_railway_right_quarter_turn_5_tiles_track_floor[4][5] = {
     { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_S_SEGMENT, SPR_FLOOR_PLANKS_N_SEGMENT, SPR_FLOOR_PLANKS_S_SEGMENT,
       SPR_FLOOR_PLANKS_90_DEG },
     { SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_W_SEGMENT, SPR_FLOOR_PLANKS_E_SEGMENT, SPR_FLOOR_PLANKS_W_SEGMENT,
@@ -893,11 +893,11 @@ static const uint32 miniature_railway_right_quarter_turn_5_tiles_track_floor[4][
       SPR_FLOOR_PLANKS },
 };
 
-static const sint8 right_quarter_turn_5_supports_type[4][7] = {
+static constexpr const sint8 right_quarter_turn_5_supports_type[4][7] = {
     { 0, -1, 4, 2, -1, 4, 1 }, { 1, -1, 5, 3, -1, 5, 0 }, { 0, -1, 2, 4, -1, 2, 1 }, { 1, -1, 3, 5, -1, 3, 0 }
 };
 
-static const sint8 miniature_railway_right_quarter_turn_5_tiles_sprite_map[] = { 0, -1, 1, 2, -1, 3, 4 };
+static constexpr const sint8 miniature_railway_right_quarter_turn_5_tiles_sprite_map[] = { 0, -1, 1, 2, -1, 3, 4 };
 
 /** rct2: 0x008AD140 */
 static void paint_miniature_railway_track_right_quarter_turn_5_tiles(paint_session * session, uint8 rideIndex,
@@ -997,9 +997,9 @@ static void paint_miniature_railway_track_left_quarter_turn_5_tiles(paint_sessio
                                                              tileElement);
 }
 
-static const sint8 s_bend_left_supports_type[4][4] = { { 0, 5, 3, 0 }, { 1, 2, 4, 1 }, { 0, 5, 3, 0 }, { 1, 2, 4, 1 } };
+static constexpr const sint8 s_bend_left_supports_type[4][4] = { { 0, 5, 3, 0 }, { 1, 2, 4, 1 }, { 0, 5, 3, 0 }, { 1, 2, 4, 1 } };
 
-static const uint32 miniature_railway_s_bend_left_tiles_track_floor[2][4] = { { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_W_SEGMENT,
+static constexpr const uint32 miniature_railway_s_bend_left_tiles_track_floor[2][4] = { { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_W_SEGMENT,
                                                                                 SPR_FLOOR_PLANKS_E_SEGMENT, SPR_FLOOR_PLANKS },
                                                                               {
                                                                                   SPR_FLOOR_PLANKS_90_DEG,
@@ -1020,14 +1020,14 @@ static void paint_miniature_railway_track_s_bend_left(paint_session * session, u
     bool isSupported = wooden_a_supports_paint_setup(session, s_bend_left_supports_type[direction][trackSequence], 0, height,
                                                      session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-    const LocationXY16 offsetList[] = {
+    static constexpr const LocationXY16 offsetList[] = {
         { 0, 2 },
         { 0, 0 },
         { 0, 6 },
         { 0, 2 },
     };
 
-    const LocationXY16 boundsList[] = {
+    static constexpr const LocationXY16 boundsList[] = {
         { 32, 27 },
         { 32, 26 },
         { 32, 26 },
@@ -1091,9 +1091,9 @@ static void paint_miniature_railway_track_s_bend_left(paint_session * session, u
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const sint8 s_bend_right_supports_type[4][4] = { { 0, 4, 2, 0 }, { 1, 5, 3, 1 }, { 0, 4, 2, 0 }, { 1, 5, 3, 1 } };
+static constexpr const sint8 s_bend_right_supports_type[4][4] = { { 0, 4, 2, 0 }, { 1, 5, 3, 1 }, { 0, 4, 2, 0 }, { 1, 5, 3, 1 } };
 
-static const uint32 miniature_railway_s_bend_right_tiles_track_floor[2][4] = { { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_S_SEGMENT,
+static constexpr const uint32 miniature_railway_s_bend_right_tiles_track_floor[2][4] = { { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_S_SEGMENT,
                                                                                  SPR_FLOOR_PLANKS_N_SEGMENT, SPR_FLOOR_PLANKS },
                                                                                {
                                                                                    SPR_FLOOR_PLANKS_90_DEG,
@@ -1114,14 +1114,14 @@ static void paint_miniature_railway_track_s_bend_right(paint_session * session, 
     bool isSupported = wooden_a_supports_paint_setup(session, s_bend_right_supports_type[direction][trackSequence], 0, height,
                                                      session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-    const LocationXY16 offsetList[] = {
+    static constexpr const LocationXY16 offsetList[] = {
         { 0, 2 },
         { 0, 6 },
         { 0, 0 },
         { 0, 2 },
     };
 
-    const LocationXY16 boundsList[] = {
+    static constexpr const LocationXY16 boundsList[] = {
         { 32, 27 },
         { 32, 26 },
         { 32, 26 },
@@ -1185,7 +1185,7 @@ static void paint_miniature_railway_track_s_bend_right(paint_session * session, 
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint32 miniature_railway_right_quarter_turn_3_tile_track_floor[4][3] = { {
+static constexpr const uint32 miniature_railway_right_quarter_turn_3_tile_track_floor[4][3] = { {
                                                                                           SPR_FLOOR_PLANKS_S_SEGMENT,
                                                                                           0,
                                                                                           SPR_FLOOR_PLANKS_S_SEGMENT,
@@ -1206,7 +1206,7 @@ static const uint32 miniature_railway_right_quarter_turn_3_tile_track_floor[4][3
                                                                                           SPR_FLOOR_PLANKS_E_SEGMENT,
                                                                                       } };
 
-const LocationXYZ16 miniature_railway_right_quarter_turn_3_tile_bound_offsets[4][3] = { {
+static constexpr const LocationXYZ16 miniature_railway_right_quarter_turn_3_tile_bound_offsets[4][3] = { {
                                                                                         { 0, 6, 0 },
                                                                                         { 16, 16, 0 },
                                                                                         { 6, 0, 0 },
@@ -1235,7 +1235,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(paint_sessi
     bool isSupported = false;
     if (trackSequence != 1 && trackSequence != 2)
     {
-        const uint8 supportType[] = { 4, 5, 2, 3 };
+        static constexpr const uint8 supportType[] = { 4, 5, 2, 3 };
         isSupported               = wooden_a_supports_paint_setup(session, supportType[direction], 0, height,
                                                     session->TrackColours[SCHEME_SUPPORTS], nullptr);
     }
@@ -1260,7 +1260,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(paint_sessi
             miniature_railway_right_quarter_turn_3_tile_track_floor, nullptr, defaultRightQuarterTurn3TilesBoundLengths,
             miniature_railway_right_quarter_turn_3_tile_bound_offsets, get_current_rotation());
 
-        static const sint8 right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
+        static constexpr const sint8 right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
 
         sint32 index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
 
@@ -1303,9 +1303,9 @@ static void paint_miniature_railway_track_left_quarter_turn_3_tiles(paint_sessio
                                                              tileElement);
 }
 
-static const sint8 paint_miniature_railway_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
+static constexpr const sint8 paint_miniature_railway_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
 
-static const uint32 miniature_railway_floor_track_pieces_left_eight_to_diag[4][5] = {
+static constexpr const uint32 miniature_railway_floor_track_pieces_left_eight_to_diag[4][5] = {
     { SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS, SPR_FLOOR_PLANKS_E_SEGMENT, SPR_FLOOR_PLANKS_W_SEGMENT, SPR_FLOOR_PLANKS_90_DEG },
     { SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_S_SEGMENT, SPR_FLOOR_PLANKS_N_SEGMENT,
       SPR_FLOOR_PLANKS },
@@ -1314,7 +1314,7 @@ static const uint32 miniature_railway_floor_track_pieces_left_eight_to_diag[4][5
       SPR_FLOOR_PLANKS },
 };
 
-static const LocationXYZ16 miniature_railway_track_floor_pieces_left_eight_to_diag_bounds[4][5] = {
+static constexpr const LocationXYZ16 miniature_railway_track_floor_pieces_left_eight_to_diag_bounds[4][5] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -1345,7 +1345,7 @@ static const LocationXYZ16 miniature_railway_track_floor_pieces_left_eight_to_di
     },
 };
 
-static const LocationXY16 miniature_railway_track_floor_pieces_left_eight_to_diag_offset[4][5] = {
+static constexpr const LocationXY16 miniature_railway_track_floor_pieces_left_eight_to_diag_offset[4][5] = {
     {
         { 0, 0 },
         { 0, 0 },
@@ -1442,7 +1442,7 @@ static void paint_miniature_railway_track_left_eighth_to_diag(paint_session * se
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
-static const uint32 miniature_railway_floor_track_pieces_right_eight_to_diag[4][5] = {
+static constexpr const uint32 miniature_railway_floor_track_pieces_right_eight_to_diag[4][5] = {
     { SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_N_SEGMENT, SPR_FLOOR_PLANKS_S_SEGMENT,
       SPR_FLOOR_PLANKS_90_DEG },
     { SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_90_DEG, SPR_FLOOR_PLANKS_E_SEGMENT, SPR_FLOOR_PLANKS_W_SEGMENT,
@@ -1452,7 +1452,7 @@ static const uint32 miniature_railway_floor_track_pieces_right_eight_to_diag[4][
       SPR_FLOOR_PLANKS },
 };
 
-static const LocationXYZ16 miniature_railway_track_floor_pieces_right_eight_to_diag_bounds[4][5] = {
+static constexpr const LocationXYZ16 miniature_railway_track_floor_pieces_right_eight_to_diag_bounds[4][5] = {
     {
         { 32, 32, 2 },
         { 32, 16, 2 },
@@ -1483,7 +1483,7 @@ static const LocationXYZ16 miniature_railway_track_floor_pieces_right_eight_to_d
     },
 };
 
-static const LocationXY16 miniature_railway_track_floor_pieces_right_eight_to_diag_offset[4][5] = {
+static constexpr const LocationXY16 miniature_railway_track_floor_pieces_right_eight_to_diag_offset[4][5] = {
     {
         { 0, 0 },
         { 0, 16 },
@@ -1603,7 +1603,7 @@ static void paint_miniature_railway_track_right_eighth_to_orthogonal(paint_sessi
                                                       tileElement);
 }
 
-static const bool miniature_railway_diag_image_segment[][4] = {
+static constexpr const bool miniature_railway_diag_image_segment[][4] = {
     { false, true, false, false },
     { false, false, false, true },
     { false, false, true, false },
@@ -1620,7 +1620,7 @@ enum
     SUPPORT_PLAIN_W      = 5,
 };
 
-static const sint16 monorail_diag_support_types[][4] = {
+static constexpr const sint16 monorail_diag_support_types[][4] = {
     { -1, SUPPORT_PLAIN_N, SUPPORT_PLAIN_S, SUPPORT_PLAIN },
     { -1, SUPPORT_PLAIN_E, SUPPORT_PLAIN_W, SUPPORT_PLAIN_90_DEG },
     { -1, SUPPORT_PLAIN_S, SUPPORT_PLAIN_N, SUPPORT_PLAIN },
@@ -1634,7 +1634,7 @@ typedef struct floor_desc
     LocationXY16 bound_offset;
 } floor_desc;
 
-static const floor_desc floors[] = {
+static constexpr const floor_desc floors[] = {
     { SPR_FLOOR_PLANKS, { 32, 32 }, { 0, 0 } },
     { SPR_FLOOR_PLANKS_90_DEG, { 32, 32 }, { 0, 0 } }, // -16,-16(1:3)
     { SPR_FLOOR_PLANKS_N_SEGMENT, { 32, 32 }, { -16, -16 } },
@@ -1752,7 +1752,7 @@ static void miniature_railway_track_diag_25_deg_up(paint_session * session, uint
         floorBoundOffset = { -16, -16 };
     }
 
-    const sint8 offsetsB[4][4][2] = {
+    static constexpr const sint8 offsetsB[4][4][2] = {
         { { 0, 0 }, { +8, +16 }, { +8, +8 }, { +8, +8 } },
         { { 0, 0 }, { -8, -8 }, { -8, -8 }, { +8, +8 } },
         { { 0, 0 }, { +8, +8 }, { +8, +16 }, { +8, +8 } },
@@ -1761,7 +1761,7 @@ static void miniature_railway_track_diag_25_deg_up(paint_session * session, uint
 
     uint32             imageId   = miniature_railway_track_pieces_diag_25_deg_up[direction];
     bool               drawRail  = miniature_railway_diag_image_segment[direction][trackSequence];
-    static const sint8 offsetB[] = { +8, 0, +8, +8 };
+    static constexpr const sint8 offsetB[] = { +8, 0, +8, +8 };
     if (hasSupports)
     {
         sub_98197C(session, floorImage | session->TrackColours[SCHEME_SUPPORTS], 0, 0, floorBoundSize.x, floorBoundSize.y,

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -138,14 +138,14 @@ enum
     SPR_MONORAIL_DIAG_25_DEG_UP_S_N                = 23340,
 };
 
-static const uint32 monorail_track_pieces_flat[4] = {
+static constexpr const uint32 monorail_track_pieces_flat[4] = {
     SPR_MONORAIL_FLAT_SW_NE,
     SPR_MONORAIL_FLAT_NW_SE,
     SPR_MONORAIL_FLAT_SW_NE,
     SPR_MONORAIL_FLAT_NW_SE,
 };
 
-static const uint32 monorail_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
+static constexpr const uint32 monorail_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     {
         SPR_MONORAIL_QUARTER_TURN_5_TILES_SW_SE_PART_0,
         SPR_MONORAIL_QUARTER_TURN_5_TILES_SW_SE_PART_1,
@@ -176,28 +176,28 @@ static const uint32 monorail_track_pieces_flat_quarter_turn_5_tiles[4][5] = {
     }
 };
 
-static const uint32 monorail_track_pieces_25_deg_up[4] = {
+static constexpr const uint32 monorail_track_pieces_25_deg_up[4] = {
     SPR_MONORAIL_25_DEG_UP_SW_NE,
     SPR_MONORAIL_25_DEG_UP_NW_SE,
     SPR_MONORAIL_25_DEG_UP_NE_SW,
     SPR_MONORAIL_25_DEG_UP_SE_NW,
 };
 
-static const uint32 monorail_track_pieces_flat_to_25_deg_up[4] = {
+static constexpr const uint32 monorail_track_pieces_flat_to_25_deg_up[4] = {
     SPR_MONORAIL_FLAT_TO_25_DEG_UP_SW_NE,
     SPR_MONORAIL_FLAT_TO_25_DEG_UP_NW_SE,
     SPR_MONORAIL_FLAT_TO_25_DEG_UP_NE_SW,
     SPR_MONORAIL_FLAT_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 monorail_track_pieces_25_deg_up_to_flat[4] = {
+static constexpr const uint32 monorail_track_pieces_25_deg_up_to_flat[4] = {
     SPR_MONORAIL_25_DEG_UP_TO_FLAT_SW_NE,
     SPR_MONORAIL_25_DEG_UP_TO_FLAT_NW_SE,
     SPR_MONORAIL_25_DEG_UP_TO_FLAT_NE_SW,
     SPR_MONORAIL_25_DEG_UP_TO_FLAT_SE_NW,
 };
 
-static const uint32 monorail_track_pieces_s_bend_left[2][4] = { {
+static constexpr const uint32 monorail_track_pieces_s_bend_left[2][4] = { {
                                                                     SPR_MONORAIL_S_BEND_LEFT_SW_NE_PART_0,
                                                                     SPR_MONORAIL_S_BEND_LEFT_SW_NE_PART_1,
                                                                     SPR_MONORAIL_S_BEND_LEFT_SW_NE_PART_2,
@@ -210,7 +210,7 @@ static const uint32 monorail_track_pieces_s_bend_left[2][4] = { {
                                                                     SPR_MONORAIL_S_BEND_LEFT_SE_NW_PART_0,
                                                                 } };
 
-static const uint32 monorail_track_pieces_s_bend_right[2][4] = { {
+static constexpr const uint32 monorail_track_pieces_s_bend_right[2][4] = { {
                                                                      SPR_MONORAIL_S_BEND_RIGHT_SW_NE_PART_0,
                                                                      SPR_MONORAIL_S_BEND_RIGHT_SW_NE_PART_1,
                                                                      SPR_MONORAIL_S_BEND_RIGHT_SW_NE_PART_2,
@@ -223,7 +223,7 @@ static const uint32 monorail_track_pieces_s_bend_right[2][4] = { {
                                                                      SPR_MONORAIL_S_BEND_RIGHT_SE_NW_PART_0,
                                                                  } };
 
-static const uint32 monorail_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
+static constexpr const uint32 monorail_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
     { SPR_MONORAIL_QUARTER_TURN_3_TILES_SW_SE_PART_0, SPR_MONORAIL_QUARTER_TURN_3_TILES_SW_SE_PART_1,
       SPR_MONORAIL_QUARTER_TURN_3_TILES_SW_SE_PART_2 },
     { SPR_MONORAIL_QUARTER_TURN_3_TILES_NW_SW_PART_0, SPR_MONORAIL_QUARTER_TURN_3_TILES_NW_SW_PART_1,
@@ -234,7 +234,7 @@ static const uint32 monorail_track_pieces_flat_quarter_turn_3_tiles[4][3] = {
       SPR_MONORAIL_QUARTER_TURN_3_TILES_SE_NE_PART_2 }
 };
 
-static const uint32 ghost_train_track_pieces_right_eight_to_diag[4][4] = {
+static constexpr const uint32 ghost_train_track_pieces_right_eight_to_diag[4][4] = {
     {
         SPR_MONORAIL_EIGHT_TO_DIAG_SW_E_PART_0,
         SPR_MONORAIL_EIGHT_TO_DIAG_SW_E_PART_1,
@@ -261,7 +261,7 @@ static const uint32 ghost_train_track_pieces_right_eight_to_diag[4][4] = {
     },
 };
 
-static const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_bounds[4][4] = {
+static constexpr const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_bounds[4][4] = {
     {
         { 32, 20 },
         { 32, 16 },
@@ -288,7 +288,7 @@ static const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_bounds[4]
     },
 };
 
-static const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_offset[4][4] = {
+static constexpr const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_offset[4][4] = {
     {
         { 0, 6 },
         { 0, 16 },
@@ -315,7 +315,7 @@ static const LocationXY16 ghost_train_track_pieces_right_eight_to_diag_offset[4]
     },
 };
 
-static const uint32 ghost_train_track_pieces_left_eight_to_diag[4][4] = {
+static constexpr const uint32 ghost_train_track_pieces_left_eight_to_diag[4][4] = {
     {
         SPR_MONORAIL_EIGHT_TO_DIAG_SW_N_PART_0,
         SPR_MONORAIL_EIGHT_TO_DIAG_SW_N_PART_1,
@@ -342,7 +342,7 @@ static const uint32 ghost_train_track_pieces_left_eight_to_diag[4][4] = {
     },
 };
 
-static const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_bounds[4][4] = {
+static constexpr const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_bounds[4][4] = {
     {
         { 32, 20 },
         { 32, 16 },
@@ -369,7 +369,7 @@ static const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_bounds[4][
     },
 };
 
-static const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_offset[4][4] = {
+static constexpr const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_offset[4][4] = {
     {
         { 0, 6 },
         { 0, 0 },
@@ -396,7 +396,7 @@ static const LocationXY16 ghost_train_track_pieces_left_eight_to_diag_offset[4][
     },
 };
 
-static const uint32 monorail_track_pieces_diag_flat[4] = {
+static constexpr const uint32 monorail_track_pieces_diag_flat[4] = {
     SPR_MONORAIL_DIAG_FLAT_W_E,
     SPR_MONORAIL_DIAG_FLAT_N_S,
     SPR_MONORAIL_DIAG_FLAT_E_W,
@@ -410,14 +410,14 @@ static const uint32 monorail_track_pieces_diag_flat_to_25_deg_up[4] = {
     SPR_MONORAIL_DIAG_FLAT_TO_25_DEG_UP_S_N,
 };
 
-static const uint32 monorail_track_pieces_diag_25_deg_up_to_flat[4] = {
+static constexpr const uint32 monorail_track_pieces_diag_25_deg_up_to_flat[4] = {
     SPR_MONORAIL_DIAG_25_DEG_UP_TO_FLAT_W_E,
     SPR_MONORAIL_DIAG_25_DEG_UP_TO_FLAT_N_S,
     SPR_MONORAIL_DIAG_25_DEG_UP_TO_FLAT_E_W,
     SPR_MONORAIL_DIAG_25_DEG_UP_TO_FLAT_S_N,
 };
 
-static const uint32 monorail_track_pieces_diag_25_deg_up[4] = {
+static constexpr const uint32 monorail_track_pieces_diag_25_deg_up[4] = {
     SPR_MONORAIL_DIAG_25_DEG_UP_W_E,
     SPR_MONORAIL_DIAG_25_DEG_UP_N_S,
     SPR_MONORAIL_DIAG_25_DEG_UP_E_W,
@@ -971,7 +971,7 @@ static void paint_monorail_track_left_quarter_turn_3_tiles(paint_session * sessi
     paint_monorail_track_right_quarter_turn_3_tiles(session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
-static const sint8 paint_monorail_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
+static constexpr const sint8 paint_monorail_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
 
 /** rct2: 0x008AE31C */
 static void paint_monorail_track_left_eighth_to_diag(paint_session * session, uint8 rideIndex, uint8 trackSequence,
@@ -1117,7 +1117,7 @@ static void paint_monorail_track_right_eighth_to_orthogonal(paint_session * sess
     paint_monorail_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
-static const bool monorail_diag_image_segment[][4] =
+static constexpr const bool monorail_diag_image_segment[][4] =
 {
     { false, true, false, false },
     { false, false, false, true },
@@ -1125,9 +1125,9 @@ static const bool monorail_diag_image_segment[][4] =
     { true, false, false, false },
 };
 
-static const uint8 monorail_diag_support_segment[] = { 1, 0, 2, 3 };
+static constexpr const uint8 monorail_diag_support_segment[] = { 1, 0, 2, 3 };
 
-static const sint32 monorail_diag_blocked_segments[] = { SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4 | SEGMENT_BC,
+static constexpr const sint32 monorail_diag_blocked_segments[] = { SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4 | SEGMENT_BC,
                                                          SEGMENT_C4 | SEGMENT_CC | SEGMENT_C8 | SEGMENT_B4,
                                                          SEGMENT_D0 | SEGMENT_C4 | SEGMENT_C0 | SEGMENT_D4,
                                                          SEGMENT_D0 | SEGMENT_C4 | SEGMENT_B8 | SEGMENT_C8 };

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -59,7 +59,7 @@ static void suspended_monorail_track_flat(paint_session * session, uint8 rideInd
 static void suspended_monorail_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                              sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_STATION_BASE_C_SW_NE, 25853, SPR_STATION_INVERTED_BAR_F_SW_NE },
         { SPR_STATION_BASE_C_NW_SE, 25854, SPR_STATION_INVERTED_BAR_F_NW_SE },
         { SPR_STATION_BASE_C_SW_NE, 25853, SPR_STATION_INVERTED_BAR_F_SW_NE },

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -359,7 +359,7 @@ enum
 static void dinghy_slide_track_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                     sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_DINGHY_SLIDE_FLAT_SW_NE, SPR_DINGHY_SLIDE_FLAT_FRONT_SW_NE },
             { SPR_DINGHY_SLIDE_FLAT_NW_SE, SPR_DINGHY_SLIDE_FLAT_FRONT_NW_SE },
@@ -396,7 +396,7 @@ static void dinghy_slide_track_flat(paint_session * session, uint8 rideIndex, ui
 static void dinghy_slide_track_station(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                        sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_STATION_SW_NE, SPR_STATION_BASE_B_SW_NE },
         { SPR_DINGHY_SLIDE_STATION_NW_SE, SPR_STATION_BASE_B_NW_SE },
         { SPR_DINGHY_SLIDE_STATION_SW_NE, SPR_STATION_BASE_B_SW_NE },
@@ -424,7 +424,7 @@ static void dinghy_slide_track_station(paint_session * session, uint8 rideIndex,
 static void dinghy_slide_track_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                          sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_DINGHY_SLIDE_25_DEG_SW_NE, SPR_DINGHY_SLIDE_25_DEG_FRONT_SW_NE },
             { SPR_DINGHY_SLIDE_25_DEG_NW_SE, SPR_DINGHY_SLIDE_25_DEG_FRONT_NW_SE },
@@ -468,7 +468,7 @@ static void dinghy_slide_track_25_deg_up(paint_session * session, uint8 rideInde
 static void dinghy_slide_track_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                          sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_60_DEG_SW_NE, SPR_DINGHY_SLIDE_60_DEG_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_60_DEG_NW_SE, SPR_DINGHY_SLIDE_60_DEG_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_60_DEG_NE_SW, SPR_DINGHY_SLIDE_60_DEG_FRONT_NE_SW },
@@ -503,7 +503,7 @@ static void dinghy_slide_track_60_deg_up(paint_session * session, uint8 rideInde
 static void dinghy_slide_track_flat_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_SW_NE, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_FRONT_SW_NE },
             { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_NW_SE, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_FRONT_NW_SE },
@@ -547,7 +547,7 @@ static void dinghy_slide_track_flat_to_25_deg_up(paint_session * session, uint8 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_SW_NE, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_NW_SE, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_NE_SW, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_FRONT_NE_SW },
@@ -582,7 +582,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(paint_session * session, u
 static void dinghy_slide_track_60_deg_up_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_SW_NE, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_NW_SE, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_NE_SW, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_FRONT_NE_SW },
@@ -617,7 +617,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(paint_session * session, u
 static void dinghy_slide_track_25_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[2][4][2] = {
+    static constexpr const uint32 imageIds[2][4][2] = {
         {
             { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_SW_NE, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_FRONT_SW_NE },
             { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_NW_SE, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_FRONT_NW_SE },
@@ -691,7 +691,7 @@ static void dinghy_slide_track_25_deg_down_to_flat(paint_session * session, uint
 static void dinghy_slide_track_right_quarter_turn_5(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][5] = {
+    static constexpr const sprite_bb imageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SW_SE_PART_0, { 0, 2, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SW_SE_PART_1, { 0, 16, 0 }, { 0, 16, 0 }, { 32, 16, 2 } },
@@ -721,7 +721,7 @@ static void dinghy_slide_track_right_quarter_turn_5(paint_session * session, uin
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SE_NE_PART_4, { 0, 2, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         }
     };
-    static const sprite_bb frontImageIds[4][5] = {
+    static constexpr const sprite_bb frontImageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_FRONT_SW_SE_PART_0, { 0, 2, 0 }, { 0, 6, 27 }, { 32, 30, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_FRONT_SW_SE_PART_1, { 0, 16, 0 }, { 0, 16, 27 }, { 32, 16, 0 } },
@@ -829,7 +829,7 @@ static void dinghy_slide_track_60_deg_down_to_25_deg_down(paint_session * sessio
 static void dinghy_slide_track_s_bend_left(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                            sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_DINGHY_SLIDE_S_BEND_SW_SE_SW_SEQ_3, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_NW_NE_SEQ_0 },
           { SPR_DINGHY_SLIDE_S_BEND_SW_SE_SW_SEQ_2, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_NW_NE_SEQ_1 },
           { SPR_DINGHY_SLIDE_S_BEND_SW_SE_SW_SEQ_1, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_NW_NE_SEQ_2 },
@@ -919,7 +919,7 @@ static void dinghy_slide_track_s_bend_left(paint_session * session, uint8 rideIn
 static void dinghy_slide_track_s_bend_right(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                             sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_DINGHY_SLIDE_S_BEND_SW_NW_SW_SEQ_3, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_SE_NE_SEQ_0 },
           { SPR_DINGHY_SLIDE_S_BEND_SW_NW_SW_SEQ_2, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_SE_NE_SEQ_1 },
           { SPR_DINGHY_SLIDE_S_BEND_SW_NW_SW_SEQ_1, SPR_DINGHY_SLIDE_S_BEND_FRONT_NE_SE_NE_SEQ_2 },
@@ -1009,7 +1009,7 @@ static void dinghy_slide_track_s_bend_right(paint_session * session, uint8 rideI
 static void dinghy_slide_track_right_quarter_turn_3(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][3] = {
+    static constexpr const sprite_bb imageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 2 } },
@@ -1031,7 +1031,7 @@ static void dinghy_slide_track_right_quarter_turn_3(paint_session * session, uin
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SE_NE_PART_2, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         }
     };
-    static const sprite_bb frontImageIds[4][3] = {
+    static constexpr const sprite_bb frontImageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 20, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 27 }, { 16, 16, 0 } },
@@ -1096,7 +1096,7 @@ static void dinghy_slide_track_left_quarter_turn_3(paint_session * session, uint
 static void dinghy_slide_track_flat_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                             sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_FLAT_COVERED_SW_NE, SPR_DINGHY_SLIDE_FLAT_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_FLAT_COVERED_NW_SE, SPR_DINGHY_SLIDE_FLAT_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_FLAT_COVERED_SW_NE, SPR_DINGHY_SLIDE_FLAT_COVERED_FRONT_SW_NE },
@@ -1124,7 +1124,7 @@ static void dinghy_slide_track_flat_covered(paint_session * session, uint8 rideI
 static void dinghy_slide_track_25_deg_up_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr  const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_25_DEG_COVERED_SW_NE, SPR_DINGHY_SLIDE_25_DEG_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_25_DEG_COVERED_NW_SE, SPR_DINGHY_SLIDE_25_DEG_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_25_DEG_COVERED_NE_SW, SPR_DINGHY_SLIDE_25_DEG_COVERED_FRONT_NE_SW },
@@ -1159,7 +1159,7 @@ static void dinghy_slide_track_25_deg_up_covered(paint_session * session, uint8 
 static void dinghy_slide_track_60_deg_up_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_60_DEG_COVERED_SW_NE, SPR_DINGHY_SLIDE_60_DEG_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_60_DEG_COVERED_NW_SE, SPR_DINGHY_SLIDE_60_DEG_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_60_DEG_COVERED_NE_SW, SPR_DINGHY_SLIDE_60_DEG_COVERED_FRONT_NE_SW },
@@ -1194,7 +1194,7 @@ static void dinghy_slide_track_60_deg_up_covered(paint_session * session, uint8 
 static void dinghy_slide_track_flat_to_25_deg_up_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                          uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_SW_NE, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_NW_SE, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_NE_SW, SPR_DINGHY_SLIDE_FLAT_TO_25_DEG_COVERED_FRONT_NE_SW },
@@ -1229,7 +1229,7 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(paint_session * session
 static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                               uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_SW_NE, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_NW_SE, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_NE_SW, SPR_DINGHY_SLIDE_25_DEG_TO_60_DEG_COVERED_FRONT_NE_SW },
@@ -1264,7 +1264,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(paint_session * se
 static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                               uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr  const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_SW_NE, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_NW_SE, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_NE_SW, SPR_DINGHY_SLIDE_60_DEG_TO_25_DEG_COVERED_FRONT_NE_SW },
@@ -1299,7 +1299,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(paint_session * se
 static void dinghy_slide_track_25_deg_up_to_flat_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                          uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_SW_NE, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_FRONT_SW_NE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_NW_SE, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_FRONT_NW_SE },
         { SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_NE_SW, SPR_DINGHY_SLIDE_25_DEG_TO_FLAT_COVERED_FRONT_NE_SW },
@@ -1365,7 +1365,7 @@ static void dinghy_slide_track_25_deg_down_to_flat_covered(paint_session * sessi
 static void dinghy_slide_track_right_quarter_turn_5_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][5] = {
+    static constexpr const sprite_bb imageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 2 } },
@@ -1395,7 +1395,7 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(paint_session * sess
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SE_NE_PART_4, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         }
     };
-    static const sprite_bb frontImageIds[4][5] = {
+    static constexpr const sprite_bb frontImageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 30, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 27 }, { 32, 16, 0 } },
@@ -1497,7 +1497,7 @@ static void dinghy_slide_track_left_quarter_turn_5_covered(paint_session * sessi
 static void dinghy_slide_track_s_bend_left_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                    uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr  const uint32 imageIds[4][4][2] = {
         { { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_SE_SW_SEQ_3, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_NW_NE_SEQ_0 },
           { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_SE_SW_SEQ_2, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_NW_NE_SEQ_1 },
           { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_SE_SW_SEQ_1, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_NW_NE_SEQ_2 },
@@ -1587,7 +1587,7 @@ static void dinghy_slide_track_s_bend_left_covered(paint_session * session, uint
 static void dinghy_slide_track_s_bend_right_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_NW_SW_SEQ_3, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_SE_NE_SEQ_0 },
           { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_NW_SW_SEQ_2, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_SE_NE_SEQ_1 },
           { SPR_DINGHY_SLIDE_S_BEND_COVERED_SW_NW_SW_SEQ_1, SPR_DINGHY_SLIDE_S_BEND_COVERED_FRONT_NE_SE_NE_SEQ_2 },
@@ -1677,7 +1677,7 @@ static void dinghy_slide_track_s_bend_right_covered(paint_session * session, uin
 static void dinghy_slide_track_right_quarter_turn_3_covered(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const sprite_bb imageIds[4][3] = {
+    static constexpr const sprite_bb imageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 2 } },
@@ -1699,7 +1699,7 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(paint_session * sess
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SE_NE_PART_2, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         }
     };
-    static const sprite_bb frontImageIds[4][3] = {
+    static constexpr const sprite_bb frontImageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 20, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 27 }, { 16, 16, 0 } },

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -161,7 +161,7 @@ enum
     SPR_LOG_FLUME_3_TURN_NW_NE_NW_SEQ_0         = 21131,
 };
 
-static const uint32 LogFlumeTrackFlatImageIds[4][2] = {
+static constexpr const uint32 LogFlumeTrackFlatImageIds[4][2] = {
     { SPR_LOG_FLUME_FLAT_SW_NE, SPR_LOG_FLUME_FLAT_FRONT_SW_NE },
     { SPR_LOG_FLUME_FLAT_NW_SE, SPR_LOG_FLUME_FLAT_FRONT_NW_SE },
     { SPR_LOG_FLUME_FLAT_NE_SW, SPR_LOG_FLUME_FLAT_FRONT_NE_SW },
@@ -227,7 +227,7 @@ static void paint_log_flume_track_station(paint_session * session, uint8 rideInd
 static void paint_log_flume_track_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                             sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_25_DEG_UP_SW_NE, SPR_LOG_FLUME_25_DEG_UP_FRONT_SW_NE },
         { SPR_LOG_FLUME_25_DEG_UP_NW_SE, SPR_LOG_FLUME_25_DEG_UP_FRONT_NW_SE },
         { SPR_LOG_FLUME_25_DEG_UP_NE_SW, SPR_LOG_FLUME_25_DEG_UP_FRONT_NE_SW },
@@ -261,7 +261,7 @@ static void paint_log_flume_track_25_deg_up(paint_session * session, uint8 rideI
 static void paint_log_flume_track_flat_to_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_SW_NE, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_SW_NE },
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_NW_SE, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_NW_SE },
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_NE_SW, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_NE_SW },
@@ -295,7 +295,7 @@ static void paint_log_flume_track_flat_to_25_deg_up(paint_session * session, uin
 static void paint_log_flume_track_25_deg_up_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                     uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_SW_NE, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_SW_NE },
         { SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_NW_SE, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_NW_SE },
         { SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_NE_SW, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_NE_SW },
@@ -329,7 +329,7 @@ static void paint_log_flume_track_25_deg_up_to_flat(paint_session * session, uin
 static void paint_log_flume_track_25_deg_down(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr  const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_25_DEG_DOWN_SW_NE, SPR_LOG_FLUME_25_DEG_UP_FRONT_NE_SW },
         { SPR_LOG_FLUME_25_DEG_DOWN_NW_SE, SPR_LOG_FLUME_25_DEG_UP_FRONT_SE_NW },
         { SPR_LOG_FLUME_25_DEG_DOWN_NE_SW, SPR_LOG_FLUME_25_DEG_UP_FRONT_SW_NE },
@@ -363,7 +363,7 @@ static void paint_log_flume_track_25_deg_down(paint_session * session, uint8 rid
 static void paint_log_flume_track_flat_to_25_deg_down(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_DOWN_SW_NE, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_NE_SW },
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_DOWN_NW_SE, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_SE_NW },
         { SPR_LOG_FLUME_FLAT_TO_25_DEG_DOWN_NE_SW, SPR_LOG_FLUME_25_DEG_UP_TO_FLAT_FRONT_SW_NE },
@@ -397,7 +397,7 @@ static void paint_log_flume_track_flat_to_25_deg_down(paint_session * session, u
 static void paint_log_flume_track_25_deg_down_to_flat(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                       uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_25_DEG_DOWN_TO_FLAT_SW_NE, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_NE_SW },
         { SPR_LOG_FLUME_25_DEG_DOWN_TO_FLAT_NW_SE, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_SE_NW },
         { SPR_LOG_FLUME_25_DEG_DOWN_TO_FLAT_NE_SW, SPR_LOG_FLUME_FLAT_TO_25_DEG_UP_FRONT_SW_NE },
@@ -431,7 +431,7 @@ static void paint_log_flume_track_25_deg_down_to_flat(paint_session * session, u
 static void paint_log_flume_track_s_bend_left(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                               sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_LOG_FLUME_3_TURN_NE_NW_NE_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_NE_NW_NE_SEQ_0 },
           { SPR_LOG_FLUME_3_TURN_NE_NW_NE_SEQ_1, SPR_LOG_FLUME_3_TURN_FRONT_NE_NW_NE_SEQ_1 },
           { SPR_LOG_FLUME_3_TURN_NE_NW_NE_SEQ_2, SPR_LOG_FLUME_3_TURN_FRONT_NE_NW_NE_SEQ_2 },
@@ -521,7 +521,7 @@ static void paint_log_flume_track_s_bend_left(paint_session * session, uint8 rid
 static void paint_log_flume_track_s_bend_right(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_LOG_FLUME_3_TURN_NE_SE_NE_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_NE_SE_NE_SEQ_0 },
           { SPR_LOG_FLUME_3_TURN_NE_SE_NE_SEQ_1, SPR_LOG_FLUME_3_TURN_FRONT_NE_SE_NE_SEQ_1 },
           { SPR_LOG_FLUME_3_TURN_NE_SE_NE_SEQ_2, SPR_LOG_FLUME_3_TURN_FRONT_NE_SE_NE_SEQ_2 },
@@ -611,14 +611,14 @@ static void paint_log_flume_track_s_bend_right(paint_session * session, uint8 ri
 static void paint_log_flume_track_left_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                             uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr  const uint32 imageIds[4][3] = {
         { SPR_LOG_FLUME_3_TURN_NW_SW_SEQ_0, SPR_LOG_FLUME_3_TURN_NW_SW_SEQ_2, SPR_LOG_FLUME_3_TURN_NW_SW_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_NE_NW_SEQ_0, SPR_LOG_FLUME_3_TURN_NE_NW_SEQ_2, SPR_LOG_FLUME_3_TURN_NE_NW_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_SE_NE_SEQ_0, SPR_LOG_FLUME_3_TURN_SE_NE_SEQ_2, SPR_LOG_FLUME_3_TURN_SE_NE_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_SW_SE_SEQ_0, SPR_LOG_FLUME_3_TURN_SW_SE_SEQ_2, SPR_LOG_FLUME_3_TURN_SW_SE_SEQ_3 },
     };
 
-    static const uint32 imageIdsFront[4][3] = {
+    static constexpr  const uint32 imageIdsFront[4][3] = {
         { SPR_LOG_FLUME_3_TURN_FRONT_SW_SE_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_SW_SE_SEQ_2,
           SPR_LOG_FLUME_3_TURN_FRONT_SW_SE_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_FRONT_SE_SW_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_SE_SW_SEQ_2,
@@ -678,14 +678,14 @@ static void paint_log_flume_track_left_quarter_turn_3_tiles(paint_session * sess
 static void paint_log_flume_track_right_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                              uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][3] = {
+    static constexpr const uint32 imageIds[4][3] = {
         { SPR_LOG_FLUME_3_TURN_NW_NE_SEQ_0, SPR_LOG_FLUME_3_TURN_NW_NE_SEQ_2, SPR_LOG_FLUME_3_TURN_NW_NE_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_NE_SE_SEQ_0, SPR_LOG_FLUME_3_TURN_NE_SE_SEQ_2, SPR_LOG_FLUME_3_TURN_NE_SE_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_SE_SW_SEQ_0, SPR_LOG_FLUME_3_TURN_SE_SW_SEQ_2, SPR_LOG_FLUME_3_TURN_SE_SW_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_SW_NW_SEQ_0, SPR_LOG_FLUME_3_TURN_SW_NW_SEQ_2, SPR_LOG_FLUME_3_TURN_SW_NW_SEQ_3 }
     };
 
-    static const uint32 imageIdsFront[4][3] = {
+    static constexpr const uint32 imageIdsFront[4][3] = {
         { SPR_LOG_FLUME_3_TURN_FRONT_NW_NE_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_NW_NE_SEQ_2,
           SPR_LOG_FLUME_3_TURN_FRONT_NW_NE_SEQ_3 },
         { SPR_LOG_FLUME_3_TURN_FRONT_SW_SE_SEQ_0, SPR_LOG_FLUME_3_TURN_FRONT_SW_SE_SEQ_2,
@@ -775,7 +775,7 @@ static void paint_log_flume_track_on_ride_photo(paint_session * session, uint8 r
 static void paint_log_flume_track_reverser(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                            sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][2] = {
+    static constexpr const uint32 imageIds[4][2] = {
         { SPR_LOG_FLUME_REVERSER_SW_NE, SPR_LOG_FLUME_REVERSER_FRONT_SW_NE },
         { SPR_LOG_FLUME_REVERSER_NW_SE, SPR_LOG_FLUME_REVERSER_FRONT_NW_SE },
         { SPR_LOG_FLUME_REVERSER_NE_SW, SPR_LOG_FLUME_REVERSER_FRONT_NE_SW },

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -27,7 +27,7 @@
 
 #ifndef NO_VEHICLES
 // 0x0099279E:
-static const vehicle_boundbox _riverRapidsBoundbox[] = { { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
+static constexpr const vehicle_boundbox _riverRapidsBoundbox[] = { { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
                                                          { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
                                                          { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
                                                          { -13, -13, 1, 26, 26, 13 }, { -13, -13, 1, 26, 26, 13 },
@@ -137,41 +137,41 @@ enum
     SPR_RIVER_RAPIDS_RAPIDS_WHIRLPOOL_FRAME_0 = 21278,
 };
 
-static const uint32 river_rapids_track_pieces_25_deg_up[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_25_deg_up[][2] = {
     { SPR_RIVER_RAPIDS_25_DEG_UP_SW_NE, SPR_RIVER_RAPIDS_25_DEG_UP_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_25_DEG_UP_NW_SE, SPR_RIVER_RAPIDS_25_DEG_UP_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_25_DEG_UP_NE_SW, SPR_RIVER_RAPIDS_25_DEG_UP_FRONT_NE_SW },
     { SPR_RIVER_RAPIDS_25_DEG_UP_SE_NW, SPR_RIVER_RAPIDS_25_DEG_UP_FRONT_SE_NW },
 };
-static const uint32 river_rapids_track_pieces_flat_to_25_deg_up[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_flat_to_25_deg_up[][2] = {
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_SW_NE, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_NW_SE, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_NE_SW, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_FRONT_NE_SW },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_SE_NW, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_UP_FRONT_SE_NW },
 };
 
-static const uint32 river_rapids_track_pieces_25_deg_up_to_flat[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_25_deg_up_to_flat[][2] = {
     { SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_SW_NE, SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_NW_SE, SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_NE_SW, SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_FRONT_NE_SW },
     { SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_SE_NW, SPR_RIVER_RAPIDS_25_DEG_UP_TO_FLAT_FRONT_SE_NW },
 };
 
-static const uint32 river_rapids_track_pieces_25_deg_down[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_25_deg_down[][2] = {
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_SW_NE, SPR_RIVER_RAPIDS_25_DEG_DOWN_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_NW_SE, SPR_RIVER_RAPIDS_25_DEG_DOWN_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_NE_SW, SPR_RIVER_RAPIDS_25_DEG_DOWN_FRONT_NE_SW },
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_SE_NW, SPR_RIVER_RAPIDS_25_DEG_DOWN_FRONT_SE_NW },
 };
 
-static const uint32 river_rapids_track_pieces_flat_to_25_deg_down[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_flat_to_25_deg_down[][2] = {
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_SW_NE, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_NW_SE, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_NE_SW, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_FRONT_NE_SW },
     { SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_SE_NW, SPR_RIVER_RAPIDS_FLAT_TO_25_DEG_DOWN_FRONT_SE_NW },
 };
 
-static const uint32 river_rapids_track_pieces_25_deg_down_to_flat[][2] = {
+static constexpr const uint32 river_rapids_track_pieces_25_deg_down_to_flat[][2] = {
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_SW_NE, SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_FRONT_SW_NE },
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_NW_SE, SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_FRONT_NW_SE },
     { SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_NE_SW, SPR_RIVER_RAPIDS_25_DEG_DOWN_TO_FLAT_FRONT_NE_SW },

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -230,133 +230,133 @@ enum
     SPR_SPLASH_BOATS_S_BEND_TOP_NW_NE_NW_SEQ_0  = 20995,
 };
 
-static const uint32 SplashBoats25DegUpImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_SE_NW,
 };
 
-static const uint32 SplashBoats25DegUpFrontImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpFrontImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoats60DegUpImageId[4] = {
+static constexpr const uint32 SplashBoats60DegUpImageId[4] = {
     SPR_SPLASH_BOATS_60_DEG_UP_SW_NE,
     SPR_SPLASH_BOATS_60_DEG_UP_NW_SE,
     SPR_SPLASH_BOATS_60_DEG_UP_NE_SW,
     SPR_SPLASH_BOATS_60_DEG_UP_SE_NW,
 };
 
-static const uint32 SplashBoats60DegUpFrontImageId[4] = {
+static constexpr const uint32 SplashBoats60DegUpFrontImageId[4] = {
     SPR_SPLASH_BOATS_60_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_60_DEG_UP_FRONT_NW_SE,
     SPR_SPLASH_BOATS_60_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_60_DEG_UP_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoatsFlatTo25DegUpImageId[4] = {
+static constexpr const uint32 SplashBoatsFlatTo25DegUpImageId[4] = {
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_SW_NE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_NW_SE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_NE_SW,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 SplashBoatsFlatTo25DegUpFrontImageId[4] = {
+static constexpr const uint32 SplashBoatsFlatTo25DegUpFrontImageId[4] = {
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_NW_SE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoats25DegUpToFlatImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpToFlatImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_SE_NW,
 };
 
-static const uint32 SplashBoats25DegUpToFlatFrontImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpToFlatFrontImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoats25DegUpTo60DegUpImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpTo60DegUpImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_SE_NW,
 };
 
-static const uint32 SplashBoats25DegUpTo60DegUpFrontImageId[4] = {
+static constexpr const uint32 SplashBoats25DegUpTo60DegUpFrontImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_FRONT_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_60_DEG_UP_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoats60DegUpTo25DegUpImageId[4] = {
+static constexpr const uint32 SplashBoats60DegUpTo25DegUpImageId[4] = {
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_SW_NE,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_NW_SE,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_NE_SW,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_SE_NW,
 };
 
-static const uint32 SplashBoats60DegUpTo25DegUpFrontImageId[4] = {
+static constexpr const uint32 SplashBoats60DegUpTo25DegUpFrontImageId[4] = {
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_FRONT_NW_SE,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_60_DEG_UP_TO_25_DEG_UP_FRONT_SE_NW,
 };
 
-static const uint32 SplashBoats25DegDownImageId[4] = {
+static constexpr const uint32 SplashBoats25DegDownImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_DOWN_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_DOWN_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_DOWN_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_DOWN_SE_NW,
 };
 
-static const uint32 SplashBoats25DegDownFrontImageId[4] = {
+static constexpr const uint32 SplashBoats25DegDownFrontImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_SE_NW,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_FRONT_NW_SE,
 };
 
-static const uint32 SplashBoatsFlatTo25DegDownImageId[4] = {
+static constexpr const uint32 SplashBoatsFlatTo25DegDownImageId[4] = {
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_DOWN_SW_NE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_DOWN_NW_SE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_DOWN_NE_SW,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_DOWN_SE_NW,
 };
 
-static const uint32 SplashBoatsFlatTo25DegDownFrontImageId[4] = {
+static constexpr const uint32 SplashBoatsFlatTo25DegDownFrontImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_SE_NW,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_UP_TO_FLAT_FRONT_NW_SE,
 };
 
-static const uint32 SplashBoats25DegDownToFlatImageId[4] = {
+static constexpr const uint32 SplashBoats25DegDownToFlatImageId[4] = {
     SPR_SPLASH_BOATS_25_DEG_DOWN_TO_FLAT_SW_NE,
     SPR_SPLASH_BOATS_25_DEG_DOWN_TO_FLAT_NW_SE,
     SPR_SPLASH_BOATS_25_DEG_DOWN_TO_FLAT_NE_SW,
     SPR_SPLASH_BOATS_25_DEG_DOWN_TO_FLAT_SE_NW,
 };
 
-static const uint32 SplashBoats25DegDownToFlatFrontImageId[4] = {
+static constexpr const uint32 SplashBoats25DegDownToFlatFrontImageId[4] = {
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_NE_SW,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_SE_NW,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_SW_NE,
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_NW_SE,
 };
 
-static const sprite_bb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
+static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_LEFT_5_TOP_SW_NW_SEQ_0, { 0, 0, 0 }, { 0, 2, 0 },  { 32, 27, 2 },
         SPR_SPLASH_BOATS_TURN_LEFT_5_TOP_SW_NW_SEQ_2, { 0, 0, 0 }, { 0, 0, 0 },  { 32, 16, 2 },
@@ -387,7 +387,7 @@ static const sprite_bb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
     }
 };
 
-static const sprite_bb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
+static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_LEFT_5_SIDE_SW_NW_SEQ_0, { 0, 0, 0 }, { 0, 2, 27 },  { 32, 27, 0 },
         SPR_SPLASH_BOATS_TURN_LEFT_5_SIDE_SW_NW_SEQ_2, { 0, 0, 0 }, { 0, 0, 27 },  { 32, 16, 0 },
@@ -418,7 +418,7 @@ static const sprite_bb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
     }
 };
 
-static const sprite_bb RiverRaftsRightQuarterTurn5_Top[4][5] = {
+static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Top[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_RIGHT_5_TOP_SW_SE_SEQ_0, { 0, 0, 0 }, { 0, 2, 0 },  { 32, 32, 2 },
         SPR_SPLASH_BOATS_TURN_RIGHT_5_TOP_SW_SE_SEQ_2, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 2 },
@@ -449,7 +449,7 @@ static const sprite_bb RiverRaftsRightQuarterTurn5_Top[4][5] = {
     }
 };
 
-static const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
+static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_RIGHT_5_SIDE_SW_SE_SEQ_0, { 0, 0, 0 }, { 0, 2, 27 },  { 32, 32, 0 },
         SPR_SPLASH_BOATS_TURN_RIGHT_5_SIDE_SW_SE_SEQ_2, { 0, 0, 0 }, { 0, 16, 27 }, { 32, 16, 0 },
@@ -633,7 +633,7 @@ static void paint_splash_boats_track_25_deg_down(paint_session * session, uint8 
     sub_98197C_rotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(session, direction, frontImageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    static const uint8 specialSupport[] = { 11, 12, 9, 10 };
+    static constexpr const uint8 specialSupport[] = { 11, 12, 9, 10 };
     wooden_a_supports_paint_setup(session, (direction & 1), specialSupport[direction], height,
                                   session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
@@ -664,7 +664,7 @@ static void paint_splash_boats_track_flat_to_25_deg_down(paint_session * session
     sub_98197C_rotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(session, direction, frontImageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    static const uint8 specialSupport[] = { 7, 8, 5, 6 };
+    static constexpr const uint8 specialSupport[] = { 7, 8, 5, 6 };
     wooden_a_supports_paint_setup(session, (direction & 1), specialSupport[direction], height,
                                   session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
@@ -701,7 +701,7 @@ static void paint_splash_boats_track_25_deg_down_to_flat(paint_session * session
     sub_98197C_rotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     sub_98197C_rotated(session, direction, frontImageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    static const uint8 specialSupport[] = { 3, 4, 1, 2 };
+    static constexpr const uint8 specialSupport[] = { 3, 4, 1, 2 };
     wooden_a_supports_paint_setup(session, (direction & 1), specialSupport[direction], height,
                                   session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
@@ -816,7 +816,7 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(paint_session * s
 
     if (trackSequence != 1 && trackSequence != 4)
     {
-        static const uint8 supportTypes[][7] = {
+        static constexpr const uint8 supportTypes[][7] = {
             { 0, 0xFF, 5, 3, 0xFF, 5, 1 },
             { 1, 0xFF, 2, 4, 0xFF, 2, 0 },
             { 0, 0xFF, 3, 5, 0xFF, 3, 1 },
@@ -893,7 +893,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(paint_session * 
 
     if (trackSequence != 1 && trackSequence != 4)
     {
-        static const uint8 supportTypes[][7] = {
+        static constexpr const uint8 supportTypes[][7] = {
             { 0, 0xFF, 4, 2, 0xFF, 4, 1 },
             { 1, 0xFF, 5, 3, 0xFF, 5, 0 },
             { 0, 0xFF, 2, 4, 0xFF, 2, 1 },
@@ -963,7 +963,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(paint_session * 
 static void paint_splash_boats_track_s_bend_left(paint_session * session, uint8 rideIndex, uint8 trackSequence, uint8 direction,
                                                  sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_SPLASH_BOATS_S_BEND_TOP_NE_NW_NE_SEQ_0, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_NW_NE_SEQ_0 },
           { SPR_SPLASH_BOATS_S_BEND_TOP_NE_NW_NE_SEQ_1, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_NW_NE_SEQ_1 },
           { SPR_SPLASH_BOATS_S_BEND_TOP_NE_NW_NE_SEQ_2, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_NW_NE_SEQ_2 },
@@ -985,8 +985,8 @@ static void paint_splash_boats_track_s_bend_left(paint_session * session, uint8 
     uint32 imageId      = imageIds[direction][trackSequence][0] | session->TrackColours[SCHEME_TRACK];
     uint32 frontImageId = imageIds[direction][trackSequence][1] | session->TrackColours[SCHEME_TRACK];
     sint16 bboy;
-    static const sint32 supportTypes1[] = { 5, 2, 3, 4 };
-    static const sint32 supportTypes2[] = { 3, 4, 5, 2 };
+    static constexpr const sint32 supportTypes1[] = { 5, 2, 3, 4 };
+    static constexpr const sint32 supportTypes2[] = { 3, 4, 5, 2 };
 
     switch (trackSequence)
     {
@@ -1052,7 +1052,7 @@ static void paint_splash_boats_track_s_bend_left(paint_session * session, uint8 
 static void paint_splash_boats_track_s_bend_right(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                   uint8 direction, sint32 height, rct_tile_element * tileElement)
 {
-    static const uint32 imageIds[4][4][2] = {
+    static constexpr const uint32 imageIds[4][4][2] = {
         { { SPR_SPLASH_BOATS_S_BEND_TOP_NE_SE_NE_SEQ_0, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_SE_NE_SEQ_0 },
           { SPR_SPLASH_BOATS_S_BEND_TOP_NE_SE_NE_SEQ_1, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_SE_NE_SEQ_1 },
           { SPR_SPLASH_BOATS_S_BEND_TOP_NE_SE_NE_SEQ_2, SPR_SPLASH_BOATS_S_BEND_SIDE_NE_SE_NE_SEQ_2 },
@@ -1074,8 +1074,8 @@ static void paint_splash_boats_track_s_bend_right(paint_session * session, uint8
     uint32 imageId      = imageIds[direction][trackSequence][0] | session->TrackColours[SCHEME_TRACK];
     uint32 frontImageId = imageIds[direction][trackSequence][1] | session->TrackColours[SCHEME_TRACK];
     sint16 bboy;
-    static const sint32 supportTypes1[] = { 4, 5, 2, 3 };
-    static const sint32 supportTypes2[] = { 2, 3, 4, 5 };
+    static constexpr const sint32 supportTypes1[] = { 4, 5, 2, 3 };
+    static constexpr const sint32 supportTypes2[] = { 2, 3, 4, 5 };
 
 
     switch (trackSequence)

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -173,7 +173,7 @@ static void submarine_ride_paint_track_left_quarter_turn_3_tiles(paint_session *
     paint_util_set_general_support_height(session, height + 16, 0x20);
 }
 
-static const uint8 submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
 static void submarine_ride_paint_track_right_quarter_turn_3_tiles(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                                   uint8 direction, sint32 height, rct_tile_element * tileElement)
 {

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -185,7 +185,7 @@ static void water_rc_track_right_quarter_turn_5_tiles_25_deg_up(paint_session * 
                                                                JUNIOR_RC_CHAIN_NONE);
 }
 
-static const uint8 water_rc_left_quarter_turn_5_tiles_to_right_turn_map[] = { 6, 4, 5, 3, 1, 2, 0 };
+static constexpr const uint8 water_rc_left_quarter_turn_5_tiles_to_right_turn_map[] = { 6, 4, 5, 3, 1, 2, 0 };
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                                  uint8 direction, sint32 height, rct_tile_element * tileElement)
@@ -219,7 +219,7 @@ static void water_rc_track_right_quarter_turn_3_tiles_25_deg_down(paint_session 
                                                                  tileElement, JUNIOR_RC_CHAIN_NONE);
 }
 
-static const uint8 water_rc_left_quarter_turn_3_tiles_to_right_turn_map[] = { 3, 1, 2, 0 };
+static constexpr const uint8 water_rc_left_quarter_turn_3_tiles_to_right_turn_map[] = { 3, 1, 2, 0 };
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(paint_session * session, uint8 rideIndex, uint8 trackSequence,
                                                                uint8 direction, sint32 height, rct_tile_element * tileElement)

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -39,7 +39,7 @@ namespace ScenarioSources
     #pragma region Scenario Data
 
     // clang-format off
-    static const ScenarioAlias ScenarioAliases[] =
+    static constexpr const ScenarioAlias ScenarioAliases[] =
     {
         // UK - US differences:
         { "Katie's Dreamland",                      "Katie's World"                             },
@@ -56,7 +56,7 @@ namespace ScenarioSources
     };
 
     // RCT
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT1[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT1[] =
     {
         { SC_FOREST_FRONTIERS,          "Forest Frontiers",     SCENARIO_CATEGORY_BEGINNER      },
         { SC_DYNAMITE_DUNES,            "Dynamite Dunes",       SCENARIO_CATEGORY_BEGINNER      },
@@ -83,7 +83,7 @@ namespace ScenarioSources
     };
 
     // RCT: Added Attractions
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT1AA[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT1AA[] =
     {
         { SC_WHISPERING_CLIFFS,         "Whispering Cliffs",    SCENARIO_CATEGORY_BEGINNER      },
         { SC_THREE_MONKEYS_PARK,        "Three Monkeys Park",   SCENARIO_CATEGORY_BEGINNER      },
@@ -118,7 +118,7 @@ namespace ScenarioSources
     };
 
     // RCT: Loopy Landscapes
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT1LL[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT1LL[] =
     {
         {   SC_ICEBERG_ISLANDS,         "Iceberg Islands",      SCENARIO_CATEGORY_BEGINNER      },
         {   SC_VOLCANIA,                "Volcania",             SCENARIO_CATEGORY_BEGINNER      },
@@ -153,7 +153,7 @@ namespace ScenarioSources
     };
 
     // RCT2
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT2[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT2[] =
     {
         { SC_UNIDENTIFIED,              "Crazy Castle",         SCENARIO_CATEGORY_BEGINNER      },
         { SC_UNIDENTIFIED,              "Electric Fields",      SCENARIO_CATEGORY_BEGINNER      },
@@ -173,7 +173,7 @@ namespace ScenarioSources
     };
 
     // RCT2: Wacky Worlds
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT2WW[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT2WW[] =
     {
         { SC_UNIDENTIFIED,              "Africa - Victoria Falls",                          SCENARIO_CATEGORY_BEGINNER      },
         { SC_UNIDENTIFIED,              "Asia - Great Wall of China Tourism Enhancement",   SCENARIO_CATEGORY_BEGINNER      },
@@ -195,7 +195,7 @@ namespace ScenarioSources
     };
 
     // RCT2: Time Twister
-    static const ScenarioTitleDescriptor ScenarioTitlesRCT2TT[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRCT2TT[] =
     {
         { SC_UNIDENTIFIED,              "Dark Age - Robin Hood",                            SCENARIO_CATEGORY_BEGINNER      },
         { SC_UNIDENTIFIED,              "Prehistoric - After the Asteroid",                 SCENARIO_CATEGORY_BEGINNER      },
@@ -214,7 +214,7 @@ namespace ScenarioSources
     };
 
     // Real parks
-    static const ScenarioTitleDescriptor ScenarioTitlesRealParks[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesRealParks[] =
     {
         { SC_ALTON_TOWERS,              "Alton Towers",                                     SCENARIO_CATEGORY_REAL  },
         { SC_HEIDE_PARK,                "Heide-Park",                                       SCENARIO_CATEGORY_REAL  },
@@ -227,7 +227,7 @@ namespace ScenarioSources
     };
 
     // Other parks
-    static const ScenarioTitleDescriptor ScenarioTitlesOtherParks[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesOtherParks[] =
     {
         { SC_FORT_ANACHRONISM,          "Fort Anachronism",                                 SCENARIO_CATEGORY_DLC               },
         { SC_PCPLAYER,                  "PC Player",                                        SCENARIO_CATEGORY_DLC               },

--- a/src/openrct2/title/TitleSequenceManager.h
+++ b/src/openrct2/title/TitleSequenceManager.h
@@ -41,7 +41,7 @@ namespace TitleSequenceManager
     void Scan();
 }
 
-constexpr size_t PREDEFINED_INDEX_CUSTOM = SIZE_MAX;
+constexpr const size_t PREDEFINED_INDEX_CUSTOM = SIZE_MAX;
 
 extern "C" {
 #endif

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -248,7 +248,7 @@ static sint32 bitcount_popcnt(uint32 source)
 static sint32 bitcount_lut(uint32 source)
 {
     // https://graphics.stanford.edu/~seander/bithacks.html
-    static const uint8 BitsSetTable256[256] =
+    static constexpr const uint8 BitsSetTable256[256] =
     {
     #define B2(n) n,     n+1,     n+1,     n+2
     #define B4(n) B2(n), B2(n+1), B2(n+1), B2(n+2)

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -492,7 +492,7 @@ extern "C"
         sint32 i, rideIndex;
         Ride *ride;
 
-        static const LocationXY16 NeighbourCheckOrder[] =
+        static constexpr const LocationXY16 NeighbourCheckOrder[] =
         {
             {  32,   0 },
             { -32,   0 },

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -396,7 +396,7 @@ const WeatherState ClimateWeatherData[6] =
     {  2, 2, 2, 2, SPR_WEATHER_STORM        }, // Thunderstorm
 };
 
-static const WeatherTransition ClimateTransitionsCoolAndWet[] =
+static constexpr const WeatherTransition ClimateTransitionsCoolAndWet[] =
 {
     {  8, 18, { 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 0, 0, 0, 0, 0 } },
     { 10, 21, { 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 0, 0 } },
@@ -407,7 +407,7 @@ static const WeatherTransition ClimateTransitionsCoolAndWet[] =
     { 16, 19, { 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 4, 4, 5, 0, 0, 0, 0 } },
     { 13, 16, { 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0 } },
 };
-static const WeatherTransition ClimateTransitionsWarm[] = {
+static constexpr const WeatherTransition ClimateTransitionsWarm[] = {
     { 12, 21, { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 4, 0, 0 } },
     { 13, 22, { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 5, 0 } },
     { 16, 17, { 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0 } },
@@ -417,7 +417,7 @@ static const WeatherTransition ClimateTransitionsWarm[] = {
     { 19, 17, { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0 } },
     { 16, 17, { 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 4, 0, 0, 0, 0, 0, 0 } },
 };
-static const WeatherTransition ClimateTransitionsHotAndDry[] = {
+static constexpr const WeatherTransition ClimateTransitionsHotAndDry[] = {
     { 12, 15, { 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0 } },
     { 14, 12, { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
     { 16, 11, { 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
@@ -427,7 +427,7 @@ static const WeatherTransition ClimateTransitionsHotAndDry[] = {
     { 21, 12, { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
     { 16, 13, { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
 };
-static const WeatherTransition ClimateTransitionsCold[] = {
+static constexpr const WeatherTransition ClimateTransitionsCold[] = {
     {  4, 18, { 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 4, 0, 0, 0, 0, 0 } },
     {  5, 21, { 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4, 5, 0, 0 } },
     {  7, 17, { 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 4, 0, 0, 0, 0, 0, 0 } },

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -32,9 +32,9 @@ enum DUCK_STATE
     DOUBLE_DRINK,
     FLY_AWAY,
 };
-constexpr sint32 DUCK_MAX_STATES = 5;
+constexpr const sint32 DUCK_MAX_STATES = 5;
 
-static const LocationXY16 DuckMoveOffset[] =
+static constexpr const LocationXY16 DuckMoveOffset[] =
 {
     { -1,  0 },
     {  0,  1 },
@@ -42,33 +42,33 @@ static const LocationXY16 DuckMoveOffset[] =
     {  0, -1 },
 };
 
-static const uint8 DuckAnimationFlyToWater[] =
+static constexpr const uint8 DuckAnimationFlyToWater[] =
 {
     8, 9, 10, 11, 12, 13
 };
 
-static const uint8 DuckAnimationSwim[] =
+static constexpr const uint8 DuckAnimationSwim[] =
 {
     0
 };
 
-static const uint8 DuckAnimationDrink[] =
+static constexpr const uint8 DuckAnimationDrink[] =
 {
     1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0xFF
 };
 
-static const uint8 DuckAnimationDoubleDrink[] =
+static constexpr const uint8 DuckAnimationDoubleDrink[] =
 {
     4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6,
     6, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 0, 0, 0, 0, 0xFF
 };
 
-static const uint8 DuckAnimationFlyAway[] =
+static constexpr const uint8 DuckAnimationFlyAway[] =
 {
     8, 9, 10, 11, 12, 13
 };
 
-static const uint8 * DuckAnimations[] =
+static constexpr const uint8 * DuckAnimations[] =
 {
     DuckAnimationFlyToWater,    // FLY_TO_WATER
     DuckAnimationSwim,          // SWIM

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -45,7 +45,7 @@ namespace FOUNTAIN_FLAG
     const uint32 DIRECTION    = 1 << 7;
 };
 
-static const LocationXY16 _fountainDirectionsNegative[] =
+static constexpr const LocationXY16 _fountainDirectionsNegative[] =
 {
     { -32,   0 },
     { -32, -32 },
@@ -57,7 +57,7 @@ static const LocationXY16 _fountainDirectionsNegative[] =
     { -32, -32 },
 };
 
-static const LocationXY16 _fountainDirectionsPositive[] =
+static constexpr const LocationXY16 _fountainDirectionsPositive[] =
 {
     { 32,  0 },
     {  0,  0 },

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -51,7 +51,7 @@ static struct
 
 #pragma region Random objects
 
-static const char * GrassTrees[] = {
+static constexpr const char * GrassTrees[] = {
     // Dark
     "TCF     ",     // Caucasian Fir Tree
     "TRF     ",     // Red Fir Tree
@@ -67,7 +67,7 @@ static const char * GrassTrees[] = {
     "TEL     ",     // European Larch Tree
 };
 
-static const char * DesertTrees[] = {
+static constexpr const char * DesertTrees[] = {
     "TMP     ",     // Monkey-Puzzle Tree
     "THL     ",     // Honey Locust Tree
     "TH1     ",     // Canary Palm Tree
@@ -78,7 +78,7 @@ static const char * DesertTrees[] = {
     "TSC     ",     // Cactus
 };
 
-static const char * SnowTrees[] = {
+static constexpr const char * SnowTrees[] = {
     "TCFS    ",     // Snow-covered Caucasian Fir Tree
     "TNSS    ",     // Snow-covered Norway Spruce Tree
     "TRF3    ",     // Snow-covered Red Fir Tree
@@ -88,7 +88,7 @@ static const char * SnowTrees[] = {
 #pragma endregion
 
 // Randomly chosen base terrains. We rarely want a whole map made out of chequerboard or rock.
-static const uint8 BaseTerrain[] = {TERRAIN_GRASS, TERRAIN_SAND, TERRAIN_SAND_LIGHT, TERRAIN_DIRT, TERRAIN_ICE};
+static constexpr const uint8 BaseTerrain[] = {TERRAIN_GRASS, TERRAIN_SAND, TERRAIN_SAND_LIGHT, TERRAIN_DIRT, TERRAIN_ICE};
 
 #define BLOB_HEIGHT 255
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -20,7 +20,7 @@
 #include "../OpenRCT2.h"
 #include "sprite.h"
 
-static const LocationXY16 _moneyEffectMoveOffset[] = {
+static constexpr const LocationXY16 _moneyEffectMoveOffset[] = {
     {1,  -1},
     {1,  1},
     {-1, 1},

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -262,7 +262,7 @@ enum EDGE_SLOPE
 };
 
 /** rct2: 0x009A3FEC */
-static const uint8 EdgeSlopes[][4] = {
+static constexpr const uint8 EdgeSlopes[][4] = {
 //  Top right                        Bottom right                   Bottom left                       Top left
     { 0,                             0,                             0,                             0                             },
     { 0,                             EDGE_SLOPE_UPWARDS,            EDGE_SLOPE_DOWNWARDS,          0                             },


### PR DESCRIPTION
This eliminates a bunch of dynamic initializer routines from MSVC.