### PR TITLE
Fix guests staying in the park after closing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
+- Fix: Guests staying in the park when the park is closed.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -770,6 +770,13 @@ static void peep_decide_whether_to_leave_park(rct_peep * peep)
         return;
     }
 
+    // Leave the park if the park is closed.
+    if (!park_is_open())
+    {
+        peep_leave_park(peep);
+        return;
+    }
+
     /* Peeps that are happy enough, have enough energy and
      * (if appropriate) have enough money will always stay
      * in the park. */


### PR DESCRIPTION
Guests are not notified about the fact that the park has closed down. This means that guests will stay in the park until they're unhappy/tired enough that they'll leave on their own, even if the park is closed down. With this change, guests will decide to leave the park more aggressively when the park is closed.

Guests that are in queues will stay in their queues as can be seen in this screenshot:

![leaving](https://user-images.githubusercontent.com/2348094/39400090-dacd7e5c-4b29-11e8-8f9f-deba2eff7c1b.PNG)

**Points of discussion:**
- This change affects gameplay. Closing and reopening your park would be a viable strategy to make a larger profit in pay per park scenarios.
- Many guests heading for the park exit at the same has a small impact on performance.
- This change does not account for the park re-opening during "the migration". Meaning that guests will continue to head for the exit once they've decided to do so. Even if the park has re-opened in the meantime.