### PR TITLE
Fix and clean up cmake builds on macOS

### DIFF
--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -18,6 +18,10 @@ add_executable(${PROJECT} ${OPENRCT2_CLI_SOURCES})
 
 target_link_libraries(${PROJECT} "libopenrct2")
 
+if (APPLE)
+    target_link_libraries(${PROJECT} "-framework Cocoa")
+endif ()
+
 # Includes
 target_include_directories(${PROJECT} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
 

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -26,9 +26,6 @@ file(GLOB_RECURSE OPENRCT2_UI_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
 
 if (APPLE)
-    file(GLOB_RECURSE OPENRCT2_UI_M_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.m")
-    set_source_files_properties(${OPENRCT2_UI_M_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c -fmodules")
-
     file(GLOB_RECURSE OPENRCT2_UI_MM_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.mm")
     set_source_files_properties(${OPENRCT2_UI_MM_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c++ -fmodules")
 endif ()
@@ -36,7 +33,7 @@ endif ()
 # Outputs
 set (PROJECT openrct2)
 project(${PROJECT})
-add_executable(${PROJECT} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_M_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
+add_executable(${PROJECT} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
 
 target_link_libraries(${PROJECT} "libopenrct2"
                                  ${SDL2_LDFLAGS}

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -55,9 +55,6 @@ file(GLOB_RECURSE OPENRCT2_CORE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.c"
                                         "${CMAKE_CURRENT_LIST_DIR}/*.h"
                                         "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
 if (APPLE)
-    file(GLOB_RECURSE OPENRCT2_CORE_M_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.m")
-    set_source_files_properties(${OPENRCT2_CORE_M_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c -fmodules")
-
     file(GLOB_RECURSE OPENRCT2_CORE_MM_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.mm")
     set_source_files_properties(${OPENRCT2_CORE_MM_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c++ -fmodules")
 endif ()
@@ -65,7 +62,7 @@ endif ()
 # Outputs
 set(PROJECT libopenrct2)
 project(${PROJECT})
-add_library(${PROJECT} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_M_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${RCT2_SECTIONS})
+add_library(${PROJECT} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${RCT2_SECTIONS})
 set_target_properties(${PROJECT} PROPERTIES PREFIX "")
 set_target_properties(${PROJECT} PROPERTIES COMPILE_FLAGS "-Wundef")
 


### PR DESCRIPTION
This fixes the cmake build for openrct2-cli on macOS, which still needed linking with Cocoa.

This also removes the globbing for `*.m` files. As the platform files for macOS now all use Objective C++ (.mm) instead of Objective C (.m), globbing is no longer needed.