### PR TITLE
Revert "Fix #6667: Match sample rate to games audio content."

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -76,10 +76,10 @@ namespace OpenRCT2 { namespace Audio
             Close();
 
             SDL_AudioSpec want = { 0 };
-            want.freq = 22050;
+            want.freq = 44100;
             want.format = AUDIO_S16SYS;
             want.channels = 2;
-            want.samples = 2048;
+            want.samples = 1024;
             want.callback = [](void * arg, uint8 * dst, sint32 length) -> void
             {
                 auto mixer = static_cast<AudioMixerImpl *>(arg);


### PR DESCRIPTION
PR #7149 intended to fix the 'crackling' some users experienced with the in-game sound effects, as reported in #6667. However, changing the sample rate has completely removed effects like crowd noises, thunder claps, and guests clapping when winning a scenario, in turn reported in #7196.

I propose to revert commit 4f011163d08374e744a7e985708de40d53425639 and reopen #6667 until a proper fix is devised.