### PR TITLE
Fix for backwards moving swinging rides

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -100,7 +100,7 @@
 - Fix: [#6846] Zoom level in some ride overview windows was erroneously set too high.
 - Fix: [#6904] Manually added multiplayer servers not saved.
 - Fix: [#7003] Building sloped paths through flat paths with clearance checks off causes glitches.
-- Fix: [#7011]: Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
+- Fix: [#7011] Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -100,6 +100,7 @@
 - Fix: [#6846] Zoom level in some ride overview windows was erroneously set too high.
 - Fix: [#6904] Manually added multiplayer servers not saved.
 - Fix: [#7003] Building sloped paths through flat paths with clearance checks off causes glitches.
+- Fix: [#7011]: Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6933,7 +6933,7 @@ static sint32 vehicle_get_swing_amount(rct_vehicle * vehicle)
  */
 static void vehicle_update_swinging_car(rct_vehicle * vehicle)
 {
-    sint32 dword_F64E08 = _vehicleVelocityF64E08;
+    sint32 dword_F64E08 = abs(_vehicleVelocityF64E08);
     vehicle->var_4E += (-vehicle->swinging_car_var_0) >> 6;
     sint32 swingAmount = vehicle_get_swing_amount(vehicle);
     if (swingAmount < 0)


### PR DESCRIPTION
This fix will make swinging rides like the suspended swinging coaster and the bobsleigh coaster bank to the outside of corners when moving backwards (For example during a rollback). This was an original bug in RCT2.

Fix for #7011 