### PR TITLE
Update official domain

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), cmake, libsdl2-dev, libsdl2-ttf-dev, gcc, pkg-c
 
 Package: openrct2
 Architecture: any
-Homepage: https://openrct2.website/
+Homepage: https://openrct2.io/
 Vcs-Browser: https://github.com/OpenRCT2/OpenRCT2
 Vcs-Git: https://github.com/OpenRCT2/OpenRCT2
 Depends: ${shlibs:Depends}, ${misc:Depends}

--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -38,7 +38,7 @@
       <image>https://camo.githubusercontent.com/888d993a9716208446bd0d5a762977d6b7993058/68747470733a2f2f692e696d6775722e636f6d2f6537434b3553632e706e67</image>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://openrct2.website/</url>
+  <url type="homepage">https://openrct2.io/</url>
   <url type="bugtracker">https://github.com/OpenRCT2/OpenRCT2/issues</url>
   <url type="help">https://github.com/OpenRCT2/OpenRCT2/wiki</url>
   <content_rating type="oars-1.0">

--- a/distribution/man/openrct2.6
+++ b/distribution/man/openrct2.6
@@ -131,16 +131,16 @@ Path to the RollerCoaster Tycoon 2 data directory (containing
 .Pa data/g1.dat )
 
 .Sh EXAMPLES
-.Bl -tag -width "openrct2 https://openrct2.website/files/SnowyPark.sv6 "
+.Bl -tag -width "openrct2 https://openrct2.io/files/SnowyPark.sv6 "
 .It openrct2 ./my_park.sv6
 Open a saved park.
-.It openrct2 https://openrct2.website/files/SnowyPark.sv6
+.It openrct2 https://openrct2.io/files/SnowyPark.sv6
 Download and open a saved park.
 .It openrct2 host ./my_park.sv6 --port 11753 --headless
 Run a headless server for a saved park.
 
 .Sh SEE ALSO
-.Lk https://openrct2.website "Offical site"
+.Lk https://openrct2.io "Offical site"
 
 .Lk https://github.com/OpenRCT2/OpenRCT2 "GitHub"
 .Sh HISTORY

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -9,9 +9,9 @@ fi
 
 cachedir=.cache
 if [[ $(uname -s) == "Darwin" ]]; then
-	liburl=https://openrct2.website/files/orctlibs-osx.zip
+	liburl=https://openrct2.io/files/orctlibs-osx.zip
 else
-	liburl=https://openrct2.website/files/orctlibs.zip
+	liburl=https://openrct2.io/files/orctlibs.zip
 fi
 mkdir -p "$cachedir"
 

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -150,7 +150,7 @@ const CommandLineExample CommandLine::RootExamples[]
     { "./SnowyPark.sc6",                              "install and open a scenario"            },
     { "./ShuttleLoop.td6",                            "install a track"                        },
 #ifndef DISABLE_HTTP
-    { "https://openrct2.website/files/SnowyPark.sv6", "download and open a saved park"         },
+    { "https://openrct2.io/files/SnowyPark.sv6", "download and open a saved park"         },
 #endif
 #ifndef DISABLE_NETWORK
     { "host ./my_park.sv6 --port 11753 --headless",   "run a headless server for a saved park" },
@@ -433,7 +433,7 @@ static void PrintAbout()
     Console::WriteLine("includes some 3rd party software under different licenses. See the file");
     Console::WriteLine("\"licence.txt\" shipped with the game for details.");
     Console::WriteLine();
-    Console::WriteLine("Website:      https://openrct2.website");
+    Console::WriteLine("Website:      https://openrct2.io");
     Console::WriteLine("GitHub:       https://github.com/OpenRCT2/OpenRCT2");
     Console::WriteLine("Contributors: https://github.com/OpenRCT2/OpenRCT2/blob/develop/contributors.md");
     Console::WriteLine();

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -155,7 +155,7 @@ char *strndup(const char *src, size_t size);
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-#define OPENRCT2_MASTER_SERVER_URL  "https://servers.openrct2.website"
+#define OPENRCT2_MASTER_SERVER_URL  "https://servers.openrct2.io"
 
 // Time (represented as number of 100-nanosecond intervals since 0001-01-01T00:00:00Z)
 typedef uint64 datetime64;


### PR DESCRIPTION
This updates all references to the official domain given the change from `openrct2.website` to `openrct2.io`.