### PR TITLE
Fix sprite dithering error

### DIFF
--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -418,7 +418,7 @@ static bool sprite_file_import(const char *path, sint16 x_offset, sint16 y_offse
 
                             if (x + 1 < width)
                             {
-                                if (!is_transparent_pixel(rgbaSrc + 4 * (width - 1)) && is_changable_pixel(get_palette_index(rgbaSrc + 4 * (width + 1))))
+                                if (!is_transparent_pixel(rgbaSrc + 4 * (width + 1)) && is_changable_pixel(get_palette_index(rgbaSrc + 4 * (width + 1))))
                                 {
                                     // Bottom right
                                     rgbaSrc[4 * (width + 1)] += dr * 1 / 16;


### PR DESCRIPTION
@DrizzlingCattus noticed an error in the automatic dithering for the sprite compiler, where a minus sign should be a plus sign. This PR fixes this.