### PR TITLE
Guard from nullptr dereference in object_entry_get_entry

### DIFF
--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -176,7 +176,12 @@ void * object_entry_get_chunk(sint32 objectType, size_t index)
 
 const rct_object_entry * object_entry_get_entry(sint32 objectType, size_t index)
 {
+    const rct_object_entry * result = nullptr;
     auto objectMgr = GetObjectManager();
     auto obj = objectMgr->GetLoadedObject(objectType, index);
-    return obj->GetObjectEntry();
+    if (obj != nullptr)
+    {
+        result = obj->GetObjectEntry();
+    }
+    return result;
 }


### PR DESCRIPTION
While looking at
https://github.com/OpenRCT2/OpenRCT2/issues/7176#issuecomment-365399194
I got a crash with stacktrace:

    #0 0x7f9e81fa2e30 in object_entry_get_entry(int, unsigned long) ../src/openrct2/object/ObjectList.cpp:181
    #1 0x7f9e81fa24ae in get_loaded_object_entry(unsigned long) ../src/openrct2/object/ObjectList.cpp:142
    #2 0x7f9e8215d64f in S6Exporter::Export() ../src/openrct2/rct2/S6Exporter.cpp:169
    #3 0x7f9e8216de71 in scenario_save(char const*, int) ../src/openrct2/rct2/S6Exporter.cpp:757
    #4 0x7f9e81c932b0 in game_autosave() ../src/openrct2/Game.cpp:1590
    #5 0x7f9e828625b6 in scenario_autosave_check() ../src/openrct2/scenario/Scenario.cpp:297
    #6 0x7f9e81c8a958 in game_update() ../src/openrct2/Game.cpp:439
    #7 0x7f9e81c6731f in OpenRCT2::Context::Update() (/home/janisozaur/workspace/OpenRCT2/build/libopenrct2.so+0x10f331f)
    #8 0x7f9e81c6674c in OpenRCT2::Context::RunVariableFrame() (/home/janisozaur/workspace/OpenRCT2/build/libopenrct2.so+0x10f274c)
    #9 0x7f9e81c6402d in OpenRCT2::Context::RunFrame() (/home/janisozaur/workspace/OpenRCT2/build/libopenrct2.so+0x10f002d)
    #10 0x7f9e81c638f4 in OpenRCT2::Context::RunGameLoop() (/home/janisozaur/workspace/OpenRCT2/build/libopenrct2.so+0x10ef8f4)
    #11 0x7f9e81c627bf in OpenRCT2::Context::Launch() (/home/janisozaur/workspace/OpenRCT2/build/libopenrct2.so+0x10ee7bf)
    #12 0x7f9e81c5b08a in OpenRCT2::Context::RunOpenRCT2(int, char const**) ../src/openrct2/Context.cpp:170
    #13 0x56323695b95e in main ../src/openrct2-ui/Ui.cpp:60

Sadly I cannot reproduce it anymore