### PR TITLE
 Fix #5261 pasting and deleting signs

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,6 +54,7 @@
 - Fix: [#5190] Cannot build Wild Mouse - Flying Dutchman Gold Mine.
 - Fix: [#5224] Multiplayer window is not closed when server shuts down.
 - Fix: [#5228] Top toolbar disappears when opening SC4 file.
+- Fix: [#5261] Deleting the sign after copy/pasting it will crash the game.
 - Fix: [#5398] Attempting to place Mini Maze.TD4 results in weird behaviour and crashes.
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1291,6 +1291,9 @@ void game_fix_save_vars()
     // Fix banner list pointing to NULL map elements
     banner_reset_broken_index();
 
+    // Fix banners which share their index
+    fix_duplicated_banners();
+
     // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
     fix_invalid_vehicle_sprite_sizes();
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -689,7 +689,7 @@ void scenario_fix_ghosts(rct_s6_data *s6)
             do {
                 if (originalElement->flags & TILE_ELEMENT_FLAG_GHOST) {
                     sint32 bannerIndex = tile_element_get_banner_index(originalElement);
-                    if (bannerIndex != -1) {
+                    if (bannerIndex != BANNER_INDEX_NULL) {
                         rct_banner *banner = &s6->banners[bannerIndex];
                         if (banner->type != BANNER_NULL)
                         {

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -50,6 +50,7 @@ sint32 create_new_banner(uint8 flags);
 rct_tile_element *banner_get_tile_element(sint32 bannerIndex);
 sint32 banner_get_closest_ride_index(sint32 x, sint32 y, sint32 z);
 void banner_reset_broken_index();
+void fix_duplicated_banners();
 void game_command_callback_place_banner(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp);
 
 #endif

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -22,6 +22,7 @@
 
 #define BANNER_NULL 255
 #define MAX_BANNERS 250
+#define BANNER_INDEX_NULL -1
 
 #pragma pack(push, 1)
 struct rct_banner {

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -3553,19 +3553,19 @@ sint32 tile_element_get_banner_index(rct_tile_element *tileElement)
     case TILE_ELEMENT_TYPE_LARGE_SCENERY:
         sceneryEntry = get_large_scenery_entry(scenery_large_get_type(tileElement));
         if (sceneryEntry->large_scenery.scrolling_mode == 0xFF)
-            return -1;
+            return BANNER_INDEX_NULL;
 
         return scenery_large_get_banner_id(tileElement);
     case TILE_ELEMENT_TYPE_WALL:
         sceneryEntry = get_wall_entry(tileElement->properties.wall.type);
         if (sceneryEntry == nullptr || sceneryEntry->wall.scrolling_mode == 0xFF)
-            return -1;
+            return BANNER_INDEX_NULL;
 
         return tileElement->properties.wall.banner_index;
     case TILE_ELEMENT_TYPE_BANNER:
         return tileElement->properties.banner.index;
     default:
-        return -1;
+        return BANNER_INDEX_NULL;
     }
 }
 
@@ -3591,7 +3591,7 @@ void tile_element_set_banner_index(rct_tile_element * tileElement, sint32 banner
 void tile_element_remove_banner_entry(rct_tile_element *tileElement)
 {
     sint32 bannerIndex = tile_element_get_banner_index(tileElement);
-    if (bannerIndex == -1)
+    if (bannerIndex == BANNER_INDEX_NULL)
         return;
 
     rct_banner* banner = &gBanners[bannerIndex];

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -3569,6 +3569,25 @@ sint32 tile_element_get_banner_index(rct_tile_element *tileElement)
     }
 }
 
+void tile_element_set_banner_index(rct_tile_element * tileElement, sint32 bannerIndex)
+{
+    switch (tile_element_get_type(tileElement))
+    {
+        case TILE_ELEMENT_TYPE_WALL:
+            tileElement->properties.wall.banner_index = (uint8)bannerIndex;
+            break;
+        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            scenery_large_set_banner_id(tileElement, (uint8)bannerIndex);
+            break;
+        case TILE_ELEMENT_TYPE_BANNER:
+            tileElement->properties.banner.index = (uint8)bannerIndex;
+            break;
+        default:
+            log_error("Tried to set banner index on unsuitable tile element!");
+            Guard::Assert(false);
+    }
+}
+
 void tile_element_remove_banner_entry(rct_tile_element *tileElement)
 {
     sint32 bannerIndex = tile_element_get_banner_index(tileElement);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -521,6 +521,7 @@ void map_update_tiles();
 sint32 map_get_highest_z(sint32 tileX, sint32 tileY);
 
 sint32 tile_element_get_banner_index(rct_tile_element *tileElement);
+void tile_element_set_banner_index(rct_tile_element * tileElement, sint32 bannerIndex);
 void tile_element_remove_banner_entry(rct_tile_element *tileElement);
 
 bool tile_element_is_underground(rct_tile_element *tileElement);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -316,8 +316,7 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
     {
         // Check if the element to be pasted refers to a banner index
         sint32 bannerIndex = tile_element_get_banner_index(&element);
-
-        if (bannerIndex != BANNER_NULL)
+        if (bannerIndex != BANNER_INDEX_NULL)
         {
             // The element to be pasted refers to a banner index - make a copy of it
             sint32 newBannerIndex = create_new_banner(flags);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -315,29 +315,12 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
         // Check if the element to be pasted refers to a banner index
-        uint8                     bannerIndex = BANNER_NULL;
-        const rct_scenery_entry * entry;
-        switch (tile_element_get_type(&element))
-        {
-        case TILE_ELEMENT_TYPE_WALL:
-            entry          = get_wall_entry(element.properties.wall.type);
-            if (entry->wall.flags & WALL_SCENERY_IS_BANNER)
-                bannerIndex = element.properties.wall.banner_index;
-            break;
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-            entry          = get_large_scenery_entry(scenery_large_get_type(&element));
-            if (entry->large_scenery.scrolling_mode != 0xFF)
-                bannerIndex = scenery_large_get_banner_id(&element);
-            break;
-        case TILE_ELEMENT_TYPE_BANNER:
-            bannerIndex = element.properties.banner.index;
-            break;
-        }
+        sint32 bannerIndex = tile_element_get_banner_index(&element);
 
         if (bannerIndex != BANNER_NULL)
         {
             // The element to be pasted refers to a banner index - make a copy of it
-            uint8 newBannerIndex = (uint8)create_new_banner(flags);
+            sint32 newBannerIndex = create_new_banner(flags);
             if (newBannerIndex == BANNER_NULL)
             {
                 return MONEY32_UNDEFINED;
@@ -348,18 +331,7 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
             newBanner.y            = y;
 
             // Use the new banner index
-            switch (tile_element_get_type(&element))
-            {
-            case TILE_ELEMENT_TYPE_WALL:
-                element.properties.wall.banner_index = newBannerIndex;
-                break;
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-                scenery_large_set_banner_id(&element, newBannerIndex);
-                break;
-            case TILE_ELEMENT_TYPE_BANNER:
-                element.properties.banner.index = newBannerIndex;
-                break;
-            }
+            tile_element_set_banner_index(&element, newBannerIndex);
 
             // Duplicate user string if needed
             rct_string_id stringIdx = newBanner.string_idx;


### PR DESCRIPTION
Previously banners could be copied and pasted using the tile inspector, causing the pasted banner to refer to the same banner entry, which in turn can refer to the same user string.

This PR fixes this behaviour by creating a new banner (and possibly user string too) when pasting a banner, and when loading a saved game.