### PR TITLE
Layout tweaks for multiplayer and misc windows

### DIFF
--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -528,7 +528,7 @@ static void window_multiplayer_players_scrollgetsize(rct_window *w, sint32 scrol
         window_invalidate(w);
     }
 
-    *height = network_get_num_players() * 10;
+    *height = network_get_num_players() * SCROLLABLE_ROW_HEIGHT;
     i = *height - window_multiplayer_players_widgets[WIDX_LIST].bottom + window_multiplayer_players_widgets[WIDX_LIST].top + 21;
     if (i < 0)
         i = 0;
@@ -542,7 +542,7 @@ static void window_multiplayer_players_scrollmousedown(rct_window *w, sint32 scr
 {
     sint32 index;
 
-    index = y / 10;
+    index = y / SCROLLABLE_ROW_HEIGHT;
     if (index >= w->no_list_items)
         return;
 
@@ -556,7 +556,7 @@ static void window_multiplayer_players_scrollmouseover(rct_window *w, sint32 scr
 {
     sint32 index;
 
-    index = y / 10;
+    index = y / SCROLLABLE_ROW_HEIGHT;
     if (index >= w->no_list_items)
         return;
 
@@ -596,25 +596,27 @@ static void window_multiplayer_players_paint(rct_window *w, rct_drawpixelinfo *d
 
 static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 scrollIndex)
 {
-    sint32 y;
-
-    y = 0;
+    sint32 y = 0;
     for (sint32 i = 0; i < network_get_num_players(); i++) {
         if (y > dpi->y + dpi->height) {
             break;
         }
 
-        if (y + 11 >= dpi->y) {
+        if (y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        {
             char buffer[300];
 
             // Draw player name
             char* lineCh = buffer;
             sint32 colour = COLOUR_BLACK;
-            if (i == w->selected_list_item) {
-                gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
+            if (i == w->selected_list_item)
+            {
+                gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
                 safe_strcpy(buffer, network_get_player_name(i), sizeof(buffer));
                 colour = w->colours[2];
-            } else {
+            }
+            else
+            {
                 if (network_get_player_flags(i) & NETWORK_PLAYER_FLAG_ISSERVER) {
                     lineCh = utf8_write_codepoint(lineCh, FORMAT_BABYBLUE);
                 } else {
@@ -623,7 +625,7 @@ static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixeli
                 safe_strcpy(lineCh, network_get_player_name(i), sizeof(buffer) - (lineCh - buffer));
             }
             gfx_clip_string(buffer, 230);
-            gfx_draw_string(dpi, buffer, colour, 0, y - 1);
+            gfx_draw_string(dpi, buffer, colour, 0, y);
 
             // Draw group name
             lineCh = buffer;
@@ -632,7 +634,7 @@ static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixeli
                 lineCh = utf8_write_codepoint(lineCh, FORMAT_BLACK);
                 safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
                 gfx_clip_string(buffer, 80);
-                gfx_draw_string(dpi, buffer, colour, 173, y - 1);
+                gfx_draw_string(dpi, buffer, colour, 173, y);
             }
 
             // Draw last action
@@ -641,7 +643,7 @@ static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixeli
             if (action != -999) {
                 set_format_arg(0, rct_string_id, network_get_action_name_string_id(action));
             }
-            gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, 256, y - 1, 100);
+            gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, 256, y, 100);
 
             // Draw ping
             lineCh = buffer;
@@ -655,9 +657,9 @@ static void window_multiplayer_players_scrollpaint(rct_window *w, rct_drawpixeli
                 lineCh = utf8_write_codepoint(lineCh, FORMAT_RED);
             }
             snprintf(lineCh, sizeof(buffer) - (lineCh - buffer), "%d ms", ping);
-            gfx_draw_string(dpi, buffer, colour, 356, y - 1);
+            gfx_draw_string(dpi, buffer, colour, 356, y);
         }
-        y += 10;
+        y += SCROLLABLE_ROW_HEIGHT;
     }
 }
 
@@ -749,7 +751,7 @@ static void window_multiplayer_groups_scrollgetsize(rct_window *w, sint32 scroll
         window_invalidate(w);
     }
 
-    *height = network_get_num_actions() * 10;
+    *height = network_get_num_actions() * SCROLLABLE_ROW_HEIGHT;
     i = *height - window_multiplayer_groups_widgets[WIDX_LIST].bottom + window_multiplayer_groups_widgets[WIDX_LIST].top + 21;
     if (i < 0)
         i = 0;
@@ -763,7 +765,7 @@ static void window_multiplayer_groups_scrollmousedown(rct_window *w, sint32 scro
 {
     sint32 index;
 
-    index = y / 10;
+    index = y / SCROLLABLE_ROW_HEIGHT;
     if (index >= w->no_list_items)
         return;
 
@@ -777,7 +779,7 @@ static void window_multiplayer_groups_scrollmouseover(rct_window *w, sint32 scro
 {
     sint32 index;
 
-    index = y / 10;
+    index = y / SCROLLABLE_ROW_HEIGHT;
     if (index >= w->no_list_items)
         return;
 
@@ -875,13 +877,14 @@ static void window_multiplayer_groups_scrollpaint(rct_window *w, rct_drawpixelin
 
     for (sint32 i = 0; i < network_get_num_actions(); i++) {
         if (i == w->selected_list_item) {
-            gfx_filter_rect(dpi, 0, y, 800, y + 9, PALETTE_DARKEN_1);
+            gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
         }
         if (y > dpi->y + dpi->height) {
             break;
         }
 
-        if (y + 11 >= dpi->y) {
+        if (y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        {
             char buffer[300] = {0};
             sint32 groupindex = network_get_group_index(_selectedGroup);
             if (groupindex != -1){
@@ -889,15 +892,15 @@ static void window_multiplayer_groups_scrollpaint(rct_window *w, rct_drawpixelin
                     char* lineCh = buffer;
                     lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
                     lineCh = utf8_write_codepoint(lineCh, FORMAT_TICK);
-                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, 0, y - 1);
+                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, 0, y);
                 }
             }
 
             // Draw action name
             set_format_arg(0, uint16, network_get_action_name_string_id(i));
-            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, y - 1);
+            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, y);
         }
-        y += 10;
+        y += SCROLLABLE_ROW_HEIGHT;
     }
 }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -400,16 +400,17 @@ static LocationXY16 window_multiplayer_information_get_size()
     }
 
     sint32 width = 450;
-    sint32 height = 110;
-    sint32 numLines, fontSpriteBase;
+    sint32 height = 60;
+    sint32 minNumLines = 5;
+    sint32 descNumLines, fontSpriteBase;
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     utf8 * buffer = _strdup(network_get_server_description());
-    gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
+    gfx_wrap_string(buffer, width, &descNumLines, &fontSpriteBase);
     free(buffer);
 
     sint32 lineHeight = font_get_line_height(fontSpriteBase);
-    height += (numLines + 1) * lineHeight;
+    height += (minNumLines + descNumLines) * lineHeight;
 
     _windowInformationSizeDirty = false;
     _windowInformationSize = { (sint16)width, (sint16)height };
@@ -451,27 +452,26 @@ static void window_multiplayer_information_paint(rct_window *w, rct_drawpixelinf
         const utf8 * name = network_get_server_name();
         {
             gfx_draw_string_left_wrapped(dpi, (void*)&name, x, y, width, STR_STRING, w->colours[1]);
-            y += 11;
+            y += LIST_ROW_HEIGHT;
         }
-        y += 3;
+        y += LIST_ROW_HEIGHT / 2;
 
         const utf8 * description = network_get_server_description();
         if (!str_is_null_or_empty(description)) {
-            gfx_draw_string_left_wrapped(dpi, (void*)&description, x, y, width, STR_STRING, w->colours[1]);
-            y += 11;
+            y += gfx_draw_string_left_wrapped(dpi, (void*)&description, x, y, width, STR_STRING, w->colours[1]);
+            y += LIST_ROW_HEIGHT / 2;
         }
-        y += 8;
 
         const utf8 * providerName = network_get_server_provider_name();
         if (!str_is_null_or_empty(providerName)) {
             gfx_draw_string_left(dpi, STR_PROVIDER_NAME, (void*)&providerName, COLOUR_BLACK, x, y);
-            y += 11;
+            y += LIST_ROW_HEIGHT;
         }
 
         const utf8 * providerEmail = network_get_server_provider_email();
         if (!str_is_null_or_empty(providerEmail)) {
             gfx_draw_string_left(dpi, STR_PROVIDER_EMAIL, (void*)&providerEmail, COLOUR_BLACK, x, y);
-            y += 11;
+            y += LIST_ROW_HEIGHT;
         }
 
         const utf8 * providerWebsite = network_get_server_provider_website();

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -521,7 +521,7 @@ void window_player_statistics_paint(rct_window *w, rct_drawpixelinfo *dpi)
     set_format_arg(0, uint32, network_get_player_commands_ran(player));
     gfx_draw_string_left(dpi, STR_COMMANDS_RAN, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
-    y += 10;
+    y += LIST_ROW_HEIGHT;
 
     set_format_arg(0, uint32, network_get_player_money_spent(player));
     gfx_draw_string_left(dpi, STR_MONEY_SPENT, gCommonFormatArgs, COLOUR_BLACK, x, y);

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -37,13 +37,13 @@ enum WINDOW_SAVE_PROMPT_WIDGET_IDX {
 };
 
 static rct_widget window_save_prompt_widgets[] = {
-    { WWT_FRAME,            0,  0,      259,    0,  49, STR_NONE,                   STR_NONE },                 // panel / background
+    { WWT_FRAME,            0,  0,      259,    0,  53, STR_NONE,                   STR_NONE },                 // panel / background
     { WWT_CAPTION,          0,  1,      258,    1,  14, 0,                          STR_WINDOW_TITLE_TIP },     // title bar
     { WWT_CLOSEBOX,         0,  247,    257,    2,  13, STR_CLOSE_X_WHITE,          STR_CLOSE_WINDOW_TIP },     // close x button
     { WWT_LABEL_CENTRED,    0,  2,      257,    19, 30, 0,                          STR_NONE },                 // question/label
-    { WWT_BUTTON,           0,  8,      85,     35, 46, STR_SAVE_PROMPT_SAVE,       STR_NONE },     // save
-    { WWT_BUTTON,           0,  91,     168,    35, 46, STR_SAVE_PROMPT_DONT_SAVE,  STR_NONE },     // don't save
-    { WWT_BUTTON,           0,  174,    251,    35, 46, STR_SAVE_PROMPT_CANCEL,     STR_NONE },     // cancel
+    { WWT_BUTTON,           0,  8,      85,     35, 48, STR_SAVE_PROMPT_SAVE,       STR_NONE },     // save
+    { WWT_BUTTON,           0,  91,     168,    35, 48, STR_SAVE_PROMPT_DONT_SAVE,  STR_NONE },     // don't save
+    { WWT_BUTTON,           0,  174,    251,    35, 48, STR_SAVE_PROMPT_CANCEL,     STR_NONE },     // cancel
     { WIDGETS_END },
 };
 
@@ -56,11 +56,11 @@ enum WINDOW_QUIT_PROMPT_WIDGET_IDX {
 };
 
 static rct_widget window_quit_prompt_widgets[] = {
-    { WWT_FRAME,            0,  0,      176,    0,  33, STR_NONE,                   STR_NONE },                 // panel / background
+    { WWT_FRAME,            0,  0,      176,    0,  37, STR_NONE,                   STR_NONE },                 // panel / background
     { WWT_CAPTION,          0,  1,      175,    1,  14, STR_QUIT_GAME_PROMPT_TITLE, STR_WINDOW_TITLE_TIP },     // title bar
     { WWT_CLOSEBOX,         0,  164,    174,    2,  13, STR_CLOSE_X_WHITE,          STR_CLOSE_WINDOW_TIP },     // close x button
-    { WWT_BUTTON,           0,  8,      85,     19, 30, STR_OK,                     STR_NONE },     // ok
-    { WWT_BUTTON,           0,  91,     168,    19, 30, STR_CANCEL,                 STR_NONE },     // cancel
+    { WWT_BUTTON,           0,  8,      85,     19, 32, STR_OK,                     STR_NONE },     // ok
+    { WWT_BUTTON,           0,  91,     168,    19, 32, STR_CANCEL,                 STR_NONE },     // cancel
     { WIDGETS_END },
 };
 
@@ -156,7 +156,7 @@ rct_window * window_save_prompt_open()
             (1 << WQIDX_OK) |
             (1 << WQIDX_CANCEL);
         width = 177;
-        height = 34;
+        height = 38;
     } else {
         widgets = window_save_prompt_widgets;
         enabled_widgets =
@@ -165,7 +165,7 @@ rct_window * window_save_prompt_open()
             (1 << WIDX_DONT_SAVE) |
             (1 << WIDX_CANCEL);
         width = 260;
-        height = 50;
+        height = 54;
     }
 
     if (prompt_mode >= Util::CountOf(window_save_prompt_labels)) {

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -60,14 +60,14 @@ enum {
 };
 
 static rct_widget window_server_list_widgets[] = {
-    { WWT_FRAME,            0,  0,      340,    0,      90,     0xFFFFFFFF,                 STR_NONE },                 // panel / background
+    { WWT_FRAME,            0,  0,      340,    0,      90,     STR_NONE,                   STR_NONE },                 // panel / background
     { WWT_CAPTION,          0,  1,      338,    1,      14,     STR_SERVER_LIST,            STR_WINDOW_TITLE_TIP },     // title bar
     { WWT_CLOSEBOX,         0,  327,    337,    2,      13,     STR_CLOSE_X,                STR_CLOSE_WINDOW_TIP },     // close x button
     { WWT_TEXT_BOX,         1,  100,    344,    20,     31,     STR_NONE,                   STR_NONE },                 // player name text box
     { WWT_SCROLL,           1,  6,      337,    37,     50,     STR_NONE,                   STR_NONE },                 // server list
-    { WWT_BUTTON,           1,  6,      106,    53,     64,     STR_FETCH_SERVERS,          STR_NONE },                 // fetch servers button
-    { WWT_BUTTON,           1,  112,    212,    53,     64,     STR_ADD_SERVER,             STR_NONE },                 // add server button
-    { WWT_BUTTON,           1,  218,    318,    53,     64,     STR_START_SERVER,           STR_NONE },                 // start server button
+    { WWT_BUTTON,           1,  6,      106,    53,     66,     STR_FETCH_SERVERS,          STR_NONE },                 // fetch servers button
+    { WWT_BUTTON,           1,  112,    212,    53,     66,     STR_ADD_SERVER,             STR_NONE },                 // add server button
+    { WWT_BUTTON,           1,  218,    318,    53,     66,     STR_START_SERVER,           STR_NONE },                 // start server button
     { WIDGETS_END },
 };
 
@@ -381,7 +381,7 @@ static void window_server_list_invalidate(rct_window *w)
     window_server_list_widgets[WIDX_CLOSE].right = w->width - 2 - 11 + 10;
 
     sint32 margin = 6;
-    sint32 buttonHeight = 11;
+    sint32 buttonHeight = 13;
     sint32 buttonTop = w->height - margin - buttonHeight - 13;
     sint32 buttonBottom = buttonTop + buttonHeight;
     sint32 listBottom = buttonTop - margin;
@@ -405,9 +405,11 @@ static void window_server_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_draw_widgets(w, dpi);
 
     gfx_draw_string_left(dpi, STR_PLAYER_NAME, nullptr, COLOUR_WHITE, w->x + 6, w->y + w->widgets[WIDX_PLAYER_NAME_INPUT].top);
+
+    // Draw version number
     std::string version = network_get_version();
     const char * versionCStr = version.c_str();
-    gfx_draw_string_left(dpi, STR_NETWORK_VERSION, (void*)&versionCStr, COLOUR_WHITE, w->x + 324, w->y + w->widgets[WIDX_START_SERVER].top);
+    gfx_draw_string_left(dpi, STR_NETWORK_VERSION, (void*)&versionCStr, COLOUR_WHITE, w->x + 324, w->y + w->widgets[WIDX_START_SERVER].top + 1);
 
     gfx_draw_string_left(dpi, status_text, (void *)&_numPlayersOnline, COLOUR_WHITE, w->x + 8, w->y + w->height - 15);
 }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -51,10 +51,10 @@ enum {
 };
 
 #define WW 300
-#define WH 152
+#define WH 154
 
 static rct_widget window_server_start_widgets[] = {
-    { WWT_FRAME,            0,  0,      WW-1,   0,          WH-1,   0xFFFFFFFF,                     STR_NONE },                 // panel / background
+    { WWT_FRAME,            0,  0,      WW-1,   0,          WH-1,   STR_NONE,                       STR_NONE },                 // panel / background
     { WWT_CAPTION,          0,  1,      WW-2,   1,          14,     STR_START_SERVER,               STR_WINDOW_TITLE_TIP },     // title bar
     { WWT_CLOSEBOX,         0,  WW-13,  WW-3,   2,          13,     STR_CLOSE_X,                    STR_CLOSE_WINDOW_TIP },     // close x button
     { WWT_TEXT_BOX,         1,  120,    WW-8,   20,         32,     STR_NONE,                       STR_NONE },                 // port text box
@@ -62,12 +62,12 @@ static rct_widget window_server_start_widgets[] = {
     { WWT_TEXT_BOX,         1,  120,    WW-8,   52,         64,     STR_NONE,                       STR_NONE },                 // description text box
     { WWT_TEXT_BOX,         1,  120,    WW-8,   68,         80,     STR_NONE,                       STR_NONE },                 // greeting text box
     { WWT_TEXT_BOX,         1,  120,    WW-8,   84,         96,     STR_NONE,                       STR_NONE },                 // password text box
-    { WWT_SPINNER,          1,  120,    WW-8,   100,        109,    STR_SERVER_MAX_PLAYERS_VALUE,   STR_NONE },                 // max players
-    { WWT_BUTTON,           1,  WW-18,  WW-8,   100,        104,    STR_NUMERIC_UP,                 STR_NONE },
-    { WWT_BUTTON,           1,  WW-18,  WW-8,   104,        108,    STR_NUMERIC_DOWN,               STR_NONE },
-    { WWT_CHECKBOX,         1,  6,      WW-8,   117,        123,    STR_ADVERTISE,                  STR_ADVERTISE_SERVER_TIP }, // advertise checkbox
-    { WWT_BUTTON,           1,  6,      106,    WH-6-11,    WH-6,   STR_NEW_GAME,                   STR_NONE },                 // start server button
-    { WWT_BUTTON,           1,  112,    212,    WH-6-11,    WH-6,   STR_LOAD_GAME,                  STR_NONE },
+    { WWT_SPINNER,          1,  120,    WW-8,   100,        111,    STR_SERVER_MAX_PLAYERS_VALUE,   STR_NONE },                 // max players
+    { WWT_BUTTON,           1,  WW-18,  WW-8,   101,        105,    STR_NUMERIC_UP,                 STR_NONE },
+    { WWT_BUTTON,           1,  WW-18,  WW-8,   106,        110,    STR_NUMERIC_DOWN,               STR_NONE },
+    { WWT_CHECKBOX,         1,  6,      WW-8,   117,        130,    STR_ADVERTISE,                  STR_ADVERTISE_SERVER_TIP }, // advertise checkbox
+    { WWT_BUTTON,           1,  6,      106,    WH-6-13,    WH-6,   STR_NEW_GAME,                   STR_NONE },                 // start server button
+    { WWT_BUTTON,           1,  112,    212,    WH-6-13,    WH-6,   STR_LOAD_GAME,                  STR_NONE },
     { WIDGETS_END },
 };
 


### PR DESCRIPTION
The scrollable lists in the multiplayer window weren't yet adjusted for non-sprite fonts use, which inspired another batch of UI tweaks accommodating CJK languages.

Adjust scrollable row height for:
- player list
- permissions list

Take font line height into account in:
- server information tab

Increase height of buttons in:
- save prompt window
- server list window