### PR TITLE
Pack nested namespaces together and add closing comments

### DIFF
--- a/src/openrct2-ui/CursorData.cpp
+++ b/src/openrct2-ui/CursorData.cpp
@@ -17,7 +17,7 @@
 #include <openrct2/interface/Cursors.h>
 #include "CursorRepository.h"
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     static constexpr const CursorData BlankCursorData =
     {
@@ -664,4 +664,4 @@ namespace OpenRCT2 { namespace Ui
         }
         return result;
     }
-} }
+}

--- a/src/openrct2-ui/CursorRepository.h
+++ b/src/openrct2-ui/CursorRepository.h
@@ -23,59 +23,56 @@
 
 struct SDL_Cursor;
 
-namespace OpenRCT2
+namespace OpenRCT2::Ui
 {
-    namespace Ui
+    class CursorRepository
     {
-        class CursorRepository
+    private:
+        class CursorSetHolder
         {
         private:
-            class CursorSetHolder
-            {
-            private:
-                SDL_Cursor * _cursors[CURSOR_COUNT] = {nullptr};
-            public:
-                CursorSetHolder(const std::function<SDL_Cursor *(CURSOR_ID)> & getCursor)
-                {
-                    for (size_t i = 0; i < CURSOR_COUNT; i++)
-                    {
-                        _cursors[i] = getCursor(static_cast<CURSOR_ID>(i));
-                    }
-                }
-
-                ~CursorSetHolder()
-                {
-                    for (size_t i = 0; i < CURSOR_COUNT; i++)
-                    {
-                        SDL_FreeCursor(_cursors[i]);
-                    }
-                }
-
-                SDL_Cursor * getScaledCursor(CURSOR_ID cursorId)
-                {
-                    return _cursors[cursorId];
-                }
-            };
-
-            constexpr static sint32 BASE_CURSOR_WIDTH  = 32;
-            constexpr static sint32 BASE_CURSOR_HEIGHT = 32;
-
-            CURSOR_ID _currentCursor  = CURSOR_UNDEFINED;
-            uint8 _currentCursorScale = 1;
-
-            std::map<uint8, CursorSetHolder> _scaledCursors;
-
+            SDL_Cursor * _cursors[CURSOR_COUNT] = {nullptr};
         public:
-            ~CursorRepository();
-            void LoadCursors();
-            CURSOR_ID GetCurrentCursor();
-            void SetCurrentCursor(CURSOR_ID cursorId);
-            void SetCursorScale(uint8 cursorScale);
+            CursorSetHolder(const std::function<SDL_Cursor *(CURSOR_ID)> & getCursor)
+            {
+                for (size_t i = 0; i < CURSOR_COUNT; i++)
+                {
+                    _cursors[i] = getCursor(static_cast<CURSOR_ID>(i));
+                }
+            }
 
-        private:
-            SDL_Cursor * Create(const CursorData * cursorInfo, uint8 scale);
-            void GenerateScaledCursorSetHolder(uint8 scale);
-            static const CursorData * GetCursorData(CURSOR_ID cursorId);
+            ~CursorSetHolder()
+            {
+                for (size_t i = 0; i < CURSOR_COUNT; i++)
+                {
+                    SDL_FreeCursor(_cursors[i]);
+                }
+            }
+
+            SDL_Cursor * getScaledCursor(CURSOR_ID cursorId)
+            {
+                return _cursors[cursorId];
+            }
         };
-    }
+
+        constexpr static sint32 BASE_CURSOR_WIDTH  = 32;
+        constexpr static sint32 BASE_CURSOR_HEIGHT = 32;
+
+        CURSOR_ID _currentCursor  = CURSOR_UNDEFINED;
+        uint8 _currentCursorScale = 1;
+
+        std::map<uint8, CursorSetHolder> _scaledCursors;
+
+    public:
+        ~CursorRepository();
+        void LoadCursors();
+        CURSOR_ID GetCurrentCursor();
+        void SetCurrentCursor(CURSOR_ID cursorId);
+        void SetCursorScale(uint8 cursorScale);
+
+    private:
+        SDL_Cursor * Create(const CursorData * cursorInfo, uint8 scale);
+        void GenerateScaledCursorSetHolder(uint8 scale);
+        static const CursorData * GetCursorData(CURSOR_ID cursorId);
+    };
 }

--- a/src/openrct2-ui/TextComposition.h
+++ b/src/openrct2-ui/TextComposition.h
@@ -20,39 +20,36 @@
 
 union SDL_Event;
 
-namespace OpenRCT2
+namespace OpenRCT2::Ui
 {
-    namespace Ui
+    /**
+     * Represents a
+     */
+    class TextComposition
     {
-        /**
-        * Represents a
-        */
-        class TextComposition
-        {
-        private:
-            TextInputSession _session = { 0 };
+    private:
+        TextInputSession _session = { 0 };
 
-            bool    _imeActive = false;
-            sint32  _imeStart = 0;
-            sint32  _imeLength = 0;
-            utf8    _imeBuffer[32] = { 0 };
+        bool    _imeActive = false;
+        sint32  _imeStart = 0;
+        sint32  _imeLength = 0;
+        utf8    _imeBuffer[32] = { 0 };
 
-        public:
-            bool IsActive();
-            TextInputSession * Start(utf8 * buffer, size_t bufferSize);
-            void Stop();
-            void HandleMessage(const SDL_Event * e);
+    public:
+        bool IsActive();
+        TextInputSession * Start(utf8 * buffer, size_t bufferSize);
+        void Stop();
+        void HandleMessage(const SDL_Event * e);
 
-        private:
-            void CursorHome();
-            void CursorEnd();
-            void CursorLeft();
-            void CursorRight();
-            void Insert(const utf8 * text);
-            void InsertCodepoint(codepoint_t codepoint);
-            void Clear();
-            void Delete();
-            void RecalculateLength();
-        };
-    }
+    private:
+        void CursorHome();
+        void CursorEnd();
+        void CursorLeft();
+        void CursorRight();
+        void Insert(const utf8 * text);
+        void InsertCodepoint(codepoint_t codepoint);
+        void Clear();
+        void Delete();
+        void RecalculateLength();
+    };
 }

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -26,54 +26,54 @@
 
 #include <SDL.h>
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
+{
+
+    class AndroidContext final : public IPlatformUiContext
     {
+    private:
 
-        class AndroidContext final : public IPlatformUiContext
+    public:
+        AndroidContext()
         {
-        private:
-
-        public:
-            AndroidContext()
-            {
-            }
-
-            void SetWindowIcon(SDL_Window * window) override
-            {
-            }
-
-            bool IsSteamOverlayAttached() override
-            {
-                return false;
-            }
-
-            void ShowMessageBox(SDL_Window * window, const std::string &message) override
-            {
-                log_verbose(message.c_str());
-
-                STUB();
-            }
-
-            std::string ShowFileDialog(SDL_Window * window, const FileDialogDesc &desc) override
-            {
-                STUB();
-
-                return nullptr;
-            }
-
-            std::string ShowDirectoryDialog(SDL_Window * window, const std::string &title) override
-            {
-                log_info(title.c_str());
-                STUB();
-
-                return "/sdcard/rct2";
-            }
-        };
-
-        IPlatformUiContext * CreatePlatformUiContext()
-        {
-            return new AndroidContext();
         }
-    } }
+
+        void SetWindowIcon(SDL_Window * window) override
+        {
+        }
+
+        bool IsSteamOverlayAttached() override
+        {
+            return false;
+        }
+
+        void ShowMessageBox(SDL_Window * window, const std::string &message) override
+        {
+            log_verbose(message.c_str());
+
+            STUB();
+        }
+
+        std::string ShowFileDialog(SDL_Window * window, const FileDialogDesc &desc) override
+        {
+            STUB();
+
+            return nullptr;
+        }
+
+        std::string ShowDirectoryDialog(SDL_Window * window, const std::string &title) override
+        {
+            log_info(title.c_str());
+            STUB();
+
+            return "/sdcard/rct2";
+        }
+    };
+
+    IPlatformUiContext * CreatePlatformUiContext()
+    {
+        return new AndroidContext();
+    }
+}
 
 #endif // __ANDROID__

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -29,7 +29,7 @@
 
 #include <SDL.h>
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     enum class DIALOG_TYPE
     {
@@ -385,6 +385,6 @@ namespace OpenRCT2 { namespace Ui
     {
         return new LinuxContext();
     }
-} }
+}
 
 #endif // __linux__ || __OpenBSD__

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -385,6 +385,6 @@ namespace OpenRCT2::Ui
     {
         return new LinuxContext();
     }
-}
+} // namespace OpenRCT2::Ui
 
 #endif // __linux__ || __OpenBSD__

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -54,7 +54,7 @@ static std::wstring SHGetPathFromIDListLongPath(LPCITEMIDLIST pidl)
     return pszPath;
 }
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     class Win32Context : public IPlatformUiContext
     {
@@ -224,6 +224,6 @@ namespace OpenRCT2 { namespace Ui
     {
         return new Win32Context();
     }
-} }
+}
 
 #endif // _WIN32

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -224,6 +224,6 @@ namespace OpenRCT2::Ui
     {
         return new Win32Context();
     }
-}
+} // namespace OpenRCT2::Ui
 
 #endif // _WIN32

--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -47,5 +47,5 @@ namespace OpenRCT2
         IPlatformUiContext * CreatePlatformUiContext();
 
         InGameConsole& GetInGameConsole();
-    }
-}
+    } // namespace Ui
+} // namespace OpenRCT2

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -182,6 +182,6 @@ namespace OpenRCT2::Ui
     {
         return new macOSContext();
     }
-}
+} // namespace OpenRCT2::Ui
 
 #endif // __APPLE__ && __MACH__

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -27,7 +27,7 @@
 
 #include <SDL.h>
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     class macOSContext final : public IPlatformUiContext
     {
@@ -182,6 +182,6 @@ namespace OpenRCT2 { namespace Ui
     {
         return new macOSContext();
     }
-} }
+}
 
 #endif // __APPLE__ && __MACH__

--- a/src/openrct2-ui/WindowManager.h
+++ b/src/openrct2-ui/WindowManager.h
@@ -16,9 +16,9 @@
 
 #include <openrct2/common.h>
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     interface IWindowManager;
 
     IWindowManager * CreateWindowManager();
-} }
+}

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -24,7 +24,7 @@
 #include "AudioContext.h"
 #include "AudioFormat.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     class AudioChannelImpl : public ISDLAudioChannel
     {
@@ -295,4 +295,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return new (std::nothrow) AudioChannelImpl();
     }
-} }
+}

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -295,4 +295,4 @@ namespace OpenRCT2::Audio
     {
         return new (std::nothrow) AudioChannelImpl();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioContext.cpp
+++ b/src/openrct2-ui/audio/AudioContext.cpp
@@ -21,7 +21,7 @@
 #include "../SDLException.h"
 #include "AudioContext.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     class AudioContext : public IAudioContext
     {
@@ -98,4 +98,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return new AudioContext();
     }
-} }
+}

--- a/src/openrct2-ui/audio/AudioContext.cpp
+++ b/src/openrct2-ui/audio/AudioContext.cpp
@@ -98,4 +98,4 @@ namespace OpenRCT2::Audio
     {
         return new AudioContext();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -9,7 +9,7 @@
 struct SDL_RWops;
 using SpeexResamplerState = struct SpeexResamplerState_;
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     struct      AudioFormat;
     interface   IAudioContext;
@@ -70,4 +70,4 @@ namespace OpenRCT2 { namespace Audio
     }
 
     IAudioContext * CreateAudioContext();
-} }
+}

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -70,4 +70,4 @@ namespace OpenRCT2::Audio
     }
 
     IAudioContext * CreateAudioContext();
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -53,4 +53,4 @@ namespace OpenRCT2::Audio
     {
         return !(lhs == rhs);
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -19,7 +19,7 @@
 #include <openrct2/common.h>
 #include <SDL2/SDL.h>
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     /**
      * Represents the size, frequency and number of channels for
@@ -53,4 +53,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return !(lhs == rhs);
     }
-} }
+}

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -36,7 +36,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/platform/platform.h>
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     class AudioMixerImpl final : public IAudioMixer
     {
@@ -513,4 +513,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return new AudioMixerImpl();
     }
-} }
+}

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -513,4 +513,4 @@ namespace OpenRCT2::Audio
     {
         return new AudioMixerImpl();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -207,4 +207,4 @@ namespace OpenRCT2::Audio
         }
         return source;
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -21,7 +21,7 @@
 #include "AudioContext.h"
 #include "AudioFormat.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     /**
      * An audio source where raw PCM data is streamed directly from
@@ -207,4 +207,4 @@ namespace OpenRCT2 { namespace Audio
         }
         return source;
     }
-} }
+}

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -243,4 +243,4 @@ namespace OpenRCT2::Audio
         }
         return source;
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -24,7 +24,7 @@
 #include "AudioContext.h"
 #include "AudioFormat.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     /**
      * An audio source where raw PCM data is initially loaded into RAM from
@@ -243,4 +243,4 @@ namespace OpenRCT2 { namespace Audio
         }
         return source;
     }
-} }
+}

--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -836,6 +836,6 @@ namespace
         shortcut_view_clipping,
         shortcut_highlight_path_issues_toggle,
     };
-}
+} // anonymous namespace
 
 #pragma endregion

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -135,8 +135,8 @@ namespace OpenRCT2
             sint32 GetFromKey(sint32 key);
             void GetKeyboardMapScroll(const uint8 * keysState, sint32 * x, sint32 * y) const;
         };
-    }
-}
+    } // namespace Input
+} // namespace OpenRCT2
 
 /** The current shortcut being changed. */
 extern uint8 gKeyboardShortcutChangeId;

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -1,6 +1,6 @@
 #include <openrct2/interface/Console.h>
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     class InGameConsole final : public InteractiveConsole
     {
@@ -53,4 +53,4 @@ namespace OpenRCT2 { namespace Ui
         void Invalidate() const;
         sint32 GetNumVisibleLines() const;
     };
-} }
+}

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -53,4 +53,4 @@ namespace OpenRCT2::Ui
         void Invalidate() const;
         sint32 GetNumVisibleLines() const;
     };
-}
+} // namespace OpenRCT2::Ui

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -114,7 +114,7 @@ namespace OpenRCT2
     IContext * CreateContext();
     IContext * CreateContext(IPlatformEnvironment * env, Audio::IAudioContext * audioContext, Ui::IUiContext * uiContext);
     IContext * GetContext();
-}
+} // namespace OpenRCT2
 
 enum
 {

--- a/src/openrct2/Editor.h
+++ b/src/openrct2/Editor.h
@@ -36,7 +36,7 @@ namespace Editor
     uint8 GetSelectedObjectFlags(sint32 objectType, size_t index);
     void ClearSelectedObject(sint32 objectType, size_t index, uint32 flags);
     void SetSelectedObject(sint32 objectType, size_t index, uint32 flags);
-}
+} // namespace Editor
 
 enum RCT2_EDITOR_STEP
 {

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -84,4 +84,4 @@ namespace OpenRCT2
 
     IPlatformEnvironment * CreatePlatformEnvironment(DIRBASE_VALUES basePaths);
     IPlatformEnvironment * CreatePlatformEnvironment();
-}
+} // namespace OpenRCT2

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -235,4 +235,4 @@ namespace GameActions
         }
         return result;
     }
-}
+} // namespace GameActions

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -252,4 +252,4 @@ namespace GameActions
         Register(T::TYPE, factory);
         return factory;
     }
-}
+} // namespace GameActions

--- a/src/openrct2/actions/GameActionRegistration.cpp
+++ b/src/openrct2/actions/GameActionRegistration.cpp
@@ -55,4 +55,4 @@ namespace GameActions
         Register<ParkSetNameAction>();
         Register<BannerSetNameAction>();
     }
-}
+} // namespace GameActions

--- a/src/openrct2/audio/AudioChannel.h
+++ b/src/openrct2/audio/AudioChannel.h
@@ -73,4 +73,4 @@ namespace OpenRCT2::Audio
 
         virtual size_t Read(void * dst, size_t len) abstract;
     };
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2/audio/AudioChannel.h
+++ b/src/openrct2/audio/AudioChannel.h
@@ -18,7 +18,7 @@
 
 #include "../common.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     interface IAudioSource;
 
@@ -73,4 +73,4 @@ namespace OpenRCT2 { namespace Audio
 
         virtual size_t Read(void * dst, size_t len) abstract;
     };
-} }
+}

--- a/src/openrct2/audio/AudioContext.h
+++ b/src/openrct2/audio/AudioContext.h
@@ -20,47 +20,44 @@
 #include <vector>
 #include "../common.h"
 
-namespace OpenRCT2
+namespace OpenRCT2::Audio
 {
-    namespace Audio
+    interface IAudioChannel;
+    interface IAudioMixer;
+    interface IAudioSource;
+
+    /**
+     * Audio services for playing music and sound effects.
+     */
+    interface IAudioContext
     {
-        interface IAudioChannel;
-        interface IAudioMixer;
-        interface IAudioSource;
+        virtual ~IAudioContext() = default;
 
-        /**
-         * Audio services for playing music and sound effects.
-         */
-        interface IAudioContext
-        {
-            virtual ~IAudioContext() = default;
+        virtual IAudioMixer * GetMixer() abstract;
 
-            virtual IAudioMixer * GetMixer() abstract;
+        virtual std::vector<std::string> GetOutputDevices() abstract;
+        virtual void SetOutputDevice(const std::string &deviceName) abstract;
 
-            virtual std::vector<std::string> GetOutputDevices() abstract;
-            virtual void SetOutputDevice(const std::string &deviceName) abstract;
-
-            virtual IAudioSource * CreateStreamFromWAV(const std::string &path) abstract;
+        virtual IAudioSource * CreateStreamFromWAV(const std::string &path) abstract;
 
 
-            virtual void StartTitleMusic() abstract;
+        virtual void StartTitleMusic() abstract;
 
-            virtual IAudioChannel * PlaySound(sint32 soundId, sint32 volume, sint32 pan) abstract;
-            virtual IAudioChannel * PlaySoundAtLocation(sint32 soundId, sint16 x, sint16 y, sint16 z) abstract;
-            virtual IAudioChannel * PlaySoundPanned(sint32 soundId, sint32 pan, sint16 x, sint16 y, sint16 z) abstract;
+        virtual IAudioChannel * PlaySound(sint32 soundId, sint32 volume, sint32 pan) abstract;
+        virtual IAudioChannel * PlaySoundAtLocation(sint32 soundId, sint16 x, sint16 y, sint16 z) abstract;
+        virtual IAudioChannel * PlaySoundPanned(sint32 soundId, sint32 pan, sint16 x, sint16 y, sint16 z) abstract;
 
-            virtual void ToggleAllSounds() abstract;
-            virtual void PauseSounds() abstract;
-            virtual void UnpauseSounds() abstract;
+        virtual void ToggleAllSounds() abstract;
+        virtual void PauseSounds() abstract;
+        virtual void UnpauseSounds() abstract;
 
-            virtual void StopAll() abstract;
-            virtual void StopCrowdSound() abstract;
-            virtual void StopRainSound() abstract;
-            virtual void StopRideMusic() abstract;
-            virtual void StopTitleMusic() abstract;
-            virtual void StopVehicleSounds() abstract;
-        };
+        virtual void StopAll() abstract;
+        virtual void StopCrowdSound() abstract;
+        virtual void StopRainSound() abstract;
+        virtual void StopRideMusic() abstract;
+        virtual void StopTitleMusic() abstract;
+        virtual void StopVehicleSounds() abstract;
+    };
 
-        IAudioContext * CreateDummyAudioContext();
-    }
+    IAudioContext * CreateDummyAudioContext();
 }

--- a/src/openrct2/audio/AudioContext.h
+++ b/src/openrct2/audio/AudioContext.h
@@ -60,4 +60,4 @@ namespace OpenRCT2::Audio
     };
 
     IAudioContext * CreateDummyAudioContext();
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -29,7 +29,7 @@ enum MIXER_GROUP
     MIXER_GROUP_TITLE_MUSIC,
 };
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     interface IAudioSource;
     interface IAudioChannel;
@@ -53,7 +53,7 @@ namespace OpenRCT2 { namespace Audio
         virtual IAudioSource * GetSoundSource(sint32 id) abstract;
         virtual IAudioSource * GetMusicSource(sint32 id) abstract;
     };
-} }
+}
 
 #ifndef DSBPAN_LEFT
 #define DSBPAN_LEFT -10000

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -53,7 +53,7 @@ namespace OpenRCT2::Audio
         virtual IAudioSource * GetSoundSource(sint32 id) abstract;
         virtual IAudioSource * GetMusicSource(sint32 id) abstract;
     };
-}
+} // namespace OpenRCT2::Audio
 
 #ifndef DSBPAN_LEFT
 #define DSBPAN_LEFT -10000

--- a/src/openrct2/audio/AudioSource.h
+++ b/src/openrct2/audio/AudioSource.h
@@ -37,4 +37,4 @@ namespace OpenRCT2::Audio
     {
         IAudioSource * CreateNull();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2/audio/AudioSource.h
+++ b/src/openrct2/audio/AudioSource.h
@@ -19,7 +19,7 @@
 #include "../common.h"
 #include "AudioMixer.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     /**
      * Represents a readable source of audio PCM data.
@@ -37,4 +37,4 @@ namespace OpenRCT2 { namespace Audio
     {
         IAudioSource * CreateNull();
     }
-} }
+}

--- a/src/openrct2/audio/DummyAudioContext.cpp
+++ b/src/openrct2/audio/DummyAudioContext.cpp
@@ -49,4 +49,4 @@ namespace OpenRCT2::Audio
     {
         return new DummyAudioContext();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2/audio/DummyAudioContext.cpp
+++ b/src/openrct2/audio/DummyAudioContext.cpp
@@ -16,7 +16,7 @@
 
 #include "AudioContext.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     class DummyAudioContext final : public IAudioContext
     {
@@ -49,4 +49,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return new DummyAudioContext();
     }
-} }
+}

--- a/src/openrct2/audio/NullAudioSource.cpp
+++ b/src/openrct2/audio/NullAudioSource.cpp
@@ -16,7 +16,7 @@
 
 #include "AudioSource.h"
 
-namespace OpenRCT2 { namespace Audio
+namespace OpenRCT2::Audio
 {
     /**
      * An audio source representing silence.
@@ -39,4 +39,4 @@ namespace OpenRCT2 { namespace Audio
     {
         return new NullAudioSource();
     }
-} }
+}

--- a/src/openrct2/audio/NullAudioSource.cpp
+++ b/src/openrct2/audio/NullAudioSource.cpp
@@ -39,4 +39,4 @@ namespace OpenRCT2::Audio
     {
         return new NullAudioSource();
     }
-}
+} // namespace OpenRCT2::Audio

--- a/src/openrct2/cmdline/CommandLine.cpp
+++ b/src/openrct2/cmdline/CommandLine.cpp
@@ -550,7 +550,7 @@ namespace CommandLine
         }
         return nullptr;
     }
-}
+} // namespace CommandLine
 
 sint32 cmdline_run(const char * * argv, sint32 argc)
 {

--- a/src/openrct2/cmdline/CommandLine.hpp
+++ b/src/openrct2/cmdline/CommandLine.hpp
@@ -108,4 +108,4 @@ namespace CommandLine
 
     exitcode_t HandleCommandConvert(CommandLineArgEnumerator * enumerator);
     exitcode_t HandleCommandUri(CommandLineArgEnumerator * enumerator);
-}
+} // namespace CommandLine

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -645,7 +645,7 @@ namespace Config
         }
         return std::string();
     }
-}
+} // namespace Config
 
 GeneralConfiguration         gConfigGeneral;
 InterfaceConfiguration       gConfigInterface;

--- a/src/openrct2/core/Collections.hpp
+++ b/src/openrct2/core/Collections.hpp
@@ -114,4 +114,4 @@ namespace Collections
     }
 
     #pragma endregion
-}
+} // namespace Collections

--- a/src/openrct2/core/Console.cpp
+++ b/src/openrct2/core/Console.cpp
@@ -101,5 +101,5 @@ namespace Console
             auto formatLn = std::string(format) + "\n";
             vfprintf(stdout, formatLn.c_str(), args);
         }
-    }
-}
+    } // namespace Error
+} // namespace Console

--- a/src/openrct2/core/Console.hpp
+++ b/src/openrct2/core/Console.hpp
@@ -37,5 +37,5 @@ namespace Console
         void WriteLine();
         void WriteLine(const utf8 * format, ...);
         void WriteLine_VA(const utf8 * format, va_list args);
-    }
-}
+    } // namespace Error
+} // namespace Console

--- a/src/openrct2/core/Diagnostics.cpp
+++ b/src/openrct2/core/Diagnostics.cpp
@@ -34,4 +34,4 @@ namespace Debug
 #endif
 #endif
     }
-}
+} // namespace Debug

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -132,7 +132,7 @@ namespace File
 #endif
         return lastModified; 
     }
-}
+} // namespace File
 
 bool readentirefile(const utf8 * path, void * * outBuffer, size_t * outLength)
 {

--- a/src/openrct2/core/File.h
+++ b/src/openrct2/core/File.h
@@ -30,4 +30,4 @@ namespace File
     void WriteAllBytes(const std::string &path, const void * buffer, size_t length);
     std::vector<std::string> ReadAllLines(const std::string &path);
     uint64 GetLastModified(const std::string &path);
-}
+} // namespace File

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -67,4 +67,4 @@ namespace Path
     void QueryDirectory(QueryDirectoryResult * result, const std::string &pattern);
 
     std::vector<std::string> GetDirectories(const std::string &path);
-}
+} // namespace Path

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -38,7 +38,6 @@ void openrct2_assert_fwd(bool expression, const char * message, ...)
     va_end(va);
 }
 
-
 namespace Guard
 {
     constexpr const utf8 * ASSERTION_MESSAGE = "An assertion failed, please report this to the OpenRCT2 developers.";
@@ -156,4 +155,4 @@ namespace Guard
 #endif
     }
 #endif
-}
+} // namespace Guard

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -60,6 +60,6 @@ namespace Guard
         Assert(argument >= min && argument <= max, message, args);
         va_end(args);
     }
-}
+} // namespace Guard
 
 #define GUARD_LINE "Location: %s:%d", __func__, __LINE__

--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -58,4 +58,4 @@ namespace Json
         size_t jsonOutputSize = String::SizeOf(jsonOutput);
         fs.Write(jsonOutput, jsonOutputSize);
     }
-}
+} // namespace Json

--- a/src/openrct2/core/Math.hpp
+++ b/src/openrct2/core/Math.hpp
@@ -48,4 +48,4 @@ namespace Math
         if (x > 0) return 1;
         return 0;
     }
-}
+} // namespace Math

--- a/src/openrct2/core/Memory.hpp
+++ b/src/openrct2/core/Memory.hpp
@@ -98,4 +98,4 @@ namespace Memory
         }
         Free(ptr);
     }
-}
+} // namespace Memory

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -274,4 +274,4 @@ namespace Path
 #endif
         return result;
     }
-}
+} // namespace Path

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -54,4 +54,4 @@ namespace Path
      * Note: This will not resolve the case for Windows.
      */
     std::string ResolveCasing(const std::string &path);
-}
+} // namespace Path

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -561,4 +561,4 @@ namespace String
         return std::string(src);
 #endif
     }
-}
+} // namespace String

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -33,7 +33,7 @@ namespace CODE_PAGE
     constexpr sint32 CP_950 = 950;      // ANSI/OEM Traditional Chinese (Taiwan; Hong Kong SAR, PRC); Chinese Traditional (Big5)
     constexpr sint32 CP_1252 = 1252;    // ANSI Latin 1; Western European (Windows)
     constexpr sint32 CP_UTF8 = 65001;   // Unicode (UTF-8)
-}
+} // namespace CODE_PAGE
 
 namespace String
 {
@@ -110,4 +110,4 @@ namespace String
      * Converts a multi-byte string from one code page to another.
      */
     std::string Convert(const std::string_view& src, sint32 srcCodePage, sint32 dstCodePage);
-}
+} // namespace String

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -158,6 +158,6 @@ namespace Zip
         }
         return result;
     }
-}
+} // namespace Zip
 
 # endif

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -20,7 +20,7 @@
 
 #include "Drawing.h"
 
-namespace OpenRCT2 { namespace Drawing
+namespace OpenRCT2::Drawing
 {
     interface IDrawingEngine;
 
@@ -39,4 +39,4 @@ namespace OpenRCT2 { namespace Drawing
         virtual void DrawSpriteSolid(uint32 image, sint32 x, sint32 y, uint8 colour)                          abstract;
         virtual void DrawGlyph(uint32 image, sint32 x, sint32 y, uint8 * palette)                             abstract;
     };
-} }
+}

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -39,4 +39,4 @@ namespace OpenRCT2::Drawing
         virtual void DrawSpriteSolid(uint32 image, sint32 x, sint32 y, uint8 colour)                          abstract;
         virtual void DrawGlyph(uint32 image, sint32 x, sint32 y, uint8 * palette)                             abstract;
     };
-}
+} // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -80,4 +80,4 @@ namespace OpenRCT2::Drawing
             sint32 xStart,
             sint32 yStart) abstract;
     };
-}
+} // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -40,7 +40,7 @@ enum DRAWING_ENGINE_FLAGS
 struct rct_drawpixelinfo;
 struct rct_palette_entry;
 
-namespace OpenRCT2 { namespace Drawing
+namespace OpenRCT2::Drawing
 {
     interface IDrawingContext;
 
@@ -80,4 +80,4 @@ namespace OpenRCT2 { namespace Drawing
             sint32 xStart,
             sint32 yStart) abstract;
     };
-} }
+}

--- a/src/openrct2/drawing/Rain.h
+++ b/src/openrct2/drawing/Rain.h
@@ -20,9 +20,9 @@
 
 struct rct_drawpixelinfo;
 
-namespace OpenRCT2 { namespace Drawing
+namespace OpenRCT2::Drawing
 {
     interface IRainDrawer;
-} }
+}
 
 void DrawRain(rct_drawpixelinfo * dpi, OpenRCT2::Drawing::IRainDrawer * rainDrawer);

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -25,7 +25,7 @@ namespace OpenRCT2
     namespace Ui
     {
         interface IUiContext;
-    }
+    } // namespace Ui
 
     namespace Drawing
     {
@@ -149,5 +149,5 @@ namespace OpenRCT2
 
             void SetDPI(rct_drawpixelinfo * dpi);
         };
-    }
-}
+    } // namespace Drawing
+} // namespace OpenRCT2

--- a/src/openrct2/interface/Cursors.h
+++ b/src/openrct2/interface/Cursors.h
@@ -65,4 +65,4 @@ namespace OpenRCT2::Ui
         uint8 Data[CURSOR_BIT_WIDTH * CURSOR_HEIGHT];
         uint8 Mask[CURSOR_BIT_WIDTH * CURSOR_HEIGHT];
     };
-}
+} // namespace OpenRCT2::Ui

--- a/src/openrct2/interface/Cursors.h
+++ b/src/openrct2/interface/Cursors.h
@@ -51,7 +51,7 @@ enum CURSOR_ID
     CURSOR_COUNT,
 };
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     constexpr size_t CURSOR_BIT_WIDTH = 32;
     constexpr size_t CURSOR_HEIGHT    = 4;
@@ -65,4 +65,4 @@ namespace OpenRCT2 { namespace Ui
         uint8 Data[CURSOR_BIT_WIDTH * CURSOR_HEIGHT];
         uint8 Mask[CURSOR_BIT_WIDTH * CURSOR_HEIGHT];
     };
-} }
+}

--- a/src/openrct2/interface/Theme.cpp
+++ b/src/openrct2/interface/Theme.cpp
@@ -657,7 +657,7 @@ namespace ThemeManager
         auto env = context->GetPlatformEnvironment();
         return env->GetDirectoryPath(DIRBASE::USER, DIRID::THEME);
     }
-}
+} // namespace ThemeManager
 
 void theme_manager_load_available_themes()
 {

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -624,4 +624,4 @@ namespace LanguagePackFactory
         auto languagePack = LanguagePack::FromText(id, text);
         return languagePack;
     }
-}
+} // namespace LanguagePackFactory

--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -533,6 +533,6 @@ namespace Convert
     {
         return ntohs(value);
     }
-}
+} // namespace Convert
 
 #endif

--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -554,7 +554,7 @@ namespace Twitch
             news_item_add_to_queue_raw(NEWS_ITEM_BLANK, buffer, 0);
         }
     }
-}
+} // namespace Twitch
 
 void twitch_update()
 {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -276,4 +276,4 @@ namespace ObjectFactory
         }
         return result;
     }
-}
+} // namespace ObjectFactory

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -371,4 +371,4 @@ namespace ObjectJsonHelpers
             }
         }
     }
-}
+} // namespace ObjectJsonHelpers

--- a/src/openrct2/object/ObjectJsonHelpers.h
+++ b/src/openrct2/object/ObjectJsonHelpers.h
@@ -54,4 +54,4 @@ namespace ObjectJsonHelpers
         }
         return flags;
     }
-};
+} // namespace ObjectJsonHelpers

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -26,12 +26,12 @@ namespace OpenRCT2
     namespace Drawing
     {
         interface IDrawingEngine;
-    }
+    } // namespace Drawing
 
     namespace Ui
     {
         interface IUiContext;
-    }
+    } // namespace Ui
 
     namespace Paint
     {
@@ -52,5 +52,5 @@ namespace OpenRCT2
             void PaintFPS(rct_drawpixelinfo * dpi);
             void MeasureFPS();
         };
-    }
-}
+    } // namespace Paint
+} // namespace OpenRCT2

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -304,6 +304,6 @@ namespace Platform
         while (size >= wExePathCapacity);
         return String::ToUtf8(wExePath.get());
     }
-}
+} // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -46,4 +46,4 @@ namespace Platform
     std::string FormatTime(std::time_t timestamp);
 
     bool IsColourTerminalSupported();
-}
+} // namespace Platform

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1427,5 +1427,5 @@ namespace RCT1
         };
         return map[sceneryType];
     }
-}
+} // namespace RCT1
 // clang-format on

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -48,4 +48,4 @@ namespace RCT1
     const char * GetWaterObject(uint8 waterType);
 
     const std::vector<const char *> GetSceneryObjects(uint8 sceneryType);
-}
+} // namespace RCT1

--- a/src/openrct2/rct12/SawyerEncoding.cpp
+++ b/src/openrct2/rct12/SawyerEncoding.cpp
@@ -63,4 +63,4 @@ namespace SawyerEncoding
             return false;
         }
     }
-}
+} // namespace SawyerEncoding

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -419,7 +419,7 @@ namespace ScenarioSources
             }
         }
     }
-}
+} // namespace ScenarioSources
 
 bool scenario_get_source_desc(const utf8 * name, source_desc * outDesc)
 {

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -312,7 +312,7 @@ namespace TitleSequenceManager
         }
         return false;
     }
-}
+} // namespace TitleSequenceManager
 
 size_t title_sequence_manager_get_count()
 {

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -96,4 +96,4 @@ namespace OpenRCT2::Ui
     {
         return new DummyUiContext();
     }
-}
+} // namespace OpenRCT2::Ui

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -20,7 +20,7 @@
 
 using namespace OpenRCT2::Drawing;
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     /**
     * Represents the window or screen that OpenRCT2 is presented on.
@@ -96,4 +96,4 @@ namespace OpenRCT2 { namespace Ui
     {
         return new DummyUiContext();
     }
-} }
+}

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -38,4 +38,4 @@ namespace OpenRCT2::Ui
     {
         return new DummyWindowManager();
     }
-}
+} // namespace OpenRCT2::Ui

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -16,7 +16,7 @@
 
 #include "WindowManager.h"
 
-namespace OpenRCT2 { namespace Ui
+namespace OpenRCT2::Ui
 {
     class DummyWindowManager final : public IWindowManager
     {
@@ -38,4 +38,4 @@ namespace OpenRCT2 { namespace Ui
     {
         return new DummyWindowManager();
     }
-} }
+}

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -30,7 +30,7 @@ namespace OpenRCT2
     {
         enum class  DRAWING_ENGINE_TYPE;
         interface   IDrawingEngine;
-    }
+    } // namespace Drawing
 
     namespace Ui
     {
@@ -150,5 +150,5 @@ namespace OpenRCT2
         };
 
         IUiContext * CreateDummyUiContext();
-    }
-}
+    } // namespace Ui
+} // namespace OpenRCT2

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -22,30 +22,27 @@
 
 #include "../interface/Window.h"
 
-namespace OpenRCT2
+namespace OpenRCT2::Ui
 {
-    namespace Ui
+    /**
+     * Manager of in-game windows and widgets.
+     */
+    interface IWindowManager
     {
-        /**
-         * Manager of in-game windows and widgets.
-         */
-        interface IWindowManager
-        {
-            virtual ~IWindowManager() = default;
-            virtual void Init() abstract;
-            virtual rct_window * OpenWindow(rct_windowclass wc) abstract;
-            virtual rct_window * OpenView(uint8 view) abstract;
-            virtual rct_window * OpenDetails(uint8 type, sint32 id) abstract;
-            virtual rct_window * OpenIntent(Intent * intent) abstract;
-            virtual void BroadcastIntent(const Intent &intent) abstract;
-            virtual rct_window * ShowError(rct_string_id title, rct_string_id message) abstract;
-            virtual void ForceClose(rct_windowclass windowClass) abstract;
-            virtual void UpdateMapTooltip() abstract;
-            virtual void HandleInput() abstract;
-            virtual void HandleKeyboard(bool isTitle) abstract;
-            virtual std::string GetKeyboardShortcutString(sint32 shortcut) abstract;
-        };
+        virtual ~IWindowManager() = default;
+        virtual void Init() abstract;
+        virtual rct_window * OpenWindow(rct_windowclass wc) abstract;
+        virtual rct_window * OpenView(uint8 view) abstract;
+        virtual rct_window * OpenDetails(uint8 type, sint32 id) abstract;
+        virtual rct_window * OpenIntent(Intent * intent) abstract;
+        virtual void BroadcastIntent(const Intent &intent) abstract;
+        virtual rct_window * ShowError(rct_string_id title, rct_string_id message) abstract;
+        virtual void ForceClose(rct_windowclass windowClass) abstract;
+        virtual void UpdateMapTooltip() abstract;
+        virtual void HandleInput() abstract;
+        virtual void HandleKeyboard(bool isTitle) abstract;
+        virtual std::string GetKeyboardShortcutString(sint32 shortcut) abstract;
+    };
 
-        IWindowManager * CreateDummyWindowManager();
-    }
+    IWindowManager * CreateDummyWindowManager();
 }

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -45,4 +45,4 @@ namespace OpenRCT2::Ui
     };
 
     IWindowManager * CreateDummyWindowManager();
-}
+} // namespace OpenRCT2::Ui

--- a/test/tests/TestData.cpp
+++ b/test/tests/TestData.cpp
@@ -13,4 +13,4 @@ namespace TestData
         std::string path = Path::Combine(GetBasePath(), "parks", name);
         return path;
     }
-};
+} // namespace TestData


### PR DESCRIPTION
~This removes now unnecessary checks for `__cplusplus`~ (already done by now), and packs nested namespaces together.

```cpp
namespace A {
    namespace B {
        // ...
    }
}
```

Becomes:

```cpp
namespace A::B {
    // ...
} // namespace A::B
```