### PR TITLE
Improved raising land near edge map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.1.3 (in development)
 ------------------------------------------------------------------------
 - Feature: [#7267] Leverage more historical data in Finances window.
+- Improved: Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1846,6 +1846,12 @@ static money32 raise_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
         audio_play_sound_at_location(SOUND_PLACE_ITEM, x, y, z);
     }
 
+    // Keep big coordinates within map boundaries
+    ax = std::max<decltype(ax)>(32, ax);
+    bx = std::min<decltype(bx)>(gMapSizeMaxXY, bx);
+    ay = std::max<decltype(bx)>(32, ay);
+    by = std::min<decltype(by)>(gMapSizeMaxXY, by);
+
     uint8 min_height = map_get_lowest_land_height(ax, bx, ay, by);
 
     for (sint32 yi = ay; yi <= by; yi += 32) {
@@ -1892,6 +1898,12 @@ static money32 lower_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
         log_warning("Improper selection type %d", selectionType);
         return MONEY32_UNDEFINED;
     }
+
+    // Keep big coordinates within map boundaries
+    ax = std::max<decltype(ax)>(32, ax);
+    bx = std::min<decltype(bx)>(gMapSizeMaxXY, bx);
+    ay = std::max<decltype(bx)>(32, ay);
+    by = std::min<decltype(by)>(gMapSizeMaxXY, by);
 
     uint8 max_height = map_get_highest_land_height(ax, bx, ay, by);
 


### PR DESCRIPTION
Rather than showing the user an 'off edge map!' error, this simply makes the affected area smaller.
![forest frontiers 2018-03-18 12-50-02](https://user-images.githubusercontent.com/9705046/37565510-f3d7935a-2aaa-11e8-8659-f66143c80346.png)
