### PR TITLE
Make network version a variable to reduce recompilations

### DIFF
--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -405,8 +405,9 @@ static void window_server_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_draw_widgets(w, dpi);
 
     gfx_draw_string_left(dpi, STR_PLAYER_NAME, nullptr, COLOUR_WHITE, w->x + 6, w->y + w->widgets[WIDX_PLAYER_NAME_INPUT].top);
-    const char * version = NETWORK_STREAM_ID;
-    gfx_draw_string_left(dpi, STR_NETWORK_VERSION, (void*)&version, COLOUR_WHITE, w->x + 324, w->y + w->widgets[WIDX_START_SERVER].top);
+    std::string version = network_get_version();
+    const char * versionCStr = version.c_str();
+    gfx_draw_string_left(dpi, STR_NETWORK_VERSION, (void*)&versionCStr, COLOUR_WHITE, w->x + 324, w->y + w->widgets[WIDX_START_SERVER].top);
 
     gfx_draw_string_left(dpi, status_text, (void *)&_numPlayersOnline, COLOUR_WHITE, w->x + 8, w->y + w->height - 15);
 }
@@ -458,7 +459,7 @@ static void window_server_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi
             compatibilitySpriteId = SPR_G2_RCT1_CLOSE_BUTTON_0;
         } else {
             // Server online... check version
-            bool correctVersion = serverDetails->version == NETWORK_STREAM_ID;
+            bool correctVersion = serverDetails->version == network_get_version();
             compatibilitySpriteId = correctVersion ? SPR_G2_RCT1_OPEN_BUTTON_2 : SPR_G2_RCT1_CLOSE_BUTTON_2;
         }
         gfx_draw_sprite(dpi, compatibilitySpriteId, right, y + 1, 0);
@@ -552,8 +553,8 @@ static bool server_compare(const server_entry &a, const server_entry &b)
     }
 
     // Then by version
-    bool serverACompatible = a.version == NETWORK_STREAM_ID;
-    bool serverBCompatible = b.version == NETWORK_STREAM_ID;
+    bool serverACompatible = a.version == network_get_version();
+    bool serverBCompatible = b.version == network_get_version();
     if (serverACompatible != serverBCompatible)
     {
         return serverACompatible;
@@ -733,5 +734,5 @@ static void fetch_servers_callback(http_response_t* response)
 
 static bool is_version_valid(const std::string &version)
 {
-    return version.empty() || version == NETWORK_STREAM_ID;
+    return version.empty() || version == network_get_version();
 }

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -47,12 +47,6 @@ struct GameAction;
 
 #ifndef DISABLE_NETWORK
 
-// This define specifies which version of network stream current build uses.
-// It is used for making sure only compatible builds get connected, even within
-// single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "33"
-#define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
-
 #include <array>
 #include <list>
 #include <set>
@@ -293,8 +287,6 @@ private:
     std::ofstream _server_log_fs;
 };
 
-#else /* DISABLE_NETWORK */
-#define NETWORK_STREAM_ID "Multiplayer disabled"
 #endif /* DISABLE_NETWORK */
 
 void network_set_env(void * env);
@@ -365,3 +357,5 @@ const utf8 * network_get_server_greeting();
 const utf8 * network_get_server_provider_name();
 const utf8 * network_get_server_provider_email();
 const utf8 * network_get_server_provider_website();
+
+std::string network_get_version();


### PR DESCRIPTION
Touching `network.h` requires whole lot of needless recompilation, moving network version to the implementation make changing the network version one file compilation and relinking.