### PR TITLE
Fix guest/staff speed when they enter a ride from a sloped path

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#7331] Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries.
 - Fix: [#7341] Staff may auto-spawn on guests walking outside of paths.
 - Fix: [#7354] Cut-away view does not draw tile elements that have been moved down on the list.
+- Fix: [#7358] Peeps and staff entering rides still have the slope speed penalty set.
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5051,6 +5051,8 @@ void rct_peep::UpdateRideShopLeave()
  * Used by entering_ride and queueing_front */
 void rct_peep::UpdateRide()
 {
+    next_flags &= ~PEEP_NEXT_FLAG_IS_SLOPED;
+
     switch (sub_state)
     {
     case PEEP_RIDE_AT_ENTRANCE:

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -490,7 +490,7 @@ bool rct_peep::CheckForPath()
     path_check_optimisation++;
     if ((path_check_optimisation & 0xF) != (sprite_index & 0xF))
     {
-        // This condition makes the check happen less often 
+        // This condition makes the check happen less often
         // As a side effect peeps hover for a short,
         // random time when a path below them has been deleted
         return true;
@@ -1781,7 +1781,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
     if (intensityHighest >= 7)
         intensityHighest = 15;
 
-    /* Check which intensity boxes are enabled 
+    /* Check which intensity boxes are enabled
      * and apply the appropriate intensity settings. */
     if (gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
     {
@@ -1790,7 +1790,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
             intensityLowest = 0;
             intensityHighest = 15;
         }
-        else 
+        else
         {
             intensityLowest = 0;
             intensityHighest = 4;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2532,6 +2532,7 @@ void rct_peep::UpdateFixing(sint32 steps)
         switch (sub_state)
         {
         case PEEP_FIXING_ENTER_STATION:
+            next_flags &= ~PEEP_NEXT_FLAG_IS_SLOPED;
             progressToNextSubstate = UpdateFixingEnterStation(ride);
             break;
 


### PR DESCRIPTION
Fix guest/staff speed when they enter a ride from a sloped path. This is accomplished by setting the peeps next_var_29 to false.