### PR TITLE
Fix encoding of scenario index names

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1087,7 +1087,7 @@ static void load_landscape()
     context_open_intent(&intent);
 }
 
-static void utf8_to_rct2_self(char * buffer, size_t length)
+void utf8_to_rct2_self(char * buffer, size_t length)
 {
     char tempBuffer[512];
     utf8_to_rct2(tempBuffer, buffer);
@@ -1125,7 +1125,7 @@ static void utf8_to_rct2_self(char * buffer, size_t length)
     while (i < length);
 }
 
-static void rct2_to_utf8_self(char * buffer, size_t length)
+void rct2_to_utf8_self(char * buffer, size_t length)
 {
     if (length > 0)
     {

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -185,5 +185,7 @@ void game_autosave();
 void game_convert_strings_to_utf8();
 void game_convert_news_items_to_utf8();
 void game_convert_strings_to_rct2(rct_s6_data * s6);
+void utf8_to_rct2_self(char * buffer, size_t length);
+void rct2_to_utf8_self(char * buffer, size_t length);
 void game_fix_save_vars();
 void game_init_all(sint32 mapSize);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -271,7 +271,10 @@ public:
             dst->objective_arg_2 = _s4.scenario_objective_currency;
         dst->objective_arg_3 = _s4.scenario_objective_num_guests;
 
-        std::string name = std::string(_s4.scenario_name, sizeof(_s4.scenario_name));
+        utf8 utf8name[256];
+        rct2_to_utf8(utf8name, _s4.scenario_name);
+
+        std::string name = std::string(utf8name, sizeof(utf8name));
         std::string details;
 
         // TryGetById won't set this property if the scenario is not recognised,

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -163,6 +163,8 @@ void S6Exporter::Export()
         log_error("Found %d disjoint null sprites", disjoint_sprites_count);
     }
     _s6.info = gS6Info;
+    utf8_to_rct2(_s6.info.name, gS6Info.name);
+    utf8_to_rct2(_s6.info.details, gS6Info.details);
     uint32 researchedTrackPiecesA[128];
     uint32 researchedTrackPiecesB[128];
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -200,6 +200,8 @@ public:
 
         // _s6.header
         gS6Info = _s6.info;
+        rct2_to_utf8(gS6Info.name, _s6.info.name);
+        rct2_to_utf8(gS6Info.details, _s6.info.details);
 
         gDateMonthsElapsed = _s6.elapsed_months;
         gDateMonthTicks    = _s6.current_day;

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -35,6 +35,7 @@
 #include "../localisation/Localisation.h"
 #include "../platform/platform.h"
 #include "Scenario.h"
+#include "../Game.h"
 
 using namespace OpenRCT2;
 
@@ -240,6 +241,8 @@ private:
                 if (header.type == S6_TYPE_SCENARIO)
                 {
                     rct_s6_info info = chunkReader.ReadChunkAs<rct_s6_info>();
+                    rct2_to_utf8_self(info.name, sizeof(info.name));
+                    rct2_to_utf8_self(info.details, sizeof(info.details));
                     *entry = CreateNewScenarioEntry(path, timestamp, &info);
                     return true;
                 }


### PR DESCRIPTION
I came across this when fixing the import of Polish scenarios.