### PR TITLE
Change Min spawn energy to 80 out of 128.

### DIFF
--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1903,9 +1903,9 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
     uint8 trousers_colour = static_cast<uint8>(scenario_rand() % Util::CountOf(trouser_colours));
     peep->trousers_colour = trouser_colours[trousers_colour];
 
-    /* It looks like 65 is about 50% energy level, so this initialises
-     * a peep with approx 50%-100% energy (0x3F = 63, 63 + 65 = 128). */
-    uint8 energy        = (scenario_rand() & 0x3F) + 65;
+    /* It looks like 80 is about 50% energy level: (128+32) / 2 = 80, so this initialises
+     * a peep with approx 50%-100% energy (0x30 = 48, 48 + 80 = 128). */
+    uint8 energy        = (scenario_rand() & 0x30) + 80;
     peep->energy        = energy;
     peep->energy_target = energy;
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1905,7 +1905,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
 
     /* It looks like 80 is about 50% energy level: (128+32) / 2 = 80, so this initialises
      * a peep with approx 50%-100% energy (0x30 = 48, 48 + 80 = 128). */
-    uint8 energy        = (scenario_rand() & 0x30) + 80;
+    uint8 energy        = (scenario_rand() % 0x30) + 80;
     peep->energy        = energy;
     peep->energy_target = energy;
 


### PR DESCRIPTION
Change Min spawn energy to 80 out of 128. The minimum energy is actually 32 so halfway up the scale is 80 not 65. Energy below 32 is not used for the energy bar. This fixes guests spawning with the sleepy eyes tired state. (128+32) / 2 = 80 was used for the halfway point.