### PR TITLE
Fix #7084: SC4 scenario completion not marked correctly

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -340,7 +340,7 @@ private:
 
     std::string GetRCT1ScenarioName()
     {
-        const scenario_index_entry * scenarioEntry = _scenarioRepository->GetByIndex(_s4.scenario_slot_index);
+        const scenario_index_entry * scenarioEntry = _scenarioRepository->GetByInternalName(_s4.scenario_name);
         return path_get_filename(scenarioEntry->path);
     }
 

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -389,7 +389,7 @@ public:
 		for (size_t i = 0; i < _scenarios.size(); i++) {
 			const scenario_index_entry * scenario = &_scenarios[i];
 
-			if (scenario->source_game == SCENARIO_SOURCE_OTHER)
+			if (scenario->source_game == SCENARIO_SOURCE_OTHER && scenario->sc_id == SC_UNIDENTIFIED)
 				continue;
 
 			// Note: this is always case insensitive search for cross platform consistency


### PR DESCRIPTION
This PR tweaks the S4 loader to use the internal scenario name rather than the slot number (which, I now realise, doesn't correspond to our internal scenario numbering!).