### PR TITLE
Fix scan objects and run before tests

### DIFF
--- a/openrct2.proj
+++ b/openrct2.proj
@@ -185,7 +185,13 @@
     <MSBuild Projects="openrct2.sln" Targets="Rebuild" Properties="$(SlnProperties)" />
   </Target>
 
-  <Target Name="Test" DependsOnTargets="Build">
+  <Target Name="Test">
+    <!-- Scan repositories prior to running tests as it can take a while -->
+    <Message Text="Building OpenRCT2 repository indexes..." Importance="high" />
+    <Exec Command="$(TargetDir)openrct2.exe scan-objects"
+          WorkingDirectory="$(TargetDir)" />
+
+    <Message Text="Running tests..." Importance="high" />
     <Exec Command="$(TargetDir)tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;"
           WorkingDirectory="$(TargetDir)" />
   </Target>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -189,7 +189,8 @@
     <!-- Scan repositories prior to running tests as it can take a while -->
     <Message Text="Building OpenRCT2 repository indexes..." Importance="high" />
     <Exec Command="$(TargetDir)openrct2.exe scan-objects"
-          WorkingDirectory="$(TargetDir)" />
+          WorkingDirectory="$(TargetDir)"
+          StandardOutputImportance="normal" />
 
     <Message Text="Running tests..." Importance="high" />
     <Exec Command="$(TargetDir)tests.exe &quot;--gtest_output=xml:$(ArtifactsDir)test-results.xml&quot;"

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -28,15 +28,15 @@ pushd build
 	if [[ $TARGET == "docker64" ]]
 	then
 		# CMAKE and MAKE opts from environment
-		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:64bit-only bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja all install $OPENRCT_MAKE_OPTS && ctest --output-on-failure"
+		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:64bit-only bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja all install $OPENRCT_MAKE_OPTS && ./openrct2-cli scan-objects && ctest --output-on-failure"
 	elif [[ $TARGET == "ubuntu_i686" ]]
 	then
 		# CMAKE and MAKE opts from environment
-		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:ubuntu_i686 bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja all testpaint install $OPENRCT_MAKE_OPTS && ctest --output-on-failure && ( ./testpaint --quiet ||  if [[ \$? -eq 1 ]] ; then echo Allowing failed tests to pass ; else echo here ; false; fi )"
+		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:ubuntu_i686 bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja all testpaint install $OPENRCT_MAKE_OPTS && ./openrct2-cli scan-objects && ctest --output-on-failure && ( ./testpaint --quiet ||  if [[ \$? -eq 1 ]] ; then echo Allowing failed tests to pass ; else echo here ; false; fi )"
 	elif [[ $TARGET == "ubuntu_amd64" ]]
 	then
 		# CMAKE and MAKE opts from environment
-		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:ubuntu_amd64 bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja $OPENRCT_MAKE_OPTS install && ctest --output-on-failure"
+		docker run -v "$PARENT":"$PARENT" -w "$PARENT"/build -i -t openrct2/openrct2:ubuntu_amd64 bash -c "cmake ../ -DWITH_TESTS=on $OPENRCT2_CMAKE_OPTS && ninja $OPENRCT_MAKE_OPTS install && ./openrct2-cli scan-objects && ctest --output-on-failure"
 	elif [[ $TARGET == "windows" ]]
 	then
 		# CMAKE and MAKE opts from environment

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -15,12 +15,13 @@
 #pragma endregion
 
 #include <ctime>
+#include <memory>
 
 #include "../config/Config.h"
+#include "../Context.h"
 #include "../platform/Crash.h"
 #include "../platform/platform.h"
 #include "../localisation/Language.h"
-
 #include "../core/Console.hpp"
 #include "../core/Memory.hpp"
 #include "../core/Path.hpp"
@@ -394,12 +395,14 @@ static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator
         return result;
     }
 
-    auto env = OpenRCT2::CreatePlatformEnvironment();
+    gOpenRCT2Headless = true;
 
     // HACK: set gCurrentLanguage otherwise it be wrong for the index file
     gCurrentLanguage = gConfigGeneral.language;
 
-    auto objectRepository = CreateObjectRepository(env);
+    auto context = std::unique_ptr<OpenRCT2::IContext>(OpenRCT2::CreateContext());
+    auto env = context->GetPlatformEnvironment();
+    auto objectRepository = std::unique_ptr<IObjectRepository>(CreateObjectRepository(env));
     objectRepository->Construct();
     return EXITCODE_OK;
 }

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -397,12 +397,13 @@ static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator
 
     gOpenRCT2Headless = true;
 
-    // HACK: set gCurrentLanguage otherwise it be wrong for the index file
-    gCurrentLanguage = gConfigGeneral.language;
-
     auto context = std::unique_ptr<OpenRCT2::IContext>(OpenRCT2::CreateContext());
     auto env = context->GetPlatformEnvironment();
     auto objectRepository = std::unique_ptr<IObjectRepository>(CreateObjectRepository(env));
+
+    // HACK: set gCurrentLanguage otherwise it be wrong for the index file
+    gCurrentLanguage = gConfigGeneral.language;
+
     objectRepository->Construct();
     return EXITCODE_OK;
 }

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -18,6 +18,7 @@
 #include "../drawing/Drawing.h"
 #include "../localisation/Language.h"
 #include "../object/Object.h"
+#include "../object/ObjectRepository.h"
 #include "BannerObject.h"
 #include "ObjectJsonHelpers.h"
 #include "ObjectList.h"
@@ -46,16 +47,20 @@ void BannerObject::ReadLegacy(IReadObjectContext * context, IStream * stream)
 
     // Add banners to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
-    const std::string identifier = GetIdentifier();
-    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    static const rct_object_entry scgPathX = Object::GetScgPathXHeader();
+    auto identifier = GetIdentifier();
 
-    if (objectEntry != nullptr &&
-            (object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_WACKY_WORLDS ||
-             object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_TIME_TWISTER ||
-             object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_CUSTOM))
+    auto& objectRepository = context->GetObjectRepository();
+    auto item = objectRepository.FindObject(identifier);
+    if (item != nullptr)
     {
-        SetPrimarySceneryGroup(&scgPathX);
+        auto objectEntry = &item->ObjectEntry;
+        if (object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_WACKY_WORLDS ||
+            object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_TIME_TWISTER ||
+            object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_CUSTOM)
+        {
+            auto scgPathX = Object::GetScgPathXHeader();
+            SetPrimarySceneryGroup(&scgPathX);
+        }
     }
 }
 

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -20,6 +20,7 @@
 #include "../interface/Cursors.h"
 #include "../localisation/Localisation.h"
 #include "../object/Object.h"
+#include "../object/ObjectRepository.h"
 #include "ObjectList.h"
 #include "FootpathItemObject.h"
 #include "ObjectJsonHelpers.h"
@@ -49,16 +50,20 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext * context, IStream * stre
 
     // Add path bits to 'Signs and items for footpaths' group, rather than lumping them in the Miscellaneous tab.
     // Since this is already done the other way round for original items, avoid adding those to prevent duplicates.
-    const std::string identifier = GetIdentifier();
-    const rct_object_entry * objectEntry = object_list_find_by_name(identifier.c_str());
-    static const rct_object_entry scgPathX = Object::GetScgPathXHeader();
+    auto identifier = GetIdentifier();
 
-    if (objectEntry != nullptr &&
-        (object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_WACKY_WORLDS ||
-         object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_TIME_TWISTER ||
-         object_entry_get_source_game(objectEntry) == OBJECT_SOURCE_CUSTOM))
+    auto& objectRepository = context->GetObjectRepository();
+    auto item = objectRepository.FindObject(identifier);
+    if (item != nullptr)
     {
-        SetPrimarySceneryGroup(&scgPathX);
+        auto sourceGame = object_entry_get_source_game(&item->ObjectEntry);
+        if (sourceGame == OBJECT_SOURCE_WACKY_WORLDS ||
+            sourceGame == OBJECT_SOURCE_TIME_TWISTER ||
+            sourceGame == OBJECT_SOURCE_CUSTOM)
+        {
+            auto scgPathX = Object::GetScgPathXHeader();
+            SetPrimarySceneryGroup(&scgPathX);
+        }
     }
 }
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -111,6 +111,7 @@ struct rct_object_filters {
 assert_struct_size(rct_object_filters, 3);
 #pragma pack(pop)
 
+interface IObjectRepository;
 interface IStream;
 struct    ObjectRepositoryItem;
 struct    rct_drawpixelinfo;
@@ -119,6 +120,7 @@ interface IReadObjectContext
 {
     virtual ~IReadObjectContext() = default;
 
+    virtual IObjectRepository& GetObjectRepository() abstract;
     virtual bool ShouldLoadImages() abstract;
 
     virtual void LogWarning(uint32 code, const utf8 * text) abstract;
@@ -206,7 +208,6 @@ sint32 object_calculate_checksum(const rct_object_entry * entry, const void * da
 bool find_object_in_entry_group(const rct_object_entry* entry, uint8* entry_type, uint8* entry_index);
 void object_create_identifier_name(char* string_buffer, size_t size, const rct_object_entry* object);
 
-const rct_object_entry * object_list_find_by_name(const char *name);
 const rct_object_entry * object_list_find(rct_object_entry *entry);
 
 void object_entry_get_name_fixed(utf8 * buffer, size_t bufferSize, const rct_object_entry * entry);

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -18,14 +18,15 @@
 
 #include "../common.h"
 
+interface IObjectRepository;
 class Object;
 struct rct_object_entry;
 
 namespace ObjectFactory
 {
-    Object * CreateObjectFromLegacyFile(const utf8 * path);
-    Object * CreateObjectFromLegacyData(const rct_object_entry * entry, const void * data, size_t dataSize);
+    Object * CreateObjectFromLegacyFile(IObjectRepository& objectRepository, const utf8 * path);
+    Object * CreateObjectFromLegacyData(IObjectRepository& objectRepository, const rct_object_entry * entry, const void * data, size_t dataSize);
     Object * CreateObject(const rct_object_entry &entry);
 
-    Object * CreateObjectFromJsonFile(const std::string &path);
+    Object * CreateObjectFromJsonFile(IObjectRepository& objectRepository, const std::string &path);
 }

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -234,7 +234,7 @@ namespace ObjectJsonHelpers
     {
         std::vector<rct_g1_element> result;
         auto objectPath = FindLegacyObject(name);
-        auto obj = ObjectFactory::CreateObjectFromLegacyFile(objectPath.c_str());
+        auto obj = ObjectFactory::CreateObjectFromLegacyFile(context->GetObjectRepository(), objectPath.c_str());
         if (obj != nullptr)
         {
             auto &imgTable = static_cast<const Object *>(obj)->GetImageTable();

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -551,10 +551,11 @@ private:
             std::vector<const char *> objects = RCT1::GetSceneryObjects(sceneryTheme);
             for (const char * objectName : objects)
             {
-                const rct_object_entry * foundEntry = object_list_find_by_name(objectName);
-                if (foundEntry != nullptr)
+                auto objectRepository = OpenRCT2::GetContext()->GetObjectRepository();
+                auto foundObject = objectRepository->FindObject(objectName);
+                if (foundObject != nullptr)
                 {
-                    uint8 objectType = object_entry_get_type(foundEntry);
+                    uint8 objectType = object_entry_get_type(&foundObject->ObjectEntry);
                     switch (objectType) {
                     case OBJECT_TYPE_SMALL_SCENERY:
                     case OBJECT_TYPE_LARGE_SCENERY:


### PR DESCRIPTION
This fixes `scan-objects` which has been broken for some time due to there being no OpenRCT2 context.

I have also made the msbuild project run an object scan before the tests so that it does not get run during the first integration test making it take significantly longer than it should.

@janisozaur This should be done for travis too but I am unsure where I am meant to stick the exec. Could you make a commit for this?