### PR TITLE
Refactor browse function in LoadSave.cpp - fixes #3596 and #5210

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,8 @@
 - Feature: [#7266] Make headless instances use an interactive terminal with access to the in-game console API.
 - Feature: [#7267] Leverage more historical data in Finances window.
 - Feature: [#7332] Keyboard shortcuts for view path issues and cutaway view.
+- Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
+- Fix: [#5210] Default system dialog not accessible from saving landscape window.
 - Improved: Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 
 0.1.2 (2018-03-18)

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <openrct2/common.h>
+#include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/ui/UiContext.h>
@@ -169,13 +170,13 @@ namespace OpenRCT2 { namespace Ui
                         // array must be carefully populated, at least the first element.
                         std::string pattern = desc.Filters[0].Pattern;
                         std::string defaultExtension = pattern.substr(pattern.find_last_of('.'));
-                        int dotPosition = output.size() - defaultExtension.size();
-                        // Add the default extension if no extension is specified
-                        if (output.substr(dotPosition, defaultExtension.size()).compare(defaultExtension) == 0)
-                        {
-                            result = output;
-                        }
-                        else
+
+                        const utf8 * filename = Path::GetFileName(output.c_str());
+
+                        // If there is no extension, append the pattern
+                        const utf8 * extension = Path::GetExtension(filename);
+                        result = output;
+                        if (extension[0] == '\0' && !defaultExtension.empty())
                         {
                             result = output.append(defaultExtension);
                         }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -27,6 +27,7 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/core/Util.hpp>
 #include <openrct2/Editor.h>
+#include <openrct2/FileClassifier.h>
 #include <openrct2/Game.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/platform/platform.h>
@@ -313,37 +314,39 @@ static void window_loadsave_resize(rct_window *w)
 
 static bool browse(bool isSave, char *path, size_t pathSize)
 {
-    safe_strcpy(path, _directory, pathSize);
-    if (isSave)
-        safe_strcat_path(path, _defaultName, pathSize);
-
     file_dialog_desc desc = { 0 };
-    desc.initial_directory = _directory;
-    desc.type = isSave ? FD_SAVE : FD_OPEN;
-    desc.default_filename = isSave ? path : nullptr;
-
+    const utf8 * extension = "";
+    uint32 fileType = FILE_EXTENSION_UNKNOWN;
     rct_string_id title = STR_NONE;
     switch (_type & 0x0E)
     {
     case LOADSAVETYPE_GAME:
+        extension = ".sv6";
+        fileType = FILE_EXTENSION_SV6;
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_SAVED_GAME);
         desc.filters[0].pattern = isSave ? "*.sv6" : "*.sv6;*.sc6;*.sv4;*.sc4";
         break;
 
     case LOADSAVETYPE_LANDSCAPE:
+        extension = ".sc6";
+        fileType = FILE_EXTENSION_SC6;
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_LANDSCAPE_FILE);
         desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4";
         break;
 
     case LOADSAVETYPE_SCENARIO:
+        extension = ".sc6";
+        fileType = FILE_EXTENSION_SC6;
         title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_SCENARIO_FILE);
         desc.filters[0].pattern = "*.sc6";
         break;
 
     case LOADSAVETYPE_TRACK:
+        extension = ".td6";
+        fileType = FILE_EXTENSION_TD6;
         title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
         desc.filters[0].name = language_get_string(STR_OPENRCT2_TRACK_DESIGN_FILE);
         desc.filters[0].pattern = isSave ? "*.td6" : "*.td6;*.td4";
@@ -356,12 +359,48 @@ static bool browse(bool isSave, char *path, size_t pathSize)
         break;
     }
 
+    safe_strcpy(path, _directory, pathSize);
+    if (isSave)
+    {
+        // The file browser requires a file path instead of just a directory
+        if (String::SizeOf(_defaultName) > 0)
+        {
+            safe_strcat_path(path, _defaultName, pathSize);
+        }
+        else
+        {
+            utf8 buffer[USER_STRING_MAX_LENGTH]{};
+            if (gParkName != STR_NONE)
+                format_string(buffer, pathSize, gParkName, nullptr);
+
+            // Use localized "Unnamed Park" if park name was empty
+            if (String::SizeOf(buffer) == 0)
+                format_string(buffer, pathSize, STR_UNNAMED_PARK, nullptr);
+
+            safe_strcat_path(path, buffer, pathSize);
+        }
+    }
+
+    desc.initial_directory = _directory;
+    desc.type = isSave ? FD_SAVE : FD_OPEN;
+    desc.default_filename = isSave ? path : nullptr;
+
     // Add 'all files' filter. If the number of filters is increased, this code will need to be adjusted.
     desc.filters[1].name = language_get_string(STR_ALL_FILES);
     desc.filters[1].pattern = "*";
 
     desc.title = language_get_string(title);
-    return platform_open_common_file_dialog(path, &desc, pathSize);
+    if (platform_open_common_file_dialog(path, &desc, pathSize))
+    {
+        // When the given save type was given, Windows still interprets a filename with a dot in its name as a custom extension,
+        // meaning files like "My Coaster v1.2" will not get the .td6 extension by default.
+        if (get_file_extension_type(path) != fileType)
+            path_append_extension(path, extension, pathSize);
+
+        return true;
+    }
+
+    return false;
 }
 
 static void window_loadsave_mouseup(rct_window *w, rct_widgetindex widgetIndex)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -792,7 +792,7 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
     utf8 absoluteDirectory[MAX_PATH];
     Path::GetAbsolute(absoluteDirectory, Util::CountOf(absoluteDirectory), directory);
     safe_strcpy(_directory, absoluteDirectory, Util::CountOf(_directory));
-    if (_extension != extension)
+    if (_extension != extension) // Note: This compares the pointers, not values
     {
         safe_strcpy(_extension, extension, Util::CountOf(_extension));
     }
@@ -922,6 +922,8 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
 
         window_loadsave_sort_list();
     }
+
+    window_invalidate(w);
 }
 
 static void window_loadsave_invoke_callback(sint32 result, const utf8 * path)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -792,7 +792,8 @@ static void window_loadsave_populate_list(rct_window *w, sint32 includeNewItem, 
     utf8 absoluteDirectory[MAX_PATH];
     Path::GetAbsolute(absoluteDirectory, Util::CountOf(absoluteDirectory), directory);
     safe_strcpy(_directory, absoluteDirectory, Util::CountOf(_directory));
-    if (_extension != extension) // Note: This compares the pointers, not values
+    // Note: This compares the pointers, not values
+    if (_extension != extension)
     {
         safe_strcpy(_extension, extension, Util::CountOf(_extension));
     }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -927,9 +927,6 @@ static void window_loadsave_select(rct_window *w, const char *path)
     switch (_type & 0x0F) {
     case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME):
         save_path(&gConfigGeneral.last_save_game_directory, pathBuffer);
-        safe_strcpy(gScenarioSavePath, pathBuffer, MAX_PATH);
-        safe_strcpy(gCurrentLoadedPath, pathBuffer, MAX_PATH);
-        gFirstTimeSaving = true;
         window_loadsave_invoke_callback(MODAL_RESULT_OK, pathBuffer);
         window_close_by_class(WC_LOADSAVE);
         gfx_invalidate_screen();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -34,6 +34,7 @@
 #include "core/MemoryStream.h"
 #include "core/Path.hpp"
 #include "core/String.hpp"
+#include "core/Util.hpp"
 #include "FileClassifier.h"
 #include "HandleParkLoad.h"
 #include "network/network.h"
@@ -426,6 +427,9 @@ namespace OpenRCT2
                         if (result.Error == PARK_LOAD_ERROR_OK)
                         {
                             parkImporter->Import();
+                            String::Set(gScenarioSavePath, Util::CountOf(gScenarioSavePath), path.c_str());
+                            String::Set(gCurrentLoadedPath, Util::CountOf(gCurrentLoadedPath), path.c_str());
+                            gFirstTimeSaving = true;
                             game_fix_save_vars();
                             sprite_position_tween_reset();
                             gScreenAge = 0;


### PR DESCRIPTION
With this PR the behaviour of browsing and selecting files has changes slightly:

- `gScenarioSavePath`, `gCurrentLoadedPath` and `gFirstTimeSaving` get set after succesfully loading a park, rather than when selecting it from the list. This means it also gets set when loading from command line (`openrct2.exe "path/to/saved_game.sv6`), which partly fixes #5210
- The proper extension is _always_ appended to the given path. Previously Windows would omit adding it when a filename contained a preriod. (Fixes #3596)
- When saving, and _defaultName is not set, it defaults to the park name, or "Unnamed Park" if the park name is empty. Without a name, saving with the system dialog on Windows wouldn't be possible. (together with the first point, this completely fixes #5210)