### PR TITLE
Fix #7239: Remove all guests cheat crashes with ferris wheel

### DIFF
--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -374,8 +374,7 @@ static void cheat_remove_all_guests()
             while (spriteIndex != SPRITE_INDEX_NULL)
             {
                 vehicle = GET_VEHICLE(spriteIndex);
-                size_t offset = 0;
-                for (size_t i = 0; i < vehicle->num_peeps; i++) 
+                for (size_t i = 0, offset = 0; i < vehicle->num_peeps; i++) 
                 {
                     while (vehicle->peep[i + offset] == SPRITE_INDEX_NULL)
                     {

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -374,10 +374,14 @@ static void cheat_remove_all_guests()
             while (spriteIndex != SPRITE_INDEX_NULL)
             {
                 vehicle = GET_VEHICLE(spriteIndex);
-
+                size_t offset = 0;
                 for (size_t i = 0; i < vehicle->num_peeps; i++) 
                 {
-                    peep = GET_PEEP(vehicle->peep[i]);
+                    while (vehicle->peep[i + offset] == SPRITE_INDEX_NULL)
+                    {
+                        offset++;
+                    }
+                    peep = GET_PEEP(vehicle->peep[i + offset]);
                     vehicle->mass -= peep->mass;
                 }
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "37"
+#define NETWORK_STREAM_VERSION "38"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Unlike other rides, a ferris wheel does not start from vehicle->peeps[0] when storing the guests that are currently riding it. This caused the loop i made in my previous commit to try and get a peep with index SPRITE_INDEX_NULL. I fixed this by adding an offset. 

If the loop now encounters a peep with SPRITE_INDEX_NULL in the list, it will increment offset until it finds one with a correct index. This loop now works regardless of whether the null index is at the start, center, or end of the list. Other rides should be unaffected because they fill vehicle->peeps starting from peeps[0].