### PR TITLE
Enable integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,23 +68,23 @@ matrix:
               fi
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_SHARED_LIBS=ON" TARGET=ubuntu_amd64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=ubuntu_amd64
         - os: linux
           if: type != cron
           env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DFORCE32=on -DBUILD_SHARED_LIBS=ON" TARGET=windows
         - os: linux
           if: type != cron
-          env: TARGET=docker64 OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_TTF=ON -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=ON"
+          env: TARGET=docker64 OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_TTF=ON -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2"
           services:
             - docker
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DBUILD_SHARED_LIBS=ON" TARGET=docker64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=docker64
           services:
             - docker
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON" TARGET=docker64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=docker64
           services:
             - docker
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
           services:
             - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DPORTABLE=ON -DDISABLE_RCT2_TESTS=on -DCMAKE_CXX_FLAGS=\"-static-libstdc++ -static-libgcc -Wl,--compress-debug-sections=zlib\"" TARGET=ubuntu_amd64
+            - OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DPORTABLE=ON -DCMAKE_CXX_FLAGS=\"-static-libstdc++ -static-libgcc -Wl,--compress-debug-sections=zlib\"" TARGET=ubuntu_amd64
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             # Android jobs are triggered from cron and overwrite `after_sucess` part
@@ -47,7 +47,7 @@ matrix:
           services:
             - docker
           env:
-            - OPENRCT2_CMAKE_OPTS="-G Ninja -DFORCE32=ON -DBUILD_SHARED_LIBS=off -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DDISABLE_RCT2_TESTS=on -DCMAKE_CXX_FLAGS=\"-static-libstdc++ -static-libgcc -Wl,--compress-debug-sections=zlib\"" TARGET=ubuntu_i686
+            - OPENRCT2_CMAKE_OPTS="-G Ninja -DFORCE32=ON -DBUILD_SHARED_LIBS=off -DCMAKE_INSTALL_PREFIX=OpenRCT2 -DCMAKE_CXX_FLAGS=\"-static-libstdc++ -static-libgcc -Wl,--compress-debug-sections=zlib\"" TARGET=ubuntu_i686
             - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
           after_success:
             # Android jobs are triggered from cron and overwrite `after_sucess` part
@@ -68,23 +68,23 @@ matrix:
               fi
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_SHARED_LIBS=ON -DDISABLE_RCT2_TESTS=on" TARGET=ubuntu_amd64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_SHARED_LIBS=ON" TARGET=ubuntu_amd64
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DFORCE32=on -DBUILD_SHARED_LIBS=ON -DDISABLE_RCT2_TESTS=on" TARGET=windows
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DFORCE32=on -DBUILD_SHARED_LIBS=ON" TARGET=windows
         - os: linux
           if: type != cron
-          env: TARGET=docker64 OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_TTF=ON -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=ON -DDISABLE_RCT2_TESTS=on"
+          env: TARGET=docker64 OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_TTF=ON -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=ON"
           services:
             - docker
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DBUILD_SHARED_LIBS=ON -DDISABLE_RCT2_TESTS=on" TARGET=docker64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DBUILD_SHARED_LIBS=ON" TARGET=docker64
           services:
             - docker
         - os: linux
           if: type != cron
-          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON -DDISABLE_RCT2_TESTS=on" TARGET=docker64
+          env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON" TARGET=docker64
           services:
             - docker
         - os: osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ configuration: Release
 build:
   project: openrct2.proj
 test_script:
-- ps: msbuild openrct2.proj /t:TestNoRCT2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- ps: msbuild openrct2.proj /t:Test /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 after_test:
 - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\artifacts\test-results.xml))
 artifacts:

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -186,8 +186,8 @@
   </Target>
 
   <Target Name="Test" DependsOnTargets="Build">
-    <Exec Command="$(TargetDir)tests\tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;"
-          WorkingDirectory="$(TargetDir)tests" />
+    <Exec Command="$(TargetDir)tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;"
+          WorkingDirectory="$(TargetDir)" />
   </Target>
 
   <!-- Target to build g2.dat containing OpenRCT2 sprites -->

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -186,10 +186,8 @@
   </Target>
 
   <Target Name="Test" DependsOnTargets="Build">
-    <Exec Command="$(TargetDir)tests\tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;" />
-  </Target>
-  <Target Name="TestNoRCT2" DependsOnTargets="Build">
-    <Exec Command="$(TargetDir)tests\tests.exe &quot;--gtest_filter=-RideRatings*:MultiLaunch*&quot; &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;" />
+    <Exec Command="$(TargetDir)tests\tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;"
+          WorkingDirectory="$(TargetDir)tests" />
   </Target>
 
   <!-- Target to build g2.dat containing OpenRCT2 sprites -->

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -28,7 +28,7 @@ pushd build
 	if [[ $TARGET == "docker64" ]]
 	then
 		# CMAKE and MAKE opts from environment
-		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:64bit-only bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja $OPENRCT_MAKE_OPTS && ctest --output-on-failure"
+		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:64bit-only bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja all install $OPENRCT_MAKE_OPTS && ctest --output-on-failure"
 	elif [[ $TARGET == "ubuntu_i686" ]]
 	then
 		# CMAKE and MAKE opts from environment

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(test-common STATIC ${COMMON_TEST_SOURCES})
 
 # Setup testdata. It should be fine here, as the only way to reach here is by explicitly requesting tests.
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_LIST_DIR}/testdata" "${CMAKE_CURRENT_BINARY_DIR}/testdata")
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2\" \"${CMAKE_CURRENT_BINARY_DIR}/data\")")
 
 # Start of our tests
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
 
-option(DISABLE_RCT2_TESTS "Disable tests that require RollerCoaster Tycoon 2 assets.")
 option(SYSTEM_GTEST "Use the googletest library provided by the system.")
 
 if (SYSTEM_GTEST)
@@ -87,14 +86,7 @@ set(COMMON_TEST_SOURCES
 add_library(test-common STATIC ${COMMON_TEST_SOURCES})
 
 # Setup testdata. It should be fine here, as the only way to reach here is by explicitly requesting tests.
-if (NOT "z$ENV{CI}" STREQUAL "z")
-    message("Detected CI environment. Disabling ride rating test.")
-    set(DISABLE_RCT2_TESTS ON)
-endif ()
-
-if (NOT DISABLE_RCT2_TESTS)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_LIST_DIR}/testdata" "${CMAKE_CURRENT_BINARY_DIR}/testdata")
-endif ()
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_LIST_DIR}/testdata" "${CMAKE_CURRENT_BINARY_DIR}/testdata")
 
 # Start of our tests
 
@@ -152,14 +144,11 @@ set(RIDE_RATINGS_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/RideRatings.cpp"
                               "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
 add_executable(test_ride_ratings ${RIDE_RATINGS_TEST_SOURCES})
 target_link_libraries(test_ride_ratings ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+add_test(NAME ride_ratings COMMAND test_ride_ratings)
 
 # Multi-launch test
 set(MULTILAUNCH_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/MultiLaunch.cpp"
                              "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
 add_executable(test_multilaunch ${MULTILAUNCH_TEST_SOURCES})
 target_link_libraries(test_multilaunch ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-    
-if (NOT DISABLE_RCT2_TESTS)
-    add_test(NAME ride_ratings COMMAND test_ride_ratings)
-    add_test(NAME multilaunch COMMAND test_multilaunch)
-endif ()
+add_test(NAME multilaunch COMMAND test_multilaunch)

--- a/test/tests/MultiLaunch.cpp
+++ b/test/tests/MultiLaunch.cpp
@@ -20,6 +20,7 @@ TEST(MultiLaunchTest, all)
     std::string path = TestData::GetParkPath("bpb.sv6");
 
     gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
 
     core_init();
     for (int i = 0; i < 3; i++)

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -59,6 +59,7 @@ TEST_F(RideRatings, all)
     std::string path = TestData::GetParkPath("bpb.sv6");
 
     gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
 
     core_init();
     auto context = CreateContext();

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <Import Project="..\..\openrct2.common.props" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)bin\tests\</OutDir>
+    <OutDir>$(SolutionDir)bin\</OutDir>
     <IncludePath>$(GtestDir);$(GtestDir)\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)bin;$(LibraryPath)</LibraryPath>
   </PropertyGroup>


### PR DESCRIPTION
Now that vanilla objects are JSON we can run our integration tests on CI.

~~Requires #7340 to be merged first to fix multiple context launching.~~