### PR TITLE
Add reasoning for not running openrct2 with elevated privileges.

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4460,7 +4460,7 @@ STR_6150    :Invalid response from master server (no JSON number)
 STR_6151    :Master server failed to return servers
 STR_6152    :Invalid response from master server (no JSON array)
 STR_6153    :Pay to enter park / Pay per ride
-STR_6154    :It is not recommended to run OpenRCT2 with elevated permissions.
+STR_6154    :For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
 STR_6155    :Neither KDialog nor Zenity are installed. Please install one, or configure from the command line.
 STR_6156    :Name is reserved
 STR_6157    :Console


### PR DESCRIPTION
I was wondering for the longest time why it was not recommended to run openrct2 with elevated privileges and I am sure others are wondering the same thing. So this adds a little reasoning to it.