### PR TITLE
Fix #7436: Only the first 32 vehicles of a train can be painted

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
+- Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4280,7 +4280,7 @@ static void window_ride_colour_mousedown(rct_window *w, rct_widgetindex widgetIn
             numItems = ride->num_cars_per_train;
 
         stringId = (ride->colour_scheme_type & 3) == VEHICLE_COLOUR_SCHEME_PER_TRAIN ? STR_RIDE_COLOUR_TRAIN_OPTION : STR_RIDE_COLOUR_VEHICLE_OPTION;
-        for (i = 0; i < 32; i++) {
+        for (i = 0; i < std::min(numItems, (sint32)DROPDOWN_ITEMS_MAX_SIZE); i++) {
             gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
             gDropdownItemsArgs[i] = ((sint64)(i + 1) << 32) | ((RideComponentNames[RideNameConvention[ride->type].vehicle].capitalised) << 16) | stringId;
         }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -35,7 +35,7 @@
 #define MAX_CATEGORIES_PER_RIDE         2
 #define DOWNTIME_HISTORY_SIZE           8
 #define CUSTOMER_HISTORY_SIZE           10
-#define MAX_CARS_PER_TRAIN              32
+#define MAX_CARS_PER_TRAIN              255
 #define MAX_STATIONS                    4
 #define RIDE_MEASUREMENT_MAX_ITEMS      4800
 #define MAX_RIDES                       255


### PR DESCRIPTION
This also raises MAX_CARS_PER_TRAIN to 255, which it already was, in practical terms. When exporting to S6, only the colours of the first 32 vehicles are saved (this PR does not touch that).