### PR TITLE
Break overlong function declarations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,11 @@
 ﻿---
 BasedOnStyle: LLVM
 AccessModifierOffset: '-4'
+AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveAssignments: 'true'
 AlignConsecutiveDeclarations: 'true'
 AllowShortFunctionsOnASingleLine: Empty
+BinPackParameters: 'false'
 BreakBeforeBraces: Allman
 ColumnLimit: '128'
 Cpp11BracedListStyle: 'false'


### PR DESCRIPTION
Before:
```diff
-static void large_scenery_paint_supports(paint_session * session, uint8 direction, uint16 height, rct_tile_element *tileElement, uint32 dword_F4387C, rct_large_scenery_tile *tile)
+static void large_scenery_paint_supports(paint_session * session, uint8 direction, uint16 height,
+                                         rct_tile_element * tileElement, uint32 dword_F4387C, rct_large_scenery_tile * tile)
-static rct_large_scenery_text_glyph *large_scenery_sign_get_glyph(rct_large_scenery_text *text, uint32 codepoint)
+static rct_large_scenery_text_glyph * large_scenery_sign_get_glyph(rct_large_scenery_text * text, uint32 codepoint)
```

After:
```diff
-static void large_scenery_paint_supports(paint_session * session, uint8 direction, uint16 height, rct_tile_element *tileElement, uint32 dword_F4387C, rct_large_scenery_tile *tile)
+static void large_scenery_paint_supports(
+    paint_session *          session,
+    uint8                    direction,
+    uint16                   height,
+    rct_tile_element *       tileElement,
+    uint32                   dword_F4387C,
+    rct_large_scenery_tile * tile)
-static rct_large_scenery_text_glyph *large_scenery_sign_get_glyph(rct_large_scenery_text *text, uint32 codepoint)
+static rct_large_scenery_text_glyph * large_scenery_sign_get_glyph(rct_large_scenery_text * text, uint32 codepoint)
```

[ci skip]