### PR TITLE
Disable link-time code generation for MSVC Debug builds

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -101,6 +101,7 @@ The following people are not part of the project team, but have been contributin
 * Ethan Smith (ethanhs) - Refactoring.
 * Robert Lewicki (rlewicki)
 * Tyler Ruckinger (TyPR124)
+* Justin Gottula (jgottula)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -73,7 +73,6 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Exactly the same as OpenRCT2/OpenLoco#18.