### PR TITLE
Fix #7223 Vehicle mass not properly recalculated when using remove all guests cheat

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -103,6 +103,7 @@ The following people are not part of the project team, but have been contributin
 * Tyler Ruckinger (TyPR124)
 * Justin Gottula (jgottula)
 * Seongsik Park (pss9205)
+* (Deurklink)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -110,6 +110,7 @@
 - Fix: [#7003] Building sloped paths through flat paths with clearance checks off causes glitches.
 - Fix: [#7011] Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
 - Fix: [#7125] No entry signs not correctly handled in pathfinding.
+- Fix: [#7223] Vehicle mass not correctly recalculated when using remove all guests cheat.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -355,22 +355,13 @@ static void cheat_remove_all_guests()
     rct_peep *peep;
     rct_vehicle *vehicle;
     uint16 spriteIndex, nextSpriteIndex;
-
-    for (spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
-        peep = &(get_sprite(spriteIndex)->peep);
-        nextSpriteIndex = peep->next;
-        if (peep->type == PEEP_TYPE_GUEST) {
-            peep_remove(peep);
-        }
-    }
-
     sint32 rideIndex;
     Ride *ride;
 
     FOR_ALL_RIDES(rideIndex, ride)
     {
         ride->num_riders = 0;
-
+ 
         for (size_t stationIndex = 0; stationIndex < MAX_STATIONS; stationIndex++)
         {
             ride->queue_length[stationIndex] = 0;
@@ -384,16 +375,29 @@ static void cheat_remove_all_guests()
             {
                 vehicle = GET_VEHICLE(spriteIndex);
 
-                vehicle->num_peeps = 0;
-                vehicle->next_free_seat = 0;
+                for (int i = 0; i < vehicle->num_peeps; i++) {
+                    peep = GET_PEEP(vehicle->peep[i]);
+                    vehicle->mass -= peep->mass;
+                }
 
                 for (auto &peepInTrainIndex : vehicle->peep)
                 {
                     peepInTrainIndex = SPRITE_INDEX_NULL;
                 }
 
+                vehicle->num_peeps = 0;
+                vehicle->next_free_seat = 0;
+
                 spriteIndex = vehicle->next_vehicle_on_train;
             }
+        }
+    }
+
+    for (spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP]; spriteIndex != SPRITE_INDEX_NULL; spriteIndex = nextSpriteIndex) {
+        peep = &(get_sprite(spriteIndex)->peep);
+        nextSpriteIndex = peep->next;
+        if (peep->type == PEEP_TYPE_GUEST) {
+            peep_remove(peep);
         }
     }
 

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -375,7 +375,8 @@ static void cheat_remove_all_guests()
             {
                 vehicle = GET_VEHICLE(spriteIndex);
 
-                for (int i = 0; i < vehicle->num_peeps; i++) {
+                for (size_t i = 0; i < vehicle->num_peeps; i++) 
+                {
                     peep = GET_PEEP(vehicle->peep[i]);
                     vehicle->mass -= peep->mass;
                 }

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -361,7 +361,7 @@ static void cheat_remove_all_guests()
     FOR_ALL_RIDES(rideIndex, ride)
     {
         ride->num_riders = 0;
- 
+
         for (size_t stationIndex = 0; stationIndex < MAX_STATIONS; stationIndex++)
         {
             ride->queue_length[stationIndex] = 0;


### PR DESCRIPTION
Made some changes to the remove all guests cheat so the mass of every vehicle gets properly recalculated.

Normally, the function first removes the peeps from the park, and then removes the list of peeps from vehicles.

I wanted to make use of the already existing loop in the function that cycles through all vehicles. To do that, i had to switch the order of the two functions. So now first the list of peeps in every vehicle is reset, and after that the peeps are removed from the park.

While cycling through all vehicles, a new loop cycles through the peeps that are currently in the vehicle, and subtracts their mass from the vehicle mass. 

I tested this in several parks, and noticed river rapids now keep running properly even when remove guests cheat is used several times. Mass gets properly set now.