### PR TITLE
Fix #7367: 'invalid name for park' shown when opening a scenario

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -17,6 +17,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/windows/Window.h>
 
+#include <openrct2/actions/ParkSetNameAction.hpp>
 #include <openrct2/Context.h>
 #include <openrct2/core/Util.hpp>
 #include <openrct2/Game.h>
@@ -794,11 +795,14 @@ static void window_editor_objective_options_main_textinput(rct_window *w, rct_wi
 
     switch (widgetIndex) {
     case WIDX_PARK_NAME:
-        park_set_name(text);
+        {
+            auto action = ParkSetNameAction(text);
+            GameActions::Execute(&action);
 
-        if (gS6Info.name[0] == '\0')
-            format_string(gS6Info.name, 64, gParkName, &gParkNameArgs);
-        break;
+            if (gS6Info.name[0] == '\0')
+                format_string(gS6Info.name, 64, gParkName, &gParkNameArgs);
+            break;
+        }
     case WIDX_SCENARIO_NAME:
         safe_strcpy(gS6Info.name, text, Util::CountOf(gS6Info.name));
         window_invalidate(w);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <openrct2/actions/ParkSetNameAction.hpp>
 #include <openrct2/config/Config.h>
 #include <openrct2/Context.h>
 #include <openrct2/core/Math.hpp>
@@ -747,7 +748,10 @@ static void window_park_entrance_update(rct_window *w)
 static void window_park_entrance_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text)
 {
     if (widgetIndex == WIDX_RENAME && text != nullptr)
-        park_set_name(text);
+    {
+        auto action = ParkSetNameAction(text);
+        GameActions::Execute(&action);
+    }
 }
 
 /**

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -41,7 +41,6 @@
 #include "Sprite.h"
 #include "../windows/Intent.h"
 #include "../Context.h"
-#include "../actions/ParkSetNameAction.hpp"
 
 rct_string_id gParkName;
 uint32 gParkNameArgs;
@@ -779,8 +778,12 @@ void update_park_fences_around_tile(sint32 x, sint32 y)
 
 void park_set_name(const char *name)
 {
-    auto parkSetNameAction = ParkSetNameAction(name);
-    GameActions::Execute(&parkSetNameAction);
+    auto nameId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, name);
+    if (nameId != 0)
+    {
+        user_string_free(gParkName);
+        gParkName = nameId;
+    }
 }
 
 static money32 map_buy_land_rights_for_tile(sint32 x, sint32 y, sint32 setting, sint32 flags) {


### PR DESCRIPTION
Apply extra changes from my own implementation of ParkSetNameAction which re-introduces logging (until we have a generic way of doing it) and calls the action directly from the UI layer.