### PR TITLE
Remove unused function arguments or mark them so

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -91,11 +91,11 @@ static void input_window_position_end(rct_window * w, sint32 x, sint32 y);
 static void input_window_resize_begin(rct_window * w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void input_window_resize_continue(rct_window * w, sint32 x, sint32 y);
 static void input_window_resize_end();
-static void input_viewport_drag_begin(rct_window * w, sint32 x, sint32 y);
+static void input_viewport_drag_begin(rct_window * w);
 static void input_viewport_drag_continue();
 static void input_viewport_drag_end();
 static void input_scroll_begin(rct_window * w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
-static void input_scroll_continue(rct_window * w, rct_widgetindex widgetIndex, sint32 state, sint32 x, sint32 y);
+static void input_scroll_continue(rct_window * w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void input_scroll_end();
 static void input_scroll_part_update_hthumb(rct_window * w, rct_widgetindex widgetIndex, sint32 x, sint32 scroll_id);
 static void input_scroll_part_update_hleft(rct_window * w, rct_widgetindex widgetIndex, sint32 scroll_id);
@@ -193,7 +193,7 @@ static rct_mouse_data * get_mouse_input()
  *
  *  rct2: 0x006E957F
  */
-static void input_scroll_drag_begin(sint32 x, sint32 y, rct_window * w, rct_widget * widget, rct_widgetindex widgetIndex)
+static void input_scroll_drag_begin(sint32 x, sint32 y, rct_window * w, rct_widgetindex widgetIndex)
 {
     _inputState = INPUT_STATE_SCROLL_RIGHT;
     gInputDragLastX = x;
@@ -325,11 +325,11 @@ static void game_handle_input_mouse(sint32 x, sint32 y, sint32 state)
                 case WWT_VIEWPORT:
                     if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO)))
                     {
-                        input_viewport_drag_begin(w, x, y);
+                        input_viewport_drag_begin(w);
                     }
                     break;
                 case WWT_SCROLL:
-                    input_scroll_drag_begin(x, y, w, widget, widgetIndex);
+                    input_scroll_drag_begin(x, y, w, widgetIndex);
                     break;
                 }
             }
@@ -427,7 +427,7 @@ static void game_handle_input_mouse(sint32 x, sint32 y, sint32 state)
         switch (state)
         {
         case MOUSE_STATE_RELEASED:
-            input_scroll_continue(w, widgetIndex, state, x, y);
+            input_scroll_continue(w, widgetIndex, x, y);
             break;
         case MOUSE_STATE_LEFT_RELEASE:
             input_scroll_end();
@@ -523,7 +523,7 @@ static void input_window_resize_end()
 
 #pragma region Viewport dragging
 
-static void input_viewport_drag_begin(rct_window * w, sint32 x, sint32 y)
+static void input_viewport_drag_begin(rct_window * w)
 {
     w->flags &= ~WF_SCROLLING_TO_LOCATION;
     _inputState = INPUT_STATE_VIEWPORT_RIGHT;
@@ -674,7 +674,7 @@ static void input_scroll_begin(rct_window * w, rct_widgetindex widgetIndex, sint
     window_invalidate_by_number(widgetIndex, w->classification);
 }
 
-static void input_scroll_continue(rct_window * w, rct_widgetindex widgetIndex, sint32 state, sint32 x, sint32 y)
+static void input_scroll_continue(rct_window * w, rct_widgetindex widgetIndex, sint32 x, sint32 y)
 {
     rct_widget * widget;
     sint32 scroll_part, scroll_id;

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -130,7 +130,7 @@ rct_window * window_changelog_open()
     return window;
 }
 
-static void window_changelog_close(rct_window *w)
+static void window_changelog_close([[maybe_unused]] rct_window * w)
 {
     window_changelog_dispose_file();
 }
@@ -164,7 +164,8 @@ static void window_changelog_resize(rct_window *w)
     }
 }
 
-static void window_changelog_scrollgetsize(rct_window *w, sint32 scrollIndex, sint32 *width, sint32 *height)
+static void window_changelog_scrollgetsize(
+    [[maybe_unused]] rct_window * w, [[maybe_unused]] sint32 scrollIndex, sint32 * width, sint32 * height)
 {
     *width = _changelogLongestLineWidth + 4;
     *height = (sint32)(_changelogLines.size() * 11);
@@ -188,7 +189,7 @@ static void window_changelog_paint(rct_window *w, rct_drawpixelinfo *dpi)
     window_draw_widgets(w, dpi);
 }
 
-static void window_changelog_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint32 scrollIndex)
+static void window_changelog_scrollpaint(rct_window * w, rct_drawpixelinfo * dpi, [[maybe_unused]] sint32 scrollIndex)
 {
     gCurrentFontFlags = 0;
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -636,7 +636,7 @@ rct_window * window_cheats_open()
     return window;
 }
 
-static void window_cheats_money_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget)
+static void window_cheats_money_mousedown(rct_window * w, rct_widgetindex widgetIndex, [[maybe_unused]] rct_widget * widget)
 {
     switch (widgetIndex)
     {
@@ -768,7 +768,7 @@ static void window_cheats_misc_mousedown(rct_window *w, rct_widgetindex widgetIn
     }
 }
 
-static void window_cheats_misc_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex)
+static void window_cheats_misc_dropdown([[maybe_unused]] rct_window * w, rct_widgetindex widgetIndex, sint32 dropdownIndex)
 {
     if (dropdownIndex == -1)
     {

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -125,7 +125,7 @@ rct_window * window_clear_scenery_open()
  *
  *  rct2: 0x006E6B65
  */
-static void window_clear_scenery_close(rct_window *w)
+static void window_clear_scenery_close([[maybe_unused]] rct_window * w)
 {
     // If the tool wasn't changed, turn tool off
     if (clear_scenery_tool_is_active())
@@ -160,7 +160,7 @@ static void window_clear_scenery_mouseup(rct_window *w, rct_widgetindex widgetIn
     }
 }
 
-static void window_clear_scenery_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget)
+static void window_clear_scenery_mousedown(rct_window * w, rct_widgetindex widgetIndex, [[maybe_unused]] rct_widget * widget)
 {
     switch (widgetIndex) {
     case WIDX_DECREMENT:

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -209,7 +209,7 @@ static void custom_currency_window_mouseup(rct_window *w, rct_widgetindex widget
     }
 }
 
-static void custom_currency_window_dropdown(rct_window *w, rct_widgetindex widgetIndex, sint32 dropdownIndex)
+static void custom_currency_window_dropdown([[maybe_unused]] rct_window * w, rct_widgetindex widgetIndex, sint32 dropdownIndex)
 {
     if(dropdownIndex == -1)
         return;
@@ -233,7 +233,7 @@ static void custom_currency_window_dropdown(rct_window *w, rct_widgetindex widge
     }
 }
 
-static void custom_currency_window_text_input(struct rct_window *w, rct_widgetindex widgetIndex, char *text)
+static void custom_currency_window_text_input([[maybe_unused]] struct rct_window * w, rct_widgetindex widgetIndex, char * text)
 {
     if (text == nullptr)
         return;

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -113,7 +113,7 @@ rct_window * window_debug_paint_open()
     return window;
 }
 
-static void window_debug_paint_mouseup(rct_window * w, rct_widgetindex widgetIndex)
+static void window_debug_paint_mouseup([[maybe_unused]] rct_window * w, rct_widgetindex widgetIndex)
 {
     switch (widgetIndex) {
         case WIDX_TOGGLE_OLD_DRAWING:

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -310,7 +310,7 @@ void window_editor_bottom_toolbar_jump_forward_to_save_scenario()
 *
 *  rct2: 0x0066F5AE
 */
-static void window_editor_bottom_toolbar_mouseup(rct_window *w, rct_widgetindex widgetIndex)
+static void window_editor_bottom_toolbar_mouseup([[maybe_unused]] rct_window * w, rct_widgetindex widgetIndex)
 {
     if (widgetIndex == WIDX_PREVIOUS_STEP_BUTTON) {
         if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) ||

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -27,7 +27,7 @@ DLLIMPORT int LaunchOpenRCT2(int argc, wchar_t * * argv);
 /**
  * Windows entry point to OpenRCT2 with a console window using a traditional C main function.
  */
-int wmain(int argc, wchar_t * * argvW, wchar_t * envp)
+int wmain(int argc, wchar_t * * argvW, [[maybe_unused]] wchar_t * envp)
 {
     return LaunchOpenRCT2(argc, argvW);
 }

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -473,7 +473,14 @@ static void cheat_own_all_land()
 
 #pragma endregion
 
-void game_command_cheat(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_cheat(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     sint32 cheat = *ecx;
     if (*ebx & GAME_COMMAND_FLAG_APPLY)

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -230,7 +230,7 @@ static bool sprite_file_export(sint32 spriteIndex, const char *outPath)
     if (spriteHeader->flags & G1_FLAG_RLE_COMPRESSION) {
         gfx_rle_sprite_to_buffer(spriteHeader->offset, pixels, (uint8*)spriteFilePalette, &dpi, IMAGE_TYPE_DEFAULT, 0, spriteHeader->height, 0, spriteHeader->width);
     } else {
-        gfx_bmp_sprite_to_buffer((uint8*)spriteFilePalette, nullptr, spriteHeader->offset, pixels, spriteHeader, &dpi, spriteHeader->height, spriteHeader->width, IMAGE_TYPE_DEFAULT);
+        gfx_bmp_sprite_to_buffer((uint8*)spriteFilePalette, spriteHeader->offset, pixels, spriteHeader, &dpi, spriteHeader->height, spriteHeader->width, IMAGE_TYPE_DEFAULT);
     }
 
     if (image_io_png_write(&dpi, (rct_palette*)spriteFilePalette, outPath)) {

--- a/src/openrct2/Diagnostic.cpp
+++ b/src/openrct2/Diagnostic.cpp
@@ -22,7 +22,7 @@
 #include <android/log.h>
 #endif
 
-static bool _log_location_enabled = true;
+[[maybe_unused]] static bool _log_location_enabled = true;
 bool _log_levels[DIAGNOSTIC_LEVEL_COUNT] = { true, true, true, false, true };
 
 static FILE * diagnostic_get_stream(DIAGNOSTIC_LEVEL level)
@@ -60,7 +60,6 @@ void diagnostic_log_with_location(DIAGNOSTIC_LEVEL diagnosticLevel, const char *
     if (!_log_levels[diagnosticLevel])
         return;
 
-    UNUSED(_log_location_enabled);
     snprintf(buf, 1024, "[%s:%d (%s)]: ", file, line, function);
 
     va_start(args, format);

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -576,7 +576,14 @@ namespace Editor
         return true;
     }
 
-    void GameCommandEditScenarioOptions(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+    void GameCommandEditScenarioOptions(
+        [[maybe_unused]] sint32 * eax,
+        sint32 *                  ebx,
+        sint32 *                  ecx,
+        sint32 *                  edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         if (!(*ebx & GAME_COMMAND_FLAG_APPLY))
         {

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1043,7 +1043,14 @@ bool game_is_not_paused()
  *
  *  rct2: 0x00667C15
  */
-void game_pause_toggle(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+void game_pause_toggle(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     if (*ebx & GAME_COMMAND_FLAG_APPLY)
         pause_toggle();
@@ -1055,7 +1062,14 @@ void game_pause_toggle(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, s
  *
  *  rct2: 0x0066DB5F
  */
-static void game_load_or_quit(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+static void game_load_or_quit(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     if (*ebx & GAME_COMMAND_FLAG_APPLY)
     {

--- a/src/openrct2/Imaging.cpp
+++ b/src/openrct2/Imaging.cpp
@@ -290,12 +290,12 @@ namespace Imaging
     {
     }
 
-    static void PngWarning(png_structp png_ptr, const char * b)
+    static void PngWarning([[maybe_unused]] png_structp png_ptr, const char * b)
     {
         log_warning(b);
     }
 
-    static void PngError(png_structp png_ptr, const char * b)
+    static void PngError([[maybe_unused]] png_structp png_ptr, const char * b)
     {
         log_error(b);
     }

--- a/src/openrct2/actions/GameActionCompat.cpp
+++ b/src/openrct2/actions/GameActionCompat.cpp
@@ -45,13 +45,14 @@
     *
     *  rct2: 0x006666E7
     */
-    void game_command_place_park_entrance(sint32* eax,
-                                          sint32* ebx,
-                                          sint32* ecx,
-                                          sint32* edx,
-                                          sint32* esi,
-                                          sint32* edi,
-                                          sint32* ebp)
+    void game_command_place_park_entrance(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_PLACE_PARK_ENTRANCE DEPRECATED");
     }
@@ -87,7 +88,14 @@
         GameActions::Execute(&gameAction);
     }
 
-    void game_command_set_park_entrance_fee(int *eax, int *ebx, int *ecx, int *edx, int *esi, int *edi, int *ebp)
+    void game_command_set_park_entrance_fee(
+        [[maybe_unused]] int * eax,
+        [[maybe_unused]] int * ebx,
+        [[maybe_unused]] int * ecx,
+        [[maybe_unused]] int * edx,
+        [[maybe_unused]] int * esi,
+        int *                  edi,
+        [[maybe_unused]] int * ebp)
     {
         money16 fee = (money16)(*edi & 0xFFFF);
         auto gameAction = SetParkEntranceFeeAction(fee);
@@ -104,7 +112,7 @@
     {
         sint32 rideEntryIndex = ride_get_entry_index(listItem.type, listItem.entry_index);
         sint32 colour1 = ride_get_random_colour_preset_index(listItem.type);
-        sint32 colour2 = ride_get_unused_preset_vehicle_colour(listItem.type, rideEntryIndex);
+        sint32 colour2 = ride_get_unused_preset_vehicle_colour(rideEntryIndex);
 
         auto gameAction = RideCreateAction(listItem.type, listItem.entry_index, colour1, colour2);
 
@@ -123,7 +131,7 @@
     {
         sint32 rideEntryIndex = ride_get_entry_index(type, subType);
         sint32 colour1 = ride_get_random_colour_preset_index(type);
-        sint32 colour2 = ride_get_unused_preset_vehicle_colour(type, rideEntryIndex);
+        sint32 colour2 = ride_get_unused_preset_vehicle_colour(rideEntryIndex);
 
         auto gameAction = RideCreateAction(type, subType, colour1, colour2);
         gameAction.SetFlags(flags);
@@ -141,7 +149,14 @@
     *
     *  rct2: 0x006B3F0F
     */
-    void game_command_create_ride(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+    void game_command_create_ride(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_CREATE_RIDE DEPRECATED");
     }
@@ -160,7 +175,14 @@
     *
     *  rct2: 0x006B4EA6
     */
-    void game_command_set_ride_status(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+    void game_command_set_ride_status(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_SET_RIDE_STATUS DEPRECATED");
     }
@@ -178,7 +200,14 @@
     *
     *  rct2: 0x006B578B
     */
-    void game_command_set_ride_name(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+    void game_command_set_ride_name(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_SET_RIDE_NAME DEPRECATED");
     }
@@ -197,7 +226,14 @@
     *
     *  rct2: 0x006B49D9
     */
-    void game_command_demolish_ride(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+    void game_command_demolish_ride(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_DEMOLISH_RIDE DEPRECATED");
     }
@@ -215,7 +251,14 @@
     *
     *  rct2: 0x00698D6C
     */
-    void game_command_set_guest_name(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+    void game_command_set_guest_name(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_SET_GUEST_NAME DEPRECATED");
     }
@@ -230,7 +273,14 @@
         GameActions::Execute(&gameAction);
     }
 
-    void game_command_set_staff_name(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+    void game_command_set_staff_name(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_SET_STAFF_NAME DEPRECATED");
     }
@@ -282,13 +332,14 @@
     *
     *  rct2: 0x006CD8CE
     */
-    void game_command_set_maze_track(sint32 * eax,
-        sint32 * ebx,
-        sint32 * ecx,
-        sint32 * edx,
-        sint32 * esi,
-        sint32 * edi,
-        sint32 * ebp)
+    void game_command_set_maze_track(
+        [[maybe_unused]] sint32 * eax,
+        [[maybe_unused]] sint32 * ebx,
+        [[maybe_unused]] sint32 * ecx,
+        [[maybe_unused]] sint32 * edx,
+        [[maybe_unused]] sint32 * esi,
+        [[maybe_unused]] sint32 * edi,
+        [[maybe_unused]] sint32 * ebp)
     {
         Guard::Assert(false, "GAME_COMMAND_SET_MAZE_TRACK DEPRECATED");
     }

--- a/src/openrct2/cmdline/CommandLine.cpp
+++ b/src/openrct2/cmdline/CommandLine.cpp
@@ -512,7 +512,7 @@ namespace CommandLine
         }
     }
 
-    static bool HandleSpecialArgument(const char * argument)
+    static bool HandleSpecialArgument([[maybe_unused]] const char * argument)
     {
 #ifdef __APPLE__
         if (String::Equals(argument, "-NSDocumentRevisionsDebugMode"))
@@ -526,7 +526,6 @@ namespace CommandLine
 #endif
         return false;
     }
-
 
     const CommandLineOptionDefinition * FindOption(const CommandLineOptionDefinition * options, char shortName)
     {

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -263,7 +263,7 @@ exitcode_t HandleCommandEdit(CommandLineArgEnumerator * enumerator)
     return EXITCODE_CONTINUE;
 }
 
-exitcode_t HandleCommandIntro(CommandLineArgEnumerator * enumerator)
+exitcode_t HandleCommandIntro([[maybe_unused]] CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
     if (result != EXITCODE_CONTINUE)
@@ -386,7 +386,7 @@ static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator * enumerator)
     }
 }
 
-static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator)
+static exitcode_t HandleCommandScanObjects([[maybe_unused]] CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
     if (result != EXITCODE_CONTINUE)
@@ -405,7 +405,7 @@ static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator
 }
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-static exitcode_t HandleCommandRegisterShell(CommandLineArgEnumerator * enumerator)
+static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnumerator * enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
     if (result != EXITCODE_CONTINUE)

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -195,17 +195,6 @@ using rct_string_id           = uint16;
     #define FASTCALL
 #endif // PLATFORM_X86
 
-// C++17 or later
-#if __cplusplus > 201402L
-    #define UNUSED_ATTR [[maybe_unused]]
-#else
-    #ifdef __GNUC__
-        #define UNUSED_ATTR [[gnu::unused]]
-    #else
-        #define UNUSED_ATTR
-    #endif
-#endif
-
 /**
  * x86 register structure, only used for easy interop to RCT2 code.
  */
@@ -258,7 +247,5 @@ struct registers {
 };
 assert_struct_size(registers, 7 * 4);
 #pragma pack(pop)
-
-#define UNUSED(x)  ((void)(x))
 
 #endif

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -292,7 +292,7 @@ bool is_csg_loaded();
 uint32 gfx_object_allocate_images(const rct_g1_element * images, uint32 count);
 void gfx_object_free_images(uint32 baseImageId, uint32 count);
 void gfx_object_check_all_images_freed();
-void FASTCALL gfx_bmp_sprite_to_buffer(const uint8* palette_pointer, uint8* unknown_pointer, uint8* source_pointer, uint8* dest_pointer, const rct_g1_element* source_image, rct_drawpixelinfo *dest_dpi, sint32 height, sint32 width, sint32 image_type);
+void FASTCALL gfx_bmp_sprite_to_buffer(const uint8* palette_pointer, uint8* source_pointer, uint8* dest_pointer, const rct_g1_element* source_image, rct_drawpixelinfo *dest_dpi, sint32 height, sint32 width, sint32 image_type);
 void FASTCALL gfx_rle_sprite_to_buffer(const uint8* RESTRICT source_bits_pointer, uint8* RESTRICT dest_bits_pointer, const uint8* RESTRICT palette_pointer, const rct_drawpixelinfo * RESTRICT dpi, sint32 image_type, sint32 source_y_start, sint32 height, sint32 source_x_start, sint32 width);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo *dpi, sint32 image_id, sint32 x, sint32 y, uint32 tertiary_colour);
 void FASTCALL gfx_draw_glpyh(rct_drawpixelinfo *dpi, sint32 image_id, sint32 x, sint32 y, uint8 * palette);

--- a/src/openrct2/drawing/Sprite.cpp
+++ b/src/openrct2/drawing/Sprite.cpp
@@ -402,7 +402,7 @@ bool gfx_load_csg()
  * image.
  *  rct2: 0x0067A690
  */
-void FASTCALL gfx_bmp_sprite_to_buffer(const uint8* palette_pointer, uint8* unknown_pointer, uint8* source_pointer, uint8* dest_pointer, const rct_g1_element* source_image, rct_drawpixelinfo *dest_dpi, sint32 height, sint32 width, sint32 image_type)
+void FASTCALL gfx_bmp_sprite_to_buffer(const uint8* palette_pointer, uint8* source_pointer, uint8* dest_pointer, const rct_g1_element* source_image, rct_drawpixelinfo *dest_dpi, sint32 height, sint32 width, sint32 image_type)
 {
     uint16 zoom_level = dest_dpi->zoom_level;
     uint8 zoom_amount = 1 << zoom_level;
@@ -718,7 +718,7 @@ void FASTCALL gfx_draw_sprite_palette_set_software(rct_drawpixelinfo *dpi, sint3
     source_pointer += g1->width*source_start_y + source_start_x;
 
     if (!(g1->flags & G1_FLAG_1)) {
-        gfx_bmp_sprite_to_buffer(palette_pointer, unknown_pointer, source_pointer, dest_pointer, g1, dpi, height, width, image_type);
+        gfx_bmp_sprite_to_buffer(palette_pointer, source_pointer, dest_pointer, g1, dpi, height, width, image_type);
     }
 }
 

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -911,8 +911,7 @@ static uint32 UTF8_getch(const char **src, size_t *srclen)
 {
     const uint8 *p = *(const uint8**)src;
     size_t left = 0;
-    bool overlong = false;
-    UNUSED(overlong);
+    [[maybe_unused]] bool overlong = false;
     bool underflow = false;
     uint32 ch = UNKNOWN_UNICODE;
 

--- a/src/openrct2/interface/Console.cpp
+++ b/src/openrct2/interface/Console.cpp
@@ -86,19 +86,19 @@ double console_parse_double(const utf8 *src, bool *valid) {
     return value;
 }
 
-static sint32 cc_clear(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32 cc_clear(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     console.Clear();
     return 0;
 }
 
-static sint32 cc_close(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32 cc_close(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     console.Close();
     return 0;
 }
 
-static sint32 cc_hide(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32 cc_hide(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     console.Hide();
     return 0;
@@ -761,7 +761,9 @@ static sint32 cc_set(InteractiveConsole &console, const utf8 **argv, sint32 argc
     }
     return 0;
 }
-static sint32 cc_twitch(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+
+static sint32
+    cc_twitch([[maybe_unused]] InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
 #ifdef DISABLE_TWITCH
     console.WriteLineError("OpenRCT2 build not compiled with Twitch integration.");
@@ -838,7 +840,8 @@ static sint32 cc_load_object(InteractiveConsole &console, const utf8 **argv, sin
     return 0;
 }
 
-static sint32 cc_object_count(InteractiveConsole &console, const utf8 **argv, sint32 argc) {
+static sint32 cc_object_count(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
+{
     const utf8* object_type_names[] = { "Rides", "Small scenery", "Large scenery", "Walls", "Banners", "Paths", "Path Additions", "Scenery groups", "Park entrances", "Water" };
     for (sint32 i = 0; i < 10; i++) {
 
@@ -855,7 +858,8 @@ static sint32 cc_object_count(InteractiveConsole &console, const utf8 **argv, si
     return 0;
 }
 
-static sint32 cc_reset_user_strings(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32 cc_reset_user_strings(
+    [[maybe_unused]] InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     reset_user_strings();
     return 0;
@@ -888,14 +892,16 @@ static sint32 cc_open(InteractiveConsole &console, const utf8 **argv, sint32 arg
     return 0;
 }
 
-static sint32 cc_remove_unused_objects(InteractiveConsole &console, const utf8 **argv, sint32 argc) 
+static sint32
+cc_remove_unused_objects(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     sint32 result = editor_remove_unused_objects();
     console.WriteFormatLine("%d unused object entries have been removed.", result);
     return 0;
 }
 
-static sint32 cc_remove_park_fences(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32
+cc_remove_park_fences(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     tile_element_iterator it;
     tile_element_iterator_begin(&it);
@@ -913,7 +919,7 @@ static sint32 cc_remove_park_fences(InteractiveConsole &console, const utf8 **ar
     return 0;
 }
 
-static sint32 cc_show_limits(InteractiveConsole &console, const utf8 ** argv, sint32 argc)
+static sint32 cc_show_limits(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     map_reorganise_elements();
     sint32 tileElementCount = gNextFreeTileElement - gTileElements - 1;
@@ -960,7 +966,7 @@ static sint32 cc_show_limits(InteractiveConsole &console, const utf8 ** argv, si
     return 0;
 }
 
-static sint32 cc_for_date(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+static sint32 cc_for_date(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     sint32 year = 0;
     sint32 month = 0;
@@ -1100,14 +1106,16 @@ static constexpr const console_command console_command_table[] = {
     { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."}
 };
 
-static sint32 cc_windows(InteractiveConsole &console, const utf8 **argv, sint32 argc) {
+static sint32 cc_windows(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
+{
     for (auto s : console_window_table)
     {
         console.WriteLine(s);
     }
     return 0;
 }
-static sint32 cc_variables(InteractiveConsole &console, const utf8 **argv, sint32 argc)
+
+static sint32 cc_variables(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
 {
     for (auto s : console_variable_table)
     {

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -649,8 +649,7 @@ void viewport_update_smart_sprite_follow(rct_window * window)
     }
     else if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
     {
-        rct_vehicle * vehicle = GET_VEHICLE(window->viewport_smart_follow_sprite);
-        viewport_update_smart_vehicle_follow(window, vehicle);
+        viewport_update_smart_vehicle_follow(window);
     }
     else if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_MISC ||
              sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
@@ -751,7 +750,7 @@ void viewport_update_smart_staff_follow(rct_window * window, rct_peep * peep)
     window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
 }
 
-void viewport_update_smart_vehicle_follow(rct_window * window, rct_vehicle * vehicle)
+void viewport_update_smart_vehicle_follow(rct_window * window)
 {
     // Can be expanded in the future if needed
     sprite_focus focus = { 0 };

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -128,7 +128,7 @@ void viewport_update_sprite_follow(rct_window *window);
 void viewport_update_smart_sprite_follow(rct_window * window);
 void viewport_update_smart_guest_follow(rct_window * window, rct_peep * peep);
 void viewport_update_smart_staff_follow(rct_window * window, rct_peep * peep);
-void viewport_update_smart_vehicle_follow(rct_window * window, rct_vehicle * vehicle);
+void viewport_update_smart_vehicle_follow(rct_window * window);
 void viewport_render(rct_drawpixelinfo *dpi, rct_viewport *viewport, sint32 left, sint32 top, sint32 right, sint32 bottom);
 void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, sint16 left, sint16 top, sint16 right, sint16 bottom);
 

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -80,7 +80,7 @@ bool award_is_positive(sint32 type)
 #pragma region Award checks
 
 /** More than 1/16 of the total guests must be thinking untidy thoughts. */
-static bool award_is_deserved_most_untidy(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_untidy(sint32 activeAwardTypes)
 {
     uint16 spriteIndex;
     rct_peep * peep;
@@ -114,7 +114,7 @@ static bool award_is_deserved_most_untidy(sint32 awardType, sint32 activeAwardTy
 }
 
 /** More than 1/64 of the total guests must be thinking tidy thoughts and less than 6 guests thinking untidy thoughts. */
-static bool award_is_deserved_most_tidy(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_tidy(sint32 activeAwardTypes)
 {
     uint16 spriteIndex;
     rct_peep * peep;
@@ -152,7 +152,7 @@ static bool award_is_deserved_most_tidy(sint32 awardType, sint32 activeAwardType
 }
 
 /** At least 6 open roller coasters. */
-static bool award_is_deserved_best_rollercoasters(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_rollercoasters([[maybe_unused]] sint32 activeAwardTypes)
 {
     sint32 i, rollerCoasters;
     Ride           * ride;
@@ -184,7 +184,7 @@ static bool award_is_deserved_best_rollercoasters(sint32 awardType, sint32 activ
 }
 
 /** Entrance fee is 0.10 less than half of the total ride value. */
-static bool award_is_deserved_best_value(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_value(sint32 activeAwardTypes)
 {
     if (activeAwardTypes & (1 << PARK_AWARD_WORST_VALUE))
         return false;
@@ -205,7 +205,7 @@ static bool award_is_deserved_best_value(sint32 awardType, sint32 activeAwardTyp
 }
 
 /** More than 1/128 of the total guests must be thinking scenic thoughts and fewer than 16 untidy thoughts. */
-static bool award_is_deserved_most_beautiful(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_beautiful(sint32 activeAwardTypes)
 {
     uint16 spriteIndex;
     rct_peep * peep;
@@ -242,7 +242,7 @@ static bool award_is_deserved_most_beautiful(sint32 awardType, sint32 activeAwar
 }
 
 /** Entrance fee is more than total ride value. */
-static bool award_is_deserved_worst_value(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_worst_value(sint32 activeAwardTypes)
 {
     if (activeAwardTypes & (1 << PARK_AWARD_BEST_VALUE))
         return false;
@@ -258,7 +258,7 @@ static bool award_is_deserved_worst_value(sint32 awardType, sint32 activeAwardTy
 }
 
 /** No more than 2 people who think the vandalism is bad and no crashes. */
-static bool award_is_deserved_safest(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_safest([[maybe_unused]] sint32 activeAwardTypes)
 {
     sint32 i, peepsWhoDislikeVandalism;
     uint16 spriteIndex;
@@ -288,7 +288,7 @@ static bool award_is_deserved_safest(sint32 awardType, sint32 activeAwardTypes)
 }
 
 /** All staff types, at least 20 staff, one staff per 32 peeps. */
-static bool award_is_deserved_best_staff(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_staff(sint32 activeAwardTypes)
 {
     uint16 spriteIndex;
     rct_peep * peep;
@@ -319,7 +319,7 @@ static bool award_is_deserved_best_staff(sint32 awardType, sint32 activeAwardTyp
 }
 
 /** At least 7 shops, 4 unique, one shop per 128 guests and no more than 12 hungry guests. */
-static bool award_is_deserved_best_food(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_food(sint32 activeAwardTypes)
 {
     sint32 i, hungryPeeps, shops, uniqueShops;
     uint64 shopTypes;
@@ -372,7 +372,7 @@ static bool award_is_deserved_best_food(sint32 awardType, sint32 activeAwardType
 }
 
 /** No more than 2 unique shops, less than one shop per 256 guests and more than 15 hungry guests. */
-static bool award_is_deserved_worst_food(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_worst_food(sint32 activeAwardTypes)
 {
     sint32 i, hungryPeeps, shops, uniqueShops;
     uint64 shopTypes;
@@ -425,7 +425,7 @@ static bool award_is_deserved_worst_food(sint32 awardType, sint32 activeAwardTyp
 }
 
 /** At least 4 restrooms, 1 restroom per 128 guests and no more than 16 guests who think they need the restroom. */
-static bool award_is_deserved_best_restrooms(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_restrooms([[maybe_unused]] sint32 activeAwardTypes)
 {
     uint32 i, numRestrooms, guestsWhoNeedRestroom;
     Ride * ride;
@@ -463,7 +463,7 @@ static bool award_is_deserved_best_restrooms(sint32 awardType, sint32 activeAwar
 }
 
 /** More than half of the rides have satisfaction <= 6 and park rating <= 650. */
-static bool award_is_deserved_most_disappointing(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_disappointing(sint32 activeAwardTypes)
 {
     uint32 i, countedRides, disappointingRides;
     Ride * ride;
@@ -494,7 +494,7 @@ static bool award_is_deserved_most_disappointing(sint32 awardType, sint32 active
 }
 
 /** At least 6 open water rides. */
-static bool award_is_deserved_best_water_rides(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_water_rides([[maybe_unused]] sint32 activeAwardTypes)
 {
     sint32 i, waterRides;
     Ride           * ride;
@@ -526,7 +526,7 @@ static bool award_is_deserved_best_water_rides(sint32 awardType, sint32 activeAw
 }
 
 /** At least 6 custom designed rides. */
-static bool award_is_deserved_best_custom_designed_rides(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_custom_designed_rides(sint32 activeAwardTypes)
 {
     sint32 i, customDesignedRides;
     Ride * ride;
@@ -555,7 +555,7 @@ static bool award_is_deserved_best_custom_designed_rides(sint32 awardType, sint3
 /** At least 5 colourful rides and more than half of the rides are colourful. */
 static constexpr const uint8 dazzling_ride_colours[] = {COLOUR_BRIGHT_PURPLE, COLOUR_BRIGHT_GREEN, COLOUR_LIGHT_ORANGE, COLOUR_BRIGHT_PINK};
 
-static bool award_is_deserved_most_dazzling_ride_colours(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_dazzling_ride_colours(sint32 activeAwardTypes)
 {
     sint32 i, countedRides, colourfulRides;
     Ride * ride;
@@ -588,7 +588,7 @@ static bool award_is_deserved_most_dazzling_ride_colours(sint32 awardType, sint3
 }
 
 /** At least 10 peeps and more than 1/64 of total guests are lost or can't find something. */
-static bool award_is_deserved_most_confusing_layout(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_most_confusing_layout([[maybe_unused]] sint32 activeAwardTypes)
 {
     uint32 peepsCounted, peepsLost;
     uint16 spriteIndex;
@@ -610,7 +610,7 @@ static bool award_is_deserved_most_confusing_layout(sint32 awardType, sint32 act
 }
 
 /** At least 10 open gentle rides. */
-static bool award_is_deserved_best_gentle_rides(sint32 awardType, sint32 activeAwardTypes)
+static bool award_is_deserved_best_gentle_rides([[maybe_unused]] sint32 activeAwardTypes)
 {
     sint32 i, gentleRides;
     Ride           * ride;
@@ -641,7 +641,7 @@ static bool award_is_deserved_best_gentle_rides(sint32 awardType, sint32 activeA
     return (gentleRides >= 10);
 }
 
-using award_deserved_check = bool (*)(sint32, sint32);
+using award_deserved_check = bool (*)(sint32);
 
 static constexpr const award_deserved_check _awardChecks[] =
 {
@@ -666,7 +666,7 @@ static constexpr const award_deserved_check _awardChecks[] =
 
 static bool award_is_deserved(sint32 awardType, sint32 activeAwardTypes)
 {
-    return _awardChecks[awardType](awardType, activeAwardTypes);
+    return _awardChecks[awardType](activeAwardTypes);
 }
 
 #pragma endregion

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2067,8 +2067,7 @@ bool Network::LoadMap(IStream * stream)
         sprite_position_tween_reset();
 
         // Read checksum
-        uint32 checksum = stream->ReadValue<uint32>();
-        UNUSED(checksum);
+        [[maybe_unused]] uint32 checksum = stream->ReadValue<uint32>();
 
         // Read other data not in normal save files
         stream->Read(gSpriteSpatialIndex, 0x10001 * sizeof(uint16));
@@ -2762,7 +2761,14 @@ void network_chat_show_server_greeting()
     }
 }
 
-void game_command_set_player_group(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_player_group(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint8 playerid = (uint8)*ecx;
     uint8 groupid = (uint8)*edx;
@@ -2821,7 +2827,8 @@ void game_command_set_player_group(sint32* eax, sint32* ebx, sint32* ecx, sint32
     *ebx = 0;
 }
 
-void game_command_modify_groups(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_modify_groups(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     uint8 action = (uint8)*eax;
     uint8 groupid = (uint8)(*eax >> 8);
@@ -3009,7 +3016,14 @@ void game_command_modify_groups(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *e
     *ebx = 0;
 }
 
-void game_command_kick_player(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_kick_player(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint8 playerid = (uint8)*eax;
     NetworkPlayer* player = gNetwork.GetPlayerByID(playerid);

--- a/src/openrct2/paint/tile_element/Path.cpp
+++ b/src/openrct2/paint/tile_element/Path.cpp
@@ -310,9 +310,7 @@ static void path_bit_benches_paint(
 static void path_bit_jumping_fountains_paint(
     paint_session *          session,
     rct_scenery_entry *      pathBitEntry,
-    const rct_tile_element * tileElement,
     sint32                   height,
-    uint8                    edges,
     uint32                   pathBitImageFlags,
     rct_drawpixelinfo *      dpi)
 {
@@ -709,7 +707,7 @@ static void sub_6A3F61(
                     path_bit_benches_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags);
                     break;
                 case PATH_BIT_DRAW_TYPE_JUMPING_FOUNTAINS:
-                    path_bit_jumping_fountains_paint(session, sceneryEntry, tile_element, height, (uint8)connectedEdges, sceneryImageFlags, dpi);
+                    path_bit_jumping_fountains_paint(session, sceneryEntry, height, sceneryImageFlags, dpi);
                     break;
                 }
 
@@ -765,7 +763,7 @@ static void sub_6A3F61(
 /**
  * rct2: 0x0006A3590
  */
-void path_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tile_element)
+void path_paint(paint_session * session, uint16 height, const rct_tile_element * tile_element)
 {
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 

--- a/src/openrct2/paint/tile_element/TileElement.cpp
+++ b/src/openrct2/paint/tile_element/TileElement.cpp
@@ -296,7 +296,7 @@ static void sub_68B3FB(paint_session * session, sint32 x, sint32 y)
             surface_paint(session, direction, height, tile_element);
             break;
         case TILE_ELEMENT_TYPE_PATH:
-            path_paint(session, direction, height, tile_element);
+            path_paint(session, height, tile_element);
             break;
         case TILE_ELEMENT_TYPE_TRACK:
             track_paint(session, direction, height, tile_element);

--- a/src/openrct2/paint/tile_element/TileElement.h
+++ b/src/openrct2/paint/tile_element/TileElement.h
@@ -100,7 +100,7 @@ void tile_element_paint_setup(paint_session * session, sint32 x, sint32 y);
 void entrance_paint(paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tile_element);
 void banner_paint(paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tile_element);
 void surface_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement);
-void path_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement);
+void path_paint(paint_session * session, uint16 height, const rct_tile_element * tileElement);
 void scenery_paint(paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tileElement);
 void fence_paint(paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tileElement);
 void large_scenery_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement);

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -235,7 +235,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
  *
  *  rct2: 0x00407978
  */
-sint32 windows_get_registry_install_info(rct2_install_info *installInfo, char *source, char *font, uint8 charset)
+sint32 windows_get_registry_install_info(rct2_install_info *installInfo, char *source)
 {
     char subkeyInfogrames[MAX_PATH], subkeyFishTechGroup[MAX_PATH], keyName[100];
     HKEY hKey;
@@ -565,7 +565,7 @@ static bool windows_setup_file_association(
     wchar_t exePathW[MAX_PATH];
     wchar_t dllPathW[MAX_PATH];
 
-    sint32 printResult;
+    [[maybe_unused]] sint32 printResult;
 
     GetModuleFileNameW(NULL, exePathW, sizeof(exePathW));
     GetModuleFileNameW(plaform_get_dll_module(), dllPathW, sizeof(dllPathW));
@@ -604,7 +604,6 @@ static bool windows_setup_file_association(
     wchar_t szIconW[MAX_PATH];
     printResult = swprintf_s(szIconW, MAX_PATH, L"\"%s\",%d", dllPathW, iconIndex);
     assert(printResult >= 0);
-    UNUSED(printResult);
     if (RegSetValueW(hKey, L"DefaultIcon", REG_SZ, szIconW, 0) != ERROR_SUCCESS) {
         goto fail;
     }
@@ -622,7 +621,6 @@ static bool windows_setup_file_association(
     // [hRootKey\OpenRCT2.sv6\shell\open\command]
     wchar_t szCommandW[MAX_PATH];
     printResult = swprintf_s(szCommandW, MAX_PATH, L"\"%s\" %s", exePathW, commandArgsW);
-    UNUSED(printResult);
     assert(printResult >= 0);
     if (RegSetValueW(hKey, L"shell\\open\\command", REG_SZ, szCommandW, 0) != ERROR_SUCCESS) {
         goto fail;

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -150,7 +150,7 @@ void core_init();
     #undef CreateWindow
     #undef GetMessage
 
-    sint32 windows_get_registry_install_info(rct2_install_info *installInfo, char *source, char *font, uint8 charset);
+    sint32 windows_get_registry_install_info(rct2_install_info *installInfo, char *source);
     void platform_setup_file_associations();
     void platform_remove_file_associations();
     bool platform_setup_uri_protocol();

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2563,7 +2563,7 @@ private:
                                 sint32 colourA = RCT1::GetColour(GetWallColour(&originalTileElement));
                                 sint32 colourB = 0;
                                 sint32 colourC = 0;
-                                ConvertWall(&type, &colourA, &colourB, &colourC);
+                                ConvertWall(&type, &colourA, &colourB);
 
                                 type = _wallTypeToEntryMap[type];
                                 const uint8 flags =
@@ -2585,7 +2585,7 @@ private:
         gCheatsBuildInPauseMode = oldCheatValue;
     }
 
-    void ConvertWall(sint32 * type, sint32 * colourA, sint32 * colourB, sint32 * colourC)
+    void ConvertWall(sint32 * type, sint32 * colourA, sint32 * colourB)
     {
         switch (*type) {
         case RCT1_WALL_TYPE_WOODEN_PANEL_FENCE:

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2692,7 +2692,7 @@ rct_peep *ride_find_closest_mechanic(Ride *ride, sint32 forInspection)
     x = location.x;
     y = location.y;
     z = location.z;
-    tileElement = ride_get_station_exit_element(ride, x, y, z);
+    tileElement = ride_get_station_exit_element(x, y, z);
     if (tileElement == nullptr)
         return nullptr;
 
@@ -3114,7 +3114,7 @@ static bool ride_does_vehicle_colour_exist(uint8 ride_sub_type, vehicle_colour *
     return true;
 }
 
-sint32 ride_get_unused_preset_vehicle_colour(uint8 ride_type, uint8 ride_sub_type)
+sint32 ride_get_unused_preset_vehicle_colour(uint8 ride_sub_type)
 {
     if (ride_sub_type >= 128)
     {
@@ -3979,7 +3979,14 @@ static money32 ride_set_setting(uint8 rideIndex, uint8 setting, uint8 value, uin
  *
  *  rct2: 0x006B5559
  */
-void game_command_set_ride_setting(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_ride_setting(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint8 rideIndex = *edx & 0xFF;
     uint8 setting = (*edx >> 8) & 0xFF;
@@ -4317,7 +4324,7 @@ static sint32 ride_check_station_length(CoordsXYE *input, CoordsXYE *output)
  *
  *  rct2: 0x006CB2DA
  */
-static bool ride_check_start_and_end_is_station(CoordsXYE * input, CoordsXYE * output)
+static bool ride_check_start_and_end_is_station(CoordsXYE * input)
 {
     rct_window *w;
     Ride *ride;
@@ -5326,7 +5333,7 @@ sint32 ride_is_valid_for_test(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
         }
 
         gGameCommandErrorText = STR_RIDE_MUST_START_AND_END_WITH_STATIONS;
-        if (!ride_check_start_and_end_is_station(&trackElement, &problematicTrackElement)) {
+        if (!ride_check_start_and_end_is_station(&trackElement)) {
             ride_scroll_to_track_error(&problematicTrackElement);
             return 0;
         }
@@ -5457,7 +5464,7 @@ sint32 ride_is_valid_for_open(sint32 rideIndex, sint32 goingToBeOpen, sint32 isA
         }
 
         gGameCommandErrorText = STR_RIDE_MUST_START_AND_END_WITH_STATIONS;
-        if (!ride_check_start_and_end_is_station(&trackElement, &problematicTrackElement)) {
+        if (!ride_check_start_and_end_is_station(&trackElement)) {
             ride_scroll_to_track_error(&problematicTrackElement);
             return 0;
         }
@@ -5878,7 +5885,14 @@ rct_ride_name get_ride_naming(const uint8 rideType, rct_ride_entry * rideEntry)
  * Only uses part that deals with construction state
  */
 
-void game_command_callback_ride_construct_placed_back(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_ride_construct_placed_back(
+    [[maybe_unused]] sint32 eax,
+    [[maybe_unused]] sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     sint32 trackDirection, x, y, z;
     track_begin_end trackBeginEnd;
@@ -5911,7 +5925,14 @@ void game_command_callback_ride_construct_placed_back(sint32 eax, sint32 ebx, si
     window_ride_construction_update_active_elements();
 }
 
-void game_command_callback_ride_construct_placed_front(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_ride_construct_placed_front(
+    [[maybe_unused]] sint32 eax,
+    [[maybe_unused]] sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     sint32 trackDirection, x, y, z;
 
@@ -5953,7 +5974,14 @@ void game_command_callback_ride_construct_placed_front(sint32 eax, sint32 ebx, s
 * Only uses part that deals with construction state
 */
 
-void game_command_callback_ride_remove_track_piece(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_ride_remove_track_piece(
+    [[maybe_unused]] sint32 eax,
+    [[maybe_unused]] sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     sint32 x, y, z, direction, type;
 
@@ -5970,7 +5998,14 @@ void game_command_callback_ride_remove_track_piece(sint32 eax, sint32 ebx, sint3
  *
  *  rct2: 0x006B2FC5
  */
-void game_command_set_ride_appearance(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_ride_appearance(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     bool apply = (*ebx & GAME_COMMAND_FLAG_APPLY);
 
@@ -6103,7 +6138,14 @@ void game_command_set_ride_appearance(sint32 *eax, sint32 *ebx, sint32 *ecx, sin
  *
  *  rct2: 0x006B53E9
  */
-void game_command_set_ride_price(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_ride_price(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint32 flags = *ebx;
     uint8 ride_number = (*edx & 0xFF);
@@ -7390,7 +7432,7 @@ static money32 ride_set_vehicles(uint8 rideIndex, uint8 setting, uint8 value, ui
 
             uint8 preset = ex;
             if (!(flags & GAME_COMMAND_FLAG_NETWORKED)) {
-                preset = ride_get_unused_preset_vehicle_colour(ride->type, ride->subtype);
+                preset = ride_get_unused_preset_vehicle_colour(ride->subtype);
             }
 
             // Validate preset
@@ -7439,7 +7481,14 @@ static money32 ride_set_vehicles(uint8 rideIndex, uint8 setting, uint8 value, ui
  *
  *  rct2: 0x006B52D4
  */
-void game_command_set_ride_vehicles(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_ride_vehicles(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint8 rideIndex = *edx & 0xFF;
     uint8 setting = (*ebx >> 8) & 0xFF;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1033,7 +1033,7 @@ sint32 ride_get_total_time(Ride *ride);
 sint32 ride_can_have_multiple_circuits(Ride *ride);
 track_colour ride_get_track_colour(Ride *ride, sint32 colourScheme);
 vehicle_colour ride_get_vehicle_colour(Ride *ride, sint32 vehicleIndex);
-sint32 ride_get_unused_preset_vehicle_colour(uint8 ride_type, uint8 ride_sub_type);
+sint32 ride_get_unused_preset_vehicle_colour(uint8 ride_sub_type);
 void ride_set_vehicle_colours_to_random_preset(Ride *ride, uint8 preset_index);
 rct_ride_entry *get_ride_entry_by_ride(Ride *ride);
 uint8 *get_ride_entry_indices_for_ride_type(uint8 rideType);
@@ -1053,7 +1053,7 @@ sint32 ride_music_params_update(sint16 x, sint16 y, sint16 z, uint8 rideIndex, u
 void ride_music_update_final();
 void ride_prepare_breakdown(sint32 rideIndex, sint32 breakdownReason);
 rct_tile_element *ride_get_station_start_track_element(Ride *ride, sint32 stationIndex);
-rct_tile_element *ride_get_station_exit_element(Ride *ride, sint32 x, sint32 y, sint32 z);
+rct_tile_element *ride_get_station_exit_element(sint32 x, sint32 y, sint32 z);
 void ride_set_status(sint32 rideIndex, sint32 status);
 void game_command_set_ride_status(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp);
 void ride_set_name(sint32 rideIndex, const char *name);

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1442,7 +1442,7 @@ static void ride_ratings_apply_rotations(rating_tuple *ratings, Ride *ride, sint
         ride->rotations * nauseaMultiplier);
 }
 
-static void ride_ratings_apply_proximity(rating_tuple *ratings, Ride *ride, sint32 excitementMultiplier)
+static void ride_ratings_apply_proximity(rating_tuple *ratings, sint32 excitementMultiplier)
 {
     ride_ratings_add(ratings,
         (ride_ratings_get_proximity_score() * excitementMultiplier) >> 16,
@@ -1549,7 +1549,7 @@ static void ride_ratings_calculate_spiral_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 28235, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 43690, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -1595,7 +1595,7 @@ static void ride_ratings_calculate_stand_up_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 34952, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 12850, 28398, 30427);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 12, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
@@ -1634,7 +1634,7 @@ static void ride_ratings_calculate_suspended_swinging_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 48036);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6971);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 8, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xC0000, 2, 2, 2);
@@ -1675,7 +1675,7 @@ static void ride_ratings_calculate_inverted_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 29552, 57186);
     ride_ratings_apply_drops(&ratings, ride, 29127, 39009, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 15291, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 15657);
+    ride_ratings_apply_proximity(&ratings, 15657);
     ride_ratings_apply_scenery(&ratings, ride, 8366);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -1719,7 +1719,7 @@ static void ride_ratings_calculate_junior_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 25700, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 9760);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 6, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -1754,7 +1754,7 @@ static void ride_ratings_calculate_miniature_railway(Ride *ride)
     ride_ratings_apply_average_speed(&ratings, ride, 291271, 436906);
     ride_ratings_apply_duration(&ratings, ride, 150, 26214);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, -6425, 6553, 23405);
-    ride_ratings_apply_proximity(&ratings, ride, 8946);
+    ride_ratings_apply_proximity(&ratings, 8946);
     ride_ratings_apply_scenery(&ratings, ride, 20915);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xC80000, 2, 2, 2);
 
@@ -1790,7 +1790,7 @@ static void ride_ratings_calculate_monorail(Ride *ride)
     ride_ratings_apply_average_speed(&ratings, ride, 291271, 218453);
     ride_ratings_apply_duration(&ratings, ride, 150, 21845);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 5140, 6553, 18724);
-    ride_ratings_apply_proximity(&ratings, ride, 8946);
+    ride_ratings_apply_proximity(&ratings, 8946);
     ride_ratings_apply_scenery(&ratings, ride, 16732);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xAA0000, 2, 2, 2);
 
@@ -1830,7 +1830,7 @@ static void ride_ratings_calculate_mini_suspended_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 34179, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 58254, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 19275, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 13943);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 6, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x80000, 2, 2, 2);
@@ -1867,7 +1867,7 @@ static void ride_ratings_calculate_boat_hire(Ride *ride)
         ride_ratings_add(&ratings, RIDE_RATING(0,20), 0, 0);
     }
 
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 22310);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -1902,7 +1902,7 @@ static void ride_ratings_calculate_wooden_wild_mouse(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 8, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -1944,7 +1944,7 @@ static void ride_ratings_calculate_steeplechase(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 25700, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 9760);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 4, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x80000, 2, 2, 2);
@@ -1984,7 +1984,7 @@ static void ride_ratings_calculate_car_ride(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 14860, 0, 11437);
     ride_ratings_apply_drops(&ratings, ride, 8738, 0, 0);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 12850, 6553, 4681);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 8366);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xC80000, 8, 2, 2);
 
@@ -2036,7 +2036,7 @@ static void ride_ratings_calculate_launched_freefall(Ride *ride)
     }
 #endif
 
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 25098);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -2071,7 +2071,7 @@ static void ride_ratings_calculate_bobsleigh_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xC0000, 2, 2, 2);
     ride_ratings_apply_max_lateral_g_penalty(&ratings, ride, FIXED_2DP(1,20), 2, 2, 2);
@@ -2104,7 +2104,7 @@ static void ride_ratings_calculate_observation_tower(Ride *ride)
         ((ride_get_total_length(ride) >> 16) * 45875) >> 16,
         0,
         ((ride_get_total_length(ride) >> 16) * 26214) >> 16);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 83662);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -2143,7 +2143,7 @@ static void ride_ratings_calculate_looping_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -2189,7 +2189,7 @@ static void ride_ratings_calculate_dinghy_slide(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 12, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -2228,7 +2228,7 @@ static void ride_ratings_calculate_mine_train_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 19275, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 21472);
+    ride_ratings_apply_proximity(&ratings, 21472);
     ride_ratings_apply_scenery(&ratings, ride, 16732);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 8, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
@@ -2266,7 +2266,7 @@ static void ride_ratings_calculate_chairlift(Ride *ride)
     ride_ratings_apply_duration(&ratings, ride, 150, 26214);
     ride_ratings_apply_turns(&ratings, ride, 7430, 3476, 4574);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, -19275, 21845, 23405);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 25098);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0x960000, 2, 2, 2);
 
@@ -2311,7 +2311,7 @@ static void ride_ratings_calculate_corkscrew_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -2427,7 +2427,7 @@ static void ride_ratings_calculate_go_karts(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 4458, 3476, 5718);
     ride_ratings_apply_drops(&ratings, ride, 8738, 5461, 6553);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 2570, 8738, 2340);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 16732);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -2464,7 +2464,7 @@ static void ride_ratings_calculate_log_flume(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 22291, 20860, 4574);
     ride_ratings_apply_drops(&ratings, ride, 69905, 62415, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 2, 2, 2, 2);
 
@@ -2497,7 +2497,7 @@ static void ride_ratings_calculate_river_rapids(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 22598, 5718);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 31314);
+    ride_ratings_apply_proximity(&ratings, 31314);
     ride_ratings_apply_scenery(&ratings, ride, 13943);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 2, 2, 2, 2);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xC80000, 2, 2, 2);
@@ -2842,7 +2842,7 @@ static void ride_ratings_calculate_reverse_freefall_coaster(Ride *ride)
     ride_ratings_apply_max_speed(&ratings, ride, 436906, 436906, 320398);
     ride_ratings_apply_gforces(&ratings, ride, 24576, 41704, 59578);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 12850, 28398, 11702);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 34, 2, 2, 2);
 
@@ -2877,7 +2877,7 @@ static void ride_ratings_calculate_lift(Ride *ride)
         0,
         (totalLength * 26214) >> 16);
 
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 83662);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -2914,7 +2914,7 @@ static void ride_ratings_calculate_vertical_drop_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 58254, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 20, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
@@ -3008,7 +3008,7 @@ static void ride_ratings_calculate_flying_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3054,7 +3054,7 @@ static void ride_ratings_calculate_virginia_reel(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 52012, 26075, 45749);
     ride_ratings_apply_drops(&ratings, ride, 43690, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xD20000, 2, 2, 2);
     ride_ratings_apply_num_drops_penalty(&ratings, ride, 2, 2, 2, 2);
@@ -3089,7 +3089,7 @@ static void ride_ratings_calculate_splash_boats(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 22291, 20860, 4574);
     ride_ratings_apply_drops(&ratings, ride, 87381, 93622, 62259);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 6, 2, 2, 2);
 
@@ -3124,7 +3124,7 @@ static void ride_ratings_calculate_mini_helicopters(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 14860, 0, 4574);
     ride_ratings_apply_drops(&ratings, ride, 8738, 0, 0);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 12850, 6553, 4681);
-    ride_ratings_apply_proximity(&ratings, ride, 8946);
+    ride_ratings_apply_proximity(&ratings, 8946);
     ride_ratings_apply_scenery(&ratings, ride, 8366);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xA00000, 2, 2, 2);
 
@@ -3160,7 +3160,7 @@ static void ride_ratings_calculate_lay_down_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0) {
@@ -3205,7 +3205,7 @@ static void ride_ratings_calculate_suspended_monorail(Ride *ride)
     ride_ratings_apply_average_speed(&ratings, ride, 291271, 218453);
     ride_ratings_apply_duration(&ratings, ride, 150, 21845);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 5140, 6553, 18724);
-    ride_ratings_apply_proximity(&ratings, ride, 12525);
+    ride_ratings_apply_proximity(&ratings, 12525);
     ride_ratings_apply_scenery(&ratings, ride, 25098);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xAA0000, 2, 2, 2);
 
@@ -3253,7 +3253,7 @@ static void ride_ratings_calculate_reverser_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
 
     if (gRideRatingsCalcData.num_reversers < 1) {
@@ -3296,7 +3296,7 @@ static void ride_ratings_calculate_heartline_twister_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 52150, 57186);
     ride_ratings_apply_drops(&ratings, ride, 29127, 53052, 55705);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 34952, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 9841);
+    ride_ratings_apply_proximity(&ratings, 9841);
     ride_ratings_apply_scenery(&ratings, ride, 3904);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3330,7 +3330,7 @@ static void ride_ratings_calculate_mini_golf(Ride *ride)
     ride_ratings_apply_length(&ratings, ride, 6000, 873);
     ride_ratings_apply_turns(&ratings, ride, 14860, 0, 0);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 5140, 6553, 4681);
-    ride_ratings_apply_proximity(&ratings, ride, 15657);
+    ride_ratings_apply_proximity(&ratings, 15657);
     ride_ratings_apply_scenery(&ratings, ride, 27887);
 
     // Apply golf holes factor
@@ -3407,7 +3407,7 @@ static void ride_ratings_calculate_ghost_train(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 14860, 0, 11437);
     ride_ratings_apply_drops(&ratings, ride, 8738, 0, 0);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 25700, 6553, 4681);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 8366);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0xB40000, 2, 2, 2);
 
@@ -3443,7 +3443,7 @@ static void ride_ratings_calculate_twister_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3489,7 +3489,7 @@ static void ride_ratings_calculate_wooden_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 12, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
@@ -3530,7 +3530,7 @@ static void ride_ratings_calculate_side_friction_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 22367);
+    ride_ratings_apply_proximity(&ratings, 22367);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 6, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x50000, 2, 2, 2);
@@ -3570,7 +3570,7 @@ static void ride_ratings_calculate_wild_mouse(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 6, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -3611,7 +3611,7 @@ static void ride_ratings_calculate_multi_dimension_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3657,7 +3657,7 @@ static void ride_ratings_calculate_giga_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 28235, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 43690, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3700,7 +3700,7 @@ static void ride_ratings_calculate_roto_drop(Ride *ride)
         lengthFactor * 2,
         lengthFactor * 2);
 
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 25098);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -3805,7 +3805,7 @@ static void ride_ratings_calculate_monorail_cycles(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 14860, 0, 4574);
     ride_ratings_apply_drops(&ratings, ride, 8738, 0, 0);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 5140, 6553, 2340);
-    ride_ratings_apply_proximity(&ratings, ride, 8946);
+    ride_ratings_apply_proximity(&ratings, 8946);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0x8C0000, 2, 2, 2);
 
@@ -3841,7 +3841,7 @@ static void ride_ratings_calculate_compact_inverted_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 29552, 57186);
     ride_ratings_apply_drops(&ratings, ride, 29127, 39009, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 15291, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 15657);
+    ride_ratings_apply_proximity(&ratings, 15657);
     ride_ratings_apply_scenery(&ratings, ride, 8366);
 
     if ((ride->inversions & 0x1F) == 0)
@@ -3885,7 +3885,7 @@ static void ride_ratings_calculate_water_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 25700, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 9760);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 8, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -3922,7 +3922,7 @@ static void ride_ratings_calculate_air_powered_vertical_coaster(Ride *ride)
     ride_ratings_apply_max_speed(&ratings, ride, 509724, 364088, 320398);
     ride_ratings_apply_gforces(&ratings, ride, 24576, 35746, 59578);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 21845, 11702);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 34, 2, 1, 1);
 
@@ -3959,7 +3959,7 @@ static void ride_ratings_calculate_inverted_hairpin_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 43458, 45749);
     ride_ratings_apply_drops(&ratings, ride, 40777, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 16705, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 17893);
+    ride_ratings_apply_proximity(&ratings, 17893);
     ride_ratings_apply_scenery(&ratings, ride, 5577);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 8, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -4020,7 +4020,7 @@ static void ride_ratings_calculate_submarine_ride(Ride *ride)
     rating_tuple ratings;
     ride_ratings_set(&ratings, RIDE_RATING(2,20), RIDE_RATING(1,80), RIDE_RATING(1,40));
     ride_ratings_apply_length(&ratings, ride, 6000, 764);
-    ride_ratings_apply_proximity(&ratings, ride, 11183);
+    ride_ratings_apply_proximity(&ratings, 11183);
     ride_ratings_apply_scenery(&ratings, ride, 22310);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -4051,7 +4051,7 @@ static void ride_ratings_calculate_river_rafts(Ride *ride)
     ride_ratings_apply_duration(&ratings, ride, 500, 13107);
     ride_ratings_apply_turns(&ratings, ride, 22291, 20860, 4574);
     ride_ratings_apply_drops(&ratings, ride, 78643, 93622, 62259);
-    ride_ratings_apply_proximity(&ratings, ride, 13420);
+    ride_ratings_apply_proximity(&ratings, 13420);
     ride_ratings_apply_scenery(&ratings, ride, 11155);
 
     ride_ratings_apply_intensity_penalty(&ratings);
@@ -4119,7 +4119,7 @@ static void ride_ratings_calculate_inverted_impulse_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 29552, 57186);
     ride_ratings_apply_drops(&ratings, ride, 29127, 39009, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 15291, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 15657);
+    ride_ratings_apply_proximity(&ratings, 15657);
     ride_ratings_apply_scenery(&ratings, ride, 9760);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 20, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0xA0000, 2, 2, 2);
@@ -4157,7 +4157,7 @@ static void ride_ratings_calculate_mini_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 25700, 30583, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 9760);
     ride_ratings_apply_highest_drop_height_penalty(&ratings, ride, 12, 2, 2, 2);
     ride_ratings_apply_max_speed_penalty(&ratings, ride, 0x70000, 2, 2, 2);
@@ -4197,7 +4197,7 @@ static void ride_ratings_calculate_mine_ride(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 29721, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 19275, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 21472);
+    ride_ratings_apply_proximity(&ratings, 21472);
     ride_ratings_apply_scenery(&ratings, ride, 16732);
     ride_ratings_apply_first_length_penalty(&ratings, ride, 0x10E0000, 2, 2, 2);
 
@@ -4234,7 +4234,7 @@ static void ride_ratings_calculate_lim_launched_roller_coaster(Ride *ride)
     ride_ratings_apply_turns(&ratings, ride, 26749, 34767, 45749);
     ride_ratings_apply_drops(&ratings, ride, 29127, 46811, 49152);
     ride_ratings_apply_sheltered_ratings(&ratings, ride, 15420, 32768, 35108);
-    ride_ratings_apply_proximity(&ratings, ride, 20130);
+    ride_ratings_apply_proximity(&ratings, 20130);
     ride_ratings_apply_scenery(&ratings, ride, 6693);
 
     if ((ride->inversions & 0x1F) == 0)

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -330,7 +330,7 @@ rct_tile_element * ride_get_station_start_track_element(Ride * ride, sint32 stat
     return nullptr;
 }
 
-rct_tile_element * ride_get_station_exit_element(Ride * ride, sint32 x, sint32 y, sint32 z)
+rct_tile_element * ride_get_station_exit_element(sint32 x, sint32 y, sint32 z)
 {
     // Find the station track element
     rct_tile_element * tileElement = map_get_first_element_at(x, y);

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1593,13 +1593,14 @@ static money32 track_place(sint32 rideIndex,
  *
  *  rct2: 0x006C511D
  */
-void game_command_place_track(sint32 * eax,
-                              sint32 * ebx,
-                              sint32 * ecx,
-                              sint32 * edx,
-                              sint32 * esi,
-                              sint32 * edi,
-                              sint32 * ebp)
+void game_command_place_track(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = track_place(
         *edx & 0xFF,
@@ -1928,13 +1929,8 @@ static money32 track_remove(uint8 type,
  *
  *  rct2: 0x006C5B69
  */
-void game_command_remove_track(sint32 * eax,
-                               sint32 * ebx,
-                               sint32 * ecx,
-                               sint32 * edx,
-                               sint32 * esi,
-                               sint32 * edi,
-                               sint32 * ebp)
+void game_command_remove_track(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, [[maybe_unused]] sint32 * ebp)
 {
     *ebx = track_remove(
         *edx & 0xFF,
@@ -1951,13 +1947,14 @@ void game_command_remove_track(sint32 * eax,
  *
  *  rct2: 0x006C5AE9
  */
-void game_command_set_brakes_speed(sint32 * eax,
-                                   sint32 * ebx,
-                                   sint32 * ecx,
-                                   sint32 * edx,
-                                   sint32 * esi,
-                                   sint32 * edi,
-                                   sint32 * ebp)
+void game_command_set_brakes_speed(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     sint32 x           = (*eax & 0xFFFF);
     sint32 y           = (*ecx & 0xFFFF);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -698,8 +698,7 @@ static void track_design_update_max_min_coordinates(sint16 x, sint16 y, sint16 z
  *  rct2: 0x006D0964
  */
 static sint32
-track_design_place_scenery(rct_td6_scenery_element * scenery_start, uint8 rideIndex, sint32 originX, sint32 originY,
-                           sint32 originZ)
+track_design_place_scenery(rct_td6_scenery_element * scenery_start, sint32 originX, sint32 originY, sint32 originZ)
 {
     for (uint8 mode = 0; mode <= 1; mode++)
     {
@@ -1721,7 +1720,6 @@ sint32 place_virtual_track(rct_track_td6 * td6, uint8 ptdOperation, bool placeSc
     {
         if (!track_design_place_scenery(
             scenery,
-            rideIndex,
             gTrackPreviewOrigin.x,
             gTrackPreviewOrigin.y,
             gTrackPreviewOrigin.z
@@ -2164,8 +2162,14 @@ static money32 place_maze_design(uint8 flags, uint8 rideIndex, uint16 mazeEntry,
  *
  *  rct2: 0x006D13FE
  */
-void game_command_place_track_design(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                     sint32 * ebp)
+void game_command_place_track_design(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     sint16 x     = *eax & 0xFFFF;
     sint16 y     = *ecx & 0xFFFF;
@@ -2180,8 +2184,8 @@ void game_command_place_track_design(sint32 * eax, sint32 * ebx, sint32 * ecx, s
  *
  *  rct2: 0x006CDEE4
  */
-void game_command_place_maze_design(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                    sint32 * ebp)
+void game_command_place_maze_design(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, [[maybe_unused]] sint32 * ebp)
 {
     *ebx = place_maze_design(
         *ebx & 0xFF,

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -127,7 +127,7 @@ void track_design_save_reset_scenery()
     gfx_invalidate_screen();
 }
 
-static void track_design_save_callback(sint32 result, const utf8 * path)
+static void track_design_save_callback(sint32 result, [[maybe_unused]] const utf8 * path)
 {
     free(_trackDesign->track_elements);
     free(_trackDesign->entrance_elements);
@@ -430,7 +430,7 @@ static void track_design_save_pop_tile_element(sint32 x, sint32 y, rct_tile_elem
  *
  *  rct2: 0x006D2FDD
  */
-static void track_design_save_pop_tile_element_desc(const rct_object_entry *entry, sint32 x, sint32 y, sint32 z, uint8 flags, uint8 primaryColour, uint8 secondaryColour)
+static void track_design_save_pop_tile_element_desc(const rct_object_entry *entry, sint32 x, sint32 y, sint32 z, uint8 flags)
 {
     size_t removeIndex = SIZE_MAX;
     for (size_t i = 0; i < _trackSavedTileElementsDescCount; i++) {
@@ -466,11 +466,8 @@ static void track_design_save_remove_scenery(sint32 x, sint32 y, rct_tile_elemen
     flags |= tileElement->type & 3;
     flags |= (tileElement->type & 0xC0) >> 4;
 
-    uint8 primaryColour = scenery_small_get_primary_colour(tileElement);
-    uint8 secondaryColour = scenery_small_get_secondary_colour(tileElement);
-
     track_design_save_pop_tile_element(x, y, tileElement);
-    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags, primaryColour, secondaryColour);
+    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags);
 }
 
 static void track_design_save_remove_large_scenery(sint32 x, sint32 y, rct_tile_element *tileElement)
@@ -507,10 +504,7 @@ static void track_design_save_remove_large_scenery(sint32 x, sint32 y, rct_tile_
             if (sequence == 0)
             {
                 uint8 flags = tileElement->type & 3;
-                uint8 primaryColour = scenery_large_get_primary_colour(tileElement);
-                uint8 secondaryColour = scenery_large_get_secondary_colour(tileElement);
-
-                track_design_save_pop_tile_element_desc(entry, x, y, z, flags, primaryColour, secondaryColour);
+                track_design_save_pop_tile_element_desc(entry, x, y, z, flags);
             }
             track_design_save_pop_tile_element(x, y, tileElement);
         }
@@ -526,11 +520,8 @@ static void track_design_save_remove_wall(sint32 x, sint32 y, rct_tile_element *
     flags |= tileElement->type & 3;
     flags |= wall_get_tertiary_colour(tileElement) << 2;
 
-    uint8 secondaryColour = wall_get_secondary_colour(tileElement);
-    uint8 primaryColour = wall_get_primary_colour(tileElement);
-
     track_design_save_pop_tile_element(x, y, tileElement);
-    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags, primaryColour, secondaryColour);
+    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags);
 }
 
 static void track_design_save_remove_footpath(sint32 x, sint32 y, rct_tile_element *tileElement)
@@ -545,7 +536,7 @@ static void track_design_save_remove_footpath(sint32 x, sint32 y, rct_tile_eleme
     flags |= (tileElement->type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) << 7;
 
     track_design_save_pop_tile_element(x, y, tileElement);
-    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags, 0, 0);
+    track_design_save_pop_tile_element_desc(entry, x, y, tileElement->base_height, flags);
 }
 
 /**

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -240,7 +240,7 @@ bool track_paint_util_has_fence(
 }
 
 void track_paint_util_paint_floor(paint_session * session, uint8 edges, uint32 colourFlags, uint16 height,
-                                  const uint32 floorSprites[4], uint8 rotation)
+                                  const uint32 floorSprites[4])
 {
     uint32 imageId;
 
@@ -314,7 +314,6 @@ bool track_paint_util_should_paint_supports(LocationXY16 position)
 static void track_paint_util_draw_station_impl(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     uint16                   coverHeight,
@@ -325,44 +324,39 @@ static void track_paint_util_draw_station_impl(
 void track_paint_util_draw_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     const rct_tile_element * tileElement)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, trackSequence, direction, height, height, tileElement, 5, 7);
+    track_paint_util_draw_station_impl(session, rideIndex, direction, height, height, tileElement, 5, 7);
 }
 
 void track_paint_util_draw_station_2(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     const rct_tile_element * tileElement,
     sint32                   fenceOffsetA,
     sint32                   fenceOffsetB)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, trackSequence, direction, height, height, tileElement, fenceOffsetA,
-                                       fenceOffsetB);
+    track_paint_util_draw_station_impl(session, rideIndex, direction, height, height, tileElement, fenceOffsetA, fenceOffsetB);
 }
 
 void track_paint_util_draw_station_3(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     uint16                   coverHeight,
     const rct_tile_element * tileElement)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, trackSequence, direction, height, coverHeight, tileElement, 5, 7);
+    track_paint_util_draw_station_impl(session, rideIndex, direction, height, coverHeight, tileElement, 5, 7);
 }
 
 static void track_paint_util_draw_station_impl(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     uint16                   coverHeight,
@@ -410,7 +404,7 @@ static void track_paint_util_draw_station_impl(
         }
         sub_98196C(session, imageId, 0, 0, 32, 8, 1, height + fenceOffsetA);
         // height -= 5 (height)
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, coverHeight);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, coverHeight);
         // height += 5 (height + 5)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_END_STATION && direction == 0)
@@ -459,7 +453,7 @@ static void track_paint_util_draw_station_impl(
             sub_98196C(session, imageId, 31, 23, 1, 8, 7, height + fenceOffsetB);
         }
         // height -= 7 (height)
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, coverHeight);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, coverHeight);
         // height += 7 (height + 7)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_BEGIN_STATION && direction == 0)
@@ -505,7 +499,7 @@ static void track_paint_util_draw_station_impl(
         }
         sub_98196C(session, imageId, 0, 0, 8, 32, 1, height + fenceOffsetA);
         // height -= 5 (height)
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, coverHeight);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, coverHeight);
         // height += 5 (height + 5)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_END_STATION && direction == 3)
@@ -555,7 +549,7 @@ static void track_paint_util_draw_station_impl(
         }
 
         // height -= 7 (height)
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, coverHeight);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, coverHeight);
         // height += 7 (height + 7)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_BEGIN_STATION && direction == 3)
@@ -574,7 +568,6 @@ static void track_paint_util_draw_station_impl(
 void track_paint_util_draw_station_inverted(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement,
@@ -620,7 +613,7 @@ void track_paint_util_draw_station_inverted(
         }
         sub_98196C(session, imageId, 0, 0, 32, 8, 1, height + 6);
         // height -= 5 (height)
-        track_paint_util_draw_station_covers_2(session, EDGE_NW, hasFence, entranceStyle, direction, height, stationVariant);
+        track_paint_util_draw_station_covers_2(session, EDGE_NW, hasFence, entranceStyle, height, stationVariant);
         // height += 5 (height + 5)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_END_STATION && direction == 0)
@@ -669,7 +662,7 @@ void track_paint_util_draw_station_inverted(
             sub_98196C(session, imageId, 31, 23, 1, 8, 7, height + 8);
         }
         // height -= 7 (height)
-        track_paint_util_draw_station_covers_2(session, EDGE_SE, hasFence, entranceStyle, direction, height, stationVariant);
+        track_paint_util_draw_station_covers_2(session, EDGE_SE, hasFence, entranceStyle, height, stationVariant);
         // height += 7 (height + 7)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_BEGIN_STATION && direction == 0)
@@ -715,7 +708,7 @@ void track_paint_util_draw_station_inverted(
         }
         sub_98196C(session, imageId, 0, 0, 8, 32, 1, height + 6);
         // height -= 5 (height)
-        track_paint_util_draw_station_covers_2(session, EDGE_NE, hasFence, entranceStyle, direction, height, stationVariant);
+        track_paint_util_draw_station_covers_2(session, EDGE_NE, hasFence, entranceStyle, height, stationVariant);
         // height += 5 (height + 5)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_END_STATION && direction == 3)
@@ -765,7 +758,7 @@ void track_paint_util_draw_station_inverted(
         }
 
         // height -= 7 (height)
-        track_paint_util_draw_station_covers_2(session, EDGE_SW, hasFence, entranceStyle, direction, height, stationVariant);
+        track_paint_util_draw_station_covers_2(session, EDGE_SW, hasFence, entranceStyle, height, stationVariant);
         // height += 7 (height + 7)
 
         if (track_element_get_type(tileElement) == TRACK_ELEM_BEGIN_STATION && direction == 3)
@@ -782,14 +775,13 @@ void track_paint_util_draw_station_inverted(
 }
 
 bool track_paint_util_draw_station_covers(paint_session * session, enum edge_t edge, bool hasFence,
-                                          const rct_ride_entrance_definition * entranceStyle, uint8 direction, uint16 height)
+                                          const rct_ride_entrance_definition * entranceStyle, uint16 height)
 {
-    return track_paint_util_draw_station_covers_2(session, edge, hasFence, entranceStyle, direction, height,
-                                                  STATION_VARIANT_BASIC);
+    return track_paint_util_draw_station_covers_2(session, edge, hasFence, entranceStyle, height, STATION_VARIANT_BASIC);
 }
 
 bool track_paint_util_draw_station_covers_2(paint_session * session, enum edge_t edge, bool hasFence,
-                                            const rct_ride_entrance_definition * entranceStyle, uint8 direction, uint16 height,
+                                            const rct_ride_entrance_definition * entranceStyle, uint16 height,
                                             uint8 stationVariant)
 {
     if (!(session->Unk141E9DB & (G141E9DB_FLAG_1 | G141E9DB_FLAG_2)))
@@ -883,7 +875,7 @@ void track_paint_util_draw_station_platform(
         uint32 imageId  = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE) |
                          session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 0, 0, 8, 32, 1, height + zOffset);
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
 
         imageId = SPR_STATION_NARROW_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 24, 0, 8, 32, 1, height + zOffset);
@@ -894,7 +886,7 @@ void track_paint_util_draw_station_platform(
             imageId = SPR_STATION_FENCE_NW_SE | session->TrackColours[SCHEME_SUPPORTS];
             sub_98196C(session, imageId, 31, 0, 1, 32, 7, height + zOffset + 2);
         }
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, height);
     }
     else
     {
@@ -902,7 +894,7 @@ void track_paint_util_draw_station_platform(
         uint32 imageId  = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW) |
                          session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 0, 0, 32, 8, 1, height + zOffset);
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
 
         imageId = SPR_STATION_NARROW_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 0, 24, 32, 8, 1, height + zOffset);
@@ -913,7 +905,7 @@ void track_paint_util_draw_station_platform(
             imageId = SPR_STATION_FENCE_SW_NE | session->TrackColours[SCHEME_SUPPORTS];
             sub_98196C(session, imageId, 0, 31, 32, 1, 7, height + zOffset + 2);
         }
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, height);
     }
 }
 
@@ -936,7 +928,7 @@ void track_paint_util_draw_pier(
         imageId =
             (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE) | session->TrackColours[SCHEME_SUPPORTS];
         sub_98197C(session, imageId, 0, 0, 6, 32, 1, height, 2, 0, height);
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
 
         imageId = SPR_STATION_PIER_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 24, 0, 8, 32, 1, height);
@@ -947,7 +939,7 @@ void track_paint_util_draw_pier(
             imageId = SPR_STATION_PIER_FENCE_SW | session->TrackColours[SCHEME_SUPPORTS];
             sub_98196C(session, imageId, 31, 0, 1, 32, 7, height + 2);
         }
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, height);
     }
     else
     {
@@ -955,7 +947,7 @@ void track_paint_util_draw_pier(
         imageId =
             (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW) | session->TrackColours[SCHEME_SUPPORTS];
         sub_98197C(session, imageId, 0, 0, 32, 6, 1, height, 0, 2, height);
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
 
         imageId = SPR_STATION_PIER_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         sub_98196C(session, imageId, 0, 24, 32, 8, 1, height);
@@ -966,7 +958,7 @@ void track_paint_util_draw_pier(
             imageId = SPR_STATION_PIER_FENCE_SE | session->TrackColours[SCHEME_SUPPORTS];
             sub_98196C(session, imageId, 0, 31, 32, 1, 7, height + 2);
         }
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, height);
     }
 }
 
@@ -1045,7 +1037,7 @@ void track_paint_util_right_helix_up_small_quarter_tiles_paint(paint_session * s
                                                                const uint32        sprites[4][3][2],
                                                                const LocationXY16  offsets[4][3][2],
                                                                const LocationXY16  boundsLengths[4][3][2],
-                                                               const LocationXYZ16 boundsOffsets[4][3][2], uint8 rotation)
+                                                               const LocationXYZ16 boundsOffsets[4][3][2])
 {
     sint32 index = right_helix_up_small_quarter_tiles_sprite_map[trackSequence];
     if (index < 0)
@@ -1149,7 +1141,7 @@ void track_paint_util_right_helix_up_large_quarter_tiles_paint(paint_session * s
                                                                const uint32        sprites[4][5][2],
                                                                const LocationXY16  offsets[4][5][2],
                                                                const LocationXY16  boundsLengths[4][5][2],
-                                                               const LocationXYZ16 boundsOffsets[4][5][2], uint8 rotation)
+                                                               const LocationXYZ16 boundsOffsets[4][5][2])
 {
     sint32 index = right_helix_up_large_quarter_sprite_map[trackSequence];
     if (index < 0)
@@ -1327,7 +1319,7 @@ void track_paint_util_eighth_to_diag_tiles_paint(paint_session * session, const 
                                                  sint32 direction, uint8 trackSequence, uint32 colourFlags,
                                                  const uint32 sprites[4][4], const LocationXY16 offsets[4][4],
                                                  const LocationXY16  boundsLengths[4][4],
-                                                 const LocationXYZ16 boundsOffsets[4][4], uint8 rotation)
+                                                 const LocationXYZ16 boundsOffsets[4][4])
 {
     sint32 index = eighth_to_diag_sprite_map[trackSequence];
     if (index < 0)
@@ -1370,7 +1362,7 @@ static constexpr const sint8 diag_sprite_map[4][4] = {
 void track_paint_util_diag_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction,
                                        uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4],
                                        const LocationXY16 offsets[4], const LocationXY16 boundsLengths[4],
-                                       const LocationXYZ16 boundsOffsets[4], uint8 rotation)
+                                       const LocationXYZ16 boundsOffsets[4])
 {
     sint32 index = diag_sprite_map[direction][trackSequence];
     if (index < 0)
@@ -1491,7 +1483,7 @@ void               track_paint_util_right_quarter_turn_5_tiles_paint(paint_sessi
                                                                      sint32 direction, uint8 trackSequence, uint32 colourFlags,
                                                                      const uint32 sprites[4][5], const LocationXY16 offsets[4][5],
                                                                      const LocationXY16  boundsLengths[4][5],
-                                                                     const LocationXYZ16 boundsOffsets[4][5], uint8 rotation)
+                                                                     const LocationXYZ16 boundsOffsets[4][5])
 {
     sint32 index = right_quarter_turn_5_tiles_sprite_map[trackSequence];
     if (index < 0)
@@ -1511,8 +1503,7 @@ void               track_paint_util_right_quarter_turn_5_tiles_paint(paint_sessi
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(paint_session * session, sint16 height, sint32 direction,
-                                                         uint8 rotation, uint8 trackSequence, uint32 colourFlags,
-                                                         const sprite_bb sprites[][5])
+                                                         uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5])
 {
     sint8 sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1529,8 +1520,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(paint_session * session
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(paint_session * session, sint16 height, sint32 direction,
-                                                         uint8 rotation, uint8 trackSequence, uint32 colourFlags,
-                                                         const sprite_bb sprites[][5])
+                                                         uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5])
 {
     sint8 sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1660,7 +1650,7 @@ void               track_paint_util_right_quarter_turn_3_tiles_paint(paint_sessi
                                                                      sint32 direction, uint8 trackSequence, uint32 colourFlags,
                                                                      const uint32 sprites[4][3], const LocationXY16 offsets[4][3],
                                                                      const LocationXY16  boundsLengths[4][3],
-                                                                     const LocationXYZ16 boundsOffsets[4][3], uint8 rotation)
+                                                                     const LocationXYZ16 boundsOffsets[4][3])
 {
     sint32 index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (index < 0)
@@ -1681,16 +1671,16 @@ void               track_paint_util_right_quarter_turn_3_tiles_paint(paint_sessi
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(paint_session * session, sint8 thickness, sint16 height,
                                                          sint32 direction, uint8 trackSequence, uint32 colourFlags,
-                                                         const uint32 sprites[4][3], uint8 rotation)
+                                                         const uint32 sprites[4][3])
 {
     track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(session, thickness, height, direction, trackSequence,
-                                                                           colourFlags, sprites, rotation, 0);
+                                                                           colourFlags, sprites, 0);
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(paint_session * session, sint8 thickness,
                                                                             sint16 height, sint32 direction,
                                                                             uint8 trackSequence, uint32 colourFlags,
-                                                                            const uint32 sprites[4][3], uint8 rotation,
+                                                                            const uint32 sprites[4][3],
                                                                             sint32 heightOffset)
 {
     sint8 sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1766,7 +1756,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(pain
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(paint_session * session, sint16 height, sint32 direction,
-                                                         uint8 rotation, uint8 trackSequence, uint32 colourFlags,
+                                                         uint8 trackSequence, uint32 colourFlags,
                                                          const sprite_bb sprites[4][3])
 {
     sint8 sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1782,8 +1772,8 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_3(paint_session * session
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(paint_session * session, sint16 height, sint32 direction,
-                                                         uint8 rotation, uint8 trackSequence, uint32 colourFlags,
-                                                         const sprite_bb sprites[4][3])
+    uint8 trackSequence, uint32 colourFlags,
+    const sprite_bb sprites[4][3])
 {
     sint8 sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1866,17 +1856,16 @@ void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(paint_sessio
 
 static constexpr const sint8 left_quarter_turn_3_tiles_sprite_map[] = { 2, -1, 1, 0 };
 void track_paint_util_left_quarter_turn_3_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction,
-                                                      uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3],
-                                                      uint8 rotation)
+                                                      uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3])
 {
     track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(session, thickness, height, direction, trackSequence,
-                                                                        colourFlags, sprites, rotation, 0);
+                                                                        colourFlags, sprites, 0);
 }
 
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(paint_session * session, sint8 thickness,
                                                                          sint16 height, sint32 direction, uint8 trackSequence,
                                                                          uint32 colourFlags, const uint32 sprites[4][3],
-                                                                         uint8 rotation, sint32 heightOffset)
+                                                                         sint32 heightOffset)
 {
     sint8 sprite = left_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1994,7 +1983,7 @@ void track_paint_util_left_quarter_turn_3_tiles_tunnel(paint_session * session, 
 
 void track_paint_util_left_quarter_turn_1_tile_paint(paint_session * session, sint8 thickness, sint16 height,
                                                      sint16 boundBoxZOffset, sint32 direction, uint32 colourFlags,
-                                                     const uint32 * sprites, uint8 rotation)
+                                                     const uint32 * sprites)
 {
     uint32 imageId = sprites[direction] | colourFlags;
 
@@ -2040,10 +2029,8 @@ void track_paint_util_left_quarter_turn_1_tile_tunnel(paint_session * session, u
     }
 }
 
-void track_paint_util_spinning_tunnel_paint(paint_session * session, sint8 thickness, sint16 height, uint8 direction,
-                                            uint8 rotation)
+void track_paint_util_spinning_tunnel_paint(paint_session * session, sint8 thickness, sint16 height, uint8 direction)
 {
-
     sint32 frame       = gScenarioTicks >> 2 & 3;
     uint32 colourFlags = session->TrackColours[SCHEME_SUPPORTS];
 

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -283,7 +283,7 @@ extern const size_t mini_golf_peep_animation_lengths[];
 
 bool track_paint_util_has_fence(
     enum edge_t edge, LocationXY16 position, const rct_tile_element * tileElement, Ride * ride, uint8 rotation);
-void track_paint_util_paint_floor(paint_session * session, uint8 edges, uint32 colourFlags, uint16 height, const uint32 floorSprites[4], uint8 rotation);
+void track_paint_util_paint_floor(paint_session * session, uint8 edges, uint32 colourFlags, uint16 height, const uint32 floorSprites[4]);
 void track_paint_util_paint_fences(
     paint_session *          session,
     uint8                    edges,
@@ -294,21 +294,19 @@ void track_paint_util_paint_fences(
     uint16                   height,
     const uint32             fenceSprites[4],
     uint8                    rotation);
-bool track_paint_util_draw_station_covers(paint_session * session, enum edge_t edge, bool hasFence, const rct_ride_entrance_definition * entranceStyle, uint8 direction, uint16 height);
-bool track_paint_util_draw_station_covers_2(paint_session * session, enum edge_t edge, bool hasFence, const rct_ride_entrance_definition * entranceStyle, uint8 direction, uint16 height, uint8 stationVariant);
+bool track_paint_util_draw_station_covers(paint_session * session, enum edge_t edge, bool hasFence, const rct_ride_entrance_definition * entranceStyle, uint16 height);
+bool track_paint_util_draw_station_covers_2(paint_session * session, enum edge_t edge, bool hasFence, const rct_ride_entrance_definition * entranceStyle, uint16 height, uint8 stationVariant);
 void track_paint_util_draw_station_platform(
     paint_session * session, Ride * ride, uint8 direction, sint32 height, sint32 zOffset, const rct_tile_element * tileElement);
 void track_paint_util_draw_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     const rct_tile_element * tileElement);
 void track_paint_util_draw_station_2(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     const rct_tile_element * tileElement,
@@ -317,7 +315,6 @@ void track_paint_util_draw_station_2(
 void track_paint_util_draw_station_3(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     uint16                   height,
     uint16                   coverHeight,
@@ -325,7 +322,6 @@ void track_paint_util_draw_station_3(
 void track_paint_util_draw_station_inverted(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement,
@@ -343,32 +339,32 @@ void track_paint_util_draw_pier(
 void track_paint_util_draw_station_metal_supports(paint_session * session, uint8 direction, uint16 height, uint32 colour);
 void track_paint_util_draw_station_metal_supports_2(paint_session * session, uint8 direction, uint16 height, uint32 colour, uint8 type);
 
-void track_paint_util_right_quarter_turn_5_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][5], const LocationXY16 offsets[4][5], const LocationXY16 boundsLengths[4][5], const LocationXYZ16 boundsOffsets[4][5], uint8 rotation);
-void track_paint_util_right_quarter_turn_5_tiles_paint_2(paint_session * session, sint16 height, sint32 direction, uint8 rotation, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5]);
-void track_paint_util_right_quarter_turn_5_tiles_paint_3(paint_session * session, sint16 height, sint32 direction, uint8 rotation, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5]);
+void track_paint_util_right_quarter_turn_5_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][5], const LocationXY16 offsets[4][5], const LocationXY16 boundsLengths[4][5], const LocationXYZ16 boundsOffsets[4][5]);
+void track_paint_util_right_quarter_turn_5_tiles_paint_2(paint_session * session, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5]);
+void track_paint_util_right_quarter_turn_5_tiles_paint_3(paint_session * session, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_tunnel(paint_session * session, sint16 height, uint8 direction, uint8 trackSequence, uint8 tunnelType);
 void track_paint_util_right_quarter_turn_5_tiles_wooden_supports(paint_session * session, sint16 height, uint8 direction, uint8 trackSequence);
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_up_tunnel(paint_session * session, sint16 height, uint8 direction, uint8 trackSequence, uint8 tunnelType0, uint8 tunnelType3);
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(paint_session * session, sint16 height, uint8 direction, uint8 trackSequence, uint8 tunnelType0, uint8 tunnelType3);
-void track_paint_util_right_quarter_turn_3_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], const LocationXY16 offsets[4][3], const LocationXY16 boundsLengths[4][3], const LocationXYZ16 boundsOffsets[4][3], uint8 rotation);
-void track_paint_util_right_quarter_turn_3_tiles_paint_2(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], uint8 rotation);
-void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], uint8 rotation, sint32 heightOffset);
-void track_paint_util_right_quarter_turn_3_tiles_paint_3(paint_session * session, sint16 height, sint32 direction, uint8 rotation, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[4][3]);
-void track_paint_util_right_quarter_turn_3_tiles_paint_4(paint_session * session, sint16 height, sint32 direction, uint8 rotation, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[4][3]);
+void track_paint_util_right_quarter_turn_3_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], const LocationXY16 offsets[4][3], const LocationXY16 boundsLengths[4][3], const LocationXYZ16 boundsOffsets[4][3]);
+void track_paint_util_right_quarter_turn_3_tiles_paint_2(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3]);
+void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], sint32 heightOffset);
+void track_paint_util_right_quarter_turn_3_tiles_paint_3(paint_session * session, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[4][3]);
+void track_paint_util_right_quarter_turn_3_tiles_paint_4(paint_session * session, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const sprite_bb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_tunnel(paint_session * session, sint16 height, uint8 direction, uint8 trackSequence, uint8 tunnelType);
-void track_paint_util_left_quarter_turn_3_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], uint8 rotation);
-void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], uint8 rotation, sint32 heightOffset);
+void track_paint_util_left_quarter_turn_3_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3]);
+void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3], sint32 heightOffset);
 void track_paint_util_left_quarter_turn_3_tiles_tunnel(paint_session * session, sint16 height, uint8 tunnelType, uint8 direction, uint8 trackSequence);
-void track_paint_util_left_quarter_turn_1_tile_paint(paint_session * session, sint8 thickness, sint16 height, sint16 boundBoxZOffset, sint32 direction, uint32 colourFlags, const uint32 * sprites, uint8 rotation);
-void track_paint_util_spinning_tunnel_paint(paint_session * session, sint8 thickness, sint16 height, uint8 direction, uint8 rotation);
+void track_paint_util_left_quarter_turn_1_tile_paint(paint_session * session, sint8 thickness, sint16 height, sint16 boundBoxZOffset, sint32 direction, uint32 colourFlags, const uint32 * sprites);
+void track_paint_util_spinning_tunnel_paint(paint_session * session, sint8 thickness, sint16 height, uint8 direction);
 void track_paint_util_onride_photo_small_paint(
     paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tileElement);
 void track_paint_util_onride_photo_paint(
     paint_session * session, uint8 direction, sint32 height, const rct_tile_element * tileElement);
-void track_paint_util_right_helix_up_small_quarter_tiles_paint(paint_session * session, const sint8 thickness[2], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3][2], const LocationXY16 offsets[4][3][2], const LocationXY16 boundsLengths[4][3][2], const LocationXYZ16 boundsOffsets[4][3][2], uint8 rotation);
-void track_paint_util_right_helix_up_large_quarter_tiles_paint(paint_session * session, const sint8 thickness[2], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][5][2], const LocationXY16 offsets[4][5][2], const LocationXY16 boundsLengths[4][5][2], const LocationXYZ16 boundsOffsets[4][5][2], uint8 rotation);
-void track_paint_util_eighth_to_diag_tiles_paint(paint_session * session, const sint8 thickness[4][4], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][4], const LocationXY16 offsets[4][4], const LocationXY16 boundsLengths[4][4], const LocationXYZ16 boundsOffsets[4][4], uint8 rotation);
-void track_paint_util_diag_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4], const LocationXY16 offsets[4], const LocationXY16 boundsLengths[4], const LocationXYZ16 boundsOffsets[4], uint8 rotation);
+void track_paint_util_right_helix_up_small_quarter_tiles_paint(paint_session * session, const sint8 thickness[2], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][3][2], const LocationXY16 offsets[4][3][2], const LocationXY16 boundsLengths[4][3][2], const LocationXYZ16 boundsOffsets[4][3][2]);
+void track_paint_util_right_helix_up_large_quarter_tiles_paint(paint_session * session, const sint8 thickness[2], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][5][2], const LocationXY16 offsets[4][5][2], const LocationXY16 boundsLengths[4][5][2], const LocationXYZ16 boundsOffsets[4][5][2]);
+void track_paint_util_eighth_to_diag_tiles_paint(paint_session * session, const sint8 thickness[4][4], sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4][4], const LocationXY16 offsets[4][4], const LocationXY16 boundsLengths[4][4], const LocationXYZ16 boundsOffsets[4][4]);
+void track_paint_util_diag_tiles_paint(paint_session * session, sint8 thickness, sint16 height, sint32 direction, uint8 trackSequence, uint32 colourFlags, const uint32 sprites[4], const LocationXY16 offsets[4], const LocationXY16 boundsLengths[4], const LocationXYZ16 boundsOffsets[4]);
 
 void track_paint_util_left_quarter_turn_1_tile_tunnel(paint_session * session, uint8 direction, uint16 baseHeight, sint8 startOffset, uint8 startTunnel, sint8 endOffset, uint8 endTunnel);
 void track_paint_util_right_quarter_turn_1_tile_tunnel(paint_session * session, uint8 direction, uint16 baseHeight, sint8 startOffset, uint8 startTunnel, sint8 endOffset, uint8 endTunnel);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -8413,7 +8413,7 @@ loc_6DB967:
  *  rct2: 0x006DBAA6
  */
 static bool vehicle_update_track_motion_backwards_get_new_track(rct_vehicle * vehicle, uint16 trackType, Ride * ride,
-                                                                rct_ride_entry * rideEntry, uint16 * progress)
+                                                                uint16 * progress)
 {
     _vehicleVAngleEndF64E36 = TrackDefinitions[trackType].vangle_start;
     _vehicleBankEndF64E37   = TrackDefinitions[trackType].bank_start;
@@ -8618,7 +8618,7 @@ loc_6DBA33:;
     regs.ax = vehicle->track_progress - 1;
     if (regs.ax == -1)
     {
-        if (!vehicle_update_track_motion_backwards_get_new_track(vehicle, trackType, ride, rideEntry, (uint16 *)&regs.ax))
+        if (!vehicle_update_track_motion_backwards_get_new_track(vehicle, trackType, ride, (uint16 *)&regs.ax))
         {
             goto loc_6DBE5E;
         }

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -2859,8 +2859,7 @@ static constexpr const vehicle_sprite_func vehicle_sprite_funcs[] = {
  *
  *  rct2: 0x006D5600
  */
-static void vehicle_visual_splash1_effect(paint_session * session, sint32 z, rct_vehicle * vehicle,
-                                          const rct_ride_entry_vehicle * vehicleEntry)
+static void vehicle_visual_splash1_effect(paint_session * session, sint32 z, rct_vehicle * vehicle)
 {
     if ((vehicle->track_type >> 2) != TRACK_ELEM_WATER_SPLASH)
     {
@@ -2887,8 +2886,7 @@ static void vehicle_visual_splash1_effect(paint_session * session, sint32 z, rct
  *
  *  rct2: 0x006D5696
  */
-static void vehicle_visual_splash2_effect(paint_session * session, sint32 z, rct_vehicle * vehicle,
-                                          const rct_ride_entry_vehicle * vehicleEntry)
+static void vehicle_visual_splash2_effect(paint_session * session, sint32 z, rct_vehicle * vehicle)
 {
     if (vehicle->sprite_direction & 7)
     {
@@ -2911,8 +2909,7 @@ static void vehicle_visual_splash2_effect(paint_session * session, sint32 z, rct
  *
  *  rct2: 0x006D57EE
  */
-static void vehicle_visual_splash3_effect(paint_session * session, sint32 z, rct_vehicle * vehicle,
-                                          const rct_ride_entry_vehicle * vehicleEntry)
+static void vehicle_visual_splash3_effect(paint_session * session, sint32 z, rct_vehicle * vehicle)
 {
     if (vehicle->sprite_direction & 7)
     {
@@ -2935,8 +2932,7 @@ static void vehicle_visual_splash3_effect(paint_session * session, sint32 z, rct
  *
  *  rct2: 0x006D5783
  */
-static void vehicle_visual_splash4_effect(paint_session * session, sint32 z, rct_vehicle * vehicle,
-                                          const rct_ride_entry_vehicle * vehicleEntry)
+static void vehicle_visual_splash4_effect(paint_session * session, sint32 z, rct_vehicle * vehicle)
 {
     rct_vehicle * vehicle2 = GET_VEHICLE(vehicle->prev_vehicle_on_ride);
     if (vehicle2->velocity <= 0x50000)
@@ -2960,8 +2956,7 @@ static void vehicle_visual_splash4_effect(paint_session * session, sint32 z, rct
  *
  *  rct2: 0x006D5701
  */
-static void vehicle_visual_splash5_effect(paint_session * session, sint32 z, rct_vehicle * vehicle,
-                                          const rct_ride_entry_vehicle * vehicleEntry)
+static void vehicle_visual_splash5_effect(paint_session * session, sint32 z, rct_vehicle * vehicle)
 {
     rct_vehicle * vehicle2 = GET_VEHICLE(vehicle->prev_vehicle_on_ride);
     if (vehicle2->velocity <= 0x50000)
@@ -2993,19 +2988,19 @@ void vehicle_visual_splash_effect(paint_session * session, sint32 z, rct_vehicle
     case 1: /* nullsub */
         break;
     case VEHICLE_VISUAL_SPLASH1_EFFECT:
-        vehicle_visual_splash1_effect(session, z, vehicle, vehicleEntry);
+        vehicle_visual_splash1_effect(session, z, vehicle);
         break;
     case VEHICLE_VISUAL_SPLASH2_EFFECT:
-        vehicle_visual_splash2_effect(session, z, vehicle, vehicleEntry);
+        vehicle_visual_splash2_effect(session, z, vehicle);
         break;
     case VEHICLE_VISUAL_SPLASH3_EFFECT:
-        vehicle_visual_splash3_effect(session, z, vehicle, vehicleEntry);
+        vehicle_visual_splash3_effect(session, z, vehicle);
         break;
     case VEHICLE_VISUAL_SPLASH4_EFFECT:
-        vehicle_visual_splash4_effect(session, z, vehicle, vehicleEntry);
+        vehicle_visual_splash4_effect(session, z, vehicle);
         break;
     case VEHICLE_VISUAL_SPLASH5_EFFECT:
-        vehicle_visual_splash5_effect(session, z, vehicle, vehicleEntry);
+        vehicle_visual_splash5_effect(session, z, vehicle);
         break;
     default:
         assert(false);
@@ -3017,7 +3012,7 @@ void vehicle_visual_splash_effect(paint_session * session, sint32 z, rct_vehicle
  *
  *  rct2: 0x006D45F8
  */
-void vehicle_visual_default(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle * vehicle,
+void vehicle_visual_default(paint_session * session, sint32 imageDirection, sint32 z, rct_vehicle * vehicle,
                             const rct_ride_entry_vehicle * vehicleEntry)
 {
     if (vehicle->vehicle_sprite_type < Util::CountOf(vehicle_sprite_funcs))
@@ -3069,7 +3064,7 @@ void vehicle_paint(paint_session * session, rct_vehicle * vehicle, sint32 imageD
     switch (vehicleEntry->car_visual)
     {
     case VEHICLE_VISUAL_DEFAULT:
-        vehicle_visual_default(session, x, imageDirection, y, z, vehicle, vehicleEntry);
+        vehicle_visual_default(session, imageDirection, z, vehicle, vehicleEntry);
         break;
     case VEHICLE_VISUAL_LAUNCHED_FREEFALL:
         vehicle_visual_launched_freefall(session, x, imageDirection, y, z, vehicle, vehicleEntry);

--- a/src/openrct2/ride/VehiclePaint.h
+++ b/src/openrct2/ride/VehiclePaint.h
@@ -36,7 +36,7 @@ extern const vehicle_boundbox VehicleBoundboxes[16][224];
 
 void vehicle_paint(paint_session * session, rct_vehicle *vehicle, sint32 imageDirection);
 
-void vehicle_visual_default(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
+void vehicle_visual_default(paint_session * session, sint32 imageDirection, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
 void vehicle_visual_roto_drop(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
 void vehicle_visual_observation_tower(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);
 void vehicle_visual_river_rapids(paint_session * session, sint32 x, sint32 imageDirection, sint32 y, sint32 z, rct_vehicle *vehicle, const rct_ride_entry_vehicle *vehicleEntry);

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -278,7 +278,7 @@ static void air_powered_vertical_rc_track_right_quarter_turn_5(
     };
 
     track_paint_util_right_quarter_turn_5_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_5_tiles_wooden_supports(session, height, direction, trackSequence);
     track_paint_util_right_quarter_turn_5_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_6);
 
@@ -465,7 +465,7 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
     };
 
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
 
     if (direction == 1 && trackSequence == 6)
     {

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -92,7 +92,7 @@ static void bobsleigh_rc_track_flat(
 static void bobsleigh_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -109,7 +109,7 @@ static void bobsleigh_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -84,7 +84,7 @@ static void compact_inverted_rc_track_flat(
 static void compact_inverted_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -103,8 +103,7 @@ static void compact_inverted_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3,
                        height + 29, 0, 6, height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                           STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -91,7 +91,7 @@ static void corkscrew_rc_track_flat(
 static void corkscrew_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -116,7 +116,7 @@ static void corkscrew_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -142,7 +142,7 @@ static void flying_rc_track_flat(
 static void flying_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -162,8 +162,7 @@ static void flying_rc_track_station(
         sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1,
                            height + 24, 0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                               STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
     }
     else
     {
@@ -187,7 +186,7 @@ static void flying_rc_track_station(
         sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                            height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+        track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -110,7 +110,7 @@ static void giga_rc_track_flat(
 static void giga_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -135,7 +135,7 @@ static void giga_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -99,7 +99,7 @@ static void heartline_twister_rc_track_flat(
 static void heartline_twister_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -116,7 +116,7 @@ static void heartline_twister_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -90,7 +90,7 @@ static void inverted_hairpin_rc_track_flat(
 static void inverted_hairpin_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -109,7 +109,7 @@ static void inverted_hairpin_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1,
                        height + 24, 0, 6, height + 24);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -65,7 +65,7 @@ static void inverted_impulse_rc_track_flat(
 static void inverted_impulse_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -84,8 +84,7 @@ static void inverted_impulse_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3,
                        height + 29, 0, 6, height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                           STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -83,7 +83,7 @@ static void inverted_rc_track_flat(
 static void inverted_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -102,8 +102,7 @@ static void inverted_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3,
                        height + 29, 0, 6, height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                           STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1651,7 +1651,7 @@ void junior_rc_paint_track_flat(
 void junior_rc_paint_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     uint16                   height,
     const rct_tile_element * tileElement,
@@ -1705,7 +1705,7 @@ void junior_rc_paint_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_6);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -1834,7 +1834,7 @@ static void junior_rc_right_quarter_turn_5_tiles_paint_setup(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_flat_quarter_turn_5_tiles, defaultRightQuarterTurn5TilesOffsets,
-        defaultRightQuarterTurn5TilesBoundLengths, defaultRightQuarterTurn5TilesBoundOffsets, session->CurrentRotation);
+        defaultRightQuarterTurn5TilesBoundLengths, defaultRightQuarterTurn5TilesBoundOffsets);
 
     sint32 supportHeight = height + junior_rc_track_right_quarter_turn_5_tiles_support_height_offset[direction][trackSequence];
     switch (trackSequence)
@@ -2119,7 +2119,7 @@ static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_banked_quarter_turn_5_tiles, nullptr, junior_rc_banked_right_quarter_turn_5_tiles_bound_lengths,
-        junior_rc_banked_right_quarter_turn_5_tiles_bound_offsets, session->CurrentRotation);
+        junior_rc_banked_right_quarter_turn_5_tiles_bound_offsets);
 
     if (direction == 1 && trackSequence == 6)
     {
@@ -2608,8 +2608,7 @@ void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_left_quarter_turn_5_tiles_25_deg_up[chainType],
-        junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets, defaultRightQuarterTurn5TilesBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_left_quarter_turn_5_tiles_25_deg_up_offsets, defaultRightQuarterTurn5TilesBoundLengths, nullptr);
 
     uint8 supportSpecial[4] = { 8, 8, 8, 3 };
     switch (trackSequence)
@@ -2691,7 +2690,7 @@ void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_quarter_turn_5_tiles_25_deg_up[chainType], defaultRightQuarterTurn5TilesOffsets,
-        defaultRightQuarterTurn5TilesBoundLengths, nullptr, session->CurrentRotation);
+        defaultRightQuarterTurn5TilesBoundLengths, nullptr);
 
     uint8 supportSpecial[4] = { 11, 8, 8, 7 };
     switch (trackSequence)
@@ -3040,7 +3039,7 @@ static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
     track_paint_util_right_quarter_turn_3_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_flat_quarter_turn_3_tiles, defaultRightQuarterTurn3TilesOffsets,
-        defaultRightQuarterTurn3TilesBoundLengths, nullptr, session->CurrentRotation);
+        defaultRightQuarterTurn3TilesBoundLengths, nullptr);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     uint8 supportType[2][4] = { { 1, 0, 0, 2 }, { 2, 0, 0, 1 } };
@@ -3141,7 +3140,7 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
     track_paint_util_right_quarter_turn_3_tiles_paint(
         session, thickness[direction][trackSequence], height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_banked_quarter_turn_3_tiles, nullptr, junior_rc_right_quarter_turn_3_tiles_bank_bound_lengths,
-        junior_rc_right_quarter_turn_3_tiles_bank_offsets, session->CurrentRotation);
+        junior_rc_right_quarter_turn_3_tiles_bank_offsets);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     if (direction == 1 && trackSequence == 3)
@@ -3445,7 +3444,7 @@ static void junior_rc_right_half_banked_helix_up_small_paint_setup(
     track_paint_util_right_helix_up_small_quarter_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_half_banked_helix_up_small_quarter_tiles, nullptr,
-        defaultRightHelixUpSmallQuarterBoundLengths, defaultRightHelixUpSmallQuarterBoundOffsets, session->CurrentRotation);
+        defaultRightHelixUpSmallQuarterBoundLengths, defaultRightHelixUpSmallQuarterBoundOffsets);
 
     if (trackSequence == 0)
     {
@@ -3515,7 +3514,7 @@ static void junior_rc_right_half_banked_helix_down_small_paint_setup(
     track_paint_util_right_helix_up_small_quarter_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_half_banked_helix_down_small_quarter_tiles, nullptr,
-        defaultRightHelixUpSmallQuarterBoundLengths, defaultRightHelixUpSmallQuarterBoundOffsets, session->CurrentRotation);
+        defaultRightHelixUpSmallQuarterBoundLengths, defaultRightHelixUpSmallQuarterBoundOffsets);
 
     if (trackSequence == 0)
     {
@@ -3625,7 +3624,7 @@ static void junior_rc_right_half_banked_helix_up_large_paint_setup(
     track_paint_util_right_helix_up_large_quarter_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_half_banked_helix_up_large_quarter_tiles, nullptr,
-        defaultRightHelixUpLargeQuarterBoundLengths, defaultRightHelixUpLargeQuarterBoundOffsets, session->CurrentRotation);
+        defaultRightHelixUpLargeQuarterBoundLengths, defaultRightHelixUpLargeQuarterBoundOffsets);
 
     if (trackSequence == 0)
     {
@@ -3711,7 +3710,7 @@ static void junior_rc_right_half_banked_helix_down_large_paint_setup(
     track_paint_util_right_helix_up_large_quarter_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_half_banked_helix_down_large_quarter_tiles, nullptr,
-        defaultRightHelixUpLargeQuarterBoundLengths, defaultRightHelixUpLargeQuarterBoundOffsets, session->CurrentRotation);
+        defaultRightHelixUpLargeQuarterBoundLengths, defaultRightHelixUpLargeQuarterBoundOffsets);
 
     if (trackSequence == 0)
     {
@@ -3909,7 +3908,7 @@ static void junior_rc_left_eighth_to_diag_paint_setup(
     track_paint_util_eighth_to_diag_tiles_paint(
         session, defaultEighthToDiagThickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_left_eight_to_diag, nullptr, defaultLeftEighthToDiagBoundLengths,
-        defaultLeftEighthToDiagBoundOffsets, session->CurrentRotation);
+        defaultLeftEighthToDiagBoundOffsets);
 
     switch (trackSequence)
     {
@@ -3976,7 +3975,7 @@ static void junior_rc_right_eighth_to_diag_paint_setup(
     track_paint_util_eighth_to_diag_tiles_paint(
         session, defaultEighthToDiagThickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_right_eight_to_diag, nullptr, defaultRightEighthToDiagBoundLengths,
-        defaultRightEighthToDiagBoundOffsets, session->CurrentRotation);
+        defaultRightEighthToDiagBoundOffsets);
 
     switch (trackSequence)
     {
@@ -4152,8 +4151,7 @@ static void junior_rc_left_eighth_to_diag_bank_paint_setup(
     track_paint_util_eighth_to_diag_tiles_paint(
         session, junior_rc_left_eighth_to_diag_bank_thickness, height, direction, trackSequence,
         session->TrackColours[SCHEME_TRACK], junior_rc_track_pieces_left_eight_to_diag_bank, nullptr,
-        junior_rc_left_eighth_to_diag_bank_bound_lengths, junior_rc_left_eighth_to_diag_bank_bound_offsets,
-        session->CurrentRotation);
+        junior_rc_left_eighth_to_diag_bank_bound_lengths, junior_rc_left_eighth_to_diag_bank_bound_offsets);
 
     switch (trackSequence)
     {
@@ -4301,8 +4299,7 @@ static void junior_rc_right_eighth_to_diag_bank_paint_setup(
     track_paint_util_eighth_to_diag_tiles_paint(
         session, junior_rc_right_eighth_to_diag_bank_thickness, height, direction, trackSequence,
         session->TrackColours[SCHEME_TRACK], junior_rc_track_pieces_right_eight_to_diag_bank, nullptr,
-        junior_rc_right_eighth_to_diag_bank_bound_lengths, junior_rc_right_eighth_to_diag_bank_bound_offsets,
-        session->CurrentRotation);
+        junior_rc_right_eighth_to_diag_bank_bound_lengths, junior_rc_right_eighth_to_diag_bank_bound_offsets);
 
     switch (trackSequence)
     {
@@ -4403,8 +4400,7 @@ void junior_rc_paint_track_diag_flat(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4429,8 +4425,7 @@ void junior_rc_paint_track_diag_25_deg_up(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4454,8 +4449,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_up(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_25_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_25_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4482,8 +4476,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_up(
 
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4507,8 +4500,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_flat(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_up_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_up_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4535,8 +4527,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_flat(
 
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_60_deg_up_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_60_deg_up_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4561,8 +4552,7 @@ void junior_rc_paint_track_diag_25_deg_down(
 
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4586,8 +4576,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_down(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_25_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_25_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4614,8 +4603,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_down(
 
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_60_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_60_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4639,8 +4627,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_flat(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_down_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_down_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4667,8 +4654,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_flat(
 
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_60_deg_down_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_60_deg_down_to_flat[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -4842,8 +4828,7 @@ static void junior_rc_diag_flat_to_left_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -4874,8 +4859,7 @@ static void junior_rc_diag_flat_to_right_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_flat_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_flat_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -4906,8 +4890,7 @@ static void junior_rc_diag_left_bank_to_flat_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_left_bank_to_flat, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_left_bank_to_flat, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -4938,8 +4921,7 @@ static void junior_rc_diag_right_bank_to_flat_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_right_bank_to_flat, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_right_bank_to_flat, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -4970,8 +4952,7 @@ static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_left_bank_to_25_deg_up, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_left_bank_to_25_deg_up, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -5001,8 +4982,7 @@ static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_right_bank_to_25_deg_up, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_right_bank_to_25_deg_up, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -5032,8 +5012,7 @@ static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_up_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_up_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -5063,8 +5042,7 @@ static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_up_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_up_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -5094,8 +5072,7 @@ static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_left_bank_to_25_deg_down, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_left_bank_to_25_deg_down, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -5125,8 +5102,7 @@ static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_right_bank_to_25_deg_down, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_right_bank_to_25_deg_down, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -5156,8 +5132,7 @@ static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_down_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_down_to_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 0 && trackSequence == 1)
     {
@@ -5187,8 +5162,7 @@ static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_down_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_down_to_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (direction == 2 && trackSequence == 2)
     {
@@ -5234,7 +5208,7 @@ static void junior_rc_diag_left_bank_paint_setup(
     track_paint_util_diag_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_diag_left_bank, defaultDiagTileOffsets, defaultDiagBoundLengths,
-        junior_rc_diag_left_bank_bound_offsets, session->CurrentRotation);
+        junior_rc_diag_left_bank_bound_offsets);
 
     if (trackSequence == 3)
     {
@@ -5261,7 +5235,7 @@ static void junior_rc_diag_right_bank_paint_setup(
     track_paint_util_diag_tiles_paint(
         session, thickness, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_diag_right_bank, defaultDiagTileOffsets, defaultDiagBoundLengths,
-        junior_rc_diag_right_bank_bound_offsets, session->CurrentRotation);
+        junior_rc_diag_right_bank_bound_offsets);
 
     if (trackSequence == 3)
     {
@@ -5579,8 +5553,7 @@ void junior_rc_paint_track_diag_60_deg_up(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -5604,8 +5577,7 @@ void junior_rc_paint_track_diag_60_deg_down(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_60_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_60_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -5629,8 +5601,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
 {
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        junior_rc_track_pieces_diag_25_deg_up_to_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr,
-        session->CurrentRotation);
+        junior_rc_track_pieces_diag_25_deg_up_to_60_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths, nullptr);
 
     if (trackSequence == 3)
     {
@@ -5664,7 +5635,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
         track_paint_util_diag_tiles_paint(
             session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
             junior_rc_track_pieces_diag_60_deg_up_to_25_deg_up[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths,
-            nullptr, session->CurrentRotation);
+            nullptr);
     }
 
     if (trackSequence == 3)
@@ -5699,7 +5670,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
         track_paint_util_diag_tiles_paint(
             session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
             junior_rc_track_pieces_diag_25_deg_down_to_60_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths,
-            nullptr, session->CurrentRotation);
+            nullptr);
     }
 
     if (trackSequence == 3)
@@ -5725,7 +5696,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
     track_paint_util_diag_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         junior_rc_track_pieces_diag_60_deg_down_to_25_deg_down[chainType], defaultDiagTileOffsets, defaultDiagBoundLengths,
-        nullptr, session->CurrentRotation);
+        nullptr);
 
     if (trackSequence == 3)
     {

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -142,7 +142,7 @@ static void lay_down_rc_track_flat(
 static void lay_down_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -163,8 +163,7 @@ static void lay_down_rc_track_station(
         sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1,
                            height + 24, 0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                               STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     }
     else
@@ -189,7 +188,7 @@ static void lay_down_rc_track_station(
         sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                            height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+        track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -30,7 +30,7 @@
 static void lim_launched_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -55,7 +55,7 @@ static void lim_launched_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -93,7 +93,7 @@ static void looping_rc_track_flat(
 static void looping_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -113,7 +113,7 @@ static void looping_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -66,7 +66,7 @@ static void mine_ride_track_flat(
 static void mine_ride_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -83,7 +83,7 @@ static void mine_ride_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -88,7 +88,7 @@ static void mine_train_rc_track_flat(
 static void mine_train_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -113,7 +113,7 @@ static void mine_train_rc_track_station(
                            height, 0, 0, height);
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -112,7 +112,7 @@ static void mini_rc_track_flat(
 static void mini_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -137,7 +137,7 @@ static void mini_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -91,7 +91,7 @@ static void mini_suspended_rc_track_flat(
 static void mini_suspended_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -110,7 +110,7 @@ static void mini_suspended_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1,
                        height + 24, 0, 2, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -148,23 +148,23 @@ static void multi_dimension_rc_track_station(
     if (direction == 0 || direction == 2)
     {
         hasFence = track_paint_util_has_fence(EDGE_NW, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
     }
     else
     {
         hasFence = track_paint_util_has_fence(EDGE_NE, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
     }
 
     if (direction == 0 || direction == 2)
     {
         hasFence = track_paint_util_has_fence(EDGE_SE, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, height);
     }
     else
     {
         hasFence = track_paint_util_has_fence(EDGE_SW, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, height);
     }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -42,7 +42,7 @@ void vehicle_visual_reverser(paint_session * session, sint32 x, sint32 imageDire
     z                         = (v1->z + v2->z) / 2;
     session->SpritePosition.x = x;
     session->SpritePosition.y = y;
-    vehicle_visual_default(session, x, imageDirection, y, z, vehicle, vehicleEntry);
+    vehicle_visual_default(session, imageDirection, z, vehicle, vehicleEntry);
 }
 #endif
 
@@ -99,7 +99,7 @@ static void reverser_rc_track_flat(
 static void reverser_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -116,7 +116,7 @@ static void reverser_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2,
                        height, 0, 2, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -100,7 +100,7 @@ static void side_friction_rc_track_flat(
 static void side_friction_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -115,7 +115,7 @@ static void side_friction_rc_track_station(
     sub_98197C_rotated(session, direction, imageIds[direction] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height,
                        0, 2, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -85,7 +85,7 @@ static void stand_up_rc_track_flat(
 static void stand_up_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -110,7 +110,7 @@ static void stand_up_rc_track_station(
     sub_98196C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1,
                        height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -78,7 +78,7 @@ static void steeplechase_track_flat(
 static void steeplechase_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -95,7 +95,7 @@ static void steeplechase_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 3,
                        height, 0, 0, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -83,7 +83,7 @@ static void suspended_swinging_rc_track_flat(
 static void suspended_swinging_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -102,8 +102,7 @@ static void suspended_swinging_rc_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3,
                        height + 29, 0, 6, height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                           STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -466,7 +466,7 @@ static void paint_virginia_reel_track_25_deg_down_to_flat(
 static void paint_virginia_reel_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -495,7 +495,7 @@ static void paint_virginia_reel_station(
     }
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -514,7 +514,7 @@ static void paint_virginia_reel_track_left_quarter_turn_3_tiles(
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
         session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        virginia_reel_track_pieces_flat_quarter_turn_3_tiles, session->CurrentRotation);
+        virginia_reel_track_pieces_flat_quarter_turn_3_tiles);
     track_paint_util_left_quarter_turn_3_tiles_tunnel(session, height, TUNNEL_6, direction, trackSequence);
 
     switch (trackSequence)
@@ -561,7 +561,7 @@ static void paint_virginia_reel_track_left_quarter_turn_1_tile(
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
         session, 2, height, 0, direction, session->TrackColours[SCHEME_TRACK],
-        virginia_reel_track_pieces_flat_quarter_turn_1_tile, session->CurrentRotation);
+        virginia_reel_track_pieces_flat_quarter_turn_1_tile);
 
     switch (direction)
     {

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -201,7 +201,7 @@ static void wild_mouse_track_flat(
 static void wild_mouse_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -228,7 +228,7 @@ static void wild_mouse_track_station(
                            0, 32, 20, 2, height, 0, 0, height);
     }
     track_paint_util_draw_station_metal_supports(session, direction, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -598,7 +598,7 @@ static void wild_mouse_track_right_quarter_turn_3(
     };
 
     track_paint_util_right_quarter_turn_3_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -471,7 +471,7 @@ static void wooden_rc_track_flat(
 static void wooden_rc_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -496,7 +496,7 @@ static void wooden_rc_track_station(
                               height, 0, 2, height);
     }
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, trackSequence, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -160,7 +160,7 @@ static void wooden_wild_mouse_track_flat(
 static void wooden_wild_mouse_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -177,7 +177,7 @@ static void wooden_wild_mouse_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 1,
                        height, 0, 0, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -577,7 +577,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_3(
     static uint8 supportType[] = { 4, 5, 2, 3 };
 
     track_paint_util_right_quarter_turn_3_tiles_paint_4(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -351,7 +351,7 @@ static void paint_car_ride_track_25_deg_down_to_flat(
 static void paint_car_ride_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -399,7 +399,7 @@ static void paint_car_ride_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -417,7 +417,7 @@ static void paint_car_ride_track_right_quarter_turn_3_tiles(
     track_paint_util_right_quarter_turn_3_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         car_ride_track_pieces_quarter_turn_3_tiles, defaultRightQuarterTurn3TilesOffsets,
-        defaultRightQuarterTurn3TilesBoundLengths, nullptr, session->CurrentRotation);
+        defaultRightQuarterTurn3TilesBoundLengths, nullptr);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)
@@ -526,7 +526,7 @@ static void paint_car_ride_track_spinning_tunnel(
         sub_98196C(session, imageId, 6, 0, 20, 32, 1, height);
     }
 
-    track_paint_util_spinning_tunnel_paint(session, 1, height, direction, session->CurrentRotation);
+    track_paint_util_spinning_tunnel_paint(session, 1, height, direction);
 
     if (direction == 0 || direction == 2)
     {

--- a/src/openrct2/ride/gentle/CircusShow.cpp
+++ b/src/openrct2/ride/gentle/CircusShow.cpp
@@ -70,8 +70,7 @@ static void paint_circus_show(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_SUPPORTS], height, fenceSpritesRope,

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -86,8 +86,7 @@ static void paint_crooked_house(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -167,8 +167,7 @@ static void paint_ferris_wheel(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     uint32 imageId;
     uint8  rotation    = session->CurrentRotation;

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -414,7 +414,7 @@ static void paint_ghost_train_track_25_deg_down_to_flat(
 static void paint_ghost_train_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -462,7 +462,7 @@ static void paint_ghost_train_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -480,7 +480,7 @@ static void paint_ghost_train_track_right_quarter_turn_3_tiles(
     track_paint_util_right_quarter_turn_3_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         ghost_train_track_pieces_quarter_turn_3_tiles, nullptr, defaultRightQuarterTurn3TilesBoundLengths,
-        defaultRightQuarterTurn3TilesBoundOffsets, session->CurrentRotation);
+        defaultRightQuarterTurn3TilesBoundOffsets);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)
@@ -533,8 +533,7 @@ static void paint_ghost_train_track_left_quarter_turn_1_tile(
     const rct_tile_element * tileElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
-        session, 3, height, 0, direction, session->TrackColours[SCHEME_TRACK], ghost_train_track_pieces_quarter_turn_1_tile,
-        session->CurrentRotation);
+        session, 3, height, 0, direction, session->TrackColours[SCHEME_TRACK], ghost_train_track_pieces_quarter_turn_1_tile);
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, 0, TUNNEL_0, 0, TUNNEL_0);
 
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
@@ -575,7 +574,7 @@ static void paint_ghost_train_track_spinning_tunnel(
         sub_98197C(session, imageId, 0, 0, 20, 28, 3, height, 6, 2, height);
     }
 
-    track_paint_util_spinning_tunnel_paint(session, 3, height, direction, session->CurrentRotation);
+    track_paint_util_spinning_tunnel_paint(session, 3, height, direction);
 
     if (direction == 0 || direction == 2)
     {

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -109,8 +109,7 @@ static void paint_haunted_house(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -128,8 +128,7 @@ static void paint_merry_go_round(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -665,8 +665,8 @@ static void paint_mini_golf_station(
             sub_98197C(session, imageId, 10, 0, 1, 32, 7, height, 31, 0, height + 2);
         }
 
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasSWFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasSWFence, entranceStyle, height);
 
         // Was leftwards tunnel in game, seems odd
         paint_util_push_tunnel_right(session, height, TUNNEL_6);
@@ -687,8 +687,8 @@ static void paint_mini_golf_station(
             sub_98197C(session, imageId, 0, 10, 32, 1, 7, height, 0, 31, height + 2);
         }
 
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasSEFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasSEFence, entranceStyle, height);
 
         paint_util_push_tunnel_left(session, height, TUNNEL_6);
     }
@@ -711,8 +711,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
     uint32 imageId;
 
     track_paint_util_left_quarter_turn_1_tile_paint(
-        session, 1, height, 0, direction, session->TrackColours[SCHEME_TRACK], mini_golf_track_sprites_quarter_turn_1_tile,
-        session->CurrentRotation);
+        session, 1, height, 0, direction, session->TrackColours[SCHEME_TRACK], mini_golf_track_sprites_quarter_turn_1_tile);
 
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
@@ -766,7 +765,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
         // TODO: The back fence uses the same x/y offsets, but uses another paint function. See if this occurs more often.
         track_paint_util_left_quarter_turn_1_tile_paint(
             session, 0, height, 24, direction, session->TrackColours[SCHEME_MISC],
-            mini_golf_track_sprites_quarter_turn_1_tile_fence_front, session->CurrentRotation);
+            mini_golf_track_sprites_quarter_turn_1_tile_fence_front);
 
         switch (direction)
         {

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -27,7 +27,7 @@
 static void paint_mini_helicopters_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -59,7 +59,7 @@ static void paint_mini_helicopters_track_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_6);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -286,7 +286,7 @@ static void paint_mini_helicopters_track_left_quarter_turn_3_tiles(
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn3Tiles, session->CurrentRotation);
+        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn3Tiles);
     track_paint_util_left_quarter_turn_3_tiles_tunnel(session, height, TUNNEL_0, direction, trackSequence);
 
     switch (trackSequence)
@@ -337,7 +337,7 @@ static void paint_mini_helicopters_track_left_quarter_turn_1_tile(
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
         session, 1, height, 0, direction, session->TrackColours[SCHEME_TRACK],
-        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn1Tile, session->CurrentRotation);
+        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn1Tile);
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, 0, TUNNEL_0, 0, TUNNEL_0);
 
     paint_util_set_segment_support_height(

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -198,7 +198,7 @@ static void paint_monorail_cycles_track_flat(
 static void paint_monorail_cycles_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -230,7 +230,7 @@ static void paint_monorail_cycles_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_6);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -247,7 +247,7 @@ static void paint_monorail_cycles_track_left_quarter_turn_3_tiles(
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        monorail_cycles_track_pieces_flat_quarter_turn_3_tiles, session->CurrentRotation);
+        monorail_cycles_track_pieces_flat_quarter_turn_3_tiles);
     track_paint_util_left_quarter_turn_3_tiles_tunnel(session, height, TUNNEL_0, direction, trackSequence);
 
     switch (trackSequence)
@@ -313,7 +313,7 @@ static void paint_monorail_cycles_track_right_quarter_turn_5_tiles(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, 1, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         monorail_cycles_track_pieces_flat_quarter_turn_5_tiles, nullptr, defaultRightQuarterTurn5TilesBoundLengths,
-        defaultRightQuarterTurn5TilesBoundOffsets, session->CurrentRotation);
+        defaultRightQuarterTurn5TilesBoundOffsets);
 
     sint32 supportHeight =
         height + monorail_cycles_track_right_quarter_turn_5_tiles_support_height_offset[direction][trackSequence];

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -108,8 +108,7 @@ static void paint_space_rings(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -76,8 +76,7 @@ static void paint_3d_cinema(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -101,8 +101,7 @@ static void paint_enterprise(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesRope,

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -412,12 +412,12 @@ static void paint_go_karts_station(
     if (direction == 0 || direction == 2)
     {
         hasFence = track_paint_util_has_fence(EDGE_NW, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
     }
     else
     {
         hasFence = track_paint_util_has_fence(EDGE_NE, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
     }
 
     imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
@@ -437,12 +437,12 @@ static void paint_go_karts_station(
     if (direction == 0 || direction == 2)
     {
         hasFence = track_paint_util_has_fence(EDGE_SE, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, height);
     }
     else
     {
         hasFence = track_paint_util_has_fence(EDGE_SW, position, tileElement, ride, session->CurrentRotation);
-        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, height);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, height);
     }
 
     if (track_element_get_type(tileElement) == TRACK_ELEM_END_STATION)

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -148,8 +148,7 @@ static void paint_motionsimulator(
     LocationXY16 position = { session->MapPosition.x, session->MapPosition.y };
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_SUPPORTS], height, fenceSpritesRope,
         session->CurrentRotation);

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -269,8 +269,7 @@ static void paint_top_spin(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork);
 
     track_paint_util_paint_fences(
         session, edges, position, tileElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -104,8 +104,7 @@ static void paint_twist(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    track_paint_util_paint_floor(
-        session, edges, session->TrackColours[SCHEME_MISC], height, floorSpritesCork, session->CurrentRotation);
+    track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_MISC], height, floorSpritesCork);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -214,7 +214,7 @@ static void chairlift_paint_station_ne_sw(
         imageId = SPR_FENCE_METAL_NW | session->TrackColours[SCHEME_TRACK];
         sub_98199C(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
     }
-    track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, direction, height);
+    track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, entranceStyle, height);
 
     if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
@@ -228,7 +228,7 @@ static void chairlift_paint_station_ne_sw(
         imageId = SPR_FENCE_METAL_SE | session->TrackColours[SCHEME_TRACK];
         sub_98197C(session, imageId, 0, 0, 32, 1, 27, height, 0, 30, height + 2);
     }
-    track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, direction, height);
+    track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, entranceStyle, height);
 
     bool drawFrontColumn = true;
     bool drawBackColumn  = true;
@@ -309,7 +309,7 @@ static void chairlift_paint_station_se_nw(
         imageId = SPR_FENCE_METAL_NE | session->TrackColours[SCHEME_TRACK];
         sub_98199C(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
     }
-    track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, direction, height);
+    track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, entranceStyle, height);
 
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
@@ -323,7 +323,7 @@ static void chairlift_paint_station_se_nw(
         imageId = SPR_FENCE_METAL_SW | session->TrackColours[SCHEME_TRACK];
         sub_98197C(session, imageId, 0, 0, 1, 32, 27, height, 30, 0, height + 2);
     }
-    track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, direction, height);
+    track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, entranceStyle, height);
 
     bool drawRightColumn = true;
     bool drawLeftColumn  = true;

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -668,7 +668,7 @@ static void paint_miniature_railway_track_flat(
 static void paint_miniature_railway_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -685,7 +685,7 @@ static void paint_miniature_railway_station(
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
 
-    track_paint_util_draw_station_3(session, rideIndex, trackSequence, direction, height + 2, height, tileElement);
+    track_paint_util_draw_station_3(session, rideIndex, direction, height + 2, height, tileElement);
     // covers shouldn't be offset by +2
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -962,7 +962,7 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
             track_paint_util_right_quarter_turn_5_tiles_paint(
                 session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
                 miniature_railway_track_pieces_flat_quarter_turn_5_tiles, miniature_railway_right_quarter_turn_5_tiles_offsets,
-                miniature_railway_right_quarter_turn_5_tiles_bound_lengths, nullptr, session->CurrentRotation);
+                miniature_railway_right_quarter_turn_5_tiles_bound_lengths, nullptr);
         }
         else
         {
@@ -970,7 +970,7 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
                 session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_SUPPORTS],
                 miniature_railway_right_quarter_turn_5_tiles_track_floor, nullptr,
                 miniature_railway_right_quarter_turn_5_tiles_bound_lengths,
-                miniature_railway_right_quarter_turn_5_tiles_bound_offsets, session->CurrentRotation);
+                miniature_railway_right_quarter_turn_5_tiles_bound_offsets);
 
             sint32 index   = miniature_railway_right_quarter_turn_5_tiles_sprite_map[trackSequence];
             uint32 imageId = miniature_railway_track_pieces_flat_quarter_turn_5_tiles[direction][index] |
@@ -1310,7 +1310,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
         track_paint_util_right_quarter_turn_3_tiles_paint(
             session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
             miniature_railway_track_pieces_flat_quarter_turn_3_tiles, defaultRightQuarterTurn3TilesOffsets,
-            defaultRightQuarterTurn3TilesBoundLengths, nullptr, session->CurrentRotation);
+            defaultRightQuarterTurn3TilesBoundLengths, nullptr);
 
         // The following piece was missing in vanilla RCT2
         if (trackSequence == 1 && direction == 0)
@@ -1324,7 +1324,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
         track_paint_util_right_quarter_turn_3_tiles_paint(
             session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_SUPPORTS],
             miniature_railway_right_quarter_turn_3_tile_track_floor, nullptr, defaultRightQuarterTurn3TilesBoundLengths,
-            miniature_railway_right_quarter_turn_3_tile_bound_offsets, session->CurrentRotation);
+            miniature_railway_right_quarter_turn_3_tile_bound_offsets);
 
         static constexpr const sint8 right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
 

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -469,7 +469,7 @@ static void paint_monorail_track_flat(
 static void paint_monorail_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -517,7 +517,7 @@ static void paint_monorail_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -715,7 +715,7 @@ static void paint_monorail_track_right_quarter_turn_5_tiles(
     track_paint_util_right_quarter_turn_5_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         monorail_track_pieces_flat_quarter_turn_5_tiles, defaultRightQuarterTurn5TilesOffsets,
-        defaultRightQuarterTurn5TilesBoundLengths, nullptr, session->CurrentRotation);
+        defaultRightQuarterTurn5TilesBoundLengths, nullptr);
 
     switch (trackSequence)
     {
@@ -999,7 +999,7 @@ static void paint_monorail_track_right_quarter_turn_3_tiles(
     track_paint_util_right_quarter_turn_3_tiles_paint(
         session, 3, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
         monorail_track_pieces_flat_quarter_turn_3_tiles, defaultRightQuarterTurn3TilesOffsets,
-        defaultRightQuarterTurn3TilesBoundLengths, nullptr, session->CurrentRotation);
+        defaultRightQuarterTurn3TilesBoundLengths, nullptr);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_6);
 
     switch (trackSequence)

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -64,7 +64,7 @@ static void suspended_monorail_track_flat(
 static void suspended_monorail_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -83,8 +83,7 @@ static void suspended_monorail_track_station(
     sub_98199C_rotated(session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3,
                        height + 32, 0, 6, height + 32);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, trackSequence, direction, height, tileElement,
-                                           STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -401,7 +401,7 @@ static void dinghy_slide_track_flat(
 static void dinghy_slide_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -423,7 +423,7 @@ static void dinghy_slide_track_station(
     metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8 - (direction & 1), 0, height,
                                  session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_station(session, rideIndex, trackSequence, direction, height, tileElement);
+    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
 
@@ -823,10 +823,9 @@ static void dinghy_slide_track_right_quarter_turn_5(
     };
 
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        frontImageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], frontImageIds);
 
     switch (trackSequence)
     {
@@ -1151,10 +1150,9 @@ static void dinghy_slide_track_right_quarter_turn_3(
     };
 
     track_paint_util_right_quarter_turn_3_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_3_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        frontImageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], frontImageIds);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)
@@ -1594,10 +1592,9 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(
     };
 
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        frontImageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], frontImageIds);
 
     switch (trackSequence)
     {
@@ -1911,10 +1908,9 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(
     };
 
     track_paint_util_right_quarter_turn_3_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_3_tiles_paint_3(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        frontImageIds);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], frontImageIds);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_0);
 
     switch (trackSequence)

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -196,7 +196,7 @@ static void paint_log_flume_track_flat(
 static void paint_log_flume_track_station(
     paint_session *          session,
     uint8                    rideIndex,
-    uint8                    trackSequence,
+    [[maybe_unused]] uint8   trackSequence,
     uint8                    direction,
     sint32                   height,
     const rct_tile_element * tileElement)
@@ -225,7 +225,7 @@ static void paint_log_flume_track_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station_3(session, rideIndex, trackSequence, direction, height + 2, height, tileElement);
+    track_paint_util_draw_station_3(session, rideIndex, direction, height + 2, height, tileElement);
     // Covers shouldn't be offset by +2
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
@@ -685,10 +685,9 @@ static void paint_log_flume_track_left_quarter_turn_3_tiles(
     };
 
     track_paint_util_left_quarter_turn_3_tiles_paint(
-        session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds, session->CurrentRotation);
+        session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
-        session, 0, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIdsFront,
-        session->CurrentRotation, 27);
+        session, 0, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIdsFront, 27);
 
     if (trackSequence != 1 && trackSequence != 2)
     {
@@ -757,10 +756,9 @@ static void paint_log_flume_track_right_quarter_turn_3_tiles(
     };
 
     track_paint_util_right_quarter_turn_3_tiles_paint_2(
-        session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds, session->CurrentRotation);
+        session, 2, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIds);
     track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
-        session, 0, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIdsFront,
-        session->CurrentRotation, 27);
+        session, 0, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], imageIdsFront, 27);
 
     if (trackSequence != 1 && trackSequence != 2)
     {

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -885,11 +885,9 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(
     const rct_tile_element * tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        RiverRaftsLeftQuarterTurn5_Top);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], RiverRaftsLeftQuarterTurn5_Top);
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        RiverRaftsLeftQuarterTurn5_Side);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], RiverRaftsLeftQuarterTurn5_Side);
 
     if (trackSequence != 1 && trackSequence != 4)
     {
@@ -969,11 +967,9 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(
     const rct_tile_element * tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        RiverRaftsRightQuarterTurn5_Top);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], RiverRaftsRightQuarterTurn5_Top);
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
-        session, height, direction, session->CurrentRotation, trackSequence, session->TrackColours[SCHEME_TRACK],
-        RiverRaftsRightQuarterTurn5_Side);
+        session, height, direction, trackSequence, session->TrackColours[SCHEME_TRACK], RiverRaftsRightQuarterTurn5_Side);
 
     if (trackSequence != 1 && trackSequence != 4)
     {

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -163,7 +163,7 @@ static void submarine_ride_paint_track_left_quarter_turn_3_tiles(
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
         session, 3, height - 16, direction, trackSequence, session->TrackColours[SCHEME_TRACK],
-        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn3Tiles, session->CurrentRotation);
+        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn3Tiles);
     track_paint_util_left_quarter_turn_3_tiles_tunnel(session, height - 16, TUNNEL_0, direction, trackSequence);
 
     switch (trackSequence)
@@ -211,7 +211,7 @@ static void submarine_ride_paint_track_left_quarter_turn_1_tile(
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
         session, 1, height - 16, 0, direction, session->TrackColours[SCHEME_TRACK],
-        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn1Tile, session->CurrentRotation);
+        trackSpritesSubmarineRideMiniHelicoptersQuarterTurn1Tile);
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height - 16, 0, TUNNEL_0, 0, TUNNEL_0);
 
     paint_util_set_segment_support_height(

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -134,8 +134,14 @@ void balloon_update(rct_balloon * balloon)
     balloon->Update();
 }
 
-void game_command_balloon_press(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+void game_command_balloon_press(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = game_command_balloon_press(*eax & 0xFFFF, *ebx & 0xFF);
 }
-

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -552,7 +552,14 @@ void fix_duplicated_banners()
  *
  *  rct2: 0x006BA058
  */
-void game_command_remove_banner(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_remove_banner(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = BannerRemove(
         *eax & 0xFFFF,
@@ -567,7 +574,14 @@ void game_command_remove_banner(sint32* eax, sint32* ebx, sint32* ecx, sint32* e
  *
  *  rct2: 0x006BA16A
  */
-void game_command_set_banner_colour(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_banner_colour(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    sint32 *                  ebp)
 {
     *ebx = BannerSetColour(
         *eax & 0xFFFF,
@@ -583,7 +597,8 @@ void game_command_set_banner_colour(sint32* eax, sint32* ebx, sint32* ecx, sint3
  *
  *  rct2: 0x006B9E6D
  */
-void game_command_place_banner(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_place_banner(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = BannerPlace(
         *eax & 0xFFFF,
@@ -597,7 +612,14 @@ void game_command_place_banner(sint32* eax, sint32* ebx, sint32* ecx, sint32* ed
     );
 }
 
-void game_command_set_banner_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_banner_style(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    sint32 *                  ebp)
 {
     *ebx = BannerSetStyle(
         *ecx & 0xFF,
@@ -607,4 +629,3 @@ void game_command_set_banner_style(sint32* eax, sint32* ebx, sint32* ecx, sint32
         *ebx & 0xFF
     );
 }
-

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -462,13 +462,14 @@ static money32 RideEntranceExitPlaceGhost(uint8 rideIndex, sint16 x, sint16 y, u
  *
  *  rct2: 0x00666A63
  */
-void game_command_remove_park_entrance(sint32 *eax,
-                                       sint32 *ebx,
-                                       sint32 *ecx,
-                                       sint32 *edx,
-                                       sint32 *esi,
-                                       sint32 *edi,
-                                       sint32 *ebp)
+void game_command_remove_park_entrance(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = ParkEntranceRemove(
         *eax & 0xFFFF,
@@ -581,13 +582,14 @@ money32 ride_entrance_exit_place_ghost(sint32 rideIndex,
  *
  *  rct2: 0x006660A8
  */
-void game_command_place_ride_entrance_or_exit(sint32 *eax,
-                                              sint32 *ebx,
-                                              sint32 *ecx,
-                                              sint32 *edx,
-                                              sint32 *esi,
-                                              sint32 *edi,
-                                              sint32 *ebp)
+void game_command_place_ride_entrance_or_exit(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = RideEntranceExitPlace(
         *eax & 0xFFFF,
@@ -605,13 +607,14 @@ void game_command_place_ride_entrance_or_exit(sint32 *eax,
  *
  *  rct2: 0x0066640B
  */
-void game_command_remove_ride_entrance_or_exit(sint32 *eax,
-                                               sint32 *ebx,
-                                               sint32 *ecx,
-                                               sint32 *edx,
-                                               sint32 *esi,
-                                               sint32 *edi,
-                                               sint32 *ebp)
+void game_command_remove_ride_entrance_or_exit(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = RideEntranceExitRemove(
         *eax & 0xFFFF,

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -549,7 +549,8 @@ money32 footpath_remove_real(sint32 x, sint32 y, sint32 z, sint32 flags)
  *
  *  rct2: 0x006A61DE
  */
-void game_command_place_footpath(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_place_footpath(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = footpath_place_real(
         (*edx >> 8) & 0xFF,
@@ -691,7 +692,14 @@ static money32 footpath_place_from_track(sint32 type, sint32 x, sint32 y, sint32
  *
  *  rct2: 0x006A68AE
  */
-void game_command_place_footpath_from_track(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_place_footpath_from_track(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = footpath_place_from_track(
         (*edx >> 8) & 0xFF,
@@ -708,7 +716,14 @@ void game_command_place_footpath_from_track(sint32 *eax, sint32 *ebx, sint32 *ec
  *
  *  rct2: 0x006A67C0
  */
-void game_command_remove_footpath(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_remove_footpath(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = footpath_remove_real((*eax & 0xFFFF), (*ecx & 0xFFFF), (*edx & 0xFF), (*ebx & 0xFF));
 }
@@ -1643,7 +1658,7 @@ void footpath_update_queue_chains()
  *
  *  rct2: 0x0069ADBD
  */
-static void footpath_fix_ownership(sint32 x, sint32 y, rct_tile_element *pathElement)
+static void footpath_fix_ownership(sint32 x, sint32 y)
 {
     const rct_tile_element * surfaceElement = map_get_surface_element_at({x, y});
     uint16 ownership;
@@ -1732,7 +1747,7 @@ static sint32 footpath_is_connected_to_map_edge_recurse(
         }
 
         if (flags & (1 << 5)) {
-            footpath_fix_ownership(x, y, tileElement);
+            footpath_fix_ownership(x, y);
         }
         edges = tileElement->properties.path.edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
         direction ^= 2;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -882,7 +882,14 @@ bool map_is_location_owned_or_has_rights(sint32 x, sint32 y)
  *
  *  rct2: 0x006B8E1B
  */
-void game_command_remove_large_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_remove_large_scenery(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     uint8 base_height = *edx;
     uint8 tileIndex = *edx >> 8;
@@ -1034,7 +1041,14 @@ void game_command_remove_large_scenery(sint32* eax, sint32* ebx, sint32* ecx, si
  *
  *  rct2: 0x006B909A
  */
-void game_command_set_large_scenery_colour(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_large_scenery_colour(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    sint32 *                  ebp)
 {
     gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
     sint32 x = *eax;
@@ -1280,7 +1294,8 @@ money32 map_clear_scenery(sint32 x0, sint32 y0, sint32 x1, sint32 y1, sint32 cle
  *
  *  rct2: 0x0068DF91
  */
-void game_command_clear_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_clear_scenery(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = map_clear_scenery(
         (sint16)(*eax & 0xFFFF),
@@ -1426,7 +1441,8 @@ static money32 map_change_surface_style(sint32 x0, sint32 y0, sint32 x1, sint32 
  *
  *  rct2: 0x00663CCD
  */
-void game_command_change_surface_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_change_surface_style(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = map_change_surface_style(
         (sint16)(*eax & 0xFFFF),
@@ -1461,7 +1477,13 @@ static constexpr const uint8 tile_element_lower_styles[5][32] = {
  *
  *  rct2: 0x00663CB9
  */
-static sint32 map_set_land_height_clear_func(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price) {
+static sint32 map_set_land_height_clear_func(
+    rct_tile_element **        tile_element,
+    [[maybe_unused]] sint32    x,
+    [[maybe_unused]] sint32    y,
+    [[maybe_unused]] uint8     flags,
+    [[maybe_unused]] money32 * price)
+{
     if (tile_element_get_type(*tile_element) == TILE_ELEMENT_TYPE_SURFACE)
         return 0;
 
@@ -1517,7 +1539,7 @@ static sint32 tile_element_get_corner_height(rct_tile_element *tileElement, sint
     return map_get_corner_height(z, slope, direction);
 }
 
-static money32 map_set_land_height(sint32 flags, sint32 x, sint32 y, sint32 height, sint32 style, sint32 selectionType)
+static money32 map_set_land_height(sint32 flags, sint32 x, sint32 y, sint32 height, sint32 style)
 {
     rct_tile_element *tileElement;
 
@@ -1727,15 +1749,21 @@ static money32 map_set_land_height(sint32 flags, sint32 x, sint32 y, sint32 heig
     return cost;
 }
 
-void game_command_set_land_height(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_land_height(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = map_set_land_height(
         *ebx & 0xFF,
         *eax & 0xFFFF,
         *ecx & 0xFFFF,
         *edx & 0xFF,
-        (*edx >> 8) & 0xFF,
-        *edi >> 5
+        (*edx >> 8) & 0xFF
     );
 }
 
@@ -1771,7 +1799,8 @@ static money32 map_set_land_ownership(uint8 flags, sint16 x1, sint16 y1, sint16 
  *
  *  rct2: 0x006648E3
  */
-void game_command_set_land_ownership(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_set_land_ownership(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     sint32 flags = *ebx & 0xFF;
 
@@ -1866,7 +1895,7 @@ static money32 raise_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
                         height += 2;
                         newStyle &= ~0x20;
                     }
-                    money32 tileCost = map_set_land_height(flags, xi, yi, height, newStyle, selectionType);
+                    money32 tileCost = map_set_land_height(flags, xi, yi, height, newStyle);
                     if (tileCost == MONEY32_UNDEFINED)
                         return MONEY32_UNDEFINED;
 
@@ -1924,7 +1953,7 @@ static money32 lower_land(sint32 flags, sint32 x, sint32 y, sint32 z, sint32 ax,
                         height -= 2;
                         newStyle &= ~0x20;
                     }
-                    money32 tileCost = map_set_land_height(flags, xi, yi, height, newStyle, selectionType);
+                    money32 tileCost = map_set_land_height(flags, xi, yi, height, newStyle);
                     if (tileCost == MONEY32_UNDEFINED)
                         return MONEY32_UNDEFINED;
 
@@ -2110,7 +2139,8 @@ money32 lower_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags)
  *
  *  rct2: 0x0068C542
  */
-void game_command_raise_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_raise_land(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = raise_land(
         *ebx,
@@ -2129,7 +2159,8 @@ void game_command_raise_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx,
  *
  *  rct2: 0x0068C6D1
  */
-void game_command_lower_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_lower_land(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = lower_land(
         *ebx,
@@ -2548,7 +2579,8 @@ static money32 smooth_land(sint32 flags, sint32 centreX, sint32 centreY, sint32 
  *
  *  rct2: 0x0068BC01
  */
-void game_command_smooth_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_smooth_land(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     sint32 flags = *ebx & 0xFF;
     sint32 centreX = *eax & 0xFFFF;
@@ -2565,7 +2597,14 @@ void game_command_smooth_land(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx
  *
  *  rct2: 0x006E66A0
  */
-void game_command_raise_water(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_raise_water(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    sint32 *                  ebp)
 {
     *ebx = raise_water(
         (sint16)(*eax & 0xFFFF),
@@ -2580,7 +2619,14 @@ void game_command_raise_water(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx
  *
  *  rct2: 0x006E6878
  */
-void game_command_lower_water(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_lower_water(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    [[maybe_unused]] sint32 * edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    sint32 *                  ebp)
 {
     *ebx = lower_water(
         (sint16)(*eax & 0xFFFF),
@@ -2595,7 +2641,14 @@ void game_command_lower_water(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx
  *
  *  rct2: 0x006E650F
  */
-void game_command_set_water_height(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_water_height(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     sint32 x = *eax;
     sint32 y = *ecx;
@@ -2690,7 +2743,8 @@ bool map_is_location_at_edge(sint32 x, sint32 y)
  *
  *  rct2: 0x006B893C
  */
-void game_command_place_large_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_place_large_scenery(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
     sint32 x = (sint16)*eax;
@@ -4250,7 +4304,15 @@ void map_clear_all_elements()
     }
 }
 
-void game_command_set_sign_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp) {
+void game_command_set_sign_style(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    sint32 *                  ebp)
+{
     uint8 bannerId = *ecx & 0xFF;
     if (bannerId > Util::CountOf(gBanners)) {
         log_warning("Invalid game command for setting sign style, banner id = %d", bannerId);
@@ -4265,7 +4327,6 @@ void game_command_set_sign_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* 
     uint8 textColour = (uint8)*edi;
 
     if (*ebp == 0) { // small sign
-
         rct_tile_element* tile_element = map_get_first_element_at(x / 32, y / 32);
         bool wall_found = false;
         do{
@@ -4328,7 +4389,8 @@ void game_command_set_sign_style(sint32* eax, sint32* ebx, sint32* ecx, sint32* 
     *ebx = 0;
 }
 
-void game_command_modify_tile(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_modify_tile(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     const sint32 flags = *ebx;
     const sint32 x = *ecx & 0xFF;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -385,7 +385,7 @@ static bool map_animation_invalidate_track_spinningtunnel(sint32 x, sint32 y, si
  *
  *  rct2: 0x0068DF8F
  */
-static bool map_animation_invalidate_remove(sint32 x, sint32 y, sint32 baseZ)
+static bool map_animation_invalidate_remove([[maybe_unused]] sint32 x, [[maybe_unused]] sint32 y, [[maybe_unused]] sint32 baseZ)
 {
     return true;
 }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -659,7 +659,14 @@ void park_set_open(sint32 open)
  *
  *  rct2: 0x00669D4A
  */
-void game_command_set_park_open(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_park_open(
+    [[maybe_unused]] sint32 * eax,
+    sint32 *                  ebx,
+    [[maybe_unused]] sint32 * ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    sint32 *                  edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     if (!(*ebx & GAME_COMMAND_FLAG_APPLY)) {
         *ebx = 0;
@@ -953,7 +960,8 @@ sint32 map_buy_land_rights(sint32 x0, sint32 y0, sint32 x1, sint32 y1, sint32 se
 *
 *  rct2: 0x006649BD
 */
-void game_command_buy_land_rights(sint32 *eax, sint32 *ebx, sint32 *ecx, sint32 *edx, sint32 *esi, sint32 *edi, sint32 *ebp)
+void game_command_buy_land_rights(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     sint32 flags = *ebx & 0xFFFF;
 

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -443,7 +443,14 @@ static money32 SmallSceneryPlace(sint16 x,
  *
  *  rct2: 0x006E0E01
  */
-void game_command_remove_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_remove_scenery(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    [[maybe_unused]] sint32 * ebp)
 {
     *ebx = SmallSceneryRemove(
         *eax & 0xFFFF,
@@ -459,7 +466,14 @@ void game_command_remove_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* 
  *
  *  rct2: 0x006E0F26
  */
-void game_command_set_scenery_colour(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_set_scenery_colour(
+    sint32 *                  eax,
+    sint32 *                  ebx,
+    sint32 *                  ecx,
+    sint32 *                  edx,
+    [[maybe_unused]] sint32 * esi,
+    [[maybe_unused]] sint32 * edi,
+    sint32 *                  ebp)
 {
     *ebx = SmallScenerySetColour(
         *eax & 0xFFFF,
@@ -548,7 +562,8 @@ sint32 map_place_non_scenery_clear_func(rct_tile_element** tile_element, sint32 
  *
  *  rct2: 0x006E08F4
  */
-void game_command_place_scenery(sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, sint32* esi, sint32* edi, sint32* ebp)
+void game_command_place_scenery(
+    sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, [[maybe_unused]] sint32 * esi, sint32 * edi, sint32 * ebp)
 {
     *ebx = SmallSceneryPlace(
         *eax & 0xFFFF,

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -37,14 +37,14 @@ uint32 windowTileInspectorTileX;
 uint32 windowTileInspectorTileY;
 sint32 windowTileInspectorElementCount = 0;
 
-static void window_tile_inspector_set_page(rct_window * w, const TILE_INSPECTOR_PAGE page)
+static void window_tile_inspector_set_page(const TILE_INSPECTOR_PAGE page)
 {
     auto intent = Intent(INTENT_ACTION_SET_TILE_INSPECTOR_PAGE);
     intent.putExtra(INTENT_EXTRA_PAGE, page);
     context_broadcast_intent(&intent);
 }
 
-static void window_tile_inspector_auto_set_buttons(rct_window * w)
+static void window_tile_inspector_auto_set_buttons()
 {
     auto intent = Intent(INTENT_ACTION_SET_TILE_INSPECTOR_BUTTONS);
     context_broadcast_intent(&intent);
@@ -146,10 +146,10 @@ sint32 tile_inspector_insert_corrupt_at(sint32 x, sint32 y, sint16 elementIndex,
 
             if (tileInspectorWindow->selected_list_item == elementIndex)
             {
-                window_tile_inspector_set_page(tileInspectorWindow, TILE_INSPECTOR_PAGE_CORRUPT);
+                window_tile_inspector_set_page(TILE_INSPECTOR_PAGE_CORRUPT);
             }
 
-            window_tile_inspector_auto_set_buttons(tileInspectorWindow);
+            window_tile_inspector_auto_set_buttons();
             window_invalidate(tileInspectorWindow);
         }
     }
@@ -189,10 +189,10 @@ sint32 tile_inspector_remove_element_at(sint32 x, sint32 y, sint16 elementIndex,
             else if (tileInspectorWindow->selected_list_item == elementIndex)
             {
                 tileInspectorWindow->selected_list_item = -1;
-                window_tile_inspector_set_page(tileInspectorWindow, TILE_INSPECTOR_PAGE_DEFAULT);
+                window_tile_inspector_set_page(TILE_INSPECTOR_PAGE_DEFAULT);
             }
 
-            window_tile_inspector_auto_set_buttons(tileInspectorWindow);
+            window_tile_inspector_auto_set_buttons();
             window_invalidate(tileInspectorWindow);
         }
     }
@@ -220,7 +220,7 @@ sint32 tile_inspector_swap_elements_at(sint32 x, sint32 y, sint16 first, sint16 
             else if (tileInspectorWindow->selected_list_item == second)
                 tileInspectorWindow->selected_list_item = first;
 
-            window_tile_inspector_auto_set_buttons(tileInspectorWindow);
+            window_tile_inspector_auto_set_buttons();
             window_invalidate(tileInspectorWindow);
         }
     }
@@ -373,7 +373,7 @@ sint32 tile_inspector_paste_element_at(sint32 x, sint32 y, rct_tile_element elem
             else if (tileInspectorWindow->selected_list_item >= newIndex)
                 tileInspectorWindow->selected_list_item++;
 
-            window_tile_inspector_auto_set_buttons(tileInspectorWindow);
+            window_tile_inspector_auto_set_buttons();
             window_invalidate(tileInspectorWindow);
         }
     }
@@ -428,9 +428,9 @@ sint32 tile_inspector_sort_elements_at(sint32 x, sint32 y, sint32 flags)
         rct_window * const tileInspectorWindow = window_find_by_class(WC_TILE_INSPECTOR);
         if (tileInspectorWindow != nullptr && (uint32)x == windowTileInspectorTileX && (uint32)y == windowTileInspectorTileY)
         {
-            window_tile_inspector_set_page(tileInspectorWindow, TILE_INSPECTOR_PAGE_DEFAULT);
+            window_tile_inspector_set_page(TILE_INSPECTOR_PAGE_DEFAULT);
             tileInspectorWindow->selected_list_item = -1;
-            window_tile_inspector_auto_set_buttons(tileInspectorWindow);
+            window_tile_inspector_auto_set_buttons();
             window_invalidate(tileInspectorWindow);
         }
     }

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -64,10 +64,7 @@ static bool TrackIsAllowedWallEdges(uint8 rideType, uint8 trackType, uint8 track
  *  rct2: 0x006E5CBA
  */
 static bool WallCheckObstructionWithTrack(rct_scenery_entry * wall,
-                                          sint32 x,
-                                          sint32 y,
                                           sint32 z0,
-                                          sint32 z1,
                                           sint32 edge,
                                           rct_tile_element * trackElement,
                                           bool * wallAcrossTrack)
@@ -239,7 +236,7 @@ static bool WallCheckObstruction(rct_scenery_entry * wall,
             }
             break;
         case TILE_ELEMENT_TYPE_TRACK:
-            if (!WallCheckObstructionWithTrack(wall, x, y, z0, z1, edge, tileElement, wallAcrossTrack))
+            if (!WallCheckObstructionWithTrack(wall, z0, edge, tileElement, wallAcrossTrack))
             {
                 return false;
             }
@@ -815,7 +812,7 @@ void game_command_place_wall(sint32 * eax,
                              sint32 * ebx,
                              sint32 * ecx,
                              sint32 * edx,
-                             sint32 * esi,
+                             [[maybe_unused]] sint32 * esi,
                              sint32 * edi,
                              sint32 * ebp)
 {
@@ -861,9 +858,9 @@ void game_command_remove_wall(sint32 * eax,
                               sint32 * ebx,
                               sint32 * ecx,
                               sint32 * edx,
-                              sint32 * esi,
-                              sint32 * edi,
-                              sint32 * ebp)
+                              [[maybe_unused]] sint32 * esi,
+                              [[maybe_unused]] sint32 * edi,
+                              [[maybe_unused]] sint32 * ebp)
 {
     *ebx = WallRemove(
         *eax & 0xFFFF,
@@ -882,8 +879,8 @@ void game_command_set_wall_colour(sint32 * eax,
                                   sint32 * ebx,
                                   sint32 * ecx,
                                   sint32 * edx,
-                                  sint32 * esi,
-                                  sint32 * edi,
+                                  [[maybe_unused]] sint32 * esi,
+                                  [[maybe_unused]] sint32 * edi,
                                   sint32 * ebp)
 {
     *ebx = WallSetColour(
@@ -897,4 +894,3 @@ void game_command_set_wall_colour(sint32 * eax,
         *ebx & 0xFF
     );
 }
-

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -87,7 +87,7 @@ uint8 gMapSelectArrowDirection;
 void entrance_paint(paint_session * session, uint8 direction, int height, const rct_tile_element * tile_element) {}
 void banner_paint(paint_session * session, uint8 direction, int height, const rct_tile_element * tile_element) {}
 void surface_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement) {}
-void path_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement) {}
+void path_paint(paint_session * session, uint16 height, const rct_tile_element * tileElement) {}
 void scenery_paint(paint_session * session, uint8 direction, int height, const rct_tile_element * tileElement) {}
 void fence_paint(paint_session * session, uint8 direction, int height, const rct_tile_element * tileElement) {}
 void large_scenery_paint(paint_session * session, uint8 direction, uint16 height, const rct_tile_element * tileElement) {}

--- a/test/testpaint/main.cpp
+++ b/test/testpaint/main.cpp
@@ -299,11 +299,9 @@ static bool openrct2_setup_rct2_segment()
 {
     // OpenRCT2 on Linux and macOS is wired to have the original Windows PE sections loaded
     // necessary. Windows does not need to do this as OpenRCT2 runs as a DLL loaded from the Windows PE.
-    int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
-    int err = 0;
     // in some configurations err and len may be unused
-    UNUSED(err);
-    UNUSED(len);
+    [[maybe_unused]] int len = 0x01429000 - 0x8a4000; // 0xB85000, 12079104 bytes or around 11.5MB
+    [[maybe_unused]] int err = 0;
 #if defined(__unix__)
     int pageSize = getpagesize();
     int numPages = (len + pageSize - 1) / pageSize;


### PR DESCRIPTION
This aims to make future refactoring easier. The arguments were removed where they were not used or needed, but kept and marked as unused where they could not be removed (e.g. when they are used as a callback, rather than called directly).

I've skipped the `rides/<category>/*` and `peep/*` source files, because the rides source files are mostly generated and have a ton of unused variables, and the peep source files are being refactored.

I've also skipped most of `window/*` source files, because most of the functions are used as callbacks which would only add a bunch of `UNUSED(w);` to them, but I may do them later.