### PR TITLE
Fix capitalisation of 'Object selection'

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3707,7 +3707,7 @@ STR_5367    :Fast
 STR_5368    :Reset crash status
 STR_5369    :Park parameters...
 STR_5370    :{SMALLFONT}{BLACK}Click this button to modify park{NEWLINE}parameters like restrictions,{NEWLINE}guest generation and money.
-STR_5371    :Object Selection
+STR_5371    :Object selection
 STR_5372    :Invert right mouse dragging
 STR_5373    :Name {STRINGID}
 STR_5374    :Date {STRINGID}


### PR DESCRIPTION
Currently 'Object Selection' is title-cased, whereas all other options in the Debug drop-down only have an initial capital letter - this fixes that.

Before:
![openrct2_2018-01-14_01-47-59](https://user-images.githubusercontent.com/16639257/34911995-3503ddc6-f8cd-11e7-904c-ba1ecc50377e.png)

After:
![openrct2_2018-01-14_01-48-47](https://user-images.githubusercontent.com/16639257/34911997-38e82f5a-f8cd-11e7-8a5d-9bf58de0ff0f.png)
