### PR TITLE
Fix #7418: Staff walk off paths with a connection but no adjacent path

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
+- Fix: [#7418] Staff walk off paths with a connection but no adjacent path.
 - Fix: Cut-away view does not draw tile elements that have been moved down on the list.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3270,6 +3270,17 @@ void rct_peep::PerformNextAction(uint8 & pathing_result, rct_tile_element * & ti
                 return;
             }
 
+            if (type == PEEP_TYPE_STAFF && !GetNextIsSurface())
+            {
+                // Prevent staff from leaving the path on their own unless they're allowed to mow.
+                if (!((this->staff_orders & STAFF_ORDERS_MOWING) && this->staff_mowing_timeout >= 12))
+                {
+                    peep_return_to_centre_of_tile(this);
+                    return;
+                }
+            }
+
+            // The peep is on a surface and not on a path
             next_x      = actionX & 0xFFE0;
             next_y      = actionY & 0xFFE0;
             next_z      = tileElement->base_height;


### PR DESCRIPTION
This PR fixes #7418 and part of #7402.

There's however one caveat with this fix. Handyman who have the mowing task enabled, and are ready to mow but are looking for litter will walk off the path in a case as seen in the issues. This is because what action a handyman is planning on doing is not stored, unless it were to recheck for litter which is likely discouraged due to performance. So instead this will probably have to be a case of new file-format for now.