### PR TITLE
Fix #7331: Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#7176] Mechanics sometimes fall down from rides.
 - Fix: [#7303] Visual glitch with virtual floor near map edges.
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
+- Fix: [#7331] Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries.
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -549,6 +549,8 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
  */
 void research_populate_list_random()
 {
+    research_reset_items();
+
     // Rides
     for (sint32 i = 0; i < MAX_RIDE_OBJECTS; i++)
     {


### PR DESCRIPTION
Clear the `gResearch`-list before populating it. This is more of a workaround to ensure, that all items in the list are valid.  
This  fixes the crash from #7331.  

`void research_remove(rct_research_item * researchItem)` seems to not work correctly, as it never really removes anything due to incorrect input-items. This should also be analyzed.