### PR TITLE
Fix cold startup

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -572,6 +572,9 @@ namespace Config
     {
         try
         {
+            auto directory = Path::GetDirectory(path);
+            Path::CreateDirectory(directory);
+
             auto fs = FileStream(path, FILE_MODE_WRITE);
             auto writer = std::unique_ptr<IIniWriter>(CreateIniWriter(&fs));
             WriteGeneral(writer.get());

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -818,6 +818,11 @@ void window_close_top()
  */
 void window_close_all()
 {
+    if (gWindowNextSlot == nullptr)
+    {
+        return;
+    }
+
     window_close_by_class(WC_DROPDOWN);
 
     for (rct_window * w = RCT2_LAST_WINDOW; w >= g_window_list; w--)
@@ -2667,11 +2672,7 @@ void window_reset_visibilities()
 
 void window_init_all()
 {
-    if (gWindowNextSlot != nullptr)
-    {
-        window_close_all();
-    }
-
+    window_close_all();
     gWindowNextSlot = g_window_list;
 }
 


### PR DESCRIPTION
Back-porting from `json-objects` branch.

This fixes issues when starting up the game for the first time without a configuration directory and a segfault that occurs when skipping the RCT2 install directory prompt.