### PR TITLE
Fix #7021 : [UI bug] Extra rating factors overflow in the vehicle tab in Korean

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,4 +1,4 @@
-﻿# Contributors to OpenRCT2
+# Contributors to OpenRCT2
 Includes all git commit authors. Aliases are GitHub user names.
 
 ## Project team

--- a/contributors.md
+++ b/contributors.md
@@ -1,4 +1,4 @@
-# Contributors to OpenRCT2
+﻿# Contributors to OpenRCT2
 Includes all git commit authors. Aliases are GitHub user names.
 
 ## Project team
@@ -102,6 +102,7 @@ The following people are not part of the project team, but have been contributin
 * Robert Lewicki (rlewicki)
 * Tyler Ruckinger (TyPR124)
 * Justin Gottula (jgottula)
+* Seongsik Park (pss9205)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2915,17 +2915,16 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     // Description
     y += gfx_draw_string_left_wrapped(dpi, &rideEntry->naming.description, x, y, 300, STR_BLACK_STRING, COLOUR_BLACK);
-    y += 5;
+    y += 2;
 
     // Capacity
     gfx_draw_string_left(dpi, STR_CAPACITY, &rideEntry->capacity, COLOUR_BLACK, x, y);
-    y += 5;
 
     // Excitement Factor
     factor = rideEntry->excitement_multiplier;
     if (factor > 0)
     {
-        y += 10;
+        y += 12;
         gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 
@@ -2933,7 +2932,7 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
     factor = rideEntry->intensity_multiplier;
     if (factor > 0)
     {
-        y += 10;
+		x += 150;
         gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 
@@ -2941,7 +2940,8 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
     factor = rideEntry->nausea_multiplier;
     if (factor > 0)
     {
-        y += 10;
+		x -= 150;
+		y += 12;
         gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2919,54 +2919,37 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     // Capacity
     gfx_draw_string_left(dpi, STR_CAPACITY, &rideEntry->capacity, COLOUR_BLACK, x, y);
-    if (font_get_line_height(FONT_SPRITE_BASE_MEDIUM) == 10) {
-        // Excitement Factor
-        factor = rideEntry->excitement_multiplier;
-        if (factor > 0)
-        {
-            y += 10;
-            gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
-        }
 
-        // Intensity Factor
-        factor = rideEntry->intensity_multiplier;
-        if (factor > 0)
-        {
-            y += 10;
-            gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x, y);
-        }
-
-        // Nausea Factor
-        factor = rideEntry->nausea_multiplier;
-        if (factor > 0)
-        {
-            y += 10;
-            gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
-        }
+    // Excitement Factor
+    factor = rideEntry->excitement_multiplier;
+    if (factor > 0)
+    {
+        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
-    else{
-        // Excitement Factor
-        factor = rideEntry->excitement_multiplier;
-        if (factor > 0)
-        {
-            y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
-        }
 
-        // Intensity Factor
-        factor = rideEntry->intensity_multiplier;
-        if (factor > 0)
-        {
-            gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x + 150, y);
-        }
-
-        // Nausea Factor
-        factor = rideEntry->nausea_multiplier;
-        if (factor > 0)
-        {
+    // Intensity Factor
+    factor = rideEntry->intensity_multiplier;
+    if (factor > 0)
+    {
+        sint32 lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+        if (lineHeight != 10)
+            x += 150;
+        else
             y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
-        }
+
+        gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x, y);
+
+        if (lineHeight != 10)
+            x -= 150;
+    }
+
+    // Nausea Factor
+    factor = rideEntry->nausea_multiplier;
+    if (factor > 0)
+    {
+        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2919,30 +2919,55 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     // Capacity
     gfx_draw_string_left(dpi, STR_CAPACITY, &rideEntry->capacity, COLOUR_BLACK, x, y);
+    if (font_get_line_height(FONT_SPRITE_BASE_MEDIUM) == 10) {
+        // Excitement Factor
+        factor = rideEntry->excitement_multiplier;
+        if (factor > 0)
+        {
+            y += 10;
+            gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
+        }
 
-    // Excitement Factor
-    factor = rideEntry->excitement_multiplier;
-    if (factor > 0)
-    {
-        y += LIST_ROW_HEIGHT;
-        gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
+        // Intensity Factor
+        factor = rideEntry->intensity_multiplier;
+        if (factor > 0)
+        {
+            y += 10;
+            gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x, y);
+        }
+
+        // Nausea Factor
+        factor = rideEntry->nausea_multiplier;
+        if (factor > 0)
+        {
+            y += 10;
+            gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
+        }
     }
+    else{
+        // Excitement Factor
+        factor = rideEntry->excitement_multiplier;
+        if (factor > 0)
+        {
+            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
+        }
 
-    // Intensity Factor
-    factor = rideEntry->intensity_multiplier;
-    if (factor > 0)
-    {
-        gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x+150, y);
+        // Intensity Factor
+        factor = rideEntry->intensity_multiplier;
+        if (factor > 0)
+        {
+            gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x + 150, y);
+        }
+
+        // Nausea Factor
+        factor = rideEntry->nausea_multiplier;
+        if (factor > 0)
+        {
+            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
+        }
     }
-
-    // Nausea Factor
-    factor = rideEntry->nausea_multiplier;
-    if (factor > 0)
-    {
-        y += LIST_ROW_HEIGHT;
-        gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
-    }
-
 }
 
 typedef struct rct_vehichle_paintinfo {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2924,7 +2924,7 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
     factor = rideEntry->excitement_multiplier;
     if (factor > 0)
     {
-        y += 12;
+        y += LIST_ROW_HEIGHT;
         gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 
@@ -2932,16 +2932,14 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
     factor = rideEntry->intensity_multiplier;
     if (factor > 0)
     {
-		x += 150;
-        gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x, y);
+        gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, x+150, y);
     }
 
     // Nausea Factor
     factor = rideEntry->nausea_multiplier;
     if (factor > 0)
     {
-		x -= 150;
-		y += 12;
+        y += LIST_ROW_HEIGHT;
         gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, x, y);
     }
 


### PR DESCRIPTION
Change X,Y coordinates about Excitement,intensity,nausea factor
to fix the Bug which text is shown at outside of ui box.
Before
![34909470-14afc202-f8e5-11e7-910a-3ae2f060fdd9](https://user-images.githubusercontent.com/13553317/35225100-b6096d38-ffca-11e7-94e4-b9b301d79193.png)
After
![fixed1](https://user-images.githubusercontent.com/13553317/35225047-901de00e-ffca-11e7-9578-fbc3fce2fdf3.PNG)![fixed2](https://user-images.githubusercontent.com/13553317/35225051-9180bff2-ffca-11e7-97c6-a71136a5fb80.PNG)

