### PR TITLE
Add more object source filters

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4524,6 +4524,7 @@ STR_6214    :Skyscraper B
 STR_6215    :Construction
 STR_6216    :Operation
 STR_6217    :Ride / track availability
+STR_6218    :OpenRCT2 Official
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -40,25 +40,32 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 
-enum {
-    FILTER_RCT2 = (1 << 0),
-    FILTER_WW = (1 << 1),
-    FILTER_TT = (1 << 2),
-    FILTER_CUSTOM = (1 << 3),
+enum
+{
+    FILTER_RCT1 = (1 << 0),
+    FILTER_AA = (1 << 1),
+    FILTER_LL = (1 << 2),
+    FILTER_RCT2 = (1 << 3),
+    FILTER_WW = (1 << 4),
+    FILTER_TT = (1 << 5),
+    FILTER_OO = (1 << 6),
+    FILTER_CUSTOM = (1 << 7),
 
-    FILTER_RIDE_TRANSPORT = (1 << 5),
-    FILTER_RIDE_GENTLE = (1 << 6),
-    FILTER_RIDE_COASTER = (1 << 7),
-    FILTER_RIDE_THRILL = (1 << 8),
-    FILTER_RIDE_WATER = (1 << 9),
-    FILTER_RIDE_STALL = (1 << 10),
+    FILTER_RIDE_TRANSPORT = (1 << 8),
+    FILTER_RIDE_GENTLE = (1 << 9),
+    FILTER_RIDE_COASTER = (1 << 10),
+    FILTER_RIDE_THRILL = (1 << 11),
+    FILTER_RIDE_WATER = (1 << 12),
+    FILTER_RIDE_STALL = (1 << 13),
 
-    FILTER_SELECTED = (1 << 12),
-    FILTER_NONSELECTED = (1 << 13),
+    FILTER_SELECTED = (1 << 14),
+    FILTER_NONSELECTED = (1 << 15),
 
     FILTER_RIDES = FILTER_RIDE_TRANSPORT | FILTER_RIDE_GENTLE | FILTER_RIDE_COASTER | FILTER_RIDE_THRILL | FILTER_RIDE_WATER | FILTER_RIDE_STALL,
-    FILTER_ALL = FILTER_RIDES | FILTER_RCT2 | FILTER_WW | FILTER_TT | FILTER_CUSTOM | FILTER_SELECTED | FILTER_NONSELECTED,
+    FILTER_ALL = FILTER_RIDES | FILTER_RCT1 | FILTER_AA | FILTER_LL | FILTER_RCT2 | FILTER_WW | FILTER_TT | FILTER_OO | FILTER_CUSTOM | FILTER_SELECTED | FILTER_NONSELECTED,
 };
+
+static constexpr uint8 _numSourceGameItems = 8;
 
 static uint32 _filter_flags;
 static uint16 _filter_object_counts[11];
@@ -66,9 +73,13 @@ static uint16 _filter_object_counts[11];
 static char _filter_string[MAX_PATH];
 
 #define _FILTER_ALL ((_filter_flags & FILTER_ALL) == FILTER_ALL)
+#define _FILTER_RCT1 (_filter_flags & FILTER_RCT1)
+#define _FILTER_AA (_filter_flags & FILTER_AA)
+#define _FILTER_LL (_filter_flags & FILTER_LL)
 #define _FILTER_RCT2 (_filter_flags & FILTER_RCT2)
 #define _FILTER_WW (_filter_flags & FILTER_WW)
 #define _FILTER_TT (_filter_flags & FILTER_TT)
+#define _FILTER_OO (_filter_flags & FILTER_OO)
 #define _FILTER_CUSTOM (_filter_flags & FILTER_CUSTOM)
 #define _FILTER_SELECTED (_filter_flags & FILTER_SELECTED)
 #define _FILTER_NONSELECTED (_filter_flags & FILTER_NONSELECTED)
@@ -251,9 +262,13 @@ enum {
 };
 
 enum {
+    DDIX_FILTER_RCT1,
+    DDIX_FILTER_AA,
+    DDIX_FILTER_LL,
     DDIX_FILTER_RCT2,
     DDIX_FILTER_WW,
     DDIX_FILTER_TT,
+    DDIX_FILTER_OO,
     DDIX_FILTER_CUSTOM,
     DDIX_FILTER_SEPARATOR,
     DDIX_FILTER_SELECTED,
@@ -505,7 +520,7 @@ static void window_editor_object_selection_mouseup(rct_window *w, rct_widgetinde
     case WIDX_FILTER_RIDE_TAB_WATER:
     case WIDX_FILTER_RIDE_TAB_STALL:
         _filter_flags &= ~FILTER_RIDES;
-        _filter_flags |= (1 << (widgetIndex - WIDX_FILTER_RIDE_TAB_TRANSPORT + 5));
+        _filter_flags |= (1 << (widgetIndex - WIDX_FILTER_RIDE_TAB_TRANSPORT + _numSourceGameItems));
         gConfigInterface.object_selection_filter_flags = _filter_flags;
         config_save_default();
 
@@ -575,23 +590,33 @@ static void window_editor_object_selection_resize(rct_window *w)
 
 void window_editor_object_selection_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
-    sint32 num_items;
+    sint32 numSelectionItems = 0;
 
     switch (widgetIndex) {
     case WIDX_FILTER_DROPDOWN:
 
-        num_items = 4;
+        gDropdownItemsFormat[DDIX_FILTER_RCT1] = STR_TOGGLE_OPTION;
+        gDropdownItemsFormat[DDIX_FILTER_AA] = STR_TOGGLE_OPTION;
+        gDropdownItemsFormat[DDIX_FILTER_LL] = STR_TOGGLE_OPTION;
         gDropdownItemsFormat[DDIX_FILTER_RCT2] = STR_TOGGLE_OPTION;
         gDropdownItemsFormat[DDIX_FILTER_WW] = STR_TOGGLE_OPTION;
         gDropdownItemsFormat[DDIX_FILTER_TT] = STR_TOGGLE_OPTION;
+        gDropdownItemsFormat[DDIX_FILTER_OO] = STR_TOGGLE_OPTION;
         gDropdownItemsFormat[DDIX_FILTER_CUSTOM] = STR_TOGGLE_OPTION;
+
+        gDropdownItemsArgs[DDIX_FILTER_RCT1] = STR_SCENARIO_CATEGORY_RCT1;
+        gDropdownItemsArgs[DDIX_FILTER_AA] = STR_SCENARIO_CATEGORY_RCT1_AA;
+        gDropdownItemsArgs[DDIX_FILTER_LL] = STR_SCENARIO_CATEGORY_RCT1_LL;
         gDropdownItemsArgs[DDIX_FILTER_RCT2] = STR_ROLLERCOASTER_TYCOON_2_DROPDOWN;
         gDropdownItemsArgs[DDIX_FILTER_WW] = STR_OBJECT_FILTER_WW;
         gDropdownItemsArgs[DDIX_FILTER_TT] = STR_OBJECT_FILTER_TT;
+        gDropdownItemsArgs[DDIX_FILTER_OO] = STR_OBJECT_FILTER_OPENRCT2_OFFICIAL;
         gDropdownItemsArgs[DDIX_FILTER_CUSTOM] = STR_OBJECT_FILTER_CUSTOM;
+
         // Track manager cannot select multiple, so only show selection filters if not in track manager
-        if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)) {
-            num_items = 7;
+        if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
+        {
+            numSelectionItems = 3;
             gDropdownItemsFormat[DDIX_FILTER_SEPARATOR] = 0;
             gDropdownItemsFormat[DDIX_FILTER_SELECTED] = STR_TOGGLE_OPTION;
             gDropdownItemsFormat[DDIX_FILTER_NONSELECTED] = STR_TOGGLE_OPTION;
@@ -606,10 +631,10 @@ void window_editor_object_selection_mousedown(rct_window *w, rct_widgetindex wid
             widget->bottom - widget->top + 1,
             w->colours[widget->colour],
             DROPDOWN_FLAG_STAY_OPEN,
-            num_items
+            _numSourceGameItems + numSelectionItems
             );
 
-        for (sint32 i = 0; i < 4; i++)
+        for (sint32 i = 0; i < _numSourceGameItems; i++)
         {
             if (_filter_flags & (1 << i))
             {
@@ -922,7 +947,6 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
     rct_widget *widget;
     rct_object_entry *highlightedEntry;
     rct_string_id stringId;
-    uint8 source;
 
     /*if (w->selected_tab == WINDOW_OBJECT_SELECTION_PAGE_RIDE_VEHICLES_ATTRACTIONS) {
         gfx_fill_rect_inset(dpi,
@@ -1058,13 +1082,7 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
     }
 
     // Draw object source
-    source = (highlightedEntry->flags & 0xF0) >> 4;
-    switch (source) {
-    case 8: stringId = STR_ROLLERCOASTER_TYCOON_2_DROPDOWN; break;
-    case 1: stringId = STR_OBJECT_FILTER_WW; break;
-    case 2: stringId = STR_OBJECT_FILTER_TT; break;
-    default: stringId = STR_OBJECT_FILTER_CUSTOM; break;
-    }
+    stringId = object_manager_get_source_game_string(highlightedEntry);
     gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->x + w->width - 5, w->y + w->height - 3 - 12 - 14);
 
     //
@@ -1369,10 +1387,21 @@ static bool filter_source(const ObjectRepositoryItem * item)
         return true;
 
     uint8 source = object_entry_get_source_game(&item->ObjectEntry);
-    return (_FILTER_RCT2 && source == OBJECT_SOURCE_RCT2) ||
+    return (_FILTER_RCT1 && source == OBJECT_SOURCE_RCT1) ||
+           (_FILTER_AA && source == OBJECT_SOURCE_ADDED_ATTRACTIONS) ||
+           (_FILTER_LL && source == OBJECT_SOURCE_LOOPY_LANDSCAPES) ||
+           (_FILTER_RCT2 && source == OBJECT_SOURCE_RCT2) ||
            (_FILTER_WW && source == OBJECT_SOURCE_WACKY_WORLDS) ||
            (_FILTER_TT && source == OBJECT_SOURCE_TIME_TWISTER) ||
-           (_FILTER_CUSTOM && source != OBJECT_SOURCE_RCT2 && source != OBJECT_SOURCE_WACKY_WORLDS && source != OBJECT_SOURCE_TIME_TWISTER);
+           (_FILTER_OO && source == OBJECT_SOURCE_OPENRCT2_OFFICIAL) ||
+           (_FILTER_CUSTOM &&
+               source != OBJECT_SOURCE_RCT1 &&
+               source != OBJECT_SOURCE_ADDED_ATTRACTIONS &&
+               source != OBJECT_SOURCE_LOOPY_LANDSCAPES &&
+               source != OBJECT_SOURCE_RCT2 &&
+               source != OBJECT_SOURCE_WACKY_WORLDS &&
+               source != OBJECT_SOURCE_TIME_TWISTER &&
+               source != OBJECT_SOURCE_OPENRCT2_OFFICIAL);
 }
 
 static bool filter_chunks(const ObjectRepositoryItem * item)
@@ -1389,7 +1418,7 @@ static bool filter_chunks(const ObjectRepositoryItem * item)
                 break;
             }
         }
-        if (_filter_flags & (1 << (gRideCategories[rideType] + 5)))
+        if (_filter_flags & (1 << (gRideCategories[rideType] + _numSourceGameItems)))
             return true;
 
         return false;

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -296,7 +296,7 @@ namespace Config
             model->console_small_font = reader->GetBoolean("console_small_font", false);
             model->current_theme_preset = reader->GetCString("current_theme", "*RCT2");
             model->current_title_sequence_preset = reader->GetCString("current_title_sequence", "*OPENRCT2");
-            model->object_selection_filter_flags = reader->GetSint32("object_selection_filter_flags", 0x7EF);
+            model->object_selection_filter_flags = reader->GetSint32("object_selection_filter_flags", 0x3FFF);
         }
     }
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3874,6 +3874,8 @@ enum {
     STR_CHEAT_GROUP_OPERATION = 6216,
     STR_CHEAT_GROUP_AVAILABILITY = 6217,
 
+    STR_OBJECT_FILTER_OPENRCT2_OFFICIAL = 6218,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -50,7 +50,10 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
     const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
     static const rct_object_entry scgPathX = Object::GetScgPathXHeader();
 
-    if (objectEntry != nullptr && object_entry_get_source_game(objectEntry) != OBJECT_SOURCE_RCT2)
+    if (objectEntry != nullptr &&
+            (object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_WACKY_WORLDS ||
+             object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_TIME_TWISTER ||
+             object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_CUSTOM))
     {
         SetPrimarySceneryGroup(&scgPathX);
     }

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -22,301 +22,393 @@
 #include "Object.h"
 #include "ObjectLimits.h"
 
-static const char _rct1Objects[][9] =
+Object::Object(const rct_object_entry &entry)
 {
-    "CLIFT1  ",
-    "MONO1   ",
-    "MONO2   ",
-    "NRL     ",
-    "CTCAR   ",
-    "DODG1   ",
-    "FWH1    ",
-    "HHBUILD ",
-    "HMAZE   ",
-    "HSKELT  ",
-    "MGR1    ",
-    "OBS1    ",
-    "RCR     ",
-    "SPCAR   ",
-    "SRINGS  ",
-    "TRUCK1  ",
-    "AMT1    ",
-    "ARRSW1  ",
-    "ARRSW2  ",
-    "BMVD    ",
-    "BOB1    ",
-    "PTCT1   ",
-    "RCKC    ",
-    "REVF1   ",
-    "SKYTR   ",
-    "STEEP1  ",
-    "STEEP2  ",
-    "TOGST   ",
-    "WMMINE  ",
-    "WMOUSE  ",
-    "ZLDB    ",
-    "ZLOG    ",
-    "C3D     ",
-    "KART1   ",
-    "SIMPOD  ",
-    "SSC1    ",
-    "SWSH1   ",
-    "SWSH2   ",
-    "TOPSP1  ",
-    "TWIST1  ",
-    "BBOAT   ",
-    "CBOAT   ",
-    "DING1   ",
-    "LFB1    ",
-    "RAPBOAT ",
-    "RBOAT   ",
-    "SWANS   ",
-    "TRIKE   ",
-    "BALLN   ",
-    "BURGB   ",
-    "CHPSH   ",
-    "CNDYF   ",
-    "DRNKS   ",
-    "ICECR1  ",
-    "ICETST  ",
-    "INFOK   ",
-    "PIZZS   ",
-    "POPCS   ",
-    "SOUVS   ",
-    "TLT1    ",
+    _objectEntry = entry;
 
-    // Small scenery
-    "ALLSORT1",
-    "ALLSORT2",
-    "TAC     ",
-    "TAL     ",
-    "TAP     ",
-    "TAS     ",
-    "TAS1    ",
-    "TAS2    ",
-    "TAS3    ",
-    "TAS4    ",
-    "TB1     ",
-    "TB2     ",
-    "TBC     ",
-    "TBP     ",
-    "TBR     ",
-    "TBR1    ",
-    "TBR2    ",
-    "TBR3    ",
-    "TBR4    ",
-    "TBW     ",
-    "TCB     ",
-    "TCC     ",
-    "TCE     ",
-    "TCF     ",
-    "TCJ     ",
-    "TCL     ",
-    "TCO     ",
-    "TCRP    ",
-    "TCT     ",
-    "TCT1    ",
-    "TCT2    ",
-    "TCY     ",
-    "TDM     ",
-    "TEL     ",
-    "TEN     ",
-    "TEP     ",
-    "TERB    ",
-    "TERS    ",
-    "TES1    ",
-    "TF1     ",
-    "TF2     ",
-    "TGHC    ",
-    "TGHC2   ",
-    "TGS     ",
-    "TH1     ",
-    "TH2     ",
-    "THL     ",
-    "THRS    ",
-    "THT     ",
-    "TIC     ",
-    "TITC    ",
-    "TK1     ",
-    "TK2     ",
-    "TK3     ",
-    "TK4     ",
-    "TL0     ",
-    "TL1     ",
-    "TL2     ",
-    "TL3     ",
-    "TLC     ",
-    "TLP     ",
-    "TLY     ",
-    "TM0     ",
-    "TM1     ",
-    "TM2     ",
-    "TM3     ",
-    "TMBJ    ",
-    "TMC     ",
-    "TMG     ",
-    "TMJ     ",
-    "TML     ",
-    "TMO1    ",
-    "TMO2    ",
-    "TMO3    ",
-    "TMO4    ",
-    "TMO5    ",
-    "TMP     ",
-    "TMS1    ",
-    "TMW     ",
-    "TMZP    ",
-    "TNS     ",
-    "TP1     ",
-    "TP2     ",
-    "TPM     ",
-    "TQ1     ",
-    "TQ2     ",
-    "TR1     ",
-    "TR2     ",
-    "TRC     ",
-    "TRF     ",
-    "TRF2    ",
-    "TRMS    ",
-    "TRWS    ",
-    "TS0     ",
-    "TS1     ",
-    "TS2     ",
-    "TS3     ",
-    "TS4     ",
-    "TS5     ",
-    "TS6     ",
-    "TSB     ",
-    "TSC     ",
-    "TSD     ",
-    "TSH     ",
-    "TSH0    ",
-    "TSH1    ",
-    "TSH2    ",
-    "TSH3    ",
-    "TSH4    ",
-    "TSH5    ",
-    "TSP     ",
-    "TSQ     ",
-    "TST1    ",
-    "TST2    ",
-    "TST3    ",
-    "TST4    ",
-    "TST5    ",
-    "TSTD    ",
-    "TT1     ",
-    "TUS     ",
-    "TVL     ",
-    "TWH1    ",
-    "TWH2    ",
-    "TWN     ",
-    "TWP     ",
-    "TWW     ",
-    "TDF     ",
-    "TEF     ",
-    "TQF     ",
-    "TTF     ",
-    "TWF     ",
-    "TCK     ",
-    "TG1     ",
-    "TG10    ",
-    "TG11    ",
-    "TG12    ",
-    "TG13    ",
-    "TG14    ",
-    "TG15    ",
-    "TG16    ",
-    "TG17    ",
-    "TG18    ",
-    "TG19    ",
-    "TG2     ",
-    "TG20    ",
-    "TG21    ",
-    "TG3     ",
-    "TG4     ",
-    "TG5     ",
-    "TG6     ",
-    "TG7     ",
-    "TG8     ",
-    "TG9     ",
+    char name[DAT_NAME_LENGTH + 1] = { 0 };
+    Memory::Copy(name, entry.name, DAT_NAME_LENGTH);
+    _identifier = String::Duplicate(name);
 
-    // Large Scenery
-    "SCLN    ",
-    "SHS1    ",
-    "SHS2    ",
-    "SMH1    ",
-    "SMH2    ",
-    "SMN1    ",
-    "SCOL    ",
-    "SMB     ",
-    "SPYR    ",
-    "SSPX    ",
+    if (IsRCT1Object())
+    {
+        SetSourceGame(OBJECT_SOURCE_RCT1);
+    }
+    else if (IsAAObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_ADDED_ATTRACTIONS);
+    }
+    else if (IsLLObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_LOOPY_LANDSCAPES);
+    }
+    else if (IsOpenRCT2OfficialObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_OPENRCT2_OFFICIAL);
+    }
+}
 
-    // Walls
-    "WC3     ",
-    "WBR1    ",
-    "WBR2    ",
-    "WBR3    ",
-    "WBRG    ",
-    "WCH     ",
-    "WCHG    ",
-    "WCW1    ",
-    "WCW2    ",
-    "WEW     ",
-    "WFW1    ",
-    "WFWG    ",
-    "WHG     ",
-    "WHGG    ",
-    "WMF     ",
-    "WMFG    ",
-    "WMW     ",
-    "WMWW    ",
-    "WPF     ",
-    "WPFG    ",
-    "WRW     ",
-    "WSW     ",
-    "WSW1    ",
-    "WSW2    ",
-    "WSWG    ",
-
-    // Paths
-    "PATHCRZY",
-    "PATHDIRT",
-    "ROAD    ",
-    "TARMAC  ",
-
-    // Path additions
-    "LAMP1   ",
-    "LAMP2   ",
-    "LAMP3   ",
-    "LAMP4   ",
-    "LITTER1 ",
-    "BENCH1  ",
-    "BENCHSTN",
-    "JUMPFNT1",
-
-    // Scenery groups
-    "SCGFENCE",
-    "SCGGARDN",
-    "SCGPATHX",
-    "SCGSHRUB",
-    "SCGTREES",
-
-    "SCGCLASS",
-    "SCGEGYPT",
-    "SCGMART ",
-    "SCGMINE ",
-    "SCGWOND ",
-
-    // Park entrance
-    "PKENT1  ",
-
-    // Water
-    "WTRCYAN ",
-};
-
-static const char _aaObjects[][9] =
+Object::~Object()
 {
+    Memory::Free(_identifier);
+}
+
+std::string Object::GetOverrideString(uint8 index) const
+{
+    const char * identifier = GetIdentifier();
+    rct_string_id stringId = language_get_object_override_string_id(identifier, index);
+
+    const utf8 * result = nullptr;
+    if (stringId != STR_NONE)
+    {
+        result = language_get_string(stringId);
+    }
+    return String::ToStd(result);
+}
+
+std::string Object::GetString(uint8 index) const
+{
+    auto sz = GetOverrideString(index);
+    if (sz.empty())
+    {
+        sz = GetStringTable()->GetString(index);
+    }
+    return sz;
+}
+
+rct_object_entry Object::GetScgWallsHeader()
+{
+    return Object::CreateHeader("SCGWALLS", 207140231, 3518650219);
+}
+
+rct_object_entry Object::GetScgPathXHeader()
+{
+    return Object::CreateHeader("SCGPATHX", 207140231, 890227440);
+}
+
+rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint32 flags, uint32 checksum)
+{
+    rct_object_entry header = { 0 };
+    header.flags = flags;
+    Memory::Copy(header.name, name, DAT_NAME_LENGTH);
+    header.checksum = checksum;
+    return header;
+}
+
+void Object::SetSourceGame(const uint8 sourceGame)
+{
+    _objectEntry.flags &= 0x0F;
+    _objectEntry.flags |= (sourceGame << 4);
+}
+
+bool Object::IsRCT1Object()
+{
+    static const char _rct1Objects[][9] =
+    {
+        "CLIFT1  ",
+        "MONO1   ",
+        "MONO2   ",
+        "NRL     ",
+        "CTCAR   ",
+        "DODG1   ",
+        "FWH1    ",
+        "HHBUILD ",
+        "HMAZE   ",
+        "HSKELT  ",
+        "MGR1    ",
+        "OBS1    ",
+        "RCR     ",
+        "SPCAR   ",
+        "SRINGS  ",
+        "TRUCK1  ",
+        "AMT1    ",
+        "ARRSW1  ",
+        "ARRSW2  ",
+        "BMVD    ",
+        "BOB1    ",
+        "PTCT1   ",
+        "RCKC    ",
+        "REVF1   ",
+        "SKYTR   ",
+        "STEEP1  ",
+        "STEEP2  ",
+        "TOGST   ",
+        "WMMINE  ",
+        "WMOUSE  ",
+        "ZLDB    ",
+        "ZLOG    ",
+        "C3D     ",
+        "KART1   ",
+        "SIMPOD  ",
+        "SSC1    ",
+        "SWSH1   ",
+        "SWSH2   ",
+        "TOPSP1  ",
+        "TWIST1  ",
+        "BBOAT   ",
+        "CBOAT   ",
+        "DING1   ",
+        "LFB1    ",
+        "RAPBOAT ",
+        "RBOAT   ",
+        "SWANS   ",
+        "TRIKE   ",
+        "BALLN   ",
+        "BURGB   ",
+        "CHPSH   ",
+        "CNDYF   ",
+        "DRNKS   ",
+        "ICECR1  ",
+        "ICETST  ",
+        "INFOK   ",
+        "PIZZS   ",
+        "POPCS   ",
+        "SOUVS   ",
+        "TLT1    ",
+
+        // Small scenery
+        "ALLSORT1",
+        "ALLSORT2",
+        "TAC     ",
+        "TAL     ",
+        "TAP     ",
+        "TAS     ",
+        "TAS1    ",
+        "TAS2    ",
+        "TAS3    ",
+        "TAS4    ",
+        "TB1     ",
+        "TB2     ",
+        "TBC     ",
+        "TBP     ",
+        "TBR     ",
+        "TBR1    ",
+        "TBR2    ",
+        "TBR3    ",
+        "TBR4    ",
+        "TBW     ",
+        "TCB     ",
+        "TCC     ",
+        "TCE     ",
+        "TCF     ",
+        "TCJ     ",
+        "TCL     ",
+        "TCO     ",
+        "TCRP    ",
+        "TCT     ",
+        "TCT1    ",
+        "TCT2    ",
+        "TCY     ",
+        "TDM     ",
+        "TEL     ",
+        "TEN     ",
+        "TEP     ",
+        "TERB    ",
+        "TERS    ",
+        "TES1    ",
+        "TF1     ",
+        "TF2     ",
+        "TGHC    ",
+        "TGHC2   ",
+        "TGS     ",
+        "TH1     ",
+        "TH2     ",
+        "THL     ",
+        "THRS    ",
+        "THT     ",
+        "TIC     ",
+        "TITC    ",
+        "TK1     ",
+        "TK2     ",
+        "TK3     ",
+        "TK4     ",
+        "TL0     ",
+        "TL1     ",
+        "TL2     ",
+        "TL3     ",
+        "TLC     ",
+        "TLP     ",
+        "TLY     ",
+        "TM0     ",
+        "TM1     ",
+        "TM2     ",
+        "TM3     ",
+        "TMBJ    ",
+        "TMC     ",
+        "TMG     ",
+        "TMJ     ",
+        "TML     ",
+        "TMO1    ",
+        "TMO2    ",
+        "TMO3    ",
+        "TMO4    ",
+        "TMO5    ",
+        "TMP     ",
+        "TMS1    ",
+        "TMW     ",
+        "TMZP    ",
+        "TNS     ",
+        "TP1     ",
+        "TP2     ",
+        "TPM     ",
+        "TQ1     ",
+        "TQ2     ",
+        "TR1     ",
+        "TR2     ",
+        "TRC     ",
+        "TRF     ",
+        "TRF2    ",
+        "TRMS    ",
+        "TRWS    ",
+        "TS0     ",
+        "TS1     ",
+        "TS2     ",
+        "TS3     ",
+        "TS4     ",
+        "TS5     ",
+        "TS6     ",
+        "TSB     ",
+        "TSC     ",
+        "TSD     ",
+        "TSH     ",
+        "TSH0    ",
+        "TSH1    ",
+        "TSH2    ",
+        "TSH3    ",
+        "TSH4    ",
+        "TSH5    ",
+        "TSP     ",
+        "TSQ     ",
+        "TST1    ",
+        "TST2    ",
+        "TST3    ",
+        "TST4    ",
+        "TST5    ",
+        "TSTD    ",
+        "TT1     ",
+        "TUS     ",
+        "TVL     ",
+        "TWH1    ",
+        "TWH2    ",
+        "TWN     ",
+        "TWP     ",
+        "TWW     ",
+        "TDF     ",
+        "TEF     ",
+        "TQF     ",
+        "TTF     ",
+        "TWF     ",
+        "TCK     ",
+        "TG1     ",
+        "TG10    ",
+        "TG11    ",
+        "TG12    ",
+        "TG13    ",
+        "TG14    ",
+        "TG15    ",
+        "TG16    ",
+        "TG17    ",
+        "TG18    ",
+        "TG19    ",
+        "TG2     ",
+        "TG20    ",
+        "TG21    ",
+        "TG3     ",
+        "TG4     ",
+        "TG5     ",
+        "TG6     ",
+        "TG7     ",
+        "TG8     ",
+        "TG9     ",
+
+        // Large Scenery
+        "SCLN    ",
+        "SHS1    ",
+        "SHS2    ",
+        "SMH1    ",
+        "SMH2    ",
+        "SMN1    ",
+        "SCOL    ",
+        "SMB     ",
+        "SPYR    ",
+        "SSPX    ",
+
+        // Walls
+        "WC3     ",
+        "WBR1    ",
+        "WBR2    ",
+        "WBR3    ",
+        "WBRG    ",
+        "WCH     ",
+        "WCHG    ",
+        "WCW1    ",
+        "WCW2    ",
+        "WEW     ",
+        "WFW1    ",
+        "WFWG    ",
+        "WHG     ",
+        "WHGG    ",
+        "WMF     ",
+        "WMFG    ",
+        "WMW     ",
+        "WMWW    ",
+        "WPF     ",
+        "WPFG    ",
+        "WRW     ",
+        "WSW     ",
+        "WSW1    ",
+        "WSW2    ",
+        "WSWG    ",
+
+        // Paths
+        "PATHCRZY",
+        "PATHDIRT",
+        "ROAD    ",
+        "TARMAC  ",
+
+        // Path additions
+        "LAMP1   ",
+        "LAMP2   ",
+        "LAMP3   ",
+        "LAMP4   ",
+        "LITTER1 ",
+        "BENCH1  ",
+        "BENCHSTN",
+        "JUMPFNT1",
+
+        // Scenery groups
+        "SCGFENCE",
+        "SCGGARDN",
+        "SCGPATHX",
+        "SCGSHRUB",
+        "SCGTREES",
+
+        "SCGCLASS",
+        "SCGEGYPT",
+        "SCGMART ",
+        "SCGMINE ",
+        "SCGWOND ",
+
+        // Park entrance
+        "PKENT1  ",
+
+        // Water
+        "WTRCYAN ",
+    };
+
+    for (const auto entry : _rct1Objects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Object::IsAAObject()
+{
+    static const char _aaObjects[][9] =
+    {
         // Rides / vehicles / stalls
         "BMFL    ",
         "BMRB    ",
@@ -418,10 +510,21 @@ static const char _aaObjects[][9] =
         "SCGJUNGL",
         "SCGJURAS",
         "SCGSPOOK",
-};
+    };
 
-static const char _llObjects[][9] =
+    for (const auto entry : _aaObjects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Object::IsLLObject()
 {
+    static const char _llObjects[][9] =
+    {
         // Rides / vehicles / stalls
         "AML1    ",
         "ARRT2   ",
@@ -536,150 +639,8 @@ static const char _llObjects[][9] =
 
         // Water
         "WTRORNG ",
-};
+    };
 
-static const char _openRCT2OfficialObjects[][9] =
-{
-    // Offical extended scenery set
-    "XXBBBR01",
-    "TTRFTL02",
-    "TTRFTL03",
-    "TTRFTL04",
-    "TTRFTL07",
-    "TTRFTL08",
-    "TTPIRF02",
-    "TTPIRF03",
-    "TTPIRF04",
-    "TTPIRF05",
-    "TTPIRF07",
-    "TTPIRF08",
-    "MG-PRAR ",
-    "TTRFWD01",
-    "TTRFWD02",
-    "TTRFWD03",
-    "TTRFWD04",
-    "TTRFWD05",
-    "TTRFWD06",
-    "TTRFWD07",
-    "TTRFWD08",
-    "TTRFGL01",
-    "TTRFGL02",
-    "TTRFGL03",
-    "ACWW33  ",
-    "ACWWF32 ",
-
-    // Official DLC
-    "BIGPANDA",
-    "LITTERPA",
-    "PANDAGR ",
-    "SCGPANDA",
-    "WTRPINK ",
-    "ZPANDA  ",
-};
-
-Object::Object(const rct_object_entry &entry)
-{
-    _objectEntry = entry;
-
-    char name[DAT_NAME_LENGTH + 1] = { 0 };
-    Memory::Copy(name, entry.name, DAT_NAME_LENGTH);
-    _identifier = String::Duplicate(name);
-
-    if (IsRCT1Object())
-    {
-        SetSourceGame(OBJECT_SOURCE_RCT1);
-    }
-    else if (IsAAObject())
-    {
-        SetSourceGame(OBJECT_SOURCE_ADDED_ATTRACTIONS);
-    }
-    else if (IsLLObject())
-    {
-        SetSourceGame(OBJECT_SOURCE_LOOPY_LANDSCAPES);
-    }
-    else if (IsOpenRCT2OfficialObject())
-    {
-        SetSourceGame(OBJECT_SOURCE_OPENRCT2_OFFICIAL);
-    }
-}
-
-Object::~Object()
-{
-    Memory::Free(_identifier);
-}
-
-std::string Object::GetOverrideString(uint8 index) const
-{
-    const char * identifier = GetIdentifier();
-    rct_string_id stringId = language_get_object_override_string_id(identifier, index);
-
-    const utf8 * result = nullptr;
-    if (stringId != STR_NONE)
-    {
-        result = language_get_string(stringId);
-    }
-    return String::ToStd(result);
-}
-
-std::string Object::GetString(uint8 index) const
-{
-    auto sz = GetOverrideString(index);
-    if (sz.empty())
-    {
-        sz = GetStringTable()->GetString(index);
-    }
-    return sz;
-}
-
-rct_object_entry Object::GetScgWallsHeader()
-{
-    return Object::CreateHeader("SCGWALLS", 207140231, 3518650219);
-}
-
-rct_object_entry Object::GetScgPathXHeader()
-{
-    return Object::CreateHeader("SCGPATHX", 207140231, 890227440);
-}
-
-rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint32 flags, uint32 checksum)
-{
-    rct_object_entry header = { 0 };
-    header.flags = flags;
-    Memory::Copy(header.name, name, DAT_NAME_LENGTH);
-    header.checksum = checksum;
-    return header;
-}
-
-void Object::SetSourceGame(const uint8 sourceGame)
-{
-    _objectEntry.flags &= 0x0F;
-    _objectEntry.flags |= (sourceGame << 4);
-}
-
-bool Object::IsRCT1Object()
-{
-    for (const auto entry : _rct1Objects)
-    {
-        if (String::Equals(_identifier, entry))
-            return true;
-    }
-
-    return false;
-}
-
-bool Object::IsAAObject()
-{
-    for (const auto entry : _aaObjects)
-    {
-        if (String::Equals(_identifier, entry))
-            return true;
-    }
-
-    return false;
-}
-
-bool Object::IsLLObject()
-{
     for (const auto entry : _llObjects)
     {
         if (String::Equals(_identifier, entry))
@@ -691,6 +652,45 @@ bool Object::IsLLObject()
 
 bool Object::IsOpenRCT2OfficialObject()
 {
+    static const char _openRCT2OfficialObjects[][9] =
+    {
+        // Offical extended scenery set
+        "XXBBBR01",
+        "TTRFTL02",
+        "TTRFTL03",
+        "TTRFTL04",
+        "TTRFTL07",
+        "TTRFTL08",
+        "TTPIRF02",
+        "TTPIRF03",
+        "TTPIRF04",
+        "TTPIRF05",
+        "TTPIRF07",
+        "TTPIRF08",
+        "MG-PRAR ",
+        "TTRFWD01",
+        "TTRFWD02",
+        "TTRFWD03",
+        "TTRFWD04",
+        "TTRFWD05",
+        "TTRFWD06",
+        "TTRFWD07",
+        "TTRFWD08",
+        "TTRFGL01",
+        "TTRFGL02",
+        "TTRFGL03",
+        "ACWW33  ",
+        "ACWWF32 ",
+
+        // Official DLC
+        "BIGPANDA",
+        "LITTERPA",
+        "PANDAGR ",
+        "SCGPANDA",
+        "WTRPINK ",
+        "ZPANDA  ",
+    };
+
     for (const auto entry : _openRCT2OfficialObjects)
     {
         if (String::Equals(_identifier, entry))

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <algorithm>
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
 #include "../localisation/Language.h"
@@ -21,6 +22,560 @@
 #include "Object.h"
 #include "ObjectLimits.h"
 
+static const char _rct1Objects[][9] =
+{
+    "CLIFT1  ",
+    "MONO1   ",
+    "MONO2   ",
+    "NRL     ",
+    "CTCAR   ",
+    "DODG1   ",
+    "FWH1    ",
+    "HHBUILD ",
+    "HMAZE   ",
+    "HSKELT  ",
+    "MGR1    ",
+    "OBS1    ",
+    "RCR     ",
+    "SPCAR   ",
+    "SRINGS  ",
+    "TRUCK1  ",
+    "AMT1    ",
+    "ARRSW1  ",
+    "ARRSW2  ",
+    "BMVD    ",
+    "BOB1    ",
+    "PTCT1   ",
+    "RCKC    ",
+    "REVF1   ",
+    "SKYTR   ",
+    "STEEP1  ",
+    "STEEP2  ",
+    "TOGST   ",
+    "WMMINE  ",
+    "WMOUSE  ",
+    "ZLDB    ",
+    "ZLOG    ",
+    "C3D     ",
+    "KART1   ",
+    "SIMPOD  ",
+    "SSC1    ",
+    "SWSH1   ",
+    "SWSH2   ",
+    "TOPSP1  ",
+    "TWIST1  ",
+    "BBOAT   ",
+    "CBOAT   ",
+    "DING1   ",
+    "LFB1    ",
+    "RAPBOAT ",
+    "RBOAT   ",
+    "SWANS   ",
+    "TRIKE   ",
+    "BALLN   ",
+    "BURGB   ",
+    "CHPSH   ",
+    "CNDYF   ",
+    "DRNKS   ",
+    "ICECR1  ",
+    "ICETST  ",
+    "INFOK   ",
+    "PIZZS   ",
+    "POPCS   ",
+    "SOUVS   ",
+    "TLT1    ",
+
+    // Small scenery
+    "ALLSORT1",
+    "ALLSORT2",
+    "TAC     ",
+    "TAL     ",
+    "TAP     ",
+    "TAS     ",
+    "TAS1    ",
+    "TAS2    ",
+    "TAS3    ",
+    "TAS4    ",
+    "TB1     ",
+    "TB2     ",
+    "TBC     ",
+    "TBP     ",
+    "TBR     ",
+    "TBR1    ",
+    "TBR2    ",
+    "TBR3    ",
+    "TBR4    ",
+    "TBW     ",
+    "TCB     ",
+    "TCC     ",
+    "TCE     ",
+    "TCF     ",
+    "TCJ     ",
+    "TCL     ",
+    "TCO     ",
+    "TCRP    ",
+    "TCT     ",
+    "TCT1    ",
+    "TCT2    ",
+    "TCY     ",
+    "TDM     ",
+    "TEL     ",
+    "TEN     ",
+    "TEP     ",
+    "TERB    ",
+    "TERS    ",
+    "TES1    ",
+    "TF1     ",
+    "TF2     ",
+    "TGHC    ",
+    "TGHC2   ",
+    "TGS     ",
+    "TH1     ",
+    "TH2     ",
+    "THL     ",
+    "THRS    ",
+    "THT     ",
+    "TIC     ",
+    "TITC    ",
+    "TK1     ",
+    "TK2     ",
+    "TK3     ",
+    "TK4     ",
+    "TL0     ",
+    "TL1     ",
+    "TL2     ",
+    "TL3     ",
+    "TLC     ",
+    "TLP     ",
+    "TLY     ",
+    "TM0     ",
+    "TM1     ",
+    "TM2     ",
+    "TM3     ",
+    "TMBJ    ",
+    "TMC     ",
+    "TMG     ",
+    "TMJ     ",
+    "TML     ",
+    "TMO1    ",
+    "TMO2    ",
+    "TMO3    ",
+    "TMO4    ",
+    "TMO5    ",
+    "TMP     ",
+    "TMS1    ",
+    "TMW     ",
+    "TMZP    ",
+    "TNS     ",
+    "TP1     ",
+    "TP2     ",
+    "TPM     ",
+    "TQ1     ",
+    "TQ2     ",
+    "TR1     ",
+    "TR2     ",
+    "TRC     ",
+    "TRF     ",
+    "TRF2    ",
+    "TRMS    ",
+    "TRWS    ",
+    "TS0     ",
+    "TS1     ",
+    "TS2     ",
+    "TS3     ",
+    "TS4     ",
+    "TS5     ",
+    "TS6     ",
+    "TSB     ",
+    "TSC     ",
+    "TSD     ",
+    "TSH     ",
+    "TSH0    ",
+    "TSH1    ",
+    "TSH2    ",
+    "TSH3    ",
+    "TSH4    ",
+    "TSH5    ",
+    "TSP     ",
+    "TSQ     ",
+    "TST1    ",
+    "TST2    ",
+    "TST3    ",
+    "TST4    ",
+    "TST5    ",
+    "TSTD    ",
+    "TT1     ",
+    "TUS     ",
+    "TVL     ",
+    "TWH1    ",
+    "TWH2    ",
+    "TWN     ",
+    "TWP     ",
+    "TWW     ",
+    "TDF     ",
+    "TEF     ",
+    "TQF     ",
+    "TTF     ",
+    "TWF     ",
+    "TCK     ",
+    "TG1     ",
+    "TG10    ",
+    "TG11    ",
+    "TG12    ",
+    "TG13    ",
+    "TG14    ",
+    "TG15    ",
+    "TG16    ",
+    "TG17    ",
+    "TG18    ",
+    "TG19    ",
+    "TG2     ",
+    "TG20    ",
+    "TG21    ",
+    "TG3     ",
+    "TG4     ",
+    "TG5     ",
+    "TG6     ",
+    "TG7     ",
+    "TG8     ",
+    "TG9     ",
+
+    // Large Scenery
+    "SCLN    ",
+    "SHS1    ",
+    "SHS2    ",
+    "SMH1    ",
+    "SMH2    ",
+    "SMN1    ",
+    "SCOL    ",
+    "SMB     ",
+    "SPYR    ",
+    "SSPX    ",
+
+    // Walls
+    "WC3     ",
+    "WBR1    ",
+    "WBR2    ",
+    "WBR3    ",
+    "WBRG    ",
+    "WCH     ",
+    "WCHG    ",
+    "WCW1    ",
+    "WCW2    ",
+    "WEW     ",
+    "WFW1    ",
+    "WFWG    ",
+    "WHG     ",
+    "WHGG    ",
+    "WMF     ",
+    "WMFG    ",
+    "WMW     ",
+    "WMWW    ",
+    "WPF     ",
+    "WPFG    ",
+    "WRW     ",
+    "WSW     ",
+    "WSW1    ",
+    "WSW2    ",
+    "WSWG    ",
+
+    // Paths
+    "PATHCRZY",
+    "PATHDIRT",
+    "ROAD    ",
+    "TARMAC  ",
+
+    // Path additions
+    "LAMP1   ",
+    "LAMP2   ",
+    "LAMP3   ",
+    "LAMP4   ",
+    "LITTER1 ",
+    "BENCH1  ",
+    "BENCHSTN",
+    "JUMPFNT1",
+
+    // Scenery groups
+    "SCGFENCE",
+    "SCGGARDN",
+    "SCGPATHX",
+    "SCGSHRUB",
+    "SCGTREES",
+
+    "SCGCLASS",
+    "SCGEGYPT",
+    "SCGMART ",
+    "SCGMINE ",
+    "SCGWOND ",
+
+    // Park entrance
+    "PKENT1  ",
+
+    // Water
+    "WTRCYAN ",
+};
+
+static const char _aaObjects[][9] =
+{
+        // Rides / vehicles / stalls
+        "BMFL    ",
+        "BMRB    ",
+        "BMSD    ",
+        "BMSU    ",
+        "CHBUILD ",
+        "CIRCUS1 ",
+        "CLIFT2  ",
+        "FSAUC   ",
+        "GDROP1  ",
+        "GOLF1   ",
+        "GTC     ",
+        "HATST   ",
+        "HELICAR ",
+        "HOTDS   ",
+        "MFT     ",
+        "MONBK   ",
+        "NRL2    ",
+        "REVCAR  ",
+        "SFRIC1  ",
+        "SMC1    ",
+        "SMONO   ",
+        "SPBOAT  ",
+        "SQDST   ",
+        "TOFFS   ",
+        "UTCAR   ",
+        "UTCARR  ",
+        "VCR     ",
+        "VEKST   ",
+        "VREEL   ",
+
+        // Small scenery
+        "TBN     ",
+        "TBN1    ",
+        "TDN4    ",
+        "TDN5    ",
+        "TDT1    ",
+        "TDT2    ",
+        "TDT3    ",
+        "TGC1    ",
+        "TGC2    ",
+        "TGE1    ",
+        "TGE2    ",
+        "TGE3    ",
+        "TGE4    ",
+        "TGE5    ",
+        "TGS1    ",
+        "TGS2    ",
+        "TGS3    ",
+        "TGS4    ",
+        "TJB1    ",
+        "TJB2    ",
+        "TJB3    ",
+        "TJB4    ",
+        "TJF     ",
+        "TJP1    ",
+        "TJP2    ",
+        "TJT1    ",
+        "TJT2    ",
+        "TJT3    ",
+        "TJT4    ",
+        "TJT5    ",
+        "TJT6    ",
+        "TMM1    ",
+        "TMM2    ",
+        "TMM3    ",
+
+        // Large scenery
+        "SDN1    ",
+        "SDN2    ",
+        "SDN3    ",
+        "SSK1    ",
+
+        // Walls
+        "WALLGL16",
+        "WBW     ",
+        "WGW2    ",
+        "WJF     ",
+        "WPW1    ",
+        "WPW2    ",
+        "WWTW    ",
+
+        // Banners
+        "BN1     ",
+        "BN2     ",
+        "BN3     ",
+        "BN4     ",
+        "BN5     ",
+        "BN6     ",
+
+        // Paths
+        "PATHASH ",
+        "PATHSPCE",
+        "TARMACB ",
+        "TARMACG ",
+
+        // Scenery groups
+        "SCGABSTR",
+        "SCGJUNGL",
+        "SCGJURAS",
+        "SCGSPOOK",
+};
+
+static const char _llObjects[][9] =
+{
+        // Rides / vehicles / stalls
+        "AML1    ",
+        "ARRT2   ",
+        "CHCKS   ",
+        "COFFS   ",
+        "CSTBOAT ",
+        "DOUGH   ",
+        "ENTERP  ",
+        "IVMC1   ",
+        "JSKI    ",
+        "LEMST   ",
+        "NEMT    ",
+        "RFTBOAT ",
+        "SLCFO   ",
+        "THCAR   ",
+        "TSHRT   ",
+
+        // Small scenery
+        "TCD     ",
+        "TCFS    ",
+        "TCN     ",
+        "TGG     ",
+        "TGH1    ",
+        "TGH2    ",
+        "TIG     ",
+        "TNSS    ",
+        "TOH1    ",
+        "TOH2    ",
+        "TOH3    ",
+        "TOS     ",
+        "TOT1    ",
+        "TOT2    ",
+        "TOT3    ",
+        "TOT4    ",
+        "TRF3    ",
+        "TRFS    ",
+        "TSC2    ",
+        "TSCP    ",
+        "TSF1    ",
+        "TSF2    ",
+        "TSF3    ",
+        "TSG     ",
+        "TSK     ",
+        "TSM     ",
+        "TSMP    ",
+        "TSNB    ",
+        "TSNC    ",
+        "TSP1    ",
+        "TSP2    ",
+        "TSPH    ",
+        "TTG     ",
+
+        // Large scenery
+        "SAH     ",
+        "SAH2    ",
+        "SAH3    ",
+        "SCT     ",
+        "SGP     ",
+        "SIP     ",
+        "SOB     ",
+        "SOH1    ",
+        "SOH2    ",
+        "SOH3    ",
+        "SPG     ",
+        "SPS     ",
+        "SSH     ",
+        "SSR     ",
+        "SST     ",
+        "STB1    ",
+        "STB2    ",
+        "STG1    ",
+        "STG2    ",
+        "STH     ",
+
+        // Walls
+        "WC1     ",
+        "WC10    ",
+        "WC11    ",
+        "WC12    ",
+        "WC13    ",
+        "WC14    ",
+        "WC15    ",
+        "WC16    ",
+        "WC17    ",
+        "WC18    ",
+        "WC2     ",
+        "WC4     ",
+        "WC5     ",
+        "WC6     ",
+        "WC7     ",
+        "WC8     ",
+        "WC9     ",
+        "WPW3    ",
+
+        // Banners
+        "BN7     ",
+        "BN8     ",
+        "BN9     ",
+
+        // Path additions
+        "BENCHSPC",
+        "JUMPSNW1",
+        "LITTERSP",
+
+        // Scenery groups
+        "SCGHALLO",
+        "SCGMEDIE",
+        "SCGORIEN",
+        "SCGSNOW ",
+        "SCGSPACE",
+        "SCGURBAN",
+
+        // Water
+        "WTRORNG ",
+};
+
+static const char _openRCT2OfficialObjects[][9] =
+{
+    // Offical extended scenery set
+    "XXBBBR01",
+    "TTRFTL02",
+    "TTRFTL03",
+    "TTRFTL04",
+    "TTRFTL07",
+    "TTRFTL08",
+    "TTPIRF02",
+    "TTPIRF03",
+    "TTPIRF04",
+    "TTPIRF05",
+    "TTPIRF07",
+    "TTPIRF08",
+    "MG-PRAR ",
+    "TTRFWD01",
+    "TTRFWD02",
+    "TTRFWD03",
+    "TTRFWD04",
+    "TTRFWD05",
+    "TTRFWD06",
+    "TTRFWD07",
+    "TTRFWD08",
+    "TTRFGL01",
+    "TTRFGL02",
+    "TTRFGL03",
+    "ACWW33  ",
+    "ACWWF32 ",
+
+    // Official DLC
+    "BIGPANDA",
+    "LITTERPA",
+    "PANDAGR ",
+    "SCGPANDA",
+    "WTRPINK ",
+    "ZPANDA  ",
+};
 
 Object::Object(const rct_object_entry &entry)
 {
@@ -29,6 +584,23 @@ Object::Object(const rct_object_entry &entry)
     char name[DAT_NAME_LENGTH + 1] = { 0 };
     Memory::Copy(name, entry.name, DAT_NAME_LENGTH);
     _identifier = String::Duplicate(name);
+
+    if (IsRCT1Object())
+    {
+        SetSourceGame(OBJECT_SOURCE_RCT1);
+    }
+    else if (IsAAObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_ADDED_ATTRACTIONS);
+    }
+    else if (IsLLObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_LOOPY_LANDSCAPES);
+    }
+    else if (IsOpenRCT2OfficialObject())
+    {
+        SetSourceGame(OBJECT_SOURCE_OPENRCT2_OFFICIAL);
+    }
 }
 
 Object::~Object()
@@ -76,6 +648,56 @@ rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint
     Memory::Copy(header.name, name, DAT_NAME_LENGTH);
     header.checksum = checksum;
     return header;
+}
+
+void Object::SetSourceGame(const uint8 sourceGame)
+{
+    _objectEntry.flags &= 0x0F;
+    _objectEntry.flags |= (sourceGame << 4);
+}
+
+bool Object::IsRCT1Object()
+{
+    for (const auto entry : _rct1Objects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Object::IsAAObject()
+{
+    for (const auto entry : _aaObjects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Object::IsLLObject()
+{
+    for (const auto entry : _llObjects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
+}
+
+bool Object::IsOpenRCT2OfficialObject()
+{
+    for (const auto entry : _openRCT2OfficialObjects)
+    {
+        if (String::Equals(_identifier, entry))
+            return true;
+    }
+
+    return false;
 }
 
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -62,6 +62,10 @@ typedef enum
     OBJECT_SOURCE_CUSTOM,
     OBJECT_SOURCE_WACKY_WORLDS,
     OBJECT_SOURCE_TIME_TWISTER,
+    OBJECT_SOURCE_OPENRCT2_OFFICIAL,
+    OBJECT_SOURCE_RCT1,
+    OBJECT_SOURCE_ADDED_ATTRACTIONS,
+    OBJECT_SOURCE_LOOPY_LANDSCAPES,
     OBJECT_SOURCE_RCT2 = 8
 } OBJECT_SOURCE_GAME;
 
@@ -165,6 +169,12 @@ protected:
 
     std::string         GetOverrideString(uint8 index) const;
     std::string         GetString(uint8 index) const;
+
+    void                SetSourceGame(const uint8 sourceGame);
+    bool                IsRCT1Object();
+    bool                IsAAObject();
+    bool                IsLLObject();
+    bool                IsOpenRCT2OfficialObject();
 
 public:
     explicit Object(const rct_object_entry &entry);

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -232,15 +232,22 @@ public:
 
     static rct_string_id GetObjectSourceGameString(const rct_object_entry * entry)
     {
-        uint8 source = (entry->flags & 0xF0) >> 4;
-        switch (source)
+        switch (object_entry_get_source_game(entry))
         {
+        case OBJECT_SOURCE_RCT1:
+            return STR_SCENARIO_CATEGORY_RCT1;
+        case OBJECT_SOURCE_ADDED_ATTRACTIONS:
+            return STR_SCENARIO_CATEGORY_RCT1_AA;
+        case OBJECT_SOURCE_LOOPY_LANDSCAPES:
+            return STR_SCENARIO_CATEGORY_RCT1_LL;
         case OBJECT_SOURCE_RCT2:
             return STR_ROLLERCOASTER_TYCOON_2_DROPDOWN;
         case OBJECT_SOURCE_WACKY_WORLDS:
             return STR_OBJECT_FILTER_WW;
         case OBJECT_SOURCE_TIME_TWISTER:
             return STR_OBJECT_FILTER_TT;
+        case OBJECT_SOURCE_OPENRCT2_OFFICIAL:
+            return STR_OBJECT_FILTER_OPENRCT2_OFFICIAL;
         default:
             return STR_OBJECT_FILTER_CUSTOM;
         }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -79,7 +79,7 @@ class ObjectFileIndex final : public FileIndex<ObjectRepositoryItem>
 {
 private:
     static constexpr uint32 MAGIC_NUMBER = 0x5844494F; // OIDX
-    static constexpr uint16 VERSION = 16;
+    static constexpr uint16 VERSION = 17;
     static constexpr auto PATTERN = "*.dat;*.pob";
 
 public:


### PR DESCRIPTION
This adds filters for RCT1, AA, LL and official OpenRCT2 objects.
Currently, it uses hard coded lists, but these can be moved to the `objects` tool and json-objects.

Implements #2893.
I hope I got all RCT1 assignments right. I think @Horsti12 might be able to confirm it.

![2018-01-30 20-22-03](https://user-images.githubusercontent.com/1478678/35586764-1724e6d8-05fc-11e8-9e7e-99061010a26e.png)
