### PR TITLE
Change shop construction to no longer auto-rotate to queue paths

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -74,7 +74,6 @@ The following people are not part of the project team, but have been contributin
 * Joshua Moerman (Jaxan) - Misc.
 * Nicolas Hawrysh (xp4xbox) - Misc.
 * Albert Morgese (Fusxfaranto) - Misc.
-* Toby Hinloopen (tobyhinloopen) - Improvements to auto-rotate of shops
 
 ## Bug fixes
 * (halfbro)
@@ -109,6 +108,7 @@ The following people are not part of the project team, but have been contributin
 * Seongsik Park (pss9205)
 * (Deurklink)
 * Nathan Zabriskie (NathanZabriskie)
+* Toby Hinloopen (tobyhinloopen)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/contributors.md
+++ b/contributors.md
@@ -74,6 +74,7 @@ The following people are not part of the project team, but have been contributin
 * Joshua Moerman (Jaxan) - Misc.
 * Nicolas Hawrysh (xp4xbox) - Misc.
 * Albert Morgese (Fusxfaranto) - Misc.
+* Toby Hinloopen (tobyhinloopen) - Improvements to auto-rotate of shops
 
 ## Bug fixes
 * (halfbro)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,7 +18,6 @@
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
-- Fix: [#7424] Auto-rotate shops ignore queue lines
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
+- Fix: [#7424] Auto-rotate shops ignore queue lines
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3451,12 +3451,6 @@ void ride_construction_toolupdate_construct(sint32 screenX, sint32 screenY)
                 pathsByDir[i] = nullptr;
             }
 
-            if (pathsByDir[i] &&
-                footpath_element_is_queue(pathsByDir[i]))
-            {
-                pathsByDir[i] = nullptr;
-            }
-
             // Sloped path on the level below
             if (!pathsByDir[i])
             {
@@ -3472,6 +3466,12 @@ void ride_construction_toolupdate_construct(sint32 screenX, sint32 screenY)
                 {
                     pathsByDir[i] = nullptr;
                 }
+            }
+
+            if (pathsByDir[i] &&
+                footpath_element_is_queue(pathsByDir[i]))
+            {
+                pathsByDir[i] = nullptr;
             }
 
             if (pathsByDir[i] && i == _currentTrackPieceDirection)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3451,6 +3451,12 @@ void ride_construction_toolupdate_construct(sint32 screenX, sint32 screenY)
                 pathsByDir[i] = nullptr;
             }
 
+            if (pathsByDir[i] &&
+                footpath_element_is_queue(pathsByDir[i]))
+            {
+                pathsByDir[i] = nullptr;
+            }
+
             // Sloped path on the level below
             if (!pathsByDir[i])
             {


### PR DESCRIPTION
Fixes #7424 