### PR TITLE
Refactor memory operations 4

### DIFF
--- a/src/openrct2/core/Memory.hpp
+++ b/src/openrct2/core/Memory.hpp
@@ -89,20 +89,6 @@ namespace Memory
     }
 
     template<typename T>
-    static T * Duplicate(const T * src, size_t size)
-    {
-        T *result = Allocate<T>(size);
-        return (T *)memcpy(result, src, size);
-    }
-
-    template<typename T>
-    static T * DuplicateArray(const T * src, size_t count)
-    {
-        T * result = AllocateArray<T>(count);
-        return (T *)memcpy(result, src, count * sizeof(T));
-    }
-
-    template<typename T>
     static void FreeArray(T * ptr, size_t count)
     {
         for (size_t i = 0; i < count; i++)

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <algorithm>
+#include <cstring>
 #include "Math.hpp"
 #include "Memory.hpp"
 #include "MemoryStream.h"
@@ -27,7 +28,8 @@ MemoryStream::MemoryStream(const MemoryStream &copy)
 
     if (_access & MEMORY_ACCESS::OWNER)
     {
-        _data = Memory::Duplicate(copy._data, _dataCapacity);
+        _data = Memory::Allocate<void>(_dataCapacity);
+        std::memcpy(_data, copy._data, _dataCapacity);
         _position = (void*)((uintptr_t)_data + copy.GetPosition());
     }
 }
@@ -71,7 +73,9 @@ const void * MemoryStream::GetData() const
 
 void * MemoryStream::GetDataCopy() const
 {
-    return Memory::Duplicate(_data, _dataSize);
+    auto result = Memory::Allocate<void>(_dataSize);
+    std::memcpy(result, _data, _dataSize);
+    return result;
 }
 
 void * MemoryStream::TakeData()

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -324,8 +324,9 @@ namespace String
         utf8 * result = nullptr;
         if (src != nullptr)
         {
-            size_t srcSize = SizeOf(src);
-            result = Memory::DuplicateArray(src, srcSize + 1);
+            size_t srcSize = SizeOf(src) + 1;
+            result = Memory::Allocate<utf8>(srcSize);
+            memcpy(result, src, srcSize);
         }
         return result;
     }

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -16,21 +16,21 @@
 
 #pragma once
 
-#include "SceneryObject.h"
-
+#include <memory>
+#include <vector>
 #include "../world/Scenery.h"
+#include "SceneryObject.h"
 
 class LargeSceneryObject final : public SceneryObject
 {
 private:
-    rct_scenery_entry           _legacyType = { 0 };
-    uint32                      _baseImageId = 0;
-    rct_large_scenery_text *    _3dFont = nullptr;
-    rct_large_scenery_tile *    _tiles = nullptr;
+    rct_scenery_entry                       _legacyType = { 0 };
+    uint32                                  _baseImageId = 0;
+    std::vector<rct_large_scenery_tile>     _tiles;
+    std::unique_ptr<rct_large_scenery_text> _3dFont;
 
 public:
     explicit LargeSceneryObject(const rct_object_entry &entry) : SceneryObject(entry) { }
-    ~LargeSceneryObject();
 
     void * GetLegacyData()  override { return &_legacyType; }
 
@@ -41,5 +41,5 @@ public:
     void DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint32 height) const override;
 
 private:
-    static rct_large_scenery_tile * ReadTiles(IStream * stream);
+    static std::vector<rct_large_scenery_tile> ReadTiles(IStream * stream);
 };

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -23,11 +23,6 @@
 #include "../drawing/Drawing.h"
 #include "../localisation/Language.h"
 
-SceneryGroupObject::~SceneryGroupObject()
-{
-    Memory::Free(_items);
-}
-
 void SceneryGroupObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
     stream->Seek(6, STREAM_SEEK_CURRENT);
@@ -39,7 +34,7 @@ void SceneryGroupObject::ReadLegacy(IReadObjectContext * context, IStream * stre
     _legacyType.entertainer_costumes = stream->ReadValue<uint32>();
 
     GetStringTable()->Read(context, stream, OBJ_STRING_ID_NAME);
-    ReadItems(stream);
+    _items = ReadItems(stream);
     GetImageTable()->Read(context, stream);
 }
 
@@ -75,18 +70,16 @@ void SceneryGroupObject::UpdateEntryIndexes()
     IObjectManager * objectManager = GetObjectManager();
 
     _legacyType.entry_count = 0;
-    for (uint32 i = 0; i < _numItems; i++)
+    for (const auto &objectEntry : _items)
     {
-        const rct_object_entry * objectEntry = &_items[i];
-
-        const ObjectRepositoryItem * ori = objectRepository->FindObject(objectEntry);
+        auto ori = objectRepository->FindObject(&objectEntry);
         if (ori == nullptr) continue;
         if (ori->LoadedObject == nullptr) continue;
 
         uint16 sceneryEntry = objectManager->GetLoadedObjectEntryIndex(ori->LoadedObject);
         Guard::Assert(sceneryEntry != UINT8_MAX, GUARD_LINE);
 
-        uint8 objectType = objectEntry->flags & 0x0F;
+        uint8 objectType = objectEntry.flags & 0x0F;
         switch (objectType) {
         case OBJECT_TYPE_SMALL_SCENERY:                        break;
         case OBJECT_TYPE_LARGE_SCENERY: sceneryEntry |= 0x300; break;
@@ -104,25 +97,22 @@ void SceneryGroupObject::SetRepositoryItem(ObjectRepositoryItem * item) const
 {
     Memory::Free(item->ThemeObjects);
 
-    item->NumThemeObjects = _numItems;
-    item->ThemeObjects = Memory::AllocateArray<rct_object_entry>(_numItems);
-    for (uint32 i = 0; i < _numItems; i++)
+    item->NumThemeObjects = (uint16)_items.size();
+    item->ThemeObjects = Memory::AllocateArray<rct_object_entry>(_items.size());
+    for (size_t i = 0; i < _items.size(); i++)
     {
         item->ThemeObjects[i] = _items[i];
     }
 }
 
-void SceneryGroupObject::ReadItems(IStream * stream)
+std::vector<rct_object_entry> SceneryGroupObject::ReadItems(IStream * stream)
 {
     auto items = std::vector<rct_object_entry>();
-
     while (stream->ReadValue<uint8>() != 0xFF)
     {
         stream->Seek(-1, STREAM_SEEK_CURRENT);
         rct_object_entry entry = stream->ReadValue<rct_object_entry>();
         items.push_back(entry);
     }
-
-    _numItems = (uint32)items.size();
-    _items = Memory::DuplicateArray(items.data(), items.size());
+    return items;
 }

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -16,22 +16,20 @@
 
 #pragma once
 
-#include "Object.h"
-
+#include <vector>
 #include "../world/Scenery.h"
+#include "Object.h"
 
 struct ObjectRepositoryItem;
 
 class SceneryGroupObject final : public Object
 {
 private:
-    rct_scenery_group_entry _legacyType = { 0 };
-    uint32                  _numItems = 0;
-    rct_object_entry *      _items = nullptr;
+    rct_scenery_group_entry         _legacyType = { 0 };
+    std::vector<rct_object_entry>   _items;
 
 public:
     explicit SceneryGroupObject(const rct_object_entry &entry) : Object(entry) { }
-    ~SceneryGroupObject();
 
     void * GetLegacyData()  override { return &_legacyType; }
 
@@ -45,5 +43,5 @@ public:
     void SetRepositoryItem(ObjectRepositoryItem * item) const override;
 
 private:
-    void ReadItems(IStream * stream);
+    static std::vector<rct_object_entry> ReadItems(IStream * stream);
 };

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -25,11 +25,6 @@
 #include "../world/Scenery.h"
 #include "../world/SmallScenery.h"
 
-SmallSceneryObject::~SmallSceneryObject()
-{
-    Memory::Free(_frameOffsets);
-}
-
 void SmallSceneryObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
     stream->Seek(6, STREAM_SEEK_CURRENT);
@@ -82,7 +77,7 @@ void SmallSceneryObject::Load()
 
     if (scenery_small_entry_has_flag(&_legacyType, SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
     {
-        _legacyType.small_scenery.frame_offsets = _frameOffsets;
+        _legacyType.small_scenery.frame_offsets = _frameOffsets.data();
     }
 
     PerformFixes();
@@ -142,7 +137,7 @@ void SmallSceneryObject::DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint
     }
 }
 
-uint8 * SmallSceneryObject::ReadFrameOffsets(IStream * stream)
+std::vector<uint8> SmallSceneryObject::ReadFrameOffsets(IStream * stream)
 {
     uint8 frameOffset;
     auto data = std::vector<uint8>();
@@ -152,7 +147,7 @@ uint8 * SmallSceneryObject::ReadFrameOffsets(IStream * stream)
         data.push_back(frameOffset);
     }
     data.push_back(frameOffset);
-    return Memory::Duplicate(data.data(), data.size());
+    return data;
 }
 
 // clang-format off

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -16,19 +16,18 @@
 
 #pragma once
 
-#include "SceneryObject.h"
-
+#include <vector>
 #include "../world/Scenery.h"
+#include "SceneryObject.h"
 
 class SmallSceneryObject final : public SceneryObject
 {
 private:
     rct_scenery_entry   _legacyType = { 0 };
-    uint8 *             _frameOffsets = nullptr;
+    std::vector<uint8>  _frameOffsets;
 
 public:
     explicit SmallSceneryObject(const rct_object_entry &entry) : SceneryObject(entry) { }
-    ~SmallSceneryObject();
 
     void * GetLegacyData()  override { return &_legacyType; }
 
@@ -39,7 +38,7 @@ public:
     void DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint32 height) const override;
 
 private:
-    static uint8 * ReadFrameOffsets(IStream * stream);
+    static std::vector<uint8> ReadFrameOffsets(IStream * stream);
     void PerformFixes();
     rct_object_entry GetScgPiratHeader();
     rct_object_entry GetScgMineHeader();


### PR DESCRIPTION
Remove `Memory::Duplicate` and `Memory::DuplicateArray`