### PR TITLE
Use table header widgets in more windows

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3832,8 +3832,8 @@ STR_5492    :Scenario options
 STR_5493    :Send Message
 STR_5494    :<removed string - do not use>
 STR_5495    :Player List
-STR_5496    :Player:
-STR_5497    :Ping:
+STR_5496    :Player
+STR_5497    :Ping
 STR_5498    :Server List
 STR_5499    :Player Name:
 STR_5500    :Add Server
@@ -3978,7 +3978,7 @@ STR_5638    :Permission denied
 STR_5639    :{SMALLFONT}{BLACK}Show list of players
 STR_5640    :{SMALLFONT}{BLACK}Manage groups
 STR_5641    :Default Group:
-STR_5642    :Group:
+STR_5642    :Group
 STR_5643    :Add Group
 STR_5644    :Remove Group
 STR_5645    :Chat
@@ -4006,7 +4006,7 @@ STR_5666    :Passwordless Login
 STR_5701    :{WINDOW_COLOUR_2}Last action: {BLACK}{STRINGID}
 STR_5702    :{SMALLFONT}{BLACK}Locate player's most recent action
 STR_5703    :Can't kick the host
-STR_5704    :Last Action:
+STR_5704    :Last Action
 STR_5705    :Can't set to this group
 STR_5706    :Can't remove group that players belong to
 STR_5707    :This group cannot be modified

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3572,8 +3572,8 @@ STR_5232    :{SMALLFONT}{BLACK}Editors
 STR_5233    :{SMALLFONT}{BLACK}Miscellaneous
 STR_5234    :{SMALLFONT}{BLACK}Prompts
 STR_5235    :{SMALLFONT}{BLACK}Settings
-STR_5236    :Window:
-STR_5237    :Palette:
+STR_5236    :Window
+STR_5237    :Palette
 STR_5238    :Current Theme:
 STR_5239    :Duplicate
 STR_5240    :Enter a name for the theme

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -41,7 +41,11 @@ enum WINDOW_MULTIPLAYER_WIDGET_IDX {
     WIDX_TAB3,
     WIDX_TAB4,
 
-    WIDX_LIST = 8,
+    WIDX_HEADER_PLAYER = 8,
+    WIDX_HEADER_GROUP,
+    WIDX_HEADER_LAST_ACTION,
+    WIDX_HEADER_PING,
+    WIDX_LIST,
 
     WIDX_DEFAULT_GROUP = 8,
     WIDX_DEFAULT_GROUP_DROPDOWN,
@@ -74,6 +78,10 @@ static rct_widget window_multiplayer_information_widgets[] = {
 
 static rct_widget window_multiplayer_players_widgets[] = {
     MAIN_MULTIPLAYER_WIDGETS,
+    { WWT_TABLE_HEADER,     0,  3,      175,    46,      60,    STR_PLAYER,                 STR_NONE },                 // Player name
+    { WWT_TABLE_HEADER,     0,  176,    258,    46,      60,    STR_GROUP,                  STR_NONE },                 // Player name
+    { WWT_TABLE_HEADER,     0,  259,    358,    46,      60,    STR_LAST_ACTION,            STR_NONE },                 // Player name
+    { WWT_TABLE_HEADER,     0,  359,    400,    46,      60,    STR_PING,                   STR_NONE },                 // Player name
     { WWT_SCROLL,           1,  3,      336,    60,     236,    SCROLL_VERTICAL,            STR_NONE },                 // list
     { WIDGETS_END }
 };
@@ -509,6 +517,8 @@ static void window_multiplayer_players_resize(rct_window *w)
     w->no_list_items = network_get_num_players();
     w->list_item_positions[0] = 0;
 
+    w->widgets[WIDX_HEADER_PING].right = w->width - 5;
+
     w->selected_list_item = -1;
     window_invalidate(w);
 }
@@ -580,12 +590,6 @@ static void window_multiplayer_players_paint(rct_window *w, rct_drawpixelinfo *d
 
     window_draw_widgets(w, dpi);
     window_multiplayer_draw_tab_images(w, dpi);
-
-    // Columns
-    gfx_draw_string_left(dpi, STR_PLAYER, nullptr, w->colours[2], w->x + 6, 58 - 12 + w->y + 1);
-    gfx_draw_string_left(dpi, STR_GROUP, nullptr, w->colours[2], w->x + 180, 58 - 12 + w->y + 1);
-    gfx_draw_string_left(dpi, STR_LAST_ACTION, nullptr, w->colours[2], w->x + 263, 58 - 12 + w->y + 1);
-    gfx_draw_string_left(dpi, STR_PING, nullptr, w->colours[2], w->x + 363, 58 - 12 + w->y + 1);
 
     // Number of players
     stringId = w->no_list_items == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -100,6 +100,8 @@ enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_THEMES_MISC_TAB,
     WIDX_THEMES_PROMPTS_TAB,
     WIDX_THEMES_FEATURES_TAB,
+    WIDX_THEMES_HEADER_WINDOW,
+    WIDX_THEMES_HEADER_PALETTE,
     WIDX_THEMES_PRESETS,
     WIDX_THEMES_PRESETS_DROPDOWN,
     WIDX_THEMES_DUPLICATE_BUTTON,
@@ -127,6 +129,8 @@ static rct_widget window_themes_widgets[] = {
     { WWT_TAB,              1,  189,    219,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,                           STR_THEMES_TAB_MISC_TIP },              // misc tab
     { WWT_TAB,              1,  220,    250,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,                           STR_THEMES_TAB_PROMPTS_TIP },           // prompts tab
     { WWT_TAB,              1,  251,    281,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,                           STR_THEMES_TAB_FEATURES_TIP },          // features tab
+    { WWT_TABLE_HEADER,     1,  5,      218,    46,     60,     STR_THEMES_HEADER_WINDOW,                       STR_NONE },                             // Window header
+    { WWT_TABLE_HEADER,     1,  219,    315,    46,     60,     STR_THEMES_HEADER_PALETTE,                      STR_NONE },                             // Palette header
     { WWT_DROPDOWN,         1,  125,    299,    60,     71,     STR_NONE,                                       STR_NONE },                             // Preset colour schemes
     { WWT_BUTTON,           1,  288,    298,    61,     70,     STR_DROPDOWN_GLYPH,                             STR_NONE },
     { WWT_BUTTON,           1,  10,     100,    82,     93,     STR_TITLE_EDITOR_ACTION_DUPLICATE,              STR_THEMES_ACTION_DUPLICATE_TIP },      // Duplicate button
@@ -716,20 +720,9 @@ void window_themes_invalidate(rct_window *w)
     window_themes_widgets[WIDX_THEMES_LIST].right = w->width - 4;
     window_themes_widgets[WIDX_THEMES_LIST].bottom = w->height - 0x0F;
 
-
-    window_themes_widgets[WIDX_THEMES_LIST].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_PRESETS].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WWT_EMPTY;
-    window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WWT_EMPTY;
-
     if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS) {
+        window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_LIST].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_EMPTY;
@@ -740,8 +733,11 @@ void window_themes_invalidate(rct_window *w)
         window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_BUTTON;
         window_themes_widgets[WIDX_THEMES_PRESETS].type = WWT_DROPDOWN;
         window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WWT_BUTTON;
+        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WWT_EMPTY;
     }
     else if (_selected_tab == WINDOW_THEMES_TAB_FEATURES) {
+        window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_LIST].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_CHECKBOX;
         window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_CHECKBOX;
@@ -752,6 +748,7 @@ void window_themes_invalidate(rct_window *w)
         window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_PRESETS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WWT_EMPTY;
 
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_RIDE_LIGHTS, theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_PARK_LIGHTS, theme_get_flags() & UITHEME_FLAG_USE_LIGHTS_PARK);
@@ -759,15 +756,19 @@ void window_themes_invalidate(rct_window *w)
         widget_set_checkbox_value(w, WIDX_THEMES_RCT1_BOTTOM_TOOLBAR, theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
     }
     else {
+        window_themes_widgets[WIDX_THEMES_HEADER_WINDOW].type = WWT_TABLE_HEADER;
+        window_themes_widgets[WIDX_THEMES_HEADER_PALETTE].type = WWT_TABLE_HEADER;
         window_themes_widgets[WIDX_THEMES_LIST].type = WWT_SCROLL;
         window_themes_widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_DELETE_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_RENAME_BUTTON].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_PRESETS].type = WWT_EMPTY;
         window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WWT_EMPTY;
+        window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WWT_EMPTY;
     }
 }
 
@@ -791,13 +792,6 @@ void window_themes_paint(rct_window *w, rct_drawpixelinfo *dpi)
             w->y + window_themes_widgets[WIDX_THEMES_PRESETS].top,
             w->x + window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].left - window_themes_widgets[WIDX_THEMES_PRESETS].left - 4
         );
-    }
-    else if (_selected_tab == WINDOW_THEMES_TAB_FEATURES) {
-
-    }
-    else {
-        gfx_draw_string_left(dpi, STR_THEMES_HEADER_WINDOW, w, w->colours[1], w->x + 6, 58 - 12 + w->y + 1);
-        gfx_draw_string_left(dpi, STR_THEMES_HEADER_PALETTE, w, w->colours[1], w->x + 220, 58 - 12 + w->y + 1);
     }
 }
 


### PR DESCRIPTION
This PR makes both the player list in the multiplayer window and the theme customisation window use table header widgets for its headers.

Initially, these changes were part of #7256, but I decided to split them off.

## Screenshots

### Player list
![multiplayer_after](https://user-images.githubusercontent.com/604665/37571714-85ef35e0-2b00-11e8-8d1c-69d5145ac731.png)
[(click for before)](https://user-images.githubusercontent.com/604665/37571715-860e22ac-2b00-11e8-9dce-e36aec2a2e6f.png)

### Themes window
![themes_after](https://user-images.githubusercontent.com/604665/37571716-862784a4-2b00-11e8-87af-1d0605482ede.png)
[(click for before)](https://user-images.githubusercontent.com/604665/37571717-8640d17a-2b00-11e8-8a80-a9fcc67be2ca.png)
