### PR TITLE
Fix clipheight assuming tile order

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
+- Fix: Cut-away view does not draw tile elements that have been moved down on the list.
 - Improved: Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 
 0.1.2 (2018-03-18)

--- a/src/openrct2/paint/tile_element/TileElement.cpp
+++ b/src/openrct2/paint/tile_element/TileElement.cpp
@@ -162,13 +162,6 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
     }
 #endif // __TESTPAINT__
 
-    /* Check if the first (lowest) tile_element is below the clip
-     * height. */
-    if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (tile_element->base_height > gClipHeight)) {
-        blank_tiles_paint(session, x, y);
-        return;
-    }
-
     sint32 dx = 0;
     switch (rotation) {
     case 0:
@@ -253,7 +246,8 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
     sint32 previousHeight = 0;
     do {
         // Only paint tile_elements below the clip height.
-        if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (tile_element->base_height > gClipHeight)) break;
+        if ((gCurrentViewportFlags & VIEWPORT_FLAG_PAINT_CLIP_TO_HEIGHT) && (tile_element->base_height > gClipHeight))
+            continue;
 
         sint32 direction = tile_element_get_direction_with_offset(tile_element, rotation);
         sint32 height = tile_element->base_height * 8;


### PR DESCRIPTION
Instead of breaking the loop when running into an element that's above the clip height, only skip it - the next element may still be below the clip height.
The check for the first tile could be removed entirely. The screen gets cleared every frame when the clip height flag is set already.