### PR TITLE
Fix Discord service compilation

### DIFF
--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -30,7 +30,7 @@ constexpr const char * APPLICATION_ID = "378612438200877056";
 constexpr const char * STEAM_APP_ID = nullptr;
 constexpr const uint32 REFRESH_INTERVAL = 5 * GAME_UPDATE_FPS; // 5 seconds
 
-static void OnReady()
+static void OnReady(const DiscordUser * request)
 {
     log_verbose("DiscordService::OnReady()");
 }


### PR DESCRIPTION
```
openrct2/network/DiscordService.cpp: In constructor ‘DiscordService::DiscordService()’:
openrct2/network/DiscordService.cpp:51:22: error: invalid conversion from ‘void (*)()’ to ‘void (*)(const DiscordUser*)’ [-fpermissive]
     handlers.ready = OnReady;
                      ^~~~~~~
```