### PR TITLE
Fix #7052: Infinite loops occur in track circuit iteration

### DIFF
--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -2402,6 +2402,14 @@ bool track_circuit_iterator_next(track_circuit_iterator * it)
     }
 }
 
+bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const track_circuit_iterator * secondIt)
+{
+    return (firstIt->currentZ == secondIt->currentZ &&
+            firstIt->currentDirection == secondIt->currentDirection &&
+            firstIt->current.x == secondIt->current.x &&
+            firstIt->current.y == secondIt->current.y);
+}
+
 void track_get_back(rct_xy_element * input, rct_xy_element * output)
 {
     rct_xy_element  lastTrack;

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -537,6 +537,7 @@ const rct_track_coordinates * get_track_coord_from_ride(Ride * ride, sint32 trac
 void track_circuit_iterator_begin(track_circuit_iterator * it, rct_xy_element first);
 bool track_circuit_iterator_previous(track_circuit_iterator * it);
 bool track_circuit_iterator_next(track_circuit_iterator * it);
+bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const track_circuit_iterator * secondIt);
 
 void track_get_back(rct_xy_element * input, rct_xy_element * output);
 void track_get_front(rct_xy_element * input, rct_xy_element * output);


### PR DESCRIPTION
This applies the tortoise-and-hare type algorithm from #4359 to other uses of `track_circuit_iterator`, preventing infinite loops.