### PR TITLE
Visual improvements to the in-game console

### DIFF
--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -180,7 +180,7 @@ static constexpr const WindowThemeDesc WindowThemeDescriptors[] =
     { THEME_WC(WC_NETWORK_STATUS),                 STR_THEMES_WINDOW_NETWORK_STATUS,                 COLOURS_1(COLOUR_LIGHT_BLUE                                                                                                    ) },
     { THEME_WC(WC_SERVER_LIST),                    STR_SERVER_LIST,                                  COLOURS_2(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_CHAT),                           STR_CHAT,                                         COLOURS_1(TRANSLUCENT(COLOUR_GREY)                                                                                             ) },
-    { THEME_WC(WC_CONSOLE),                        STR_CONSOLE,                                      COLOURS_1(TRANSLUCENT(COLOUR_LIGHT_BLUE)                                                                                       ) },
+    { THEME_WC(WC_CONSOLE),                        STR_CONSOLE,                                      COLOURS_2(TRANSLUCENT(COLOUR_LIGHT_BLUE),  COLOUR_WHITE                                                                                       ) },
 };
 
 #pragma endregion


### PR DESCRIPTION
This PR makes a few small visual improvements to the console, and a minor attempt to make the code easier to read.

- The caret is now visible (before it was very hard to make out)
- Scrollback no longer overlaps the input area
- The input area is now slightly more visually distinct (more opaque) for translucent styles.
- Various magic numbers have been replaced with `#define`s where possible.
- Black outlines removed from TTF console text, improving readability.
- Console text colour now themeable.