### PR TITLE
Fix #7137: Water, gentle and transport rides can only have 1 vehicle/train

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7068,6 +7068,7 @@ static sint32 ride_get_track_length(Ride * ride)
             trackType = track_element_get_type(it.current.element);
             result += TrackPieceLengths[trackType];
 
+            moveSlowIt = !moveSlowIt;
             if (moveSlowIt)
             {
                 track_circuit_iterator_next(&slowIt);


### PR DESCRIPTION
I am aware that the issue was assigned to rwjuk 3 days ago, but people are complaining so I decided to quickly add the missing line.