### PR TITLE
Refactor ride->entrances and ride->exits

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -702,7 +702,6 @@
 		4C7B54282007646A00A52E21 /* Fountain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fountain.h; sourceTree = "<group>"; };
 		4C7B54292007646A00A52E21 /* LargeScenery.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LargeScenery.cpp; sourceTree = "<group>"; };
 		4C7B542A2007646A00A52E21 /* LargeScenery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LargeScenery.h; sourceTree = "<group>"; };
-		4C7B542B2007646A00A52E21 /* Location.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Location.h; sourceTree = "<group>"; };
 		4C7B542C2007646A00A52E21 /* Map.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Map.cpp; sourceTree = "<group>"; };
 		4C7B542D2007646A00A52E21 /* Map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Map.h; sourceTree = "<group>"; };
 		4C7B542E2007646A00A52E21 /* MapAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MapAnimation.cpp; sourceTree = "<group>"; };
@@ -738,6 +737,7 @@
 		4C8B426E1EEB1ABD00F015CA /* X8DrawingEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = X8DrawingEngine.cpp; sourceTree = "<group>"; };
 		4C8B426F1EEB1ABD00F015CA /* X8DrawingEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = X8DrawingEngine.h; sourceTree = "<group>"; };
 		4C8B42711EEB1AE400F015CA /* HardwareDisplayDrawingEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HardwareDisplayDrawingEngine.cpp; sourceTree = "<group>"; };
+		4C9196ED204FF3E000869A24 /* Location.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Location.hpp; sourceTree = "<group>"; };
 		4C93F1181F8B744400A9330D /* AirPoweredVerticalCoaster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AirPoweredVerticalCoaster.cpp; sourceTree = "<group>"; };
 		4C93F1191F8B744400A9330D /* BobsleighCoaster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BobsleighCoaster.cpp; sourceTree = "<group>"; };
 		4C93F11A1F8B744400A9330D /* BolligerMabillardTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BolligerMabillardTrack.h; sourceTree = "<group>"; };
@@ -2444,7 +2444,7 @@
 				4C7B54282007646A00A52E21 /* Fountain.h */,
 				4C7B54292007646A00A52E21 /* LargeScenery.cpp */,
 				4C7B542A2007646A00A52E21 /* LargeScenery.h */,
-				4C7B542B2007646A00A52E21 /* Location.h */,
+				4C9196ED204FF3E000869A24 /* Location.hpp */,
 				4C7B542C2007646A00A52E21 /* Map.cpp */,
 				4C7B542D2007646A00A52E21 /* Map.h */,
 				4C7B542E2007646A00A52E21 /* MapAnimation.cpp */,
@@ -2983,7 +2983,6 @@
 				C68313C81FDB4ED4006DB3D8 /* MouseInput.cpp in Sources */,
 				C68878C920289B710084B384 /* TextureCache.cpp in Sources */,
 				C61ADB1F1FB6A0A70024F2EF /* TopToolbar.cpp in Sources */,
-				F7C44AF72030E74B007E099F /* AVX2Drawing.cpp in Sources */,
 				F76C887B1EC5324E00FA49E2 /* FileAudioSource.cpp in Sources */,
 				C68878CA20289B710084B384 /* TransparencyDepth.cpp in Sources */,
 				C64644FD1F3FA4120026AC2D /* Land.cpp in Sources */,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2536,12 +2536,12 @@ static rct_string_id window_ride_get_status_station(rct_window *w, void *argumen
 
     // Entrance / exit
     if (ride->status == RIDE_STATUS_CLOSED) {
-        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
+        if (ride_get_entrance_location((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_NO_ENTRANCE;
-        else if (ride_get_exit_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
+        else if (ride_get_exit_location((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_NO_EXIT;
     } else {
-        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
+        if (ride_get_entrance_location((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_EXIT_ONLY;
     }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -45,6 +45,7 @@
 #include <openrct2/sprites.h>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2/windows/Intent.h>
+#include <openrct2/ride/Station.h>
 
 enum {
     WINDOW_RIDE_PAGE_MAIN,
@@ -2535,12 +2536,12 @@ static rct_string_id window_ride_get_status_station(rct_window *w, void *argumen
 
     // Entrance / exit
     if (ride->status == RIDE_STATUS_CLOSED) {
-        if (ride->entrances[stationIndex].xy == RCT_XY8_UNDEFINED)
+        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
             stringId = STR_NO_ENTRANCE;
-        else if (ride->exits[stationIndex].xy == RCT_XY8_UNDEFINED)
+        else if (ride_get_exit_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
             stringId = STR_NO_EXIT;
     } else {
-        if (ride->entrances[stationIndex].xy == RCT_XY8_UNDEFINED)
+        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
             stringId = STR_EXIT_ONLY;
     }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2536,12 +2536,12 @@ static rct_string_id window_ride_get_status_station(rct_window *w, void *argumen
 
     // Entrance / exit
     if (ride->status == RIDE_STATUS_CLOSED) {
-        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_NO_ENTRANCE;
-        else if (ride_get_exit_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
+        else if (ride_get_exit_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_NO_EXIT;
     } else {
-        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station((uint8)w->number, (uint8)stationIndex).isNull())
             stringId = STR_EXIT_ONLY;
     }
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1296,9 +1296,6 @@ void game_fix_save_vars()
 
     // Fix gParkEntrance locations for which the tile_element no longer exists
     fix_park_entrance_locations();
-
-    // Fix ride entrances and exits that were moved without updating ride->entrances[] / ride->exits[]
-    fix_ride_entrance_and_exit_locations();
 }
 
 void handle_park_load_failure_with_title_opt(const ParkLoadResult * result, const std::string & path, bool loadTitleFirst)

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -148,8 +148,8 @@ public:
         for (sint32 i = 0; i < MAX_STATIONS; i++)
         {
             ride->station_starts[i].xy = RCT_XY8_UNDEFINED;
-            ride_clear_entrance_location_of_station(ride, i);
-            ride_clear_exit_location_of_station(ride, i);
+            ride_clear_entrance_location(ride, i);
+            ride_clear_exit_location(ride, i);
             ride->train_at_station[i] = 255;
             ride->queue_time[i] = 0;
         }

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -148,8 +148,8 @@ public:
         for (size_t i = 0; i < MAX_STATIONS; i++)
         {
             ride->station_starts[i].xy = RCT_XY8_UNDEFINED;
-            ride->entrances[i].xy = RCT_XY8_UNDEFINED;
-            ride->exits[i].xy = RCT_XY8_UNDEFINED;
+            ride_clear_entrance_location_of_station(ride, i);
+            ride_clear_exit_location_of_station(ride, i);
             ride->train_at_station[i] = 255;
             ride->queue_time[i] = 0;
         }

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -145,7 +145,7 @@ public:
             ride_set_name_to_default(ride, rideEntry);
         }
 
-        for (size_t i = 0; i < MAX_STATIONS; i++)
+        for (sint32 i = 0; i < MAX_STATIONS; i++)
         {
             ride->station_starts[i].xy = RCT_XY8_UNDEFINED;
             ride_clear_entrance_location_of_station(ride, i);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "36"
+#define NETWORK_STREAM_VERSION "37"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2683,7 +2683,8 @@ static void peep_update_ride_sub_state_0(rct_peep * peep)
             sint16 z = peep->z;
             if (xy_distance < 16)
             {
-                z = ride->station_heights[peep->current_ride_station] * 8 + 2;
+                auto entrance = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
+                z = entrance.z * 8 + 2;
             }
             sprite_move(x, y, z, (rct_sprite *)peep);
             invalidate_sprite_2((rct_sprite *)peep);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2617,7 +2617,7 @@ static void peep_choose_seat_from_car(rct_peep * peep, Ride * ride, rct_vehicle 
  */
 static void peep_go_to_ride_entrance(rct_peep * peep, Ride * ride)
 {
-    TileCoordsXYZD location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+    TileCoordsXYZD location = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
     Guard::Assert(!location.isNull());
     sint32 x = location.x;
     sint32 y = location.y;
@@ -2683,7 +2683,7 @@ static void peep_update_ride_sub_state_0(rct_peep * peep)
             sint16 z = peep->z;
             if (xy_distance < 16)
             {
-                auto entrance = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
+                auto entrance = ride_get_entrance_location(ride, peep->current_ride_station);
                 z = entrance.z * 8 + 2;
             }
             sprite_move(x, y, z, (rct_sprite *)peep);
@@ -2907,7 +2907,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_NO_VEHICLES))
     {
-        TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+        TileCoordsXYZD entranceLocation = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
         Guard::Assert(!entranceLocation.isNull());
         x = entranceLocation.x;
         y = entranceLocation.y;
@@ -2992,7 +2992,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
 
     if (vehicle_type->flags & VEHICLE_ENTRY_FLAG_26)
     {
-        TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+        TileCoordsXYZD entranceLocation = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
         uint8 direction_entrance = entranceLocation.direction;
 
         x = ride->station_starts[peep->current_ride_station].x;
@@ -3096,7 +3096,7 @@ static void peep_go_to_ride_exit(rct_peep * peep, Ride * ride, sint16 x, sint16 
     invalidate_sprite_2((rct_sprite *)peep);
 
     Guard::Assert(peep->current_ride_station < MAX_STATIONS);
-    auto exit = ride_get_exit_location_of_station(ride, peep->current_ride_station);
+    auto exit = ride_get_exit_location(ride, peep->current_ride_station);
     Guard::Assert(!exit.isNull());
     x = exit.x;
     y = exit.y;
@@ -3205,7 +3205,7 @@ static void peep_update_ride_sub_state_2_enter_ride(rct_peep * peep, Ride * ride
  */
 static void peep_update_ride_sub_state_2_rejoin_queue(rct_peep * peep, Ride * ride)
 {
-    TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+    TileCoordsXYZD entranceLocation = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
 
     sint32 x = entranceLocation.x * 32;
     sint32 y = entranceLocation.y * 32;
@@ -3438,7 +3438,7 @@ static void peep_update_ride_sub_state_7(rct_peep * peep)
     if (!(vehicle_entry->flags & VEHICLE_ENTRY_FLAG_26))
     {
         assert(peep->current_ride_station < MAX_STATIONS);
-        TileCoordsXYZD exitLocation = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+        TileCoordsXYZD exitLocation = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
         sint32 x, y;
         sint32 z = ride->station_heights[peep->current_ride_station];
 
@@ -3530,7 +3530,7 @@ static void peep_update_ride_sub_state_7(rct_peep * peep)
         return;
     }
 
-    TileCoordsXYZD exitLocation = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+    TileCoordsXYZD exitLocation = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
     Guard::Assert(!exitLocation.isNull());
     sint16 z = (sint16)exitLocation.z;
 
@@ -3606,7 +3606,7 @@ static void peep_update_ride_prepare_for_state_9(rct_peep * peep)
     Ride * ride = get_ride(peep->current_ride);
 
     Guard::Assert(peep->current_ride_station < Util::CountOf(ride->exits), GUARD_LINE);
-    auto exit = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+    auto exit = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
     sint16 x = exit.x;
     sint16 y = exit.y;
     uint8 exit_direction = exit.direction;
@@ -3850,7 +3850,7 @@ static void peep_update_ride_sub_state_13(rct_peep * peep)
 
     peep->var_37 |= 3;
 
-    auto exit = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+    auto exit = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
     x = exit.x;
     y = exit.y;
     uint8 exit_direction = exit.direction ^ 2;
@@ -3923,7 +3923,7 @@ static void peep_update_ride_sub_state_14(rct_peep * peep)
 
         if (last_ride)
         {
-            auto exit = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+            auto exit = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
             uint8 exit_direction = exit.direction;
 
             peep->var_37 = (exit_direction * 4) | (peep->var_37 & 0x30) | 1;
@@ -4117,7 +4117,7 @@ static void peep_update_ride_sub_state_16(rct_peep * peep)
 
     peep->var_37 |= 3;
 
-    auto exit = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+    auto exit = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
     x         = exit.x;
     y         = exit.y;
 
@@ -5110,10 +5110,10 @@ static bool peep_update_fixing_sub_state_12(bool firstRun, rct_peep * peep, Ride
 
     if (!firstRun)
     {
-        TileCoordsXYZD stationPosition = ride_get_exit_location_of_station(ride, peep->current_ride_station);
+        TileCoordsXYZD stationPosition = ride_get_exit_location(ride, peep->current_ride_station);
         if (stationPosition.isNull())
         {
-            stationPosition = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
+            stationPosition = ride_get_entrance_location(ride, peep->current_ride_station);
 
             if (stationPosition.isNull())
             {
@@ -5202,10 +5202,10 @@ static bool peep_update_fixing_sub_state_14(bool firstRun, rct_peep * peep, Ride
 
     if (!firstRun)
     {
-        TileCoordsXYZD exitPosition = ride_get_exit_location_of_station(ride, peep->current_ride_station);
+        TileCoordsXYZD exitPosition = ride_get_exit_location(ride, peep->current_ride_station);
         if (exitPosition.isNull())
         {
-            exitPosition = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
+            exitPosition = ride_get_entrance_location(ride, peep->current_ride_station);
 
             if (exitPosition.isNull())
             {
@@ -6492,7 +6492,7 @@ static void peep_update_heading_to_inspect(rct_peep * peep)
         return;
     }
 
-    if (ride_get_exit_location_of_station(ride, peep->current_ride_station).isNull())
+    if (ride_get_exit_location(ride, peep->current_ride_station).isNull())
     {
         ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
         peep_decrement_num_riders(peep);
@@ -6553,7 +6553,7 @@ static void peep_update_heading_to_inspect(rct_peep * peep)
 
         if (_unk_F1EE18 & F1EE18_RIDE_ENTRANCE)
         {
-            if (!ride_get_exit_location_of_station(ride, exit_index).isNull())
+            if (!ride_get_exit_location(ride, exit_index).isNull())
             {
                 return;
             }
@@ -6679,7 +6679,7 @@ static void peep_update_answering(rct_peep * peep)
 
         if (_unk_F1EE18 & F1EE18_RIDE_ENTRANCE)
         {
-            if (!ride_get_exit_location_of_station(ride, exit_index).isNull())
+            if (!ride_get_exit_location(ride, exit_index).isNull())
             {
                 return;
             }
@@ -11432,13 +11432,13 @@ static sint32 guest_path_finding(rct_peep * peep)
     for (uint8 stationNum = 0; stationNum < MAX_STATIONS; ++stationNum)
     {
         // Skip if stationNum has no entrance (so presumably an exit only station)
-        if (ride_get_entrance_location_of_station(rideIndex, stationNum).isNull())
+        if (ride_get_entrance_location(rideIndex, stationNum).isNull())
             continue;
 
         numEntranceStations++;
         entranceStations |= (1 << stationNum);
 
-        TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(rideIndex, stationNum);
+        TileCoordsXYZD entranceLocation = ride_get_entrance_location(rideIndex, stationNum);
 
         sint16 stationX = (sint16)(entranceLocation.x * 32);
         sint16 stationY = (sint16)(entranceLocation.y * 32);
@@ -11488,7 +11488,7 @@ static sint32 guest_path_finding(rct_peep * peep)
     }
     else
     {
-        TileCoordsXYZD entranceXYZD = ride_get_entrance_location_of_station(rideIndex, closestStationNum);
+        TileCoordsXYZD entranceXYZD = ride_get_entrance_location(rideIndex, closestStationNum);
         x = entranceXYZD.x * 32;
         y = entranceXYZD.y * 32;
         z = entranceXYZD.z;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2618,7 +2618,7 @@ static void peep_choose_seat_from_car(rct_peep * peep, Ride * ride, rct_vehicle 
 static void peep_go_to_ride_entrance(rct_peep * peep, Ride * ride)
 {
     TileCoordsXYZD location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
-    Guard::Assert(location.x != LOCATION_NULL);
+    Guard::Assert(!location.isNull());
     sint32 x = location.x;
     sint32 y = location.y;
 
@@ -2907,7 +2907,7 @@ static void peep_update_ride_sub_state_1(rct_peep * peep)
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_NO_VEHICLES))
     {
         TileCoordsXYZD entranceLocation = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
-        Guard::Assert(entranceLocation.x != LOCATION_NULL);
+        Guard::Assert(!entranceLocation.isNull());
         x = entranceLocation.x;
         y = entranceLocation.y;
 
@@ -3094,9 +3094,9 @@ static void peep_go_to_ride_exit(rct_peep * peep, Ride * ride, sint16 x, sint16 
     sprite_move(x, y, z, (rct_sprite *)peep);
     invalidate_sprite_2((rct_sprite *)peep);
 
-    assert(peep->current_ride_station < MAX_STATIONS);
+    Guard::Assert(peep->current_ride_station < MAX_STATIONS);
     auto exit = ride_get_exit_location_of_station(ride, peep->current_ride_station);
-    assert(exit.x != LOCATION_NULL);
+    Guard::Assert(!exit.isNull());
     x = exit.x;
     y = exit.y;
     x *= 32;
@@ -3530,7 +3530,7 @@ static void peep_update_ride_sub_state_7(rct_peep * peep)
     }
 
     TileCoordsXYZD exitLocation = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
-    Guard::Assert(exitLocation.x != LOCATION_NULL);
+    Guard::Assert(!exitLocation.isNull());
     sint16 z = (sint16)exitLocation.z;
 
     uint8 exit_direction = exitLocation.direction;
@@ -5110,11 +5110,11 @@ static bool peep_update_fixing_sub_state_12(bool firstRun, rct_peep * peep, Ride
     if (!firstRun)
     {
         TileCoordsXYZD stationPosition = ride_get_exit_location_of_station(ride, peep->current_ride_station);
-        if (stationPosition.x == LOCATION_NULL)
+        if (stationPosition.isNull())
         {
             stationPosition = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
 
-            if (stationPosition.x == LOCATION_NULL)
+            if (stationPosition.isNull())
             {
                 return true;
             }
@@ -5202,11 +5202,11 @@ static bool peep_update_fixing_sub_state_14(bool firstRun, rct_peep * peep, Ride
     if (!firstRun)
     {
         TileCoordsXYZD exitPosition = ride_get_exit_location_of_station(ride, peep->current_ride_station);
-        if (exitPosition.x == LOCATION_NULL)
+        if (exitPosition.isNull())
         {
             exitPosition = ride_get_entrance_location_of_station(ride, peep->current_ride_station);
 
-            if (exitPosition.x == LOCATION_NULL)
+            if (exitPosition.isNull())
             {
                 peep_decrement_num_riders(peep);
                 peep->state = 0;
@@ -6491,7 +6491,7 @@ static void peep_update_heading_to_inspect(rct_peep * peep)
         return;
     }
 
-    if (ride_get_exit_location_of_station(ride, peep->current_ride_station).x == LOCATION_NULL)
+    if (ride_get_exit_location_of_station(ride, peep->current_ride_station).isNull())
     {
         ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
         peep_decrement_num_riders(peep);
@@ -6552,7 +6552,7 @@ static void peep_update_heading_to_inspect(rct_peep * peep)
 
         if (_unk_F1EE18 & F1EE18_RIDE_ENTRANCE)
         {
-            if (ride_get_exit_location_of_station(ride, exit_index).x != LOCATION_NULL)
+            if (!ride_get_exit_location_of_station(ride, exit_index).isNull())
             {
                 return;
             }
@@ -6678,7 +6678,7 @@ static void peep_update_answering(rct_peep * peep)
 
         if (_unk_F1EE18 & F1EE18_RIDE_ENTRANCE)
         {
-            if (ride_get_exit_location_of_station(ride, exit_index).x != LOCATION_NULL)
+            if (!ride_get_exit_location_of_station(ride, exit_index).isNull())
             {
                 return;
             }
@@ -11431,7 +11431,7 @@ static sint32 guest_path_finding(rct_peep * peep)
     for (uint8 stationNum = 0; stationNum < MAX_STATIONS; ++stationNum)
     {
         // Skip if stationNum has no entrance (so presumably an exit only station)
-        if (ride_get_entrance_location_of_station(rideIndex, stationNum).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(rideIndex, stationNum).isNull())
             continue;
 
         numEntranceStations++;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1210,7 +1210,7 @@ static uint8 staff_mechanic_direction_surface(rct_peep * peep)
     if ((peep->state == PEEP_STATE_ANSWERING || peep->state == PEEP_STATE_HEADING_TO_INSPECTION) && scenario_rand() & 1)
     {
         TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
-        if (location.x == LOCATION_NULL)
+        if (location.isNull())
         {
             location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
         }
@@ -1304,12 +1304,12 @@ static uint8 staff_mechanic_direction_path(rct_peep * peep, uint8 validDirection
         /* Find location of the exit for the target ride station
          * or if the ride has no exit, the entrance. */
         TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
-        if (location.x == LOCATION_NULL)
+        if (location.isNull())
         {
             location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
 
             // If no entrance is present either. This is an incorrect state.
-            if (location.x == LOCATION_NULL)
+            if (location.isNull())
             {
                 return staff_mechanic_direction_path_rand(peep, pathDirections);
             }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1209,13 +1209,10 @@ static uint8 staff_mechanic_direction_surface(rct_peep * peep)
 
     if ((peep->state == PEEP_STATE_ANSWERING || peep->state == PEEP_STATE_HEADING_TO_INSPECTION) && scenario_rand() & 1)
     {
-
-        Ride * ride = get_ride(peep->current_ride);
-
-        LocationXY8 location = ride->exits[peep->current_ride_station];
-        if (location.xy == RCT_XY8_UNDEFINED)
+        TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+        if (location.x == LOCATION_NULL)
         {
-            location = ride->entrances[peep->current_ride_station];
+            ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
         }
 
         LocationXY16 chosenTile = { static_cast<sint16>(location.x * 32), static_cast<sint16>(location.y * 32) };

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1212,7 +1212,7 @@ static uint8 staff_mechanic_direction_surface(rct_peep * peep)
         TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
         if (location.x == LOCATION_NULL)
         {
-            ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+            location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
         }
 
         LocationXY16 chosenTile = { static_cast<sint16>(location.x * 32), static_cast<sint16>(location.y * 32) };

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1209,10 +1209,10 @@ static uint8 staff_mechanic_direction_surface(rct_peep * peep)
 
     if ((peep->state == PEEP_STATE_ANSWERING || peep->state == PEEP_STATE_HEADING_TO_INSPECTION) && scenario_rand() & 1)
     {
-        TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+        TileCoordsXYZD location = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
         if (location.isNull())
         {
-            location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+            location = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
         }
 
         LocationXY16 chosenTile = { static_cast<sint16>(location.x * 32), static_cast<sint16>(location.y * 32) };
@@ -1303,10 +1303,10 @@ static uint8 staff_mechanic_direction_path(rct_peep * peep, uint8 validDirection
     {
         /* Find location of the exit for the target ride station
          * or if the ride has no exit, the entrance. */
-        TileCoordsXYZD location = ride_get_exit_location_of_station(peep->current_ride, peep->current_ride_station);
+        TileCoordsXYZD location = ride_get_exit_location(peep->current_ride, peep->current_ride_station);
         if (location.isNull())
         {
-            location = ride_get_entrance_location_of_station(peep->current_ride, peep->current_ride_station);
+            location = ride_get_entrance_location(peep->current_ride, peep->current_ride_station);
 
             // If no entrance is present either. This is an incorrect state.
             if (location.isNull())

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -792,8 +792,8 @@ private:
 
             dst->train_at_station[i] = src->station_depart[i];
 
-            dst->entrances[i] = src->entrance[i];
-            dst->exits[i] = src->exit[i];
+            ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2});
+            ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2});
             dst->queue_time[i] = src->queue_time[i];
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
             dst->queue_length[i] = src->num_peeps_in_queue[i];
@@ -806,8 +806,8 @@ private:
         {
             dst->station_starts[i].xy = RCT_XY8_UNDEFINED;
             dst->train_at_station[i] = 255;
-            dst->entrances[i].xy = RCT_XY8_UNDEFINED;
-            dst->exits[i].xy = RCT_XY8_UNDEFINED;
+            ride_clear_entrance_location_of_station(dst, i);
+            ride_clear_exit_location_of_station(dst, i);
             dst->last_peep_in_queue[i] = SPRITE_INDEX_NULL;
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -791,9 +791,9 @@ private:
             dst->station_depart[i] = src->station_light[i];
 
             dst->train_at_station[i] = src->station_depart[i];
-
-            ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2});
-            ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2});
+            // Direction is fixed later.
+            ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2, 0});
+            ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2, 0});
             dst->queue_time[i] = src->queue_time[i];
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
             dst->queue_length[i] = src->num_peeps_in_queue[i];

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -791,9 +791,18 @@ private:
             dst->station_depart[i] = src->station_light[i];
 
             dst->train_at_station[i] = src->station_depart[i];
+
             // Direction is fixed later.
-            ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2, 0});
-            ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2, 0});
+            if (src->entrance[i].xy == RCT_XY8_UNDEFINED)
+                ride_clear_entrance_location_of_station(dst, i);
+            else
+                ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2, 0});
+
+            if (src->exit[i].xy == RCT_XY8_UNDEFINED)
+                ride_clear_exit_location_of_station(dst, i);
+            else
+                ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2, 0});
+
             dst->queue_time[i] = src->queue_time[i];
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
             dst->queue_length[i] = src->num_peeps_in_queue[i];

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -234,6 +234,7 @@ public:
         ImportSavedView();
         FixLandOwnership();
         CountBlockSections();
+        determine_ride_entrance_and_exit_locations();
 
         // Importing the strings is done later on, although that approach needs looking at.
         //game_convert_strings_to_utf8();

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -795,14 +795,14 @@ private:
 
             // Direction is fixed later.
             if (src->entrance[i].xy == RCT_XY8_UNDEFINED)
-                ride_clear_entrance_location_of_station(dst, i);
+                ride_clear_entrance_location(dst, i);
             else
-                ride_set_entrance_location_of_station(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2, 0});
+                ride_set_entrance_location(dst, i, { src->entrance[i].x, src->entrance[i].y, src->station_height[i] / 2, 0});
 
             if (src->exit[i].xy == RCT_XY8_UNDEFINED)
-                ride_clear_exit_location_of_station(dst, i);
+                ride_clear_exit_location(dst, i);
             else
-                ride_set_exit_location_of_station(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2, 0});
+                ride_set_exit_location(dst, i, { src->exit[i].x, src->exit[i].y, src->station_height[i] / 2, 0});
 
             dst->queue_time[i] = src->queue_time[i];
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
@@ -816,8 +816,8 @@ private:
         {
             dst->station_starts[i].xy = RCT_XY8_UNDEFINED;
             dst->train_at_station[i] = 255;
-            ride_clear_entrance_location_of_station(dst, i);
-            ride_clear_exit_location_of_station(dst, i);
+            ride_clear_entrance_location(dst, i);
+            ride_clear_exit_location(dst, i);
             dst->last_peep_in_queue[i] = SPRITE_INDEX_NULL;
         }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -487,13 +487,13 @@ void S6Exporter::ExportRide(rct2_ride * dst, const Ride * src)
         dst->station_depart[i] = src->station_depart[i];
         dst->train_at_station[i] = src->train_at_station[i];
 
-        TileCoordsXYZD entrance = ride_get_entrance_location_of_station(src, i);
+        TileCoordsXYZD entrance = ride_get_entrance_location(src, i);
         if (entrance.isNull())
             dst->entrances[i].xy = RCT_XY8_UNDEFINED;
         else
             dst->entrances[i] = { (uint8)entrance.x, (uint8)entrance.y };
 
-        TileCoordsXYZD exit = ride_get_exit_location_of_station(src, i);
+        TileCoordsXYZD exit = ride_get_exit_location(src, i);
         if (exit.isNull())
             dst->exits[i].xy = RCT_XY8_UNDEFINED;
         else

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -52,6 +52,7 @@
 #include "../world/MapAnimation.h"
 #include "../world/Park.h"
 #include "../world/Sprite.h"
+#include "../ride/Station.h"
 
 S6Exporter::S6Exporter()
 {
@@ -485,8 +486,10 @@ void S6Exporter::ExportRide(rct2_ride * dst, const Ride * src)
         dst->station_length[i] = src->station_length[i];
         dst->station_depart[i] = src->station_depart[i];
         dst->train_at_station[i] = src->train_at_station[i];
-        dst->entrances[i] = src->entrances[i];
-        dst->exits[i] = src->exits[i];
+        TileCoordsXYZD entrance = ride_get_entrance_location_of_station(src, i);
+        TileCoordsXYZD exit = ride_get_exit_location_of_station(src, i);
+        dst->entrances[i] = { (uint8)entrance.x, (uint8)entrance.y };
+        dst->exits[i] = { (uint8)exit.x, (uint8)exit.y };
         dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
         dst->length[i] = src->length[i];

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -486,10 +486,19 @@ void S6Exporter::ExportRide(rct2_ride * dst, const Ride * src)
         dst->station_length[i] = src->station_length[i];
         dst->station_depart[i] = src->station_depart[i];
         dst->train_at_station[i] = src->train_at_station[i];
+
         TileCoordsXYZD entrance = ride_get_entrance_location_of_station(src, i);
+        if (entrance.isNull())
+            dst->entrances[i].xy = RCT_XY8_UNDEFINED;
+        else
+            dst->entrances[i] = { (uint8)entrance.x, (uint8)entrance.y };
+
         TileCoordsXYZD exit = ride_get_exit_location_of_station(src, i);
-        dst->entrances[i] = { (uint8)entrance.x, (uint8)entrance.y };
-        dst->exits[i] = { (uint8)exit.x, (uint8)exit.y };
+        if (exit.isNull())
+            dst->exits[i].xy = RCT_XY8_UNDEFINED;
+        else
+            dst->exits[i] = { (uint8)exit.x, (uint8)exit.y };
+
         dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
         dst->length[i] = src->length[i];

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -518,8 +518,17 @@ public:
             dst->station_depart[i] = src->station_depart[i];
             dst->train_at_station[i] = src->train_at_station[i];
             // Direction is fixed later.
-            ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
-            ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+
+            if (src->entrances[i].xy == RCT_XY8_UNDEFINED)
+                ride_clear_entrance_location_of_station(dst, i);
+            else
+                ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+
+            if (src->exits[i].xy == RCT_XY8_UNDEFINED)
+                ride_clear_exit_location_of_station(dst, i);
+            else
+                ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
             dst->length[i] = src->length[i];

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -521,14 +521,14 @@ public:
             // Direction is fixed later.
 
             if (src->entrances[i].xy == RCT_XY8_UNDEFINED)
-                ride_clear_entrance_location_of_station(dst, i);
+                ride_clear_entrance_location(dst, i);
             else
-                ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+                ride_set_entrance_location(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
 
             if (src->exits[i].xy == RCT_XY8_UNDEFINED)
-                ride_clear_exit_location_of_station(dst, i);
+                ride_clear_exit_location(dst, i);
             else
-                ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+                ride_set_exit_location(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
 
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
@@ -544,8 +544,8 @@ public:
         {
             dst->station_starts[i].xy = RCT_XY8_UNDEFINED;
             dst->train_at_station[i] = 255;
-            ride_clear_entrance_location_of_station(dst, i);
-            ride_clear_exit_location_of_station(dst, i);
+            ride_clear_entrance_location(dst, i);
+            ride_clear_exit_location(dst, i);
             dst->last_peep_in_queue[i] = SPRITE_INDEX_NULL;
         }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -447,6 +447,7 @@ public:
         map_update_tile_pointers();
         game_convert_strings_to_utf8();
         map_count_remaining_land_rights();
+        determine_ride_entrance_and_exit_locations();
 
         // We try to fix the cycles on import, hence the 'true' parameter
         check_for_sprite_list_cycles(true);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -517,8 +517,8 @@ public:
             dst->station_length[i] = src->station_length[i];
             dst->station_depart[i] = src->station_depart[i];
             dst->train_at_station[i] = src->train_at_station[i];
-            dst->entrances[i] = src->entrances[i];
-            dst->exits[i] = src->exits[i];
+            ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i] });
+            ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i] });
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
             dst->length[i] = src->length[i];
@@ -533,8 +533,8 @@ public:
         {
             dst->station_starts[i].xy = RCT_XY8_UNDEFINED;
             dst->train_at_station[i] = 255;
-            dst->entrances[i].xy = RCT_XY8_UNDEFINED;
-            dst->exits[i].xy = RCT_XY8_UNDEFINED;
+            ride_clear_entrance_location_of_station(dst, i);
+            ride_clear_exit_location_of_station(dst, i);
             dst->last_peep_in_queue[i] = SPRITE_INDEX_NULL;
         }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -517,8 +517,9 @@ public:
             dst->station_length[i] = src->station_length[i];
             dst->station_depart[i] = src->station_depart[i];
             dst->train_at_station[i] = src->train_at_station[i];
-            ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i] });
-            ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i] });
+            // Direction is fixed later.
+            ride_set_entrance_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
+            ride_set_exit_location_of_station(dst, i, { src->entrances[i].x, src->entrances[i].y, src->station_heights[i], 0 });
             dst->last_peep_in_queue[i] = src->last_peep_in_queue[i];
 
             dst->length[i] = src->length[i];

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -8259,7 +8259,7 @@ LocationXY16 ride_get_rotated_coords(sint16 x, sint16 y, sint16 z)
 // an ever-so-slight chance two entrances/exits for the same station reside on the same tile.
 // In cases like this, the one at station height will be considered the "true" one.
 // If none exists at that height, newer and higher placed ones take precedence.
-void fix_ride_entrance_and_exit_locations()
+void determine_ride_entrance_and_exit_locations()
 {
     sint32 rideIndex;
     Ride * ride;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -8361,7 +8361,7 @@ void determine_ride_entrance_and_exit_locations()
                                     if (ride->exits[stationIndex].z == expectedHeight)
                                         continue;
                                     if (ride->exits[stationIndex].z > tileElement->base_height)
-                                        continue;;
+                                        continue;
                                 }
 
                                 // Found our exit

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4087,8 +4087,6 @@ static sint32 ride_check_for_entrance_exit(sint32 rideIndex)
  */
 static void sub_6B5952(sint32 rideIndex)
 {
-    Ride *ride = get_ride(rideIndex);
-
     for (sint32 i = 0; i < MAX_STATIONS; i++)
     {
         TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -343,7 +343,7 @@ sint32 ride_get_total_queue_length(Ride *ride)
 {
     sint32 i, queueLength = 0;
     for (i = 0; i < MAX_STATIONS; i++)
-        if (ride_get_entrance_location_of_station(ride, i).x != LOCATION_NULL)
+        if (!ride_get_entrance_location_of_station(ride, i).isNull())
             queueLength += ride->queue_length[i];
     return queueLength;
 }
@@ -352,7 +352,7 @@ sint32 ride_get_max_queue_time(Ride *ride)
 {
     uint8 i, queueTime = 0;
     for (i = 0; i < MAX_STATIONS; i++)
-        if (ride_get_entrance_location_of_station(ride, i).x != LOCATION_NULL)
+        if (!ride_get_entrance_location_of_station(ride, i).isNull())
             queueTime = Math::Max(queueTime, ride->queue_time[i]);
     return (sint32)queueTime;
 }
@@ -1137,7 +1137,7 @@ void ride_remove_peeps(sint32 rideIndex)
     sint32 exitDirection = 255;
     if (stationIndex != -1) {
         TileCoordsXYZD location = ride_get_exit_location_of_station(ride, stationIndex);
-        if (location.x != LOCATION_NULL) {
+        if (!location.isNull()) {
             exitX = location.x;
             exitY = location.y;
             exitZ = location.z;
@@ -2667,9 +2667,9 @@ rct_peep *ride_find_closest_mechanic(Ride *ride, sint32 forInspection)
     // Get either exit position or entrance position if there is no exit
     stationIndex = ride->inspection_station;
     location = ride_get_exit_location_of_station(ride, stationIndex);
-    if (location.x == LOCATION_NULL) {
+    if (location.isNull()) {
         location = ride_get_entrance_location_of_station(ride, stationIndex);
-        if (location.x == LOCATION_NULL)
+        if (location.isNull())
             return nullptr;
     }
 
@@ -3192,7 +3192,7 @@ static sint32 ride_entrance_exit_is_reachable(TileCoordsXYZD coordinates)
 {
     sint32 x, y, z;
 
-    if (coordinates.x == LOCATION_NULL)
+    if (coordinates.isNull())
         return 1;
 
     x = coordinates.x;
@@ -3220,7 +3220,7 @@ static void ride_entrance_exit_connected(Ride* ride, sint32 ride_idx)
 
         if (station_start.xy == RCT_XY8_UNDEFINED )
             continue;
-        if (entrance.x != LOCATION_NULL && !ride_entrance_exit_is_reachable(entrance))
+        if (!entrance.isNull() && !ride_entrance_exit_is_reachable(entrance))
         {
             // name of ride is parameter of the format string
             set_format_arg(0, rct_string_id, ride->name);
@@ -3231,7 +3231,7 @@ static void ride_entrance_exit_connected(Ride* ride, sint32 ride_idx)
             ride->connected_message_throttle = 3;
         }
 
-        if (exit.x != LOCATION_NULL && !ride_entrance_exit_is_reachable(exit))
+        if (!exit.isNull() && !ride_entrance_exit_is_reachable(exit))
         {
             // name of ride is parameter of the format string
             set_format_arg(0, rct_string_id, ride->name);
@@ -3382,7 +3382,7 @@ static void ride_entrance_set_map_tooltip(rct_tile_element *tileElement)
     if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_ENTRANCE) {
         // Get the queue length
         sint32 queueLength = 0;
-        if (ride_get_entrance_location_of_station(ride, stationIndex).x != LOCATION_NULL)
+        if (!ride_get_entrance_location_of_station(ride, stationIndex).isNull())
             queueLength = ride->queue_length[stationIndex];
 
         set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
@@ -4050,18 +4050,18 @@ static sint32 ride_check_for_entrance_exit(sint32 rideIndex)
         if (ride->station_starts[i].xy == RCT_XY8_UNDEFINED)
             continue;
 
-        if (ride_get_entrance_location_of_station(ride, i).x != LOCATION_NULL) {
+        if (!ride_get_entrance_location_of_station(ride, i).isNull()) {
             entrance = 1;
         }
 
-        if (ride_get_exit_location_of_station(ride, i).x != LOCATION_NULL) {
+        if (!ride_get_exit_location_of_station(ride, i).isNull()) {
             exit = 1;
         }
 
         // If station start and no entrance/exit
         // Sets same error message as no entrance
-        if (ride_get_exit_location_of_station(ride, i).x == LOCATION_NULL &&
-            ride_get_entrance_location_of_station(ride, i).x == LOCATION_NULL)
+        if (ride_get_exit_location_of_station(ride, i).isNull() &&
+            ride_get_entrance_location_of_station(ride, i).isNull())
         {
             entrance = 0;
             break;
@@ -4090,7 +4090,7 @@ static void sub_6B5952(sint32 rideIndex)
     for (sint32 i = 0; i < MAX_STATIONS; i++)
     {
         TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);
-        if (location.x == LOCATION_NULL)
+        if (location.isNull())
             continue;
 
         sint32 x = location.x * 32;
@@ -4390,17 +4390,17 @@ static void ride_set_maze_entrance_exit_points(Ride *ride)
         const auto entrance = ride_get_entrance_location_of_station(ride, i);
         const auto exit = ride_get_exit_location_of_station(ride, i);
 
-        if (entrance.x != LOCATION_NULL) {
+        if (!entrance.isNull()) {
             *position++ = entrance;
         }
-        if (exit.x != LOCATION_NULL) {
+        if (!exit.isNull()) {
             *position++ = exit;
         }
     }
-    (*position++).x = LOCATION_NULL;
+    (*position++).x = COORDS_NULL;
 
     // Enumerate entrance and exit positions
-    for (position = positions; (*position).x != LOCATION_NULL; position++)
+    for (position = positions; !(*position).isNull(); position++)
     {
         sint32 x = (*position).x << 5;
         sint32 y = (*position).y << 5;
@@ -5140,12 +5140,12 @@ static void loc_6B51C0(sint32 rideIndex)
         if (ride->station_starts[i].xy == RCT_XY8_UNDEFINED)
             continue;
 
-        if (ride_get_entrance_location_of_station(rideIndex, i).x == LOCATION_NULL) {
+        if (ride_get_entrance_location_of_station(rideIndex, i).isNull()) {
             entranceOrExit = 0;
             break;
         }
 
-        if (ride_get_exit_location_of_station(rideIndex, i).x == LOCATION_NULL) {
+        if (ride_get_exit_location_of_station(rideIndex, i).isNull()) {
             entranceOrExit = 1;
             break;
         }
@@ -6835,12 +6835,12 @@ bool ride_are_all_possible_entrances_and_exits_built(Ride *ride)
         {
             continue;
         }
-        if (ride_get_entrance_location_of_station(ride, i).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, i).isNull())
         {
             gGameCommandErrorText = STR_ENTRANCE_NOT_YET_BUILT;
             return false;
         }
-        if (ride_get_exit_location_of_station(ride, i).x == LOCATION_NULL) {
+        if (ride_get_exit_location_of_station(ride, i).isNull()) {
             gGameCommandErrorText = STR_EXIT_NOT_YET_BUILT;
             return false;
         }
@@ -7524,23 +7524,23 @@ void sub_6CB945(sint32 rideIndex)
     for (uint8 stationId = 0; stationId < MAX_STATIONS; ++stationId)
     {
         TileCoordsXYZD entrance = ride_get_entrance_location_of_station(rideIndex, stationId);
-        if (entrance.x != LOCATION_NULL)
+        if (!entrance.isNull())
         {
             *locationList++ = entrance;
             ride_clear_entrance_location_of_station(ride, stationId);
         }
 
         TileCoordsXYZD exit = ride_get_exit_location_of_station(rideIndex, stationId);
-        if (exit.x != LOCATION_NULL)
+        if (!exit.isNull())
         {
             *locationList++ = exit;
             ride_clear_exit_location_of_station(ride, stationId);
         }
     }
-    (*locationList++).x = LOCATION_NULL;
+    (*locationList++).x = COORDS_NULL;
 
     locationList = locations;
-    for (; (*locationList).x != LOCATION_NULL; locationList++) {
+    for (; !(*locationList).isNull(); locationList++) {
         TileCoordsXYZD * locationList2 = locationList;
         locationList2++;
 
@@ -7552,7 +7552,7 @@ void sub_6CB945(sint32 rideIndex)
                 duplicateLocation = true;
                 break;
             }
-        } while ((*locationList2++).x != LOCATION_NULL);
+        } while (!(*locationList2++).isNull());
 
         if (duplicateLocation)
         {
@@ -7594,7 +7594,7 @@ void sub_6CB945(sint32 rideIndex)
 
                 if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_EXIT)
                 {
-                    if (ride_get_exit_location_of_station(ride, stationId).x != LOCATION_NULL)
+                    if (!ride_get_exit_location_of_station(ride, stationId).isNull())
                         break;
 
                     ride_set_exit_location_of_station(ride, stationId,
@@ -7602,7 +7602,7 @@ void sub_6CB945(sint32 rideIndex)
                 }
                 else
                 {
-                    if (ride_get_entrance_location_of_station(ride, stationId).x != LOCATION_NULL)
+                    if (!ride_get_entrance_location_of_station(ride, stationId).isNull())
                         break;
 
                     ride_set_entrance_location_of_station(ride, stationId,
@@ -8275,7 +8275,7 @@ void fix_ride_entrance_and_exit_locations()
             const rct_tile_element * tileElement;
 
             // Skip if the station has no entrance
-            if (entranceLoc.x != LOCATION_NULL)
+            if (!entranceLoc.isNull())
             {
                 tileElement = map_get_ride_entrance_element_at(entranceLoc.x * 32, entranceLoc.y * 32, entranceLoc.z, false);
 
@@ -8289,7 +8289,7 @@ void fix_ride_entrance_and_exit_locations()
                 }
             }
 
-            if (exitLoc.x != LOCATION_NULL)
+            if (!exitLoc.isNull())
             {
                 tileElement = map_get_ride_exit_element_at(exitLoc.x * 32, exitLoc.y * 32, entranceLoc.z, false);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1136,7 +1136,7 @@ void ride_remove_peeps(sint32 rideIndex)
     sint32 exitZ = 0;
     sint32 exitDirection = 255;
     if (stationIndex != -1) {
-        TileCoordsXYZD location = ride_get_exit_location_of_station(rideIndex, stationIndex);
+        TileCoordsXYZD location = ride_get_exit_location_of_station(ride, stationIndex);
         if (location.x != LOCATION_NULL) {
             exitX = location.x;
             exitY = location.y;
@@ -3382,7 +3382,7 @@ static void ride_entrance_set_map_tooltip(rct_tile_element *tileElement)
     if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_ENTRANCE) {
         // Get the queue length
         sint32 queueLength = 0;
-        if (ride_get_entrance_location_of_station(rideIndex, stationIndex).x != LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, stationIndex).x != LOCATION_NULL)
             queueLength = ride->queue_length[stationIndex];
 
         set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
@@ -4050,18 +4050,18 @@ static sint32 ride_check_for_entrance_exit(sint32 rideIndex)
         if (ride->station_starts[i].xy == RCT_XY8_UNDEFINED)
             continue;
 
-        if (ride_get_entrance_location_of_station(rideIndex, i).x != LOCATION_NULL) {
+        if (ride_get_entrance_location_of_station(ride, i).x != LOCATION_NULL) {
             entrance = 1;
         }
 
-        if (ride_get_exit_location_of_station(rideIndex, i).x != LOCATION_NULL) {
+        if (ride_get_exit_location_of_station(ride, i).x != LOCATION_NULL) {
             exit = 1;
         }
 
         // If station start and no entrance/exit
         // Sets same error message as no entrance
-        if (ride_get_exit_location_of_station(rideIndex, i).x == LOCATION_NULL &&
-            ride_get_entrance_location_of_station(rideIndex, i).x == LOCATION_NULL)
+        if (ride_get_exit_location_of_station(ride, i).x == LOCATION_NULL &&
+            ride_get_entrance_location_of_station(ride, i).x == LOCATION_NULL)
         {
             entrance = 0;
             break;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -8285,7 +8285,7 @@ void fix_ride_entrance_and_exit_locations()
                 }
                 else
                 {
-                    entranceLoc.direction = (uint8)tile_element_get_direction(tileElement);
+                    ride->entrances[stationIndex].direction = (uint8)tile_element_get_direction(tileElement);
                 }
             }
 
@@ -8299,7 +8299,7 @@ void fix_ride_entrance_and_exit_locations()
                 }
                 else
                 {
-                    exitLoc.direction = (uint8)tile_element_get_direction(tileElement);
+                    ride->exits[stationIndex].direction = (uint8)tile_element_get_direction(tileElement);
                 }
             }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3188,26 +3188,17 @@ void ride_check_all_reachable()
  *  rct2: 0x006B7C59
  * @return 1 if the coordinate is reachable or has no entrance, 0 otherwise
  */
-static sint32 ride_entrance_exit_is_reachable(LocationXY8 coordinates, Ride* ride, sint32 index)
+static sint32 ride_entrance_exit_is_reachable(TileCoordsXYZD coordinates)
 {
     sint32 x, y, z;
-    rct_tile_element *tileElement;
+
+    if (coordinates.x == LOCATION_NULL)
+        return 1;
 
     x = coordinates.x;
     y = coordinates.y;
-    z = ride->station_heights[index];
-    tileElement = map_get_first_element_at(x, y);
-
-    for (;;) {
-        if (tile_element_get_type(tileElement) == TILE_ELEMENT_TYPE_ENTRANCE && z == tileElement->base_height) {
-            break;
-        } else if (tile_element_is_last_for_tile(tileElement)) {
-            return 1;
-        }
-        tileElement++;
-    }
-
-    uint8 face_direction = tile_element_get_direction(tileElement);
+    z = coordinates.z;
+    uint8 face_direction = coordinates.direction;
 
     x *= 32;
     y *= 32;
@@ -3229,7 +3220,8 @@ static void ride_entrance_exit_connected(Ride* ride, sint32 ride_idx)
 
         if (station_start.xy == RCT_XY8_UNDEFINED )
             continue;
-        if (entrance.x != LOCATION_NULL && !ride_entrance_exit_is_reachable({ (uint8)entrance.x, (uint8)entrance.y }, ride, i)) {
+        if (entrance.x != LOCATION_NULL && !ride_entrance_exit_is_reachable(entrance))
+        {
             // name of ride is parameter of the format string
             set_format_arg(0, rct_string_id, ride->name);
             set_format_arg(2, uint32, ride->name_arguments);
@@ -3239,7 +3231,8 @@ static void ride_entrance_exit_connected(Ride* ride, sint32 ride_idx)
             ride->connected_message_throttle = 3;
         }
 
-        if (exit.x != LOCATION_NULL && !ride_entrance_exit_is_reachable({ (uint8)exit.x, (uint8)exit.y }, ride, i)) {
+        if (exit.x != LOCATION_NULL && !ride_entrance_exit_is_reachable(exit))
+        {
             // name of ride is parameter of the format string
             set_format_arg(0, rct_string_id, ride->name);
             set_format_arg(2, uint32, ride->name_arguments);
@@ -7546,7 +7539,7 @@ void sub_6CB945(sint32 rideIndex)
             ride_clear_exit_location_of_station(ride, stationId);
         }
     }
-    *locationList++ = { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL, 0 };
+    (*locationList++).x = LOCATION_NULL;
 
     locationList = locations;
     for (; (*locationList).x != LOCATION_NULL; locationList++) {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -343,7 +343,7 @@ sint32 ride_get_total_queue_length(Ride *ride)
 {
     sint32 i, queueLength = 0;
     for (i = 0; i < MAX_STATIONS; i++)
-        if (!ride_get_entrance_location_of_station(ride, i).isNull())
+        if (!ride_get_entrance_location(ride, i).isNull())
             queueLength += ride->queue_length[i];
     return queueLength;
 }
@@ -352,7 +352,7 @@ sint32 ride_get_max_queue_time(Ride *ride)
 {
     uint8 i, queueTime = 0;
     for (i = 0; i < MAX_STATIONS; i++)
-        if (!ride_get_entrance_location_of_station(ride, i).isNull())
+        if (!ride_get_entrance_location(ride, i).isNull())
             queueTime = Math::Max(queueTime, ride->queue_time[i]);
     return (sint32)queueTime;
 }
@@ -1136,7 +1136,7 @@ void ride_remove_peeps(sint32 rideIndex)
     sint32 exitZ = 0;
     sint32 exitDirection = 255;
     if (stationIndex != -1) {
-        TileCoordsXYZD location = ride_get_exit_location_of_station(ride, stationIndex);
+        TileCoordsXYZD location = ride_get_exit_location(ride, stationIndex);
         if (!location.isNull()) {
             exitX = location.x;
             exitY = location.y;
@@ -2666,9 +2666,9 @@ rct_peep *ride_find_closest_mechanic(Ride *ride, sint32 forInspection)
 
     // Get either exit position or entrance position if there is no exit
     stationIndex = ride->inspection_station;
-    location = ride_get_exit_location_of_station(ride, stationIndex);
+    location = ride_get_exit_location(ride, stationIndex);
     if (location.isNull()) {
-        location = ride_get_entrance_location_of_station(ride, stationIndex);
+        location = ride_get_entrance_location(ride, stationIndex);
         if (location.isNull())
             return nullptr;
     }
@@ -3215,8 +3215,8 @@ static void ride_entrance_exit_connected(Ride* ride, sint32 ride_idx)
     for (sint32 i = 0; i < MAX_STATIONS; ++i)
     {
         LocationXY8 station_start = ride->station_starts[i];
-        TileCoordsXYZD entrance = ride_get_entrance_location_of_station(ride_idx, i);
-        TileCoordsXYZD exit = ride_get_exit_location_of_station(ride_idx, i);
+        TileCoordsXYZD entrance = ride_get_entrance_location(ride_idx, i);
+        TileCoordsXYZD exit = ride_get_exit_location(ride_idx, i);
 
         if (station_start.xy == RCT_XY8_UNDEFINED )
             continue;
@@ -3382,7 +3382,7 @@ static void ride_entrance_set_map_tooltip(rct_tile_element *tileElement)
     if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_ENTRANCE) {
         // Get the queue length
         sint32 queueLength = 0;
-        if (!ride_get_entrance_location_of_station(ride, stationIndex).isNull())
+        if (!ride_get_entrance_location(ride, stationIndex).isNull())
             queueLength = ride->queue_length[stationIndex];
 
         set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
@@ -4050,18 +4050,18 @@ static sint32 ride_check_for_entrance_exit(sint32 rideIndex)
         if (ride->station_starts[i].xy == RCT_XY8_UNDEFINED)
             continue;
 
-        if (!ride_get_entrance_location_of_station(ride, i).isNull()) {
+        if (!ride_get_entrance_location(ride, i).isNull()) {
             entrance = 1;
         }
 
-        if (!ride_get_exit_location_of_station(ride, i).isNull()) {
+        if (!ride_get_exit_location(ride, i).isNull()) {
             exit = 1;
         }
 
         // If station start and no entrance/exit
         // Sets same error message as no entrance
-        if (ride_get_exit_location_of_station(ride, i).isNull() &&
-            ride_get_entrance_location_of_station(ride, i).isNull())
+        if (ride_get_exit_location(ride, i).isNull() &&
+            ride_get_entrance_location(ride, i).isNull())
         {
             entrance = 0;
             break;
@@ -4089,7 +4089,7 @@ static void sub_6B5952(sint32 rideIndex)
 {
     for (sint32 i = 0; i < MAX_STATIONS; i++)
     {
-        TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);
+        TileCoordsXYZD location = ride_get_entrance_location(rideIndex, i);
         if (location.isNull())
             continue;
 
@@ -4387,8 +4387,8 @@ static void ride_set_maze_entrance_exit_points(Ride *ride)
     TileCoordsXYZD * position = positions;
     for (sint32 i = 0; i < MAX_STATIONS; i++)
     {
-        const auto entrance = ride_get_entrance_location_of_station(ride, i);
-        const auto exit = ride_get_exit_location_of_station(ride, i);
+        const auto entrance = ride_get_entrance_location(ride, i);
+        const auto exit = ride_get_exit_location(ride, i);
 
         if (!entrance.isNull()) {
             *position++ = entrance;
@@ -5140,12 +5140,12 @@ static void loc_6B51C0(sint32 rideIndex)
         if (ride->station_starts[i].xy == RCT_XY8_UNDEFINED)
             continue;
 
-        if (ride_get_entrance_location_of_station(rideIndex, i).isNull()) {
+        if (ride_get_entrance_location(rideIndex, i).isNull()) {
             entranceOrExit = 0;
             break;
         }
 
-        if (ride_get_exit_location_of_station(rideIndex, i).isNull()) {
+        if (ride_get_exit_location(rideIndex, i).isNull()) {
             entranceOrExit = 1;
             break;
         }
@@ -6835,12 +6835,12 @@ bool ride_are_all_possible_entrances_and_exits_built(Ride *ride)
         {
             continue;
         }
-        if (ride_get_entrance_location_of_station(ride, i).isNull())
+        if (ride_get_entrance_location(ride, i).isNull())
         {
             gGameCommandErrorText = STR_ENTRANCE_NOT_YET_BUILT;
             return false;
         }
-        if (ride_get_exit_location_of_station(ride, i).isNull()) {
+        if (ride_get_exit_location(ride, i).isNull()) {
             gGameCommandErrorText = STR_EXIT_NOT_YET_BUILT;
             return false;
         }
@@ -7523,18 +7523,18 @@ void sub_6CB945(sint32 rideIndex)
     TileCoordsXYZD *locationList = locations;
     for (uint8 stationId = 0; stationId < MAX_STATIONS; ++stationId)
     {
-        TileCoordsXYZD entrance = ride_get_entrance_location_of_station(rideIndex, stationId);
+        TileCoordsXYZD entrance = ride_get_entrance_location(rideIndex, stationId);
         if (!entrance.isNull())
         {
             *locationList++ = entrance;
-            ride_clear_entrance_location_of_station(ride, stationId);
+            ride_clear_entrance_location(ride, stationId);
         }
 
-        TileCoordsXYZD exit = ride_get_exit_location_of_station(rideIndex, stationId);
+        TileCoordsXYZD exit = ride_get_exit_location(rideIndex, stationId);
         if (!exit.isNull())
         {
             *locationList++ = exit;
-            ride_clear_exit_location_of_station(ride, stationId);
+            ride_clear_exit_location(ride, stationId);
         }
     }
     (*locationList++).x = COORDS_NULL;
@@ -7594,18 +7594,18 @@ void sub_6CB945(sint32 rideIndex)
 
                 if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_EXIT)
                 {
-                    if (!ride_get_exit_location_of_station(ride, stationId).isNull())
+                    if (!ride_get_exit_location(ride, stationId).isNull())
                         break;
 
-                    ride_set_exit_location_of_station(ride, stationId,
+                    ride_set_exit_location(ride, stationId,
                         { location.x / 32, location.y / 32, ride->station_heights[stationId], (uint8)tile_element_get_direction(tileElement) });
                 }
                 else
                 {
-                    if (!ride_get_entrance_location_of_station(ride, stationId).isNull())
+                    if (!ride_get_entrance_location(ride, stationId).isNull())
                         break;
 
-                    ride_set_entrance_location_of_station(ride, stationId,
+                    ride_set_entrance_location(ride, stationId,
                         { location.x / 32, location.y / 32, ride->station_heights[stationId], (uint8)tile_element_get_direction(tileElement) });
                 }
 
@@ -8349,7 +8349,7 @@ void determine_ride_entrance_and_exit_locations()
                                 }
 
                                 // Found our entrance
-                                ride_set_entrance_location_of_station(ride, stationIndex, { x, y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) });
+                                ride_set_entrance_location(ride, stationIndex, { x, y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) });
                                 alreadyFoundEntrance = true;
 
                                 log_info("Fixed disconnected entrance of ride %d, station %d to x = %d, y = %d and z = %d.", rideIndex, stationIndex, x, y, tileElement->base_height);
@@ -8365,7 +8365,7 @@ void determine_ride_entrance_and_exit_locations()
                                 }
 
                                 // Found our exit
-                                ride_set_exit_location_of_station(ride, stationIndex, { x, y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) });
+                                ride_set_exit_location(ride, stationIndex, { x, y, tileElement->base_height, (uint8)tile_element_get_direction(tileElement) });
                                 alreadyFoundExit = true;
 
                                 log_info("Fixed disconnected exit of ride %d, station %d to x = %d, y = %d and z = %d.", rideIndex, stationIndex, x, y, tileElement->base_height);
@@ -8378,13 +8378,13 @@ void determine_ride_entrance_and_exit_locations()
 
             if (fixEntrance && !alreadyFoundEntrance)
             {
-                ride_clear_entrance_location_of_station(ride, stationIndex);
+                ride_clear_entrance_location(ride, stationIndex);
                 log_info("Cleared disconnected entrance of ride %d, station %d.", rideIndex, stationIndex);
 
             }
             if (fixExit && !alreadyFoundExit)
             {
-                ride_clear_exit_location_of_station(ride, stationIndex);
+                ride_clear_exit_location(ride, stationIndex);
                 log_info("Cleared disconnected exit of ride %d, station %d.", rideIndex, stationIndex);
             }
         }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1194,6 +1194,6 @@ void ride_stop_peeps_queuing(sint32 rideIndex);
 
 LocationXY16 ride_get_rotated_coords(sint16 x, sint16 y, sint16 z);
 
-void fix_ride_entrance_and_exit_locations();
+void determine_ride_entrance_and_exit_locations();
 
 #endif

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -163,8 +163,8 @@ struct Ride
     // ride->vehicle index for current train waiting for passengers
     // at station
     uint8 train_at_station[MAX_STATIONS];
-    LocationXY8 entrances[MAX_STATIONS];
-    LocationXY8 exits[MAX_STATIONS];
+    TileCoordsXYZD entrances[MAX_STATIONS];
+    TileCoordsXYZD exits[MAX_STATIONS];
     uint16 last_peep_in_queue[MAX_STATIONS];
     uint16 vehicles[MAX_VEHICLES_PER_RIDE];                         // Points to the first car in the train
     uint8 depart_flags;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -212,7 +212,7 @@ static void ride_ratings_update_state_2()
             if (trackType == TRACK_ELEM_END_STATION) {
                 sint32 entranceIndex = tile_element_get_station(tileElement);
                 gRideRatingsCalcData.station_flags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-                if (ride_get_entrance_location_of_station(rideIndex, entranceIndex).x == LOCATION_NULL)
+                if (ride_get_entrance_location_of_station(rideIndex, entranceIndex).isNull())
                 {
                     gRideRatingsCalcData.station_flags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
                 }
@@ -353,7 +353,7 @@ static void ride_ratings_begin_proximity_loop()
     for (sint32 i = 0; i < MAX_STATIONS; i++) {
         if (ride->station_starts[i].xy != RCT_XY8_UNDEFINED) {
             gRideRatingsCalcData.station_flags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-            if (ride_get_entrance_location_of_station(rideIndex, i).x == LOCATION_NULL)
+            if (ride_get_entrance_location_of_station(rideIndex, i).isNull())
             {
                 gRideRatingsCalcData.station_flags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
             }

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -212,7 +212,7 @@ static void ride_ratings_update_state_2()
             if (trackType == TRACK_ELEM_END_STATION) {
                 sint32 entranceIndex = tile_element_get_station(tileElement);
                 gRideRatingsCalcData.station_flags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-                if (ride_get_entrance_location_of_station(rideIndex, entranceIndex).isNull())
+                if (ride_get_entrance_location(rideIndex, entranceIndex).isNull())
                 {
                     gRideRatingsCalcData.station_flags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
                 }
@@ -353,7 +353,7 @@ static void ride_ratings_begin_proximity_loop()
     for (sint32 i = 0; i < MAX_STATIONS; i++) {
         if (ride->station_starts[i].xy != RCT_XY8_UNDEFINED) {
             gRideRatingsCalcData.station_flags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-            if (ride_get_entrance_location_of_station(rideIndex, i).isNull())
+            if (ride_get_entrance_location(rideIndex, i).isNull())
             {
                 gRideRatingsCalcData.station_flags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
             }
@@ -1277,7 +1277,7 @@ static sint32 ride_ratings_get_scenery_score(Ride *ride)
 
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        TileCoordsXYZD location = ride_get_entrance_location_of_station(ride, 0);
+        TileCoordsXYZD location = ride_get_entrance_location(ride, 0);
         x = location.x;
         y = location.y;
     }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -346,7 +346,7 @@ sint8 ride_get_first_valid_station_exit(Ride * ride)
 {
     for (sint32 i = 0; i < MAX_STATIONS; i++)
     {
-        if (ride->exits[i].x != LOCATION_NULL)
+        if (ride->exits[i].x != COORDS_NULL)
         {
             return i;
         }
@@ -404,14 +404,14 @@ void ride_clear_entrance_location_of_station(
         Ride * ride,
         const sint32 stationIndex)
 {
-    ride->entrances[stationIndex].x = LOCATION_NULL;
+    ride->entrances[stationIndex].x = COORDS_NULL;
 }
 
 void ride_clear_exit_location_of_station(
         Ride * ride,
         const sint32 stationIndex)
 {
-    ride->exits[stationIndex].x = LOCATION_NULL;
+    ride->exits[stationIndex].x = COORDS_NULL;
 }
 
 void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location)

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -378,48 +378,48 @@ sint8 ride_get_first_empty_station_start(const Ride * ride)
     return -1;
 }
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const sint32 rideIndex, const sint32 stationIndex)
+TileCoordsXYZD ride_get_entrance_location(const sint32 rideIndex, const sint32 stationIndex)
 {
     const Ride * ride = get_ride(rideIndex);
     return ride->entrances[stationIndex];
 }
 
-TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const sint32 stationIndex)
+TileCoordsXYZD ride_get_exit_location(const sint32 rideIndex, const sint32 stationIndex)
 {
     const Ride * ride = get_ride(rideIndex);
     return ride->exits[stationIndex];
 }
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex)
+TileCoordsXYZD ride_get_entrance_location(const Ride * ride, const sint32 stationIndex)
 {
     return ride->entrances[stationIndex];
 }
 
-TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex)
+TileCoordsXYZD ride_get_exit_location(const Ride * ride, const sint32 stationIndex)
 {
     return ride->exits[stationIndex];
 }
 
-void ride_clear_entrance_location_of_station(
+void ride_clear_entrance_location(
         Ride * ride,
         const sint32 stationIndex)
 {
     ride->entrances[stationIndex].x = COORDS_NULL;
 }
 
-void ride_clear_exit_location_of_station(
+void ride_clear_exit_location(
         Ride * ride,
         const sint32 stationIndex)
 {
     ride->exits[stationIndex].x = COORDS_NULL;
 }
 
-void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location)
+void ride_set_entrance_location(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location)
 {
     ride->entrances[stationIndex] = location;
 }
 
-void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location)
+void ride_set_exit_location(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location)
 {
     ride->exits[stationIndex] = location;
 }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -437,3 +437,46 @@ TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const s
 {
     return ride_get_entrance_or_exit_location_of_station(rideIndex, stationIndex, ENTRANCE_TYPE_RIDE_EXIT);
 }
+
+TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex)
+{
+    const auto entrance = ride->entrances[stationIndex];
+    if (entrance.xy == RCT_XY8_UNDEFINED)
+        return { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL, 0 };
+    else
+        return { entrance.x, entrance.y, ride->station_heights[stationIndex], 0 };
+}
+
+TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex)
+{
+    const auto exit = ride->exits[stationIndex];
+    if (exit.xy == RCT_XY8_UNDEFINED)
+        return { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL, 0 };
+    else
+        return { exit.x, exit.y, ride->station_heights[stationIndex], 0 };
+}
+
+void ride_clear_entrance_location_of_station(
+        Ride * ride,
+        const sint32 stationIndex)
+{
+    ride->entrances[stationIndex].xy = RCT_XY8_UNDEFINED;
+}
+
+void ride_clear_exit_location_of_station(
+        Ride * ride,
+        const sint32 stationIndex)
+{
+    ride->exits[stationIndex].xy = RCT_XY8_UNDEFINED;
+}
+
+void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location)
+{
+    ride->entrances[stationIndex] = { (uint8)location.x, (uint8)location.y };
+}
+
+void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location)
+{
+    ride->exits[stationIndex] = { (uint8)location.x, (uint8)location.y };
+    ride->station_heights[stationIndex] = (uint8)location.z;
+}

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -379,8 +379,8 @@ sint8 ride_get_first_empty_station_start(const Ride * ride)
 }
 
 static TileCoordsXYZD ride_get_entrance_or_exit_location_of_station(
-        const uint8 rideIndex,
-        const uint8 stationIndex,
+        const sint32 rideIndex,
+        const sint32 stationIndex,
         const uint8 entranceType)
 {
     const Ride * ride = get_ride(rideIndex);
@@ -428,12 +428,12 @@ static TileCoordsXYZD ride_get_entrance_or_exit_location_of_station(
     return retVal;
 }
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const uint8 rideIndex, const uint8 stationIndex)
+TileCoordsXYZD ride_get_entrance_location_of_station(const sint32 rideIndex, const sint32 stationIndex)
 {
     return ride_get_entrance_or_exit_location_of_station(rideIndex, stationIndex, ENTRANCE_TYPE_RIDE_ENTRANCE);
 }
 
-TileCoordsXYZD ride_get_exit_location_of_station(const uint8 rideIndex, const uint8 stationIndex)
+TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const sint32 stationIndex)
 {
     return ride_get_entrance_or_exit_location_of_station(rideIndex, stationIndex, ENTRANCE_TYPE_RIDE_EXIT);
 }

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -25,13 +25,13 @@ sint8 ride_get_first_valid_station_exit(Ride * ride);
 sint8 ride_get_first_valid_station_start(const Ride * ride);
 sint8 ride_get_first_empty_station_start(const Ride * ride);
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
-TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
-TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex);
-TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_entrance_location(const sint32 rideIndex, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location(const sint32 rideIndex, const sint32 stationIndex);
+TileCoordsXYZD ride_get_entrance_location(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location(const Ride * ride, const sint32 stationIndex);
 
-void ride_clear_entrance_location_of_station(Ride * ride, const sint32 stationIndex);
-void ride_clear_exit_location_of_station(Ride * ride, const sint32 stationIndex);
+void ride_clear_entrance_location(Ride * ride, const sint32 stationIndex);
+void ride_clear_exit_location(Ride * ride, const sint32 stationIndex);
 
-void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);
-void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);
+void ride_set_entrance_location(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);
+void ride_set_exit_location(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -27,4 +27,11 @@ sint8 ride_get_first_empty_station_start(const Ride * ride);
 
 TileCoordsXYZD ride_get_entrance_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
 TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
+TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex);
 
+void ride_clear_entrance_location_of_station(Ride * ride, const sint32 stationIndex);
+void ride_clear_exit_location_of_station(Ride * ride, const sint32 stationIndex);
+
+void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location);
+void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location);

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -33,5 +33,5 @@ TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32
 void ride_clear_entrance_location_of_station(Ride * ride, const sint32 stationIndex);
 void ride_clear_exit_location_of_station(Ride * ride, const sint32 stationIndex);
 
-void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location);
-void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZ location);
+void ride_set_entrance_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);
+void ride_set_exit_location_of_station(Ride * ride, const sint32 stationIndex, const TileCoordsXYZD location);

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -25,6 +25,6 @@ sint8 ride_get_first_valid_station_exit(Ride * ride);
 sint8 ride_get_first_valid_station_start(const Ride * ride);
 sint8 ride_get_first_empty_station_start(const Ride * ride);
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const uint8 rideIndex, const uint8 stationIndex);
-TileCoordsXYZD ride_get_exit_location_of_station(const uint8 rideIndex, const uint8 stationIndex);
+TileCoordsXYZD ride_get_entrance_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location_of_station(const sint32 rideIndex, const sint32 stationIndex);
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -36,6 +36,7 @@
 #include "TrackData.h"
 #include "TrackDesign.h"
 #include "TrackDesignRepository.h"
+#include "Station.h"
 
 
 #define TRACK_MAX_SAVED_TILE_ELEMENTS 1500
@@ -860,10 +861,10 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
         x = 0;
     }
 
-    Ride *ride = get_ride(rideIndex);
-    LocationXY8 location = ride->entrances[0];
+    TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, 0);
 
-    if (location.xy == RCT_XY8_UNDEFINED) {
+    if (location.x == LOCATION_NULL)
+    {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
         SafeFree(td6->maze_elements);
         return false;
@@ -888,11 +889,12 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
     maze++;
     numMazeElements++;
 
-    location = ride->exits[0];
-    if (location.xy == RCT_XY8_UNDEFINED) {
+    location = ride_get_entrance_location_of_station(rideIndex, 0);
+    if (location.x == LOCATION_NULL)
+    {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
         SafeFree(td6->maze_elements);
-        return 0;
+        return false;
     }
 
     x = location.x * 32;
@@ -1059,14 +1061,14 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
         for (sint32 station_index = 0; station_index < RCT12_MAX_STATIONS_PER_RIDE; station_index++) {
             z = ride->station_heights[station_index];
 
-            LocationXY8 location;
+            TileCoordsXYZD location;
             if (i == 0) {
-                location = ride->entrances[station_index];
+                location = ride_get_entrance_location_of_station(rideIndex, station_index);
             } else {
-                location = ride->exits[station_index];
+                location = ride_get_exit_location_of_station(rideIndex, station_index);
             }
 
-            if (location.xy == RCT_XY8_UNDEFINED) {
+            if (location.x == LOCATION_NULL) {
                 continue;
             }
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -863,7 +863,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
 
     TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, 0);
 
-    if (location.x == LOCATION_NULL)
+    if (location.isNull())
     {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
         SafeFree(td6->maze_elements);
@@ -890,7 +890,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
     numMazeElements++;
 
     location = ride_get_entrance_location_of_station(rideIndex, 0);
-    if (location.x == LOCATION_NULL)
+    if (location.isNull())
     {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
         SafeFree(td6->maze_elements);
@@ -1068,7 +1068,7 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
                 location = ride_get_exit_location_of_station(rideIndex, station_index);
             }
 
-            if (location.x == LOCATION_NULL) {
+            if (location.isNull()) {
                 continue;
             }
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -861,7 +861,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
         x = 0;
     }
 
-    TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, 0);
+    TileCoordsXYZD location = ride_get_entrance_location(rideIndex, 0);
 
     if (location.isNull())
     {
@@ -889,7 +889,7 @@ static bool track_design_save_to_td6_for_maze(uint8 rideIndex, rct_track_td6 *td
     maze++;
     numMazeElements++;
 
-    location = ride_get_entrance_location_of_station(rideIndex, 0);
+    location = ride_get_entrance_location(rideIndex, 0);
     if (location.isNull())
     {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
@@ -1063,9 +1063,9 @@ static bool track_design_save_to_td6_for_tracked_ride(uint8 rideIndex, rct_track
 
             TileCoordsXYZD location;
             if (i == 0) {
-                location = ride_get_entrance_location_of_station(rideIndex, station_index);
+                location = ride_get_entrance_location(rideIndex, station_index);
             } else {
-                location = ride_get_exit_location_of_station(rideIndex, station_index);
+                location = ride_get_exit_location(rideIndex, station_index);
             }
 
             if (location.isNull()) {

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -233,8 +233,8 @@ bool track_paint_util_has_fence(
     const TileCoordsXYZD entrance = ride_get_entrance_location_of_station(ride, entranceId);
     const TileCoordsXYZD exit = ride_get_exit_location_of_station(ride, entranceId);
 
-    return ((entrance.x != entranceX && entrance.y != entranceY) &&
-            (exit.x != entranceX && exit.y != entranceY));
+    return ((entrance.x != entranceX || entrance.y != entranceY) &&
+            (exit.x != entranceX || exit.y != entranceY));
 }
 
 void track_paint_util_paint_floor(paint_session * session, uint8 edges, uint32 colourFlags, uint16 height,

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -230,8 +230,8 @@ bool track_paint_util_has_fence(
     sint32 entranceY = (position.y / 32) + offset.y;
 
     sint32 entranceId = tile_element_get_station(tileElement);
-    const TileCoordsXYZD entrance = ride_get_entrance_location_of_station(ride, entranceId);
-    const TileCoordsXYZD exit = ride_get_exit_location_of_station(ride, entranceId);
+    const TileCoordsXYZD entrance = ride_get_entrance_location(ride, entranceId);
+    const TileCoordsXYZD exit = ride_get_exit_location(ride, entranceId);
 
     return ((entrance.x != entranceX || entrance.y != entranceY) &&
             (exit.x != entranceX || exit.y != entranceY));

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -28,6 +28,7 @@
 #include "TrackData.h"
 #include "RideData.h"
 #include "TrackPaint.h"
+#include "Station.h"
 
 // clang-format off
 /* rct2: 0x007667AC */
@@ -225,11 +226,15 @@ bool track_paint_util_has_fence(
         break;
     }
 
-    uint16 entranceLoc = ((position.x / 32) + offset.x) | (((position.y / 32) + offset.y) * (1 << 8));
+    sint32 entranceX = (position.x / 32) + offset.x;
+    sint32 entranceY = (position.y / 32) + offset.y;
 
     sint32 entranceId = tile_element_get_station(tileElement);
+    const TileCoordsXYZD entrance = ride_get_entrance_location_of_station(ride, entranceId);
+    const TileCoordsXYZD exit = ride_get_exit_location_of_station(ride, entranceId);
 
-    return (ride->entrances[entranceId].xy != entranceLoc && ride->exits[entranceId].xy != entranceLoc);
+    return ((entrance.x != entranceX && entrance.y != entranceY) &&
+            (exit.x != entranceX && exit.y != entranceY));
 }
 
 void track_paint_util_paint_floor(paint_session * session, uint8 edges, uint32 colourFlags, uint16 height,

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1539,7 +1539,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
     }
 
     uint8 stationId = ride->current_test_station;
-    if (ride_get_entrance_location_of_station(vehicle->ride, stationId).x != LOCATION_NULL)
+    if (ride_get_entrance_location_of_station(ride, stationId).x != LOCATION_NULL)
     {
         uint8 test_segment = ride->current_test_segment;
 
@@ -1603,7 +1603,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         ride->cur_test_track_z           = vehicle->track_z / 8;
         ride->cur_test_track_location.xy = map_location;
 
-        if (ride_get_entrance_location_of_station(vehicle->ride, ride->current_test_station).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, ride->current_test_station).x == LOCATION_NULL)
             return;
 
         uint16 track_elem_type = vehicle->track_type / 4;
@@ -1813,7 +1813,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         }
     }
 
-    if (ride_get_entrance_location_of_station(vehicle->ride, ride->current_test_station).x == LOCATION_NULL)
+    if (ride_get_entrance_location_of_station(ride, ride->current_test_station).x == LOCATION_NULL)
         return;
 
     sint16 x, y;
@@ -2235,7 +2235,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle * vehicle)
         if (!vehicle_open_restraints(vehicle))
             return;
 
-        if (ride_get_entrance_location_of_station(vehicle->ride, vehicle->current_station).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, vehicle->current_station).x == LOCATION_NULL)
         {
             ride->train_at_station[vehicle->current_station] = 0xFF;
             vehicle->sub_state                               = 2;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1539,7 +1539,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
     }
 
     uint8 stationId = ride->current_test_station;
-    if (ride->entrances[stationId].xy != RCT_XY8_UNDEFINED)
+    if (ride_get_entrance_location_of_station(vehicle->ride, stationId).x != LOCATION_NULL)
     {
         uint8 test_segment = ride->current_test_segment;
 
@@ -1603,7 +1603,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         ride->cur_test_track_z           = vehicle->track_z / 8;
         ride->cur_test_track_location.xy = map_location;
 
-        if (ride->entrances[ride->current_test_station].xy == RCT_XY8_UNDEFINED)
+        if (ride_get_entrance_location_of_station(vehicle->ride, ride->current_test_station).x == LOCATION_NULL)
             return;
 
         uint16 track_elem_type = vehicle->track_type / 4;
@@ -1813,7 +1813,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         }
     }
 
-    if (ride->entrances[ride->current_test_station].xy == RCT_XY8_UNDEFINED)
+    if (ride_get_entrance_location_of_station(vehicle->ride, ride->current_test_station).x == LOCATION_NULL)
         return;
 
     sint16 x, y;
@@ -2235,7 +2235,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle * vehicle)
         if (!vehicle_open_restraints(vehicle))
             return;
 
-        if (ride->entrances[vehicle->current_station].xy == RCT_XY8_UNDEFINED)
+        if (ride_get_entrance_location_of_station(vehicle->ride, vehicle->current_station).x == LOCATION_NULL)
         {
             ride->train_at_station[vehicle->current_station] = 0xFF;
             vehicle->sub_state                               = 2;
@@ -2510,7 +2510,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
             }
             else
             {
-                if (ride->exits[vehicle->current_station].xy != RCT_XY8_UNDEFINED)
+                if (ride_get_exit_location_of_station(ride, vehicle->current_station).x != LOCATION_NULL)
                 {
                     vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                     vehicle->sub_state = 0;
@@ -2528,7 +2528,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 
                 if (curVehicle->num_peeps != 0)
                 {
-                    if (ride->exits[vehicle->current_station].xy != RCT_XY8_UNDEFINED)
+                    if (ride_get_exit_location_of_station(ride, vehicle->current_station).x != LOCATION_NULL)
                     {
                         vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                         vehicle->sub_state = 0;
@@ -4114,7 +4114,7 @@ static void vehicle_update_unloading_passengers(rct_vehicle * vehicle)
     }
     else
     {
-        if (ride->exits[vehicle->current_station].xy == RCT_XY8_UNDEFINED)
+        if (ride_get_exit_location_of_station(ride, vehicle->current_station).x == LOCATION_NULL)
         {
             if (vehicle->sub_state != 1)
                 return;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1539,7 +1539,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
     }
 
     uint8 stationId = ride->current_test_station;
-    if (ride_get_entrance_location_of_station(ride, stationId).x != LOCATION_NULL)
+    if (!ride_get_entrance_location_of_station(ride, stationId).isNull())
     {
         uint8 test_segment = ride->current_test_segment;
 
@@ -1603,7 +1603,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         ride->cur_test_track_z           = vehicle->track_z / 8;
         ride->cur_test_track_location.xy = map_location;
 
-        if (ride_get_entrance_location_of_station(ride, ride->current_test_station).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, ride->current_test_station).isNull())
             return;
 
         uint16 track_elem_type = vehicle->track_type / 4;
@@ -1813,7 +1813,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         }
     }
 
-    if (ride_get_entrance_location_of_station(ride, ride->current_test_station).x == LOCATION_NULL)
+    if (ride_get_entrance_location_of_station(ride, ride->current_test_station).isNull())
         return;
 
     sint16 x, y;
@@ -2235,7 +2235,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle * vehicle)
         if (!vehicle_open_restraints(vehicle))
             return;
 
-        if (ride_get_entrance_location_of_station(ride, vehicle->current_station).x == LOCATION_NULL)
+        if (ride_get_entrance_location_of_station(ride, vehicle->current_station).isNull())
         {
             ride->train_at_station[vehicle->current_station] = 0xFF;
             vehicle->sub_state                               = 2;
@@ -2510,7 +2510,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
             }
             else
             {
-                if (ride_get_exit_location_of_station(ride, vehicle->current_station).x != LOCATION_NULL)
+                if (!ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
                 {
                     vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                     vehicle->sub_state = 0;
@@ -2528,7 +2528,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 
                 if (curVehicle->num_peeps != 0)
                 {
-                    if (ride_get_exit_location_of_station(ride, vehicle->current_station).x != LOCATION_NULL)
+                    if (!ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
                     {
                         vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                         vehicle->sub_state = 0;
@@ -4114,7 +4114,7 @@ static void vehicle_update_unloading_passengers(rct_vehicle * vehicle)
     }
     else
     {
-        if (ride_get_exit_location_of_station(ride, vehicle->current_station).x == LOCATION_NULL)
+        if (ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
         {
             if (vehicle->sub_state != 1)
                 return;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1539,7 +1539,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
     }
 
     uint8 stationId = ride->current_test_station;
-    if (!ride_get_entrance_location_of_station(ride, stationId).isNull())
+    if (!ride_get_entrance_location(ride, stationId).isNull())
     {
         uint8 test_segment = ride->current_test_segment;
 
@@ -1603,7 +1603,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         ride->cur_test_track_z           = vehicle->track_z / 8;
         ride->cur_test_track_location.xy = map_location;
 
-        if (ride_get_entrance_location_of_station(ride, ride->current_test_station).isNull())
+        if (ride_get_entrance_location(ride, ride->current_test_station).isNull())
             return;
 
         uint16 track_elem_type = vehicle->track_type / 4;
@@ -1813,7 +1813,7 @@ static void vehicle_update_measurements(rct_vehicle * vehicle)
         }
     }
 
-    if (ride_get_entrance_location_of_station(ride, ride->current_test_station).isNull())
+    if (ride_get_entrance_location(ride, ride->current_test_station).isNull())
         return;
 
     sint16 x, y;
@@ -2235,7 +2235,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle * vehicle)
         if (!vehicle_open_restraints(vehicle))
             return;
 
-        if (ride_get_entrance_location_of_station(ride, vehicle->current_station).isNull())
+        if (ride_get_entrance_location(ride, vehicle->current_station).isNull())
         {
             ride->train_at_station[vehicle->current_station] = 0xFF;
             vehicle->sub_state                               = 2;
@@ -2510,7 +2510,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
             }
             else
             {
-                if (!ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
+                if (!ride_get_exit_location(ride, vehicle->current_station).isNull())
                 {
                     vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                     vehicle->sub_state = 0;
@@ -2528,7 +2528,7 @@ static void vehicle_update_waiting_to_depart(rct_vehicle * vehicle)
 
                 if (curVehicle->num_peeps != 0)
                 {
-                    if (!ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
+                    if (!ride_get_exit_location(ride, vehicle->current_station).isNull())
                     {
                         vehicle->status    = VEHICLE_STATUS_UNLOADING_PASSENGERS;
                         vehicle->sub_state = 0;
@@ -4114,7 +4114,7 @@ static void vehicle_update_unloading_passengers(rct_vehicle * vehicle)
     }
     else
     {
-        if (ride_get_exit_location_of_station(ride, vehicle->current_station).isNull())
+        if (ride_get_exit_location(ride, vehicle->current_station).isNull())
         {
             if (vehicle->sub_state != 1)
                 return;

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -194,7 +194,7 @@ static money32 RideEntranceExitPlace(sint16 x,
 
         if (isExit)
         {
-            const auto exit = ride_get_exit_location_of_station(rideIndex, stationNum);
+            const auto exit = ride_get_exit_location(rideIndex, stationNum);
             if (!exit.isNull())
             {
                 if (flags & GAME_COMMAND_FLAG_GHOST)
@@ -210,7 +210,7 @@ static money32 RideEntranceExitPlace(sint16 x,
         }
         else
         {
-            const auto entrance = ride_get_entrance_location_of_station(rideIndex, stationNum);
+            const auto entrance = ride_get_entrance_location(rideIndex, stationNum);
             if (!entrance.isNull())
             {
                 if (flags & GAME_COMMAND_FLAG_GHOST)
@@ -302,11 +302,11 @@ static money32 RideEntranceExitPlace(sint16 x,
 
             if (isExit)
             {
-                ride_set_exit_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
+                ride_set_exit_location(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
             }
             else
             {
-                ride_set_entrance_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
+                ride_set_entrance_location(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
                 ride->last_peep_in_queue[stationNum] = SPRITE_INDEX_NULL;
                 ride->queue_length[stationNum] = 0;
 
@@ -423,11 +423,11 @@ static money32 RideEntranceExitRemove(sint16 x, sint16 y, uint8 rideIndex, uint8
 
         if (isExit)
         {
-            ride_clear_exit_location_of_station(ride, stationNum);
+            ride_clear_exit_location(ride, stationNum);
         }
         else
         {
-            ride_clear_entrance_location_of_station(ride, stationNum);
+            ride_clear_entrance_location(ride, stationNum);
         }
 
         footpath_update_queue_chains();

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -388,7 +388,10 @@ static money32 RideEntranceExitRemove(sint16 x, sint16 y, uint8 rideIndex, uint8
             if (tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_ENTRANCE)
                 continue;
 
-            if (tileElement->base_height != ride->station_heights[stationNum])
+            if (tile_element_get_ride_index(tileElement) != rideIndex)
+                continue;
+
+            if (tile_element_get_station(tileElement) != stationNum)
                 continue;
 
             if (flags & GAME_COMMAND_FLAG_5 && !(tileElement->flags & TILE_ELEMENT_FLAG_GHOST))

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -302,11 +302,11 @@ static money32 RideEntranceExitPlace(sint16 x,
 
             if (isExit)
             {
-                ride_set_exit_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8});
+                ride_set_exit_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
             }
             else
             {
-                ride_set_entrance_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8});
+                ride_set_entrance_location_of_station(ride, stationNum, { x / 32, y / 32, z / 8, (uint8)tile_element_get_direction(tileElement)});
                 ride->last_peep_in_queue[stationNum] = SPRITE_INDEX_NULL;
                 ride->queue_length[stationNum] = 0;
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -195,7 +195,7 @@ static money32 RideEntranceExitPlace(sint16 x,
         if (isExit)
         {
             const auto exit = ride_get_exit_location_of_station(rideIndex, stationNum);
-            if (exit.x != LOCATION_NULL)
+            if (!exit.isNull())
             {
                 if (flags & GAME_COMMAND_FLAG_GHOST)
                 {
@@ -211,7 +211,7 @@ static money32 RideEntranceExitPlace(sint16 x,
         else
         {
             const auto entrance = ride_get_entrance_location_of_station(rideIndex, stationNum);
-            if (entrance.x != LOCATION_NULL)
+            if (!entrance.isNull())
             {
                 if (flags & GAME_COMMAND_FLAG_GHOST)
                 {

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -18,7 +18,7 @@
 #define _ENTRANCE_H_
 
 #include "../common.h"
-#include "Location.h"
+#include "Location.hpp"
 
 #pragma pack(push, 1)
 struct rct_entrance_type {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1609,7 +1609,7 @@ void footpath_update_queue_chains()
 
         for (sint32 i = 0; i < MAX_STATIONS; i++)
         {
-            TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);
+            TileCoordsXYZD location = ride_get_entrance_location(rideIndex, i);
             if (location.isNull())
                 continue;
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1609,12 +1609,11 @@ void footpath_update_queue_chains()
 
         for (sint32 i = 0; i < MAX_STATIONS; i++)
         {
-            if (ride->entrances[i].xy == RCT_XY8_UNDEFINED)
+            TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);
+            if (location.x == LOCATION_NULL)
                 continue;
 
-            uint8              x           = ride->entrances[i].x;
-            uint8              y           = ride->entrances[i].y;
-            rct_tile_element * tileElement = map_get_first_element_at(x, y);
+            rct_tile_element * tileElement = map_get_first_element_at(location.x, location.y);
             do
             {
                 if (tile_element_get_type(tileElement) != TILE_ELEMENT_TYPE_ENTRANCE)
@@ -1625,7 +1624,7 @@ void footpath_update_queue_chains()
                     continue;
 
                 uint8 direction = tile_element_get_direction_with_offset(tileElement, 2);
-                footpath_chain_ride_queue(rideIndex, i, x << 5, y << 5, tileElement, direction);
+                footpath_chain_ride_queue(rideIndex, i, location.x << 5, location.y << 5, tileElement, direction);
             } while (!tile_element_is_last_for_tile(tileElement++));
         }
     }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1610,7 +1610,7 @@ void footpath_update_queue_chains()
         for (sint32 i = 0; i < MAX_STATIONS; i++)
         {
             TileCoordsXYZD location = ride_get_entrance_location_of_station(rideIndex, i);
-            if (location.x == LOCATION_NULL)
+            if (location.isNull())
                 continue;
 
             rct_tile_element * tileElement = map_get_first_element_at(location.x, location.y);

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -45,6 +45,9 @@ struct LocationXYZ16 {
 assert_struct_size(LocationXYZ16, 6);
 #pragma pack(pop)
 
+constexpr sint32 COORDS_NULL = -1;
+
+
 /*
  * Tile coordinates use 1 x/y increment per tile.
  * Regular ('big', 'sprite') coordinates use 32 x/y increments per tile.
@@ -73,12 +76,16 @@ struct TileCoordsXYZD
 {
     sint32 x, y, z;
     uint8 direction;
+
+    bool isNull() const { return x == COORDS_NULL; };
 };
 
 struct CoordsXYZD
 {
     sint32 x, y, z;
     uint8 direction;
+
+    bool isNull() const { return x == COORDS_NULL; };
 };
 
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -19,7 +19,7 @@
 
 #include <initializer_list>
 #include "../common.h"
-#include "Location.h"
+#include "Location.hpp"
 
 #pragma pack(push, 1)
 struct rct_tile_element_surface_properties {

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -259,19 +259,19 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
             // Update ride's known entrance/exit rotation
             Ride * ride         = get_ride(tileElement->properties.entrance.ride_index);
             uint8  stationIndex = tileElement->properties.entrance.index;
-            auto   entrance     = ride_get_entrance_location_of_station(ride, stationIndex);
-            auto   exit         = ride_get_exit_location_of_station(ride, stationIndex);
+            auto   entrance     = ride_get_entrance_location(ride, stationIndex);
+            auto   exit         = ride_get_exit_location(ride, stationIndex);
             uint8  entranceType = entrance_element_get_type(tileElement);
             uint8  z            = tileElement->base_height;
 
             // Make sure this is the correct entrance or exit
             if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE && entrance.x == x && entrance.y == y && entrance.z == z)
             {
-                ride_set_entrance_location_of_station(ride, stationIndex, { entrance.x, entrance.y, entrance.z, newRotation });
+                ride_set_entrance_location(ride, stationIndex, { entrance.x, entrance.y, entrance.z, newRotation });
             }
             else if (entranceType == ENTRANCE_TYPE_RIDE_EXIT && exit.x == x && exit.y == y && exit.z == z)
             {
-                ride_set_exit_location_of_station(ride, stationIndex, { exit.x, exit.y, exit.z, newRotation });
+                ride_set_exit_location(ride, stationIndex, { exit.x, exit.y, exit.z, newRotation });
             }
             break;
         }
@@ -423,16 +423,16 @@ sint32 tile_inspector_any_base_height_offset(sint32 x, sint32 y, sint16 elementI
                 // Update the ride's known entrance or exit height
                 Ride * ride          = get_ride(tileElement->properties.entrance.ride_index);
                 uint8  entranceIndex = tileElement->properties.entrance.index;
-                auto   entrance      = ride_get_entrance_location_of_station(ride, entranceIndex);
-                auto   exit          = ride_get_exit_location_of_station(ride, entranceIndex);
+                auto   entrance      = ride_get_entrance_location(ride, entranceIndex);
+                auto   exit          = ride_get_exit_location(ride, entranceIndex);
                 uint8 z = tileElement->base_height;
 
                 // Make sure this is the correct entrance or exit
                 if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE && entrance.x == x && entrance.y == y && entrance.z == z)
-                    ride_set_entrance_location_of_station(
+                    ride_set_entrance_location(
                         ride, entranceIndex, { entrance.x, entrance.y, z + heightOffset, entrance.direction });
                 else if (entranceType == ENTRANCE_TYPE_RIDE_EXIT && exit.x == x && exit.y == y && exit.z == z)
-                    ride_set_exit_location_of_station(
+                    ride_set_exit_location(
                         ride, entranceIndex, { exit.x, exit.y, z + heightOffset, exit.direction });
             }
         }
@@ -648,10 +648,10 @@ sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementInd
         switch (entranceElement->properties.entrance.type)
         {
         case ENTRANCE_TYPE_RIDE_ENTRANCE:
-            ride_set_entrance_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
+            ride_set_entrance_location(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
             break;
         case ENTRANCE_TYPE_RIDE_EXIT:
-            ride_set_exit_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
+            ride_set_exit_location(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
             break;
         }
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -256,7 +256,7 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
             tileElement->type &= ~TILE_ELEMENT_DIRECTION_MASK;
             tileElement->type |= newRotation;
 
-            // Update ride's known entrance/exit rotataion
+            // Update ride's known entrance/exit rotation
             Ride * ride         = get_ride(tileElement->properties.entrance.ride_index);
             uint8  stationIndex = tileElement->properties.entrance.index;
             auto   entrance     = ride_get_entrance_location_of_station(ride, stationIndex);
@@ -264,7 +264,7 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
             uint8  entranceType = entrance_element_get_type(tileElement);
             uint8  z            = tileElement->base_height;
 
-            // Make sure this is the correct entrance or exit, in case there are multiple on the same tile
+            // Make sure this is the correct entrance or exit
             if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE && entrance.x == x && entrance.y == y && entrance.z == z)
             {
                 ride_set_entrance_location_of_station(ride, stationIndex, { entrance.x, entrance.y, entrance.z, newRotation });
@@ -427,7 +427,7 @@ sint32 tile_inspector_any_base_height_offset(sint32 x, sint32 y, sint16 elementI
                 auto   exit          = ride_get_exit_location_of_station(ride, entranceIndex);
                 uint8 z = tileElement->base_height;
 
-                // Make sure this is the correct entrance or exit, in case there are multiple on the same tile
+                // Make sure this is the correct entrance or exit
                 if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE && entrance.x == x && entrance.y == y && entrance.z == z)
                     ride_set_entrance_location_of_station(
                         ride, entranceIndex, { entrance.x, entrance.y, z + heightOffset, entrance.direction });

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -601,10 +601,10 @@ sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementInd
         switch (entranceElement->properties.entrance.type)
         {
         case ENTRANCE_TYPE_RIDE_ENTRANCE:
-            ride_set_entrance_location_of_station(ride, stationIndex, { x, y });
+            ride_set_entrance_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
             break;
         case ENTRANCE_TYPE_RIDE_EXIT:
-            ride_set_exit_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height });
+            ride_set_exit_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height, (uint8)tile_element_get_direction(entranceElement) });
             break;
         }
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -257,19 +257,21 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
             tileElement->type |= newRotation;
 
             // Update ride's known entrance/exit rotataion
-            Ride * ride = get_ride(tileElement->properties.entrance.ride_index);
+            Ride * ride         = get_ride(tileElement->properties.entrance.ride_index);
             uint8  stationIndex = tileElement->properties.entrance.index;
-            if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_ENTRANCE)
+            auto   entrance     = ride_get_entrance_location_of_station(ride, stationIndex);
+            auto   exit         = ride_get_exit_location_of_station(ride, stationIndex);
+            uint8  entranceType = entrance_element_get_type(tileElement);
+            uint8  z            = tileElement->base_height;
+
+            // Make sure this is the correct entrance or exit, in case there are multiple on the same tile
+            if (entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE && entrance.x == x && entrance.y == y && entrance.z == z)
             {
-                auto entrance = ride_get_entrance_location_of_station(ride, stationIndex);
-                entrance.direction = newRotation;
-                ride_set_entrance_location_of_station(ride, stationIndex, entrance);
+                ride_set_entrance_location_of_station(ride, stationIndex, { entrance.x, entrance.y, entrance.z, newRotation });
             }
-            else if (tileElement->properties.entrance.type == ENTRANCE_TYPE_RIDE_EXIT)
+            else if (entranceType == ENTRANCE_TYPE_RIDE_EXIT && exit.x == x && exit.y == y && exit.z == z)
             {
-                auto exit = ride_get_exit_location_of_station(ride, stationIndex);
-                exit.direction = newRotation;
-                ride_set_exit_location_of_station(ride, stationIndex, exit);
+                ride_set_exit_location_of_station(ride, stationIndex, { exit.x, exit.y, exit.z, newRotation });
             }
             break;
         }

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -26,6 +26,7 @@
 #include "Footpath.h"
 #include "Map.h"
 #include "TileInspector.h"
+#include "../ride/Station.h"
 
 uint32 windowTileInspectorTileX;
 uint32 windowTileInspectorTileY;
@@ -600,15 +601,10 @@ sint32 tile_inspector_entrance_make_usable(sint32 x, sint32 y, sint32 elementInd
         switch (entranceElement->properties.entrance.type)
         {
         case ENTRANCE_TYPE_RIDE_ENTRANCE:
-            ride->entrances[stationIndex].x = x;
-            ride->entrances[stationIndex].y = y;
+            ride_set_entrance_location_of_station(ride, stationIndex, { x, y });
             break;
         case ENTRANCE_TYPE_RIDE_EXIT:
-            ride->exits[stationIndex].x = x;
-            ride->exits[stationIndex].y = y;
-
-            // TODO: Remove once mechanics don't assume exits always match the station heights
-            ride->station_heights[stationIndex] = entranceElement->base_height;
+            ride_set_exit_location_of_station(ride, stationIndex, { x, y, entranceElement->base_height });
             break;
         }
 

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -50,6 +50,9 @@ const CoordsXY TileDirectionDelta[] = {
     {-32, -32}
 };
 
+TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex);
+
 uint8 get_current_rotation() {
     return gCurrentRotation & 3;
 }

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -50,8 +50,8 @@ const CoordsXY TileDirectionDelta[] = {
     {-32, -32}
 };
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex);
-TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_entrance_location(const Ride * ride, const sint32 stationIndex);
+TileCoordsXYZD ride_get_exit_location(const Ride * ride, const sint32 stationIndex);
 
 uint8 get_current_rotation() {
     return gCurrentRotation & 3;
@@ -298,12 +298,12 @@ void track_element_clear_cable_lift(rct_tile_element * trackElement)
     trackElement->properties.track.colour &= ~TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT;
 }
 
-TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex)
+TileCoordsXYZD ride_get_entrance_location(const Ride * ride, const sint32 stationIndex)
 {
     return ride->entrances[stationIndex];
 }
 
-TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex)
+TileCoordsXYZD ride_get_exit_location(const Ride * ride, const sint32 stationIndex)
 {
     return ride->exits[stationIndex];
 }

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -294,3 +294,13 @@ void track_element_clear_cable_lift(rct_tile_element * trackElement)
 {
     trackElement->properties.track.colour &= ~TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT;
 }
+
+TileCoordsXYZD ride_get_entrance_location_of_station(const Ride * ride, const sint32 stationIndex)
+{
+    return ride->entrances[stationIndex];
+}
+
+TileCoordsXYZD ride_get_exit_location_of_station(const Ride * ride, const sint32 stationIndex)
+{
+    return ride->exits[stationIndex];
+}


### PR DESCRIPTION
Continuation of #7197. Mostly addresses #7095. Besides avoiding the need to step through tile elements, this also gets rid of lots of height assumptions.