### PR TITLE
Temporarily fix #7173: cannot load saves into vanilla

### DIFF
--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -97,8 +97,9 @@ rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint
 
 void Object::SetSourceGame(const uint8 sourceGame)
 {
-    _objectEntry.flags &= 0x0F;
-    _objectEntry.flags |= (sourceGame << 4);
+    // FIXME: Temporary disabled because it breaks exporting to vanilla.
+    /*_objectEntry.flags &= 0x0F;
+    _objectEntry.flags |= (sourceGame << 4);*/
 }
 
 bool Object::IsRCT1Object()


### PR DESCRIPTION
This is a temporary fix in order to make export to vanilla work again.

It also undoes the categorisation into RCT1/AA/LL/Official. This will need another approach - it might need to wait until json-objects.