### PR TITLE
Fix the order predicate for GameCommands

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -217,7 +217,14 @@ private:
         uint8 callback = 0;
         uint32 commandIndex = 0;
         bool operator<(const GameCommand& comp) const {
-            return tick < comp.tick && commandIndex < comp.commandIndex;
+            // First sort by tick
+            if (tick < comp.tick)
+                return true;
+            if (tick > comp.tick)
+                return false;
+
+            // If the ticks are equal sort by commandIndex
+            return commandIndex < comp.commandIndex;
         }
     };
 


### PR DESCRIPTION
This PR fixes a bug in the ordering of the game commands. With the old version the order of the commands depended on the order in which they were inserted into the `MultiSet`. Through this commit they'll always have a uniform order.

This PR also bumps the network version.