### PR TITLE
More consistent naming in the object selection and invention list windows

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1425,10 +1425,21 @@ static void filter_update_counts()
 static rct_string_id get_ride_type_string_id(const ObjectRepositoryItem * item)
 {
     rct_string_id result = STR_NONE;
-    for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++) {
+    for (sint32 i = 0; i < MAX_RIDE_TYPES_PER_RIDE_ENTRY; i++)
+    {
         uint8 rideType = item->RideType[i];
-        if (rideType != RIDE_TYPE_NULL) {
-            result = RideNaming[rideType].name;
+        if (rideType != RIDE_TYPE_NULL)
+        {
+            if (RideGroupManager::RideTypeHasRideGroups(rideType))
+            {
+                const RideGroup * rideGroup = RideGroupManager::RideGroupFind(rideType, item->RideGroupIndex);
+                result = rideGroup->Naming.name;
+            }
+            else
+            {
+                result = RideNaming[rideType].name;
+            }
+
             break;
         }
     }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -808,15 +808,9 @@ rct_string_id research_item_get_name(rct_research_item * researchItem)
         {
             return STR_EMPTY;
         }
-        else if (rideEntry->flags & RIDE_ENTRY_FLAG_SEPARATE_RIDE)
-        {
-            return rideEntry->naming.name;
-        }
         else
         {
-            uint8 baseRideType = researchItem->baseRideType;
-            // Makes sure the correct track name is displayed, e.g. Hyper-Twister instead of Steel Twister.
-            return research_get_friendly_base_ride_type_name(baseRideType, rideEntry);
+            return rideEntry->naming.name;
         }
     }
     else


### PR DESCRIPTION
This PR makes the ride type in the object selection match the one in the New Ride window. Previously, both regular Twister and Hyper-Twister vehicles were all listed as Twister vehicles, making it hard to see the difference.

![forest frontiers 2018-01-29 18-11-44](https://user-images.githubusercontent.com/1478678/35523777-e95ba386-051f-11e8-9301-e72ffc1480d4.png)
