### PR TITLE
Fix #7229: Exploding guests cheat gets rides stuck and freezes game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -111,6 +111,7 @@
 - Fix: [#7011] Swinging and bobsleigh cars going backwards swing in the wrong direction (original bug).
 - Fix: [#7125] No entry signs not correctly handled in pathfinding.
 - Fix: [#7223] Vehicle mass not correctly recalculated when using remove all guests cheat.
+- Fix: [#7229] Exploding guests cheat causes rides to get stuck and freezes game.
 - Fix: Infinite loop when removing scenery elements with >127 base height.
 - Fix: Ghosting of transparent map elements when the viewport is moved in OpenGL mode.
 - Fix: Clear IME buffer after committing composed text.

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -415,16 +415,6 @@ static void cheat_explode_guests()
     rct_peep *peep;
 
     FOR_ALL_GUESTS(sprite_index, peep) {
-        // To prevent blowing up peeps that will break
-        // ride vehicle logic.
-        if (peep->state == PEEP_STATE_ENTERING_RIDE ||
-            peep->state == PEEP_STATE_QUEUING_FRONT ||
-            peep->state == PEEP_STATE_LEAVING_RIDE ||
-            peep->state == PEEP_STATE_ON_RIDE ||
-            peep->state == PEEP_STATE_QUEUING) {
-            continue;
-        }
-
         if (scenario_rand_max(6) == 0) {
             peep->peep_flags |= PEEP_FLAGS_EXPLODE;
         }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "39"
+#define NETWORK_STREAM_VERSION "40"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -989,13 +989,20 @@ static void sub_68F41A(rct_peep * peep, sint32 index)
 
         if (peep->peep_flags & PEEP_FLAGS_EXPLODE && peep->x != LOCATION_NULL)
         {
-            audio_play_sound_at_location(SOUND_CRASH, peep->x, peep->y, peep->z);
+            if (peep->state == PEEP_STATE_WALKING || peep->state == PEEP_STATE_SITTING)
+            {
+                audio_play_sound_at_location(SOUND_CRASH, peep->x, peep->y, peep->z);
 
-            sprite_misc_explosion_cloud_create(peep->x, peep->y, peep->z + 16);
-            sprite_misc_explosion_flare_create(peep->x, peep->y, peep->z + 16);
+                sprite_misc_explosion_cloud_create(peep->x, peep->y, peep->z + 16);
+                sprite_misc_explosion_flare_create(peep->x, peep->y, peep->z + 16);
 
-            peep_remove(peep);
-            return;
+                peep_remove(peep);
+                return;
+            }
+            else
+            {
+                peep->peep_flags &= ~PEEP_FLAGS_EXPLODE;
+            }
         }
 
         if (peep->peep_flags & PEEP_FLAGS_HUNGER)


### PR DESCRIPTION
When Exploding guests cheat is activated, random guests get a flag set which makes them explode when a function in Peep.cpp is called. There was a check for certain peep states in the original function, which would prevent the explode flag to get set when a peep was queuing, for example. 
The function which makes a peep explode gets called after some time has passed though, so the peep may enter a queue or ride in the meantime. This will make the ride get stuck and will freeze the game after a while.
I have removed the peep state checks from the function which sets the explode flag, and added a state check in the function that actually makes the peep explode. Only if the peep is walking or sitting it will actually explode. It is it not, the explode flag will be reset. 
I tested this on several parks and they no longer freeze and rides no longer get stuck when this cheat is used.

Other (safe) peep states can easily be added to the exploding function. For now i just added walking and sitting.