### PR TITLE
Fix #6667: Match sample rate to games audio content.

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -76,10 +76,10 @@ namespace OpenRCT2 { namespace Audio
             Close();
 
             SDL_AudioSpec want = { 0 };
-            want.freq = 44100;
+            want.freq = 22050;
             want.format = AUDIO_S16SYS;
             want.channels = 2;
-            want.samples = 1024;
+            want.samples = 2048;
             want.callback = [](void * arg, uint8 * dst, sint32 length) -> void
             {
                 auto mixer = static_cast<AudioMixerImpl *>(arg);


### PR DESCRIPTION
Apparently SDL is not capable of converting streams properly and adds zero padding therefor the crackle noise as seen here https://github.com/spurious/SDL-mirror/blob/master/src/audio/SDL_audiocvt.c#L726

The solution is to set the frequency back to 22050hz which matches the games audio content so no conversion is required. The other possible solution is to pre-convert everything but adds quite the loading time.

Also keep in mind this noise only happens when audio is upsampled while downsampling should be okay.