### PR TITLE
Fix graphs skipping values of 0

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
+- Fix: Graphs not drawing values of 0 properly.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,7 +19,7 @@
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
-- Fix: Graphs not drawing values of 0 properly.
+- Fix: Graphs skip values of 0.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -18,7 +18,7 @@
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2-ui/interface/Graph.h>
 
-static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, const uint8 *history, sint32 count, sint32 baseX, sint32 baseY)
+static void graph_draw_months_uint8(rct_drawpixelinfo * dpi, const uint8 * history, sint32 count, sint32 baseX, sint32 baseY)
 {
     sint32 i, x, y, yearOver32, currentMonth, currentDay;
 
@@ -27,8 +27,10 @@ static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
     x = baseX;
     y = baseY;
-    for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 255 && yearOver32 % 4 == 0) {
+    for (i = count - 1; i >= 0; i--)
+    {
+        if (history[i] != 255 && yearOver32 % 4 == 0)
+        {
             // Draw month text
             set_format_arg(0, uint32, DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
             gfx_draw_string_centred(dpi, STR_GRAPH_LABEL, x, y - 10, COLOUR_BLACK, gCommonFormatArgs);
@@ -42,17 +44,20 @@ static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     }
 }
 
-static void graph_draw_line_a_uint8(rct_drawpixelinfo *dpi, const uint8 *history, sint32 count, sint32 baseX, sint32 baseY)
+static void graph_draw_line_a_uint8(rct_drawpixelinfo * dpi, const uint8 * history, sint32 count, sint32 baseX, sint32 baseY)
 {
     sint32 i, x, y, lastX, lastY;
     lastX = -1;
     lastY = -1;
     x = baseX;
-    for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 255) {
+    for (i = count - 1; i >= 0; i--)
+    {
+        if (history[i] != 255)
+        {
             y = baseY + ((255 - history[i]) * 100) / 256;
 
-            if (lastX != -1) {
+            if (lastX != -1)
+            {
                 gfx_draw_line(dpi, lastX + 1, lastY + 1, x + 1, y + 1, PALETTE_INDEX_10);
                 gfx_draw_line(dpi, lastX, lastY + 1, x, y + 1, PALETTE_INDEX_10);
             }
@@ -66,15 +71,17 @@ static void graph_draw_line_a_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     }
 }
 
-static void graph_draw_line_b_uint8(rct_drawpixelinfo *dpi, const uint8 *history, sint32 count, sint32 baseX, sint32 baseY)
+static void graph_draw_line_b_uint8(rct_drawpixelinfo * dpi, const uint8 * history, sint32 count, sint32 baseX, sint32 baseY)
 {
     sint32 i, x, y, lastX, lastY;
 
     lastX = -1;
     lastY = -1;
     x = baseX;
-    for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 255) {
+    for (i = count - 1; i >= 0; i--)
+    {
+        if (history[i] != 255)
+        {
             y = baseY + ((255 - history[i]) * 100) / 256;
 
             if (lastX != -1)
@@ -89,7 +96,7 @@ static void graph_draw_line_b_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     }
 }
 
-void graph_draw_uint8(rct_drawpixelinfo *dpi, uint8 *history, sint32 count, sint32 baseX, sint32 baseY)
+void graph_draw_uint8(rct_drawpixelinfo * dpi, uint8 * history, sint32 count, sint32 baseX, sint32 baseY)
 {
     graph_draw_months_uint8(dpi, history, count, baseX, baseY);
     graph_draw_line_a_uint8(dpi, history, count, baseX, baseY);

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -28,7 +28,7 @@ static void graph_draw_months_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     x = baseX;
     y = baseY;
     for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 0 && history[i] != 255 && yearOver32 % 4 == 0) {
+        if (history[i] != 255 && yearOver32 % 4 == 0) {
             // Draw month text
             set_format_arg(0, uint32, DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
             gfx_draw_string_centred(dpi, STR_GRAPH_LABEL, x, y - 10, COLOUR_BLACK, gCommonFormatArgs);
@@ -49,7 +49,7 @@ static void graph_draw_line_a_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     lastY = -1;
     x = baseX;
     for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 0 && history[i] != 255) {
+        if (history[i] != 255) {
             y = baseY + ((255 - history[i]) * 100) / 256;
 
             if (lastX != -1) {
@@ -74,7 +74,7 @@ static void graph_draw_line_b_uint8(rct_drawpixelinfo *dpi, const uint8 *history
     lastY = -1;
     x = baseX;
     for (i = count - 1; i >= 0; i--) {
-        if (history[i] != 0 && history[i] != 255) {
+        if (history[i] != 255) {
             y = baseY + ((255 - history[i]) * 100) / 256;
 
             if (lastX != -1)


### PR DESCRIPTION
Graphs simply ignored values of 0 (for example in the guest count graph). This was not the case in vanilla Rollercoaster Tycoon 2.