### PR TITLE
Compress debug sections on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
           services:
             - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DPORTABLE=ON -DDISABLE_RCT2_TESTS=on" TARGET=ubuntu_amd64
+            - OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DPORTABLE=ON -DDISABLE_RCT2_TESTS=on -DCMAKE_CXX_FLAGS=-Wl,--compress-debug-sections=zlib" TARGET=ubuntu_amd64
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             # Android jobs are triggered from cron and overwrite `after_sucess` part
@@ -47,7 +47,7 @@ matrix:
           services:
             - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-G Ninja -DFORCE32=ON -DBUILD_SHARED_LIBS=off -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DDISABLE_RCT2_TESTS=on" TARGET=ubuntu_i686
+            - OPENRCT2_CMAKE_OPTS="-G Ninja -DFORCE32=ON -DBUILD_SHARED_LIBS=off -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DDISABLE_RCT2_TESTS=on -DCMAKE_CXX_FLAGS=-Wl,--compress-debug-sections=zlib" TARGET=ubuntu_i686
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             # Android jobs are triggered from cron and overwrite `after_sucess` part


### PR DESCRIPTION
Pass linker option to compress debug sections. Only enable this for
Travis, as spending additional cycles on it in development would not be
desirable.

This uses GCC's pass-through to linker instead of what should really be
`-gz` because of Ubuntu's outdated versions.

This (partially) addresses
https://github.com/OpenRCT2/OpenRCT2/issues/6232.