### PR TITLE
Fix #7327: Draw transparent images see-through too

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#7348] Add large half loops to the Vertical Drop Roller Coaster.
 - Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.
+- Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
 - Improved: Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 
 0.1.2 (2018-03-18)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -659,26 +659,24 @@ static void paint_ps_image(rct_drawpixelinfo * dpi, paint_struct * ps, uint32 im
 
 static uint32 paint_ps_colourify_image(uint32 imageId, uint8 spriteType, uint32 viewFlags)
 {
+    constexpr uint32 primaryColour   = COLOUR_BRIGHT_YELLOW;
+    constexpr uint32 secondaryColour = COLOUR_GREY;
+    constexpr uint32 seeThoughFlags  = IMAGE_TYPE_TRANSPARENT | (primaryColour << 19) | (secondaryColour << 24);
+
     if (viewFlags & VIEWPORT_FLAG_SEETHROUGH_RIDES)
     {
         if (spriteType == VIEWPORT_INTERACTION_ITEM_RIDE)
         {
-            if (!(imageId & IMAGE_TYPE_TRANSPARENT))
-            {
-                imageId &= 0x7FFFF;
-                imageId |= 0x41880000;
-            }
+            imageId &= 0x7FFFF;
+            imageId |= seeThoughFlags;
         }
     }
     if (viewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
     {
         if (spriteType == VIEWPORT_INTERACTION_ITEM_WALL)
         {
-            if (!(imageId & IMAGE_TYPE_TRANSPARENT))
-            {
-                imageId &= 0x7FFFF;
-                imageId |= 0x41880000;
-            }
+            imageId &= 0x7FFFF;
+            imageId |= seeThoughFlags;
         }
     }
     if (viewFlags & VIEWPORT_FLAG_SEETHROUGH_PATHS)
@@ -688,11 +686,8 @@ static uint32 paint_ps_colourify_image(uint32 imageId, uint8 spriteType, uint32 
         case VIEWPORT_INTERACTION_ITEM_FOOTPATH:
         case VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM:
         case VIEWPORT_INTERACTION_ITEM_BANNER:
-            if (!(imageId & IMAGE_TYPE_TRANSPARENT))
-            {
-                imageId &= 0x7FFFF;
-                imageId |= 0x41880000;
-            }
+            imageId &= 0x7FFFF;
+            imageId |= seeThoughFlags;
             break;
         }
     }
@@ -703,11 +698,8 @@ static uint32 paint_ps_colourify_image(uint32 imageId, uint8 spriteType, uint32 
         case VIEWPORT_INTERACTION_ITEM_SCENERY:
         case VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY:
         case VIEWPORT_INTERACTION_ITEM_WALL:
-            if (!(imageId & IMAGE_TYPE_TRANSPARENT))
-            {
-                imageId &= 0x7FFFF;
-                imageId |= 0x41880000;
-            }
+            imageId &= 0x7FFFF;
+            imageId |= seeThoughFlags;
             break;
         }
     }


### PR DESCRIPTION
This removes the check for transparent images before applying the hardcoded colours. It sets the transparency flag anyway.

Before and after:
![image](https://user-images.githubusercontent.com/9705046/37882004-7426108c-309f-11e8-8f14-67ac4f2929e8.png)