### PR TITLE
Replace month count magic numbers

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -30,7 +30,7 @@ static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     for (i = count - 1; i >= 0; i--) {
         if (history[i] != 0 && history[i] != 255 && yearOver32 % 4 == 0) {
             // Draw month text
-            set_format_arg(0, uint32, DateGameShortMonthNames[((yearOver32 / 4) + 8) % 8]);
+            set_format_arg(0, uint32, DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
             gfx_draw_string_centred(dpi, STR_GRAPH_LABEL, x, y - 10, COLOUR_BLACK, gCommonFormatArgs);
 
             // Draw month mark
@@ -108,7 +108,7 @@ static void graph_draw_months_money32(rct_drawpixelinfo *dpi, const money32 *his
     for (i = count - 1; i >= 0; i--) {
         if (history[i] != MONEY32_UNDEFINED && yearOver32 % 4 == 0) {
             // Draw month text
-            sint32 monthFormat = DateGameShortMonthNames[((yearOver32 / 4) + 8) % 8];
+            sint32 monthFormat = DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)];
             gfx_draw_string_centred(dpi, STR_GRAPH_LABEL, x, y - 10, COLOUR_BLACK, &monthFormat);
 
             // Draw month mark

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -245,7 +245,7 @@ static void window_game_bottom_toolbar_tooltip(rct_window* w, rct_widgetindex wi
         set_format_arg(0, sint16, gParkRating);
         break;
     case WIDX_DATE:
-        month = gDateMonthsElapsed % 8;
+        month = date_get_month(gDateMonthsElapsed);
         day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
 
         set_format_arg(0, rct_string_id, DateDayNames[day]);
@@ -555,7 +555,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, 
 
     // Date
     sint32 year = date_get_year(gDateMonthsElapsed) + 1;
-    sint32 month = date_get_month(gDateMonthsElapsed & 7);
+    sint32 month = date_get_month(gDateMonthsElapsed);
     sint32 day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
 
     rct_string_id stringId = DateFormatStringFormatIds[gConfigGeneral.date_format];

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -304,7 +304,7 @@ static void window_news_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, sint3
 
         // Date text
         set_format_arg(0, rct_string_id, DateDayNames[newsItem->Day - 1]);
-        set_format_arg(2, rct_string_id, DateGameMonthNames[(newsItem->MonthYear % 8)]);
+        set_format_arg(2, rct_string_id, DateGameMonthNames[date_get_month(newsItem->MonthYear)]);
         gfx_draw_string_left(dpi, STR_NEWS_DATE_FORMAT, gCommonFormatArgs, COLOUR_WHITE, 2, y);
 
         // Item text

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -330,7 +330,7 @@ void news_item_add_to_queue_raw(uint8 type, const utf8 * text, uint32 assoc)
     newsItem->Assoc     = assoc;
     newsItem->Ticks     = 0;
     newsItem->MonthYear = gDateMonthsElapsed;
-    newsItem->Day       = ((days_in_month[(newsItem->MonthYear & 7)] * gDateMonthTicks) >> 16) + 1;
+    newsItem->Day       = ((days_in_month[date_get_month(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
     safe_strcpy(newsItem->Text, text, sizeof(newsItem->Text));
 
     // Blatant disregard for what happens on the last element.

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -326,7 +326,7 @@ static void scenario_day_update()
 
 static void scenario_week_update()
 {
-    sint32 month = gDateMonthsElapsed & 7;
+    sint32 month = date_get_month(gDateMonthsElapsed);
 
     finance_pay_wages();
     finance_pay_research();
@@ -740,11 +740,11 @@ static void scenario_objective_check_guests_by()
     sint16 objectiveGuests = gScenarioObjectiveNumGuests;
     sint16 currentMonthYear = gDateMonthsElapsed;
 
-    if (currentMonthYear == 8 * objectiveYear || gConfigGeneral.allow_early_completion) {
+    if (currentMonthYear == MONTH_COUNT * objectiveYear || gConfigGeneral.allow_early_completion) {
         if (parkRating >= 600 && guestsInPark >= objectiveGuests) {
             scenario_success();
         }
-        else if (currentMonthYear == 8 * objectiveYear) {
+        else if (currentMonthYear == MONTH_COUNT * objectiveYear) {
             scenario_failure();
         }
     }
@@ -757,11 +757,11 @@ static void scenario_objective_check_park_value_by()
     money32 objectiveParkValue = gScenarioObjectiveCurrency;
     money32 parkValue = gParkValue;
 
-    if (currentMonthYear == 8 * objectiveYear || gConfigGeneral.allow_early_completion) {
+    if (currentMonthYear == MONTH_COUNT * objectiveYear || gConfigGeneral.allow_early_completion) {
         if (parkValue >= objectiveParkValue) {
             scenario_success();
         }
-        else if (currentMonthYear == 8 * objectiveYear) {
+        else if (currentMonthYear == MONTH_COUNT * objectiveYear) {
             scenario_failure();
         }
     }


### PR DESCRIPTION
`months = 8 * years`, `months % 8` and `months & 7` was used to determine the month index. Those instances now make use of `MONTH_COUNT`. With this PR the number of months in a year (8 in RCT) can be changed without breaking parts of the game.