### PR TITLE
Fix build on FreeBSD 10

### DIFF
--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -223,7 +223,7 @@ bool avx2_available()
 // https://github.com/gcc-mirror/gcc/commit/132fa33ce998df69a9f793d63785785f4b93e6f1
 // which causes it to ignore subleafs, but the new function is unavailable on Ubuntu's
 // prehistoric toolchains
-#if defined(OpenRCT2_CPUID_GNUC_X86)
+#if defined(OpenRCT2_CPUID_GNUC_X86) && !defined(__FreeBSD__)
     return __builtin_cpu_supports("avx2");
 #else
     // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7, ECX = 0).

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -223,7 +223,7 @@ bool avx2_available()
 // https://github.com/gcc-mirror/gcc/commit/132fa33ce998df69a9f793d63785785f4b93e6f1
 // which causes it to ignore subleafs, but the new function is unavailable on Ubuntu's
 // prehistoric toolchains
-#if defined(OpenRCT2_CPUID_GNUC_X86) && !defined(__FreeBSD__)
+#if defined(OpenRCT2_CPUID_GNUC_X86) && (!defined(__FreeBSD__) || (__FreeBSD__ > 10))
     return __builtin_cpu_supports("avx2");
 #else
     // AVX2 support is declared as the 5th bit of EBX with CPUID(EAX = 7, ECX = 0).


### PR DESCRIPTION
NOTE: This can be reverted once FreeBSD 10.4-RELEASE goes EoL.

Not using this patch gives following error on FreeBSD 10:
```
libopenrct2.a(Util.cpp.o): In function `avx2_available()':
/usr/local/poudriere/ports/default/games/openrct2/work/OpenRCT2-0.1.2/src/openrct2/util/Util.cpp:(.text+0x6e7): undefined reference to `__cpu_model'
```