### PR TITLE
Fix cursor behaviour in text composition

### DIFF
--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -194,7 +194,15 @@ void TextComposition::CursorHome()
 
 void TextComposition::CursorEnd()
 {
-    _session.SelectionStart = _session.SelectionSize;
+    size_t selectionOffset = _session.Size;
+    const utf8 * ch = _session.Buffer + _session.SelectionStart;
+    while (!utf8_is_codepoint_start(ch) && selectionOffset > 0)
+    {
+        ch--;
+        selectionOffset--;
+    }
+
+    _session.SelectionStart = selectionOffset;
 }
 
 void TextComposition::CursorLeft()


### PR DESCRIPTION
This PR addresses two bugs regarding text composition: the end key not moving the cursor properly, as well as not taking multibyte characters into account when deleting text.

There may be a better way of tackling this, but most of this should be rewritten at some point, anyway, when we leave the old `utf8` buffer arrays behind.