### PR TITLE
Refactor console

### DIFF
--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -1,4 +1,4 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
 /*****************************************************************************
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
  *
@@ -323,7 +323,7 @@ void FASTCALL gfx_draw_sprite_palette_set_software(rct_drawpixelinfo *dpi, sint3
 void FASTCALL gfx_draw_sprite_raw_masked_software(rct_drawpixelinfo *dpi, sint32 x, sint32 y, sint32 maskImage, sint32 colourImage);
 
 // string
-void gfx_draw_string(rct_drawpixelinfo *dpi, char *buffer, uint8 colour, sint32 x, sint32 y);
+void gfx_draw_string(rct_drawpixelinfo *dpi, const_utf8string buffer, uint8 colour, sint32 x, sint32 y);
 
 void gfx_draw_string_left(rct_drawpixelinfo *dpi, rct_string_id format, void *args, uint8 colour, sint32 x, sint32 y);
 void gfx_draw_string_centred(rct_drawpixelinfo *dpi, rct_string_id format, sint32 x, sint32 y, uint8 colour, void *args);
@@ -351,7 +351,7 @@ sint32 gfx_get_string_width_new_lined(char* buffer);
 sint32 string_get_height_raw(char *buffer);
 sint32 gfx_clip_string(char* buffer, sint32 width);
 void shorten_path(utf8 *buffer, size_t bufferSize, const utf8 *path, sint32 availableWidth);
-void ttf_draw_string(rct_drawpixelinfo *dpi, char *text, sint32 colour, sint32 x, sint32 y);
+void ttf_draw_string(rct_drawpixelinfo *dpi, const_utf8string text, sint32 colour, sint32 x, sint32 y);
 
 typedef struct paint_session paint_session;
 

--- a/src/openrct2/drawing/String.cpp
+++ b/src/openrct2/drawing/String.cpp
@@ -1,4 +1,4 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
 /*****************************************************************************
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
  *
@@ -810,7 +810,7 @@ static void ttf_process_initial_colour(sint32 colour, text_draw_info *info)
     }
 }
 
-void ttf_draw_string(rct_drawpixelinfo *dpi, char *text, sint32 colour, sint32 x, sint32 y)
+void ttf_draw_string(rct_drawpixelinfo *dpi, const_utf8string text, sint32 colour, sint32 x, sint32 y)
 {
     if (text == nullptr) return;
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -1,4 +1,4 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
 /*****************************************************************************
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
  *
@@ -20,7 +20,7 @@
 
 static TextPaint _legacyPaint;
 
-static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * paint, utf8string text);
+static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * paint, const_utf8string text);
 static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * paint, rct_string_id format, void * args);
 
 StaticLayout::StaticLayout(utf8string source, TextPaint paint, sint32 width)
@@ -82,7 +82,7 @@ sint32 StaticLayout::GetLineCount()
     return _lineCount;
 }
 
-static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * paint, utf8string text)
+static void DrawText(rct_drawpixelinfo * dpi, sint32 x, sint32 y, TextPaint * paint, const_utf8string text)
 {
     sint32 width = gfx_get_string_width(text);
 
@@ -146,7 +146,7 @@ static void DrawTextEllipsisedCompat(rct_drawpixelinfo * dpi, sint32 x, sint32 y
 
 extern "C"
 {
-    void gfx_draw_string(rct_drawpixelinfo *dpi, char *buffer, uint8 colour, sint32 x, sint32 y)
+    void gfx_draw_string(rct_drawpixelinfo *dpi, const_utf8string buffer, uint8 colour, sint32 x, sint32 y)
     {
         _legacyPaint.UnderlineText = false;
         _legacyPaint.Colour = colour;

--- a/src/openrct2/interface/Console.cpp
+++ b/src/openrct2/interface/Console.cpp
@@ -16,8 +16,8 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <deque>
 #include <string>
-#include <vector>
 
 #include "../config/Config.h"
 #include "../Context.h"
@@ -60,6 +60,7 @@
 #include "../drawing/TTF.h"
 #endif
 
+#define CONSOLE_MAX_LINES 300
 #define CONSOLE_HISTORY_SIZE 64
 #define CONSOLE_INPUT_SIZE 256
 #define CONSOLE_CARET_FLASH_THRESHOLD 15
@@ -74,7 +75,7 @@ bool gConsoleOpen = false;
 static bool                     _consoleInitialised = false;
 static sint32                   _consoleLeft, _consoleTop, _consoleRight, _consoleBottom;
 static sint32                   _lastMainViewportX, _lastMainViewportY;
-static std::vector<std::string> _consoleLines;
+static std::deque<std::string>  _consoleLines;
 static utf8                     _consoleCurrentLine[CONSOLE_INPUT_SIZE];
 static sint32                   _consoleCaretTicks;
 static sint32                   _consoleScrollPos = 0;
@@ -339,6 +340,12 @@ void console_writeline(const utf8 * src, uint32 colourFormat)
         line     = input.substr(stringOffset, splitPos - stringOffset);
         _consoleLines.push_back(colourCodepoint + line);
         stringOffset = splitPos + 1;
+    }
+
+    if (_consoleLines.size() > CONSOLE_MAX_LINES)
+    {
+        const std::size_t linesToErase = _consoleLines.size() - CONSOLE_MAX_LINES;
+        _consoleLines.erase(_consoleLines.begin(), _consoleLines.begin() + linesToErase);
     }
 }
 

--- a/src/openrct2/interface/Console.h
+++ b/src/openrct2/interface/Console.h
@@ -47,7 +47,7 @@ void console_draw(rct_drawpixelinfo *dpi);
 
 void console_input(CONSOLE_INPUT input);
 void console_write(const utf8 *src);
-void console_writeline(const utf8 *src, uint32 colourFormat = FORMAT_WHITE);
+void console_writeline(const utf8 * src, uint32 colourFormat = FORMAT_WINDOW_COLOUR_2);
 void console_writeline_error(const utf8 *src);
 void console_writeline_warning(const utf8 *src);
 void console_printf(const utf8 *format, ...);

--- a/src/openrct2/interface/Console.h
+++ b/src/openrct2/interface/Console.h
@@ -1,4 +1,4 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright (c) 2014-2018 OpenRCT2 Developers
 /*****************************************************************************
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
  *
@@ -19,6 +19,7 @@
 
 #include "../common.h"
 #include "../drawing/Drawing.h"
+#include "../localisation/FormatCodes.h"
 
 typedef enum CONSOLE_INPUT
 {
@@ -46,7 +47,7 @@ void console_draw(rct_drawpixelinfo *dpi);
 
 void console_input(CONSOLE_INPUT input);
 void console_write(const utf8 *src);
-void console_writeline(const utf8 *src);
+void console_writeline(const utf8 *src, uint32 colourFormat = FORMAT_WHITE);
 void console_writeline_error(const utf8 *src);
 void console_writeline_warning(const utf8 *src);
 void console_printf(const utf8 *format, ...);


### PR DESCRIPTION
In short, this fixes a few issues with buffer lengths and makes the code easier to understand, by using `std::string` rather than `utf8` arrays. Safe for strings not being cut off anymore, there should be no visual changes.

There was a limit of 8192 characters first, but that has been removed. I assume adding a maximum number of lines would be nice to add?