### PR TITLE
Prevent decrement of a potentially invalid pointer

### DIFF
--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -690,7 +690,7 @@ static void initialise_list_items(rct_window *w)
                         (it + 1)->type == LIST_ITEM_TYPE::HEADING)
                     {
                         _listItems.erase(it);
-                        it--;
+                        it = _listItems.begin();
                     }
                 }
             }


### PR DESCRIPTION
The erase function could reallocate memory making it invalid. To be on the safe side it is always best to throw out the pointer.