### PR TITLE
Fix #7251 "Own ALL Land" Cheat is broken

### DIFF
--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -448,7 +448,7 @@ static void cheat_own_all_land()
     const sint32 max = gMapSizeUnits - 32;
 
     for (CoordsXY coords = {min, min}; coords.y <= max; coords.y += 32) {
-        for (; coords.x <= max; coords.x += 32) {
+        for (coords.x = min; coords.x <= max; coords.x += 32) {
             rct_tile_element * surfaceElement = map_get_surface_element_at(coords);
 
             // Ignore already owned tiles.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "38"
+#define NETWORK_STREAM_VERSION "39"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
`coords.x` was not set back to `min` in the second for loop, causing all second iterations to immediately stop.