### PR TITLE
Check Guest Tile When Placing New Staff

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#7303] Visual glitch with virtual floor near map edges.
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
 - Fix: [#7331] Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries.
+- Fix: [#7341] Staff may auto-spawn on guests walking outside of paths
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -89,16 +89,22 @@ static inline void staff_autoposition_new_staff_member(rct_peep * newPeep)
 
     newPeep->state = PEEP_STATE_FALLING;
 
-    sint16     x, y, z;
-    uint32     count = 0;
-    uint16     sprite_index;
-    rct_peep * guest = nullptr;
+    sint16             x, y, z;
+    uint32             count = 0;
+    uint16             sprite_index;
+    rct_peep *         guest = nullptr;
+    rct_tile_element * guest_tile = nullptr;
 
     // Count number of walking guests
     FOR_ALL_GUESTS(sprite_index, guest)
     {
         if (guest->state == PEEP_STATE_WALKING)
-            ++count;
+        {
+            // Check the walking guest's tile. Only count them if they're on a path tile.
+            guest_tile = map_get_path_element_at(guest->next_x / 32, guest->next_y / 32, guest->next_z);
+            if (guest_tile != nullptr)
+                ++count;
+        }
     }
 
     if (count > 0)
@@ -109,9 +115,13 @@ static inline void staff_autoposition_new_staff_member(rct_peep * newPeep)
         {
             if (guest->state == PEEP_STATE_WALKING)
             {
-                if (rand == 0)
-                    break;
-                --rand;
+                guest_tile = map_get_path_element_at(guest->next_x / 32, guest->next_y / 32, guest->next_z);
+                if (guest_tile != nullptr)
+                {
+                    if (rand == 0)
+                        break;
+                    --rand;
+                }
             }
         }
 


### PR DESCRIPTION
Added a check for the guest's tile when iterating through the set of walking guests during staff placement. We only consider that guest when the tile they're on is a path tile. If no guests are on a path tile we fall back to the park entrance.