### PR TITLE
Fix pending breakdown interfering with mechanic heading to inspection

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -4706,8 +4706,8 @@ static void peep_update_fixing(sint32 steps, rct_peep * peep)
     if ((peep->state == PEEP_STATE_INSPECTING) &&
         (ride->lifecycle_flags & ( RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
     {
-	// Ride has broken down since Mechanic was called to inspect it.
-	// Mechanic identifies the breakdown and switches to fixing it.
+        // Ride has broken down since Mechanic was called to inspect it.
+        // Mechanic identifies the breakdown and switches to fixing it.
         peep->state     = PEEP_STATE_FIXING;
     }
 
@@ -5292,7 +5292,7 @@ static bool peep_update_fixing_finish_fix_or_inspect(bool firstRun, sint32 steps
 
     if (!firstRun)
     {
-	ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
+        ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
 
         if (peep->state == PEEP_STATE_INSPECTING)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2444,11 +2444,9 @@ void ride_prepare_breakdown(sint32 rideIndex, sint32 breakdownReason)
     if (ride->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
         return;
 
-    ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
     ride->lifecycle_flags |= RIDE_LIFECYCLE_BREAKDOWN_PENDING;
 
     ride->breakdown_reason_pending = breakdownReason;
-    ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
     ride->breakdown_sound_modifier = 0;
     ride->not_fixed_timeout = 0;
 
@@ -2565,8 +2563,14 @@ static void ride_mechanic_status_update(sint32 rideIndex, sint32 mechanicStatus)
     rct_peep *mechanic;
 
     ride = get_ride(rideIndex);
-    switch (mechanicStatus) {
-    case RIDE_MECHANIC_STATUS_UNDEFINED:
+
+    // Turn a pending breakdown into a breakdown.
+    if ((mechanicStatus == RIDE_MECHANIC_STATUS_UNDEFINED ||
+        mechanicStatus == RIDE_MECHANIC_STATUS_CALLING ||
+        mechanicStatus == RIDE_MECHANIC_STATUS_HEADING) &&
+	(ride->lifecycle_flags & RIDE_LIFECYCLE_BREAKDOWN_PENDING) &&
+	!(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
+    {
         breakdownReason = ride->breakdown_reason_pending;
         if (
             breakdownReason == BREAKDOWN_SAFETY_CUT_OUT ||
@@ -2575,9 +2579,15 @@ static void ride_mechanic_status_update(sint32 rideIndex, sint32 mechanicStatus)
         ) {
             ride->lifecycle_flags |= RIDE_LIFECYCLE_BROKEN_DOWN;
             ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE | RIDE_INVALIDATE_RIDE_LIST | RIDE_INVALIDATE_RIDE_MAIN;
-            ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
             ride->breakdown_reason = breakdownReason;
             ride_breakdown_add_news_item(rideIndex);
+        }
+    }
+    switch (mechanicStatus) {
+    case RIDE_MECHANIC_STATUS_UNDEFINED:
+	if (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
+        {
+            ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
         }
         break;
     case RIDE_MECHANIC_STATUS_CALLING:

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2568,8 +2568,8 @@ static void ride_mechanic_status_update(sint32 rideIndex, sint32 mechanicStatus)
     if ((mechanicStatus == RIDE_MECHANIC_STATUS_UNDEFINED ||
         mechanicStatus == RIDE_MECHANIC_STATUS_CALLING ||
         mechanicStatus == RIDE_MECHANIC_STATUS_HEADING) &&
-	(ride->lifecycle_flags & RIDE_LIFECYCLE_BREAKDOWN_PENDING) &&
-	!(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        (ride->lifecycle_flags & RIDE_LIFECYCLE_BREAKDOWN_PENDING) &&
+        !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
     {
         breakdownReason = ride->breakdown_reason_pending;
         if (
@@ -2585,7 +2585,7 @@ static void ride_mechanic_status_update(sint32 rideIndex, sint32 mechanicStatus)
     }
     switch (mechanicStatus) {
     case RIDE_MECHANIC_STATUS_UNDEFINED:
-	if (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
+        if (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
         {
             ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
         }


### PR DESCRIPTION
If, when a mechanic is heading to inspect a ride, a ride breakdown is prepared, the ride lifecycle_flags for the inspection are removed and the ride mechanic_status is reset, resulting in the mechanic being "reset" when he arrives at the exit station.  The mechanic is reset by setting the peep state to falling. When the exit station is over water, the mechanic will drown. This appears to be be main cause of falling/drowning mechanics in #7176.

Revise peep behaviour so a ride breakdown does not interfere with mechanics already heading to inspect the ride. A mechanic inspecting a broken down ride will change from inspecting to fixing the ride.

Rename 'loc_992A18' to 'peep_fixing_sub_state_mask' and comment the various fixing sub_states accordingly.