### PR TITLE
Adding missing packages to mac build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ The recommended way of building OpenRCT2 for macOS is with Xcode. The Xcode buil
 #### CMake:
 A command line version of OpenRCT2 can be built using CMake. This type of build requires you to provide the dependencies yourself. The supported method of doing this is with [Homebrew](http://brew.sh). Once you have Homebrew installed, you can download all the required libraries with this command:
 ```
-brew install cmake openssl jansson libpng sdl2 speexdsp libzip
+brew install cmake openssl jansson libpng sdl2 speexdsp libzip freetype pkg-config
 ```
 
 Once you have the dependencies installed, you can build the project using CMake using the following commands:


### PR DESCRIPTION
I get these errors if I don't have the following packages installed:

``` bash
CMake Error at /usr/local/Cellar/cmake/3.10.2/share/cmake/Modules/FindPkgConfig.cmake:470 (message):
  pkg-config tool not found
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.10.2/share/cmake/Modules/FindPkgConfig.cmake:593 (_pkg_check_modules_internal)
  src/openrct2/CMakeLists.txt:23 (PKG_CHECK_MODULES)
  CMakeLists.txt:171 (include)
```

and 

```
CMake Error at /usr/local/Cellar/cmake/3.10.2/share/cmake/Modules/FindPkgConfig.cmake:415 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.10.2/share/cmake/Modules/FindPkgConfig.cmake:593 (_pkg_check_modules_internal)
  src/openrct2/CMakeLists.txt:40 (PKG_CHECK_MODULES)
  CMakeLists.txt:171 (include)
```