### PR TITLE
Give context the ownership of repositories and the object manager

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -929,15 +929,17 @@ static sint32 get_num_track_designs(ride_list_item item)
         }
     }
 
+    ITrackDesignRepository * repo = OpenRCT2::GetContext()->GetTrackDesignRepository();
+
     if (rideEntry != nullptr && RideGroupManager::RideTypeHasRideGroups(item.type))
     {
         const RideGroup * rideGroup = RideGroupManager::GetRideGroup(item.type, rideEntry);
-        ITrackDesignRepository * repo = GetTrackDesignRepository();
         return (sint32)repo->GetCountForRideGroup(item.type, rideGroup);
     }
-
-    ITrackDesignRepository * repo = GetTrackDesignRepository();
-    return (sint32)repo->GetCountForObjectEntry(item.type, String::ToStd(entryPtr));
+    else
+    {
+        return (sint32)repo->GetCountForObjectEntry(item.type, String::ToStd(entryPtr));
+    }
 }
 
 /**

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -742,7 +742,7 @@ static void window_track_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi,
 
 static void track_list_load_designs(ride_list_item item)
 {
-    auto repo = GetTrackDesignRepository();
+    auto repo = OpenRCT2::GetContext()->GetTrackDesignRepository();
     if (!RideGroupManager::RideTypeHasRideGroups(item.type))
     {
         char entry[9];

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -166,6 +166,26 @@ namespace OpenRCT2
             return _env;
         }
 
+        IObjectManager * GetObjectManager() override
+        {
+            return _objectManager;
+        }
+
+        IObjectRepository * GetObjectRepository() override
+        {
+            return _objectRepository;
+        }
+
+        ITrackDesignRepository * GetTrackDesignRepository() override
+        {
+            return _trackDesignRepository;
+        }
+
+        IScenarioRepository * GetScenarioRepository() override
+        {
+            return _scenarioRepository;
+        }
+
         sint32 RunOpenRCT2(int argc, const char * * argv) override
         {
             if (Initialise())

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -20,7 +20,12 @@
 
 #include <string>
 
+interface IObjectManager;
+interface IObjectRepository;
+interface IScenarioRepository;
 interface IStream;
+interface ITrackDesignRepository;
+
 class Intent;
 struct rct_window;
 using rct_windowclass = uint8;
@@ -83,9 +88,13 @@ namespace OpenRCT2
     {
         virtual ~IContext() = default;
 
-        virtual Audio::IAudioContext *  GetAudioContext() abstract;
-        virtual Ui::IUiContext *        GetUiContext() abstract;
-        virtual IPlatformEnvironment *  GetPlatformEnvironment() abstract;
+        virtual Audio::IAudioContext *   GetAudioContext() abstract;
+        virtual Ui::IUiContext *         GetUiContext() abstract;
+        virtual IPlatformEnvironment *   GetPlatformEnvironment() abstract;
+        virtual IObjectManager *         GetObjectManager() abstract;
+        virtual IObjectRepository *      GetObjectRepository() abstract;
+        virtual ITrackDesignRepository * GetTrackDesignRepository() abstract;
+        virtual IScenarioRepository *    GetScenarioRepository() abstract;
 
         virtual sint32 RunOpenRCT2(int argc, const char * * argv) abstract;
 
@@ -109,7 +118,7 @@ namespace OpenRCT2
 
 enum
 {
-    // The game update inverval in milliseconds, (1000 / 40fps) = 25ms
+    // The game update interval in milliseconds, (1000 / 40fps) = 25ms
     GAME_UPDATE_TIME_MS = 25,
     // The number of logical update / ticks per second.
     GAME_UPDATE_FPS = 40,
@@ -216,4 +225,3 @@ void context_quit();
 const utf8 * context_get_path_legacy(sint32 pathId);
 bool context_load_park_from_file(const utf8 * path);
 bool context_load_park_from_stream(void * stream);
-

--- a/src/openrct2/ParkImporter.cpp
+++ b/src/openrct2/ParkImporter.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <memory>
+#include "Context.h"
 #include "core/Path.hpp"
 #include "core/String.hpp"
 #include "object/ObjectManager.h"
@@ -108,7 +109,8 @@ namespace ParkImporter
         }
         else
         {
-            parkImporter = CreateS6(GetObjectRepository(), GetObjectManager());
+            auto context = OpenRCT2::GetContext();
+            parkImporter = CreateS6(context->GetObjectRepository(), context->GetObjectManager());
         }
         return parkImporter;
     }
@@ -150,4 +152,3 @@ bool park_importer_extension_is_scenario(const utf8 * extension)
 {
     return ParkImporter::ExtensionIsScenario(String::ToStd(extension));
 }
-

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <stack>
+#include "../Context.h"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
 #include "../core/StringBuilder.hpp"
@@ -157,7 +158,8 @@ bool language_open(sint32 id)
         TryLoadFonts();
 
         // Objects and their localised strings need to be refreshed
-        GetObjectManager()->ResetObjects();
+        auto context = OpenRCT2::GetContext();
+        context->GetObjectManager()->ResetObjects();
         return true;
     }
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1106,7 +1106,8 @@ void Network::Server_Send_MAP(NetworkConnection* connection)
     } else {
         // This will send all custom objects to connected clients
         // TODO: fix it so custom objects negotiation is performed even in this case.
-        IObjectManager * objManager = GetObjectManager();
+        auto context = GetContext();
+        IObjectManager * objManager = context->GetObjectManager();
         objects = objManager->GetPackableObjects();
     }
 
@@ -1792,7 +1793,8 @@ void Network::Server_Client_Joined(const char* name, const std::string &keyhash,
         format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
         chat_history_add(text);
 
-        IObjectManager * objManager = GetObjectManager();
+        auto context = GetContext();
+        IObjectManager * objManager = context->GetObjectManager();
         auto objects = objManager->GetPackableObjects();
         Server_Send_OBJECTS(connection, objects);
 
@@ -1813,7 +1815,7 @@ void Network::Server_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& 
 
 void Network::Client_Handle_OBJECTS(NetworkConnection& connection, NetworkPacket& packet)
 {
-    IObjectRepository * repo = GetObjectRepository();
+    IObjectRepository * repo = GetContext()->GetObjectRepository();
     uint32 size;
     packet >> size;
     log_verbose("client received object list, it has %u entries", size);
@@ -1866,7 +1868,7 @@ void Network::Server_Handle_OBJECTS(NetworkConnection& connection, NetworkPacket
         return;
     }
     log_verbose("Client requested %u objects", size);
-    IObjectRepository * repo = GetObjectRepository();
+    IObjectRepository * repo = GetContext()->GetObjectRepository();
     for (uint32 i = 0; i < size; i++)
     {
         const char * name = (const char *)packet.Read(8);
@@ -2056,8 +2058,9 @@ bool Network::LoadMap(IStream * stream)
     bool result = false;
     try
     {
+        auto context = GetContext();
         auto importer = std::unique_ptr<IParkImporter>(
-            ParkImporter::CreateS6(GetObjectRepository(), GetObjectManager()));
+            ParkImporter::CreateS6(GetContext()->GetObjectRepository(), context->GetObjectManager()));
         importer->LoadFromStream(stream, false);
         importer->Import();
 

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 
+#include "../Context.h"
 #include "../core/Math.hpp"
 #include "../core/Util.hpp"
 #include "../Game.h"
@@ -167,7 +168,7 @@ void * object_entry_get_chunk(sint32 objectType, size_t index)
     }
 
     void * result = nullptr;
-    auto objectMgr = GetObjectManager();
+    auto objectMgr = OpenRCT2::GetContext()->GetObjectManager();
     auto obj = objectMgr->GetLoadedObject(objectIndex);
     if (obj != nullptr)
     {
@@ -179,7 +180,7 @@ void * object_entry_get_chunk(sint32 objectType, size_t index)
 const rct_object_entry * object_entry_get_entry(sint32 objectType, size_t index)
 {
     const rct_object_entry * result = nullptr;
-    auto objectMgr = GetObjectManager();
+    auto objectMgr = OpenRCT2::GetContext()->GetObjectManager();
     auto obj = objectMgr->GetLoadedObject(objectType, index);
     if (obj != nullptr)
     {

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <memory>
 #include <unordered_set>
+#include "../Context.h"
 #include "../core/Console.hpp"
 #include "../core/Memory.hpp"
 #include "../localisation/StringIds.h"
@@ -571,36 +572,28 @@ private:
     }
 };
 
-static ObjectManager * _objectManager = nullptr;
-
 IObjectManager * CreateObjectManager(IObjectRepository * objectRepository)
 {
-    _objectManager = new ObjectManager(objectRepository);
-    return _objectManager;
-}
-
-IObjectManager * GetObjectManager()
-{
-    return _objectManager;
+    return new ObjectManager(objectRepository);
 }
 
 void * object_manager_get_loaded_object_by_index(size_t index)
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     Object * loadedObject = objectManager->GetLoadedObject(index);
     return (void *)loadedObject;
 }
 
 void * object_manager_get_loaded_object(const rct_object_entry * entry)
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     Object * loadedObject = objectManager->GetLoadedObject(entry);
     return (void *)loadedObject;
 }
 
 uint8 object_manager_get_loaded_object_entry_index(const void * loadedObject)
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     const Object * object = static_cast<const Object *>(loadedObject);
     uint8 entryIndex = objectManager->GetLoadedObjectEntryIndex(object);
     return entryIndex;
@@ -608,20 +601,20 @@ uint8 object_manager_get_loaded_object_entry_index(const void * loadedObject)
 
 void * object_manager_load_object(const rct_object_entry * entry)
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     Object * loadedObject = objectManager->LoadObject(entry);
     return (void *)loadedObject;
 }
 
 void object_manager_unload_objects(const rct_object_entry * entries, size_t count)
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     objectManager->UnloadObjects(entries, count);
 }
 
 void object_manager_unload_all_objects()
 {
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
     if (objectManager != nullptr)
     {
         objectManager->UnloadAll();
@@ -632,4 +625,3 @@ rct_string_id object_manager_get_source_game_string(const rct_object_entry * ent
 {
     return ObjectManager::GetObjectSourceGameString(entry);
 }
-

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -45,7 +45,6 @@ interface IObjectManager
 };
 
 IObjectManager * CreateObjectManager(IObjectRepository * objectRepository);
-IObjectManager * GetObjectManager();
 
 void *        object_manager_get_loaded_object_by_index(size_t index);
 void *        object_manager_get_loaded_object(const rct_object_entry * entry);

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../common.h"
+#include "../Context.h"
 #include "../core/Console.hpp"
 #include "../core/FileIndex.hpp"
 #include "../core/FileStream.hpp"
@@ -633,17 +634,9 @@ private:
     }
 };
 
-static ObjectRepository * _objectRepository = nullptr;
-
 IObjectRepository * CreateObjectRepository(IPlatformEnvironment * env)
 {
-    _objectRepository = new ObjectRepository(env);
-    return _objectRepository;
-}
-
-IObjectRepository * GetObjectRepository()
-{
-    return _objectRepository;
+    return new ObjectRepository(env);
 }
 
 bool IsObjectCustom(const ObjectRepositoryItem * object)
@@ -657,7 +650,7 @@ bool IsObjectCustom(const ObjectRepositoryItem * object)
 const rct_object_entry * object_list_find(rct_object_entry * entry)
 {
     const rct_object_entry * result = nullptr;
-    auto objRepo = GetObjectRepository();
+    auto objRepo = GetContext()->GetObjectRepository();
     auto item = objRepo->FindObject(entry);
     if (item != nullptr)
     {
@@ -669,7 +662,7 @@ const rct_object_entry * object_list_find(rct_object_entry * entry)
 const rct_object_entry * object_list_find_by_name(const char * name)
 {
     const rct_object_entry * result = nullptr;
-    auto objRepo = GetObjectRepository();
+    auto objRepo = GetContext()->GetObjectRepository();
     auto item = objRepo->FindObject(name);
     if (item != nullptr)
     {
@@ -680,17 +673,18 @@ const rct_object_entry * object_list_find_by_name(const char * name)
 
 void object_list_load()
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
+    auto context = GetContext();
+    IObjectRepository * objectRepository = context->GetObjectRepository();
     objectRepository->LoadOrConstruct();
 
-    IObjectManager * objectManager = GetObjectManager();
+    IObjectManager * objectManager = context->GetObjectManager();
     objectManager->UnloadAll();
 }
 
 void * object_repository_load_object(const rct_object_entry * objectEntry)
 {
     Object * object = nullptr;
-    IObjectRepository * objRepository = GetObjectRepository();
+    IObjectRepository * objRepository = GetContext()->GetObjectRepository();
     const ObjectRepositoryItem * ori = objRepository->FindObject(objectEntry);
     if (ori != nullptr)
     {
@@ -722,7 +716,7 @@ void scenario_translate(scenario_index_entry * scenarioEntry, const rct_object_e
         // Checks for a scenario string object (possibly for localisation)
         if ((stexObjectEntry->flags & 0xFF) != 255)
         {
-            IObjectRepository * objectRepository = GetObjectRepository();
+            IObjectRepository * objectRepository = GetContext()->GetObjectRepository();
             const ObjectRepositoryItem * ori = objectRepository->FindObject(stexObjectEntry);
             if (ori != nullptr)
             {
@@ -745,25 +739,25 @@ void scenario_translate(scenario_index_entry * scenarioEntry, const rct_object_e
 
 size_t object_repository_get_items_count()
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
+    IObjectRepository * objectRepository = GetContext()->GetObjectRepository();
     return objectRepository->GetNumObjects();
 }
 
 const ObjectRepositoryItem * object_repository_get_items()
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
+    IObjectRepository * objectRepository = GetContext()->GetObjectRepository();
     return objectRepository->GetObjects();
 }
 
 const ObjectRepositoryItem * object_repository_find_object_by_entry(const rct_object_entry * entry)
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
+    IObjectRepository * objectRepository = GetContext()->GetObjectRepository();
     return objectRepository->FindObject(entry);
 }
 
 const ObjectRepositoryItem * object_repository_find_object_by_name(const char * name)
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
+    IObjectRepository * objectRepository = GetContext()->GetObjectRepository();
     return objectRepository->FindObject(name);
 }
 
@@ -848,4 +842,3 @@ sint32 object_calculate_checksum(const rct_object_entry * entry, const void * da
 
     return (sint32)checksum;
 }
-

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -56,7 +56,7 @@ struct ObjectRepositoryItem
 
 interface IObjectRepository
 {
-    virtual ~IObjectRepository() { }
+    virtual ~IObjectRepository() = default;
 
     virtual void                            LoadOrConstruct() abstract;
     virtual void                            Construct() abstract;
@@ -78,7 +78,6 @@ interface IObjectRepository
 };
 
 IObjectRepository * CreateObjectRepository(OpenRCT2::IPlatformEnvironment * env);
-IObjectRepository * GetObjectRepository();
 
 bool IsObjectCustom(const ObjectRepositoryItem * object);
 

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -17,6 +17,7 @@
 #pragma warning(disable : 4706) // assignment within conditional expression
 
 #include <unordered_map>
+#include "../Context.h"
 #include "../core/IStream.hpp"
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
@@ -27,6 +28,8 @@
 #include "ObjectManager.h"
 #include "ObjectRepository.h"
 #include "SceneryGroupObject.h"
+
+using namespace OpenRCT2;
 
 void SceneryGroupObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 {
@@ -71,8 +74,9 @@ void SceneryGroupObject::DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint
 
 void SceneryGroupObject::UpdateEntryIndexes()
 {
-    IObjectRepository * objectRepository = GetObjectRepository();
-    IObjectManager * objectManager = GetObjectManager();
+    auto context = GetContext();
+    IObjectRepository * objectRepository = context->GetObjectRepository();
+    IObjectManager * objectManager = context->GetObjectManager();
 
     _legacyType.entry_count = 0;
     for (const auto &objectEntry : _items)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include "../Context.h"
 #include "../core/Collections.hpp"
 #include "../core/Console.hpp"
 #include "../core/FileStream.hpp"
@@ -340,7 +341,7 @@ private:
         String::Set(gScenarioFileName, sizeof(gScenarioFileName), GetRCT1ScenarioName().c_str());
 
         // Do map initialisation, same kind of stuff done when loading scenario editor
-        GetObjectManager()->UnloadAll();
+        OpenRCT2::GetContext()->GetObjectManager()->UnloadAll();
         game_init_all(mapSize);
         gS6Info.editor_step = EDITOR_STEP_OBJECT_SELECTION;
         gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
@@ -1860,7 +1861,7 @@ private:
 
     void LoadObjects(uint8 objectType, const std::vector<const char *> &entries)
     {
-        IObjectManager * objectManager = GetObjectManager();
+        IObjectManager * objectManager = OpenRCT2::GetContext()->GetObjectManager();
 
         uint32 entryIndex = 0;
         for (const char * objectName : entries)
@@ -1909,7 +1910,7 @@ private:
 
     void GetInvalidObjects(uint8 objectType, const std::vector<const char *> &entries, std::vector<rct_object_entry> &missingObjects)
     {
-        IObjectRepository * objectRepository = GetObjectRepository();
+        IObjectRepository * objectRepository = OpenRCT2::GetContext()->GetObjectRepository();
         for (const char * objectName : entries)
         {
             rct_object_entry entry;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include "../Context.h"
 #include "../core/FileStream.hpp"
 #include "../core/IStream.hpp"
 #include "../core/String.hpp"
@@ -105,7 +106,7 @@ void S6Exporter::Save(IStream * stream, bool isScenario)
     // 2: Write packed objects
     if (_s6.header.num_packed_objects > 0)
     {
-        IObjectRepository * objRepo = GetObjectRepository();
+        IObjectRepository * objRepo = OpenRCT2::GetContext()->GetObjectRepository();
         objRepo->WritePackedObjects(stream, ExportObjectsList);
     }
 
@@ -772,7 +773,7 @@ sint32 scenario_save(const utf8 * path, sint32 flags)
     {
         if (flags & S6_SAVE_FLAG_EXPORT)
         {
-            IObjectManager * objManager   = GetObjectManager();
+            IObjectManager * objManager   = OpenRCT2::GetContext()->GetObjectManager();
             s6exporter->ExportObjectsList = objManager->GetPackableObjects();
         }
         s6exporter->RemoveTracklessRides = true;
@@ -800,4 +801,3 @@ sint32 scenario_save(const utf8 * path, sint32 flags)
     }
     return result;
 }
-

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <algorithm>
+#include "../Context.h"
 #include "../core/Console.hpp"
 #include "../core/FileStream.hpp"
 #include "../core/IStream.hpp"
@@ -848,7 +849,8 @@ IParkImporter * ParkImporter::CreateS6(IObjectRepository * objectRepository, IOb
 ParkLoadResult * load_from_sv6(const char * path)
 {
     ParkLoadResult * result = nullptr;
-    auto s6Importer = new S6Importer(GetObjectRepository(), GetObjectManager());
+    auto context = OpenRCT2::GetContext();
+    auto s6Importer = new S6Importer(context->GetObjectRepository(), context->GetObjectManager());
     try
     {
         result = new ParkLoadResult(s6Importer->LoadSavedGame(path));
@@ -900,7 +902,8 @@ ParkLoadResult * load_from_sv6(const char * path)
 ParkLoadResult * load_from_sc6(const char * path)
 {
     ParkLoadResult * result = nullptr;
-    auto s6Importer = new S6Importer(GetObjectRepository(), GetObjectManager());
+    auto context = OpenRCT2::GetContext();
+    auto s6Importer = new S6Importer(context->GetObjectRepository(), context->GetObjectManager());
     try
     {
         result = new ParkLoadResult(s6Importer->LoadScenario(path));
@@ -940,4 +943,3 @@ ParkLoadResult * load_from_sc6(const char * path)
     }
     return result;
 }
-

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -237,7 +237,7 @@ Ride *get_ride(sint32 index)
 rct_ride_entry * get_ride_entry(sint32 index)
 {
     rct_ride_entry * result = nullptr;
-    auto objMgr =  GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_RIDE, index);

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include "../Context.h"
 #include "../config/Config.h"
 #include "../core/Collections.hpp"
 #include "../core/Console.hpp"
@@ -164,7 +165,7 @@ public:
     size_t GetCountForObjectEntry(uint8 rideType, const std::string &entry) const override
     {
         size_t count = 0;
-        const IObjectRepository * repo = GetObjectRepository();
+        const IObjectRepository * repo = GetContext()->GetObjectRepository();
 
         for (const auto &item : _items)
         {
@@ -193,7 +194,7 @@ public:
     size_t GetCountForRideGroup(uint8 rideType, const RideGroup * rideGroup) const override
     {
         size_t count = 0;
-        const IObjectRepository * repo = GetObjectRepository();
+        const IObjectRepository * repo = GetContext()->GetObjectRepository();
 
         for (const auto &item : _items)
         {
@@ -225,7 +226,7 @@ public:
     std::vector<track_design_file_ref> GetItemsForObjectEntry(uint8 rideType, const std::string &entry) const override
     {
         std::vector<track_design_file_ref> refs;
-        const IObjectRepository * repo = GetObjectRepository();
+        const IObjectRepository * repo = GetContext()->GetObjectRepository();
 
         for (const auto &item : _items)
         {
@@ -258,7 +259,7 @@ public:
     std::vector<track_design_file_ref> GetItemsForRideGroup(uint8 rideType, const RideGroup * rideGroup) const override
     {
         std::vector<track_design_file_ref> refs;
-        const IObjectRepository * repo = GetObjectRepository();
+        const IObjectRepository * repo = GetContext()->GetObjectRepository();
 
         for (const auto &item : _items)
         {
@@ -395,42 +396,33 @@ private:
     }
 };
 
-static TrackDesignRepository * _trackDesignRepository = nullptr;
-
 ITrackDesignRepository * CreateTrackDesignRepository(IPlatformEnvironment * env)
 {
-    _trackDesignRepository = new TrackDesignRepository(env);
-    return _trackDesignRepository;
-}
-
-ITrackDesignRepository * GetTrackDesignRepository()
-{
-    return _trackDesignRepository;
+    return new TrackDesignRepository(env);
 }
 
 void track_repository_scan()
 {
-    ITrackDesignRepository * repo = GetTrackDesignRepository();
+    ITrackDesignRepository * repo = GetContext()->GetTrackDesignRepository();
     repo->Scan();
 }
 
 bool track_repository_delete(const utf8 * path)
 {
-    ITrackDesignRepository * repo = GetTrackDesignRepository();
+    ITrackDesignRepository * repo = GetContext()->GetTrackDesignRepository();
     return repo->Delete(path);
 }
 
 bool track_repository_rename(const utf8 * path, const utf8 * newName)
 {
-    ITrackDesignRepository * repo = GetTrackDesignRepository();
+    ITrackDesignRepository * repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Rename(path, newName);
     return !newPath.empty();
 }
 
 bool track_repository_install(const utf8 * srcPath)
 {
-    ITrackDesignRepository * repo = GetTrackDesignRepository();
+    ITrackDesignRepository * repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Install(srcPath);
     return !newPath.empty();
 }
-

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -52,11 +52,9 @@ interface ITrackDesignRepository
 };
 
 ITrackDesignRepository * CreateTrackDesignRepository(OpenRCT2::IPlatformEnvironment * env);
-ITrackDesignRepository * GetTrackDesignRepository();
 std::string GetNameFromTrackPath(const std::string &path);
 
 void    track_repository_scan();
 bool    track_repository_delete(const utf8 *path);
 bool    track_repository_rename(const utf8 *path, const utf8 *newName);
 bool    track_repository_install(const utf8 *srcPath);
-

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -85,4 +85,3 @@ size_t  scenario_repository_get_count();
 const   scenario_index_entry *scenario_repository_get_by_index(size_t index);
 bool    scenario_repository_try_record_highscore(const utf8 * scenarioFileName, money32 companyValue, const utf8 * name);
 void    scenario_translate(scenario_index_entry * scenarioEntry, const struct rct_object_entry * stexObjectEntry);
-

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include "../Cheats.h"
+#include "../Context.h"
 #include "../core/Guard.hpp"
 #include "../core/Math.hpp"
 #include "../core/Util.hpp"
@@ -2418,7 +2419,7 @@ void footpath_remove_edges_at(sint32 x, sint32 y, rct_tile_element *tileElement)
 rct_footpath_entry *get_footpath_entry(sint32 entryIndex)
 {
     rct_footpath_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_PATHS, entryIndex);

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include "../common.h"
+#include "../Context.h"
 #include "../Cheats.h"
 #include "../Game.h"
 #include "../localisation/Localisation.h"
@@ -281,7 +282,7 @@ void scenery_remove_ghost_tool_placement(){
 rct_scenery_entry *get_small_scenery_entry(sint32 entryIndex)
 {
     rct_scenery_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_SMALL_SCENERY, entryIndex);
@@ -296,7 +297,7 @@ rct_scenery_entry *get_small_scenery_entry(sint32 entryIndex)
 rct_scenery_entry *get_large_scenery_entry(sint32 entryIndex)
 {
     rct_scenery_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_LARGE_SCENERY, entryIndex);
@@ -311,7 +312,7 @@ rct_scenery_entry *get_large_scenery_entry(sint32 entryIndex)
 rct_scenery_entry *get_wall_entry(sint32 entryIndex)
 {
     rct_scenery_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_WALLS, entryIndex);
@@ -326,7 +327,7 @@ rct_scenery_entry *get_wall_entry(sint32 entryIndex)
 rct_scenery_entry *get_banner_entry(sint32 entryIndex)
 {
     rct_scenery_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_BANNERS, entryIndex);
@@ -341,7 +342,7 @@ rct_scenery_entry *get_banner_entry(sint32 entryIndex)
 rct_scenery_entry *get_footpath_item_entry(sint32 entryIndex)
 {
     rct_scenery_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_PATH_BITS, entryIndex);
@@ -356,7 +357,7 @@ rct_scenery_entry *get_footpath_item_entry(sint32 entryIndex)
 rct_scenery_group_entry *get_scenery_group_entry(sint32 entryIndex)
 {
     rct_scenery_group_entry * result = nullptr;
-    auto objMgr = GetObjectManager();
+    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
     if (objMgr != nullptr)
     {
         auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_SCENERY_GROUP, entryIndex);


### PR DESCRIPTION
This makes them no longer a singleton, which fixes annoying behaviour when creating multiple contexts in one game session.

Some information about why it didn't work properly before:
Some of the tests try to create a context multiple times for loading a scenario. The first iteration goes fine, but the second time it would crash. This happened because the Object Manager is requested before it's initialized. The first itteration this is no problem, because there is a check for `nullptr`, but at the end of the loop the object manager gets deleted, making the singleton a dangling pointer. There is no nice way of setting the pointer to `nullptr`, as it's local to the `ObjectManager.cpp` source, but gets deleted in `Context.cpp`. This PR fixes that.

This fixes https://github.com/OpenRCT2/OpenRCT2/issues/7271