### PR TITLE
Fix #6314: SV4s do not mark corresponding scenario as completed

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -126,6 +126,9 @@ private:
     uint8 _researchRideEntryUsed[MAX_RIDE_OBJECTS];
     uint8 _researchRideTypeUsed[RCT1_RIDE_TYPE_COUNT];
 
+    // Scenario repository - used for determining scenario name
+    IScenarioRepository * _scenarioRepository = GetScenarioRepository();
+
 public:
     ParkLoadResult Load(const utf8 * path) override
     {
@@ -325,7 +328,7 @@ private:
         InitialiseEntryMaps();
         uint16 mapSize = _s4.map_size == 0 ? 128 : _s4.map_size;
 
-        String::Set(gScenarioFileName, sizeof(gScenarioFileName), Path::GetFileName(_s4Path));
+        String::Set(gScenarioFileName, sizeof(gScenarioFileName), GetRCT1ScenarioName().c_str());
 
         // Do map initialisation, same kind of stuff done when loading scenario editor
         GetObjectManager()->UnloadAll();
@@ -333,6 +336,12 @@ private:
         gS6Info.editor_step = EDITOR_STEP_OBJECT_SELECTION;
         gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gS6Info.category = SCENARIO_CATEGORY_OTHER;
+    }
+
+    std::string GetRCT1ScenarioName()
+    {
+        const scenario_index_entry * scenarioEntry = _scenarioRepository->GetByIndex(_s4.scenario_slot_index);
+        return path_get_filename(scenarioEntry->path);
     }
 
     void InitialiseEntryMaps()


### PR DESCRIPTION
This PR correctly sets `gScenarioFileName` when loading SV4s - previously we just took the filename, which wouldn't correspond to the RCT1 scenario in the scenario index.

I'm aware that this could have edge-case oddities, like RCT1 workbenches marking whatever scenario they were derived from as complete should you complete the objective, but this is a very unlikely case given that there are plenty of SV6 workbenches out there.