### PR TITLE
Improve track preview window with OpenGL renderer

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4531,6 +4531,7 @@ STR_6221    :{SMALLFONT}{BLACK}This will set the ride's known entrance or exit l
 STR_6222    :Can't place peep spawn here...
 STR_6223    :Must be outside park boundaries!
 STR_6224    :{STRING} placed a peep spawn.
+STR_6225    :Not supported with OpenGL renderer
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -526,7 +526,6 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
             _loadedTrackDesignIndex = trackIndex;
         } else {
             _loadedTrackDesignIndex = TRACK_DESIGN_INDEX_UNLOADED;
-            return;
         }
     }
 
@@ -535,15 +534,24 @@ static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi)
         return;
     }
 
-    rct_g1_element g1temp = { nullptr };
-    g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
-    g1temp.width = 370;
-    g1temp.height = 217;
-    g1temp.flags = G1_FLAG_BMP;
-    gfx_set_g1_element(SPR_TEMP, &g1temp);
-    gfx_draw_sprite(dpi, SPR_TEMP, x, y, 0);
-
+    sint32 trackPreviewX = x, trackPreviewY = y;
     x = w->x + (widget->left + widget->right) / 2;
+    y = w->y + (widget->top + widget->bottom) / 2;
+
+    if (drawing_engine_get_type() != DRAWING_ENGINE_OPENGL) {
+        rct_g1_element g1temp = { nullptr };
+        g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
+        g1temp.width = 370;
+        g1temp.height = 217;
+        g1temp.flags = G1_FLAG_BMP;
+        gfx_set_g1_element(SPR_TEMP, &g1temp);
+        gfx_draw_sprite(dpi, SPR_TEMP, trackPreviewX, trackPreviewY, 0);
+    }
+    else
+    {
+        gfx_draw_string_centred_clipped(dpi, STR_NOT_SUPPPORTED_IN_OPENGL, nullptr, COLOUR_BLACK, x, y, 368);
+    }
+
     y = w->y + widget->bottom - 12;
 
     // Warnings
@@ -766,8 +774,10 @@ static bool track_list_load_design_for_preview(utf8 *path)
     _loadedTrackDesign = nullptr;
 
     _loadedTrackDesign = track_design_open(path);
-    if (_loadedTrackDesign != nullptr && drawing_engine_get_type() != DRAWING_ENGINE_OPENGL) {
-        track_design_draw_preview(_loadedTrackDesign, _trackDesignPreviewPixels.data());
+    if (_loadedTrackDesign != nullptr) {
+        if (drawing_engine_get_type() != DRAWING_ENGINE_OPENGL) {
+            track_design_draw_preview(_loadedTrackDesign, _trackDesignPreviewPixels.data());
+        }
         return true;
     }
     return false;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3885,6 +3885,8 @@ enum {
     STR_ERR_MUST_BE_OUTSIDE_PARK_BOUNDARIES = 6223,
     STR_LOG_PLACE_PEEP_SPAWN = 6224,
 
+    STR_NOT_SUPPPORTED_IN_OPENGL = 6225,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
This adds a warning to track preview window explaining it's not
supported with OpenGL renderer. Also fixes the issue whereby no stats
were printed because of early exit.

Before:
![selection_006](https://user-images.githubusercontent.com/550290/37520740-8441681e-291e-11e8-99e2-d3620255a522.png)

After:
![selection_004](https://user-images.githubusercontent.com/550290/37520746-8e25d18a-291e-11e8-8156-ef2fcdf7a8e2.png)
