### PR TITLE
Fix #7209: Reset spatial index before removing peeps on fix save.

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1251,6 +1251,12 @@ void game_fix_save_vars()
         }
     }
 
+    if (peepsToRemove.size() > 0)
+    {
+        // Some broken saves have broken spatial indexes
+        reset_sprite_spatial_index();
+    }
+
     for (auto ptr : peepsToRemove)
     {
         peep_remove(ptr);


### PR DESCRIPTION
If the spatial index is corrupted such as in IndianaJones then deleting multiple peeps from the same spatial index will cause an infinite loop. Therefore this will now reset and remake the spatial index if there are peeps that require removing. Note it doesn't reset the spatial index for all saves as it is not required