### PR TITLE
Fix #7367: Prevent ParkSetNameAction to be executed on identical names.

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -779,6 +779,17 @@ void update_park_fences_around_tile(sint32 x, sint32 y)
 
 void park_set_name(const char *name)
 {
+    // Check if the park name is identical before actually executing the action.
+    if (gParkName != 0)
+    {
+        utf8 parkName[128] = {};
+        format_string(parkName, sizeof(parkName), gParkName, &gParkNameArgs);
+        if (strcmp(parkName, name) == 0)
+        {
+            // Identical name, nothing required to do.
+            return;
+        }
+    }
     auto parkSetNameAction = ParkSetNameAction(name);
     GameActions::Execute(&parkSetNameAction);
 }


### PR DESCRIPTION
Small regression from #7343, I didn't consider this situation, now it will prevent it from executing at all if the name is identical.