### PR TITLE
Remove and replace C typedefs

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -345,7 +345,7 @@ public:
         case INTENT_ACTION_SET_TILE_INSPECTOR_PAGE:
         {
             auto window = window_find_by_class(WC_TILE_INSPECTOR);
-            window_tile_inspector_set_page(window, static_cast<tile_inspector_page>(intent.GetUIntExtra(INTENT_EXTRA_PAGE)));
+            window_tile_inspector_set_page(window, static_cast<TILE_INSPECTOR_PAGE>(intent.GetUIntExtra(INTENT_EXTRA_PAGE)));
             break;
         }
 

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -7,8 +7,7 @@
 #include <openrct2/audio/AudioSource.h>
 
 struct SDL_RWops;
-struct SpeexResamplerState_;
-typedef struct SpeexResamplerState_ SpeexResamplerState;
+using SpeexResamplerState = struct SpeexResamplerState_;
 
 namespace OpenRCT2 { namespace Audio
 {

--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -127,5 +127,5 @@ struct DrawRectCommand
     };
 };
 
-typedef CommandBatch<DrawLineCommand> LineCommandBatch;
-typedef CommandBatch<DrawRectCommand> RectCommandBatch;
+using LineCommandBatch = CommandBatch<DrawLineCommand>;
+using RectCommandBatch = CommandBatch<DrawRectCommand>;

--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -39,7 +39,7 @@
 
 uint8 gKeyboardShortcutChangeId;
 
-typedef void (*shortcut_action)();
+using shortcut_action = void (*)();
 
 namespace
 {

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -136,8 +136,6 @@ namespace OpenRCT2
     }
 }
 
-typedef struct rct_window rct_window;
-
 /** The current shortcut being changed. */
 extern uint8 gKeyboardShortcutChangeId;
 extern const rct_string_id ShortcutStringIds[SHORTCUT_COUNT];
@@ -154,4 +152,3 @@ void keyboard_shortcut_handle_command(sint32 shortcutIndex);
 void keyboard_shortcut_format_string(char *buffer, size_t size, uint16 shortcutKey);
 
 void get_keyboard_map_scroll(const uint8 * keysState, sint32 * x, sint32 * y);
-

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -39,12 +39,12 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Sprite.h>
 
-typedef struct rct_mouse_data
+struct rct_mouse_data
 {
     uint32 x;
     uint32 y;
     uint32 state;
-} rct_mouse_data;
+};
 
 static rct_mouse_data _mouseInputQueue[64];
 static uint8 _mouseInputQueueReadIndex = 0;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -271,16 +271,16 @@ enum {
     DDIX_FILTER_NONSELECTED,
 };
 
-typedef struct list_item {
+struct list_item {
     const ObjectRepositoryItem * repositoryItem;
     rct_object_entry *entry;
     rct_object_filters *filter;
     uint8 *flags;
-} list_item;
+};
 
 static rct_string_id get_ride_type_string_id(const ObjectRepositoryItem * item);
 
-typedef bool (*sortFunc_t)(const list_item &, const list_item &);
+using sortFunc_t = bool (*)(const list_item &, const list_item &);
 
 static std::vector<list_item> _listItems;
 static sint32 _listSortType = RIDE_SORT_TYPE;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -133,7 +133,7 @@ enum
     TYPE_FILE,
 };
 
-typedef struct LoadSaveListItem
+struct LoadSaveListItem
 {
     std::string name;
     std::string path;
@@ -142,7 +142,7 @@ typedef struct LoadSaveListItem
     std::string time_formatted;
     uint8 type;
     bool loaded;
-} LoadSaveListItem;
+};
 
 static loadsave_callback _loadSaveCallback;
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -28,11 +28,11 @@ enum {
     NOTIFICATION_CATEGORY_GUEST
 };
 
-typedef struct notification_def {
+struct notification_def {
     uint8 category;
     rct_string_id caption;
     size_t config_offset;
-} notification_def;
+};
 
 static constexpr const notification_def NewsItemOptionDefinitions[] = {
     { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_AWARD,                        offsetof(NotificationConfiguration, park_award)                         },

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -518,10 +518,10 @@ static uint32 window_park_page_hold_down_widgets[] = {
 
 #pragma endregion
 
-typedef struct window_park_award {
+struct window_park_award {
     rct_string_id text;
     uint32 sprite;
-} window_park_award;
+};
 
 static constexpr const window_park_award ParkAwards[] = {
     { STR_AWARD_MOST_UNTIDY,                SPR_AWARD_MOST_UNTIDY },

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -964,10 +964,10 @@ static void set_operating_setting(sint32 rideNumber, uint8 setting, uint8 value)
 
 // Cached overall view for each ride
 // (Re)calculated when the ride window is opened
-typedef struct ride_overall_view_t {
+struct ride_overall_view {
     sint16 x, y, z;
     uint8 zoom;
-} ride_overall_view;
+};
 
 static ride_overall_view ride_overall_views[MAX_RIDES] = {0};
 
@@ -1095,10 +1095,10 @@ static constexpr const rct_string_id MusicStyleNames[] = {
     STR_MUSIC_STYLE_CANDY_STYLE,
 };
 
-typedef struct window_ride_maze_design_option {
+struct window_ride_maze_design_option {
     rct_string_id text;
     uint32 sprite;
-} window_ride_maze_design_option;
+};
 
 static constexpr const window_ride_maze_design_option MazeOptions[] = {
     { STR_RIDE_DESIGN_MAZE_BRICK_WALLS,     SPR_RIDE_DESIGN_PREVIEW_MAZE_BRICK_WALLS },
@@ -1107,11 +1107,11 @@ static constexpr const window_ride_maze_design_option MazeOptions[] = {
     { STR_RIDE_DESIGN_MAZE_WOODEN_FENCES,   SPR_RIDE_DESIGN_PREVIEW_MAZE_WOODEN_FENCES },
 };
 
-typedef struct window_ride_colour_preview
+struct window_ride_colour_preview
 {
     uint32 track;
     uint32 supports;
-} window_ride_colour_preview;
+};
 
 static constexpr const window_ride_colour_preview TrackColourPreviews[] = {
     { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK,          SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS},
@@ -1207,12 +1207,12 @@ static constexpr const window_ride_colour_preview TrackColourPreviews[] = {
     { SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_TRACK,    SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_SUPPORTS},
 };
 
-typedef struct rct_window_graphs_y_axis {
+struct rct_window_graphs_y_axis {
     uint8 interval;
     sint8 unit;
     sint8 unit_interval;
     rct_string_id label;
-} rct_window_graphs_y_axis;
+};
 
 /** rct2: 0x0098DD98 */
 static constexpr const rct_window_graphs_y_axis window_graphs_y_axi[] = {
@@ -2859,7 +2859,7 @@ static void window_ride_vehicle_invalidate(rct_window *w)
     }
 
     set_format_arg(6, uint16, carsPerTrain);
-    ride_component_type vehicleType = RideNameConvention[ride->type].vehicle;
+    RIDE_COMPONENT_TYPE vehicleType = RideNameConvention[ride->type].vehicle;
     stringId = RideComponentNames[vehicleType].count;
     if (ride->num_vehicles > 1) {
         stringId = RideComponentNames[vehicleType].count_plural;
@@ -2953,12 +2953,12 @@ static void window_ride_vehicle_paint(rct_window *w, rct_drawpixelinfo *dpi)
     }
 }
 
-typedef struct rct_vehichle_paintinfo {
+struct rct_vehichle_paintinfo {
     sint16 x;
     sint16 y;
     sint32 sprite_index;
     sint32 tertiary_colour;
-} rct_vehichle_paintinfo;
+};
 
 static rct_vehichle_paintinfo _sprites_to_draw[144];
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -506,11 +506,11 @@ static sint32 count_rows(sint32 items){
     return rows;
 }
 
-typedef struct scenery_item {
+struct scenery_item {
     sint32 allRows;
     sint32 selected_item;
     sint16 sceneryId;
-} scenery_item;
+};
 
 static scenery_item window_scenery_count_rows_with_selected_item(sint32 tabIndex)
 {

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -134,12 +134,12 @@ static sint32 _windowStaffListSelectedTab = WINDOW_STAFF_LIST_TAB_HANDYMEN;
 
 static uint8 window_staff_list_get_random_entertainer_costume();
 
-typedef struct staff_naming_convention
+struct staff_naming_convention
 {
     rct_string_id plural;
     rct_string_id singular;
     rct_string_id action_hire;
-} staff_naming_convention;
+};
 
 static constexpr const staff_naming_convention StaffNamingConvention[] = {
     { STR_HANDYMAN_PLURAL,          STR_HANDYMAN_SINGULAR,          STR_HIRE_HANDYMAN },

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -605,7 +605,7 @@ static void window_tile_inspector_select_element_from_list(rct_window *w, sint32
         page = (Math::Min<uint32>(tile_element_get_type(tileElement), TILE_ELEMENT_TYPE_CORRUPT) >> 2) + 1;
     }
 
-    window_tile_inspector_set_page(w, (tile_inspector_page)page);
+    window_tile_inspector_set_page(w, (TILE_INSPECTOR_PAGE)page);
 
     // Enable/disable buttons
     window_tile_inspector_auto_set_buttons(w);
@@ -1346,7 +1346,7 @@ static void window_tile_inspector_scrollgetsize(rct_window *w, sint32 scrollInde
     *height = windowTileInspectorElementCount * LIST_ITEM_HEIGHT;
 }
 
-void window_tile_inspector_set_page(rct_window *w, const tile_inspector_page page)
+void window_tile_inspector_set_page(rct_window *w, const TILE_INSPECTOR_PAGE page)
 {
     w->page = page;
     w->widgets = PageWidgets[page];

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -32,12 +32,12 @@
 #include <openrct2/util/Util.h>
 #include <openrct2-ui/interface/Dropdown.h>
 
-typedef struct TITLE_COMMAND_ORDER {
+struct TITLE_COMMAND_ORDER {
     // originally a uint8, but the new millisecond wait times require a uint16.
     uint16 command;
     rct_string_id nameStringId;
     rct_string_id descStringId;
-} TITLE_COMMAND_ORDER;
+};
 
 static TITLE_COMMAND_ORDER _window_title_command_editor_orders[] = {
     { TITLE_SCRIPT_LOAD,        STR_TITLE_EDITOR_ACTION_LOAD_SAVE, STR_TITLE_EDITOR_ARGUMENT_SAVEFILE },

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -83,7 +83,7 @@ validate_global_widx(WC_TOP_TOOLBAR, WIDX_WATER);
 validate_global_widx(WC_TOP_TOOLBAR, WIDX_SCENERY);
 validate_global_widx(WC_TOP_TOOLBAR, WIDX_PATH);
 
-typedef enum {
+enum FILE_MENU_DDIDX {
     DDIDX_NEW_GAME = 0,
     DDIDX_LOAD_GAME = 1,
     DDIDX_SAVE_GAME = 2,
@@ -98,9 +98,9 @@ typedef enum {
     DDIDX_EXIT_OPENRCT2 = 11,
     // separator
     DDIDX_ENABLE_TWITCH = 13
-} FILE_MENU_DDIDX;
+};
 
-typedef enum {
+enum TOP_TOOLBAR_VIEW_MENU_DDIDX {
     DDIDX_UNDERGROUND_INSIDE = 0,
     DDIDX_HIDE_BASE = 1,
     DDIDX_HIDE_VERTICAL = 2,
@@ -117,9 +117,9 @@ typedef enum {
     DDIDX_HIGHLIGHT_PATH_ISSUES = 15,
 
     TOP_TOOLBAR_VIEW_MENU_COUNT
-} TOP_TOOLBAR_VIEW_MENU_DDIDX;
+};
 
-typedef enum {
+enum TOP_TOOLBAR_DEBUG_DDIDX {
     DDIDX_CONSOLE = 0,
     DDIDX_TILE_INSPECTOR = 1,
     DDIDX_OBJECT_SELECTION = 2,
@@ -128,11 +128,11 @@ typedef enum {
     DDIDX_DEBUG_PAINT = 5,
 
     TOP_TOOLBAR_DEBUG_COUNT
-} TOP_TOOLBAR_DEBUG_DDIDX;
+};
 
-typedef enum {
+enum TOP_TOOLBAR_NETWORK_DDIDX {
     DDIDX_MULTIPLAYER = 0
-} TOP_TOOLBAR_NETWORK_DDIDX;
+};
 
 enum {
     DDIDX_CHEATS,

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -21,8 +21,8 @@
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2/windows/tile_inspector.h>
 
-typedef void (*loadsave_callback)(sint32 result, const utf8 * path);
-typedef void (*scenarioselect_callback)(const utf8 *path);
+using loadsave_callback       = void (*)(sint32 result, const utf8 * path);
+using scenarioselect_callback = void (*)(const utf8 *path);
 
 rct_window * window_about_open();
 rct_window * window_changelog_open();
@@ -158,7 +158,7 @@ rct_window * window_editor_bottom_toolbar_open();
 
 rct_window * window_tile_inspector_open();
 void window_tile_inspector_clear_clipboard();
-void window_tile_inspector_set_page(rct_window *w, tile_inspector_page page);
+void window_tile_inspector_set_page(rct_window *w, TILE_INSPECTOR_PAGE page);
 void window_tile_inspector_auto_set_buttons(rct_window *w);
 
 rct_window * window_editor_object_selection_open();

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -32,21 +32,21 @@
 
 #pragma pack(push, 1)
 
-typedef struct rct_sprite_file_header {
+struct rct_sprite_file_header {
     uint32 num_entries;
     uint32 total_size;
-} rct_sprite_file_header;
+};
 
 assert_struct_size(rct_sprite_file_header, 8);
 
-typedef struct rct_sprite_file_palette_entry {
+struct rct_sprite_file_palette_entry {
     uint8 b, g, r, a;
-} rct_sprite_file_palette_entry;
+};
 
-typedef struct rle_code {
+struct rle_code {
     uint8 num_pixels;
     uint8 offset_x;
-} rle_code;
+};
 
 assert_struct_size(rle_code, 2);
 

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -18,17 +18,11 @@
 
 #include "common.h"
 
-#ifdef __cplusplus
 class Intent;
-#else
-// Allow C code to use `Intent *`
-typedef struct Intent Intent;
-#endif
+struct rct_window;
+using rct_windowclass = uint8;
 
-typedef struct rct_window rct_window;
-typedef uint8 rct_windowclass;
-
-typedef struct CursorState
+struct CursorState
 {
     sint32  x, y;
     uint8   left, middle, right, any;
@@ -36,9 +30,9 @@ typedef struct CursorState
     sint32  old;
     bool    touch, touchIsDouble;
     uint32  touchDownTimestamp;
-} CursorState;
+};
 
-typedef struct TextInputSession
+struct TextInputSession
 {
     utf8 * Buffer;          // UTF-8 stream
     size_t BufferSize;      // Maximum number of bytes (excluding null terminator)
@@ -48,7 +42,7 @@ typedef struct TextInputSession
     size_t SelectionSize;   // Selection length in bytes
 
     const utf8 * ImeBuffer; // IME UTF-8 stream
-} TextInputSession;
+};
 
 struct Resolution
 {

--- a/src/openrct2/Diagnostic.cpp
+++ b/src/openrct2/Diagnostic.cpp
@@ -26,7 +26,7 @@
 static bool _log_location_enabled = true;
 bool _log_levels[DIAGNOSTIC_LEVEL_COUNT] = { true, true, true, false, true };
 
-static FILE * diagnostic_get_stream(DiagnosticLevel level)
+static FILE * diagnostic_get_stream(DIAGNOSTIG_LEVEL level)
 {
     switch (level) {
     case DIAGNOSTIC_LEVEL_VERBOSE:
@@ -41,7 +41,7 @@ static FILE * diagnostic_get_stream(DiagnosticLevel level)
 
 int _android_log_priority[DIAGNOSTIC_LEVEL_COUNT] = {ANDROID_LOG_FATAL, ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_VERBOSE, ANDROID_LOG_INFO};
 
-void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
+void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
 {
     va_list args;
 
@@ -53,7 +53,7 @@ void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
     va_end(args);
 }
 
-void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
+void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
 {
     va_list args;
     char buf[1024];
@@ -79,7 +79,7 @@ static constexpr const char * _level_strings[] = {
     "INFO"
 };
 
-void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
+void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
 {
     va_list args;
 
@@ -100,7 +100,7 @@ void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...)
     fprintf(stream, "\n");
 }
 
-void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
+void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
 {
     va_list args;
 

--- a/src/openrct2/Diagnostic.cpp
+++ b/src/openrct2/Diagnostic.cpp
@@ -26,7 +26,7 @@
 static bool _log_location_enabled = true;
 bool _log_levels[DIAGNOSTIC_LEVEL_COUNT] = { true, true, true, false, true };
 
-static FILE * diagnostic_get_stream(DIAGNOSTIG_LEVEL level)
+static FILE * diagnostic_get_stream(DIAGNOSTIC_LEVEL level)
 {
     switch (level) {
     case DIAGNOSTIC_LEVEL_VERBOSE:
@@ -41,7 +41,7 @@ static FILE * diagnostic_get_stream(DIAGNOSTIG_LEVEL level)
 
 int _android_log_priority[DIAGNOSTIC_LEVEL_COUNT] = {ANDROID_LOG_FATAL, ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_VERBOSE, ANDROID_LOG_INFO};
 
-void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
+void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char *format, ...)
 {
     va_list args;
 
@@ -53,7 +53,7 @@ void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
     va_end(args);
 }
 
-void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
+void diagnostic_log_with_location(DIAGNOSTIC_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
 {
     va_list args;
     char buf[1024];
@@ -79,7 +79,7 @@ static constexpr const char * _level_strings[] = {
     "INFO"
 };
 
-void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
+void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char *format, ...)
 {
     va_list args;
 
@@ -100,7 +100,7 @@ void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...)
     fprintf(stream, "\n");
 }
 
-void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
+void diagnostic_log_with_location(DIAGNOSTIC_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...)
 {
     va_list args;
 

--- a/src/openrct2/Diagnostic.h
+++ b/src/openrct2/Diagnostic.h
@@ -19,14 +19,14 @@
 
 #include "common.h"
 
-typedef enum {
+enum DIAGNOSTIG_LEVEL {
     DIAGNOSTIC_LEVEL_FATAL,
     DIAGNOSTIC_LEVEL_ERROR,
     DIAGNOSTIC_LEVEL_WARNING,
     DIAGNOSTIC_LEVEL_VERBOSE,
     DIAGNOSTIC_LEVEL_INFORMATION,
     DIAGNOSTIC_LEVEL_COUNT
-} DiagnosticLevel;
+};
 
 /**
  * Compile-time debug levels.
@@ -77,8 +77,8 @@ typedef enum {
 
 extern bool _log_levels[DIAGNOSTIC_LEVEL_COUNT];
 
-void diagnostic_log(DiagnosticLevel diagnosticLevel, const char *format, ...);
-void diagnostic_log_with_location(DiagnosticLevel diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
+void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...);
+void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
 
 #ifdef _MSC_VER
 #define diagnostic_log_macro(level, format, ...)    diagnostic_log_with_location(level, __FILE__, __FUNCTION__, __LINE__, format, ## __VA_ARGS__)

--- a/src/openrct2/Diagnostic.h
+++ b/src/openrct2/Diagnostic.h
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-enum DIAGNOSTIG_LEVEL {
+enum DIAGNOSTIC_LEVEL {
     DIAGNOSTIC_LEVEL_FATAL,
     DIAGNOSTIC_LEVEL_ERROR,
     DIAGNOSTIC_LEVEL_WARNING,
@@ -77,8 +77,8 @@ enum DIAGNOSTIG_LEVEL {
 
 extern bool _log_levels[DIAGNOSTIC_LEVEL_COUNT];
 
-void diagnostic_log(DIAGNOSTIG_LEVEL diagnosticLevel, const char *format, ...);
-void diagnostic_log_with_location(DIAGNOSTIG_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
+void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char *format, ...);
+void diagnostic_log_with_location(DIAGNOSTIC_LEVEL diagnosticLevel, const char *file, const char *function, sint32 line, const char *format, ...);
 
 #ifdef _MSC_VER
 #define diagnostic_log_macro(level, format, ...)    diagnostic_log_with_location(level, __FILE__, __FUNCTION__, __LINE__, format, ## __VA_ARGS__)

--- a/src/openrct2/Editor.h
+++ b/src/openrct2/Editor.h
@@ -42,7 +42,7 @@ namespace Editor
     void SetSelectedObject(sint32 objectType, size_t index, uint32 flags);
 }
 
-typedef enum
+enum RCT2_EDITOR_STEP
 {
     EDITOR_STEP_OBJECT_SELECTION,           // 0
     EDITOR_STEP_LANDSCAPE_EDITOR,           // 1
@@ -52,7 +52,7 @@ typedef enum
     EDITOR_STEP_SAVE_SCENARIO,              // 5
     EDITOR_STEP_ROLLERCOASTER_DESIGNER,     // 6
     EDITOR_STEP_TRACK_DESIGNS_MANAGER       // 7
-} RCT2_EDITOR_STEP;
+};
 
 enum
 {

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -122,9 +122,8 @@ enum
     ERROR_TYPE_FILE_LOAD = 255
 };
 
-typedef void (GAME_COMMAND_POINTER)(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp);
-
-typedef void (GAME_COMMAND_CALLBACK_POINTER)(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp);
+using GAME_COMMAND_POINTER          = void(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp);
+using GAME_COMMAND_CALLBACK_POINTER = void(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp);
 
 extern GAME_COMMAND_CALLBACK_POINTER * game_command_callback;
 sint32 game_command_callback_get_index(GAME_COMMAND_CALLBACK_POINTER * callback);

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -19,7 +19,7 @@
 
 #include "interface/Window.h"
 
-typedef enum INPUT_FLAGS {
+enum INPUT_FLAGS {
     INPUT_FLAG_WIDGET_PRESSED = (1 << 0),
 
     // The dropdown can stay open if the mouse is released, set on flag DROPDOWN_FLAG_STAY_OPEN
@@ -41,7 +41,7 @@ typedef enum INPUT_FLAGS {
     INPUT_FLAG_6 = (1 << 6),
 
     INPUT_FLAG_VIEWPORT_SCROLLING = (1 << 7)
-} INPUT_FLAGS;
+};
 
 enum MOUSE_STATE {
     MOUSE_STATE_RELEASED,
@@ -51,7 +51,7 @@ enum MOUSE_STATE {
     MOUSE_STATE_RIGHT_RELEASE
 };
 
-typedef enum INPUT_STATE {
+enum INPUT_STATE {
     INPUT_STATE_RESET,
     INPUT_STATE_NORMAL,
     INPUT_STATE_WIDGET_PRESSED,
@@ -62,19 +62,19 @@ typedef enum INPUT_STATE {
     INPUT_STATE_SCROLL_LEFT,
     INPUT_STATE_RESIZING,
     INPUT_STATE_SCROLL_RIGHT
-} INPUT_STATE;
+};
 
-typedef enum PLACE_OBJECT_MODIFIER {
+enum PLACE_OBJECT_MODIFIER {
     PLACE_OBJECT_MODIFIER_NONE = 0,
     PLACE_OBJECT_MODIFIER_SHIFT_Z = (1 << 0),
     PLACE_OBJECT_MODIFIER_COPY_Z = (1 << 1),
-} PLACE_OBJECT_MODIFIER;
+};
 
-typedef struct widget_ref {
+struct widget_ref {
     rct_windowclass window_classification;
     rct_windownumber window_number;
     rct_widgetindex widget_index;
-} widget_ref;
+};
 
 extern uint8 gInputPlaceObjectModifier;
 

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -20,16 +20,14 @@
 
 #include "object/Object.h"
 
-typedef enum PARK_LOAD_ERROR
+enum PARK_LOAD_ERROR
 {
     PARK_LOAD_ERROR_OK,
     PARK_LOAD_ERROR_MISSING_OBJECTS,
     PARK_LOAD_ERROR_INVALID_EXTENSION,
     PARK_LOAD_ERROR_UNSUPPORTED_RCTC_FLAG,
     PARK_LOAD_ERROR_UNKNOWN = 255
-} PARK_LOAD_ERROR;
-
-#ifdef __cplusplus
+};
 
 #include <string>
 #include <vector>
@@ -89,12 +87,6 @@ namespace ParkImporter
     bool ExtensionIsScenario(const std::string &extension);
 }
 
-#else
-
-typedef struct ParkLoadResult ParkLoadResult;
-
-#endif
-
 void park_importer_load_from_stream(void * stream, const utf8 * hintPath);
 bool park_importer_extension_is_scenario(const utf8 * extension);
 
@@ -104,4 +96,3 @@ const rct_object_entry *    ParkLoadResult_GetMissingObjects(const ParkLoadResul
 uint8                       ParkLoadResult_GetFlag(const ParkLoadResult * t);
 void                        ParkLoadResult_Delete(ParkLoadResult * t);
 ParkLoadResult *            ParkLoadResult_CreateInvalidExtension();
-

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -70,7 +70,7 @@ namespace GA_FLAGS
 class GameActionResult
 {
 public:
-    typedef std::unique_ptr<GameActionResult> Ptr;
+    using Ptr = std::unique_ptr<GameActionResult>;
 
     GA_ERROR                Error = GA_ERROR::OK;
     rct_string_id           ErrorTitle = STR_NONE;
@@ -91,8 +91,8 @@ public:
 struct GameAction
 {
 public:
-    typedef std::unique_ptr<GameAction> Ptr;
-    typedef std::function<void(const struct GameAction *, const GameActionResult *)> Callback_t;
+    using Ptr        = std::unique_ptr<GameAction>;
+    using Callback_t = std::function<void(const struct GameAction *, const GameActionResult *)>;
 
 private:
     uint32 const _type;
@@ -205,7 +205,7 @@ template<uint32 TType, typename TResultType>
 struct GameActionBase : GameAction
 {
 public:
-    typedef TResultType Result;
+    using Result = TResultType;
 
     static constexpr uint32 TYPE = TType;
 
@@ -223,7 +223,7 @@ public:
     }
 };
 
-typedef GameAction *(*GameActionFactory)();
+using GameActionFactory = GameAction *(*)();
 
 namespace GameActions
 {

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -26,12 +26,12 @@
 #define AUDIO_PLAY_AT_LOCATION      0x8001
 #define SOUND_ID_NULL               0xFFFF
 
-typedef struct audio_device
+struct audio_device
 {
     char name[AUDIO_DEVICE_NAME_SIZE];
-} audio_device;
+};
 
-typedef struct rct_ride_music
+struct rct_ride_music
 {
     uint8 ride_id;
     uint8 tune_id;
@@ -39,16 +39,16 @@ typedef struct rct_ride_music
     sint16 pan;
     uint16 frequency;
     void* sound_channel;
-} rct_ride_music;
+};
 
-typedef struct rct_ride_music_info
+struct rct_ride_music_info
 {
     uint8 path_id;
     uint32 offset;
     uint32 length;
-} rct_ride_music_info;
+};
 
-typedef struct rct_ride_music_params
+struct rct_ride_music_params
 {
     uint8 ride_id;
     uint8 tune_id;
@@ -56,9 +56,9 @@ typedef struct rct_ride_music_params
     sint16 volume;
     sint16 pan;
     uint16 frequency;
-} rct_ride_music_params;
+};
 
-typedef struct rct_vehicle_sound
+struct rct_vehicle_sound
 {
     uint16 id;
     sint16 volume;
@@ -72,9 +72,9 @@ typedef struct rct_vehicle_sound
     uint16 sound2_freq;
     void* sound1_channel;
     void* sound2_channel;
-} rct_vehicle_sound;
+};
 
-typedef struct rct_vehicle_sound_params
+struct rct_vehicle_sound_params
 {
     uint16 id;
     sint16 pan_x;
@@ -82,9 +82,9 @@ typedef struct rct_vehicle_sound_params
     uint16 frequency;
     sint16 volume;
     uint16 priority;
-} rct_vehicle_sound_params;
+};
 
-typedef enum RCT2_SOUND
+enum RCT2_SOUND
 {
     SOUND_LIFT_1,
     SOUND_TRACK_FRICTION_1,
@@ -150,7 +150,7 @@ typedef enum RCT2_SOUND
     SOUND_DOOR_CLOSE,
     SOUND_62,
     SOUND_MAXID
-} RCT2_SOUND;
+};
 
 extern audio_device *   gAudioDevices;
 extern sint32           gAudioDeviceCount;

--- a/src/openrct2/cmdline/CommandLine.hpp
+++ b/src/openrct2/cmdline/CommandLine.hpp
@@ -43,8 +43,8 @@ public:
     bool TryPopString(const char * * result);
 };
 
-typedef sint32 exitcode_t;
-typedef exitcode_t (*CommandLineFunc)(CommandLineArgEnumerator *);
+using exitcode_t      = sint32;
+using CommandLineFunc = exitcode_t (*)(CommandLineArgEnumerator *);
 
 enum
 {

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -35,23 +35,23 @@
 #include <string.h>
 #include <stdbool.h>
 
-typedef int8_t sint8;
-typedef int16_t sint16;
-typedef int32_t sint32;
-typedef int64_t sint64;
-typedef uint8_t uint8;
-typedef uint16_t uint16;
-typedef uint32_t uint32;
-typedef uint64_t uint64;
+using sint8 = int8_t;
+using sint16 = int16_t;
+using sint32 = int32_t;
+using sint64 = int64_t;
+using uint8 = uint8_t;
+using uint16 = uint16_t;
+using uint32 = uint32_t;
+using uint64 = uint64_t;
 
 #include "Diagnostic.h"
 
-typedef char utf8;
-typedef utf8* utf8string;
-typedef const utf8* const_utf8string;
+using utf8             = char;
+using utf8string       = utf8 *;
+using const_utf8string = const utf8 *;
 #ifdef _WIN32
-typedef wchar_t utf16;
-typedef utf16* utf16string;
+using utf16 = wchar_t;
+using utf16string = utf16*;
 #endif
 
 // Define MAX_PATH for various headers that don't want to include system headers
@@ -60,8 +60,8 @@ typedef utf16* utf16string;
 #define MAX_PATH 260
 #endif
 
-typedef uint32 codepoint_t;
-typedef uint8 colour_t;
+using codepoint_t = uint32;
+using colour_t = uint8;
 
 #define rol8(x, shift)      (((uint8)(x) << (shift)) | ((uint8)(x) >> (8 - (shift))))
 #define ror8(x, shift)      (((uint8)(x) >> (shift)) | ((uint8)(x) << (8 - (shift))))
@@ -152,24 +152,24 @@ char *strndup(const char *src, size_t size);
 #define OPENRCT2_MASTER_SERVER_URL  "https://servers.openrct2.io"
 
 // Time (represented as number of 100-nanosecond intervals since 0001-01-01T00:00:00Z)
-typedef uint64 datetime64;
+using datetime64 = uint64;
 
 #define DATETIME64_MIN ((datetime64)0)
 
 // Represent fixed point numbers. dp = decimal point
-typedef uint8 fixed8_1dp;
-typedef uint8 fixed8_2dp;
-typedef sint16 fixed16_1dp;
-typedef sint16 fixed16_2dp;
-typedef sint32 fixed32_1dp;
-typedef sint32 fixed32_2dp;
-typedef sint64 fixed64_1dp;
+using fixed8_1dp = uint8;
+using fixed8_2dp = uint8;
+using fixed16_1dp = sint16;
+using fixed16_2dp = sint16;
+using fixed32_1dp = sint32;
+using fixed32_2dp = sint32;
+using fixed64_1dp = sint64;
 
 // Money is stored as a multiple of 0.10.
-typedef fixed8_1dp money8;
-typedef fixed16_1dp money16;
-typedef fixed32_1dp money32;
-typedef fixed64_1dp money64;
+using money8 = fixed8_1dp;
+using money16 = fixed16_1dp;
+using money32 = fixed32_1dp;
+using money64 = fixed64_1dp;
 
 // Construct a fixed point number. For example, to create the value 3.65 you
 // would write FIXED_2DP(3,65)
@@ -184,8 +184,8 @@ typedef fixed64_1dp money64;
 #define MONEY16_UNDEFINED               (money16)(uint16)0xFFFF
 #define MONEY32_UNDEFINED               ((money32)0x80000000)
 
-typedef void (EMPTY_ARGS_VOID_POINTER)();
-typedef uint16 rct_string_id;
+using EMPTY_ARGS_VOID_POINTER = void();
+using rct_string_id           = uint16;
 
 #define SafeFree(x) do { free(x); (x) = nullptr; } while (false)
 
@@ -266,7 +266,7 @@ typedef uint16 rct_string_id;
  * x86 register structure, only used for easy interop to RCT2 code.
  */
 #pragma pack(push, 1)
-typedef struct registers {
+struct registers {
     union {
         sint32 eax;
         sint16 ax;
@@ -311,7 +311,7 @@ typedef struct registers {
         sint32 ebp;
         sint16 bp;
     };
-} registers;
+};
 assert_struct_size(registers, 7 * 4);
 #pragma pack(pop)
 

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-typedef struct GeneralConfiguration
+struct GeneralConfiguration
 {
     // Paths
     utf8 *      rct1_path;
@@ -98,9 +98,9 @@ typedef struct GeneralConfiguration
     utf8 *      last_run_version;
 
     sint32      screenshot_format;
-} GeneralConfiguration;
+};
 
-typedef struct InterfaceConfiguration
+struct InterfaceConfiguration
 {
     bool        toolbar_show_finances;
     bool        toolbar_show_research;
@@ -111,9 +111,9 @@ typedef struct InterfaceConfiguration
     utf8 *      current_theme_preset;
     utf8 *      current_title_sequence_preset;
     sint32      object_selection_filter_flags;
-} InterfaceConfiguration;
+};
 
-typedef struct SoundConfiguration
+struct SoundConfiguration
 {
     utf8 *      device;
     uint8       master_volume;
@@ -123,9 +123,9 @@ typedef struct SoundConfiguration
     bool        ride_music_enabled;
     uint8       ride_music_volume;
     bool        audio_focus;
-} SoundConfiguration;
+};
 
-typedef struct TwitchConfiguration
+struct TwitchConfiguration
 {
     utf8 *      channel;
     bool        enable_follower_peep_names;
@@ -133,9 +133,9 @@ typedef struct TwitchConfiguration
     bool        enable_chat_peep_names;
     bool        enable_chat_peep_tracking;
     bool        enable_news;
-} TwitchConfiguration;
+};
 
-typedef struct NetworkConfiguration
+struct NetworkConfiguration
 {
     utf8 *      player_name;
     sint32      default_port;
@@ -155,9 +155,9 @@ typedef struct NetworkConfiguration
     bool        log_chat;
     bool        log_server_actions;
     bool        pause_server_if_no_clients;
-} NetworkConfiguration;
+};
 
-typedef struct NotificationConfiguration
+struct NotificationConfiguration
 {
     bool        park_award;
     bool        park_marketing_campaign_finished;
@@ -176,9 +176,9 @@ typedef struct NotificationConfiguration
     bool        guest_bought_item;
     bool        guest_used_facility;
     bool        guest_died;
-} NotificationConfiguration;
+};
 
-typedef struct FontConfiguration
+struct FontConfiguration
 {
     utf8 *      file_name;
     utf8 *      font_name;
@@ -194,7 +194,7 @@ typedef struct FontConfiguration
     sint32      height_big;
     bool        enable_hinting;
     sint32      hinting_threshold;
-} FontConfiguration;
+};
 
 enum SORT
 {

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -62,7 +62,7 @@ struct StringIHash
 {
     std::size_t operator()(const std::string &s) const
     {
-        typedef std::char_traits<char> Traits;
+        using Traits = std::char_traits<char>;
         std::size_t seed = 0;
         for (const char &c : s)
         {
@@ -78,7 +78,7 @@ struct StringICmp
 {
     bool operator()(const std::string &a, const std::string &b) const
     {
-        typedef std::char_traits<char> Traits;
+        using Traits = std::char_traits<char>;
         if (a.size() != b.size()) return false;
         const char *s1 = a.data(), *s2 = b.data();
         for (std::size_t i = a.size(); i > 0; --i, ++s1, ++s2)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -21,7 +21,7 @@
 #include "../interface/Colour.h"
 #include "Font.h"
 
-typedef struct rct_g1_element {
+struct rct_g1_element {
     uint8* offset;          // 0x00
     sint16 width;           // 0x04
     sint16 height;          // 0x06
@@ -29,9 +29,9 @@ typedef struct rct_g1_element {
     sint16 y_offset;        // 0x0A
     uint16 flags;           // 0x0C
     uint16 zoomed_offset;   // 0x0E
-} rct_g1_element;
+};
 
-typedef struct rct_drawpixelinfo {
+struct rct_drawpixelinfo {
     uint8* bits;        // 0x00
     sint16 x;           // 0x04
     sint16 y;           // 0x06
@@ -39,9 +39,9 @@ typedef struct rct_drawpixelinfo {
     sint16 height;      // 0x0A
     sint16 pitch;       // 0x0C         note: this is actually (pitch - width)
     uint16 zoom_level;  // 0x0E
-} rct_drawpixelinfo;
+};
 
-typedef struct rct_g1_element_32bit {
+struct rct_g1_element_32bit {
     uint32 offset;                  // 0x00 note: uint32 always!
     sint16 width;                   // 0x04
     sint16 height;                  // 0x06
@@ -49,7 +49,7 @@ typedef struct rct_g1_element_32bit {
     sint16 y_offset;                // 0x0A
     uint16 flags;                   // 0x0C
     uint16 zoomed_offset;           // 0x0E
-} rct_g1_element_32bit;
+};
 assert_struct_size(rct_g1_element_32bit, 0x10);
 
 
@@ -79,7 +79,7 @@ enum {
     INSET_RECT_FLAG_FILL_MID_LIGHT = (1 << 7), // 0x80
 };
 
-typedef enum {
+enum FILTER_PALETTE_ID {
     PALETTE_NULL = 0,
 
     PALETTE_WATER = 32,
@@ -186,35 +186,35 @@ typedef enum {
     PALETTE_GLASS_DARK_PINK         = 112 + COLOUR_DARK_PINK,
     PALETTE_GLASS_BRIGHT_PINK       = 112 + COLOUR_BRIGHT_PINK,
     PALETTE_GLASS_LIGHT_PINK        = 112 + COLOUR_LIGHT_PINK,
-} FILTER_PALETTE_ID;
+};
 
-typedef struct translucent_window_palette {
+struct translucent_window_palette {
     FILTER_PALETTE_ID base;
     FILTER_PALETTE_ID highlight;
     FILTER_PALETTE_ID shadow;
-} translucent_window_palette;
+};
 
 #pragma pack(push, 1)
 
-typedef struct rct_palette_entry {
+struct rct_palette_entry {
     uint8 blue;
     uint8 green;
     uint8 red;
     uint8 alpha;
-} rct_palette_entry;
+};
 assert_struct_size(rct_palette_entry, 4);
 
 #pragma pack(pop)
 
-typedef struct rct_palette {
+struct rct_palette {
     rct_palette_entry entries[256];
-} rct_palette;
+};
 
-typedef struct rct_size16
+struct rct_size16
 {
     sint16 width;
     sint16 height;
-} rct_size16;
+};
 
 #define SPRITE_ID_PALETTE_COLOUR_1(colourId) (IMAGE_TYPE_REMAP | ((colourId) << 19))
 #define SPRITE_ID_PALETTE_COLOUR_2(primaryId, secondaryId) (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP | ((primaryId << 19) | (secondaryId << 24)))
@@ -335,11 +335,9 @@ sint32 gfx_clip_string(char* buffer, sint32 width);
 void shorten_path(utf8 *buffer, size_t bufferSize, const utf8 *path, sint32 availableWidth);
 void ttf_draw_string(rct_drawpixelinfo *dpi, const_utf8string text, sint32 colour, sint32 x, sint32 y);
 
-typedef struct paint_session paint_session;
-
 // scrolling text
 void scrolling_text_initialise_bitmaps();
-sint32 scrolling_text_setup(paint_session * session, rct_string_id stringId, uint16 scroll, uint16 scrollingMode);
+sint32 scrolling_text_setup(struct paint_session * session, rct_string_id stringId, uint16 scroll, uint16 scrollingMode);
 
 rct_size16 FASTCALL gfx_get_sprite_size(uint32 image_id);
 

--- a/src/openrct2/drawing/Font.h
+++ b/src/openrct2/drawing/Font.h
@@ -40,8 +40,9 @@ enum {
 
 #ifndef NO_TTF
 
-typedef struct _TTF_Font TTF_Font;
-typedef struct TTFFontDescriptor {
+struct _TTF_Font;
+using TTF_Font = _TTF_Font;
+struct TTFFontDescriptor {
     const utf8 *filename;
     const utf8 *font_name;
     sint32 ptSize;
@@ -50,11 +51,11 @@ typedef struct TTFFontDescriptor {
     sint32 line_height;
     sint32 hinting_threshold;
     TTF_Font * font;
-} TTFFontDescriptor;
+};
 
-typedef struct  TTFFontSetDescriptor {
+struct TTFFontSetDescriptor {
     TTFFontDescriptor size[FONT_SIZE_COUNT];
-} TTFFontSetDescriptor;
+};
 
 extern TTFFontSetDescriptor *gCurrentTTFFontSet;
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -46,7 +46,7 @@ static void* _light_rendered_buffer_front = nullptr;
 static uint32   _lightPolution_back = 0;
 static uint32   _lightPolution_front = 0;
 
-typedef struct lightlist_entry {
+struct lightlist_entry {
     sint16  x, y, z;
     uint8   lightType;
     uint8   lightIntensity;
@@ -54,7 +54,7 @@ typedef struct lightlist_entry {
     uint16  lightIDqualifier;
     uint8   lightLinger;
     uint8   pad[1];
-} lightlist_entry;
+};
 
 static lightlist_entry  _LightListA[16000];
 static lightlist_entry  _LightListB[16000];

--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-typedef struct rct_drawpixelinfo rct_drawpixelinfo;
+struct rct_drawpixelinfo;
 
 extern rct_string_id DrawingEngineStringIds[3];
 

--- a/src/openrct2/drawing/Rain.cpp
+++ b/src/openrct2/drawing/Rain.cpp
@@ -27,7 +27,7 @@
 
 using namespace OpenRCT2::Drawing;
 
-typedef void (* DrawRainFunc)(IRainDrawer * rainDrawer, sint32 left, sint32 top, sint32 width, sint32 height);
+using DrawRainFunc = void (*)(IRainDrawer * rainDrawer, sint32 left, sint32 top, sint32 width, sint32 height);
 
 static void DrawLightRain(IRainDrawer * rainDrawer, sint32 left, sint32 top, sint32 width, sint32 height);
 static void DrawHeavyRain(IRainDrawer * rainDrawer, sint32 left, sint32 top, sint32 width, sint32 height);

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -25,7 +25,7 @@
 
 #pragma pack(push, 1)
 /* size: 0xA12 */
-typedef struct rct_draw_scroll_text {
+struct rct_draw_scroll_text {
     rct_string_id string_id;    // 0x00
     uint32 string_args_0;       // 0x02
     uint32 string_args_1;       // 0x06
@@ -33,7 +33,7 @@ typedef struct rct_draw_scroll_text {
     uint16 mode;                // 0x0C
     uint32 id;                  // 0x0E
     uint8 bitmap[64 * 40];      // 0x12
-} rct_draw_scroll_text;
+};
 assert_struct_size(rct_draw_scroll_text, 0xA12);
 #pragma pack(pop)
 

--- a/src/openrct2/drawing/String.cpp
+++ b/src/openrct2/drawing/String.cpp
@@ -422,7 +422,7 @@ void gfx_draw_string_centred_wrapped_partial(rct_drawpixelinfo *dpi, sint32 x, s
     }
 }
 
-typedef struct text_draw_info {
+struct text_draw_info {
     sint32 startX;
     sint32 startY;
     sint32 x;
@@ -433,7 +433,7 @@ typedef struct text_draw_info {
     uint8 palette[8];
     uint16 font_sprite_base;
     const sint8 *y_offset;
-} text_draw_info;
+};
 
 static void ttf_draw_character_sprite(rct_drawpixelinfo *dpi, sint32 codepoint, text_draw_info *info)
 {

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -30,21 +30,21 @@ static bool _ttfInitialised = false;
 #define TTF_SURFACE_CACHE_SIZE 256
 #define TTF_GETWIDTH_CACHE_SIZE 1024
 
-typedef struct ttf_cache_entry
+struct ttf_cache_entry
 {
     TTFSurface *    surface;
     TTF_Font *      font;
     utf8 *          text;
     uint32          lastUseTick;
-} ttf_cache_entry;
+};
 
-typedef struct ttf_getwidth_cache_entry
+struct ttf_getwidth_cache_entry
 {
     uint32      width;
     TTF_Font *  font;
     utf8 *      text;
     uint32      lastUseTick;
-} ttf_getwidth_cache_entry;
+};
 
 static ttf_cache_entry _ttfSurfaceCache[TTF_SURFACE_CACHE_SIZE] = { nullptr };
 static sint32 _ttfSurfaceCacheCount = 0;

--- a/src/openrct2/drawing/TTF.h
+++ b/src/openrct2/drawing/TTF.h
@@ -23,12 +23,12 @@ void ttf_dispose();
 
 #ifndef NO_TTF
 
-typedef struct TTFSurface {
+struct TTFSurface {
     const void *    pixels;
     sint32          w;
     sint32          h;
     sint32          pitch;
-} TTFSurface;
+};
 
 TTFFontDescriptor * ttf_get_font_from_sprite_base(uint16 spriteBase);
 void ttf_toggle_hinting();

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -74,7 +74,7 @@ in the result FT_Bitmap after the FT_Render_Glyph() call. */
 #define CACHED_PIXMAP   0x02
 
 /* Cached glyph information */
-typedef struct cached_glyph {
+struct c_glyph {
     int stored;
     FT_UInt index;
     FT_Bitmap bitmap;
@@ -86,7 +86,7 @@ typedef struct cached_glyph {
     int yoffset;
     int advance;
     uint16 cached;
-} c_glyph;
+};
 
 /* The structure used to hold internal font information */
 struct _TTF_Font {

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -25,12 +25,12 @@
 #define CHAT_MAX_MESSAGE_LENGTH 200
 #define CHAT_MAX_WINDOW_WIDTH 600
 
-typedef enum CHAT_INPUT
+enum CHAT_INPUT
 {
     CHAT_INPUT_NONE,
     CHAT_INPUT_SEND,
     CHAT_INPUT_CLOSE,
-} CHAT_INPUT;
+};
 
 extern bool gChatOpen;
 

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -130,7 +130,7 @@ enum {
 #define NOT_TRANSLUCENT(x)           ((x) & ~COLOUR_FLAG_TRANSLUCENT)
 #define BASE_COLOUR(x)               ((x) & 0x1F)
 
-typedef struct rct_colour_map
+struct rct_colour_map
 {
     uint8 colour_0;
     uint8 colour_1;
@@ -144,7 +144,7 @@ typedef struct rct_colour_map
     uint8 lightest;
     uint8 colour_10;
     uint8 colour_11;
-} rct_colour_map;
+};
 
 extern rct_colour_map ColourMapA[COLOUR_COUNT];
 

--- a/src/openrct2/interface/Console.cpp
+++ b/src/openrct2/interface/Console.cpp
@@ -1368,14 +1368,13 @@ static sint32 cc_for_date(const utf8 **argv, sint32 argc)
     return 1;
 }
 
-
-typedef sint32 (*console_command_func)(const utf8 **argv, sint32 argc);
-typedef struct console_command {
+using console_command_func = sint32 (*)(const utf8 ** argv, sint32 argc);
+struct console_command {
     const utf8 * command;
     console_command_func func;
     const utf8 * help;
     const utf8 * usage;
-} console_command;
+};
 
 static constexpr const utf8* console_variable_table[] = {
     "park_rating",

--- a/src/openrct2/interface/Console.h
+++ b/src/openrct2/interface/Console.h
@@ -21,7 +21,7 @@
 #include "../drawing/Drawing.h"
 #include "../localisation/FormatCodes.h"
 
-typedef enum CONSOLE_INPUT
+enum CONSOLE_INPUT
 {
     CONSOLE_INPUT_NONE,
     CONSOLE_INPUT_LINE_CLEAR,
@@ -30,7 +30,7 @@ typedef enum CONSOLE_INPUT
     CONSOLE_INPUT_HISTORY_NEXT,
     CONSOLE_INPUT_SCROLL_PREVIOUS,
     CONSOLE_INPUT_SCROLL_NEXT,
-} CONSOLE_INPUT;
+};
 
 extern bool gConsoleOpen;
 

--- a/src/openrct2/interface/FontFamilies.h
+++ b/src/openrct2/interface/FontFamilies.h
@@ -24,7 +24,7 @@
 #include <vector>
 #include "Fonts.h"
 
-typedef std::vector<TTFFontSetDescriptor *> TTFontFamily;
+using TTFontFamily = std::vector<TTFFontSetDescriptor *>;
 
 extern TTFontFamily const TTFFamilyChineseSimplified;
 extern TTFontFamily const TTFFamilyChineseTraditional;

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-typedef struct rct_drawpixelinfo rct_drawpixelinfo;
+struct rct_drawpixelinfo;
 
 extern uint8 gScreenshotCountdown;
 

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -76,7 +76,7 @@ enum {
     VIEWPORT_INTERACTION_MASK_BANNER = ~(1 << (VIEWPORT_INTERACTION_ITEM_BANNER - 2)), // Note the -2 for BANNER
 };
 
-typedef struct viewport_interaction_info {
+struct viewport_interaction_info {
     sint32 type;
     sint32 x;
     sint32 y;
@@ -86,7 +86,7 @@ typedef struct viewport_interaction_info {
         rct_peep *peep;
         rct_vehicle *vehicle;
     };
-} viewport_interaction_info;
+};
 
 #define MAX_VIEWPORT_COUNT WINDOW_LIMIT_MAX
 #define MAX_ZOOM_LEVEL 3

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -19,7 +19,7 @@
 
 #include "Window.h"
 
-typedef enum {
+enum WINDOW_WIDGET_TYPES {
     WWT_EMPTY = 0,
     WWT_FRAME = 1,
     WWT_RESIZE = 2,
@@ -43,7 +43,7 @@ typedef enum {
     WWT_PLACEHOLDER = 25,
     WWT_TEXT_BOX = 27,
     WWT_LAST = 26,
-} WINDOW_WIDGET_TYPES;
+};
 
 #define WIDGETS_END     WWT_LAST, 0, 0, 0, 0, 0, 0, 0
 #define BAR_BLINK       (1u << 31)

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -33,7 +33,7 @@ union rct_window_event;
 struct track_design_file_ref;
 struct TitleSequence;
 struct TextInputSession;
-typedef struct scenario_index_entry scenario_index_entry;
+struct scenario_index_entry;
 
 #define SCROLLABLE_ROW_HEIGHT 12
 #define LIST_ROW_HEIGHT 12
@@ -50,21 +50,21 @@ extern sint32 gTextBoxFrameNo;
 extern bool gUsingWidgetTextBox;
 extern struct TextInputSession * gTextInput;
 
-typedef void wndproc(struct rct_window*, union rct_window_event*);
+using wndproc = void(struct rct_window*, union rct_window_event*);
 
-typedef uint8 rct_windowclass;
-typedef uint16 rct_windownumber;
-typedef sint16 rct_widgetindex;
+using rct_windowclass = uint8;
+using rct_windownumber = uint16;
+using rct_widgetindex = sint16;
 
-typedef struct window_identifier {
+struct window_identifier {
     rct_windowclass classification;
     rct_windownumber number;
-} window_identifier;
+};
 
-typedef struct widget_identifier {
+struct widget_identifier {
     window_identifier window;
     rct_widgetindex widget_index;
-} widget_identifier;
+};
 
 extern widget_identifier gCurrentTextBox;
 
@@ -72,7 +72,7 @@ extern widget_identifier gCurrentTextBox;
  * Widget structure
  * size: 0x10
  */
-typedef struct rct_widget {
+struct rct_widget {
     uint8 type;                     // 0x00
     uint8 colour;                   // 0x01
     sint16 left;                    // 0x02
@@ -86,12 +86,12 @@ typedef struct rct_widget {
         utf8 * string;
     };
     rct_string_id tooltip;          // 0x0E
-} rct_widget;
+};
 
 /**
  * Viewport structure
  */
-typedef struct rct_viewport {
+struct rct_viewport {
     sint16 width;                   // 0x00
     sint16 height;                  // 0x02
     sint16 x;                       // 0x04
@@ -104,13 +104,13 @@ typedef struct rct_viewport {
     uint8 zoom;                     // 0x10
     uint8 var_11;
     uint8 visibility;               // VISIBILITY_CACHE
-} rct_viewport;
+};
 
 /**
  * Scroll structure
  * size: 0x12
  */
-typedef struct rct_scroll {
+struct rct_scroll {
     uint16 flags;               // 0x00
     uint16 h_left;              // 0x02
     uint16 h_right;             // 0x04
@@ -120,14 +120,14 @@ typedef struct rct_scroll {
     uint16 v_bottom;            // 0x0C
     uint16 v_thumb_top;         // 0x0E
     uint16 v_thumb_bottom;      // 0x10
-} rct_scroll;
+};
 
 /**
  * Viewport focus structure.
  * size: 0xA
  * Use sprite.type to work out type.
  */
-typedef struct coordinate_focus {
+struct coordinate_focus {
     sint16 var_480;
     sint16 x; //0x482
     sint16 y; //0x484 & VIEWPORT_FOCUS_Y_MASK
@@ -136,10 +136,10 @@ typedef struct coordinate_focus {
     uint8 zoom;//0x489
     sint16 width;
     sint16 height;
-} coordinate_focus;
+};
 
 // Type is viewport_target_sprite_id & 0x80000000 != 0
-typedef struct sprite_focus {
+struct sprite_focus {
     sint16 var_480;
     uint16 sprite_id; //0x482
     uint8 pad_484;
@@ -147,7 +147,7 @@ typedef struct sprite_focus {
     uint16 pad_486;
     uint8 rotation; //0x488
     uint8 zoom; //0x489
-} sprite_focus;
+};
 
 #define VIEWPORT_FOCUS_TYPE_MASK 0xC0
 enum{
@@ -156,7 +156,7 @@ enum{
 };
 #define VIEWPORT_FOCUS_Y_MASK 0x3FFF
 
-typedef struct rct_window_event_list {
+struct rct_window_event_list {
     void (*close)(struct rct_window*);
     void (*mouse_up)(struct rct_window*, rct_widgetindex);
     void (*resize)(struct rct_window*);
@@ -185,65 +185,65 @@ typedef struct rct_window_event_list {
     void (*invalidate)(struct rct_window*);
     void (*paint)(struct rct_window*, rct_drawpixelinfo*);
     void (*scroll_paint)(struct rct_window*, rct_drawpixelinfo*, sint32);
-} rct_window_event_list;
+};
 
-typedef struct campaign_variables {
+struct campaign_variables {
     sint16 campaign_type;
     sint16 no_weeks; //0x482
     uint16 ride_id; //0x484
     uint32 pad_486;
-} campaign_variables;
+};
 
-typedef struct new_ride_variables {
+struct new_ride_variables {
     sint16 selected_ride_id; //0x480
     sint16 highlighted_ride_id; //0x482
     uint16 pad_484;
     uint16 pad_486;
     uint16 selected_ride_countdown; //488
-} new_ride_variables;
+};
 
-typedef struct news_variables {
+struct news_variables {
     sint16 var_480;
     sint16 var_482;
     uint16 var_484;
     uint16 var_486;
     uint16 var_488;
-} news_variables;
+};
 
-typedef struct map_variables {
+struct map_variables {
     sint16 rotation;
     sint16 var_482;
     uint16 var_484;
     uint16 var_486;
     uint16 var_488;
-} map_variables;
+};
 
-typedef struct ride_variables {
+struct ride_variables {
     sint16 view;
     sint32 var_482;
     sint32 var_486;
-} ride_variables;
+};
 
-typedef struct scenery_variables {
+struct scenery_variables {
     sint16 selected_scenery_id;
     sint16 hover_counter;
-} scenery_variables;
+};
 
-typedef struct track_list_variables {
+struct track_list_variables {
     bool track_list_being_updated;
     bool reload_track_designs;
-} track_list_variables;
+};
 
-typedef struct error_variables {
+struct error_variables {
     uint16 var_480;
-} error_variables;
+};
 
-typedef struct rct_window rct_window;
+struct rct_window;
 
 #define RCT_WINDOW_RIGHT(w) (w->x + w->width)
 #define RCT_WINDOW_BOTTOM(w) (w->y + w->height)
 
-typedef enum {
+enum WINDOW_EVENTS {
     WE_CLOSE = 0,
     WE_MOUSE_UP = 1,
     WE_RESIZE = 2,
@@ -277,9 +277,9 @@ typedef enum {
     WE_INVALIDATE = 25,
     WE_PAINT = 26,
     WE_SCROLL_PAINT = 27,
-} WINDOW_EVENTS;
+};
 
-typedef enum {
+enum WINDOW_FLAGS {
     /*
     WF_TIMEOUT_SHL = 0,
     WF_TIMEOUT_MASK = 7,
@@ -304,7 +304,7 @@ typedef enum {
     WF_WHITE_BORDER_MASK = (1 << 12) | (1 << 13),
 
     WF_NO_SNAPPING = (1 << 15)
-} WINDOW_FLAGS;
+};
 
 enum SCROLL_FLAGS {
     HSCROLLBAR_VISIBLE = (1 << 0),
@@ -482,13 +482,13 @@ enum PROMPT_MODE {
     PM_QUIT
 };
 
-typedef enum {
+enum BTM_TOOLBAR_DIRTY_FLAGS {
     BTM_TB_DIRTY_FLAG_MONEY = (1 << 0),
     BTM_TB_DIRTY_FLAG_DATE = (1 << 1),
     BTM_TB_DIRTY_FLAG_PEEP_COUNT = (1 << 2),
     BTM_TB_DIRTY_FLAG_CLIMATE = (1 << 3),
     BTM_TB_DIRTY_FLAG_PARK_RATING = (1 << 4)
-} BTM_TOOLBAR_DIRTY_FLAGS;
+};
 
 // 000N_TTTL
 enum {
@@ -523,7 +523,7 @@ enum GUEST_LIST_FILTER_TYPE
     GLFT_GUESTS_THINKING_X,
 };
 
-typedef enum {
+enum TOOL_IDX {
     TOOL_ARROW = 0,
     TOOL_UP_ARROW = 2,
     TOOL_UP_DOWN_ARROW = 3,
@@ -535,11 +535,10 @@ typedef enum {
     TOOL_WALK_DOWN = 22,
     TOOL_PAINT_DOWN = 23,
     TOOL_ENTRANCE_DOWN = 24,
-} TOOL_IDX;
+};
 
-typedef void (*modal_callback)(sint32 result);
-
-typedef void (*close_callback)();
+using modal_callback = void (*)(sint32 result);
+using close_callback = void (*)();
 
 #define WINDOW_LIMIT_MIN 4
 #define WINDOW_LIMIT_MAX 64

--- a/src/openrct2/localisation/ConversionTables.h
+++ b/src/openrct2/localisation/ConversionTables.h
@@ -18,12 +18,11 @@
 
 #include "../common.h"
 
-typedef struct encoding_convert_entry
+struct encoding_convert_entry
 {
     uint16 code;
     uint32 unicode;
-}
-encoding_convert_entry;
+};
 
 extern const encoding_convert_entry GB2312ToUnicodeTable[7445];
 extern const encoding_convert_entry Big5ToUnicodeTable[13710];
@@ -31,7 +30,7 @@ extern const encoding_convert_entry RCT2ToUnicodeTable[256];
 extern const encoding_convert_entry CP932ToUnicodeTable[7916];
 extern const encoding_convert_entry CP949ToUnicodeTable[17176];
 
-typedef enum RCT2Polish
+enum RCT2Polish
 {
     RCT2_A_OGONEK_UC = 159, // 0x9F
     RCT2_C_ACUTE_UC =  162, // 0xA2
@@ -50,10 +49,9 @@ typedef enum RCT2Polish
     RCT2_S_ACUTE =     248, // 0xF8
     RCT2_Z_DOT =       253, // 0xFD
     RCT2_Z_ACUTE =     254, // 0xFE
-}
-RCT2Polish;
+};
 
-typedef enum UnicodePolish
+enum UnicodePolish
 {
     UNICODE_A_OGONEK_UC = 260,
     UNICODE_C_ACUTE_UC = 262,
@@ -72,5 +70,4 @@ typedef enum UnicodePolish
     UNICODE_S_ACUTE = 347,
     UNICODE_Z_DOT = 380,
     UNICODE_Z_ACUTE = 378,
-}
-UnicodePolish;
+};

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -20,7 +20,7 @@
 #include "../common.h"
 
 // List of currencies
-typedef enum {
+enum CURRENCY_TYPE {
     CURRENCY_POUNDS,            // British Pound
     CURRENCY_DOLLARS,           // US Dollar
     CURRENCY_FRANC,             // French Franc
@@ -41,18 +41,18 @@ typedef enum {
     CURRENCY_CUSTOM,            // Custom currency
 
     CURRENCY_END                // Last item
-} CURRENCY_TYPE;
+};
 
-typedef enum {
+enum CURRENCY_AFFIX {
     CURRENCY_PREFIX,
     CURRENCY_SUFFIX
-} CURRENCY_AFFIX;
+};
 
 #define CURRENCY_SYMBOL_MAX_SIZE 8
 #define CURRENCY_RATE_MAX_NUM_DIGITS 9
 
 // Currency format specification - inspired by OpenTTD
-typedef struct currency_descriptor {
+struct currency_descriptor {
     char isoCode[4];
     // Rate is relative to 0.10 GBP
     sint32 rate;
@@ -61,7 +61,7 @@ typedef struct currency_descriptor {
     uint8 affix_ascii;
     char symbol_ascii[CURRENCY_SYMBOL_MAX_SIZE];
     rct_string_id stringId;
-} currency_descriptor;
+};
 
 // List of currency formats
 extern currency_descriptor CurrencyDescriptors[CURRENCY_END];

--- a/src/openrct2/localisation/Date.h
+++ b/src/openrct2/localisation/Date.h
@@ -39,11 +39,11 @@ enum {
     DATE_FORMAT_YEAR_DAY_MONTH
 };
 
-typedef struct openrct_timeofday {
+struct openrct_timeofday {
     uint8 second;
     uint8 minute;
     uint8 hour;
-} openrct_timeofday;
+};
 
 extern const sint16 days_in_month[MONTH_COUNT];
 extern const rct_string_id DateFormatStringIds[];

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -21,10 +21,10 @@
 
 #pragma region Format codes
 
-typedef struct format_code_token {
+struct format_code_token {
     uint32 code;
     const char *token;
-} format_code_token;
+};
 
 // clang-format off
 static constexpr const format_code_token format_code_tokens[] = {

--- a/src/openrct2/localisation/Language.h
+++ b/src/openrct2/localisation/Language.h
@@ -47,7 +47,7 @@ enum {
     LANGUAGE_COUNT
 };
 
-typedef enum RCT2LanguageId
+enum RCT2LanguageId
 {
     RCT2_LANGUAGE_ID_ENGLISH_UK,
     RCT2_LANGUAGE_ID_ENGLISH_US,
@@ -65,13 +65,13 @@ typedef enum RCT2LanguageId
     RCT2_LANGUAGE_ID_PORTUGUESE,
     RCT2_LANGUAGE_ID_BLANK = 254,
     RCT2_LANGUAGE_ID_END = 255
-} RCT2LanguageId;
+};
 
 #define FONT_OPENRCT2_SPRITE NULL
 
 #include "../interface/FontFamilies.h"
 
-typedef struct language_descriptor {
+struct language_descriptor {
     const char *locale;
     const utf8 *english_name;
     const utf8 *native_name;
@@ -81,7 +81,7 @@ typedef struct language_descriptor {
     void * font_family;
 #endif
     RCT2LanguageId rct2_original_id;
-} language_descriptor;
+};
 
 extern const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT];
 

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -640,7 +640,7 @@ static bool award_is_deserved_best_gentle_rides(sint32 awardType, sint32 activeA
     return (gentleRides >= 10);
 }
 
-typedef bool (* award_deserved_check)(sint32, sint32);
+using award_deserved_check = bool (*)(sint32, sint32);
 
 static constexpr const award_deserved_check _awardChecks[] =
 {

--- a/src/openrct2/management/Award.h
+++ b/src/openrct2/management/Award.h
@@ -18,11 +18,11 @@
 
 #include "../common.h"
 
-typedef struct Award
+struct Award
 {
     uint16 Time;
     uint16 Type;
-} Award;
+};
 
 enum PARK_AWARD
 {

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -20,7 +20,7 @@
 #include "../peep/Staff.h"
 #include "Research.h"
 
-typedef sint32 rct_expenditure_type;
+using rct_expenditure_type = sint32;
 
 enum {
     RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION,

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -46,7 +46,7 @@ enum
 /**
  * A single news item / message.
  */
-typedef struct NewsItem
+struct NewsItem
 {
     uint8  Type;
     uint8  Flags;
@@ -55,7 +55,7 @@ typedef struct NewsItem
     uint16 MonthYear;
     uint8  Day;
     utf8   Text[256];
-} NewsItem;
+};
 
 #define MAX_NEWS_ITEMS 61
 

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -20,10 +20,10 @@
 #include "../object/ObjectLimits.h"
 #include "../ride/Ride.h"
 
-typedef struct rct_ride_entry rct_ride_entry;
+struct rct_ride_entry;
 
 #pragma pack(push, 1)
-typedef struct rct_research_item
+struct rct_research_item
 {
     // Bit 16 (0: scenery entry, 1: ride entry)
     union
@@ -38,7 +38,7 @@ typedef struct rct_research_item
         };
     };
     uint8 category;
-} rct_research_item;
+};
 assert_struct_size(rct_research_item, 5);
 #pragma pack(pop)
 

--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -43,7 +43,7 @@ struct HttpRequest2
     void *          Tag = nullptr;
     std::string     Method;
     std::string     Url;
-    http_data_type  Type;
+    HTTP_DATA_TYPE  Type;
     bool            ForceIPv4 = false;
     size_t          Size = 0;
     union
@@ -105,17 +105,17 @@ struct HttpRequest2
     }
 };
 
-typedef struct read_buffer {
+struct read_buffer {
     char *ptr;
     size_t length;
     size_t position;
-} read_buffer;
+};
 
-typedef struct write_buffer {
+struct write_buffer {
     char *ptr;
     size_t length;
     size_t capacity;
-} write_buffer;
+};
 
 void http_init()
 {

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -22,8 +22,8 @@
 #include "../common.h"
 #include <string>
 
-typedef struct evp_pkey_st EVP_PKEY;
-typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+using EVP_PKEY     = evp_pkey_st;
+using EVP_PKEY_CTX = evp_pkey_ctx_st;
 
 interface IStream;
 

--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -47,7 +47,7 @@
     #include <sys/socket.h>
     #include <fcntl.h>
     #include "../common.h"
-    typedef sint32 SOCKET;
+    using SOCKET = sint32;
     #define SOCKET_ERROR -1
     #define INVALID_SOCKET -1
     #define LAST_SOCKET_ERROR() errno

--- a/src/openrct2/network/http.h
+++ b/src/openrct2/network/http.h
@@ -22,35 +22,35 @@
 #include <jansson.h>
 #include "../common.h"
 
-typedef enum http_data_type_T {
+enum HTTP_DATA_TYPE {
     HTTP_DATA_NONE,
     HTTP_DATA_RAW,
     HTTP_DATA_JSON
-} http_data_type;
+};
 
-typedef struct http_request_t {
+struct http_request_t {
     void *tag;
     std::string method;
     std::string url;
-    http_data_type type = HTTP_DATA_NONE;
+    HTTP_DATA_TYPE type = HTTP_DATA_NONE;
     bool forceIPv4;
     size_t size;
     union {
         const json_t *root;
         char* body;
     };
-} http_request_t;
+};
 
-typedef struct http_response_t {
+struct http_response_t {
     void *tag;
     sint32 status_code;
-    http_data_type type;
+    HTTP_DATA_TYPE type;
     size_t size;
     union {
         json_t *root;
         char* body;
     };
-} http_response_t;
+};
 
 #define HTTP_METHOD_GET     "GET"
 #define HTTP_METHOD_POST    "POST"

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -43,7 +43,7 @@ enum {
 #include "../Version.h"
 #include "NetworkTypes.h"
 
-typedef struct GameAction GameAction;
+struct GameAction;
 
 #ifndef DISABLE_NETWORK
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -21,7 +21,7 @@
 #include "StringTable.h"
 
 // First 0xF of rct_object_entry->flags
-typedef enum
+enum OBJECT_TYPE
 {
     OBJECT_TYPE_RIDE,
     OBJECT_TYPE_SMALL_SCENERY,
@@ -36,9 +36,9 @@ typedef enum
     OBJECT_TYPE_SCENARIO_TEXT,
     
     OBJECT_TYPE_COUNT
-} OBJECT_TYPE;
+};
 
-typedef enum
+enum OBJECT_SELECTION_FLAGS
 {
     OBJECT_SELECTION_FLAG_SELECTED = (1 << 0),
     OBJECT_SELECTION_FLAG_2 = (1 << 1),
@@ -49,11 +49,11 @@ typedef enum
     OBJECT_SELECTION_FLAG_7 = (1 << 6),
     OBJECT_SELECTION_FLAG_8 = (1 << 7),
     OBJECT_SELECTION_FLAG_ALL = 0xFF,
-} OBJECT_SELECTION_FLAGS;
+};
 
 #define OBJECT_SELECTION_NOT_SELECTED_OR_REQUIRED 0
 
-typedef enum
+enum OBJECT_SOURCE_GAME
 {
     OBJECT_SOURCE_CUSTOM,
     OBJECT_SOURCE_WACKY_WORLDS,
@@ -63,7 +63,7 @@ typedef enum
     OBJECT_SOURCE_ADDED_ATTRACTIONS,
     OBJECT_SOURCE_LOOPY_LANDSCAPES,
     OBJECT_SOURCE_RCT2 = 8
-} OBJECT_SOURCE_GAME;
+};
 
 #define OBJECT_ENTRY_COUNT 721
 
@@ -72,7 +72,7 @@ typedef enum
  * Object entry structure.
  * size: 0x10
  */
-typedef struct rct_object_entry {
+struct rct_object_entry {
     union {
         uint8 end_flag; // needed not to read past allocated buffer.
         uint32 flags;
@@ -85,28 +85,28 @@ typedef struct rct_object_entry {
         };
     };
 
-} rct_object_entry;
+};
 assert_struct_size(rct_object_entry, 0x10);
 
-typedef struct rct_object_entry_group {
+struct rct_object_entry_group {
     void **chunks;
     rct_object_entry *entries;
-} rct_object_entry_group;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_object_entry_group, 8);
 #endif
 
-typedef struct rct_ride_filters {
+struct rct_ride_filters {
     uint8 category[2];
     uint8 ride_type;
-} rct_ride_filters;
+};
 assert_struct_size(rct_ride_filters, 3);
 
-typedef struct rct_object_filters {
+struct rct_object_filters {
     union {
         rct_ride_filters ride;
     };
-} rct_object_filters;
+};
 assert_struct_size(rct_object_filters, 3);
 #pragma pack(pop)
 

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -28,10 +28,9 @@ namespace OpenRCT2
     interface IPlatformEnvironment;
 }
 
+struct rct_drawpixelinfo;
 
-typedef struct rct_drawpixelinfo rct_drawpixelinfo;
-
-typedef struct ObjectRepositoryItem
+struct ObjectRepositoryItem
 {
     size_t             Id;
     rct_object_entry   ObjectEntry;
@@ -53,7 +52,7 @@ typedef struct ObjectRepositoryItem
             rct_object_entry * ThemeObjects;
         };
     };
-} ObjectRepositoryItem;
+};
 
 interface IObjectRepository
 {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -21,10 +21,6 @@
 #include "../interface/Colour.h"
 #include "../drawing/Drawing.h"
 
-typedef struct attached_paint_struct attached_paint_struct;
-typedef struct paint_struct paint_struct;
-typedef union paint_entry paint_entry;
-
 #pragma pack(push, 1)
 /* size 0x12 */
 struct attached_paint_struct {
@@ -51,14 +47,14 @@ enum PAINT_QUADRANT_FLAGS {
     PAINT_QUADRANT_FLAG_NEXT = (1 << 1),
 };
 
-typedef struct paint_struct_bound_box {
+struct paint_struct_bound_box {
     uint16 x;
     uint16 y;
     uint16 z;
     uint16 x_end;
     uint16 y_end;
     uint16 z_end;
-} paint_struct_bound_box;
+};
 
 /* size 0x34 */
 struct paint_struct {
@@ -89,8 +85,6 @@ struct paint_struct {
 assert_struct_size(paint_struct, 0x34);
 #endif
 
-typedef struct paint_string_struct paint_string_struct;
-
 /* size 0x1E */
 struct paint_string_struct {
     rct_string_id string_id;        // 0x00
@@ -111,32 +105,32 @@ union paint_entry {
     paint_string_struct string;
 };
 
-typedef struct sprite_bb {
+struct sprite_bb {
     uint32 sprite_id;
     LocationXYZ16 offset;
     LocationXYZ16 bb_offset;
     LocationXYZ16 bb_size;
-} sprite_bb;
+};
 
 enum PAINT_STRUCT_FLAGS {
     PAINT_STRUCT_FLAG_IS_MASKED = (1 << 0)
 };
 
-typedef struct support_height {
+struct support_height {
     uint16 height;
     uint8 slope;
     uint8 pad;
-} support_height;
+};
 
-typedef struct tunnel_entry {
+struct tunnel_entry {
     uint8 height;
     uint8 type;
-} tunnel_entry;
+};
 
 #define MAX_PAINT_QUADRANTS 512
 #define TUNNEL_MAX_COUNT    65
 
-typedef struct paint_session
+struct paint_session
 {
     rct_drawpixelinfo *      Unk140E9A8;
     paint_entry              PaintStructs[4000];
@@ -169,7 +163,7 @@ typedef struct paint_session
     uint8                    Unk141E9DB;
     uint16                   WaterHeight;
     uint32                   TrackColours[4];
-} paint_session;
+};
 
 extern paint_session gPaintSession;
 

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -134,10 +134,10 @@ static constexpr const uint8 supportTypeToHeight[] = {
     6,
 };
 
-typedef struct metal_supports_images {
+struct metal_supports_images {
     uint16 base_id;
     uint16 beam_id;
-} metal_supports_images;
+};
 
 /** rct2: 0x0097B15C */
 static constexpr const metal_supports_images _97B15C[] = {
@@ -179,12 +179,12 @@ static constexpr const uint8 metal_supports_slope_image_map[] = {
      0,  0,  0,  0,  0,  0,  0, 15,  0,  0,  0, 16,  0, 17, 18,  0,
 };
 
-typedef struct supports_id_desc {
+struct supports_id_desc {
     uint16 full;
     uint16 half;
     uint16 flat;
     uint16 slope;
-} supports_id_desc;
+};
 
 /* 0x0097B1C4 */
 static constexpr const supports_id_desc WoodenSupportImageIds[] = {
@@ -218,20 +218,20 @@ static constexpr const uint16 WoodenCurveSupportImageIds[] = {
     0,
 };
 
-typedef struct unk_supports_desc_bound_box {
+struct unk_supports_desc_bound_box {
     struct {
         uint8 x, y, z;
     } offset;
     struct {
         uint8 x, y, z;
     } length;
-} unk_supports_desc_bound_box;
+};
 
-typedef struct unk_supports_desc {
+struct unk_supports_desc {
     unk_supports_desc_bound_box bounding_box;
     uint8 var_6;
     uint8 var_7;
-} unk_supports_desc;
+};
 
 /* 0x0097B23C */
 static constexpr const unk_supports_desc byte_97B23C[] = {

--- a/src/openrct2/paint/sprite/Litter.cpp
+++ b/src/openrct2/paint/sprite/Litter.cpp
@@ -45,10 +45,10 @@ enum {
     SPR_LITTER_EMPTY_BOWL_BLUE = 23129,
 };
 
-typedef struct litter_sprite {
+struct litter_sprite {
     uint16 base_id;
     uint8 direction_mask;
-} litter_sprite;
+};
 
 /** rct2: 0x0097EF6C */
 static constexpr const litter_sprite litter_sprites[] = {

--- a/src/openrct2/paint/sprite/Sprite.h
+++ b/src/openrct2/paint/sprite/Sprite.h
@@ -20,7 +20,7 @@
 #include "../../common.h"
 #include "../../world/Sprite.h"
 
-typedef struct paint_session paint_session;
+struct paint_session;
 
 void sprite_paint_setup(paint_session * session, const uint16 eax, const uint16 ecx);
 

--- a/src/openrct2/paint/tile_element/LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/LargeScenery.cpp
@@ -162,10 +162,10 @@ static void large_scenery_sign_paint_line(paint_session * session, const utf8 *s
     }
 }
 
-typedef struct boundbox {
+struct boundbox {
     LocationXY16 offset;
     LocationXY16 length;
-} boundbox;
+};
 
 static constexpr const boundbox s98E3C4[] = {
     { 3,   3, 26, 26 },

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -70,8 +70,6 @@ enum
     CORNER_LEFT
 };
 
-typedef struct corner_height corner_height;
-
 struct corner_height
 {
     uint8 top;
@@ -365,8 +363,6 @@ static constexpr const uint32 dword_97B898[][2] =
     { SPR_TERRAIN_GRASS_MOWED_90, SPR_TERRAIN_GRASS_MOWED_90_GRID },
     { SPR_TERRAIN_GRASS_MOWED,    SPR_TERRAIN_GRASS_MOWED_GRID }
 };
-
-typedef struct tile_descriptor tile_descriptor;
 
 struct tile_descriptor
 {

--- a/src/openrct2/paint/tile_element/TileElement.h
+++ b/src/openrct2/paint/tile_element/TileElement.h
@@ -20,9 +20,9 @@
 #include "../../common.h"
 #include "../../world/Map.h"
 
-typedef struct paint_session paint_session;
+struct paint_session;
 
-typedef enum edge_t
+enum edge_t
 {
     EDGE_NE = (1 << 0),
     EDGE_SE = (1 << 1),
@@ -32,7 +32,7 @@ typedef enum edge_t
     EDGE_BOTTOMRIGHT = EDGE_SE,
     EDGE_TOPLEFT = EDGE_NW,
     EDGE_TOPRIGHT = EDGE_NE
-} edge_t;
+};
 
 enum
 {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1834,12 +1834,12 @@ static void set_sprite_type(rct_peep * peep, uint8 type)
     }
 }
 
-typedef struct item_pref_t
+struct item_pref_t
 {
     uint8  type; // 0 for standard, 1 for extra
     uint32 item; // And this with the relevant flags
     uint8  sprite_type;
-} item_pref_t;
+};
 
 // clang-format off
 static item_pref_t item_order_preference[] = {
@@ -12441,7 +12441,7 @@ static bool peep_has_valid_xy(rct_peep * peep)
     return false;
 }
 
-typedef void (*easter_egg_function)(rct_peep * peep, rct_peep * otherPeep);
+using easter_egg_function = void (*)(rct_peep * peep, rct_peep * otherPeep);
 
 static void peep_apply_easter_egg_to_nearby_guests(rct_peep * peep, easter_egg_function easter_egg)
 {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -468,16 +468,16 @@ enum PEEP_RIDE_DECISION
 };
 
 #pragma pack(push, 1)
-typedef struct rct_peep_thought
+struct rct_peep_thought
 {
     uint8 type;  // 0
     uint8 item;  // 1
     uint8 var_2; // 2
     uint8 var_3; // 3
-} rct_peep_thought;
+};
 assert_struct_size(rct_peep_thought, 4);
 
-typedef struct rct_peep
+struct rct_peep
 {
     uint8  sprite_identifier; // 0x00
     uint8  var_01;
@@ -649,29 +649,29 @@ typedef struct rct_peep
     uint8  favourite_ride_rating; // 0xFA
     uint8  pad_FB;
     uint32 item_standard_flags; // 0xFC
-} rct_peep;
+};
 assert_struct_size(rct_peep, 0x100);
 #pragma pack(pop)
 
-typedef struct rct_sprite_bounds
+struct rct_sprite_bounds
 {
     uint8 sprite_width;           // 0x00
     uint8 sprite_height_negative; // 0x01
     uint8 sprite_height_positive; // 0x02
-} rct_sprite_bounds;
+};
 
-typedef struct rct_peep_animation
+struct rct_peep_animation
 {
     uint32        base_image; // 0x00
     size_t        num_frames;
     const uint8 * frame_offsets;
-} rct_peep_animation;
+};
 
-typedef struct rct_peep_animation_entry
+struct rct_peep_animation_entry
 {
     const rct_peep_animation * sprite_animation; // 0x00
     const rct_sprite_bounds *  sprite_bounds;    // 0x04
-} rct_peep_animation_entry;
+};
 
 enum
 {

--- a/src/openrct2/platform/Crash.h
+++ b/src/openrct2/platform/Crash.h
@@ -17,7 +17,7 @@
 #ifndef _OPENRCT2_CRASH_
 #define _OPENRCT2_CRASH_
 
-typedef void * CExceptionHandler;
+using CExceptionHandler = void *;
 
 extern bool gOpenRCT2SilentBreakpad;
 CExceptionHandler crash_init();

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -71,7 +71,7 @@ static uint32        _frequency = 0;
 static LARGE_INTEGER _entryTimestamp;
 #endif
 
-typedef void (*update_palette_func)(const uint8 *, sint32, sint32);
+using update_palette_func = void (*)(const uint8 *, sint32, sint32);
 
 rct_palette_entry gPalette[256];
 

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -20,8 +20,8 @@
 #include <time.h>
 #include "../common.h"
 
-typedef struct TTFFontDescriptor TTFFontDescriptor;
-typedef struct rct2_install_info rct2_install_info;
+struct TTFFontDescriptor;
+struct rct2_install_info;
 
 #ifndef MAX_PATH
 #define MAX_PATH 260
@@ -44,32 +44,36 @@ typedef struct rct2_install_info rct2_install_info;
 #define ALT 0x400
 #define CMD 0x800
 
-typedef struct resolution {
+struct resolution_t {
     sint32 width, height;
-} resolution_t;
+};
 
-typedef struct file_info {
+struct file_info {
     const char *path;
     uint64 size;
     uint64 last_modified;
-} file_info;
+};
 
-typedef struct rct2_date {
+struct rct2_date {
     uint8 day;
     uint8 month;
     sint16 year;
     uint8 day_of_week;
-} rct2_date;
+};
 
-typedef struct rct2_time {
+struct rct2_time {
     uint8 hour;
     uint8 minute;
     uint8 second;
-} rct2_time;
+};
 
-typedef enum {FD_OPEN, FD_SAVE} filedialog_type;
+enum FILEDIALOG_TYPE
+{
+    FD_OPEN,
+    FD_SAVE
+};
 
-typedef struct file_dialog_desc {
+struct file_dialog_desc {
     uint8 type;
     const utf8 *title;
     const utf8 *initial_directory;
@@ -78,7 +82,7 @@ typedef struct file_dialog_desc {
         const utf8 *name;           // E.g. "Image Files"
         const utf8 *pattern;        // E.g. "*.png;*.jpg;*.gif"
     } filters[8];
-} file_dialog_desc;
+};
 
 // Platform shared definitions
 void platform_update_palette(const uint8 *colours, sint32 start_index, sint32 num_colours);

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -36,22 +36,22 @@
 #define RCT1_RESEARCH_FLAGS_SEPARATOR 0xFF
 #define RCT1_MAX_ANIMATED_OBJECTS     1000
 
-typedef struct ParkLoadResult ParkLoadResult;
+struct ParkLoadResult;
 
 #pragma pack(push, 1)
-typedef struct rct1_entrance {
+struct rct1_entrance {
     uint16 x;
     uint16 y;
     uint16 z;
     uint8 direction;
-} rct1_entrance;
+};
 assert_struct_size(rct1_entrance, 7);
 
 /**
  * RCT1 ride structure
  * size: 0x260
  */
-typedef struct rct1_ride {
+struct rct1_ride {
     uint8 type;                                             // 0x000
     uint8 vehicle_type;                                     // 0x001
     uint16 lifecycle_flags;                                 // 0x002
@@ -211,10 +211,10 @@ typedef struct rct1_ride {
     uint8 music;                                            // 0x178
     uint8 entrance_style;                                   // 0x179
     uint8 unk_17A[230];                                     // 0x17A
-} rct1_ride;
+};
 assert_struct_size(rct1_ride, 0x260);
 
-typedef struct rct1_unk_sprite {
+struct rct1_unk_sprite {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -245,9 +245,9 @@ typedef struct rct1_unk_sprite {
     uint8 var_2B;
     uint8 pad_2C[0x45];
     uint8 var_71;
-} rct1_unk_sprite;
+};
 
-typedef struct rct1_vehicle {
+struct rct1_vehicle {
     uint8 sprite_identifier;        // 0x00
     uint8 is_child;                 // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -361,9 +361,9 @@ typedef struct rct1_vehicle {
     uint8 mini_golf_flags;          // 0xD5
     uint8 ride_subtype;             // 0xD6
     uint8 colours_extended;         // 0xD7
-} rct1_vehicle;
+};
 
-typedef struct rct1_peep {
+struct rct1_peep {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -517,9 +517,8 @@ typedef struct rct1_peep {
     uint8 favourite_ride_rating;    // 0xFA
     uint8 pad_FB;
     uint32 item_standard_flags;     // 0xFC
-} rct1_peep;
+};
 assert_struct_size(rct1_peep, 0x100);
-
 
 enum RCT1_PEEP_SPRITE_TYPE {
     RCT1_PEEP_SPRITE_TYPE_NORMAL = 0,
@@ -552,7 +551,7 @@ enum RCT1_PEEP_SPRITE_TYPE {
     RCT1_PEEP_SPRITE_TYPE_TOFFEE_APPLE = 30
 };
 
-typedef union rct1_sprite {
+union rct1_sprite {
     uint8 pad_00[0x100];
     rct1_unk_sprite unknown;
     rct1_vehicle vehicle;
@@ -565,23 +564,23 @@ typedef union rct1_sprite {
     rct_crashed_vehicle_particle crashed_vehicle_particle;
     rct_crash_splash crash_splash;
     rct_steam_particle steam_particle;
-} rct1_sprite;
+};
 assert_struct_size(rct1_sprite, 0x100);
 
-typedef struct rct1_research_item {
+struct rct1_research_item {
     uint8 item;
     uint8 related_ride;
     uint8 type;
     uint8 flags;
     uint8 category;
-} rct1_research_item;
+};
 assert_struct_size(rct1_research_item, 5);
 
 /**
  * RCT1,AA,LL scenario / saved game structure.
  * size: 0x1F850C
  */
-typedef struct rct1_s4 {
+struct rct1_s4 {
     uint16 month;
     uint16 day;
     uint32 ticks;
@@ -750,14 +749,14 @@ typedef struct rct1_s4 {
     uint32 scenario_flags;
     uint8 unk_1F8358[432];
     uint32 expansion_pack_checksum;
-} rct1_s4;
+};
 assert_struct_size(rct1_s4, 0x1F850C);
 
 /**
  * Track design structure.
  * size: 0x2006
  */
-typedef struct rct_track_td4 {
+struct rct_track_td4 {
     uint8 type;                                     // 0x00
     uint8 vehicle_type;
     uint32 flags;                                   // 0x02
@@ -805,7 +804,7 @@ typedef struct rct_track_td4 {
 
     void *elements;                                 // 0xC4 (data starts here in file, 38 for original RCT1)
     size_t elementsSize;
-} rct_track_td4;
+};
 #pragma pack(pop)
 
 enum {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -44,18 +44,18 @@
 
 #pragma pack(push, 1)
 
-typedef struct rct12_award
+struct rct12_award
 {
     uint16 time;
     uint16 type;
-} rct12_award;
+};
 assert_struct_size(rct12_award, 4);
 
 /**
  * A single news item / message.
  * size: 0x10C
  */
-typedef struct rct12_news_item
+struct rct12_news_item
 {
     uint8   Type;
     uint8   Flags;
@@ -65,7 +65,7 @@ typedef struct rct12_news_item
     uint8   Day;
     uint8   pad_0B;
     char    Text[256];
-} rct12_news_item;
+};
 assert_struct_size(rct12_news_item, 0x10C);
 
 #pragma pack(pop)

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -41,7 +41,7 @@
 
 
 
-typedef struct rct2_install_info {
+struct rct2_install_info {
     uint32 installLevel;
     char title[260];
     char path[260];
@@ -49,7 +49,7 @@ typedef struct rct2_install_info {
     uint8 pad_210[256];
     char expansionPackNames[16][128];
     uint32 activeExpansionPacks;        //0xB10
-} rct2_install_info;
+};
 
 #pragma pack(push, 1)
 
@@ -57,7 +57,7 @@ typedef struct rct2_install_info {
  * Ride structure.
  * size: 0x0260
  */
-typedef struct rct2_ride {
+struct rct2_ride {
     uint8 type;                                                     // 0x000
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
     // 0x4c.
@@ -264,7 +264,7 @@ typedef struct rct2_ride {
     uint16 cable_lift;                                              // 0x1FE
     uint16 queue_length[RCT12_MAX_STATIONS_PER_RIDE];               // 0x200
     uint8 pad_208[0x58];                                            // 0x208
-} rct2_ride;
+};
 assert_struct_size(rct2_ride, 0x260);
 
 /**

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -47,7 +47,7 @@
 /**
  * Couples a ride type and subtype together.
  */
-typedef struct ride_list_item {
+struct ride_list_item {
     union {
         struct {
             uint8 type;
@@ -55,46 +55,46 @@ typedef struct ride_list_item {
         };
         uint16 ride_type_and_entry;
     };
-} ride_list_item;
+};
 assert_struct_size(ride_list_item, 2);
 
-typedef struct track_colour {
+struct track_colour {
     uint8 main;
     uint8 additional;
     uint8 supports;
-} track_colour;
+};
 assert_struct_size(track_colour, 3);
 
-typedef struct vehicle_colour {
+struct vehicle_colour {
     uint8 main;
     uint8 additional_1;
     uint8 additional_2;
-} vehicle_colour;
+};
 assert_struct_size(vehicle_colour, 3);
 
-typedef struct track_colour_preset_list {
+struct track_colour_preset_list {
     uint8 count;
     track_colour list[256];
-} track_colour_preset_list;
+};
 assert_struct_size(track_colour_preset_list, (1 + 256 * 3));
 
-typedef struct vehicle_colour_preset_list {
+struct vehicle_colour_preset_list {
     uint8 count;
     vehicle_colour list[256];
-} vehicle_colour_preset_list;
+};
 assert_struct_size(vehicle_colour_preset_list, (1 + 256 * 3));
 
-typedef struct rct_ride_name {
+struct rct_ride_name {
     rct_string_id name;
     rct_string_id description;
-} rct_ride_name;
+};
 assert_struct_size(rct_ride_name, 4);
 
 /**
  * Ride type structure.
  * size: unknown
  */
-typedef struct rct_ride_entry {
+struct rct_ride_entry {
     rct_ride_name naming;
     uint32 images_offset;                               // 0x004. The first three images are previews. They correspond to the ride_type[] array.
     uint32 flags;                                       // 0x008
@@ -126,7 +126,7 @@ typedef struct rct_ride_entry {
     uint8 shop_item;                                    // 0x1C0
     uint8 shop_item_secondary;                          // 0x1C1
     rct_string_id capacity;
-} rct_ride_entry;
+};
 
 #pragma pack(pop)
 
@@ -136,7 +136,7 @@ typedef struct rct_ride_entry {
  * This is based on RCT2's ride structure.
  * Padding and no longer used fields have been removed.
  */
-typedef struct Ride 
+struct Ride 
 {
     uint8 type;
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
@@ -329,7 +329,7 @@ typedef struct Ride
     uint8 cable_lift_z;
     uint16 cable_lift;
     uint16 queue_length[MAX_STATIONS];
-} Ride;
+};
 
 #pragma pack(push, 1)
 
@@ -337,7 +337,7 @@ typedef struct Ride
  * Ride measurement structure.
  * size: 0x04B0C
  */
-typedef struct rct_ride_measurement {
+struct rct_ride_measurement {
     uint8 ride_index;                           // 0x0000
     uint8 flags;                                // 0x0001
     uint32 last_use_tick;                       // 0x0002
@@ -349,10 +349,10 @@ typedef struct rct_ride_measurement {
     sint8 lateral[RIDE_MEASUREMENT_MAX_ITEMS];  // 0x12CC
     uint8 velocity[RIDE_MEASUREMENT_MAX_ITEMS]; // 0x258C
     uint8 altitude[RIDE_MEASUREMENT_MAX_ITEMS]; // 0x384C
-} rct_ride_measurement;
+};
 assert_struct_size(rct_ride_measurement, 0x4b0c);
 
-typedef struct track_begin_end {
+struct track_begin_end {
     sint32 begin_x;
     sint32 begin_y;
     sint32 begin_z;
@@ -362,15 +362,15 @@ typedef struct track_begin_end {
     sint32 end_y;
     sint32 end_direction;
     rct_tile_element *end_element;
-} track_begin_end;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(track_begin_end, 36);
 #endif
 
-typedef struct ride_name_args {
+struct ride_name_args {
     uint16 type_name;
     uint16 number;
-} ride_name_args;
+};
 assert_struct_size(ride_name_args, 4);
 
 #pragma pack(pop)
@@ -442,7 +442,7 @@ enum {
     RIDE_ENTRY_FLAG_ALTERNATIVE_SWING_MODE_2        = 1 << 20,
 };
 
-enum{
+enum {
     RIDE_TESTING_SHELTERED = (1 << 0),
     RIDE_TESTING_TURN_LEFT = (1 << 1),
     RIDE_TESTING_TURN_RIGHT = (1 << 2),
@@ -896,7 +896,7 @@ enum {
     TRACK_SELECTION_FLAG_RECHECK          = 1 << 3,
 };
 
-typedef struct rct_ride_properties {
+struct rct_ride_properties {
     uint32 flags;
     uint8 min_value;
     uint8 max_value;
@@ -904,7 +904,7 @@ typedef struct rct_ride_properties {
     uint8 powered_lift_acceleration;
     uint8 booster_acceleration;
     sint8 booster_speed_factor; // The factor to shift the raw booster speed with
-} rct_ride_properties;
+};
 
 #define RIDE_MODE_COUNT 37
 

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -20,7 +20,7 @@
 #include "../common.h"
 #include "Ride.h"
 
-typedef struct ride_component_name {
+struct ride_component_name {
     rct_string_id singular;
     rct_string_id plural;
     rct_string_id capitalised;
@@ -28,9 +28,9 @@ typedef struct ride_component_name {
     rct_string_id count;
     rct_string_id count_plural;
     rct_string_id number;
-} ride_component_name;
+};
 
-typedef enum  {
+enum RIDE_COMPONENT_TYPE {
     RIDE_COMPONENT_TYPE_TRAIN,
     RIDE_COMPONENT_TYPE_BOAT,
     RIDE_COMPONENT_TYPE_TRACK,
@@ -46,46 +46,46 @@ typedef enum  {
     RIDE_COMPONENT_TYPE_PLAYER,
     RIDE_COMPONENT_TYPE_COURSE,
     RIDE_COMPONENT_TYPE_COUNT
-} ride_component_type;
+};
 
-typedef struct rct_ride_name_convention {
-    ride_component_type vehicle;
-    ride_component_type structure;
-    ride_component_type station;
-} rct_ride_name_convention;
+struct rct_ride_name_convention {
+    RIDE_COMPONENT_TYPE vehicle;
+    RIDE_COMPONENT_TYPE structure;
+    RIDE_COMPONENT_TYPE station;
+};
 
-typedef struct rct_ride_entrance_definition {
+struct rct_ride_entrance_definition {
     uint32 sprite_index;
     uint16 height;
     uint16 scrolling_mode;
     uint32 base_image_id;
     rct_string_id string_id;
     uint16 colour_use_flags;
-} rct_ride_entrance_definition;
+};
 
-typedef struct rct_shop_item_string_types {
+struct rct_shop_item_string_types {
     rct_string_id price_label;      // Balloon price:
     rct_string_id singular;         // Balloon
     rct_string_id plural;           // Balloons
     rct_string_id indefinite;       // a Balloon
     rct_string_id display;          // "Diamond Heights" Balloon
-} rct_shop_item_string_types;
+};
 
-typedef struct rct_ride_data_4 {
+struct rct_ride_data_4 {
     uint8 price;
     uint8 price_secondary;
     uint16 flags;
     uint8 default_music;
     uint8 alternate_type;
     uint8 pad[2];
-} rct_ride_data_4;
+};
 
-typedef struct ride_cost {
+struct ride_cost {
     uint16 track_price;
     uint16 support_price;
-} ride_cost;
+};
 
-typedef struct rct_ride_data_5 {
+struct rct_ride_data_5 {
     uint8 max_height;
     uint8 clearance_height;
     sint8 z_offset;
@@ -94,13 +94,13 @@ typedef struct rct_ride_data_5 {
     uint8 price;
     uint8 bonus_value;      // Deprecated. Use rideBonusValue instead
     uint8 pad;
-} rct_ride_data_5;
+};
 
-typedef struct rct_ride_lift_data {
+struct rct_ride_lift_data {
     uint8 sound_id;
     uint8 minimum_speed;
     uint8 maximum_speed;
-} rct_ride_lift_data;
+};
 
 enum {
     RIDE_TYPE_FLAG4_ALLOW_DOORS_ON_TRACK = (1 << 0),
@@ -127,12 +127,12 @@ enum {
     RIDE_TYPE_ALTERNATIVE_TRACK_TYPE = 2,   // Flying RC, Lay-down RC, Multi-dimension RC
 };
 
-typedef struct rct_shop_item_stats {
+struct rct_shop_item_stats {
     uint16 cost;
     uint16 base_value;
     uint16 hot_value;
     uint16 cold_value;
-} rct_shop_item_stats;
+};
 
 extern const bool hasRunningTrack[RIDE_TYPE_COUNT];
 extern const uint8 initialUpkeepCosts[RIDE_TYPE_COUNT];

--- a/src/openrct2/ride/RideGroupManager.h
+++ b/src/openrct2/ride/RideGroupManager.h
@@ -27,13 +27,13 @@
 
 extern const uint8 gRideCategories[RIDE_TYPE_COUNT];
 
-typedef struct RideGroup
+struct RideGroup
 {
     uint8 RideType;
     uint16 MaximumHeight;
     uint64 AvailableTrackPieces;
     rct_ride_name Naming;
-} RideGroup;
+};
 
 #ifdef __cplusplus
 class RideGroupManager

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -68,7 +68,7 @@ enum {
     PROXIMITY_COUNT
 };
 
-typedef void (*ride_ratings_calculation)(Ride *ride);
+using ride_ratings_calculation = void (*)(Ride *ride);
 
 rct_ride_rating_calc_data gRideRatingsCalcData;
 

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-typedef fixed16_2dp ride_rating;
+using ride_rating = fixed16_2dp;
 
 // Convenience function for writing ride ratings. The result is a 16 bit signed
 // integer. To create the ride rating 3.65 type RIDE_RATING(3,65)
@@ -28,11 +28,11 @@ typedef fixed16_2dp ride_rating;
 #pragma pack(push, 1)
 
 // Used for return values, for functions that modify all three.
-typedef struct rating_tuple {
+struct rating_tuple {
     ride_rating excitement;
     ride_rating intensity;
     ride_rating nausea;
-} rating_tuple;
+};
 assert_struct_size(rating_tuple, 6);
 
 #pragma pack(pop)
@@ -41,7 +41,7 @@ enum {
     RIDE_RATING_STATION_FLAG_NO_ENTRANCE = 1 << 0
 };
 
-typedef struct rct_ride_rating_calc_data {
+struct rct_ride_rating_calc_data {
     uint16  proximity_x;
     uint16  proximity_y;
     uint16  proximity_z;
@@ -57,7 +57,7 @@ typedef struct rct_ride_rating_calc_data {
     uint16  num_brakes;
     uint16  num_reversers;
     uint16  station_flags;
-} rct_ride_rating_calc_data;
+};
 
 extern rct_ride_rating_calc_data gRideRatingsCalcData;
 

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -21,7 +21,7 @@
 #include "Ride.h"
 
 #pragma pack(push, 1)
-typedef struct rct_trackdefinition
+struct rct_trackdefinition
 {
     uint8 type;
     uint8 vangle_end;
@@ -30,14 +30,14 @@ typedef struct rct_trackdefinition
     uint8 bank_start;
     sint8 preview_z_offset;
     uint8 pad[2];
-} rct_trackdefinition;
+};
 assert_struct_size(rct_trackdefinition, 8);
 #pragma pack(pop)
 
 /**
 * Size: 0x0A
 */
-typedef struct rct_preview_track
+struct rct_preview_track
 {
     uint8  index;    // 0x00
     sint16 x;       // 0x01
@@ -46,10 +46,10 @@ typedef struct rct_preview_track
     uint8  var_07;
     uint8  var_08;
     uint8  var_09;
-} rct_preview_track;
+};
 
 /* size 0x0A */
-typedef struct rct_track_coordinates
+struct rct_track_coordinates
 {
     sint8  rotation_begin;   // 0x00
     sint8  rotation_end;     // 0x01
@@ -57,7 +57,7 @@ typedef struct rct_track_coordinates
     sint16 z_end;           // 0x04
     sint16 x;               // 0x06
     sint16 y;               // 0x08
-} rct_track_coordinates;
+};
 
 enum
 {
@@ -508,7 +508,7 @@ enum
     GC_SET_MAZE_TRACK_FILL  = 2,
 };
 
-typedef struct track_circuit_iterator
+struct track_circuit_iterator
 {
     rct_xy_element  last;
     rct_xy_element  current;
@@ -517,7 +517,7 @@ typedef struct track_circuit_iterator
     rct_tile_element * first;
     bool            firstIteration;
     bool            looped;
-} track_circuit_iterator;
+};
 
 extern const rct_trackdefinition FlatRideTrackDefinitions[256];
 extern const rct_trackdefinition TrackDefinitions[256];

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -34,11 +34,11 @@ extern const rct_preview_track * FlatRideTrackBlocks[256];
 
 extern const uint8 TrackPieceLengths[256];
 
-typedef struct track_curve_chain
+struct track_curve_chain
 {
     uint16 next;
     uint16 previous;
-} track_curve_chain;
+};
 
 extern const track_curve_chain gTrackCurveChain[256];
 extern const track_curve_chain gFlatRideTrackCurveChain[256];
@@ -46,7 +46,7 @@ extern const track_curve_chain gFlatRideTrackCurveChain[256];
 extern const TRACK_PAINT_FUNCTION_GETTER RideTypeTrackPaintFunctions[RIDE_TYPE_COUNT];
 extern const uint32 *                    RideTypeTrackPaintFunctionsOld[RIDE_TYPE_COUNT];
 
-typedef struct track_descriptor
+struct track_descriptor
 {
     bool  starts_diagonal;
     uint8 slope_start;
@@ -55,15 +55,15 @@ typedef struct track_descriptor
     uint8 slope_end;
     uint8 bank_end;
     uint8 track_element;
-} track_descriptor;
+};
 
 extern const track_descriptor gTrackDescriptors[142];
 
-typedef struct
+struct rct_vehicle_info_list
 {
     uint16                   size;
     const rct_vehicle_info * info;
-} rct_vehicle_info_list;
+};
 
 extern const rct_vehicle_info_list * const * const gTrackVehicleInfo[17];
 
@@ -72,13 +72,13 @@ extern const sint16 AlternativeTrackTypes[256];
 extern const money32 TrackPricing[256];
 extern const money32 FlatRideTrackPricing[256];
 
-typedef struct dodgems_track_size
+struct dodgems_track_size
 {
     uint8 left;
     uint8 top;
     uint8 right;
     uint8 bottom;
-} dodgems_track_size;
+};
 
 extern const dodgems_track_size DodgemsTrackSize[256];
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -41,7 +41,7 @@
 #include "../world/Scenery.h"
 #include "../world/SmallScenery.h"
 
-typedef struct map_backup
+struct map_backup
 {
     rct_tile_element tile_elements[MAX_TILE_ELEMENTS];
     rct_tile_element * tile_pointers[MAX_TILE_TILE_ELEMENT_POINTERS];
@@ -50,7 +50,7 @@ typedef struct map_backup
     uint16          map_size_units_minus_2;
     uint16          map_size;
     uint8           current_rotation;
-} map_backup;
+};
 
 rct_track_td6 * gActiveTrackDesign;
 bool          gTrackDesignSceneryToggle;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -28,7 +28,7 @@
 
 #pragma pack(push, 1)
 /* Maze Element entry   size: 0x04 */
-typedef struct rct_td6_maze_element {
+struct rct_td6_maze_element {
     union {
         uint32 all;
         struct {
@@ -43,27 +43,27 @@ typedef struct rct_td6_maze_element {
             };
         };
     };
-} rct_td6_maze_element;
+};
 assert_struct_size(rct_td6_maze_element, 0x04);
 
 /* Track Element entry  size: 0x02 */
-typedef struct rct_td6_track_element {
+struct rct_td6_track_element {
     uint8 type;                         // 0x00
     uint8 flags;                        // 0x01
-} rct_td6_track_element;
+};
 assert_struct_size(rct_td6_track_element, 0x02);
 
 /* Track Entrance entry size: 0x06 */
-typedef struct rct_td6_entrance_element {
+struct rct_td6_entrance_element {
     sint8 z;                            // 0x00
     uint8 direction;                    // 0x01
     sint16 x;                           // 0x02
     sint16 y;                           // 0x04
-} rct_td6_entrance_element;
+};
 assert_struct_size(rct_td6_entrance_element, 0x06);
 
 /* Track Scenery entry  size: 0x16 */
-typedef struct rct_td6_scenery_element {
+struct rct_td6_scenery_element {
     rct_object_entry scenery_object;    // 0x00
     sint8 x;                            // 0x10
     sint8 y;                            // 0x11
@@ -71,14 +71,14 @@ typedef struct rct_td6_scenery_element {
     uint8 flags;                        // 0x13 direction quadrant tertiary colour
     uint8 primary_colour;               // 0x14
     uint8 secondary_colour;             // 0x15
-} rct_td6_scenery_element;
+};
 assert_struct_size(rct_td6_scenery_element, 0x16);
 
 /**
  * Track design structure.
  * size: 0x4E72B
  */
-typedef struct rct_track_td6 {
+struct rct_track_td6 {
     uint8 type;                                     // 0x00
     uint8 vehicle_type;
     union{
@@ -147,7 +147,7 @@ typedef struct rct_track_td6 {
     rct_td6_scenery_element     *scenery_elements;
 
     utf8 *name;
-} rct_track_td6;
+};
 //Warning: improper struct size in comment
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_track_td6, 0xbf);

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -20,11 +20,11 @@
 #include "RideGroupManager.h"
 
 
-typedef struct track_design_file_ref
+struct track_design_file_ref
 {
     utf8 * name;
     utf8 * path;
-} track_design_file_ref;
+};
 
 #ifdef __cplusplus
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -1177,11 +1177,11 @@ static size_t track_design_get_scenery_elements_count(rct_track_td6 *td6)
     return count;
 }
 
-typedef struct auto_buffer {
+struct auto_buffer {
     void *ptr;
     size_t length;
     size_t capacity;
-} auto_buffer;
+};
 
 static void auto_buffer_write(auto_buffer *buffer, const void *src, size_t len)
 {

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -377,14 +377,14 @@ void track_paint_util_right_vertical_loop_segments(paint_session * session, uint
 
 void track_paint_util_left_corkscrew_up_supports(paint_session * session, uint8 direction, uint16 height);
 
-typedef void (*TRACK_PAINT_FUNCTION)(
+using TRACK_PAINT_FUNCTION = void (*)(
     paint_session *          session,
     uint8                    rideIndex,
     uint8                    trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement);
-typedef TRACK_PAINT_FUNCTION (*TRACK_PAINT_FUNCTION_GETTER)(sint32 trackType, sint32 direction);
+using TRACK_PAINT_FUNCTION_GETTER = TRACK_PAINT_FUNCTION (*)(sint32 trackType, sint32 direction);
 
 TRACK_PAINT_FUNCTION get_track_paint_function_stand_up_rc(sint32 trackType, sint32 direction);
 TRACK_PAINT_FUNCTION get_track_paint_function_suspended_swinging_rc(sint32 trackType, sint32 direction);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -469,12 +469,12 @@ static constexpr const sint8 * SwingingTimeToSpriteMaps[] = {
     SwingingTimeToSpriteMap_11,
 };
 
-typedef struct
+struct unk_9a36c4
 {
     sint16 x;
     sint16 y;
     uint32 distance;
-} unk_9a36c4;
+};
 
 /** rct2: 0x009A36C4 */
 static constexpr const unk_9a36c4 Unk9A36C4[] =
@@ -2711,12 +2711,12 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 }
 
 #pragma pack(push, 1)
-typedef struct rct_synchronised_vehicle
+struct rct_synchronised_vehicle
 {
     uint8  ride_id;
     uint8  station_id;
     uint16 vehicle_id;
-} rct_synchronised_vehicle;
+};
 assert_struct_size(rct_synchronised_vehicle, 4);
 #pragma pack(pop)
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -20,17 +20,17 @@
 #include "../common.h"
 #include "../world/Map.h"
 
-typedef struct rct_vehicle_colour {
+struct rct_vehicle_colour {
     uint8 body_colour;
     uint8 trim_colour;
-} rct_vehicle_colour;
+};
 
 #pragma pack(push, 1)
 /**
  * Ride type vehicle structure.
  * size: 0x65
  */
-typedef struct rct_ride_entry_vehicle {
+struct rct_ride_entry_vehicle {
     uint16 rotation_frame_mask;     // 0x00 , 0x1A
     uint8 num_vertical_frames;      // 0x02 , 0x1C, Appears to be unused, except as a temporary variable in RCT2 (not needed for OpenRCT2)
     uint8 num_horizontal_frames;    // 0x03 , 0x1D, Appears to be unused, except as a temporary variable in RCT2 (not needed for OpenRCT2)
@@ -78,10 +78,10 @@ typedef struct rct_ride_entry_vehicle {
     uint8 num_vertical_frames_override; // 0x60 , 0x7A, A custom number that can be used rather than letting RCT2 determine it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
     sint8* peep_loading_positions;  // 0x61 , 0x7B
     uint16 peep_loading_positions_count;
-} rct_ride_entry_vehicle;
+};
 #pragma pack(pop)
 
-typedef struct rct_vehicle {
+struct rct_vehicle {
     uint8 sprite_identifier;        // 0x00
     uint8 is_child;                 // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -207,22 +207,22 @@ typedef struct rct_vehicle {
     uint8 colours_extended;         // 0xD7
     uint8 seat_rotation;            // 0xD8
     uint8 target_seat_rotation;     // 0xD9
-} rct_vehicle;
+};
 
-typedef struct train_ref {
+struct train_ref {
     rct_vehicle *head;
     rct_vehicle *tail;
-} train_ref;
+};
 
 // Size: 0x09
-typedef struct rct_vehicle_info {
+struct rct_vehicle_info {
     sint16 x;           // 0x00
     sint16 y;           // 0x02
     sint16 z;           // 0x04
     uint8 direction;    // 0x06
     uint8 vehicle_sprite_type;  // 0x07
     uint8 bank_rotation;    // 0x08
-} rct_vehicle_info;
+};
 
 enum {
     VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY = 1 << 0, // Set on powered vehicles that do not slow down when going down a hill

--- a/src/openrct2/ride/VehicleData.h
+++ b/src/openrct2/ride/VehicleData.h
@@ -23,10 +23,10 @@ extern const uint8 * Rotation1TimeToSpriteMaps[];
 extern const uint8 * Rotation2TimeToSpriteMaps[];
 extern const uint8 * Rotation3TimeToSpriteMaps[];
 
-typedef struct top_spin_time_to_sprite_map {
+struct top_spin_time_to_sprite_map {
     uint8 arm_rotation;
     uint8 bank_rotation;
-} top_spin_time_to_sprite_map;
+};
 
 extern const top_spin_time_to_sprite_map * TopSpinTimeToSpriteMaps[];
 

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -2783,8 +2783,13 @@ static void vehicle_sprite_59(paint_session * session, rct_vehicle * vehicle, si
 }
 
 // 0x009A3B14:
-typedef void (*vehicle_sprite_func)(paint_session * session, rct_vehicle * vehicle, sint32 imageDirection, sint32 z,
-                                    const rct_ride_entry_vehicle * vehicleEntry);
+using vehicle_sprite_func = void (*)(
+    paint_session *                session,
+    rct_vehicle *                  vehicle,
+    sint32                         imageDirection,
+    sint32                         z,
+    const rct_ride_entry_vehicle * vehicleEntry);
+
 // clang-format off
 static constexpr const vehicle_sprite_func vehicle_sprite_funcs[] = {
     vehicle_sprite_0,

--- a/src/openrct2/ride/VehiclePaint.h
+++ b/src/openrct2/ride/VehiclePaint.h
@@ -19,14 +19,14 @@
 
 #include "Vehicle.h"
 
-typedef struct vehicle_boundbox {
+struct vehicle_boundbox {
     sint8 offset_x;
     sint8 offset_y;
     sint8 offset_z;
     uint8 length_x;
     uint8 length_y;
     uint8 length_z;
-} vehicle_boundbox;
+};
 
 extern const vehicle_boundbox VehicleBoundboxes[16][224];
 

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.h
@@ -20,12 +20,12 @@
 #include "../../common.h"
 #include "../../paint/tile_element/TileElement.h"
 
-typedef enum JUNIOR_RC_CHAINTYPE
+enum JUNIOR_RC_CHAINTYPE
 {
     JUNIOR_RC_CHAIN_NONE,
     JUNIOR_RC_CHAIN_FRICTION_WHEELS,
     JUNIOR_RC_CHAIN_CHAIN_LIFT,
-} JUNIOR_RC_CHAINTYPE;
+};
 
 void junior_rc_paint_station(
     paint_session *          session,

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -26,14 +26,14 @@
 #include "../TrackData.h"
 #include "../TrackPaint.h"
 
-typedef struct sprite_bb_2
+struct sprite_bb_2
 {
     uint32    sprite_id_a;
     uint32    sprite_id_b;
     LocationXYZ16 offset;
     LocationXYZ16 bb_offset;
     LocationXYZ16 bb_size;
-} sprite_bb_2;
+};
 
 enum
 {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -20,13 +20,13 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-typedef struct rct_crooked_house_bound_box
+struct rct_crooked_house_bound_box
 {
     sint16 offset_x;
     sint16 offset_y;
     sint16 length_x;
     sint16 length_y;
-} rct_crooked_house_bound_box;
+};
 
 static constexpr const rct_crooked_house_bound_box crooked_house_data[] = { { 6, 0, 42, 24 },
                                                      { 0, 0, 0, 0 },

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -34,13 +34,13 @@ static constexpr const uint8 edges_1x4_nw_se[] = {
     EDGE_NE | EDGE_SW | EDGE_SE,
 };
 
-typedef struct ferris_wheel_bound_box
+struct ferris_wheel_bound_box
 {
     sint16 length_x;
     sint16 length_y;
     sint16 offset_x;
     sint16 offset_y;
-} ferris_wheel_bound_box;
+};
 
 /** rct2: 0x008A8CA8 */
 static ferris_wheel_bound_box ferris_wheel_data[] = {

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -20,13 +20,13 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-typedef struct haunted_house_bound_box
+struct haunted_house_bound_box
 {
     sint16 offset_x;
     sint16 offset_y;
     sint16 length_x;
     sint16 length_y;
-} haunted_house_bound_box;
+};
 
 /** rct2: 0x1428180 */
 static haunted_house_bound_box haunted_house_data[] = { { 6, 0, 42, 24 }, { 0 }, { -16, -16, 32, 32 }, { 0 },

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -38,13 +38,13 @@ enum
     SPR_MAGIC_CARPET_PENDULUM_SW = 22102,
 };
 
-typedef struct bound_box
+struct bound_box
 {
     sint16 x;
     sint16 y;
     sint16 width;
     sint16 height;
-} bound_box;
+};
 
 /** rct2: 0x01428220 */
 static constexpr const sint16 MagicCarpetOscillationZ[] = { -2, -1, 1,  5,  10, 16, 23, 30, 37, 45, 52, 59, 65, 70, 74, 76,

--- a/src/openrct2/ride/thrill/PirateShip.cpp
+++ b/src/openrct2/ride/thrill/PirateShip.cpp
@@ -28,13 +28,13 @@ static constexpr const uint8 track_map_1x5[][5] = {
     { 0, 1, 2, 3, 4 },
 };
 
-typedef struct pirate_ship_bound_box
+struct pirate_ship_bound_box
 {
     sint16 length_x;
     sint16 length_y;
     sint16 offset_x;
     sint16 offset_y;
-} pirate_ship_bound_box;
+};
 
 /** rct2: 0x008A83B0 */
 static constexpr const uint32 pirate_ship_base_sprite_offset[] = { 0, 9, 0, 9 };

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -26,13 +26,13 @@ static constexpr const uint32 swinging_inverter_ship_base_sprite_offset[] = { 0,
 /** rct2: 0x01428020 */
 static constexpr const uint32 swinging_inverter_ship_animating_base_sprite_offset[] = { 32, 33, 32, 33 };
 
-typedef struct swinging_inverter_ship_bound_box
+struct swinging_inverter_ship_bound_box
 {
     sint16 length_x;
     sint16 length_y;
     sint16 offset_x;
     sint16 offset_y;
-} swinging_inverter_ship_bound_box;
+};
 
 /** rct2: 0x01428020 */
 static constexpr const swinging_inverter_ship_bound_box swinging_inverter_ship_bounds[] = {

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -1711,12 +1711,12 @@ static constexpr const sint16 monorail_diag_support_types[][4] = {
     { -1, SUPPORT_PLAIN_W, SUPPORT_PLAIN_E, SUPPORT_PLAIN_90_DEG },
 };
 
-typedef struct floor_desc
+struct floor_desc
 {
     uint32   image_id;
     LocationXY16 bound_size;
     LocationXY16 bound_offset;
-} floor_desc;
+};
 
 static constexpr const floor_desc floors[] = {
     { SPR_FLOOR_PLANKS, { 32, 32 }, { 0, 0 } },

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -30,28 +30,28 @@
 #include "../world/MapAnimation.h"
 #include "../world/Sprite.h"
 
-typedef struct ParkLoadResult ParkLoadResult;
+struct ParkLoadResult;
 
 #pragma pack(push, 1)
 /**
  * SV6/SC6 header chunk
  * size: 0x20
  */
-typedef struct rct_s6_header {
+struct rct_s6_header {
     uint8 type;                 // 0x00
     uint8 classic_flag;         // 0x01
     uint16 num_packed_objects;  // 0x02
     uint32 version;             // 0x04
     uint32 magic_number;        // 0x08
     uint8 pad_0C[0x14];
-} rct_s6_header;
+};
 assert_struct_size(rct_s6_header, 0x20);
 
 /**
  * SC6 information chunk
  * size: 0x198
  */
-typedef struct rct_s6_info {
+struct rct_s6_info {
     uint8 editor_step;
     uint8 category;             // 0x01
     uint8 objective_type;       // 0x02
@@ -62,10 +62,10 @@ typedef struct rct_s6_info {
     char name[64];              // 0x48
     char details[256];          // 0x88
     rct_object_entry entry;     // 0x188
-} rct_s6_info;
+};
 assert_struct_size(rct_s6_info, 0x198);
 
-typedef enum scenario_source {
+enum SCENARIO_SOURCE {
     SCENARIO_SOURCE_RCT1,
     SCENARIO_SOURCE_RCT1_AA,
     SCENARIO_SOURCE_RCT1_LL,
@@ -73,19 +73,19 @@ typedef enum scenario_source {
     SCENARIO_SOURCE_RCT2_WW,
     SCENARIO_SOURCE_RCT2_TT,
     SCENARIO_SOURCE_REAL,
-    SCENARIO_SOURCE_OTHER
-} scenario_source;
+    SCENARIO_SOURCE_OTHER,
+};
 
-typedef struct rct_stex_entry {
+struct rct_stex_entry {
     rct_string_id scenario_name;    // 0x00
     rct_string_id park_name;        // 0x02
     rct_string_id details;          // 0x04
     uint8 var_06;
-} rct_stex_entry;
+};
 assert_struct_size(rct_stex_entry, 7);
 
 // This will be useful for backwards compatibility
-typedef struct rct_s6_data {
+struct rct_s6_data {
     // SC6[0]
     rct_s6_header header;
 
@@ -294,7 +294,7 @@ typedef struct rct_s6_data {
     uint16 wide_path_tile_loop_x;
     uint16 wide_path_tile_loop_y;
     uint8 pad_13CE778[434];
-} rct_s6_data;
+};
 assert_struct_size(rct_s6_data, 0x46b44a);
 #pragma pack(pop)
 

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -20,15 +20,15 @@
 
 struct rct_object_entry;
 
-typedef struct scenario_highscore_entry
+struct scenario_highscore_entry
 {
     utf8 *      fileName;
     utf8 *      name;
     money32     company_value;
     datetime64  timestamp;
-} scenario_highscore_entry;
+};
 
-typedef struct scenario_index_entry
+struct scenario_index_entry
 {
     utf8    path[MAX_PATH];
     uint64  timestamp;
@@ -49,7 +49,7 @@ typedef struct scenario_index_entry
     utf8 internal_name[64]; // Untranslated name
     utf8 name[64];          // Translated name
     utf8 details[256];
-} scenario_index_entry;
+};
 
 namespace OpenRCT2
 {

--- a/src/openrct2/scenario/ScenarioSources.h
+++ b/src/openrct2/scenario/ScenarioSources.h
@@ -18,14 +18,14 @@
 
 #include "../common.h"
 
-typedef struct source_desc
+struct source_desc
 {
     const utf8 * title;
     uint8        id;
     uint8        source;
     sint32       index;
     uint8        category;
-} source_desc;
+};
 
 namespace ScenarioSources
 {

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -21,7 +21,7 @@
 
 #define TITLE_COMMAND_SCENARIO_LENGTH 64
 
-typedef struct TitleCommand
+struct TitleCommand
 {
     uint8 Type;
     union {
@@ -42,9 +42,9 @@ typedef struct TitleCommand
         uint16 Milliseconds;                             // WAIT
         utf8   Scenario[TITLE_COMMAND_SCENARIO_LENGTH];  // LOADSC
     };
-} TitleCommand;
+};
 
-typedef struct TitleSequence
+struct TitleSequence
 {
     const utf8 * Name;
     const utf8 * Path;
@@ -56,13 +56,13 @@ typedef struct TitleSequence
     utf8 * * Saves;
 
     bool IsZip;
-} TitleSequence;
+};
 
-typedef struct TitleSequenceParkHandle
+struct TitleSequenceParkHandle
 {
     const utf8 *    HintPath;
     void *          Stream;
-} TitleSequenceParkHandle;
+};
 
 enum TITLE_SCRIPT
 {

--- a/src/openrct2/util/SawyerCoding.h
+++ b/src/openrct2/util/SawyerCoding.h
@@ -20,10 +20,10 @@
 #include "../common.h"
 
 #pragma pack(push, 1)
-typedef struct sawyercoding_chunk_header {
+struct sawyercoding_chunk_header {
     uint8 encoding;
     uint32 length;
-} sawyercoding_chunk_header;
+};
 assert_struct_size(sawyercoding_chunk_header, 5);
 #pragma pack(pop)
 

--- a/src/openrct2/windows/tile_inspector.h
+++ b/src/openrct2/windows/tile_inspector.h
@@ -19,7 +19,7 @@
 #include "../common.h"
 #include "../interface/Window.h"
 
-typedef enum tile_inspector_page
+enum TILE_INSPECTOR_PAGE
 {
     TILE_INSPECTOR_PAGE_DEFAULT,
     TILE_INSPECTOR_PAGE_SURFACE,
@@ -31,7 +31,7 @@ typedef enum tile_inspector_page
     TILE_INSPECTOR_PAGE_LARGE_SCENERY,
     TILE_INSPECTOR_PAGE_BANNER,
     TILE_INSPECTOR_PAGE_CORRUPT
-} tile_inspector_page;
+};
 
 extern uint32 windowTileInspectorTileX;
 extern uint32 windowTileInspectorTileY;

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -24,7 +24,7 @@
 #define MAX_BANNERS 250
 
 #pragma pack(push, 1)
-typedef struct rct_banner {
+struct rct_banner {
     uint8 type;
     uint8 flags; // 0x01 bit 0 is no entry
     rct_string_id string_idx; // 0x02
@@ -32,7 +32,7 @@ typedef struct rct_banner {
     uint8 text_colour; // 0x05
     uint8 x; // 0x06
     uint8 y; // 0x07
-} rct_banner;
+};
 assert_struct_size(rct_banner, 8);
 #pragma pack(pop)
 

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -52,23 +52,23 @@ enum RAIN_LEVEL
     RAIN_LEVEL_HEAVY,
 };
 
-typedef struct WeatherState
+struct WeatherState
 {
     sint8   TemperatureDelta;
     sint8   EffectLevel;
     sint8   GloomLevel;
     sint8   RainLevel;
     uint32  SpriteId;
-} WeatherState;
+};
 
-typedef struct ClimateState
+struct ClimateState
 {
     uint8 Weather;
     sint8 Temperature;
     uint8 WeatherEffect;
     uint8 WeatherGloom;
     uint8 RainLevel;
-} ClimateState;
+};
 
 extern uint8        gClimate;
 extern ClimateState gClimateCurrent;

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -20,20 +20,20 @@
 #include "../common.h"
 
 #pragma pack(push, 1)
-typedef struct rct_entrance_type {
+struct rct_entrance_type {
     rct_string_id string_idx;   // 0x00
     uint32 image_id;            // 0x02
     uint8 scrolling_mode;       // 0x06
     uint8 text_height;          // 0x07
-} rct_entrance_type;
+};
 assert_struct_size(rct_entrance_type, 8);
 #pragma pack(pop)
 
 void game_command_remove_park_entrance(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp);
 
-typedef struct LocationXYZ16 LocationXYZ16;
-typedef struct LocationXYZD16 LocationXYZD16;
-typedef struct rct_tile_element rct_tile_element;
+struct LocationXYZ16;
+struct LocationXYZD16;
+struct rct_tile_element;
 
 extern bool gParkEntranceGhostExists;
 extern LocationXYZ16 gParkEntranceGhostPosition;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1108,17 +1108,17 @@ static void footpath_connect_corners(sint32 initialX, sint32 initialY, rct_tile_
     }
 }
 
-typedef struct rct_neighbour {
+struct rct_neighbour {
     uint8 order;
     uint8 direction;
     uint8 ride_index;
     uint8 entrance_index;
-} rct_neighbour;
+};
 
-typedef struct rct_neighbour_list {
+struct rct_neighbour_list {
     rct_neighbour items[8];
     sint32 count;
-} rct_neighbour_list;
+};
 
 static sint32 rct_neighbour_compare(const void *a, const void *b)
 {

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -29,14 +29,14 @@ enum
 };
 
 #pragma pack(push, 1)
-typedef struct rct_footpath_entry {
+struct rct_footpath_entry {
     rct_string_id string_idx;   // 0x00
     uint32 image;               // 0x02
     uint32 bridge_image;        // 0x06
     uint8 support_type;         // 0x0A
     uint8 flags;                // 0x0B
     uint8 scrolling_mode;       // 0x0C
-} rct_footpath_entry;
+};
 assert_struct_size(rct_footpath_entry, 13);
 #pragma pack(pop)
 

--- a/src/openrct2/world/Location.h
+++ b/src/openrct2/world/Location.h
@@ -23,49 +23,49 @@
 #define MakeXY16(x, y)    {(sint16)(x), (sint16)(y)}
 
 #pragma pack(push, 1)
-typedef struct LocationXY8 {
+struct LocationXY8 {
     union {
         struct {
             uint8 x, y;
         };
         uint16 xy;
     };
-} LocationXY8;
+};
 assert_struct_size(LocationXY8, 2);
 
-typedef struct LocationXYZ8 {
+struct LocationXYZ8 {
     uint8 x, y, z;
-} LocationXYZ8;
+};
 assert_struct_size(LocationXYZ8, 3);
 
-typedef struct LocationXYZD8 {
+struct LocationXYZD8 {
     uint8 x, y, z, direction;
-} LocationXYZD8;
+};
 assert_struct_size(LocationXYZD8, 4);
 
-typedef struct LocationXY16 {
+struct LocationXY16 {
     sint16 x, y;
-} LocationXY16;
+};
 assert_struct_size(LocationXY16, 4);
 
 
-typedef struct LocationXYZ16 {
+struct LocationXYZ16 {
     sint16 x, y, z;
-} LocationXYZ16;
+};
 assert_struct_size(LocationXYZ16, 6);
 
-typedef struct LocationXYZD16 {
+struct LocationXYZD16 {
     sint16 x, y, z;
     uint8 direction;
-} LocationXYZD16;
+};
 assert_struct_size(LocationXYZD16, 7);
 
-typedef struct LocationXY32 {
+struct LocationXY32 {
     sint32 x, y;
-} LocationXY32;
+};
 
-typedef struct LocationXYZ32 {
+struct LocationXYZ32 {
     sint32 x, y, z;
-} LocationXYZ32;
+};
 
 #pragma pack(pop)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -3254,7 +3254,7 @@ void map_obstruction_set_error_text(rct_tile_element *tileElement)
  *  ebp = clearFunc
  *  bl = bl
  */
-sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC *clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode)
+sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode)
 {
     sint32 al, ah, bh, cl, ch, water_height;
     al = ah = bh = cl = ch = water_height = 0;
@@ -4363,7 +4363,7 @@ void game_command_modify_tile(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx
     const sint32 flags = *ebx;
     const sint32 x = *ecx & 0xFF;
     const sint32 y = (*ecx >> 8) & 0xFF;
-    const tile_inspector_instruction instruction = static_cast<tile_inspector_instruction>(*eax);
+    const TILE_INSPECTOR_INSTRUCTION_TYPE instruction = static_cast<TILE_INSPECTOR_INSTRUCTION_TYPE>(*eax);
 
     switch (instruction)
     {

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -22,15 +22,15 @@
 #include "Location.h"
 
 #pragma pack(push, 1)
-typedef struct rct_tile_element_surface_properties {
+struct rct_tile_element_surface_properties {
     uint8 slope; //4 0xE0 Edge Style, 0x1F Slope
     uint8 terrain; //5 0xE0 Terrain Style, 0x1F Water height
     uint8 grass_length; //6
     uint8 ownership; //7
-} rct_tile_element_surface_properties;
+};
 assert_struct_size(rct_tile_element_surface_properties, 4);
 
-typedef struct rct_tile_element_path_properties {
+struct rct_tile_element_path_properties {
     uint8 type; //4 0xF0 Path type, 0x08 Ride sign, 0x04 Set when path is diagonal, 0x03 Rotation
     uint8 additions; //5
     uint8 edges; //6
@@ -38,10 +38,10 @@ typedef struct rct_tile_element_path_properties {
         uint8 addition_status; //7
         uint8 ride_index;
     };
-} rct_tile_element_path_properties;
+};
 assert_struct_size(rct_tile_element_path_properties, 4);
 
-typedef struct rct_tile_element_track_properties {
+struct rct_tile_element_track_properties {
     uint8 type; //4
     union{
         struct{
@@ -62,26 +62,26 @@ typedef struct rct_tile_element_track_properties {
         uint16 maze_entry; // 5
     };
     uint8 ride_index; //7
-} rct_tile_element_track_properties;
+};
 assert_struct_size(rct_tile_element_track_properties, 4);
 
-typedef struct rct_tile_element_scenery_properties {
+struct rct_tile_element_scenery_properties {
     uint8 type; //4
     uint8 age; //5
     uint8 colour_1; //6
     uint8 colour_2; //7
-} rct_tile_element_scenery_properties;
+};
 assert_struct_size(rct_tile_element_scenery_properties, 4);
 
-typedef struct rct_tile_element_entrance_properties {
+struct rct_tile_element_entrance_properties {
     uint8 type; //4
     uint8 index; //5
     uint8 path_type; //6
     uint8 ride_index; //7
-} rct_tile_element_entrance_properties;
+};
 assert_struct_size(rct_tile_element_entrance_properties, 4);
 
-typedef struct rct_tile_element_wall_properties {
+struct rct_tile_element_wall_properties {
     uint8 type; //4
     union {
         uint8 colour_3; //5
@@ -89,24 +89,24 @@ typedef struct rct_tile_element_wall_properties {
     };
     uint8 colour_1; //6 0b_2221_1111 2 = colour_2 (uses flags for rest of colour2), 1 = colour_1
     uint8 animation; //7 0b_dfff_ft00 d = direction, f = frame num, t = across track flag (not used)
-} rct_tile_element_wall_properties;
+};
 assert_struct_size(rct_tile_element_wall_properties, 4);
 
-typedef struct rct_tile_element_scenerymultiple_properties {
+struct rct_tile_element_scenerymultiple_properties {
     uint16 type; //4
     uint8 colour[2]; //6
-} rct_tile_element_scenerymultiple_properties;
+};
 assert_struct_size(rct_tile_element_scenerymultiple_properties, 4);
 
-typedef struct rct_tile_element_banner_properties {
+struct rct_tile_element_banner_properties {
     uint8 index; //4
     uint8 position; //5
     uint8 flags; //6
     uint8 unused; //7
-} rct_tile_element_banner_properties;
+};
 assert_struct_size(rct_tile_element_banner_properties, 4);
 
-typedef union {
+union rct_tile_element_properties {
     rct_tile_element_surface_properties surface;
     rct_tile_element_path_properties path;
     rct_tile_element_track_properties track;
@@ -115,20 +115,20 @@ typedef union {
     rct_tile_element_wall_properties wall;
     rct_tile_element_scenerymultiple_properties scenerymultiple;
     rct_tile_element_banner_properties banner;
-} rct_tile_element_properties;
+};
 assert_struct_size(rct_tile_element_properties, 4);
 
 /**
  * Map element structure
  * size: 0x08
  */
-typedef struct rct_tile_element {
+struct rct_tile_element {
     uint8 type; //0
     uint8 flags; //1
     uint8 base_height; //2
     uint8 clearance_height; //3
     rct_tile_element_properties properties;
-} rct_tile_element;
+};
 assert_struct_size(rct_tile_element, 8);
 #pragma pack(pop)
 
@@ -324,20 +324,20 @@ enum {
 #define TILE_UNDEFINED_TILE_ELEMENT NULL
 
 #pragma pack(push, 1)
-typedef struct rct_xy_element {
+struct rct_xy_element {
     sint32 x, y;
     rct_tile_element *element;
-} rct_xy_element;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_xy_element, 12);
 #endif
 
-typedef struct rct2_peep_spawn {
+struct rct2_peep_spawn {
     uint16 x;
     uint16 y;
     uint8 z;
     uint8 direction;
-} rct2_peep_spawn;
+};
 assert_struct_size(rct2_peep_spawn, 6);
 #pragma pack(pop)
 
@@ -478,10 +478,11 @@ void map_remove_virtual_floor();
 void map_invalidate_virtual_floor_tiles();
 bool map_tile_is_part_of_virtual_floor(sint16 x, sint16 y);
 
-typedef sint32 (CLEAR_FUNC)(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
+using CLEAR_FUNC = sint32(*)(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
+
 sint32 map_place_non_scenery_clear_func(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
 sint32 map_place_scenery_clear_func(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
-sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC *clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode);
+sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode);
 sint32 map_can_construct_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, uint8 bl);
 void rotate_map_coordinates(sint16 *x, sint16 *y, sint32 rotation);
 LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, sint32 rotation);
@@ -520,11 +521,11 @@ void game_command_set_banner_style(sint32* eax, sint32* ebx, sint32* ecx, sint32
 void game_command_set_sign_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp);
 void game_command_modify_tile(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp);
 
-typedef struct tile_element_iterator {
+struct tile_element_iterator{
     sint32 x;
     sint32 y;
     rct_tile_element *element;
-} tile_element_iterator;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(tile_element_iterator, 12);
 #endif

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -26,7 +26,7 @@
 #include "Sprite.h"
 #include "Footpath.h"
 
-typedef bool (*map_animation_invalidate_event_handler)(sint32 x, sint32 y, sint32 baseZ);
+using map_animation_invalidate_event_handler = bool (*)(sint32 x, sint32 y, sint32 baseZ);
 
 static bool map_animation_invalidate(rct_map_animation *obj);
 

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -24,12 +24,12 @@
  * Animated object
  * size: 0x06
  */
-typedef struct rct_map_animation {
+struct rct_map_animation {
     uint8 baseZ;
     uint8 type;
     uint16 x;
     uint16 y;
-} rct_map_animation;
+};
 assert_struct_size(rct_map_animation, 6);
 #pragma pack(pop)
 

--- a/src/openrct2/world/MapGen.h
+++ b/src/openrct2/world/MapGen.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-typedef struct mapgen_settings
+struct mapgen_settings
 {
     // Base
     sint32 mapSize;
@@ -41,7 +41,7 @@ typedef struct mapgen_settings
     bool   smooth_height_map;
     uint32 smooth_strength;
     bool   normalize_height;
-} mapgen_settings;
+};
 
 void mapgen_generate_blank(mapgen_settings * settings);
 void mapgen_generate(mapgen_settings * settings);

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -35,7 +35,7 @@
 #define SCENERY_WITHER_AGE_THRESHOLD_2  0x37
 
 #pragma pack(push, 1)
-typedef struct rct_small_scenery_entry {
+struct rct_small_scenery_entry {
     uint32 flags;           // 0x06
     uint8 height;           // 0x0A
     uint8 tool_id;          // 0x0B
@@ -46,44 +46,44 @@ typedef struct rct_small_scenery_entry {
     uint16 animation_mask;  // 0x16
     uint16 num_frames;      // 0x18
     uint8 scenery_tab_id;   // 0x1A
-} rct_small_scenery_entry;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_small_scenery_entry, 21);
 #endif
 
-typedef struct rct_large_scenery_tile {
+struct rct_large_scenery_tile {
     sint16 x_offset;
     sint16 y_offset;
     sint16 z_offset;
     uint8 z_clearance;
     uint16 var_7;
-} rct_large_scenery_tile;
+};
 assert_struct_size(rct_large_scenery_tile, 9);
 
-typedef struct rct_large_scenery_text_glyph {
+struct rct_large_scenery_text_glyph {
     uint8 image_offset;
     uint8 width;
     uint8 height;
     uint8 var_3;
-} rct_large_scenery_text_glyph;
+};
 assert_struct_size(rct_large_scenery_text_glyph, 4);
 
-typedef struct rct_large_scenery_text {
+struct rct_large_scenery_text {
     LocationXY16 offset[2];     // 0x0
     uint16 max_width;       // 0x8
     uint16 pad_A;           // 0xA
     uint8 flags;            // 0xC
     uint8 var_D;            // 0xD
     rct_large_scenery_text_glyph glyphs[256]; // 0xE
-} rct_large_scenery_text;
+};
 assert_struct_size(rct_large_scenery_text, 14 + 4 * 256);
 
-typedef enum {
+enum LARGE_SCENERY_TEXT_FLAGS {
     LARGE_SCENERY_TEXT_FLAG_VERTICAL = (1 << 0),    // 0x1
     LARGE_SCENERY_TEXT_FLAG_TWO_LINE = (1 << 1),    // 0x2
-} LARGE_SCENERY_TEXT_FLAGS;
+};
 
-typedef struct rct_large_scenery_entry {
+struct rct_large_scenery_entry {
     uint8 tool_id;                 // 0x06
     uint8 flags;                   // 0x07
     sint16 price;                  // 0x08
@@ -93,20 +93,20 @@ typedef struct rct_large_scenery_entry {
     uint8 scrolling_mode;          // 0x11
     rct_large_scenery_text* text;  // 0x12
     uint32 text_image;             // 0x16
-} rct_large_scenery_entry;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_large_scenery_entry, 20);
 #endif
 
-typedef enum {
+enum LARGE_SCENERY_FLAGS {
     LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 0),   // 0x1
     LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 1), // 0x2
     LARGE_SCENERY_FLAG_3D_TEXT = (1 << 2),              // 0x4
     LARGE_SCENERY_FLAG_ANIMATED = (1 << 3),             // 0x8
     LARGE_SCENERY_FLAG_PHOTOGENIC = (1 << 4),           // 0x10
-} LARGE_SCENERY_FLAGS;
+};
 
-typedef struct rct_wall_scenery_entry {
+struct rct_wall_scenery_entry {
     uint8 tool_id;          // 0x06
     uint8 flags;            // 0x07
     uint8 height;           // 0x08
@@ -114,10 +114,11 @@ typedef struct rct_wall_scenery_entry {
     sint16 price;           // 0x0A
     uint8 scenery_tab_id;   // 0x0C
     uint8 scrolling_mode;   // 0x0D 0xFF if no scrolling
-} rct_wall_scenery_entry;
+};
 assert_struct_size(rct_wall_scenery_entry, 8);
 
-typedef enum {
+enum WALL_SCENERY_FLAGS
+{
     WALL_SCENERY_HAS_PRIMARY_COLOUR = (1 << 0),     // 0x1
     WALL_SCENERY_HAS_GLASS = (1 << 1),      // 0x2
     WALL_SCENERY_CANT_BUILD_ON_SLOPE = (1 << 2),        // 0x4
@@ -126,34 +127,34 @@ typedef enum {
     WALL_SCENERY_LONG_DOOR_ANIMATION = (1 << 5),      // 0x20
     WALL_SCENERY_HAS_SECONDARY_COLOUR = (1 << 6),       // 0x40
     WALL_SCENERY_HAS_TERNARY_COLOUR = (1 << 7),         // 0x80
-} WALL_SCENERY_FLAGS;
+};
 
-typedef enum {
+enum WALL_SCENERY_2_FLAGS {
     WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR = (1 << 0),     // 0x1
     WALL_SCENERY_2_DOOR_SOUND_MASK = 0x6,
     WALL_SCENERY_2_DOOR_SOUND_SHIFT = 1,
     WALL_SCENERY_2_IS_OPAQUE = (1 << 3),        // 0x8
     WALL_SCENERY_2_ANIMATED = (1 << 4),        // 0x10
-} WALL_SCENERY_2_FLAGS;
+};
 
-typedef struct rct_path_bit_scenery_entry {
+struct rct_path_bit_scenery_entry {
     uint16 flags;           // 0x06
     uint8 draw_type;        // 0x08
     uint8 tool_id;          // 0x09
     sint16 price;           // 0x0A
     uint8 scenery_tab_id;   // 0x0C
-} rct_path_bit_scenery_entry;
+};
 assert_struct_size(rct_path_bit_scenery_entry, 7);
 
-typedef struct rct_banner_scenery_entry {
+struct rct_banner_scenery_entry {
     uint8 scrolling_mode;   // 0x06
     uint8 flags;            // 0x07
     sint16 price;           // 0x08
     uint8 scenery_tab_id;   // 0x0A
-} rct_banner_scenery_entry;
+};
 assert_struct_size(rct_banner_scenery_entry, 5);
 
-typedef struct rct_scenery_entry {
+struct rct_scenery_entry {
     rct_string_id name;     // 0x00
     uint32 image;           // 0x02
     union {
@@ -163,12 +164,12 @@ typedef struct rct_scenery_entry {
         rct_path_bit_scenery_entry path_bit;
         rct_banner_scenery_entry banner;
     };
-} rct_scenery_entry;
+};
 #ifdef PLATFORM_32BIT
 assert_struct_size(rct_scenery_entry, 6 + 21);
 #endif
 
-typedef struct rct_scenery_group_entry {
+struct rct_scenery_group_entry {
     rct_string_id name;             // 0x00
     uint32 image;                   // 0x02
     uint16 scenery_entries[0x80];   // 0x06
@@ -177,7 +178,7 @@ typedef struct rct_scenery_group_entry {
     uint8 priority;                 // 0x108
     uint8 pad_109;
     uint32 entertainer_costumes;    // 0x10A
-} rct_scenery_group_entry;
+};
 assert_struct_size(rct_scenery_group_entry, 14 + 2 * 0x80);
 #pragma pack(pop)
 

--- a/src/openrct2/world/SmallScenery.h
+++ b/src/openrct2/world/SmallScenery.h
@@ -20,7 +20,7 @@
 #include "Map.h"
 #include "Scenery.h"
 
-typedef enum
+enum SMALL_SCENERY_FLAGS
 {
     SMALL_SCENERY_FLAG_FULL_TILE            = (1 << 0),  // 0x1
     SMALL_SCENERY_FLAG_VOFFSET_CENTRE       = (1 << 1),  // 0x2
@@ -50,8 +50,7 @@ typedef enum
     SMALL_SCENERY_FLAG_THREE_QUARTERS       = (1 << 25), // 0x2000000
     SMALL_SCENERY_FLAG_PAINT_SUPPORTS       = (1 << 26), // 0x4000000; used for scenery items which are support structures
     SMALL_SCENERY_FLAG27                    = (1 << 27), // 0x8000000
-}
-SMALL_SCENERY_FLAGS;
+};
 
 sint32 scenery_small_get_primary_colour(const rct_tile_element * tileElement);
 sint32 scenery_small_get_secondary_colour(const rct_tile_element * tileElement);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -43,7 +43,7 @@ enum SPRITE_LIST {
 };
 
 #pragma pack(push, 1)
-typedef struct rct_unk_sprite {
+struct rct_unk_sprite {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -70,10 +70,10 @@ typedef struct rct_unk_sprite {
     rct_string_id name_string_idx;  // 0x22
     uint16 pad_24;
     uint16 frame;                   // 0x26
-} rct_unk_sprite;
+};
 assert_struct_size(rct_unk_sprite, 0x28);
 
-typedef struct rct_litter {
+struct rct_litter {
     uint8 sprite_identifier;        // 0x00
     uint8 type;                     // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -92,10 +92,10 @@ typedef struct rct_litter {
     uint8 sprite_direction;         // 0x1E
     uint8 pad_1F[5];
     uint32 creationTick;            // 0x24
-} rct_litter;
+};
 assert_struct_size(rct_litter, 0x28);
 
-typedef struct rct_balloon {
+struct rct_balloon {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -120,10 +120,10 @@ typedef struct rct_balloon {
     void Update();
     void Pop();
     void Press();
-} rct_balloon;
+};
 assert_struct_size(rct_balloon, 0x2D);
 
-typedef struct rct_duck {
+struct rct_duck {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -158,10 +158,10 @@ typedef struct rct_duck {
     void Remove();
     void MoveTo(sint16 x, sint16 y, sint16 z);
 
-} rct_duck;
+};
 assert_struct_size(rct_duck, 0x49);
 
-typedef struct rct_jumping_fountain {
+struct rct_jumping_fountain {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -187,10 +187,10 @@ typedef struct rct_jumping_fountain {
     sint16 target_y;                // 0x32
     uint8 pad_34[0x12];
     uint16 iteration;               // 0x46
-} rct_jumping_fountain;
+};
 assert_struct_size(rct_jumping_fountain, 0x48);
 
-typedef struct rct_money_effect {
+struct rct_money_effect {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -213,10 +213,10 @@ typedef struct rct_money_effect {
     uint8 pad_2C[0x18];
     sint16 offset_x;                // 0x44
     uint16 wiggle;                  // 0x46
-} rct_money_effect;
+};
 assert_struct_size(rct_money_effect, 0x48);
 
-typedef struct rct_crashed_vehicle_particle {
+struct rct_crashed_vehicle_particle {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -253,10 +253,10 @@ typedef struct rct_crashed_vehicle_particle {
     sint32 acceleration_x;          // 0x38
     sint32 acceleration_y;          // 0x3C
     sint32 acceleration_z;          // 0x40
-} rct_crashed_vehicle_particle;
+};
 assert_struct_size(rct_crashed_vehicle_particle, 0x44);
 
-typedef struct rct_crash_splash {
+struct rct_crash_splash {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -283,10 +283,10 @@ typedef struct rct_crash_splash {
     uint16 name_string_idx;         // 0x22
     uint16 pad_24;
     uint16 frame;                   // 0x26
-} rct_crash_splash;
+};
 assert_struct_size(rct_crash_splash, 0x28);
 
-typedef struct rct_steam_particle {
+struct rct_steam_particle {
     uint8 sprite_identifier;        // 0x00
     uint8 misc_identifier;          // 0x01
     uint16 next_in_quadrant;        // 0x02
@@ -313,14 +313,14 @@ typedef struct rct_steam_particle {
     uint16 name_string_idx;         // 0x22
     uint16 time_to_move;            // 0x24 Moves +1 z every 3 ticks after intitial 4 ticks
     uint16 frame;                   // 0x26
-} rct_steam_particle;
+};
 assert_struct_size(rct_steam_particle, 0x28);
 
 /**
  * Sprite structure.
  * size: 0x0100
  */
-typedef union {
+union rct_sprite {
     uint8 pad_00[0x100];
     rct_unk_sprite unknown;
     rct_peep peep;
@@ -339,7 +339,7 @@ typedef union {
     rct_balloon * AsBalloon();
     rct_duck * AsDuck();
 
-} rct_sprite;
+};
 assert_struct_size(rct_sprite, 0x100);
 
 #pragma pack(pop)

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -31,7 +31,7 @@ uint32 windowTileInspectorTileX;
 uint32 windowTileInspectorTileY;
 sint32 windowTileInspectorElementCount = 0;
 
-static void window_tile_inspector_set_page(rct_window * w, const tile_inspector_page page)
+static void window_tile_inspector_set_page(rct_window * w, const TILE_INSPECTOR_PAGE page)
 {
     auto intent = Intent(INTENT_ACTION_SET_TILE_INSPECTOR_PAGE);
     intent.putExtra(INTENT_EXTRA_PAGE, page);

--- a/src/openrct2/world/TileInspector.h
+++ b/src/openrct2/world/TileInspector.h
@@ -19,7 +19,7 @@
 #include "../common.h"
 #include "Map.h"
 
-typedef enum {
+enum TILE_INSPECTOR_ELEMENT_TYPE {
     TILE_INSPECTOR_ELEMENT_ANY = 0,
     TILE_INSPECTOR_ELEMENT_SURFACE,
     TILE_INSPECTOR_ELEMENT_PATH,
@@ -30,9 +30,9 @@ typedef enum {
     TILE_INSPECTOR_ELEMENT_SCENERYMULTIPLE,
     TILE_INSPECTOR_ELEMENT_BANNER,
     TILE_INSPECTOR_ELEMENT_CORRUPT,
-} tile_inspector_element_type;
+};
 
-typedef enum {
+enum TILE_INSPECTOR_INSTRUCTION_TYPE {
     TILE_INSPECTOR_ANY_REMOVE,
     TILE_INSPECTOR_ANY_SWAP,
     TILE_INSPECTOR_ANY_INSERT_CORRUPT,
@@ -53,7 +53,7 @@ typedef enum {
     TILE_INSPECTOR_SCENERY_SET_QUARTER_COLLISION,
     TILE_INSPECTOR_BANNER_TOGGLE_BLOCKING_EDGE,
     TILE_INSPECTOR_CORRUPT_CLAMP,
-} tile_inspector_instruction;
+};
 
 sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex, sint32 flags);
 sint32 tile_inspector_remove_element_at(sint32 x, sint32 y, sint16 elementIndex, sint32 flags);

--- a/src/openrct2/world/Water.h
+++ b/src/openrct2/world/Water.h
@@ -24,13 +24,13 @@ enum {
 };
 
 #pragma pack(push, 1)
-typedef struct rct_water_type {
+struct rct_water_type {
     rct_string_id string_idx;   // 0x00
     uint32 image_id;            // 0x02
     uint32 palette_index_1;     // 0x06
     uint32 palette_index_2;     // 0x0A
     uint16 flags;               // 0x0E
-} rct_water_type;
+};
 assert_struct_size(rct_water_type, 16);
 #pragma pack(pop)
 

--- a/test/testpaint/FunctionCall.hpp
+++ b/test/testpaint/FunctionCall.hpp
@@ -34,7 +34,7 @@ enum
     SET_SEGMENT_HEIGHT,
 };
 
-typedef struct
+struct function_call
 {
     uint8 function;
     struct paint
@@ -56,7 +56,7 @@ typedef struct
         uint32 colour_flags;
         sint32 prepend_to;
     } supports;
-} function_call;
+};
 
 class FunctionCall {
 public:

--- a/test/testpaint/Hook.cpp
+++ b/test/testpaint/Hook.cpp
@@ -161,7 +161,7 @@ static void hookfunc(uintptr_t address, uintptr_t hookAddress, sint32 stacksize)
 #endif // _WIN32
 }
 
-void addhook(uintptr_t address, hook_function *function)
+void addhook(uintptr_t address, hook_function function)
 {
     if (!_hookTableAddress) {
         size_t size = _maxHooks * HOOK_BYTE_COUNT;

--- a/test/testpaint/Hook.h
+++ b/test/testpaint/Hook.h
@@ -30,8 +30,8 @@ enum {
     X86_FLAG_SIGN = 1 << 7,
 };
 
-typedef uint8 (hook_function)(registers *regs);
+using hook_function = uint8 (*)(registers * regs);
 
-void addhook(uintptr_t address, hook_function *function);
+void addhook(uintptr_t address, hook_function function);
 
 #endif

--- a/test/testpaint/TestTrack.cpp
+++ b/test/testpaint/TestTrack.cpp
@@ -210,7 +210,7 @@ static void CallNew(
     newPaintFunction(&gPaintSession, 0, trackSequence, direction, height, tileElement);
 }
 
-typedef uint8 (*TestFunction)(uint8, uint8, uint8, std::string *);
+using TestFunction = uint8 (*)(uint8, uint8, uint8, std::string *);
 
 static uint8 TestTrackElementPaintCalls(uint8 rideType, uint8 trackType, uint8 trackSequence, std::string *error);
 

--- a/test/testpaint/main.cpp
+++ b/test/testpaint/main.cpp
@@ -35,10 +35,10 @@
 #include <openrct2/ride/Track.h>
 #include <openrct2/ride/TrackData.h>
 
-typedef struct {
+struct TestCase {
     uint8 rideType;
     std::vector<uint8> trackTypes;
-} TestCase;
+};
 
 enum CLIColour {
     DEFAULT,


### PR DESCRIPTION
`typedef struct/union/enum name { ... } name_again;` is the C way of assigning an identifier to a type. Since the project moved to C++ now, this way of defining structs is not needed anymore.

This PR:
- removes the use of typedefs in the code, except for the ones in the opengl lib files
Typedefs used to refer to other objects now use the C++ `using` keyword instead. They have better readability, especially for function pointer types, and would allow more flexibility when used with templates.
- renames some enums to adapt the ALL_CAPS coding style, but only the ones that I stumbled upon that used `typedef`s.
- changes a function types into function pointer types, that's how they were used anyway (`hook_function` for example).