### PR TITLE
Add guard to ensure game action is registered

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -19,12 +19,11 @@
 #include "../core/Memory.hpp"
 #include "../core/MemoryStream.h"
 #include "../core/Util.hpp"
-#include "../network/network.h"
-#include "GameAction.h"
-
-#include "../platform/platform.h"
 #include "../localisation/Localisation.h"
+#include "../network/network.h"
+#include "../platform/platform.h"
 #include "../world/Park.h"
+#include "GameAction.h"
 
 GameActionResult::GameActionResult()
 {
@@ -88,6 +87,7 @@ namespace GameActions
                 result = factory();
             }
         }
+        Guard::ArgumentNotNull(result);
         return std::unique_ptr<GameAction>(result);
     }
 

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -211,7 +211,7 @@ public:
         window_close_by_class(WC_NEW_CAMPAIGN);
 
         // Refresh windows that display the ride name
-        auto windowManager = GetContext()->GetUiContext()->GetWindowManager();
+        auto windowManager = OpenRCT2::GetContext()->GetUiContext()->GetWindowManager();
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_GUEST_LIST));
 


### PR DESCRIPTION
`GameAction::Query` assumes the game command is registered in the `GameActionFactory`, since it uses it's return values right away. I think that assumption in valid, this guard just makes sure that when adding new actions, you know what's wrong before the actions starts running on garbage.

This also reorders the includes, which caused RideDemolishAction to fail compiling, but that's solved by adding the `OpenRCT2` namespace before the call.