### PR TITLE
Fix #6804: Network permissions are not visible.

### DIFF
--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -92,7 +92,7 @@ void NetworkGroup::Read(NetworkPacket &packet)
 {
     packet >> Id;
     SetName(packet.ReadString());
-    for (auto action : ActionsAllowed)
+    for (auto &action : ActionsAllowed)
     {
         packet >> action;
     }

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -102,9 +102,9 @@ void NetworkGroup::Write(NetworkPacket &packet)
 {
     packet << Id;
     packet.WriteString(GetName().c_str());
-    for (size_t i = 0; i < ActionsAllowed.size(); i++)
+    for (const auto &action : ActionsAllowed)
     {
-        packet << ActionsAllowed[i];
+        packet << action;
     }
 }
 


### PR DESCRIPTION
This PR fixes network permissions not showing up in the multiplayer window, which turned out to be a regression from #6788.

Fixing this probably also fixes #7028, but I have been unable to verify this, as I don't have the relevant permission on any server. :-)