### PR TITLE
Fix #6277: unable to advertise on IPv6-enabled link

### DIFF
--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -44,6 +44,7 @@ struct HttpRequest2
     std::string     Method;
     std::string     Url;
     http_data_type  Type;
+    bool            ForceIPv4 = false;
     size_t          Size = 0;
     union
     {
@@ -59,6 +60,7 @@ struct HttpRequest2
         Method = request.Method;
         Url = request.Url;
         Type = request.Type;
+        ForceIPv4 = request.ForceIPv4;
         Size = request.Size;
         if (request.Type == HTTP_DATA_JSON)
         {
@@ -77,6 +79,7 @@ struct HttpRequest2
         Method = std::string(request->method);
         Url = std::string(request->url);
         Type = request->type;
+        ForceIPv4 = request->forceIPv4;
         Size = request->size;
         if (request->type == HTTP_DATA_JSON)
         {
@@ -198,8 +201,11 @@ static http_response_t *http_request(const HttpRequest2 &request)
     curl_easy_setopt(curl, CURLOPT_URL, request.Url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writeBuffer);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, http_request_write_func);
-    // Force resolving to IPv4 to fix issues where advertising over IPv6 does not work
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+    if (request.ForceIPv4)
+    {
+        // Force resolving to IPv4 to fix issues where advertising over IPv6 does not work
+        curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+    }
 
     curlResult = curl_easy_perform(curl);
 

--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -198,6 +198,8 @@ static http_response_t *http_request(const HttpRequest2 &request)
     curl_easy_setopt(curl, CURLOPT_URL, request.Url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writeBuffer);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, http_request_write_func);
+    // Force resolving to IPv4 to fix issues where advertising over IPv6 does not work
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 
     curlResult = curl_easy_perform(curl);
 

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -186,10 +186,12 @@ private:
                 }
                 Console::Error::WriteLine("Unable to advertise (%d): %s", status, message);
                 // Hack for https://github.com/OpenRCT2/OpenRCT2/issues/6277
-                // Master server may not reply correctly if using IPv6, retry forcing IPv4
+                // Master server may not reply correctly if using IPv6, retry forcing IPv4,
+                // don't wait the full timeout.
                 if (!_forceIPv4 && status == 500)
                 {
                     _forceIPv4 = true;
+                    _lastAdvertiseTime = 0;
                     log_info("Retry with ipv4 only");
                 }
             }

--- a/src/openrct2/network/http.h
+++ b/src/openrct2/network/http.h
@@ -33,6 +33,7 @@ typedef struct http_request_t {
     std::string method;
     std::string url;
     http_data_type type = HTTP_DATA_NONE;
+    bool forceIPv4;
     size_t size;
     union {
         const json_t *root;


### PR DESCRIPTION
Credit goes to @ZehMatt for coming up with what might be wrong.

Our master server is hosted on heroku, which doesn't (fully?) support ipv6, yet somehow curl resolves it's address to ipv6.

This is problematic, because master server will use address of the incoming request to check for server being present there. To ~~solve~~ work around this issue, force curl to resolve the master server address to ipv4.