### PR TITLE
Create passageways in European Extravaganza

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2771,17 +2771,6 @@ private:
         }
     }
 
-    void FixLandOwnershipTiles(std::initializer_list<LocationXY8> tiles)
-    {
-
-        rct_tile_element * currentElement;
-        for (const LocationXY8 * tile = tiles.begin(); tile != tiles.end(); ++tile)
-        {
-            currentElement = map_get_surface_element_at((*tile).x, (*tile).y);
-            currentElement->properties.surface.ownership |= OWNERSHIP_AVAILABLE;
-        }
-    }
-
     /**
      * Counts the block sections. The reason this iterates over the map is to avoid getting into infinite loops,
      * which can happen with hacked parks.

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -456,6 +456,17 @@ public:
         {
             log_error("Found %d disjoint null sprites", disjoint_sprites_count);
         }
+
+        if (String::Equals(_s6.scenario_filename, "Europe - European Cultural Festival.SC6"))
+        {
+            // This scenario breaks pathfinding. Create passages between the worlds. (List is grouped by neighbouring tiles.)
+            FixLandOwnershipTilesWithOwnership({
+                { 67, 94 }, { 68, 94 }, { 69, 94 },
+                { 58, 24 }, { 58, 25 }, { 58, 26 }, { 58, 27 }, { 58, 28 }, { 58, 29 }, { 58, 30 }, { 58, 31 }, { 58, 32 },
+                { 26, 44 }, { 26, 45 },
+                { 32, 79 }, { 32, 80 }, { 32, 81 }
+            }, OWNERSHIP_OWNED);
+        }
     }
 
     void ImportRides()

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -4894,3 +4894,19 @@ bool map_tile_is_part_of_virtual_floor(sint16 x, sint16 y)
 
     return false;
 }
+
+void FixLandOwnershipTiles(std::initializer_list<LocationXY8> tiles)
+{
+    FixLandOwnershipTilesWithOwnership(tiles, OWNERSHIP_AVAILABLE);
+}
+
+void FixLandOwnershipTilesWithOwnership(std::initializer_list<LocationXY8> tiles, uint8 ownership)
+{
+    rct_tile_element * currentElement;
+    for (const LocationXY8 * tile = tiles.begin(); tile != tiles.end(); ++tile)
+    {
+        currentElement = map_get_surface_element_at((*tile).x, (*tile).y);
+        currentElement->properties.surface.ownership |= ownership;
+        update_park_fences_around_tile((*tile).x * 32, (*tile).y * 32);
+    }
+}

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -20,6 +20,10 @@
 #include "../common.h"
 #include "Location.h"
 
+#ifdef __cplusplus
+#include <initializer_list>
+#endif
+
 #pragma pack(push, 1)
 typedef struct rct_tile_element_surface_properties {
     uint8 slope; //4 0xE0 Edge Style, 0x1F Slope
@@ -589,6 +593,9 @@ uint16 check_max_allowable_land_rights_for_tile(uint8 x, uint8 y, uint8 base_z);
 uint8 tile_element_get_ride_index(const rct_tile_element * tileElement);
 
 #ifdef __cplusplus
+void FixLandOwnershipTiles(std::initializer_list<LocationXY8> tiles);
+void FixLandOwnershipTilesWithOwnership(std::initializer_list<LocationXY8> tiles, uint8 ownership);
+
 }
 #endif
 


### PR DESCRIPTION
Again showing how little care went into the expansions, this park breaks pathfinding in RCT2, because it lacks passageways between the countries. This PR fixes that.

![european extravaganza 2018-02-01 10-25-31](https://user-images.githubusercontent.com/1478678/35670957-4257518a-073a-11e8-974e-4a5c1b71d310.png)
