### PR TITLE
Use enum type that guarantee to support its values

### DIFF
--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -99,7 +99,7 @@ enum GAME_COMMAND
     GAME_COMMAND_COUNT
 };
 
-enum
+enum : uint32
 {
     GAME_COMMAND_FLAG_APPLY               = (1 << 0), // If this flag is set, the command is applied, otherwise only the cost is retrieved
     GAME_COMMAND_FLAG_2                   = (1 << 2),

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -61,7 +61,8 @@ enum {
     G1_FLAG_NO_ZOOM_DRAW    = (1 << 5), // Does not get drawn at higher zoom levels (only zoom 0)
 };
 
-enum {
+enum : uint32
+{
     IMAGE_TYPE_DEFAULT = 0,
     IMAGE_TYPE_REMAP = (1 << 29),
     IMAGE_TYPE_TRANSPARENT = (1 << 30),

--- a/src/openrct2/drawing/String.cpp
+++ b/src/openrct2/drawing/String.cpp
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <algorithm>
+#include "../common.h"
 #include "../config/Config.h"
 #include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
@@ -24,7 +25,8 @@
 #include "../util/Util.h"
 #include "TTF.h"
 
-enum {
+enum : uint32
+{
     TEXT_DRAW_FLAG_INSET = 1 << 0,
     TEXT_DRAW_FLAG_OUTLINE = 1 << 1,
     TEXT_DRAW_FLAG_DARK = 1 << 2,

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include "../common.h"
 #include "../Context.h"
 #include "../core/FileStream.hpp"
 #include "../core/IStream.hpp"
@@ -739,7 +740,8 @@ void S6Exporter::ExportResearchList()
     memcpy(_s6.research_items, gResearchItems, sizeof(_s6.research_items));
 }
 
-enum {
+enum : uint32
+{
     S6_SAVE_FLAG_EXPORT    = 1 << 0,
     S6_SAVE_FLAG_SCENARIO  = 1 << 1,
     S6_SAVE_FLAG_AUTOMATIC = 1u << 31,

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -752,7 +752,8 @@ enum {
     RIDE_ELEMENT_WHIRLPOOL               = 1 << 7
 };
 
-enum ride_type_flags {
+enum ride_type_flags : uint32
+{
     RIDE_TYPE_FLAG_HAS_TRACK_COLOUR_MAIN = 1 << 0,
     RIDE_TYPE_FLAG_HAS_TRACK_COLOUR_ADDITIONAL = 1 << 1,
     RIDE_TYPE_FLAG_HAS_TRACK_COLOUR_SUPPORTS = 1 << 2,

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -155,7 +155,8 @@ assert_struct_size(rct_track_td6, 0xbf);
 #pragma pack(pop)
 
 // Only written to in RCT2, not used in OpenRCT2. All of these are elements that had to be invented in RCT1.
-enum {
+enum : uint32
+{
     TRACK_FLAGS_CONTAINS_VERTICAL_LOOP = (1 << 7),
     TRACK_FLAGS_CONTAINS_INLINE_TWIST = (1 << 17),
     TRACK_FLAGS_CONTAINS_HALF_LOOP = (1 << 18),
@@ -166,16 +167,19 @@ enum {
     TRACK_FLAGS_CONTAINS_LARGE_HALF_LOOP = (1u << 31),
 };
 
-enum {
+enum : uint32
+{
     TRACK_FLAGS2_CONTAINS_LOG_FLUME_REVERSER = (1 << 1),
     TRACK_FLAGS2_SIX_FLAGS_RIDE_DEPRECATED = (1u << 31)     // Not used anymore.
 };
 
-enum {
+enum
+{
     TDPF_PLACE_SCENERY = 1 << 0,
 };
 
-enum {
+enum
+{
     TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE = (1 << 0),
     TRACK_DESIGN_FLAG_HAS_SCENERY = (1 << 1),
     TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE = (1 << 2),

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -240,7 +240,8 @@ struct rct_vehicle_info {
     uint8 bank_rotation;    // 0x08
 };
 
-enum {
+enum : uint32
+{
     VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY = 1 << 0, // Set on powered vehicles that do not slow down when going down a hill
     VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS = 1 << 1,
     VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH = 1 << 2,
@@ -322,7 +323,8 @@ enum {
     VEHICLE_STATUS_STOPPED_BY_BLOCK_BRAKES
 };
 
-enum{
+enum : uint32
+{
     VEHICLE_UPDATE_FLAG_ON_LIFT_HILL = (1 << 0),
     VEHICLE_UPDATE_FLAG_1 = (1 << 1),
     VEHICLE_UPDATE_FLAG_WAIT_ON_ADJACENT = (1 << 2),
@@ -339,7 +341,8 @@ enum{
     VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE = (1 << 13) // After passing a rotation toggle track piece this will enable
 };
 
-enum {
+enum : uint32
+{
     VEHICLE_SPRITE_FLAG_FLAT = (1 << 0),
     VEHICLE_SPRITE_FLAG_GENTLE_SLOPES = (1 << 1),
     VEHICLE_SPRITE_FLAG_STEEP_SLOPES = (1 << 2),
@@ -378,7 +381,8 @@ enum {
     VEHICLE_VISUAL_SUBMARINE
 };
 
-enum {
+enum : uint32
+{
     VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION = 1 << 0,
     VEHICLE_UPDATE_MOTION_TRACK_FLAG_1 = 1 << 1,
     VEHICLE_UPDATE_MOTION_TRACK_FLAG_2 = 1 << 2,

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -26,7 +26,8 @@
 
 struct rct_peep;
 
-enum {
+enum : uint32
+{
     PARK_FLAGS_PARK_OPEN = (1 << 0),
     PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT = (1 << 1),
     PARK_FLAGS_FORBID_LANDSCAPE_CHANGES = (1 << 2),


### PR DESCRIPTION
By default enumerators use type `int` which can store values up to `1 << 31 - 1`. The clang compiler generates this error for enumerators with values that use the sign bit: `enumerator value is not representable in the underlying type 'int'.`

To get rid of those warnings (and technically improve the code) the erroneous enumerators are now of type of `uint32`.

Note: I've skipped peep.h to prevent conflicts with the peep refactor branch.