### PR TITLE
Fix issue in 'GetExtension'

### DIFF
--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -162,7 +162,7 @@ namespace Path
     const utf8 * GetExtension(const utf8 * path)
     {
         const utf8 * lastDot = nullptr;
-        const utf8 * ch = path;
+        const utf8 * ch = GetFileName(path);
         for (; *ch != '\0'; ch++)
         {
             if (*ch == '.')


### PR DESCRIPTION
`Path::GetExtension` would iterate over the full path instead of just the filename, meaning a path like `C:\My.docs\file` (note the missing file extension) would return `.docs\file` as the extension.