### PR TITLE
Improve TrueType appearance in scrolling text

### DIFF
--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1501,7 +1501,7 @@ static void scrolling_text_set_bitmap_for_sprite(utf8 *text, sint32 scroll, uint
         sint32 characterWidth = font_sprite_get_codepoint_width(FONT_SPRITE_BASE_TINY, codepoint);
         uint8 *characterBitmap = font_sprite_get_codepoint_bitmap(codepoint);
         for (; characterWidth != 0; characterWidth--, characterBitmap++) {
-            // Skip any none displayed columns
+            // Skip any non-displayed columns
             if (scroll != 0) {
                 scroll--;
                 continue;
@@ -1566,41 +1566,46 @@ static void scrolling_text_set_bitmap_for_ttf(utf8 *text, sint32 scroll, uint8 *
 
     sint32 pitch = surface->pitch;
     sint32 width = surface->w;
-    sint32 height = surface->h;
     auto src = (const uint8 *)surface->pixels;
 
-    // Offset
-    height -= 3;
-    src += 3 * pitch;
-    height = std::min(height, 8);
+    // Pitch offset
+    src += 2 * pitch;
 
-    sint32 x = 0;
-    while (true) {
-        // Skip any none displayed columns
-        if (scroll == 0) {
+    // Line height offset
+    sint32 min_vpos = -fontDesc->offset_y;
+    sint32 max_vpos = std::min(surface->h - 2, min_vpos + 7);
+
+    for (sint32 x = 0; ; x++)
+    {
+        if (x >= width)
+            x = 0;
+
+        // Skip any non-displayed columns
+        if (scroll == 0)
+        {
             sint16 scrollPosition = *scrollPositionOffsets;
-            if (scrollPosition == -1) return;
-            if (scrollPosition > -1) {
+            if (scrollPosition == -1)
+                return;
+
+            if (scrollPosition > -1)
+            {
                 uint8 *dst = &bitmap[scrollPosition];
 
-                for (sint32 y = 0; y < height; y++)
+                for (sint32 y = min_vpos; y < max_vpos; y++)
                 {
                     if (src[y * pitch + x] > 92 || (src[y * pitch + x] != 0 && !gConfigFonts.enable_hinting))
-                    {
                         *dst = colour;
-                    }
 
                     // Jump to next row
                     dst += 64;
                 }
             }
             scrollPositionOffsets++;
-        } else {
+        }
+        else
+        {
             scroll--;
         }
-
-        x++;
-        if (x >= width) x = 0;
     }
 #endif // NO_TTF
 }

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1595,8 +1595,17 @@ static void scrolling_text_set_bitmap_for_ttf(utf8 *text, sint32 scroll, uint8 *
 
                 for (sint32 y = min_vpos; y < max_vpos; y++)
                 {
-                    if (src[y * pitch + x] > 92 || (src[y * pitch + x] != 0 && !use_hinting))
+                    uint8 src_pixel = src[y * pitch + x];
+                    if ((!use_hinting && src_pixel != 0) || src_pixel > 140)
+                    {
+                        // Centre of the glyph: use full colour.
                         *dst = colour;
+                    }
+                    else if (use_hinting && src_pixel > fontDesc->hinting_threshold)
+                    {
+                        // Simulate font hinting by shading the background colour instead.
+                        *dst = blendColours(colour, *dst);
+                    }
 
                     // Jump to next row
                     dst += 64;

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1575,6 +1575,8 @@ static void scrolling_text_set_bitmap_for_ttf(utf8 *text, sint32 scroll, uint8 *
     sint32 min_vpos = -fontDesc->offset_y;
     sint32 max_vpos = std::min(surface->h - 2, min_vpos + 7);
 
+    bool use_hinting = gConfigFonts.enable_hinting && fontDesc->hinting_threshold > 0;
+
     for (sint32 x = 0; ; x++)
     {
         if (x >= width)
@@ -1593,7 +1595,7 @@ static void scrolling_text_set_bitmap_for_ttf(utf8 *text, sint32 scroll, uint8 *
 
                 for (sint32 y = min_vpos; y < max_vpos; y++)
                 {
-                    if (src[y * pitch + x] > 92 || (src[y * pitch + x] != 0 && !gConfigFonts.enable_hinting))
+                    if (src[y * pitch + x] > 92 || (src[y * pitch + x] != 0 && !use_hinting))
                         *dst = colour;
 
                     // Jump to next row

--- a/src/openrct2/drawing/String.cpp
+++ b/src/openrct2/drawing/String.cpp
@@ -541,6 +541,7 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
         {
             dst = dst_orig;
             src = src_orig;
+            bool use_hinting = gConfigFonts.enable_hinting && fontDesc->hinting_threshold > 0;
             for (sint32 yy = 0; yy < height; yy++) {
                 for (sint32 xx = 0; xx < width; xx++) {
                     if (*src != 0) {
@@ -548,12 +549,12 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo *dpi, const utf8 *text, te
                             *(dst + width + dstScanSkip + 1) = info->palette[3];
                         }
 
-                        if (*src > 180 || !gConfigFonts.enable_hinting)
+                        if (*src > 180 || !use_hinting)
                         {
                             // Centre of the glyph: use full colour.
                             *dst = colour;
                         }
-                        else if (*src > fontDesc->hinting_threshold)
+                        else if (use_hinting && *src > fontDesc->hinting_threshold)
                         {
                             // Simulate font hinting by shading the background colour instead.
                             if (info->flags & TEXT_DRAW_FLAG_OUTLINE)

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -165,7 +165,8 @@ void ttf_toggle_hinting()
     for (sint32 i = 0; i < FONT_SIZE_COUNT; i++)
     {
         TTFFontDescriptor *fontDesc = &(gCurrentTTFFontSet->size[i]);
-        TTF_SetFontHinting(fontDesc->font, gConfigFonts.enable_hinting ? 1 : 0);
+        bool use_hinting = gConfigFonts.enable_hinting && fontDesc->hinting_threshold;
+        TTF_SetFontHinting(fontDesc->font, use_hinting ? 1 : 0);
     }
 
     if (_ttfSurfaceCacheCount)
@@ -299,7 +300,7 @@ static bool ttf_get_size(TTF_Font * font, const utf8 * text, sint32 * outWidth, 
 
 static TTFSurface * ttf_render(TTF_Font * font, const utf8 * text)
 {
-    if (gConfigFonts.enable_hinting)
+    if (TTF_GetFontHinting(font) != 0)
     {
         return TTF_RenderUTF8_Shaded(font, text, 0x000000FF, 0x000000FF);
     }

--- a/src/openrct2/drawing/TTF.h
+++ b/src/openrct2/drawing/TTF.h
@@ -46,6 +46,7 @@ TTFSurface * TTF_RenderUTF8_Solid(TTF_Font *font, const char *text, uint32 colou
 TTFSurface * TTF_RenderUTF8_Shaded(TTF_Font *font, const char *text, uint32 fg, uint32 bg);
 void TTF_CloseFont(TTF_Font *font);
 void TTF_SetFontHinting(TTF_Font* font, int hinting);
+int TTF_GetFontHinting(const TTF_Font* font);
 void TTF_Quit(void);
 
 #endif // NO_TTF

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -1401,6 +1401,17 @@ void TTF_SetFontHinting(TTF_Font* font, int hinting)
     Flush_Cache(font);
 }
 
+int TTF_GetFontHinting(const TTF_Font* font)
+{
+    if (font->hinting == FT_LOAD_TARGET_LIGHT)
+        return TTF_HINTING_LIGHT;
+    else if (font->hinting == FT_LOAD_TARGET_MONO)
+        return TTF_HINTING_MONO;
+    else if (font->hinting == FT_LOAD_NO_HINTING)
+        return TTF_HINTING_NONE;
+    return 0;
+}
+
 void TTF_Quit(void)
 {
     if (TTF_initialized) {

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -31,70 +31,70 @@ uint8 const HINTING_THRESHOLD_MEDIUM = 60;
 
 // clang-format off
 TTFFontSetDescriptor TTFFontMSGothic = { {
-    { "msgothic.ttc", "MS PGothic",  9, 1, -1, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "msgothic.ttc", "MS PGothic",  9, 1,  1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "msgothic.ttc", "MS PGothic", 12, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "msgothic.ttc", "MS PGothic", 12, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "msgothic.ttc", "MS PGothic", 13, 1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontHiragano = { {
-    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN",  8, 1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN",  9, 1,  1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 11, 1,  0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 11, 1,  0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"ヒラギノ丸ゴ ProN W4.ttc", "Hiragino Maru Gothic ProN", 12, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontMingLiu = { {
-    {    "msjh.ttc", "JhengHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    {    "msjh.ttc", "JhengHei",  9, -1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "mingliu.ttc",  "MingLiU", 11,  1,  1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "mingliu.ttc",  "MingLiU", 12,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "mingliu.ttc",  "MingLiU", 13,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontHeiti = { {
-    { u8"华文黑体.ttf", "STHeiti",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"华文黑体.ttf", "STHeiti",  9, -1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"华文黑体.ttf", "STHeiti", 11,  1,  1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"华文黑体.ttf", "STHeiti", 12,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"华文黑体.ttf", "STHeiti", 13,  1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontSimSun = { {
-    {   "msyh.ttc",  "YaHei",  9, -1, -3,  6, HINTING_THRESHOLD_MEDIUM, nullptr },
+    {   "msyh.ttc",  "YaHei",  9, -1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 11,  1, -1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 12,  1, -2, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 13,  1,  0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontLiHeiPro = { {
-    { u8"儷黑 Pro.ttf", "LiHei Pro",  9, 1, -1, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { u8"儷黑 Pro.ttf", "LiHei Pro",  9, 1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"儷黑 Pro.ttf", "LiHei Pro", 11, 1,  0, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"儷黑 Pro.ttf", "LiHei Pro", 12, 1,  0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { u8"儷黑 Pro.ttf", "LiHei Pro", 13, 1,  0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontGulim = { {
-    { "gulim.ttc", "Gulim", 11, 1, 0, 13, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "gulim.ttc", "Gulim", 10, 1, 0, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 13, 1, 0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontNanum = { {
-    { "NanumGothic.ttc", "Nanum Gothic", 11, 1, 0, 13, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttc", "Nanum Gothic", 10, 1, 0, 10, HINTING_THRESHOLD_LOW, nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 13, 1, 0, 16, HINTING_THRESHOLD_LOW, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontArial = { {
-    { "arial.ttf", "Arial",  8, 0, -1,  6, HINTING_THRESHOLD_LOW, nullptr },
+    { "arial.ttf", "Arial",  9, 0, -1,  9, HINTING_THRESHOLD_LOW, nullptr },
     { "arial.ttf", "Arial", 10, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arial.ttf", "Arial", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arial.ttf", "Arial", 12, 0, -1, 14, HINTING_THRESHOLD_LOW, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontArialUnicode = { {
-    { "arialuni.ttf", "Arial Unicode MS",  8, 0, -1,  6, HINTING_THRESHOLD_LOW, nullptr },
+    { "arialuni.ttf", "Arial Unicode MS",  9, 0, -1,  9, HINTING_THRESHOLD_LOW, nullptr },
     { "arialuni.ttf", "Arial Unicode MS", 10, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arialuni.ttf", "Arial Unicode MS", 11, 0, -1, 12, HINTING_THRESHOLD_LOW, nullptr },
     { "arialuni.ttf", "Arial Unicode MS", 12, 0, -1, 14, HINTING_THRESHOLD_LOW, nullptr },

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -26,6 +26,7 @@
 #include "../localisation/Language.h"
 
 #ifndef NO_TTF
+uint8 const HINTING_DISABLED         =  0;
 uint8 const HINTING_THRESHOLD_LOW    = 40;
 uint8 const HINTING_THRESHOLD_MEDIUM = 60;
 
@@ -73,14 +74,14 @@ TTFFontSetDescriptor TTFFontLiHeiPro = { {
 } };
 
 TTFFontSetDescriptor TTFFontGulim = { {
-    { "gulim.ttc", "Gulim", 10, 1, 0, 10, HINTING_THRESHOLD_MEDIUM, nullptr },
+    { "gulim.ttc", "Gulim", 10, 1, 0, 10, HINTING_DISABLED,         nullptr },
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "gulim.ttc", "Gulim", 13, 1, 0, 16, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontNanum = { {
-    { "NanumGothic.ttc", "Nanum Gothic", 10, 1, 0, 10, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttc", "Nanum Gothic", 10, 1, 0, 10, HINTING_DISABLED,      nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 13, 1, 0, 16, HINTING_THRESHOLD_LOW, nullptr },


### PR DESCRIPTION
As outlined in #7153, the appearance of TrueType glyphs in scrolling texts (banners) isn't quite ideal at the moment.

This PR aims to improve it by resetting vertical glyph offsets, while also actively including them for user font customisation purposes.

**Screenshots:**
Japanese: [before](https://user-images.githubusercontent.com/604665/36036171-6fc82a6a-0db9-11e8-8dbc-1dede7f0772f.png), [after](https://user-images.githubusercontent.com/604665/36036170-6fa848b2-0db9-11e8-991f-74fe016fc8bd.png)
Korean: [before](https://user-images.githubusercontent.com/604665/36036172-6ff73012-0db9-11e8-8a15-20048f095eba.png), [after](https://user-images.githubusercontent.com/604665/36036169-6f8ab068-0db9-11e8-8963-3259f97ebcfd.png)