### PR TITLE
Correct identification of thin junctions in the heuristic search.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -105,6 +105,7 @@
 - Fix: [#6904] Manually added multiplayer servers not saved.
 - Fix: [#7003] Building sloped paths through flat paths with clearance checks off causes glitches.
 - Fix: [#7011] Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
+- Fix: [#7125] No entry signs not correctly handled in pathfinding.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -9856,7 +9856,7 @@ static uint8 peep_pathfind_get_max_number_junctions(rct_peep * peep)
  */
 static bool path_is_thin_junction(rct_tile_element * path, sint16 x, sint16 y, uint8 z)
 {
-    uint8 edges = path->properties.path.edges & 0xF;
+    uint8 edges = footpath_get_edges(path);
 
     sint32 test_edge = bitscanforward(edges);
     if (test_edge == -1)
@@ -10119,7 +10119,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 
             searchResult = PATH_SEARCH_THIN;
 
-            uint8 numEdges = bitcount(tileElement->properties.path.edges & 0x0F);
+            uint8 numEdges = bitcount(footpath_get_edges(tileElement));
 
             if (numEdges < 2)
             {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -9849,14 +9849,14 @@ static uint8 peep_pathfind_get_max_number_junctions(rct_peep * peep)
 /**
  * Returns if the path as xzy is a 'thin' junction.
  * A junction is considered 'thin' if it has more than 2 edges
- * leading to non-wide path elements; edges leading to non-path elements
- * (e.g. ride/shop entrances) or ride queues are not counted, since entrances
- * and ride queues coming off a path should not result in the path being
- * considered a junction.
+ * leading to/from non-wide path elements; edges leading to/from non-path
+ * elements (e.g. ride/shop entrances) or ride queues are not counted,
+ * since entrances and ride queues coming off a path should not result in
+ * the path being considered a junction.
  */
 static bool path_is_thin_junction(rct_tile_element * path, sint16 x, sint16 y, uint8 z)
 {
-    uint8 edges = path_get_permitted_edges(path);
+    uint8 edges = path->properties.path.edges & 0xF;
 
     sint32 test_edge = bitscanforward(edges);
     if (test_edge == -1)
@@ -10119,7 +10119,7 @@ static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep
 
             searchResult = PATH_SEARCH_THIN;
 
-            uint8 numEdges = bitcount(path_get_permitted_edges(tileElement));
+            uint8 numEdges = bitcount(tileElement->properties.path.edges & 0x0F);
 
             if (numEdges < 2)
             {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2273,3 +2273,8 @@ rct_footpath_entry *get_footpath_entry(sint32 entryIndex)
 {
     return gFootpathEntries[entryIndex];
 }
+
+uint8 footpath_get_edges(const rct_tile_element * element)
+{
+    return element->properties.path.edges & 0xF;
+}

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -171,4 +171,6 @@ rct_footpath_entry * get_footpath_entry(sint32 entryIndex);
 void footpath_queue_chain_reset();
 void footpath_queue_chain_push(uint8 rideIndex);
 
+uint8 footpath_get_edges(const rct_tile_element * element);
+
 #endif


### PR DESCRIPTION
Previously, thin junctions were identified based on the permitted edges - i.e. exit edges from the path tile. This causes incorrect handling of path tiles with 'no entry' signs. This breaks the heuristic search for paths with 'no entry' signs (path finding faults become far more noticeable when multiple 'no entry' signs are used) causing peeps to get stuck in the worst case. Corrected to identify thin junctions based on all path tile edges rather than only the permitted edges.

Fixes #7125.