### PR TITLE
fix #7030 Reliability goes above 100% on old rides that lack inspection

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3964,7 +3964,7 @@ static void window_ride_maintenance_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     uint16 reliability = ride->reliability_percentage;
     gfx_draw_string_left(dpi, STR_RELIABILITY_LABEL_1757, &reliability, COLOUR_BLACK, x, y);
-    window_ride_maintenance_draw_bar(w, dpi, x + 103, y, Math::Max<sint32>(10, reliability), COLOUR_BRIGHT_GREEN);
+    window_ride_maintenance_draw_bar(w, dpi, x + 103, y, Math::Max<sint32>(0, reliability), COLOUR_BRIGHT_GREEN);
     y += 11;
 
     uint16 downTime = ride->downtime;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2327,7 +2327,7 @@ static void ride_breakdown_update(sint32 rideIndex)
 
     // Calculate breakdown probability?
     sint32 unreliabilityAccumulator = ride->unreliability_factor + get_age_penalty(ride);
-    ride->reliability = Math::Max((uint16)0, (uint16)(ride->reliability - unreliabilityAccumulator));
+    ride->reliability = Math::Max<sint32>(0, (ride->reliability - unreliabilityAccumulator));
     ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE;
 
     // Random probability of a breakdown. Roughly this is 1 in


### PR DESCRIPTION
Reliability Graph goes over 100%. Its a overflow issue of uint16
additionally, change min value of reliability graph from 10 to 0
![fixed1](https://user-images.githubusercontent.com/13553317/35471496-a72d5670-039f-11e8-9876-4ce9133d56ec.PNG)
