### PR TITLE
Introduce big and small coordinates

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1731,7 +1731,7 @@ static void window_ride_construction_construct(rct_window *w)
             y -= TileDirectionDelta[trackDirection].y;
         }
 
-        BigCoordsXYE next_track;
+        CoordsXYE next_track;
         if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, trackDirection, &next_track, &z, &trackDirection)) {
             _currentTrackBeginX = next_track.x;
             _currentTrackBeginY = next_track.y;
@@ -1764,7 +1764,7 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
 {
     sint32 x, y, z, direction, type;
     rct_tile_element *tileElement;
-    BigCoordsXYE inputElement, outputElement;
+    CoordsXYE inputElement, outputElement;
     track_begin_end trackBeginEnd;
     //bool gotoStartPlacementMode;
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1731,7 +1731,7 @@ static void window_ride_construction_construct(rct_window *w)
             y -= TileDirectionDelta[trackDirection].y;
         }
 
-        rct_xy_element next_track;
+        BigCoordsXYE next_track;
         if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, trackDirection, &next_track, &z, &trackDirection)) {
             _currentTrackBeginX = next_track.x;
             _currentTrackBeginY = next_track.y;
@@ -1764,7 +1764,7 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
 {
     sint32 x, y, z, direction, type;
     rct_tile_element *tileElement;
-    rct_xy_element inputElement, outputElement;
+    BigCoordsXYE inputElement, outputElement;
     track_begin_end trackBeginEnd;
     //bool gotoStartPlacementMode;
 

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -465,7 +465,7 @@ static void cheat_own_all_land()
         sint32 x = spawn.x;
         sint32 y = spawn.y;
         if (x != PEEP_SPAWN_UNDEFINED) {
-            rct_tile_element * surfaceElement = map_get_surface_element_at((BigCoordsXY){x, y});
+            rct_tile_element * surfaceElement = map_get_surface_element_at({x, y});
             surfaceElement->properties.surface.ownership = OWNERSHIP_UNOWNED;
             update_park_fences_around_tile(x, y);
             uint16 baseHeight = surfaceElement->base_height * 8;

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -436,25 +436,26 @@ static void cheat_set_staff_speed(uint8 value)
 
 static void cheat_own_all_land()
 {
-    sint32 min = 32;
-    sint32 max = gMapSizeUnits - 32;
-    for (sint32 y = min; y <= max; y += 32) {
-        for (sint32 x = min; x <= max; x += 32) {
-            rct_tile_element * surfaceElement = map_get_surface_element_at(x >> 5, y >> 5);
+    const sint32 min = 32;
+    const sint32 max = gMapSizeUnits - 32;
+
+    for (BigCoordsXY coords = {min, min}; coords.y <= max; coords.y += 32) {
+        for (; coords.x <= max; coords.x += 32) {
+            rct_tile_element * surfaceElement = map_get_surface_element_at(coords);
 
             // Ignore already owned tiles.
             if (surfaceElement->properties.surface.ownership & OWNERSHIP_OWNED)
                 continue;
 
             sint32 base_z = surfaceElement->base_height;
-            sint32 destOwnership = check_max_allowable_land_rights_for_tile(x >> 5, y >> 5, base_z);
+            sint32 destOwnership = check_max_allowable_land_rights_for_tile(coords.x >> 5, coords.y >> 5, base_z);
 
             // only own tiles that were not set to 0
             if (destOwnership != OWNERSHIP_UNOWNED) {
                 surfaceElement->properties.surface.ownership |= destOwnership;
-                update_park_fences_around_tile(x, y);
+                update_park_fences_around_tile(coords.x, coords.y);
                 uint16 baseHeight = surfaceElement->base_height * 8;
-                map_invalidate_tile(x, y, baseHeight, baseHeight + 16);
+                map_invalidate_tile(coords.x, coords.y, baseHeight, baseHeight + 16);
             }
         }
     }
@@ -464,7 +465,7 @@ static void cheat_own_all_land()
         sint32 x = spawn.x;
         sint32 y = spawn.y;
         if (x != PEEP_SPAWN_UNDEFINED) {
-            rct_tile_element * surfaceElement = map_get_surface_element_at(x >> 5, y >> 5);
+            rct_tile_element * surfaceElement = map_get_surface_element_at((BigCoordsXY){x, y});
             surfaceElement->properties.surface.ownership = OWNERSHIP_UNOWNED;
             update_park_fences_around_tile(x, y);
             uint16 baseHeight = surfaceElement->base_height * 8;

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -439,7 +439,7 @@ static void cheat_own_all_land()
     const sint32 min = 32;
     const sint32 max = gMapSizeUnits - 32;
 
-    for (BigCoordsXY coords = {min, min}; coords.y <= max; coords.y += 32) {
+    for (CoordsXY coords = {min, min}; coords.y <= max; coords.y += 32) {
         for (; coords.x <= max; coords.x += 32) {
             rct_tile_element * surfaceElement = map_get_surface_element_at(coords);
 

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -158,7 +158,7 @@ public:
 
         sint8 zLow = _z * 2;
         sint8 zHigh = zLow + 12;
-        LocationXY16 entranceLoc = { _x, _y };
+        BigCoordsXY entranceLoc = { _x, _y };
         for (uint8 index = 0; index < 3; index++)
         {
             if (index == 1)
@@ -174,7 +174,7 @@ public:
 
             if (!(flags & GAME_COMMAND_FLAG_GHOST))
             {
-                rct_tile_element* surfaceElement = map_get_surface_element_at(entranceLoc.x / 32, entranceLoc.y / 32);
+                rct_tile_element* surfaceElement = map_get_surface_element_at(entranceLoc);
                 surfaceElement->properties.surface.ownership = 0;
             }
 

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -158,7 +158,7 @@ public:
 
         sint8 zLow = _z * 2;
         sint8 zHigh = zLow + 12;
-        BigCoordsXY entranceLoc = { _x, _y };
+        CoordsXY entranceLoc = { _x, _y };
         for (uint8 index = 0; index < 3; index++)
         {
             if (index == 1)

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -217,7 +217,7 @@ AudioParams audio_get_params_from_location(sint32 soundId, const LocationXYZ16 *
     params.volume = 0;
     params.pan = 0;
 
-    rct_tile_element * element = map_get_surface_element_at(location->x >> 5, location->y >> 5);
+    rct_tile_element * element = map_get_surface_element_at((BigCoordsXY){location->x, location->y});
     if (element && (element->base_height * 8) - 5 > location->z)
     {
         volumeDown = 10;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -217,7 +217,7 @@ AudioParams audio_get_params_from_location(sint32 soundId, const LocationXYZ16 *
     params.volume = 0;
     params.pan = 0;
 
-    rct_tile_element * element = map_get_surface_element_at((BigCoordsXY){location->x, location->y});
+    rct_tile_element * element = map_get_surface_element_at({location->x, location->y});
     if (element && (element->base_height * 8) - 5 > location->z)
     {
         volumeDown = 10;

--- a/src/openrct2/interface/ViewportInteraction.cpp
+++ b/src/openrct2/interface/ViewportInteraction.cpp
@@ -370,7 +370,7 @@ sint32 viewport_interaction_right_over(sint32 x, sint32 y)
  */
 sint32 viewport_interaction_right_click(sint32 x, sint32 y)
 {
-    BigCoordsXYE tileElement;
+    CoordsXYE tileElement;
     viewport_interaction_info info;
 
     switch (viewport_interaction_get_item_right(x, y, &info)) {

--- a/src/openrct2/interface/ViewportInteraction.cpp
+++ b/src/openrct2/interface/ViewportInteraction.cpp
@@ -370,7 +370,7 @@ sint32 viewport_interaction_right_over(sint32 x, sint32 y)
  */
 sint32 viewport_interaction_right_click(sint32 x, sint32 y)
 {
-    rct_xy_element tileElement;
+    BigCoordsXYE tileElement;
     viewport_interaction_info info;
 
     switch (viewport_interaction_get_item_right(x, y, &info)) {

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -22,7 +22,7 @@
 #include "tile_element/TileElement.h"
 #include "VirtualFloor.h"
 
-static constexpr const BigCoordsXY offsets[4] =
+static constexpr const CoordsXY offsets[4] =
 {
     { -32,   0 },
     {   0,  32 },

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -22,7 +22,7 @@
 #include "tile_element/TileElement.h"
 #include "VirtualFloor.h"
 
-static constexpr const rct_xy_element offsets[4] =
+static constexpr const BigCoordsXY offsets[4] =
 {
     { -32,   0 },
     {   0,  32 },

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -787,7 +787,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, const r
 
     sint16 x = session->MapPosition.x, y = session->MapPosition.y;
 
-    rct_tile_element * surface = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element * surface = map_get_surface_element_at((BigCoordsXY){session->MapPosition.x, session->MapPosition.y});
 
     uint16 bl = height / 8;
     if (surface == nullptr) {

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -787,7 +787,7 @@ void path_paint(paint_session * session, uint8 direction, uint16 height, const r
 
     sint16 x = session->MapPosition.x, y = session->MapPosition.y;
 
-    rct_tile_element * surface = map_get_surface_element_at((BigCoordsXY){session->MapPosition.x, session->MapPosition.y});
+    rct_tile_element * surface = map_get_surface_element_at({session->MapPosition.x, session->MapPosition.y});
 
     uint16 bl = height / 8;
     if (surface == nullptr) {

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -957,7 +957,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, cons
     for (sint32 i = 0; i < 4; i++)
     {
         const LocationXY16& offset = viewport_surface_paint_data[i][rotation];
-        const BigCoordsXY position =
+        const CoordsXY position =
         {
             (sint32)(base.x + offset.x),
             (sint32)(base.y + offset.y)

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -957,10 +957,10 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, cons
     for (sint32 i = 0; i < 4; i++)
     {
         const LocationXY16& offset = viewport_surface_paint_data[i][rotation];
-        const LocationXY16 position =
+        const BigCoordsXY position =
         {
-            (sint16)(base.x + offset.x),
-            (sint16)(base.y + offset.y)
+            (sint32)(base.x + offset.x),
+            (sint32)(base.y + offset.y)
         };
 
         tile_descriptor& descriptor = tileDescriptors[i + 1];
@@ -971,7 +971,7 @@ void surface_paint(paint_session * session, uint8 direction, uint16 height, cons
             continue;
         }
 
-        rct_tile_element * surfaceElement = map_get_surface_element_at(position.x / 32, position.y / 32);
+        rct_tile_element * surfaceElement = map_get_surface_element_at(position);
         if (surfaceElement == nullptr)
         {
             continue;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -86,7 +86,7 @@ static uint8  _peepPathFindFewestNumSteps;
  * be declared properly. */
 static struct
 {
-    SmallCoordsXYZ location;
+    TileCoordsXYZ location;
     uint8          direction;
 } _peepPathFindHistory[16];
 
@@ -455,7 +455,7 @@ static constexpr const ride_rating NauseaMaximumThresholds[] = {
 // Locations of the spiral slide platform that a peep walks from the entrance of the ride to the
 // entrance of the slide. Up to 4 locations for each 4 sides that an ride entrance can be located
 // and 4 different rotations of the ride. 4 * 4 * 4 = 64 locations.
-static constexpr const BigCoordsXY SpiralSlideWalkingPath[64] = {
+static constexpr const CoordsXY SpiralSlideWalkingPath[64] = {
     {  56,   8 },
     {   8,   8 },
     {   8,  32 },
@@ -2962,7 +2962,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
         y *= 32;
 
         assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-        const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+        const CoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
         x += slidePlatformDestination.x;
         y += slidePlatformDestination.y;
@@ -3962,7 +3962,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
             x *= 32;
             y *= 32;
             assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-            const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+            const CoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
             x += slidePlatformDestination.x;
             y += slidePlatformDestination.y;
@@ -3982,7 +3982,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
     y *= 32;
 
     assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-    const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+    const CoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
     x += slidePlatformDestination.x;
     y += slidePlatformDestination.y;
@@ -3992,7 +3992,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
 }
 
 /** rct2: 0x00981F0C, 0x00981F0E */
-static constexpr const BigCoordsXY _981F0C[] = {
+static constexpr const CoordsXY _981F0C[] = {
     { 25, 56 },
     { 56, 7 },
     { 7, -24 },
@@ -4000,7 +4000,7 @@ static constexpr const BigCoordsXY _981F0C[] = {
 };
 
 /** rct2: 0x00981F1C, 0x00981F1E */
-static constexpr const BigCoordsXY _981F1C[] = {
+static constexpr const CoordsXY _981F1C[] = {
     { 8, 56 },
     { 56, 24 },
     { 24, -24 },
@@ -4090,7 +4090,7 @@ static void peep_update_ride_sub_state_15(rct_peep * peep)
     y *= 32;
 
     assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-    const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+    const CoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
     x += slidePlatformDestination.x;
     y += slidePlatformDestination.y;
@@ -4134,7 +4134,7 @@ static void peep_update_ride_sub_state_16(rct_peep * peep)
         y *= 32;
 
         assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-        const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+        const CoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
         x += slidePlatformDestination.x;
         y += slidePlatformDestination.y;
@@ -4877,7 +4877,7 @@ static bool peep_update_fixing_sub_state_6(bool firstRun, rct_peep * peep, Ride 
 }
 
 /** rct2: 0x00992A3C */
-static constexpr const BigCoordsXY _992A3C[] = {
+static constexpr const CoordsXY _992A3C[] = {
     { -12, 0 },
     { 0, 12 },
     { 12, 0 },
@@ -4916,7 +4916,7 @@ static bool peep_update_fixing_sub_state_7(bool firstRun, rct_peep * peep, Ride 
         }
 
         sint32      direction = tile_element_get_direction(tileElement);
-        BigCoordsXY offset    = _992A3C[direction];
+        CoordsXY offset    = _992A3C[direction];
 
         stationX += 16 + offset.x;
         if (offset.x == 0)
@@ -4997,7 +4997,7 @@ static bool peep_update_fixing_sub_state_9(bool firstRun, rct_peep * peep, Ride 
 
         uint8 stationZ = ride->station_heights[peep->current_ride_station];
 
-        BigCoordsXYE input;
+        CoordsXYE input;
         input.x       = stationPosition.x * 32;
         input.y       = stationPosition.y * 32;
         input.element = map_get_track_element_at_from_ride(input.x, input.y, stationZ, peep->current_ride);
@@ -5027,7 +5027,7 @@ static bool peep_update_fixing_sub_state_9(bool firstRun, rct_peep * peep, Ride 
         uint16 destinationX = input.x + 16;
         uint16 destinationY = input.y + 16;
 
-        BigCoordsXY offset = _992A3C[direction];
+        CoordsXY offset = _992A3C[direction];
 
         destinationX -= offset.x;
         if (offset.x == 0)
@@ -9965,8 +9965,8 @@ static bool path_is_thin_junction(rct_tile_element * path, sint16 x, sint16 y, u
  */
 static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep * peep, rct_tile_element * currentTileElement,
                                            bool inPatrolArea, uint8 counter, uint16 * endScore, sint32 test_edge,
-                                           uint8 * endJunctions, SmallCoordsXYZ junctionList[16], uint8 directionList[16],
-                                           SmallCoordsXYZ * endXYZ, uint8 * endSteps)
+                                           uint8 * endJunctions, TileCoordsXYZ junctionList[16], uint8 directionList[16],
+                                           TileCoordsXYZ * endXYZ, uint8 * endSteps)
 {
     uint8 searchResult = PATH_SEARCH_FAILED;
 
@@ -10558,7 +10558,7 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
     // Used to allow walking through no entry banners
     _peepPathFindIsStaff = (peep->type == PEEP_TYPE_STAFF);
 
-    SmallCoordsXYZ goal = { (uint8)(gPeepPathFindGoalPosition.x >> 5),
+    TileCoordsXYZ goal = { (uint8)(gPeepPathFindGoalPosition.x >> 5),
                       (uint8)(gPeepPathFindGoalPosition.y >> 5),
                       (uint8)(gPeepPathFindGoalPosition.z) };
 
@@ -10722,9 +10722,9 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
         uint8          bestJunctions         = 0;
-        SmallCoordsXYZ bestJunctionList[16]  = { 0 };
+        TileCoordsXYZ bestJunctionList[16]  = { 0 };
         uint8          bestDirectionList[16] = { 0 };
-        SmallCoordsXYZ bestXYZ               = { 0, 0, 0 };
+        TileCoordsXYZ bestXYZ               = { 0, 0, 0 };
 
         if (gPathFindDebug)
         {
@@ -10769,7 +10769,7 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
             uint16 score = 0xFFFF;
             /* Variable endXYZ contains the end location of the
              * search path. */
-            SmallCoordsXYZ endXYZ;
+            TileCoordsXYZ endXYZ;
             endXYZ.x = 0;
             endXYZ.y = 0;
             endXYZ.z = 0;
@@ -10784,7 +10784,7 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
              * In the future these could be used to visualise the
              * pathfinding on the map. */
             uint8          endJunctions         = 0;
-            SmallCoordsXYZ endJunctionList[16]  = { 0 };
+            TileCoordsXYZ endJunctionList[16]  = { 0 };
             uint8          endDirectionList[16] = { 0 };
 
             bool inPatrolArea = false;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -455,7 +455,7 @@ static constexpr const ride_rating NauseaMaximumThresholds[] = {
 // Locations of the spiral slide platform that a peep walks from the entrance of the ride to the
 // entrance of the slide. Up to 4 locations for each 4 sides that an ride entrance can be located
 // and 4 different rotations of the ride. 4 * 4 * 4 = 64 locations.
-static constexpr const LocationXY16 SpiralSlideWalkingPath[64] = {
+static constexpr const BigCoordsXY SpiralSlideWalkingPath[64] = {
     {  56,   8 },
     {   8,   8 },
     {   8,  32 },
@@ -2962,7 +2962,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
         y *= 32;
 
         assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-        const LocationXY16 slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+        const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
         x += slidePlatformDestination.x;
         y += slidePlatformDestination.y;
@@ -3962,7 +3962,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
             x *= 32;
             y *= 32;
             assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-            const LocationXY16 slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+            const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
             x += slidePlatformDestination.x;
             y += slidePlatformDestination.y;
@@ -3982,7 +3982,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
     y *= 32;
 
     assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-    const LocationXY16 slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+    const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
     x += slidePlatformDestination.x;
     y += slidePlatformDestination.y;
@@ -3992,7 +3992,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
 }
 
 /** rct2: 0x00981F0C, 0x00981F0E */
-static constexpr const LocationXY16 _981F0C[] = {
+static constexpr const BigCoordsXY _981F0C[] = {
     { 25, 56 },
     { 56, 7 },
     { 7, -24 },
@@ -4000,7 +4000,7 @@ static constexpr const LocationXY16 _981F0C[] = {
 };
 
 /** rct2: 0x00981F1C, 0x00981F1E */
-static constexpr const LocationXY16 _981F1C[] = {
+static constexpr const BigCoordsXY _981F1C[] = {
     { 8, 56 },
     { 56, 24 },
     { 24, -24 },
@@ -4090,7 +4090,7 @@ static void peep_update_ride_sub_state_15(rct_peep * peep)
     y *= 32;
 
     assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-    const LocationXY16 slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+    const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
     x += slidePlatformDestination.x;
     y += slidePlatformDestination.y;
@@ -4134,7 +4134,7 @@ static void peep_update_ride_sub_state_16(rct_peep * peep)
         y *= 32;
 
         assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
-        const LocationXY16 slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
+        const BigCoordsXY slidePlatformDestination = SpiralSlideWalkingPath[peep->var_37];
 
         x += slidePlatformDestination.x;
         y += slidePlatformDestination.y;
@@ -4877,7 +4877,7 @@ static bool peep_update_fixing_sub_state_6(bool firstRun, rct_peep * peep, Ride 
 }
 
 /** rct2: 0x00992A3C */
-static constexpr const LocationXY16 _992A3C[] = {
+static constexpr const BigCoordsXY _992A3C[] = {
     { -12, 0 },
     { 0, 12 },
     { 12, 0 },
@@ -4915,8 +4915,8 @@ static bool peep_update_fixing_sub_state_7(bool firstRun, rct_peep * peep, Ride 
             return false;
         }
 
-        sint32       direction = tile_element_get_direction(tileElement);
-        LocationXY16 offset    = _992A3C[direction];
+        sint32      direction = tile_element_get_direction(tileElement);
+        BigCoordsXY offset    = _992A3C[direction];
 
         stationX += 16 + offset.x;
         if (offset.x == 0)
@@ -5027,7 +5027,7 @@ static bool peep_update_fixing_sub_state_9(bool firstRun, rct_peep * peep, Ride 
         uint16 destinationX = input.x + 16;
         uint16 destinationY = input.y + 16;
 
-        LocationXY16 offset = _992A3C[direction];
+        BigCoordsXY offset = _992A3C[direction];
 
         destinationX -= offset.x;
         if (offset.x == 0)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2059,7 +2059,7 @@ bool peep_pickup_place(rct_peep * peep, sint32 x, sint32 y, sint32 z, bool apply
 
     if (!tileElement)
     {
-        tileElement = map_get_surface_element_at(x / 32, y / 32);
+        tileElement = map_get_surface_element_at({x, y});
     }
 
     if (!tileElement)
@@ -6919,7 +6919,7 @@ static sint32 peep_update_patrolling_find_grass(rct_peep * peep)
     if ((peep->next_var_29 & 0x18) != 8)
         return 0;
 
-    rct_tile_element * tile_element = map_get_surface_element_at(peep->next_x / 32, peep->next_y / 32);
+    rct_tile_element * tile_element = map_get_surface_element_at({peep->next_x, peep->next_y});
 
     if ((tile_element->properties.surface.terrain & TILE_ELEMENT_SURFACE_TERRAIN_MASK) != TERRAIN_GRASS)
         return 0;
@@ -6991,7 +6991,7 @@ static void peep_update_patrolling(rct_peep * peep)
 
     if ((peep->next_var_29 & 0x18) == 8)
     {
-        rct_tile_element * tile_element = map_get_surface_element_at(peep->next_x / 32, peep->next_y / 32);
+        rct_tile_element * tile_element = map_get_surface_element_at({peep->next_x, peep->next_y});
 
         if (tile_element != nullptr)
         {
@@ -7193,7 +7193,7 @@ static void peep_update_walking(rct_peep * peep)
 
     if ((peep->next_var_29 & 0x18) == 8)
     {
-        rct_tile_element * tile_element = map_get_surface_element_at(peep->next_x / 32, peep->next_y / 32);
+        rct_tile_element * tile_element = map_get_surface_element_at({peep->next_x, peep->next_y});
 
         sint32 water_height = map_get_water_height(tile_element);
         if (water_height)
@@ -11662,7 +11662,7 @@ static sint32 peep_perform_next_action(rct_peep * peep)
                 return peep_return_to_centre_of_tile(peep);
             }
 
-            tileElement = map_get_surface_element_at(x / 32, y / 32);
+            tileElement = map_get_surface_element_at({x, y});
             if (tileElement == nullptr)
                 return peep_return_to_centre_of_tile(peep);
 
@@ -12646,7 +12646,7 @@ static bool peep_find_ride_to_look_at(rct_peep * peep, uint8 edge, uint8 * rideT
 {
     rct_tile_element *tileElement, *surfaceElement;
 
-    surfaceElement = map_get_surface_element_at(peep->next_x / 32, peep->next_y / 32);
+    surfaceElement = map_get_surface_element_at({peep->next_x, peep->next_y});
 
     tileElement = surfaceElement;
     do
@@ -12680,7 +12680,7 @@ static bool peep_find_ride_to_look_at(rct_peep * peep, uint8 edge, uint8 * rideT
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+    surfaceElement = map_get_surface_element_at({x, y});
 
     tileElement = surfaceElement;
     do
@@ -12792,7 +12792,7 @@ static bool peep_find_ride_to_look_at(rct_peep * peep, uint8 edge, uint8 * rideT
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+    surfaceElement = map_get_surface_element_at({x, y});
 
     // TODO: extract loop A
     tileElement = surfaceElement;
@@ -12904,7 +12904,7 @@ static bool peep_find_ride_to_look_at(rct_peep * peep, uint8 edge, uint8 * rideT
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+    surfaceElement = map_get_surface_element_at({x, y});
 
     // TODO: extract loop A
     tileElement = surfaceElement;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -4997,7 +4997,7 @@ static bool peep_update_fixing_sub_state_9(bool firstRun, rct_peep * peep, Ride 
 
         uint8 stationZ = ride->station_heights[peep->current_ride_station];
 
-        rct_xy_element input;
+        BigCoordsXYE input;
         input.x       = stationPosition.x * 32;
         input.y       = stationPosition.y * 32;
         input.element = map_get_track_element_at_from_ride(input.x, input.y, stationZ, peep->current_ride);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -86,8 +86,8 @@ static uint8  _peepPathFindFewestNumSteps;
  * be declared properly. */
 static struct
 {
-    LocationXYZ8 location;
-    uint8        direction;
+    SmallCoordsXYZ location;
+    uint8          direction;
 } _peepPathFindHistory[16];
 
 static uint8             _unk_F1AEF0;
@@ -9965,8 +9965,8 @@ static bool path_is_thin_junction(rct_tile_element * path, sint16 x, sint16 y, u
  */
 static void peep_pathfind_heuristic_search(sint16 x, sint16 y, uint8 z, rct_peep * peep, rct_tile_element * currentTileElement,
                                            bool inPatrolArea, uint8 counter, uint16 * endScore, sint32 test_edge,
-                                           uint8 * endJunctions, LocationXYZ8 junctionList[16], uint8 directionList[16],
-                                           LocationXYZ8 * endXYZ, uint8 * endSteps)
+                                           uint8 * endJunctions, SmallCoordsXYZ junctionList[16], uint8 directionList[16],
+                                           SmallCoordsXYZ * endXYZ, uint8 * endSteps)
 {
     uint8 searchResult = PATH_SEARCH_FAILED;
 
@@ -10558,7 +10558,7 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
     // Used to allow walking through no entry banners
     _peepPathFindIsStaff = (peep->type == PEEP_TYPE_STAFF);
 
-    LocationXYZ8 goal = { (uint8)(gPeepPathFindGoalPosition.x >> 5),
+    SmallCoordsXYZ goal = { (uint8)(gPeepPathFindGoalPosition.x >> 5),
                       (uint8)(gPeepPathFindGoalPosition.y >> 5),
                       (uint8)(gPeepPathFindGoalPosition.z) };
 
@@ -10721,10 +10721,10 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
         uint8  best_sub   = 0xFF;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        uint8        bestJunctions         = 0;
-        LocationXYZ8 bestJunctionList[16]  = { 0 };
-        uint8        bestDirectionList[16] = { 0 };
-        LocationXYZ8 bestXYZ               = { 0, 0, 0 };
+        uint8          bestJunctions         = 0;
+        SmallCoordsXYZ bestJunctionList[16]  = { 0 };
+        uint8          bestDirectionList[16] = { 0 };
+        SmallCoordsXYZ bestXYZ               = { 0, 0, 0 };
 
         if (gPathFindDebug)
         {
@@ -10769,7 +10769,7 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
             uint16 score = 0xFFFF;
             /* Variable endXYZ contains the end location of the
              * search path. */
-            LocationXYZ8 endXYZ;
+            SmallCoordsXYZ endXYZ;
             endXYZ.x = 0;
             endXYZ.y = 0;
             endXYZ.z = 0;
@@ -10783,9 +10783,9 @@ sint32 peep_pathfind_choose_direction(sint16 x, sint16 y, uint8 z, rct_peep * pe
              * of the search path.
              * In the future these could be used to visualise the
              * pathfinding on the map. */
-            uint8        endJunctions         = 0;
-            LocationXYZ8 endJunctionList[16]  = { 0 };
-            uint8        endDirectionList[16] = { 0 };
+            uint8          endJunctions         = 0;
+            SmallCoordsXYZ endJunctionList[16]  = { 0 };
+            uint8          endDirectionList[16] = { 0 };
 
             bool inPatrolArea = false;
             if (peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_MECHANIC)

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -18,6 +18,7 @@
 #define _PEEP_H_
 
 #include "../common.h"
+#include "../rct12/RCT12.h"
 #include "../world/Map.h"
 
 #define PEEP_MAX_THOUGHTS 5
@@ -603,8 +604,8 @@ struct rct_peep
     };
     uint8     photo1_ride_ref;     // 0xC7
     uint32    peep_flags;          // 0xC8
-    LocationXYZD8 pathfind_goal;       // 0xCC
-    LocationXYZD8 pathfind_history[4]; // 0xD0
+    rct12_xyzd8 pathfind_goal;       // 0xCC
+    rct12_xyzd8 pathfind_history[4]; // 0xD0
     uint8     no_action_frame_no;  // 0xE0
     // 0x3F Litter Count split into lots of 3 with time, 0xC0 Time since last recalc
     uint8 litter_count; // 0xE1

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -943,8 +943,8 @@ static uint8 staff_handyman_direction_to_nearest_litter(rct_peep * peep)
         nextDirection = x_diff < 0 ? 0 : 2;
     }
 
-    LocationXY16 nextTile = { static_cast<sint16>((nearestLitter->x & 0xFFE0) - TileDirectionDelta[nextDirection].x),
-                          static_cast<sint16>((nearestLitter->y & 0xFFE0) - TileDirectionDelta[nextDirection].y) };
+    BigCoordsXY nextTile = { static_cast<sint32>((nearestLitter->x & 0xFFE0) - TileDirectionDelta[nextDirection].x),
+                          static_cast<sint32>((nearestLitter->y & 0xFFE0) - TileDirectionDelta[nextDirection].y) };
 
     sint16 nextZ = ((peep->z + 8) & 0xFFF0) / 8;
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -990,7 +990,7 @@ static uint8 staff_handyman_direction_to_uncut_grass(rct_peep * peep, uint8 vali
     if (!(peep->next_var_29 & 0x18))
     {
 
-        rct_tile_element * tileElement = map_get_surface_element_at(peep->next_x / 32, peep->next_y / 32);
+        rct_tile_element * tileElement = map_get_surface_element_at({peep->next_x, peep->next_y});
 
         if (peep->next_z != tileElement->base_height)
             return 0xFF;
@@ -1014,13 +1014,13 @@ static uint8 staff_handyman_direction_to_uncut_grass(rct_peep * peep, uint8 vali
             continue;
         }
 
-        LocationXY16 chosenTile = { static_cast<sint16>(peep->next_x + TileDirectionDelta[chosenDirection].x),
-                                static_cast<sint16>(peep->next_y + TileDirectionDelta[chosenDirection].y) };
+        BigCoordsXY chosenTile = { static_cast<sint32>(peep->next_x + TileDirectionDelta[chosenDirection].x),
+                                static_cast<sint32>(peep->next_y + TileDirectionDelta[chosenDirection].y) };
 
         if (chosenTile.x > 0x1FFF || chosenTile.y > 0x1FFF)
             continue;
 
-        rct_tile_element * tileElement = map_get_surface_element_at(chosenTile.x / 32, chosenTile.y / 32);
+        rct_tile_element * tileElement = map_get_surface_element_at(chosenTile);
 
         if (tile_element_get_terrain(tileElement) != 0)
             continue;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -943,7 +943,7 @@ static uint8 staff_handyman_direction_to_nearest_litter(rct_peep * peep)
         nextDirection = x_diff < 0 ? 0 : 2;
     }
 
-    BigCoordsXY nextTile = { static_cast<sint32>((nearestLitter->x & 0xFFE0) - TileDirectionDelta[nextDirection].x),
+    CoordsXY nextTile = { static_cast<sint32>((nearestLitter->x & 0xFFE0) - TileDirectionDelta[nextDirection].x),
                           static_cast<sint32>((nearestLitter->y & 0xFFE0) - TileDirectionDelta[nextDirection].y) };
 
     sint16 nextZ = ((peep->z + 8) & 0xFFF0) / 8;
@@ -1014,7 +1014,7 @@ static uint8 staff_handyman_direction_to_uncut_grass(rct_peep * peep, uint8 vali
             continue;
         }
 
-        BigCoordsXY chosenTile = { static_cast<sint32>(peep->next_x + TileDirectionDelta[chosenDirection].x),
+        CoordsXY chosenTile = { static_cast<sint32>(peep->next_x + TileDirectionDelta[chosenDirection].x),
                                 static_cast<sint32>(peep->next_y + TileDirectionDelta[chosenDirection].y) };
 
         if (chosenTile.x > 0x1FFF || chosenTile.y > 0x1FFF)

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -485,8 +485,8 @@ struct rct1_peep {
     };
     uint8 photo1_ride_ref;          // 0xC7
     uint32 peep_flags;              // 0xC8
-    LocationXYZD8 pathfind_goal;        // 0xCC
-    LocationXYZD8 pathfind_history[4];  // 0xD0
+    rct12_xyzd8 pathfind_goal;        // 0xCC
+    rct12_xyzd8 pathfind_history[4];  // 0xD0
     uint8 no_action_frame_no;       // 0xE0
     // 0x3F Litter Count split into lots of 3 with time, 0xC0 Time since last recalc
     uint8 litter_count;             // 0xE1

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -68,4 +68,10 @@ struct rct12_news_item
 };
 assert_struct_size(rct12_news_item, 0x10C);
 
+struct rct12_xyzd8
+{
+    uint8 x, y, z, direction;
+};
+assert_struct_size(rct12_xyzd8, 4);
+
 #pragma pack(pop)

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -39,8 +39,6 @@
 #define RCT2_MAX_RESEARCHED_SCENERY_ITEM_QUADS 56
 #define RCT2_MAX_RESEARCHED_SCENERY_ITEMS      (RCT2_MAX_RESEARCHED_SCENERY_ITEM_QUADS * 32) // There are 32 bits per quad.
 
-
-
 struct rct2_install_info {
     uint32 installLevel;
     char title[260];

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -260,8 +260,8 @@ static bool sub_6DF01A_loop(rct_vehicle * vehicle)
                 0
             );
 
-            BigCoordsXYE   input;
-            BigCoordsXYE   output;
+            CoordsXYE   input;
+            CoordsXYE   output;
             sint32         outputZ;
             sint32         outputDirection;
 
@@ -344,7 +344,7 @@ static bool sub_6DF21B_loop(rct_vehicle * vehicle)
                 0
             );
 
-            BigCoordsXYE    input;
+            CoordsXYE    input;
 
             input.x       = vehicle->track_x;
             input.y       = vehicle->track_y;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -260,8 +260,8 @@ static bool sub_6DF01A_loop(rct_vehicle * vehicle)
                 0
             );
 
-            rct_xy_element input;
-            rct_xy_element output;
+            BigCoordsXYE   input;
+            BigCoordsXYE   output;
             sint32         outputZ;
             sint32         outputDirection;
 
@@ -344,7 +344,7 @@ static bool sub_6DF21B_loop(rct_vehicle * vehicle)
                 0
             );
 
-            rct_xy_element input;
+            BigCoordsXYE    input;
 
             input.x       = vehicle->track_x;
             input.y       = vehicle->track_y;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -488,7 +488,7 @@ static money32 ride_calculate_income_per_hour(Ride *ride)
  * dl ride index
  * esi result map element
  */
-bool ride_try_get_origin_element(sint32 rideIndex, BigCoordsXYE *output)
+bool ride_try_get_origin_element(sint32 rideIndex, CoordsXYE *output)
 {
     rct_tile_element *resultTileElement = nullptr;
 
@@ -536,7 +536,7 @@ bool ride_try_get_origin_element(sint32 rideIndex, BigCoordsXYE *output)
 * Use track_block_get_next if you are unsure if you are
 * on the first element of a track block
 */
-bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, BigCoordsXYE *output, sint32 *z, sint32 *direction)
+bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, CoordsXYE *output, sint32 *z, sint32 *direction)
 {
     Ride* ride = get_ride(rideIndex);
 
@@ -596,7 +596,7 @@ bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 ri
  *
  *  rct2: 0x006C60C2
  */
-bool track_block_get_next(BigCoordsXYE *input, BigCoordsXYE *output, sint32 *z, sint32 *direction)
+bool track_block_get_next(CoordsXYE *input, CoordsXYE *output, sint32 *z, sint32 *direction)
 {
     uint8 rideIndex = track_element_get_ride_index(input->element);
     Ride* ride = get_ride(rideIndex);
@@ -805,7 +805,7 @@ bool track_block_get_previous(sint32 x, sint32 y, rct_tile_element *tileElement,
  * bx result y
  * esi input / output map element
  */
-sint32 ride_find_track_gap(BigCoordsXYE *input, BigCoordsXYE *output)
+sint32 ride_find_track_gap(CoordsXYE *input, CoordsXYE *output)
 {
     rct_window *w;
     Ride *ride;
@@ -1029,7 +1029,7 @@ static rct_window *ride_create_or_find_construction_window(sint32 rideIndex)
  */
 void ride_construct(sint32 rideIndex)
 {
-    BigCoordsXYE trackElement;
+    CoordsXYE trackElement;
 
     if (ride_try_get_origin_element(rideIndex, &trackElement)) {
         ride_find_track_gap(&trackElement, &trackElement);
@@ -1390,7 +1390,7 @@ void ride_remove_provisional_track_piece()
             x -= TileDirectionDelta[direction].x;
             y -= TileDirectionDelta[direction].y;
         }
-        BigCoordsXYE next_track;
+        CoordsXYE next_track;
         if (track_block_get_next_from_zero(x, y, z, rideIndex, direction, &next_track, &z, &direction)) {
             sint32 flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5 | GAME_COMMAND_FLAG_GHOST;
             game_do_command(
@@ -1502,7 +1502,7 @@ void ride_construction_set_default_next_piece()
     sint32 x, y, z, direction, rideIndex, trackType, curve, bank, slope;
     Ride *ride;
     track_begin_end trackBeginEnd;
-    BigCoordsXYE xyElement;
+    CoordsXYE xyElement;
     rct_tile_element *tileElement;
 
     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1653,7 +1653,7 @@ void ride_select_next_section()
             window_ride_construction_update_active_elements();
             return;
         }
-        BigCoordsXYE inputElement, outputElement;
+        CoordsXYE inputElement, outputElement;
         inputElement.x = x;
         inputElement.y = y;
         inputElement.element = tileElement;
@@ -1836,10 +1836,10 @@ static sint32 ride_modify_maze(rct_tile_element *tileElement, sint32 x, sint32 y
  *
  *  rct2: 0x006CC056
  */
-sint32 ride_modify(BigCoordsXYE *input)
+sint32 ride_modify(CoordsXYE *input)
 {
     sint32 rideIndex, x, y, z, direction, type;
-    BigCoordsXYE tileElement, endOfTrackElement;
+    CoordsXYE tileElement, endOfTrackElement;
     Ride *ride;
     rct_ride_entry *rideEntry;
 
@@ -4114,7 +4114,7 @@ static void sub_6B5952(sint32 rideIndex)
  *
  *  rct2: 0x006D3319
  */
-static sint32 ride_check_block_brakes(BigCoordsXYE *input, BigCoordsXYE *output)
+static sint32 ride_check_block_brakes(CoordsXYE *input, CoordsXYE *output)
 {
     rct_window *w;
     track_circuit_iterator it;
@@ -4163,7 +4163,7 @@ static sint32 ride_check_block_brakes(BigCoordsXYE *input, BigCoordsXYE *output)
  * @returns true if an inversion track piece is found, otherwise false.
  *  rct2: 0x006CB149
  */
-static bool ride_check_track_contains_inversions(BigCoordsXYE *input, BigCoordsXYE *output)
+static bool ride_check_track_contains_inversions(CoordsXYE *input, CoordsXYE *output)
 {
     sint32 rideIndex = track_element_get_ride_index(input->element);
     Ride *ride = get_ride(rideIndex);
@@ -4208,7 +4208,7 @@ static bool ride_check_track_contains_inversions(BigCoordsXYE *input, BigCoordsX
  * @returns true if a banked track piece is found, otherwise false.
  *  rct2: 0x006CB1D3
  */
-static bool ride_check_track_contains_banked(BigCoordsXYE *input, BigCoordsXYE *output)
+static bool ride_check_track_contains_banked(CoordsXYE *input, CoordsXYE *output)
 {
     sint32 rideIndex = track_element_get_ride_index(input->element);
     Ride *ride = get_ride(rideIndex);
@@ -4250,7 +4250,7 @@ static bool ride_check_track_contains_banked(BigCoordsXYE *input, BigCoordsXYE *
  *
  *  rct2: 0x006CB25D
  */
-static sint32 ride_check_station_length(BigCoordsXYE *input, BigCoordsXYE *output)
+static sint32 ride_check_station_length(CoordsXYE *input, CoordsXYE *output)
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
     if (w != nullptr &&
@@ -4271,7 +4271,7 @@ static sint32 ride_check_station_length(BigCoordsXYE *input, BigCoordsXYE *outpu
     }
 
     sint32 num_station_elements = 0;
-    BigCoordsXYE last_good_station = *output;
+    CoordsXYE last_good_station = *output;
 
     do{
         if (TrackSequenceProperties[track_element_get_type(output->element)][0] & TRACK_SEQUENCE_FLAG_ORIGIN){
@@ -4300,12 +4300,12 @@ static sint32 ride_check_station_length(BigCoordsXYE *input, BigCoordsXYE *outpu
  *
  *  rct2: 0x006CB2DA
  */
-static bool ride_check_start_and_end_is_station(BigCoordsXYE * input, BigCoordsXYE * output)
+static bool ride_check_start_and_end_is_station(CoordsXYE * input, CoordsXYE * output)
 {
     rct_window *w;
     Ride *ride;
     sint32 rideIndex, trackType;
-    BigCoordsXYE trackBack, trackFront;
+    CoordsXYE trackBack, trackFront;
 
     rideIndex = track_element_get_ride_index(input->element);
     ride = get_ride(rideIndex);
@@ -4342,7 +4342,7 @@ static bool ride_check_start_and_end_is_station(BigCoordsXYE * input, BigCoordsX
  * station or the last track piece from the end of the direction.
  *  rct2: 0x006B4D39
  */
-static void ride_set_boat_hire_return_point(Ride * ride, BigCoordsXYE * startElement)
+static void ride_set_boat_hire_return_point(Ride * ride, CoordsXYE * startElement)
 {
     sint32 trackType = -1;
     sint32 returnX = startElement->x;
@@ -4419,9 +4419,9 @@ static void ride_set_maze_entrance_exit_points(Ride *ride)
  * Sets a flag on all the track elements that can be the start of a circuit block. i.e. where a train can start.
  *  rct2: 0x006B4E6B
  */
-static void ride_set_block_points(BigCoordsXYE *startElement)
+static void ride_set_block_points(CoordsXYE *startElement)
 {
-    BigCoordsXYE currentElement = *startElement;
+    CoordsXYE currentElement = *startElement;
     do {
         sint32 trackType = track_element_get_type(currentElement.element);
         switch (trackType) {
@@ -4442,7 +4442,7 @@ static void ride_set_block_points(BigCoordsXYE *startElement)
  *
  *  rct2: 0x006B4D26
  */
-static void ride_set_start_finish_points(sint32 rideIndex, BigCoordsXYE *startElement)
+static void ride_set_start_finish_points(sint32 rideIndex, CoordsXYE *startElement)
 {
     Ride *ride = get_ride(rideIndex);
 
@@ -4749,7 +4749,7 @@ static void vehicle_unset_update_flag_b1(rct_vehicle *head)
  *
  *  rct2: 0x006DDE9E
  */
-static void ride_create_vehicles_find_first_block(Ride *ride, BigCoordsXYE *outXYElement)
+static void ride_create_vehicles_find_first_block(Ride *ride, CoordsXYE *outXYElement)
 {
     rct_vehicle *vehicle = GET_VEHICLE(ride->vehicles[0]);
     sint32 firstX = vehicle->track_x;
@@ -4817,7 +4817,7 @@ static void ride_create_vehicles_find_first_block(Ride *ride, BigCoordsXYE *outX
  *
  *  rct2: 0x006DD84C
  */
-static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, BigCoordsXYE *element, sint32 isApplying)
+static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, CoordsXYE *element, sint32 isApplying)
 {
     ride_update_max_vehicles(rideIndex);
     if (ride->subtype == RIDE_ENTRY_INDEX_NULL) {
@@ -4870,7 +4870,7 @@ static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, BigCoordsXYE *ele
     //
     if (ride->type != RIDE_TYPE_SPACE_RINGS && !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_16)) {
         if (ride_is_block_sectioned(ride)) {
-            BigCoordsXYE firstBlock;
+            CoordsXYE firstBlock;
             ride_create_vehicles_find_first_block(ride, &firstBlock);
             loc_6DDF9C(ride, firstBlock.element);
         } else {
@@ -5153,7 +5153,7 @@ static void loc_6B51C0(sint32 rideIndex)
         sint32 z = ride->station_heights[i] * 8;
         window_scroll_to_location(w, x, y, z);
 
-        BigCoordsXYE trackElement;
+        CoordsXYE trackElement;
         ride_try_get_origin_element(rideIndex, &trackElement);
         ride_find_track_gap(&trackElement, &trackElement);
         sint32 ok = ride_modify(&trackElement);
@@ -5171,7 +5171,7 @@ static void loc_6B51C0(sint32 rideIndex)
  *
  *  rct2: 0x006B528A
  */
-static void ride_scroll_to_track_error(BigCoordsXYE *trackElement)
+static void ride_scroll_to_track_error(CoordsXYE *trackElement)
 {
     if (!gGameCommandIsNetworked && gUnk141F568 == gUnk13CA740) {
         rct_window *w = window_get_main();
@@ -5213,7 +5213,7 @@ sint32 ride_is_valid_for_test(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
 {
     sint32 stationIndex;
     Ride *ride;
-    BigCoordsXYE trackElement, problematicTrackElement = { 0 };
+    CoordsXYE trackElement, problematicTrackElement = { 0 };
 
     ride = get_ride(rideIndex);
     if (ride->type == RIDE_TYPE_NULL)
@@ -5342,7 +5342,7 @@ sint32 ride_is_valid_for_open(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
 {
     sint32 stationIndex;
     Ride *ride;
-    BigCoordsXYE trackElement, problematicTrackElement = { 0 };
+    CoordsXYE trackElement, problematicTrackElement = { 0 };
 
     ride = get_ride(rideIndex);
 
@@ -5903,7 +5903,7 @@ void game_command_callback_ride_construct_placed_front(sint32 eax, sint32 ebx, s
         y -= TileDirectionDelta[trackDirection].y;
     }
 
-    BigCoordsXYE next_track;
+    CoordsXYE next_track;
     if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, trackDirection, &next_track, &z, &trackDirection)) {
         _currentTrackBeginX = next_track.x;
         _currentTrackBeginY = next_track.y;
@@ -6787,7 +6787,7 @@ bool ride_select_forwards_from_back()
     y = _currentTrackBeginY;
     z = _currentTrackBeginZ;
     direction = _currentTrackPieceDirection ^ 2;
-    BigCoordsXYE next_track;
+    CoordsXYE next_track;
 
     if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, direction, &next_track, &z, &direction)) {
         _rideConstructionState = RIDE_CONSTRUCTION_STATE_SELECTED;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -488,7 +488,7 @@ static money32 ride_calculate_income_per_hour(Ride *ride)
  * dl ride index
  * esi result map element
  */
-bool ride_try_get_origin_element(sint32 rideIndex, rct_xy_element *output)
+bool ride_try_get_origin_element(sint32 rideIndex, BigCoordsXYE *output)
 {
     rct_tile_element *resultTileElement = nullptr;
 
@@ -536,7 +536,7 @@ bool ride_try_get_origin_element(sint32 rideIndex, rct_xy_element *output)
 * Use track_block_get_next if you are unsure if you are
 * on the first element of a track block
 */
-bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, rct_xy_element *output, sint32 *z, sint32 *direction)
+bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, BigCoordsXYE *output, sint32 *z, sint32 *direction)
 {
     Ride* ride = get_ride(rideIndex);
 
@@ -596,7 +596,7 @@ bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 ri
  *
  *  rct2: 0x006C60C2
  */
-bool track_block_get_next(rct_xy_element *input, rct_xy_element *output, sint32 *z, sint32 *direction)
+bool track_block_get_next(BigCoordsXYE *input, BigCoordsXYE *output, sint32 *z, sint32 *direction)
 {
     uint8 rideIndex = track_element_get_ride_index(input->element);
     Ride* ride = get_ride(rideIndex);
@@ -805,7 +805,7 @@ bool track_block_get_previous(sint32 x, sint32 y, rct_tile_element *tileElement,
  * bx result y
  * esi input / output map element
  */
-sint32 ride_find_track_gap(rct_xy_element *input, rct_xy_element *output)
+sint32 ride_find_track_gap(BigCoordsXYE *input, BigCoordsXYE *output)
 {
     rct_window *w;
     Ride *ride;
@@ -1029,7 +1029,7 @@ static rct_window *ride_create_or_find_construction_window(sint32 rideIndex)
  */
 void ride_construct(sint32 rideIndex)
 {
-    rct_xy_element trackElement;
+    BigCoordsXYE trackElement;
 
     if (ride_try_get_origin_element(rideIndex, &trackElement)) {
         ride_find_track_gap(&trackElement, &trackElement);
@@ -1390,7 +1390,7 @@ void ride_remove_provisional_track_piece()
             x -= TileDirectionDelta[direction].x;
             y -= TileDirectionDelta[direction].y;
         }
-        rct_xy_element next_track;
+        BigCoordsXYE next_track;
         if (track_block_get_next_from_zero(x, y, z, rideIndex, direction, &next_track, &z, &direction)) {
             sint32 flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_5 | GAME_COMMAND_FLAG_GHOST;
             game_do_command(
@@ -1502,7 +1502,7 @@ void ride_construction_set_default_next_piece()
     sint32 x, y, z, direction, rideIndex, trackType, curve, bank, slope;
     Ride *ride;
     track_begin_end trackBeginEnd;
-    rct_xy_element xyElement;
+    BigCoordsXYE xyElement;
     rct_tile_element *tileElement;
 
     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1653,7 +1653,7 @@ void ride_select_next_section()
             window_ride_construction_update_active_elements();
             return;
         }
-        rct_xy_element inputElement, outputElement;
+        BigCoordsXYE inputElement, outputElement;
         inputElement.x = x;
         inputElement.y = y;
         inputElement.element = tileElement;
@@ -1836,10 +1836,10 @@ static sint32 ride_modify_maze(rct_tile_element *tileElement, sint32 x, sint32 y
  *
  *  rct2: 0x006CC056
  */
-sint32 ride_modify(rct_xy_element *input)
+sint32 ride_modify(BigCoordsXYE *input)
 {
     sint32 rideIndex, x, y, z, direction, type;
-    rct_xy_element tileElement, endOfTrackElement;
+    BigCoordsXYE tileElement, endOfTrackElement;
     Ride *ride;
     rct_ride_entry *rideEntry;
 
@@ -4114,7 +4114,7 @@ static void sub_6B5952(sint32 rideIndex)
  *
  *  rct2: 0x006D3319
  */
-static sint32 ride_check_block_brakes(rct_xy_element *input, rct_xy_element *output)
+static sint32 ride_check_block_brakes(BigCoordsXYE *input, BigCoordsXYE *output)
 {
     rct_window *w;
     track_circuit_iterator it;
@@ -4163,7 +4163,7 @@ static sint32 ride_check_block_brakes(rct_xy_element *input, rct_xy_element *out
  * @returns true if an inversion track piece is found, otherwise false.
  *  rct2: 0x006CB149
  */
-static bool ride_check_track_contains_inversions(rct_xy_element *input, rct_xy_element *output)
+static bool ride_check_track_contains_inversions(BigCoordsXYE *input, BigCoordsXYE *output)
 {
     sint32 rideIndex = track_element_get_ride_index(input->element);
     Ride *ride = get_ride(rideIndex);
@@ -4208,7 +4208,7 @@ static bool ride_check_track_contains_inversions(rct_xy_element *input, rct_xy_e
  * @returns true if a banked track piece is found, otherwise false.
  *  rct2: 0x006CB1D3
  */
-static bool ride_check_track_contains_banked(rct_xy_element *input, rct_xy_element *output)
+static bool ride_check_track_contains_banked(BigCoordsXYE *input, BigCoordsXYE *output)
 {
     sint32 rideIndex = track_element_get_ride_index(input->element);
     Ride *ride = get_ride(rideIndex);
@@ -4250,7 +4250,7 @@ static bool ride_check_track_contains_banked(rct_xy_element *input, rct_xy_eleme
  *
  *  rct2: 0x006CB25D
  */
-static sint32 ride_check_station_length(rct_xy_element *input, rct_xy_element *output)
+static sint32 ride_check_station_length(BigCoordsXYE *input, BigCoordsXYE *output)
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
     if (w != nullptr &&
@@ -4271,7 +4271,7 @@ static sint32 ride_check_station_length(rct_xy_element *input, rct_xy_element *o
     }
 
     sint32 num_station_elements = 0;
-    rct_xy_element last_good_station = *output;
+    BigCoordsXYE last_good_station = *output;
 
     do{
         if (TrackSequenceProperties[track_element_get_type(output->element)][0] & TRACK_SEQUENCE_FLAG_ORIGIN){
@@ -4300,12 +4300,12 @@ static sint32 ride_check_station_length(rct_xy_element *input, rct_xy_element *o
  *
  *  rct2: 0x006CB2DA
  */
-static bool ride_check_start_and_end_is_station(rct_xy_element *input, rct_xy_element *output)
+static bool ride_check_start_and_end_is_station(BigCoordsXYE * input, BigCoordsXYE * output)
 {
     rct_window *w;
     Ride *ride;
     sint32 rideIndex, trackType;
-    rct_xy_element trackBack, trackFront;
+    BigCoordsXYE trackBack, trackFront;
 
     rideIndex = track_element_get_ride_index(input->element);
     ride = get_ride(rideIndex);
@@ -4342,7 +4342,7 @@ static bool ride_check_start_and_end_is_station(rct_xy_element *input, rct_xy_el
  * station or the last track piece from the end of the direction.
  *  rct2: 0x006B4D39
  */
-static void ride_set_boat_hire_return_point(Ride *ride, rct_xy_element *startElement)
+static void ride_set_boat_hire_return_point(Ride * ride, BigCoordsXYE * startElement)
 {
     sint32 trackType = -1;
     sint32 returnX = startElement->x;
@@ -4419,9 +4419,9 @@ static void ride_set_maze_entrance_exit_points(Ride *ride)
  * Sets a flag on all the track elements that can be the start of a circuit block. i.e. where a train can start.
  *  rct2: 0x006B4E6B
  */
-static void ride_set_block_points(rct_xy_element *startElement)
+static void ride_set_block_points(BigCoordsXYE *startElement)
 {
-    rct_xy_element currentElement = *startElement;
+    BigCoordsXYE currentElement = *startElement;
     do {
         sint32 trackType = track_element_get_type(currentElement.element);
         switch (trackType) {
@@ -4442,7 +4442,7 @@ static void ride_set_block_points(rct_xy_element *startElement)
  *
  *  rct2: 0x006B4D26
  */
-static void ride_set_start_finish_points(sint32 rideIndex, rct_xy_element *startElement)
+static void ride_set_start_finish_points(sint32 rideIndex, BigCoordsXYE *startElement)
 {
     Ride *ride = get_ride(rideIndex);
 
@@ -4749,7 +4749,7 @@ static void vehicle_unset_update_flag_b1(rct_vehicle *head)
  *
  *  rct2: 0x006DDE9E
  */
-static void ride_create_vehicles_find_first_block(Ride *ride, rct_xy_element *outXYElement)
+static void ride_create_vehicles_find_first_block(Ride *ride, BigCoordsXYE *outXYElement)
 {
     rct_vehicle *vehicle = GET_VEHICLE(ride->vehicles[0]);
     sint32 firstX = vehicle->track_x;
@@ -4817,7 +4817,7 @@ static void ride_create_vehicles_find_first_block(Ride *ride, rct_xy_element *ou
  *
  *  rct2: 0x006DD84C
  */
-static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, rct_xy_element *element, sint32 isApplying)
+static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, BigCoordsXYE *element, sint32 isApplying)
 {
     ride_update_max_vehicles(rideIndex);
     if (ride->subtype == RIDE_ENTRY_INDEX_NULL) {
@@ -4870,7 +4870,7 @@ static bool ride_create_vehicles(Ride *ride, sint32 rideIndex, rct_xy_element *e
     //
     if (ride->type != RIDE_TYPE_SPACE_RINGS && !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_16)) {
         if (ride_is_block_sectioned(ride)) {
-            rct_xy_element firstBlock;
+            BigCoordsXYE firstBlock;
             ride_create_vehicles_find_first_block(ride, &firstBlock);
             loc_6DDF9C(ride, firstBlock.element);
         } else {
@@ -5153,7 +5153,7 @@ static void loc_6B51C0(sint32 rideIndex)
         sint32 z = ride->station_heights[i] * 8;
         window_scroll_to_location(w, x, y, z);
 
-        rct_xy_element trackElement;
+        BigCoordsXYE trackElement;
         ride_try_get_origin_element(rideIndex, &trackElement);
         ride_find_track_gap(&trackElement, &trackElement);
         sint32 ok = ride_modify(&trackElement);
@@ -5171,7 +5171,7 @@ static void loc_6B51C0(sint32 rideIndex)
  *
  *  rct2: 0x006B528A
  */
-static void ride_scroll_to_track_error(rct_xy_element *trackElement)
+static void ride_scroll_to_track_error(BigCoordsXYE *trackElement)
 {
     if (!gGameCommandIsNetworked && gUnk141F568 == gUnk13CA740) {
         rct_window *w = window_get_main();
@@ -5213,7 +5213,7 @@ sint32 ride_is_valid_for_test(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
 {
     sint32 stationIndex;
     Ride *ride;
-    rct_xy_element trackElement, problematicTrackElement = { 0 };
+    BigCoordsXYE trackElement, problematicTrackElement = { 0 };
 
     ride = get_ride(rideIndex);
     if (ride->type == RIDE_TYPE_NULL)
@@ -5342,7 +5342,7 @@ sint32 ride_is_valid_for_open(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
 {
     sint32 stationIndex;
     Ride *ride;
-    rct_xy_element trackElement, problematicTrackElement = { 0 };
+    BigCoordsXYE trackElement, problematicTrackElement = { 0 };
 
     ride = get_ride(rideIndex);
 
@@ -5903,7 +5903,7 @@ void game_command_callback_ride_construct_placed_front(sint32 eax, sint32 ebx, s
         y -= TileDirectionDelta[trackDirection].y;
     }
 
-    rct_xy_element next_track;
+    BigCoordsXYE next_track;
     if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, trackDirection, &next_track, &z, &trackDirection)) {
         _currentTrackBeginX = next_track.x;
         _currentTrackBeginY = next_track.y;
@@ -6787,7 +6787,7 @@ bool ride_select_forwards_from_back()
     y = _currentTrackBeginY;
     z = _currentTrackBeginZ;
     direction = _currentTrackPieceDirection ^ 2;
-    rct_xy_element next_track;
+    BigCoordsXYE next_track;
 
     if (track_block_get_next_from_zero(x, y, z, _currentRideIndex, direction, &next_track, &z, &direction)) {
         _rideConstructionState = RIDE_CONSTRUCTION_STATE_SELECTED;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1019,11 +1019,11 @@ money32 get_shop_item_cost(sint32 shopItem);
 money16 get_shop_base_value(sint32 shopItem);
 money16 get_shop_hot_value(sint32 shopItem);
 money16 get_shop_cold_value(sint32 shopItem);
-bool ride_try_get_origin_element(sint32 rideIndex, BigCoordsXYE *output);
-sint32 ride_find_track_gap(BigCoordsXYE *input, BigCoordsXYE *output);
+bool ride_try_get_origin_element(sint32 rideIndex, CoordsXYE *output);
+sint32 ride_find_track_gap(CoordsXYE *input, CoordsXYE *output);
 void ride_construct_new(ride_list_item listItem);
 void ride_construct(sint32 rideIndex);
-sint32 ride_modify(BigCoordsXYE *input);
+sint32 ride_modify(CoordsXYE *input);
 void ride_remove_peeps(sint32 rideIndex);
 void ride_get_status(sint32 rideIndex, rct_string_id *formatSecondary, sint32 *argument);
 rct_peep *ride_get_assigned_mechanic(Ride *ride);
@@ -1114,8 +1114,8 @@ void ride_all_has_any_track_elements(bool *rideIndexArray);
 
 void ride_construction_set_default_next_piece();
 
-bool track_block_get_next(BigCoordsXYE *input, BigCoordsXYE *output, sint32 *z, sint32 *direction);
-bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, BigCoordsXYE *output, sint32 *z, sint32 *direction);
+bool track_block_get_next(CoordsXYE *input, CoordsXYE *output, sint32 *z, sint32 *direction);
+bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, CoordsXYE *output, sint32 *z, sint32 *direction);
 
 bool track_block_get_previous(sint32 x, sint32 y, rct_tile_element *tileElement, track_begin_end *outTrackBeginEnd);
 bool track_block_get_previous_from_zero(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8 direction, track_begin_end *outTrackBeginEnd);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1019,11 +1019,11 @@ money32 get_shop_item_cost(sint32 shopItem);
 money16 get_shop_base_value(sint32 shopItem);
 money16 get_shop_hot_value(sint32 shopItem);
 money16 get_shop_cold_value(sint32 shopItem);
-bool ride_try_get_origin_element(sint32 rideIndex, rct_xy_element *output);
-sint32 ride_find_track_gap(rct_xy_element *input, rct_xy_element *output);
+bool ride_try_get_origin_element(sint32 rideIndex, BigCoordsXYE *output);
+sint32 ride_find_track_gap(BigCoordsXYE *input, BigCoordsXYE *output);
 void ride_construct_new(ride_list_item listItem);
 void ride_construct(sint32 rideIndex);
-sint32 ride_modify(rct_xy_element *input);
+sint32 ride_modify(BigCoordsXYE *input);
 void ride_remove_peeps(sint32 rideIndex);
 void ride_get_status(sint32 rideIndex, rct_string_id *formatSecondary, sint32 *argument);
 rct_peep *ride_get_assigned_mechanic(Ride *ride);
@@ -1114,8 +1114,8 @@ void ride_all_has_any_track_elements(bool *rideIndexArray);
 
 void ride_construction_set_default_next_piece();
 
-bool track_block_get_next(rct_xy_element *input, rct_xy_element *output, sint32 *z, sint32 *direction);
-bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, rct_xy_element *output, sint32 *z, sint32 *direction);
+bool track_block_get_next(BigCoordsXYE *input, BigCoordsXYE *output, sint32 *z, sint32 *direction);
+bool track_block_get_next_from_zero(sint16 x, sint16 y, sint16 z_start, uint8 rideIndex, uint8 direction_start, BigCoordsXYE *output, sint32 *z, sint32 *direction);
 
 bool track_block_get_previous(sint32 x, sint32 y, rct_tile_element *tileElement, track_begin_end *outTrackBeginEnd);
 bool track_block_get_previous_from_zero(sint16 x, sint16 y, sint16 z, uint8 rideIndex, uint8 direction, track_begin_end *outTrackBeginEnd);

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -218,12 +218,12 @@ static void ride_ratings_update_state_2()
 
             ride_ratings_score_close_proximity(tileElement);
 
-            BigCoordsXYE trackElement = {
+            CoordsXYE trackElement = {
                 /* .x = */ gRideRatingsCalcData.proximity_x,
                 /* .y = */ gRideRatingsCalcData.proximity_y,
                 /* .element = */ tileElement
             };
-            BigCoordsXYE nextTrackElement;
+            CoordsXYE nextTrackElement;
             if (!track_block_get_next(&trackElement, &nextTrackElement, NULL, NULL)) {
                 gRideRatingsCalcData.state = RIDE_RATINGS_STATE_4;
                 return;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -218,12 +218,12 @@ static void ride_ratings_update_state_2()
 
             ride_ratings_score_close_proximity(tileElement);
 
-            rct_xy_element trackElement = {
+            BigCoordsXYE trackElement = {
                 /* .x = */ gRideRatingsCalcData.proximity_x,
                 /* .y = */ gRideRatingsCalcData.proximity_y,
                 /* .element = */ tileElement
             };
-            rct_xy_element nextTrackElement;
+            BigCoordsXYE nextTrackElement;
             if (!track_block_get_next(&trackElement, &nextTrackElement, NULL, NULL)) {
                 gRideRatingsCalcData.state = RIDE_RATINGS_STATE_4;
                 return;

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -2325,7 +2325,7 @@ void game_command_set_brakes_speed(sint32 * eax,
     *ebx = 0;
 }
 
-void track_circuit_iterator_begin(track_circuit_iterator * it, BigCoordsXYE first)
+void track_circuit_iterator_begin(track_circuit_iterator * it, CoordsXYE first)
 {
     it->last           = first;
     it->first          = nullptr;
@@ -2410,9 +2410,9 @@ bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const
             firstIt->current.y == secondIt->current.y);
 }
 
-void track_get_back(BigCoordsXYE * input, BigCoordsXYE * output)
+void track_get_back(CoordsXYE * input, CoordsXYE * output)
 {
-    BigCoordsXYE  lastTrack;
+    CoordsXYE  lastTrack;
     track_begin_end currentTrack;
     bool            result;
 
@@ -2431,9 +2431,9 @@ void track_get_back(BigCoordsXYE * input, BigCoordsXYE * output)
     *output = lastTrack;
 }
 
-void track_get_front(BigCoordsXYE * input, BigCoordsXYE * output)
+void track_get_front(CoordsXYE * input, CoordsXYE * output)
 {
-    BigCoordsXYE lastTrack, currentTrack;
+    CoordsXYE lastTrack, currentTrack;
     sint32       z, direction;
     bool         result;
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1300,7 +1300,7 @@ static money32 track_place(sint32 rideIndex,
 
         if ((rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER) && !byte_9D8150)
         {
-            tileElement = map_get_surface_element_at(x / 32, y / 32);
+            tileElement = map_get_surface_element_at({x, y});
 
             uint8 water_height = map_get_water_height(tileElement) * 2;
             if (water_height == 0)
@@ -1370,7 +1370,7 @@ static money32 track_place(sint32 rideIndex,
             }
         }
         //6c5648 12 push
-        tileElement = map_get_surface_element_at(x / 32, y / 32);
+        tileElement = map_get_surface_element_at({x, y});
         if (!gCheatsDisableSupportLimits)
         {
             sint32 ride_height = clearanceZ - tileElement->base_height;
@@ -1550,7 +1550,7 @@ static money32 track_place(sint32 rideIndex,
 
         if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER)
         {
-            rct_tile_element * surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+            rct_tile_element * surfaceElement = map_get_surface_element_at({x, y});
             surfaceElement->type |= (1 << 6);
             tileElement = surfaceElement;
         }
@@ -1810,7 +1810,7 @@ static money32 track_remove(uint8 type,
             }
         }
 
-        rct_tile_element * surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+        rct_tile_element * surfaceElement = map_get_surface_element_at({x, y});
         if (surfaceElement == nullptr)
         {
             return MONEY32_UNDEFINED;
@@ -2029,7 +2029,7 @@ static money32 set_maze_track(uint16 x, uint8 flags, uint8 direction, uint16 y, 
         return MONEY32_UNDEFINED;
     }
 
-    rct_tile_element * tileElement = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element * tileElement = map_get_surface_element_at({x, y});
     if (tileElement == nullptr)
     {
         return MONEY32_UNDEFINED;

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -2325,7 +2325,7 @@ void game_command_set_brakes_speed(sint32 * eax,
     *ebx = 0;
 }
 
-void track_circuit_iterator_begin(track_circuit_iterator * it, rct_xy_element first)
+void track_circuit_iterator_begin(track_circuit_iterator * it, BigCoordsXYE first)
 {
     it->last           = first;
     it->first          = nullptr;
@@ -2410,9 +2410,9 @@ bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const
             firstIt->current.y == secondIt->current.y);
 }
 
-void track_get_back(rct_xy_element * input, rct_xy_element * output)
+void track_get_back(BigCoordsXYE * input, BigCoordsXYE * output)
 {
-    rct_xy_element  lastTrack;
+    BigCoordsXYE  lastTrack;
     track_begin_end currentTrack;
     bool            result;
 
@@ -2431,11 +2431,11 @@ void track_get_back(rct_xy_element * input, rct_xy_element * output)
     *output = lastTrack;
 }
 
-void track_get_front(rct_xy_element * input, rct_xy_element * output)
+void track_get_front(BigCoordsXYE * input, BigCoordsXYE * output)
 {
-    rct_xy_element lastTrack, currentTrack;
-    sint32         z, direction;
-    bool           result;
+    BigCoordsXYE lastTrack, currentTrack;
+    sint32       z, direction;
+    bool         result;
 
     lastTrack = *input;
     do

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -510,8 +510,8 @@ enum
 
 struct track_circuit_iterator
 {
-    BigCoordsXYE       last;
-    BigCoordsXYE       current;
+    CoordsXYE       last;
+    CoordsXYE       current;
     sint32             currentZ;
     sint32             currentDirection;
     rct_tile_element * first;
@@ -530,13 +530,13 @@ const rct_preview_track * get_track_def_from_ride(Ride * ride, sint32 trackType)
 const rct_preview_track * get_track_def_from_ride_index(sint32 rideIndex, sint32 trackType);
 const rct_track_coordinates * get_track_coord_from_ride(Ride * ride, sint32 trackType);
 
-void track_circuit_iterator_begin(track_circuit_iterator * it, BigCoordsXYE first);
+void track_circuit_iterator_begin(track_circuit_iterator * it, CoordsXYE first);
 bool track_circuit_iterator_previous(track_circuit_iterator * it);
 bool track_circuit_iterator_next(track_circuit_iterator * it);
 bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const track_circuit_iterator * secondIt);
 
-void track_get_back(BigCoordsXYE * input, BigCoordsXYE * output);
-void track_get_front(BigCoordsXYE * input, BigCoordsXYE * output);
+void track_get_back(CoordsXYE * input, CoordsXYE * output);
+void track_get_front(CoordsXYE * input, CoordsXYE * output);
 
 bool track_element_is_block_start(rct_tile_element * trackElement);
 bool track_element_is_covered(sint32 trackElementType);

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -510,13 +510,13 @@ enum
 
 struct track_circuit_iterator
 {
-    rct_xy_element  last;
-    rct_xy_element  current;
-    sint32          currentZ;
-    sint32          currentDirection;
+    BigCoordsXYE       last;
+    BigCoordsXYE       current;
+    sint32             currentZ;
+    sint32             currentDirection;
     rct_tile_element * first;
-    bool            firstIteration;
-    bool            looped;
+    bool               firstIteration;
+    bool               looped;
 };
 
 extern const rct_trackdefinition FlatRideTrackDefinitions[256];
@@ -530,13 +530,13 @@ const rct_preview_track * get_track_def_from_ride(Ride * ride, sint32 trackType)
 const rct_preview_track * get_track_def_from_ride_index(sint32 rideIndex, sint32 trackType);
 const rct_track_coordinates * get_track_coord_from_ride(Ride * ride, sint32 trackType);
 
-void track_circuit_iterator_begin(track_circuit_iterator * it, rct_xy_element first);
+void track_circuit_iterator_begin(track_circuit_iterator * it, BigCoordsXYE first);
 bool track_circuit_iterator_previous(track_circuit_iterator * it);
 bool track_circuit_iterator_next(track_circuit_iterator * it);
 bool track_circuit_iterators_match(const track_circuit_iterator * firstIt, const track_circuit_iterator * secondIt);
 
-void track_get_back(rct_xy_element * input, rct_xy_element * output);
-void track_get_front(rct_xy_element * input, rct_xy_element * output);
+void track_get_back(BigCoordsXYE * input, BigCoordsXYE * output);
+void track_get_front(BigCoordsXYE * input, BigCoordsXYE * output);
 
 bool track_element_is_block_start(rct_tile_element * trackElement);
 bool track_element_is_covered(sint32 trackElementType);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1194,7 +1194,7 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
     for (; maze_element->all != 0; maze_element++)
     {
         uint8    rotation = _currentTrackPieceDirection & 3;
-        BigCoordsXY mapCoord = {maze_element->x * 32, maze_element->y * 32};
+        CoordsXY mapCoord = {maze_element->x * 32, maze_element->y * 32};
         sint16 tmpX = mapCoord.x;
         sint16 tmpY = mapCoord.y;
         rotate_map_coordinates(&tmpX, &tmpY, rotation);
@@ -1494,7 +1494,7 @@ static bool track_design_place_ride(rct_track_td6 * td6, sint16 x, sint16 y, sin
             sint32                       tempZ        = z - TrackCoordinates[trackType].z_begin;
             for (const rct_preview_track * trackBlock = TrackBlocks[trackType]; trackBlock->index != 0xFF; trackBlock++)
             {
-                BigCoordsXY tile = {x, y};
+                CoordsXY tile = {x, y};
                 sint16 tmpX = tile.x;
                 sint16 tmpY = tile.y;
                 map_offset_with_rotation(&tmpX, &tmpY, trackBlock->x, trackBlock->y, rotation);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1194,8 +1194,10 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
     for (; maze_element->all != 0; maze_element++)
     {
         uint8    rotation = _currentTrackPieceDirection & 3;
-        LocationXY16 mapCoord = {(sint16) (maze_element->x * 32), (sint16) (maze_element->y * 32)};
-        rotate_map_coordinates(&mapCoord.x, &mapCoord.y, rotation);
+        BigCoordsXY mapCoord = {maze_element->x * 32, maze_element->y * 32};
+        sint16 tmpX = mapCoord.x;
+        sint16 tmpY = mapCoord.y;
+        rotate_map_coordinates(&tmpX, &tmpY, rotation);
         mapCoord.x += x;
         mapCoord.y += y;
 
@@ -1337,7 +1339,7 @@ static sint32 track_design_place_maze(rct_track_td6 * td6, sint16 x, sint16 y, s
                 continue;
             }
 
-            rct_tile_element * tile_element = map_get_surface_element_at(mapCoord.x / 32, mapCoord.y / 32);
+            rct_tile_element * tile_element = map_get_surface_element_at(mapCoord);
             sint16          map_height    = tile_element->base_height * 8;
             if (tile_element->properties.surface.slope & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
             {
@@ -1492,14 +1494,16 @@ static bool track_design_place_ride(rct_track_td6 * td6, sint16 x, sint16 y, sin
             sint32                       tempZ        = z - TrackCoordinates[trackType].z_begin;
             for (const rct_preview_track * trackBlock = TrackBlocks[trackType]; trackBlock->index != 0xFF; trackBlock++)
             {
-                LocationXY16 tile = {x, y};
-                map_offset_with_rotation(&tile.x, &tile.y, trackBlock->x, trackBlock->y, rotation);
+                BigCoordsXY tile = {x, y};
+                sint16 tmpX = tile.x;
+                sint16 tmpY = tile.y;
+                map_offset_with_rotation(&tmpX, &tmpY, trackBlock->x, trackBlock->y, rotation);
                 if (tile.x < 0 || tile.y < 0 || tile.x >= (256 * 32) || tile.y >= (256 * 32))
                 {
                     continue;
                 }
 
-                rct_tile_element * tileElement = map_get_surface_element_at(tile.x >> 5, tile.y >> 5);
+                rct_tile_element * tileElement = map_get_surface_element_at(tile);
                 if (tileElement == nullptr)
                 {
                     return false;
@@ -2061,7 +2065,7 @@ static money32 place_maze_design(uint8 flags, uint8 rideIndex, uint16 mazeEntry,
     // Check support height
     if (!gCheatsDisableSupportLimits)
     {
-        rct_tile_element * tileElement = map_get_surface_element_at(x >> 5, y >> 5);
+        rct_tile_element * tileElement = map_get_surface_element_at({x, y});
         uint8           supportZ     = (z + 32) >> 3;
         if (supportZ > tileElement->base_height)
         {

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -944,7 +944,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
 static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track_td6 *td6)
 {
     Ride *ride = get_ride(rideIndex);
-    BigCoordsXYE trackElement;
+    CoordsXYE trackElement;
     track_begin_end trackBeginEnd;
 
     if (!ride_try_get_origin_element(rideIndex, &trackElement)) {
@@ -958,7 +958,7 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
     if (track_block_get_previous(trackElement.x, trackElement.y, trackElement.element, &trackBeginEnd)) {
         rct_tile_element* initial_map = trackElement.element;
         do {
-            BigCoordsXYE lastGood = {
+            CoordsXYE lastGood = {
                 /* .x = */ trackBeginEnd.begin_x,
                 /* .y = */ trackBeginEnd.begin_y,
                 /* .element = */ trackBeginEnd.begin_element

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -944,7 +944,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
 static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track_td6 *td6)
 {
     Ride *ride = get_ride(rideIndex);
-    rct_xy_element trackElement;
+    BigCoordsXYE trackElement;
     track_begin_end trackBeginEnd;
 
     if (!ride_try_get_origin_element(rideIndex, &trackElement)) {
@@ -958,7 +958,7 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
     if (track_block_get_previous(trackElement.x, trackElement.y, trackElement.element, &trackBeginEnd)) {
         rct_tile_element* initial_map = trackElement.element;
         do {
-            rct_xy_element lastGood = {
+            BigCoordsXYE lastGood = {
                 /* .x = */ trackBeginEnd.begin_x,
                 /* .y = */ trackBeginEnd.begin_y,
                 /* .element = */ trackBeginEnd.begin_element

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2566,7 +2566,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_CABLE_LIFT)
     {
-        BigCoordsXYE track;
+        CoordsXYE track;
         sint32       z;
         sint32       direction;
 
@@ -7920,7 +7920,7 @@ static void sub_6DBF3E(rct_vehicle * vehicle)
     {
         if (vehicle->track_progress > 3 && !(vehicle->update_flags & VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE))
         {
-            BigCoordsXYE   input, output;
+            CoordsXYE   input, output;
             sint32         outputZ, outputDirection;
 
             input.x       = vehicle->track_x;
@@ -8050,7 +8050,7 @@ loc_6DB32A:
 
 loc_6DB358:
 {
-    BigCoordsXYE        xyElement;
+    CoordsXYE        xyElement;
     sint32              z, direction;
     xyElement.x       = vehicle->track_x;
     xyElement.y       = vehicle->track_y;
@@ -8491,8 +8491,8 @@ static bool vehicle_update_track_motion_backwards_get_new_track(rct_vehicle * ve
     else
     {
         // loc_6DBB4F:;
-        BigCoordsXYE   input;
-        BigCoordsXYE   output;
+        CoordsXYE   input;
+        CoordsXYE   output;
         sint32         outputZ;
 
         input.x       = x;
@@ -8882,7 +8882,7 @@ loc_6DC476:
     sint16 x, y, z;
     sint32 direction;
     {
-        BigCoordsXYE   input, output;
+        CoordsXYE   input, output;
         sint32         outZ, outDirection;
         input.x       = vehicle->track_x;
         input.y       = vehicle->track_y;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -978,7 +978,7 @@ static void vehicle_update_sound_params(rct_vehicle * vehicle)
 
     if (vehicle->x != LOCATION_NULL)
     {
-        rct_tile_element * tile_element = map_get_surface_element_at(vehicle->x >> 5, vehicle->y >> 5);
+        rct_tile_element * tile_element = map_get_surface_element_at({vehicle->x, vehicle->y});
 
         // vehicle underground
         if (tile_element != nullptr && tile_element->base_height * 8 > vehicle->z)
@@ -1826,7 +1826,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         return;
     }
 
-    rct_tile_element * tile_element = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element * tile_element = map_get_surface_element_at({x, y});
     if (tile_element->base_height * 8 <= vehicle->z)
     {
 
@@ -7252,7 +7252,7 @@ static void vehicle_update_spinning_car(rct_vehicle * vehicle)
  */
 static void steam_particle_create(sint16 x, sint16 y, sint16 z)
 {
-    rct_tile_element * tileElement = map_get_surface_element_at(x >> 5, y >> 5);
+    rct_tile_element * tileElement = map_get_surface_element_at({x, y});
     if (tileElement != nullptr && z > tileElement->base_height * 8)
     {
         rct_steam_particle * steam = (rct_steam_particle *)create_sprite(2);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2566,9 +2566,9 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_CABLE_LIFT)
     {
-        rct_xy_element track;
-        sint32         z;
-        sint32         direction;
+        BigCoordsXYE track;
+        sint32       z;
+        sint32       direction;
 
         if (track_block_get_next_from_zero(vehicle->track_x, vehicle->track_y, vehicle->track_z, vehicle->ride,
                                            (uint8)(vehicle->track_direction & 0x3), &track, &z, &direction))
@@ -7920,7 +7920,7 @@ static void sub_6DBF3E(rct_vehicle * vehicle)
     {
         if (vehicle->track_progress > 3 && !(vehicle->update_flags & VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE))
         {
-            rct_xy_element input, output;
+            BigCoordsXYE   input, output;
             sint32         outputZ, outputDirection;
 
             input.x       = vehicle->track_x;
@@ -8050,8 +8050,8 @@ loc_6DB32A:
 
 loc_6DB358:
 {
-    rct_xy_element xyElement;
-    sint32         z, direction;
+    BigCoordsXYE        xyElement;
+    sint32              z, direction;
     xyElement.x       = vehicle->track_x;
     xyElement.y       = vehicle->track_y;
     xyElement.element = tileElement;
@@ -8491,8 +8491,8 @@ static bool vehicle_update_track_motion_backwards_get_new_track(rct_vehicle * ve
     else
     {
         // loc_6DBB4F:;
-        rct_xy_element input;
-        rct_xy_element output;
+        BigCoordsXYE   input;
+        BigCoordsXYE   output;
         sint32         outputZ;
 
         input.x       = x;
@@ -8882,7 +8882,7 @@ loc_6DC476:
     sint16 x, y, z;
     sint32 direction;
     {
-        rct_xy_element input, output;
+        BigCoordsXYE   input, output;
         sint32         outZ, outDirection;
         input.x       = vehicle->track_x;
         input.y       = vehicle->track_y;

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -158,8 +158,8 @@ static void spiral_slide_paint_tile_front(
         {
 
             sint32       offset            = SPIRAL_SLIDE_PEEP + 46 * direction;
-            BigCoordsXYZ boundingBox       = { 0, 0, 108 };
-            BigCoordsXYZ boundingBoxOffset = { 0, 0, static_cast<sint16>(height + 3) };
+            CoordsXYZ boundingBox       = { 0, 0, 108 };
+            CoordsXYZ boundingBoxOffset = { 0, 0, static_cast<sint16>(height + 3) };
 
             if (direction == 0)
             {

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -157,9 +157,9 @@ static void spiral_slide_paint_tile_front(
         if (slide_progress < 46)
         {
 
-            sint32    offset            = SPIRAL_SLIDE_PEEP + 46 * direction;
-            LocationXYZ8  boundingBox       = { 0, 0, 108 };
-            LocationXYZ16 boundingBoxOffset = { 0, 0, static_cast<sint16>(height + 3) };
+            sint32       offset            = SPIRAL_SLIDE_PEEP + 46 * direction;
+            BigCoordsXYZ boundingBox       = { 0, 0, 108 };
+            BigCoordsXYZ boundingBoxOffset = { 0, 0, static_cast<sint16>(height + 3) };
 
             if (direction == 0)
             {

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -146,8 +146,8 @@ static bool chairlift_paint_util_is_first_track(uint8 rideIndex, const rct_tile_
         return false;
     }
 
-    BigCoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
-    BigCoordsXY newPos = {
+    CoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
+    CoordsXY newPos = {
         static_cast<sint32>(pos.x - delta.x),
         static_cast<sint32>(pos.y - delta.y),
     };
@@ -166,8 +166,8 @@ static bool chairlift_paint_util_is_last_track(uint8 rideIndex, const rct_tile_e
         return false;
     }
 
-    BigCoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
-    BigCoordsXY newPos = {
+    CoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
+    CoordsXY newPos = {
         static_cast<sint32>(pos.x + delta.x),
         static_cast<sint32>(pos.y + delta.y),
     };

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -146,10 +146,10 @@ static bool chairlift_paint_util_is_first_track(uint8 rideIndex, const rct_tile_
         return false;
     }
 
-    LocationXY16 delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
-    LocationXY16 newPos = {
-        static_cast<sint16>(pos.x - delta.x),
-        static_cast<sint16>(pos.y - delta.y),
+    BigCoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
+    BigCoordsXY newPos = {
+        static_cast<sint32>(pos.x - delta.x),
+        static_cast<sint32>(pos.y - delta.y),
     };
 
     const rct_tile_element * nextTrack =
@@ -166,10 +166,10 @@ static bool chairlift_paint_util_is_last_track(uint8 rideIndex, const rct_tile_e
         return false;
     }
 
-    LocationXY16 delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
-    LocationXY16 newPos = {
-        static_cast<sint16>(pos.x + delta.x),
-        static_cast<sint16>(pos.y + delta.y),
+    BigCoordsXY delta  = TileDirectionDelta[tile_element_get_direction(tileElement)];
+    BigCoordsXY newPos = {
+        static_cast<sint32>(pos.x + delta.x),
+        static_cast<sint32>(pos.y + delta.y),
     };
 
     const rct_tile_element * nextTrack =

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -125,7 +125,7 @@ void rct_duck::UpdateFlyToWater()
     sint32 newY = y + DuckMoveOffset[direction].y;
     sint32 manhattanDistanceN = abs(target_x - newX) + abs(target_y - newY);
 
-    rct_tile_element * tileElement = map_get_surface_element_at(target_x >> 5, target_y >> 5);
+    rct_tile_element * tileElement = map_get_surface_element_at({target_x, target_y});
     sint32 waterHeight = map_get_water_height(tileElement);
     if (waterHeight == 0)
     {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -222,7 +222,7 @@ static money32 footpath_element_insert(sint32 type, sint32 x, sint32 y, sint32 z
         return MONEY32_UNDEFINED;
     }
 
-    tileElement = map_get_surface_element_at((x / 32), (y / 32));
+    tileElement = map_get_surface_element_at({x, y});
 
     sint32 supportHeight = z - tileElement->base_height;
     gFootpathPrice += supportHeight < 0 ? MONEY(20, 00) : (supportHeight / 2) * MONEY(5, 00);
@@ -631,7 +631,7 @@ static money32 footpath_place_from_track(sint32 type, sint32 x, sint32 y, sint32
         return MONEY32_UNDEFINED;
     }
 
-    tileElement = map_get_surface_element_at((x / 32), (y / 32));
+    tileElement = map_get_surface_element_at({x, y});
 
     sint32 supportHeight = z - tileElement->base_height;
     gFootpathPrice += supportHeight < 0 ? MONEY(20, 00) : (supportHeight / 2) * MONEY(5, 00);
@@ -1636,7 +1636,7 @@ void footpath_update_queue_chains()
  */
 static void footpath_fix_ownership(sint32 x, sint32 y, rct_tile_element *pathElement)
 {
-    const rct_tile_element * surfaceElement = map_get_surface_element_at(x >> 5, y >> 5);
+    const rct_tile_element * surfaceElement = map_get_surface_element_at({x, y});
     uint16 ownership;
 
     // Unlikely to be NULL unless deliberate.

--- a/src/openrct2/world/Location.h
+++ b/src/openrct2/world/Location.h
@@ -60,36 +60,36 @@ struct LocationXYZ32 {
 #pragma pack(pop)
 
 /*
- * Small coordinates use 1 x/y increment per tile.
- * Big coordinates use 32 x/y increments per tile.
+ * Tile coordinates use 1 x/y increment per tile.
+ * Regular ('big', 'sprite') coordinates use 32 x/y increments per tile.
  * */
-struct SmallCoordsXY
+struct TileCoordsXY
 {
     sint32 x, y;
 };
 
-struct BigCoordsXY
+struct CoordsXY
 {
     sint32 x, y;
 };
 
-struct SmallCoordsXYZ
+struct TileCoordsXYZ
 {
     sint32 x, y, z;
 };
 
-struct BigCoordsXYZ
+struct CoordsXYZ
 {
     sint32 x, y, z;
 };
 
-struct SmallCoordsXYZD
+struct TileCoordsXYZD
 {
     sint32 x, y, z;
     uint8 direction;
 };
 
-struct BigCoordsXYZD
+struct CoordsXYZD
 {
     sint32 x, y, z;
     uint8 direction;

--- a/src/openrct2/world/Location.h
+++ b/src/openrct2/world/Location.h
@@ -67,5 +67,42 @@ struct LocationXY32 {
 struct LocationXYZ32 {
     sint32 x, y, z;
 };
-
 #pragma pack(pop)
+
+/*
+ * Small coordinates use 1 x/y increment per tile.
+ * Big coordinates use 32 x/y increments per tile.
+ * */
+struct SmallCoordsXY
+{
+    sint32 x, y;
+};
+
+struct BigCoordsXY
+{
+    sint32 x, y;
+};
+
+struct SmallCoordsXYZ
+{
+    sint32 x, y, z;
+};
+
+struct BigCoordsXYZ
+{
+    sint32 x, y, z;
+};
+
+struct SmallCoordsXYZD
+{
+    sint32 x, y, z;
+    uint8 direction;
+};
+
+struct BigCoordsXYZD
+{
+    sint32 x, y, z;
+    uint8 direction;
+};
+
+

--- a/src/openrct2/world/Location.h
+++ b/src/openrct2/world/Location.h
@@ -33,11 +33,6 @@ struct LocationXY8 {
 };
 assert_struct_size(LocationXY8, 2);
 
-struct LocationXYZ8 {
-    uint8 x, y, z;
-};
-assert_struct_size(LocationXYZ8, 3);
-
 struct LocationXYZD8 {
     uint8 x, y, z, direction;
 };

--- a/src/openrct2/world/Location.h
+++ b/src/openrct2/world/Location.h
@@ -33,11 +33,6 @@ struct LocationXY8 {
 };
 assert_struct_size(LocationXY8, 2);
 
-struct LocationXYZD8 {
-    uint8 x, y, z, direction;
-};
-assert_struct_size(LocationXYZD8, 4);
-
 struct LocationXY16 {
     sint16 x, y;
 };

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -52,7 +52,7 @@
 /**
  * Replaces 0x00993CCC, 0x00993CCE
  */
-const LocationXY16 TileDirectionDelta[] = {
+const BigCoordsXY TileDirectionDelta[] = {
     { -32,   0 },
     {   0, +32 },
     { +32,   0 },

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -52,7 +52,7 @@
 /**
  * Replaces 0x00993CCC, 0x00993CCE
  */
-const BigCoordsXY TileDirectionDelta[] = {
+const CoordsXY TileDirectionDelta[] = {
     { -32,   0 },
     {   0, +32 },
     { +32,   0 },
@@ -352,7 +352,7 @@ rct_tile_element * map_get_surface_element_at(sint32 x, sint32 y)
     return tileElement;
 }
 
-rct_tile_element * map_get_surface_element_at(BigCoordsXY coords)
+rct_tile_element * map_get_surface_element_at(CoordsXY coords)
 {
     return map_get_surface_element_at(coords.x / 32, coords.y / 32);
 }
@@ -4904,15 +4904,15 @@ bool map_tile_is_part_of_virtual_floor(sint16 x, sint16 y)
     return false;
 }
 
-void FixLandOwnershipTiles(std::initializer_list<SmallCoordsXY> tiles)
+void FixLandOwnershipTiles(std::initializer_list<TileCoordsXY> tiles)
 {
     FixLandOwnershipTilesWithOwnership(tiles, OWNERSHIP_AVAILABLE);
 }
 
-void FixLandOwnershipTilesWithOwnership(std::initializer_list<SmallCoordsXY> tiles, uint8 ownership)
+void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tiles, uint8 ownership)
 {
     rct_tile_element * currentElement;
-    for (const SmallCoordsXY * tile = tiles.begin(); tile != tiles.end(); ++tile)
+    for (const TileCoordsXY * tile = tiles.begin(); tile != tiles.end(); ++tile)
     {
         currentElement = map_get_surface_element_at((*tile).x, (*tile).y);
         currentElement->properties.surface.ownership |= ownership;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -324,14 +324,6 @@ enum {
 #define TILE_UNDEFINED_TILE_ELEMENT NULL
 
 #pragma pack(push, 1)
-struct rct_xy_element {
-    sint32 x, y;
-    rct_tile_element *element;
-};
-#ifdef PLATFORM_32BIT
-assert_struct_size(rct_xy_element, 12);
-#endif
-
 struct rct2_peep_spawn {
     uint16 x;
     uint16 y;
@@ -340,6 +332,12 @@ struct rct2_peep_spawn {
 };
 assert_struct_size(rct2_peep_spawn, 6);
 #pragma pack(pop)
+
+struct BigCoordsXYE
+{
+    sint32 x, y;
+    rct_tile_element * element;
+};
 
 enum {
     MAP_SELECT_FLAG_ENABLE              = 1 << 0,
@@ -375,7 +373,7 @@ enum
     CREATE_CROSSING_MODE_PATH_OVER_TRACK,
 };
 
-extern const LocationXY16 TileDirectionDelta[];
+extern const BigCoordsXY TileDirectionDelta[];
 extern const money32 TerrainPricing[];
 
 extern uint16 gWidePathTileLoopX;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -444,6 +444,7 @@ void tile_element_set_terrain_edge(rct_tile_element *element, sint32 terrain);
 sint32 map_height_from_slope(sint32 x, sint32 y, sint32 slope);
 rct_tile_element* map_get_banner_element_at(sint32 x, sint32 y, sint32 z, uint8 direction);
 rct_tile_element *map_get_surface_element_at(sint32 x, sint32 y);
+rct_tile_element * map_get_surface_element_at(BigCoordsXY coords);
 rct_tile_element* map_get_path_element_at(sint32 x, sint32 y, sint32 z);
 rct_tile_element *map_get_wall_element_at(sint32 x, sint32 y, sint32 z, sint32 direction);
 rct_tile_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant);
@@ -584,7 +585,7 @@ uint32 map_get_available_peep_spawn_index_list(uint32* peepSpawnIndexList);
 uint16 check_max_allowable_land_rights_for_tile(uint8 x, uint8 y, uint8 base_z);
 uint8 tile_element_get_ride_index(const rct_tile_element * tileElement);
 
-void FixLandOwnershipTiles(std::initializer_list<LocationXY8> tiles);
-void FixLandOwnershipTilesWithOwnership(std::initializer_list<LocationXY8> tiles, uint8 ownership);
+void FixLandOwnershipTiles(std::initializer_list<SmallCoordsXY> tiles);
+void FixLandOwnershipTilesWithOwnership(std::initializer_list<SmallCoordsXY> tiles, uint8 ownership);
 
 #endif

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -333,7 +333,7 @@ struct rct2_peep_spawn {
 assert_struct_size(rct2_peep_spawn, 6);
 #pragma pack(pop)
 
-struct BigCoordsXYE
+struct CoordsXYE
 {
     sint32 x, y;
     rct_tile_element * element;
@@ -373,7 +373,7 @@ enum
     CREATE_CROSSING_MODE_PATH_OVER_TRACK,
 };
 
-extern const BigCoordsXY TileDirectionDelta[];
+extern const CoordsXY TileDirectionDelta[];
 extern const money32 TerrainPricing[];
 
 extern uint16 gWidePathTileLoopX;
@@ -444,7 +444,7 @@ void tile_element_set_terrain_edge(rct_tile_element *element, sint32 terrain);
 sint32 map_height_from_slope(sint32 x, sint32 y, sint32 slope);
 rct_tile_element* map_get_banner_element_at(sint32 x, sint32 y, sint32 z, uint8 direction);
 rct_tile_element *map_get_surface_element_at(sint32 x, sint32 y);
-rct_tile_element * map_get_surface_element_at(BigCoordsXY coords);
+rct_tile_element * map_get_surface_element_at(CoordsXY coords);
 rct_tile_element* map_get_path_element_at(sint32 x, sint32 y, sint32 z);
 rct_tile_element *map_get_wall_element_at(sint32 x, sint32 y, sint32 z, sint32 direction);
 rct_tile_element *map_get_small_scenery_element_at(sint32 x, sint32 y, sint32 z, sint32 type, uint8 quadrant);
@@ -585,7 +585,7 @@ uint32 map_get_available_peep_spawn_index_list(uint32* peepSpawnIndexList);
 uint16 check_max_allowable_land_rights_for_tile(uint8 x, uint8 y, uint8 base_z);
 uint8 tile_element_get_ride_index(const rct_tile_element * tileElement);
 
-void FixLandOwnershipTiles(std::initializer_list<SmallCoordsXY> tiles);
-void FixLandOwnershipTilesWithOwnership(std::initializer_list<SmallCoordsXY> tiles, uint8 ownership);
+void FixLandOwnershipTiles(std::initializer_list<TileCoordsXY> tiles);
+void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tiles, uint8 ownership);
 
 #endif

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -704,7 +704,7 @@ void update_park_fences(sint32 x, sint32 y)
     if (y <= 0 || y >= gMapSizeUnits)
         return;
 
-    rct_tile_element* sufaceElement = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element* sufaceElement = map_get_surface_element_at({x, y});
     if (sufaceElement == nullptr)return;
 
     uint8 newOwnership = sufaceElement->properties.surface.ownership & 0xF0;
@@ -859,7 +859,7 @@ void game_command_set_park_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
 }
 
 static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, sint32 flags) {
-    rct_tile_element* surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element* surfaceElement = map_get_surface_element_at({x, y});
     if (surfaceElement == nullptr)
         return MONEY32_UNDEFINED;
 

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -268,7 +268,7 @@ static money32 SmallSceneryPlace(sint16 x,
         }
     }
 
-    rct_tile_element* surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+    rct_tile_element* surfaceElement = map_get_surface_element_at({x, y});
 
     if (surfaceElement != nullptr && !gCheatsDisableClearanceChecks && map_get_water_height(surfaceElement) > 0)
     {

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -754,7 +754,7 @@ sint32 tile_inspector_track_base_height_offset(sint32 x, sint32 y, sint32 elemen
 
             // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
             // you decrease the map size.
-            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5,
+            openrct2_assert(map_get_surface_element_at({elemX, elemY}) != nullptr, "No surface at %d,%d", elemX >> 5,
                             elemY >> 5);
 
             // Keep?
@@ -887,7 +887,7 @@ sint32 tile_inspector_track_set_chain(sint32 x, sint32 y, sint32 elementIndex, b
 
             // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
             // you decrease the map size.
-            openrct2_assert(map_get_surface_element_at(elemX >> 5, elemY >> 5) != nullptr, "No surface at %d,%d", elemX >> 5,
+            openrct2_assert(map_get_surface_element_at({elemX, elemY}) != nullptr, "No surface at %d,%d", elemX >> 5,
                             elemY >> 5);
 
             // Keep?

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -350,7 +350,7 @@ static money32 WallPlace(uint8 wallType,
     uint8 edgeSlope = 0;
     if (position.z == 0)
     {
-        rct_tile_element * surfaceElement = map_get_surface_element_at(position.x / 32, position.y / 32);
+        rct_tile_element * surfaceElement = map_get_surface_element_at({position.x, position.y});
         if (surfaceElement == nullptr)
         {
             return MONEY32_UNDEFINED;
@@ -366,7 +366,7 @@ static money32 WallPlace(uint8 wallType,
         }
     }
 
-    rct_tile_element * surfaceElement = map_get_surface_element_at(position.x / 32, position.y / 32);
+    rct_tile_element * surfaceElement = map_get_surface_element_at({position.x, position.y});
     if (surfaceElement == nullptr)
     {
         return MONEY32_UNDEFINED;

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -39,7 +39,7 @@ uint32 gCurrentViewportFlags;
 uint32 gScenarioTicks;
 uint8 gCurrentRotation;
 
-const BigCoordsXY TileDirectionDelta[] = {
+const CoordsXY TileDirectionDelta[] = {
     {-32, 0},
     {0,   +32},
     {+32, 0},

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -39,7 +39,7 @@ uint32 gCurrentViewportFlags;
 uint32 gScenarioTicks;
 uint8 gCurrentRotation;
 
-const LocationXY16 TileDirectionDelta[] = {
+const BigCoordsXY TileDirectionDelta[] = {
     {-32, 0},
     {0,   +32},
     {+32, 0},


### PR DESCRIPTION
Currently, we have three different sizes when storing coordinates (8, 16 and 32 bit) and two kinds of coordinates. This means a lot of casting and diving/multiplying by 32. This PR aims to clean both things up.