### PR TITLE
Better support for displaced entrances and exits

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4526,6 +4526,8 @@ STR_6216    :Operation
 STR_6217    :Ride / track availability
 STR_6218    :OpenRCT2 Official
 STR_6219    :Highlight path issues
+STR_6220    :Make Usable
+STR_6221    :{SMALLFONT}{BLACK}This will set the ride's known entrance or exit location to the currently selected tile. Only one entrance and exit location can be made usable per stations.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Feature: [#6731] Object indexing progress is now reported via command line output.
 - Feature: [#6779] On-ride photo segment for Splash Boats.
 - Feature: [#6838] Ability to auto-pause server when no clients are connected.
+- Feature: [#7031] Better support for displaced ride entrances and exits.
 - Feature: Add search box to track design window.
 - Feature: Allow using object files from RCT Classic.
 - Feature: Title sequences now testable in-game.

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -171,6 +171,7 @@ enum WINDOW_TILE_INSPECTOR_WIDGET_IDX {
     WIDX_ENTRANCE_SPINNER_HEIGHT = PAGE_WIDGETS,
     WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE,
     WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE,
+    WIDX_ENTRANCE_BUTTON_MAKE_USABLE,
 
     // Wall
     WIDX_WALL_SPINNER_HEIGHT = PAGE_WIDGETS,
@@ -360,7 +361,7 @@ static rct_widget SceneryWidgets[] = {
 };
 
 #define ENT_GBPB PADDING_BOTTOM                 // Entrance group box properties bottom
-#define ENT_GBPT (ENT_GBPB + 16 + 1 * 21)       // Entrance group box properties top
+#define ENT_GBPT (ENT_GBPB + 16 + 2 * 21)       // Entrance group box properties top
 #define ENT_GBDB (ENT_GBPT + GROUPBOX_PADDING)  // Entrance group box info bottom
 #define ENT_GBDT (ENT_GBDB + 20 + 3 * 11)       // Entrance group box info top
 static rct_widget EntranceWidgets[] = {
@@ -368,6 +369,7 @@ static rct_widget EntranceWidgets[] = {
     { WWT_SPINNER,          1,  GBS(WH - ENT_GBPT, 1, 0),   STR_NONE,                                       STR_NONE }, // WIDX_ENTRANCE_SPINNER_HEIGHT
     { WWT_BUTTON,           1,  GBSI(WH - ENT_GBPT, 1, 0),  STR_NUMERIC_UP,                                 STR_NONE }, // WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE
     { WWT_BUTTON,           1,  GBSD(WH - ENT_GBPT, 1, 0),  STR_NUMERIC_DOWN,                               STR_NONE }, // WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE
+    { WWT_BUTTON,           1,  GBB(WH - ENT_GBPT, 0, 1),   STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE,        STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE_TIP }, // WIDX_ENTRANCE_BUTTON_MAKE_USABLE
     { WIDGETS_END },
 };
 
@@ -521,7 +523,7 @@ static uint64 PageEnabledWidgets[] = {
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_PATH_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_PATH_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_PATH_CHECK_SLOPED) | (1ULL << WIDX_PATH_CHECK_EDGE_N) | (1ULL << WIDX_PATH_CHECK_EDGE_NE) | (1ULL << WIDX_PATH_CHECK_EDGE_E) | (1ULL << WIDX_PATH_CHECK_EDGE_SE) | (1ULL << WIDX_PATH_CHECK_EDGE_S) | (1ULL << WIDX_PATH_CHECK_EDGE_SW) | (1ULL << WIDX_PATH_CHECK_EDGE_W) | (1ULL << WIDX_PATH_CHECK_EDGE_NW),
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_TRACK_CHECK_APPLY_TO_ALL) | (1ULL << WIDX_TRACK_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_TRACK_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_TRACK_CHECK_CHAIN_LIFT),
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_SCENERY_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_SCENERY_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_SCENERY_CHECK_QUARTER_N) | (1ULL << WIDX_SCENERY_CHECK_QUARTER_E) | (1ULL << WIDX_SCENERY_CHECK_QUARTER_S) | (1ULL << WIDX_SCENERY_CHECK_QUARTER_W) | (1ULL << WIDX_SCENERY_CHECK_COLLISION_N) | (1ULL << WIDX_SCENERY_CHECK_COLLISION_E) | (1ULL << WIDX_SCENERY_CHECK_COLLISION_S) | (1ULL << WIDX_SCENERY_CHECK_COLLISION_W),
-    (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE),
+    (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_ENTRANCE_BUTTON_MAKE_USABLE),
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_WALL_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_WALL_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_WALL_DROPDOWN_SLOPE) | (1ULL << WIDX_WALL_DROPDOWN_SLOPE_BUTTON),
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_LARGE_SCENERY_SPINNER_HEIGHT) | (1ULL << WIDX_LARGE_SCENERY_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_LARGE_SCENERY_SPINNER_HEIGHT_DECREASE),
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT) | (1ULL << WIDX_BUTTON_REMOVE) | (1ULL << WIDX_BUTTON_ROTATE) | (1ULL << WIDX_BUTTON_COPY) | (1ULL << WIDX_BANNER_SPINNER_HEIGHT) | (1ULL << WIDX_BANNER_SPINNER_HEIGHT_INCREASE) | (1ULL << WIDX_BANNER_SPINNER_HEIGHT_DECREASE) | (1ULL << WIDX_BANNER_CHECK_BLOCK_NE) | (1ULL << WIDX_BANNER_CHECK_BLOCK_SE) | (1ULL << WIDX_BANNER_CHECK_BLOCK_SW) | (1ULL << WIDX_BANNER_CHECK_BLOCK_NW),
@@ -810,6 +812,20 @@ static void window_tile_inspector_path_toggle_edge(sint32 elementIndex, sint32 c
         elementIndex,
         GAME_COMMAND_MODIFY_TILE,
         cornerIndex,
+        0
+    );
+}
+
+static void window_tile_inspector_entrance_make_usable(sint32 elementIndex)
+{
+    Guard::ArgumentInRange(elementIndex, 0, windowTileInspectorElementCount - 1);
+    game_do_command(
+        TILE_INSPECTOR_ENTRANCE_MAKE_USABLE,
+        GAME_COMMAND_FLAG_APPLY,
+        windowTileInspectorTileX | (windowTileInspectorTileY << 8),
+        elementIndex,
+        GAME_COMMAND_MODIFY_TILE,
+        0,
         0
     );
 }
@@ -1110,6 +1126,9 @@ static void window_tile_inspector_mouseup(rct_window *w, rct_widgetindex widgetI
             break;
         case WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE:
             window_tile_inspector_base_height_offset(w->selected_list_item, -1);
+            break;
+        case WIDX_ENTRANCE_BUTTON_MAKE_USABLE:
+            window_tile_inspector_entrance_make_usable(w->selected_list_item);
             break;
         } // switch widget index
         break;
@@ -1558,6 +1577,9 @@ static void window_tile_inspector_invalidate(rct_window *w)
         w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE].bottom = GBBT(propertiesAnchor, 0) + 8;
         w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE].top = GBBB(propertiesAnchor, 0) - 8;
         w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT_DECREASE].bottom = GBBB(propertiesAnchor, 0) - 4;
+        w->widgets[WIDX_ENTRANCE_BUTTON_MAKE_USABLE].top = GBBT(propertiesAnchor, 1);
+        w->widgets[WIDX_ENTRANCE_BUTTON_MAKE_USABLE].bottom = GBBB(propertiesAnchor, 1);
+        widget_set_enabled(w, WIDX_ENTRANCE_BUTTON_MAKE_USABLE, tileElement->properties.entrance.type != ENTRANCE_TYPE_PARK_ENTRANCE);
         break;
     case TILE_INSPECTOR_PAGE_WALL:
         w->widgets[WIDX_WALL_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3878,6 +3878,9 @@ enum {
 
     STR_HIGHLIGHT_PATH_ISSUES_MENU = 6219,
 
+    STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE = 6220,
+    STR_TILE_INSPECTOR_ENTRANCE_MAKE_USABLE_TIP = 6220,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1598,27 +1598,29 @@ void footpath_queue_chain_push(uint8 rideIndex)
  */
 void footpath_update_queue_chains()
 {
-    for (uint8 *queueChainPtr = _footpathQueueChain; queueChainPtr < _footpathQueueChainNext; queueChainPtr++) {
-        uint8 rideIndex = *queueChainPtr;
-        Ride *ride = get_ride(rideIndex);
-        if (ride->type == RIDE_TYPE_NULL) {
+    for (uint8 * queueChainPtr = _footpathQueueChain; queueChainPtr < _footpathQueueChainNext; queueChainPtr++)
+    {
+        uint8  rideIndex = *queueChainPtr;
+        Ride * ride      = get_ride(rideIndex);
+        if (ride->type == RIDE_TYPE_NULL)
             continue;
-        }
 
-        for (sint32 i = 0; i < MAX_STATIONS; i++) {
-            if (ride->entrances[i].xy == RCT_XY8_UNDEFINED) {
+        for (sint32 i = 0; i < MAX_STATIONS; i++)
+        {
+            if (ride->entrances[i].xy == RCT_XY8_UNDEFINED)
                 continue;
-            }
 
-            uint8 x = ride->entrances[i].x;
-            uint8 y = ride->entrances[i].y;
-            uint8 z = ride->station_heights[i];
-
-            rct_tile_element *tileElement = map_get_first_element_at(x, y);
-            do {
-                if (tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_ENTRANCE) continue;
-                if (tileElement->base_height != z) continue;
-                if (tileElement->properties.entrance.type != ENTRANCE_TYPE_RIDE_ENTRANCE) continue;
+            uint8              x           = ride->entrances[i].x;
+            uint8              y           = ride->entrances[i].y;
+            rct_tile_element * tileElement = map_get_first_element_at(x, y);
+            do
+            {
+                if (tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_ENTRANCE)
+                    continue;
+                if (tileElement->properties.entrance.type != ENTRANCE_TYPE_RIDE_ENTRANCE)
+                    continue;
+                if (tileElement->properties.entrance.ride_index != rideIndex)
+                    continue;
 
                 uint8 direction = tile_element_get_direction_with_offset(tileElement, 2);
                 footpath_chain_ride_queue(rideIndex, i, x << 5, y << 5, tileElement, direction);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -4444,6 +4444,12 @@ void game_command_modify_tile(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx
         *ebx = tile_inspector_path_toggle_edge(x, y, elementIndex, edgeIndex, flags);
         break;
     }
+    case TILE_INSPECTOR_ENTRANCE_MAKE_USABLE:
+    {
+        const sint32 elementIndex = *edx;
+        *ebx = tile_inspector_entrance_make_usable(x, y, elementIndex, flags);
+        break;
+    }
     case TILE_INSPECTOR_WALL_SET_SLOPE:
     {
         const sint32 elementIndex = *edx;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -588,6 +588,42 @@ sint32 tile_inspector_path_toggle_edge(sint32 x, sint32 y, sint32 elementIndex, 
     return 0;
 }
 
+sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementIndex, sint32 flags)
+{
+    rct_tile_element * const entranceElement = map_get_nth_element_at(x, y, elementIndex);
+
+    if (!entranceElement || tile_element_get_type(entranceElement) != TILE_ELEMENT_TYPE_ENTRANCE)
+    {
+        return MONEY32_UNDEFINED;
+    }
+
+    if (flags & GAME_COMMAND_FLAG_APPLY)
+    {
+        Ride * ride         = get_ride(entranceElement->properties.entrance.ride_index);
+        uint8  stationIndex = entranceElement->properties.entrance.index >> 6;
+
+        switch (entranceElement->properties.entrance.type)
+        {
+        case ENTRANCE_TYPE_RIDE_ENTRANCE:
+            ride->entrances[stationIndex].x = x;
+            ride->entrances[stationIndex].y = y;
+            break;
+        case ENTRANCE_TYPE_RIDE_EXIT:
+            ride->exits[stationIndex].x = x;
+            ride->exits[stationIndex].y = y;
+            break;
+        }
+
+        rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
+        {
+            window_invalidate(tileInspectorWindow);
+        }
+    }
+
+    return 0;
+}
+
 sint32 tile_inspector_wall_set_slope(sint32 x, sint32 y, sint32 elementIndex, sint32 slopeValue, sint32 flags)
 {
     rct_tile_element * const wallElement = map_get_nth_element_at(x, y, elementIndex);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -1,23 +1,23 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
 /*****************************************************************************
-* OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
-*
-* OpenRCT2 is the work of many authors, a full list can be found in contributors.md
-* For more information, visit https://github.com/OpenRCT2/OpenRCT2
-*
-* OpenRCT2 is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* A full copy of the GNU General Public License can be found in licence.txt
-*****************************************************************************/
+ * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
+ *
+ * OpenRCT2 is the work of many authors, a full list can be found in contributors.md
+ * For more information, visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * A full copy of the GNU General Public License can be found in licence.txt
+ *****************************************************************************/
 #pragma endregion
 
 #include "../common.h"
 #include "../Context.h"
-#include "../core/Guard.hpp"
 #include "../Game.h"
+#include "../core/Guard.hpp"
 #include "../interface/Window.h"
 #include "../interface/Window_internal.h"
 #include "../ride/Track.h"
@@ -67,8 +67,8 @@ static bool map_swap_elements_at(sint32 x, sint32 y, sint16 first, sint16 second
 
     // Swap their memory
     rct_tile_element temp = *firstElement;
-    *firstElement  = *secondElement;
-    *secondElement = temp;
+    *firstElement         = *secondElement;
+    *secondElement        = temp;
 
     // Swap the 'last map element for tile' flag if either one of them was last
     if (tile_element_is_last_for_tile(firstElement) || tile_element_is_last_for_tile(secondElement))
@@ -90,9 +90,7 @@ sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex,
 {
     // Make sure there is enough space for the new element
     if (!map_check_free_elements_and_reorganise(1))
-    {
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -130,7 +128,7 @@ sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex,
 
         // Update the tile inspector's list for everyone who has the tile selected
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             windowTileInspectorElementCount++;
 
@@ -155,10 +153,10 @@ sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex,
 }
 
 /**
-* Forcefully removes an element for a given tile
-* @param x, y: The coordinates of the tile
-* @param elementIndex: The nth element on this tile
-*/
+ * Forcefully removes an element for a given tile
+ * @param x, y: The coordinates of the tile
+ * @param elementIndex: The nth element on this tile
+ */
 sint32 tile_inspector_remove_element_at(sint32 x, sint32 y, sint16 elementIndex, sint32 flags)
 {
     if (flags & GAME_COMMAND_FLAG_APPLY)
@@ -174,7 +172,7 @@ sint32 tile_inspector_remove_element_at(sint32 x, sint32 y, sint16 elementIndex,
 
         // Update the window
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             windowTileInspectorElementCount--;
 
@@ -208,7 +206,7 @@ sint32 tile_inspector_swap_elements_at(sint32 x, sint32 y, sint16 first, sint16 
 
         // Update the window
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             // If one of them was selected, update selected list item
             if (tileInspectorWindow->selected_list_item == first)
@@ -244,8 +242,8 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
                 tileElement->properties.path.type &= ~TILE_ELEMENT_DIRECTION_MASK;
                 tileElement->properties.path.type |= newRotation;
             }
-            pathEdges   = tileElement->properties.path.edges & 0x0F;
-            pathCorners = tileElement->properties.path.edges & 0xF0;
+            pathEdges                          = tileElement->properties.path.edges & 0x0F;
+            pathCorners                        = tileElement->properties.path.edges & 0xF0;
             tileElement->properties.path.edges = 0;
             tileElement->properties.path.edges |= ((pathEdges << 1) | (pathEdges >> 3)) & 0x0F;
             tileElement->properties.path.edges |= ((pathCorners << 1) | (pathCorners >> 3)) & 0xF0;
@@ -268,7 +266,7 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
 
         map_invalidate_tile_full(x << 5, y << 5);
 
-        if ((uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if ((uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate_by_class(WC_TILE_INSPECTOR);
         }
@@ -290,7 +288,7 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
         rct_tile_element * const pastedElement = tile_element_insert(x, y, element.base_height, 0);
 
         bool lastForTile = tile_element_is_last_for_tile(pastedElement);
-        *pastedElement = element;
+        *pastedElement   = element;
         pastedElement->flags &= ~TILE_ELEMENT_FLAG_LAST_TILE;
         if (lastForTile)
         {
@@ -300,12 +298,12 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             windowTileInspectorElementCount++;
 
             // Select new element if there was none selected already
-            sint16 newIndex = (sint16) (pastedElement - map_get_first_element_at(x, y));
+            sint16 newIndex = (sint16)(pastedElement - map_get_first_element_at(x, y));
             if (tileInspectorWindow->selected_list_item == -1)
                 tileInspectorWindow->selected_list_item = newIndex;
             else if (tileInspectorWindow->selected_list_item >= newIndex)
@@ -326,25 +324,25 @@ sint32 tile_inspector_sort_elements_at(sint32 x, sint32 y, sint32 flags)
         const rct_tile_element * const firstElement = map_get_first_element_at(x, y);
 
         // Count elements on tile
-        sint32                 numElement        = 0;
+        sint32                   numElement      = 0;
         const rct_tile_element * elementIterator = firstElement;
         do
         {
             numElement++;
-        }
-        while (!tile_element_is_last_for_tile(elementIterator++));
+        } while (!tile_element_is_last_for_tile(elementIterator++));
 
         // Bubble sort
         for (sint32 loopStart = 1; loopStart < numElement; loopStart++)
         {
-            sint32                 currentId        = loopStart;
+            sint32                   currentId      = loopStart;
             const rct_tile_element * currentElement = firstElement + currentId;
             const rct_tile_element * otherElement   = currentElement - 1;
 
-            // While current element's base height is lower, or (when their baseheight is the same) the other map element's clearance height is lower...
-            while (currentId > 0 &&
-                   (otherElement->base_height > currentElement->base_height ||
-                    (otherElement->base_height == currentElement->base_height && otherElement->clearance_height > currentElement->clearance_height)))
+            // While current element's base height is lower, or (when their baseheight is the same) the other map element's
+            // clearance height is lower...
+            while (currentId > 0 && (otherElement->base_height > currentElement->base_height ||
+                                     (otherElement->base_height == currentElement->base_height &&
+                                      otherElement->clearance_height > currentElement->clearance_height)))
             {
                 if (!map_swap_elements_at(x, y, currentId - 1, currentId))
                 {
@@ -364,7 +362,7 @@ sint32 tile_inspector_sort_elements_at(sint32 x, sint32 y, sint32 flags)
 
         // Deselect tile for clients who had it selected
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_tile_inspector_set_page(tileInspectorWindow, TILE_INSPECTOR_PAGE_DEFAULT);
             tileInspectorWindow->selected_list_item = -1;
@@ -379,12 +377,11 @@ sint32 tile_inspector_sort_elements_at(sint32 x, sint32 y, sint32 flags)
 sint32 tile_inspector_any_base_height_offset(sint32 x, sint32 y, sint16 elementIndex, sint8 heightOffset, sint32 flags)
 {
     rct_tile_element * const tileElement = map_get_nth_element_at(x, y, elementIndex);
-    if (!tileElement)
-    {
+    if (tileElement == nullptr)
         return MONEY32_UNDEFINED;
-    }
-    sint16 newBaseHeight      = (sint16) tileElement->base_height + heightOffset;
-    sint16 newClearanceHeight = (sint16) tileElement->clearance_height + heightOffset;
+
+    sint16 newBaseHeight      = (sint16)tileElement->base_height + heightOffset;
+    sint16 newClearanceHeight = (sint16)tileElement->clearance_height + heightOffset;
     if (newBaseHeight < 0 || newBaseHeight > 0xff || newClearanceHeight < 0 || newClearanceHeight > 0xff)
     {
         return MONEY32_UNDEFINED;
@@ -398,7 +395,7 @@ sint32 tile_inspector_any_base_height_offset(sint32 x, sint32 y, sint16 elementI
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -425,7 +422,7 @@ sint32 tile_inspector_surface_show_park_fences(sint32 x, sint32 y, bool showFenc
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -489,7 +486,7 @@ sint32 tile_inspector_surface_toggle_corner(sint32 x, sint32 y, sint32 cornerInd
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -525,7 +522,7 @@ sint32 tile_inspector_surface_toggle_diagonal(sint32 x, sint32 y, sint32 flags)
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -538,10 +535,8 @@ sint32 tile_inspector_path_set_sloped(sint32 x, sint32 y, sint32 elementIndex, b
 {
     rct_tile_element * const pathElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!pathElement || tile_element_get_type(pathElement) != TILE_ELEMENT_TYPE_PATH)
-    {
+    if (pathElement == nullptr || tile_element_get_type(pathElement) != TILE_ELEMENT_TYPE_PATH)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -554,7 +549,7 @@ sint32 tile_inspector_path_set_sloped(sint32 x, sint32 y, sint32 elementIndex, b
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -567,10 +562,8 @@ sint32 tile_inspector_path_toggle_edge(sint32 x, sint32 y, sint32 elementIndex, 
 {
     rct_tile_element * const pathElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!pathElement || tile_element_get_type(pathElement) != TILE_ELEMENT_TYPE_PATH)
-    {
+    if (pathElement == nullptr || tile_element_get_type(pathElement) != TILE_ELEMENT_TYPE_PATH)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -579,7 +572,7 @@ sint32 tile_inspector_path_toggle_edge(sint32 x, sint32 y, sint32 elementIndex, 
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -592,15 +585,17 @@ sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementInd
 {
     rct_tile_element * const entranceElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!entranceElement || tile_element_get_type(entranceElement) != TILE_ELEMENT_TYPE_ENTRANCE)
-    {
+    if (entranceElement == nullptr || tile_element_get_type(entranceElement) != TILE_ELEMENT_TYPE_ENTRANCE)
         return MONEY32_UNDEFINED;
-    }
+
+    Ride * ride = get_ride(entranceElement->properties.entrance.ride_index);
+
+    if (ride == nullptr)
+        return MONEY32_UNDEFINED;
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
-        Ride * ride         = get_ride(entranceElement->properties.entrance.ride_index);
-        uint8  stationIndex = entranceElement->properties.entrance.index >> 6;
+        uint8 stationIndex = entranceElement->properties.entrance.index >> 6;
 
         switch (entranceElement->properties.entrance.type)
         {
@@ -628,10 +623,8 @@ sint32 tile_inspector_wall_set_slope(sint32 x, sint32 y, sint32 elementIndex, si
 {
     rct_tile_element * const wallElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!wallElement || tile_element_get_type(wallElement) != TILE_ELEMENT_TYPE_WALL)
-    {
+    if (wallElement == nullptr || tile_element_get_type(wallElement) != TILE_ELEMENT_TYPE_WALL)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -642,7 +635,7 @@ sint32 tile_inspector_wall_set_slope(sint32 x, sint32 y, sint32 elementIndex, si
         map_invalidate_tile_full(x << 5, y << 5);
 
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
-        if (tileInspectorWindow != nullptr && (uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate(tileInspectorWindow);
         }
@@ -658,24 +651,20 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
     rct_tile_element * const trackElement = map_get_nth_element_at(x, y, elementIndex);
 
     if (offset == 0)
-    {
-        return MONEY32_UNDEFINED;
-    }
+        return 0;
 
-    if (!trackElement || tile_element_get_type(trackElement) != TILE_ELEMENT_TYPE_TRACK)
-    {
+    if (trackElement == nullptr || tile_element_get_type(trackElement) != TILE_ELEMENT_TYPE_TRACK)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
-        uint8  type      = track_element_get_type(trackElement);
-        sint16 originX   = x << 5;
-        sint16 originY   = y << 5;
-        sint16 originZ   = trackElement->base_height * 8;
-        uint8  rotation  = tile_element_get_direction(trackElement);
-        uint8  rideIndex = track_element_get_ride_index(trackElement);
-        Ride                    * ride       = get_ride(rideIndex);
+        uint8                     type       = track_element_get_type(trackElement);
+        sint16                    originX    = x << 5;
+        sint16                    originY    = y << 5;
+        sint16                    originZ    = trackElement->base_height * 8;
+        uint8                     rotation   = tile_element_get_direction(trackElement);
+        uint8                     rideIndex  = track_element_get_ride_index(trackElement);
+        Ride *                    ride       = get_ride(rideIndex);
         const rct_preview_track * trackBlock = get_track_def_from_ride(ride, type);
         trackBlock += tile_element_get_track_sequence(trackElement);
 
@@ -731,7 +720,7 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
 
             map_invalidate_tile_full(elemX, elemY);
 
-            bool             found         = false;
+            bool               found       = false;
             rct_tile_element * tileElement = map_get_first_element_at(elemX >> 5, elemY >> 5);
             do
             {
@@ -752,8 +741,7 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
 
                 found = true;
                 break;
-            }
-            while (!tile_element_is_last_for_tile(tileElement++));
+            } while (!tile_element_is_last_for_tile(tileElement++));
 
             if (!found)
             {
@@ -761,11 +749,13 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
                 return MONEY32_UNDEFINED;
             }
 
-            // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when you decrease the map size.
-            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
+            // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
+            // you decrease the map size.
+            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5,
+                            elemY >> 5);
 
             // Keep?
-            //invalidate_test_results(rideIndex);
+            // invalidate_test_results(rideIndex);
 
             tileElement->base_height += offset;
             tileElement->clearance_height += offset;
@@ -780,14 +770,13 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
 
 // Sets chainlift, optionally for an entire track block
 // Broxzier: Basically a copy of the above function, with just two different lines... should probably be combined somehow
-sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, bool entireTrackBlock, bool setChain, sint32 flags)
+sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, bool entireTrackBlock, bool setChain,
+                                      sint32 flags)
 {
     rct_tile_element * const trackElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!trackElement || tile_element_get_type(trackElement) != TILE_ELEMENT_TYPE_TRACK)
-    {
+    if (trackElement == nullptr || tile_element_get_type(trackElement) != TILE_ELEMENT_TYPE_TRACK)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -802,13 +791,13 @@ sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, b
             return 0;
         }
 
-        uint8  type      = track_element_get_type(trackElement);
-        sint16 originX   = x << 5;
-        sint16 originY   = y << 5;
-        sint16 originZ   = trackElement->base_height * 8;
-        uint8  rotation  = tile_element_get_direction(trackElement);
-        uint8  rideIndex = track_element_get_ride_index(trackElement);
-        Ride                    * ride       = get_ride(rideIndex);
+        uint8                     type       = track_element_get_type(trackElement);
+        sint16                    originX    = x << 5;
+        sint16                    originY    = y << 5;
+        sint16                    originZ    = trackElement->base_height * 8;
+        uint8                     rotation   = tile_element_get_direction(trackElement);
+        uint8                     rideIndex  = track_element_get_ride_index(trackElement);
+        Ride *                    ride       = get_ride(rideIndex);
         const rct_preview_track * trackBlock = get_track_def_from_ride(ride, type);
         trackBlock += tile_element_get_track_sequence(trackElement);
 
@@ -864,7 +853,7 @@ sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, b
 
             map_invalidate_tile_full(elemX, elemY);
 
-            bool             found         = false;
+            bool               found       = false;
             rct_tile_element * tileElement = map_get_first_element_at(elemX >> 5, elemY >> 5);
             do
             {
@@ -885,8 +874,7 @@ sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, b
 
                 found = true;
                 break;
-            }
-            while (!tile_element_is_last_for_tile(tileElement++));
+            } while (!tile_element_is_last_for_tile(tileElement++));
 
             if (!found)
             {
@@ -894,11 +882,13 @@ sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, b
                 return MONEY32_UNDEFINED;
             }
 
-            // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when you decrease the map size.
-            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
+            // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
+            // you decrease the map size.
+            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5,
+                            elemY >> 5);
 
             // Keep?
-            //invalidate_test_results(rideIndex);
+            // invalidate_test_results(rideIndex);
 
             if (track_element_is_lift_hill(tileElement) != setChain)
             {
@@ -917,10 +907,8 @@ sint32 tile_inspector_scenery_set_quarter_location(sint32 x, sint32 y, sint32 el
 {
     rct_tile_element * const tileElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!tileElement || tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_SMALL_SCENERY)
-    {
+    if (tileElement == nullptr || tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_SMALL_SCENERY)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
@@ -933,7 +921,7 @@ sint32 tile_inspector_scenery_set_quarter_location(sint32 x, sint32 y, sint32 el
         tileElement->flags |= 1 << ((quarterIndex + 2) & 3);
 
         map_invalidate_tile_full(x << 5, y << 5);
-        if ((uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if ((uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate_by_class(WC_TILE_INSPECTOR);
         }
@@ -946,17 +934,15 @@ sint32 tile_inspector_scenery_set_quarter_collision(sint32 x, sint32 y, sint32 e
 {
     rct_tile_element * const tileElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!tileElement || tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_SMALL_SCENERY)
-    {
+    if (tileElement == nullptr || tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_SMALL_SCENERY)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
         tileElement->flags ^= 1 << quarterIndex;
 
         map_invalidate_tile_full(x << 5, y << 5);
-        if ((uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if ((uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate_by_class(WC_TILE_INSPECTOR);
         }
@@ -969,16 +955,14 @@ sint32 tile_inspector_banner_toggle_blocking_edge(sint32 x, sint32 y, sint32 ele
 {
     rct_tile_element * const bannerElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!bannerElement || tile_element_get_type(bannerElement) != TILE_ELEMENT_TYPE_BANNER)
-    {
+    if (bannerElement == nullptr || tile_element_get_type(bannerElement) != TILE_ELEMENT_TYPE_BANNER)
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
         bannerElement->properties.banner.flags ^= 1 << edgeIndex;
 
-        if ((uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if ((uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate_by_class(WC_TILE_INSPECTOR);
         }
@@ -991,22 +975,18 @@ sint32 tile_inspector_corrupt_clamp(sint32 x, sint32 y, sint32 elementIndex, sin
 {
     rct_tile_element * const corruptElement = map_get_nth_element_at(x, y, elementIndex);
 
-    if (!corruptElement || tile_element_get_type(corruptElement) != TILE_ELEMENT_TYPE_CORRUPT)
-    {
+    if (corruptElement == nullptr || tile_element_get_type(corruptElement) != TILE_ELEMENT_TYPE_CORRUPT)
         return MONEY32_UNDEFINED;
-    }
 
     if (tile_element_is_last_for_tile(corruptElement))
-    {
         return MONEY32_UNDEFINED;
-    }
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
         rct_tile_element * const nextElement = corruptElement + 1;
         corruptElement->base_height = corruptElement->clearance_height = nextElement->base_height;
 
-        if ((uint32) x == windowTileInspectorTileX && (uint32) y == windowTileInspectorTileY)
+        if ((uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
             window_invalidate_by_class(WC_TILE_INSPECTOR);
         }

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -606,6 +606,9 @@ sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementInd
         case ENTRANCE_TYPE_RIDE_EXIT:
             ride->exits[stationIndex].x = x;
             ride->exits[stationIndex].y = y;
+
+            // TODO: Remove once mechanics don't assume exits always match the station heights
+            ride->station_heights[stationIndex] = entranceElement->base_height;
             break;
         }
 

--- a/src/openrct2/world/TileInspector.h
+++ b/src/openrct2/world/TileInspector.h
@@ -45,6 +45,7 @@ typedef enum {
     TILE_INSPECTOR_SURFACE_TOGGLE_DIAGONAL,
     TILE_INSPECTOR_PATH_SET_SLOPE,
     TILE_INSPECTOR_PATH_TOGGLE_EDGE,
+    TILE_INSPECTOR_ENTRANCE_MAKE_USABLE,
     TILE_INSPECTOR_WALL_SET_SLOPE,
     TILE_INSPECTOR_TRACK_BASE_HEIGHT_OFFSET,
     TILE_INSPECTOR_TRACK_SET_CHAIN,
@@ -66,6 +67,7 @@ sint32 tile_inspector_surface_toggle_corner(sint32 x, sint32 y, sint32 cornerInd
 sint32 tile_inspector_surface_toggle_diagonal(sint32 x, sint32 y, sint32 flags);
 sint32 tile_inspector_path_set_sloped(sint32 x, sint32 y, sint32 elementIndex, bool sloped, sint32 flags);
 sint32 tile_inspector_path_toggle_edge(sint32 x, sint32 y, sint32 elementIndex, sint32 cornerIndex, sint32 flags);
+sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementIndex, sint32 flags);
 sint32 tile_inspector_wall_set_slope(sint32 x, sint32 y, sint32 elementIndex, sint32 slopeValue, sint32 flags);
 sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elementIndex, sint8 offset, sint32 flags);
 sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, bool entireTrackBlock, bool setChain, sint32 flags);


### PR DESCRIPTION
Rides have a list of XY locations for the entrances and exits of every station, and a list of station heights which basically acts as the Z axis. At many places the game assumes that the entrances are there, making them not work properly when they have been moved. As a result, building a working queue from the entrance is only possible by copying over a path from the actual station, and peeps will try to navigate to the original location.

This PR makes detached ride entrances usable by making the path tool search for them on the known tile when placing a path. Instead of checking for the expected height, it loops over the elements on tile XY and checks for the ride index instead (which it didn't do before, so it happens you have two entrances at the same tile, it would always choose the first in the list, even if it's from another ride!).

To make entrances and exits usable that have been moved, I've added a button to the Tile Inspector which can update the location that the ride has saved.

This PR only takes care of the assumption for when building queues, but there are many more (example: mechanics don't get called when the ride exit is not where the ride thinks it is). I'd like to leave those for later, preferably after the next release.