### PR TITLE
Fix import of park entrance locations

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "40"
+#define NETWORK_STREAM_VERSION "41"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -244,9 +244,9 @@ struct rct_s6_data {
     uint8 current_interest_rate;
     uint8 pad_0135934B;
     uint32 same_price_throughout_extended;
-    uint16 park_entrance_x[RCT12_MAX_PARK_ENTRANCES];
-    uint16 park_entrance_y[RCT12_MAX_PARK_ENTRANCES];
-    uint16 park_entrance_z[RCT12_MAX_PARK_ENTRANCES];
+    sint16 park_entrance_x[RCT12_MAX_PARK_ENTRANCES];
+    sint16 park_entrance_y[RCT12_MAX_PARK_ENTRANCES];
+    sint16 park_entrance_z[RCT12_MAX_PARK_ENTRANCES];
     uint8 park_entrance_direction[RCT12_MAX_PARK_ENTRANCES];
     char scenario_filename[256];
     uint8 saved_expansion_pack_names[3256];


### PR DESCRIPTION
gParkEntrances was changed to sint32 positions from sint16 positions in f4ac2b4d5bbedc1dc564471e1365949630655ddf. This caused a regression as the locations were not being sign extended when imported from S6 files.

E.g. 0x8000 was not becoming 0xFFFF8000.

This fixes the log errors seen when starting vanilla RCT2 maps.