### PR TITLE
Remove some entrance/exit height assumptions

### DIFF
--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -50,7 +50,7 @@ struct GameAction;
 // This define specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "32"
+#define NETWORK_STREAM_VERSION "33"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 #include <array>

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2617,13 +2617,12 @@ static void peep_choose_seat_from_car(rct_peep * peep, Ride * ride, rct_vehicle 
  */
 static void peep_go_to_ride_entrance(rct_peep * peep, Ride * ride)
 {
-    sint32 x = ride->entrances[peep->current_ride_station].x;
-    sint32 y = ride->entrances[peep->current_ride_station].y;
-    sint32 z = ride->station_heights[peep->current_ride_station];
+    TileCoordsXYZD location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+    Guard::Assert(location.x != LOCATION_NULL);
+    sint32 x = location.x;
+    sint32 y = location.y;
 
-    rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
-
-    uint8 direction = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
+    uint8 direction = location.direction;
 
     x *= 32;
     y *= 32;
@@ -2907,13 +2906,12 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_NO_VEHICLES))
     {
-        x = ride->entrances[peep->current_ride_station].x;
-        y = ride->entrances[peep->current_ride_station].y;
-        z = ride->station_heights[peep->current_ride_station];
+        TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+        Guard::Assert(entranceLocation.x != LOCATION_NULL);
+        x = entranceLocation.x;
+        y = entranceLocation.y;
 
-        rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
-
-        uint8 direction_entrance = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
+        uint8 direction_entrance = entranceLocation.direction;
 
         if (ride->type == RIDE_TYPE_MAZE)
         {
@@ -2952,7 +2950,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
         x = ride->station_starts[peep->current_ride_station].x;
         y = ride->station_starts[peep->current_ride_station].y;
 
-        tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
+        rct_tile_element * tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
 
         uint8 direction_track = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
 
@@ -2993,18 +2991,13 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
 
     if (vehicle_type->flags & VEHICLE_ENTRY_FLAG_26)
     {
-        x = ride->entrances[peep->current_ride_station].x;
-        y = ride->entrances[peep->current_ride_station].y;
-        z = ride->station_heights[peep->current_ride_station];
-
-        rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
-
-        uint8 direction_entrance = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
+        TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+        uint8 direction_entrance = entranceLocation.direction;
 
         x = ride->station_starts[peep->current_ride_station].x;
         y = ride->station_starts[peep->current_ride_station].y;
 
-        tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
+        rct_tile_element * tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
 
         uint8 direction_track = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
 
@@ -3209,19 +3202,12 @@ static void peep_update_ride_sub_state_2_enter_ride(rct_peep * peep, Ride * ride
  */
 static void peep_update_ride_sub_state_2_rejoin_queue(rct_peep * peep, Ride * ride)
 {
-    sint16 x, y, z;
-    x = ride->entrances[peep->current_ride_station].x;
-    y = ride->entrances[peep->current_ride_station].y;
-    z = ride->station_heights[peep->current_ride_station];
+    TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
 
-    rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
-
-    uint8 direction_entrance = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
-
-    x *= 32;
-    y *= 32;
-    x += 16 - word_981D6C[direction_entrance].x * 20;
-    y += 16 - word_981D6C[direction_entrance].y * 20;
+    sint32 x = entranceLocation.x * 32;
+    sint32 y = entranceLocation.y * 32;
+    x += 16 - word_981D6C[entranceLocation.direction].x * 20;
+    y += 16 - word_981D6C[entranceLocation.direction].y * 20;
 
     peep->destination_x         = x;
     peep->destination_y         = y;
@@ -3448,15 +3434,12 @@ static void peep_update_ride_sub_state_7(rct_peep * peep)
 
     if (!(vehicle_entry->flags & VEHICLE_ENTRY_FLAG_26))
     {
-        sint16 x, y, z;
         assert(peep->current_ride_station < MAX_STATIONS);
-        x = ride->exits[peep->current_ride_station].x;
-        y = ride->exits[peep->current_ride_station].y;
-        z = ride->station_heights[peep->current_ride_station];
+        TileCoordsXYZD exitLocation = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+        sint32 x, y;
+        sint32 z = ride->station_heights[peep->current_ride_station];
 
-        rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
-
-        uint8 exit_direction = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
+        uint8 exit_direction = exitLocation.direction;
         exit_direction ^= (1 << 1);
 
         if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_16))
@@ -3544,19 +3527,16 @@ static void peep_update_ride_sub_state_7(rct_peep * peep)
         return;
     }
 
-    sint16 x, y, z;
-    x = ride->exits[peep->current_ride_station].x;
-    y = ride->exits[peep->current_ride_station].y;
-    z = ride->station_heights[peep->current_ride_station];
+    TileCoordsXYZD exitLocation = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+    Guard::Assert(exitLocation.x != LOCATION_NULL);
+    sint16 z = (sint16)exitLocation.z;
 
-    rct_tile_element * tile_element = ride_get_station_exit_element(ride, x, y, z);
+    uint8 exit_direction = exitLocation.direction;
 
-    uint8 exit_direction = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
+    sint16 x = ride->station_starts[peep->current_ride_station].x;
+    sint16 y = ride->station_starts[peep->current_ride_station].y;
 
-    x = ride->station_starts[peep->current_ride_station].x;
-    y = ride->station_starts[peep->current_ride_station].y;
-
-    tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
+    rct_tile_element * tile_element = ride_get_station_start_track_element(ride, peep->current_ride_station);
 
     uint8 station_direction = (tile_element == nullptr ? 0 : tile_element_get_direction(tile_element));
 

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -377,3 +377,55 @@ sint8 ride_get_first_empty_station_start(const Ride * ride)
     }
     return -1;
 }
+
+static TileCoordsXYZD ride_get_entrance_or_exit_location_of_station(
+        const uint8 rideIndex,
+        const uint8 stationIndex,
+        const uint8 entranceType)
+{
+    const Ride * ride = get_ride(rideIndex);
+    LocationXY8 tileLocation = {};
+
+    if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE)
+    {
+        tileLocation = ride->entrances[stationIndex];
+    }
+    else
+    {
+        tileLocation = ride->exits[stationIndex];
+    }
+
+    rct_tile_element * tileElement = map_get_first_element_at(tileLocation.x, tileLocation.y);
+    TileCoordsXYZD retVal = { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL, 0 };
+
+    if (tileElement != nullptr && tileLocation.xy != RCT_XY8_UNDEFINED)
+    {
+        do
+        {
+            if (tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_ENTRANCE)
+                continue;
+            if (entrance_element_get_type(tileElement) != entranceType)
+                continue;
+            if (tile_element_get_ride_index(tileElement) != rideIndex)
+                continue;
+            if (tile_element_get_station(tileElement) != stationIndex)
+                continue;
+
+            retVal = { tileLocation.x, tileLocation.y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) };
+            break;
+        }
+        while (!tile_element_is_last_for_tile(tileElement++));
+    }
+
+    return retVal;
+}
+
+TileCoordsXYZD ride_get_entrance_location_of_station(const uint8 rideIndex, const uint8 stationIndex)
+{
+    return ride_get_entrance_or_exit_location_of_station(rideIndex, stationIndex, ENTRANCE_TYPE_RIDE_ENTRANCE);
+}
+
+TileCoordsXYZD ride_get_exit_location_of_station(const uint8 rideIndex, const uint8 stationIndex)
+{
+    return ride_get_entrance_or_exit_location_of_station(rideIndex, stationIndex, ENTRANCE_TYPE_RIDE_EXIT);
+}

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -395,8 +395,15 @@ static TileCoordsXYZD ride_get_entrance_or_exit_location_of_station(
         tileLocation = ride->exits[stationIndex];
     }
 
+    // Normally, a station has at most one entrance and one exit, which are at the same height
+    // as the station. But in hacked parks, neither can be taken for granted. Import code ensures
+    // that the ride->entrances and ride->exits arrays will point to one of them. There is, however,
+    // an ever-so-slight chance two entrances/exits for the same station reside on the same tile.
+    // In cases like this, the one at station height will be considered the "true" one.
+    // If none exists at that height, newer ones take precedence.
     rct_tile_element * tileElement = map_get_first_element_at(tileLocation.x, tileLocation.y);
     TileCoordsXYZD retVal = { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL, 0 };
+    const uint8 expectedHeight = ride->station_heights[stationIndex];
 
     if (tileElement != nullptr && tileLocation.xy != RCT_XY8_UNDEFINED)
     {
@@ -412,7 +419,8 @@ static TileCoordsXYZD ride_get_entrance_or_exit_location_of_station(
                 continue;
 
             retVal = { tileLocation.x, tileLocation.y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) };
-            break;
+            if (tileElement->base_height == expectedHeight)
+                break;
         }
         while (!tile_element_is_last_for_tile(tileElement++));
     }

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -25,3 +25,6 @@ sint8 ride_get_first_valid_station_exit(Ride * ride);
 sint8 ride_get_first_valid_station_start(const Ride * ride);
 sint8 ride_get_first_empty_station_start(const Ride * ride);
 
+TileCoordsXYZD ride_get_entrance_location_of_station(const uint8 rideIndex, const uint8 stationIndex);
+TileCoordsXYZD ride_get_exit_location_of_station(const uint8 rideIndex, const uint8 stationIndex);
+

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -4919,3 +4919,8 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
         update_park_fences_around_tile((*tile).x * 32, (*tile).y * 32);
     }
 }
+
+uint8 entrance_element_get_type(const rct_tile_element * tileElement)
+{
+    return (tileElement->properties.entrance.type);
+}

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -582,4 +582,6 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
 
 bool place_peep_spawn(CoordsXYZD location);
 
+uint8 entrance_element_get_type(const rct_tile_element * tileElement);
+
 #endif


### PR DESCRIPTION
This is a step in implementing #7095 and supporting parks with hacked entrances/exits better. Most notably, this will fix the mechanic exit lookup.

I put some asserts in places that would previously silently continue. I did that because I prefer a hard fail over continuing with incorrect data and causing far more subtle pathfinding bugs later on. If a park hits this, it's most likely hacked and should be fixed on import.

Tagging @zaxcav in order to be sure.