### PR TITLE
Feature #7459: Allow opening and closing of parks that use no money

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Feature: [#7316] Cheat to allow freezing all staff
 - Feature: [#7332] Keyboard shortcuts for view path issues and cutaway view.
 - Feature: [#7348] Add large half loops to the Vertical Drop Roller Coaster.
+- Feature: Allow opening and closing of parks that use no money.
 - Fix: [#2611] Some objects show (undefined string) instead of a description in Korean.
 - Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Feature: [#7316] Cheat to allow freezing all staff
 - Feature: [#7332] Keyboard shortcuts for view path issues and cutaway view.
 - Feature: [#7348] Add large half loops to the Vertical Drop Roller Coaster.
-- Feature: Allow opening and closing of parks that use no money.
+- Feature: [#7459] Allow opening and closing of parks that use no money.
 - Fix: [#2611] Some objects show (undefined string) instead of a description in Korean.
 - Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -775,9 +775,7 @@ static void window_park_entrance_invalidate(rct_window *w)
     window_park_entrance_widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + park_is_open() * 2 + widget_is_pressed(w, WIDX_OPEN_LIGHT);
 
     // Only allow closing of park for guest / rating objective
-    // Only allow closing of park when there is money
-    if (gScenarioObjectiveType == OBJECTIVE_GUESTS_AND_RATING ||
-        (gParkFlags & PARK_FLAGS_NO_MONEY))
+    if (gScenarioObjectiveType == OBJECTIVE_GUESTS_AND_RATING)
         w->disabled_widgets |= (1 << WIDX_OPEN_OR_CLOSE) | (1 << WIDX_CLOSE_LIGHT) | (1 << WIDX_OPEN_LIGHT);
     else
         w->disabled_widgets &= ~((1 << WIDX_OPEN_OR_CLOSE) | (1 << WIDX_CLOSE_LIGHT) | (1 << WIDX_OPEN_LIGHT));


### PR DESCRIPTION
I removed the check for the no_money flag in the function that decides if you can use the open/close button in the park UI window. Parks with no money now behave the same as normal parks for opening / closing. 