### PR TITLE
Prepare tunnel door support

### DIFF
--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -149,7 +149,7 @@ static constexpr const uint8 byte_97B55D[] = {
     1, 5, 1, 3, 2, 3, 1, 5, 0
 };
 
-static constexpr const uint8 stru_97B570[][2] = {
+static constexpr const uint8 _tunnelHeights[TUNNEL_TYPE_COUNT][2] = {
     { 2, 2 },
     { 3, 3 },
     { 3, 5 },
@@ -165,10 +165,17 @@ static constexpr const uint8 stru_97B570[][2] = {
     { 2, 3 },
     { 3, 4 },
     { 2, 3 },
-    { 3, 4 }
+    { 3, 4 },
+    { 2, 2 },
+    { 2, 2 },
+    { 2, 2 },
+    { 2, 2 },
+    { 2, 2 },
+    { 2, 2 },
+    { 2, 2 },
 };
 
-static constexpr const sint16 word_97B590[] = {
+static constexpr const sint16 _boundBoxZOffsets[TUNNEL_TYPE_COUNT] = {
     0,
     0,
     -32,
@@ -185,13 +192,23 @@ static constexpr const sint16 word_97B590[] = {
     -16,
     -16,
     -16,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
 };
 
 // tunnel offset
-static constexpr const uint8 byte_97B5B0[] = {
+static constexpr const uint8 byte_97B5B0[TUNNEL_TYPE_COUNT] = {
     0, 0, 0, 3, 3, 3, 6, 6, 6, 6,
-    10, 11, 12, 13, 14, 14
+    10, 11, 12, 13, 14, 14,
+    16, 17, 18, 19, 20, 21, 22
 };
+
+#define EDGE_SPRITE_TYPE_COUNT 4
 
 #define DEFINE_EDGE_SPRITES(base) { \
     (base) +  0, \
@@ -216,9 +233,42 @@ static constexpr const uint8 byte_97B5B0[] = {
     (base) + 48, \
     (base) + 60, \
     (base) + 72, \
+    (base) + 36, \
+    (base) + 36, \
+    (base) + 36, \
+    (base) + 36, \
+    (base) + 36, \
+    (base) + 36, \
+    (base) + 36, \
 }
 
-static constexpr const uint32 _terrainEdgeSpriteIds[][TERRAIN_EDGE_COUNT] =
+#define DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(base) { \
+    (base) + 36, \
+    (base) + 40, \
+    (base) + 44, \
+    (base) + 48, \
+    (base) + 52, \
+    (base) + 56, \
+    (base) + 60, \
+    (base) + 64, \
+    (base) + 68, \
+    (base) + 72, \
+    (base) + 76, \
+    (base) + 80, \
+    (base) + 36, \
+    (base) + 48, \
+    (base) + 60, \
+    (base) + 72, \
+    (base) + 76, \
+    (base) + 80, \
+    (base) + 84, \
+    (base) + 88, \
+    (base) + 92, \
+    (base) + 96, \
+    (base) + 100, \
+}
+
+static constexpr const uint32 _terrainEdgeSpriteIds[][EDGE_SPRITE_TYPE_COUNT] =
 {
     DEFINE_EDGE_SPRITES(SPR_EDGE_ROCK_BASE),
     DEFINE_EDGE_SPRITES(SPR_EDGE_WOOD_RED_BASE),
@@ -237,7 +287,7 @@ static constexpr const uint32 _terrainEdgeSpriteIds[][TERRAIN_EDGE_COUNT] =
     DEFINE_EDGE_SPRITES(SPR_CSG_EDGE_SKYSCRAPER_B_BASE),
 };
 
-static constexpr const uint32 _terrainEdgeTunnelSpriteIds[][TERRAIN_EDGE_COUNT * 4] =
+static constexpr const uint32 _terrainEdgeTunnelSpriteIds[][TUNNEL_TYPE_COUNT] =
 {
     DEFINE_EDGE_TUNNEL_SPRITES(SPR_EDGE_ROCK_BASE),
     DEFINE_EDGE_TUNNEL_SPRITES(SPR_EDGE_WOOD_RED_BASE),
@@ -245,15 +295,15 @@ static constexpr const uint32 _terrainEdgeTunnelSpriteIds[][TERRAIN_EDGE_COUNT *
     DEFINE_EDGE_TUNNEL_SPRITES(SPR_EDGE_ICE_BASE),
     DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_BRICK_BASE),
     DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_IRON_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_GREY_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_YELLOW_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_RED_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_PURPLE_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_GREEN_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_STONE_BROWN_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_STONE_GREY_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_SKYSCRAPER_A_BASE),
-    DEFINE_EDGE_TUNNEL_SPRITES(SPR_CSG_EDGE_SKYSCRAPER_B_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_GREY_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_YELLOW_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_RED_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_PURPLE_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_GREEN_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_STONE_BROWN_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_STONE_GREY_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_SKYSCRAPER_A_BASE),
+    DEFINE_EDGE_TUNNEL_SPRITES_WITH_DOORS(SPR_CSG_EDGE_SKYSCRAPER_B_BASE),
 };
 
 static constexpr const uint8 byte_97B740[] =
@@ -715,7 +765,7 @@ static void viewport_surface_draw_tile_side_bottom(paint_session * session, enum
 
         // Tunnels
         uint8 tunnelType = tunnelArray[tunnelIndex].type;
-        uint8 tunnelHeight = stru_97B570[tunnelType][0];
+        uint8 tunnelHeight = _tunnelHeights[tunnelType][0];
         sint16 zOffset = curHeight;
 
         if ((zOffset + tunnelHeight) > ah || (zOffset + tunnelHeight) > al)
@@ -725,8 +775,8 @@ static void viewport_surface_draw_tile_side_bottom(paint_session * session, enum
 
         zOffset *= 16;
 
-        sint16 boundBoxOffsetZ = zOffset + word_97B590[tunnelType];
-        sint8 boundBoxLength = stru_97B570[tunnelType][1] * 16;
+        sint16 boundBoxOffsetZ = zOffset + _boundBoxZOffsets[tunnelType];
+        sint8 boundBoxLength = _tunnelHeights[tunnelType][1] * 16;
         if (boundBoxOffsetZ < 16)
         {
             boundBoxOffsetZ += 16;
@@ -739,8 +789,8 @@ static void viewport_surface_draw_tile_side_bottom(paint_session * session, enum
             boundBoxOffsetZ);
 
         boundBoxOffsetZ = curHeight * 16;
-        boundBoxLength = stru_97B570[tunnelType][1] * 16;
-        boundBoxOffsetZ += word_97B590[tunnelType];
+        boundBoxLength = _tunnelHeights[tunnelType][1] * 16;
+        boundBoxOffsetZ += _boundBoxZOffsets[tunnelType];
         if (boundBoxOffsetZ == 0)
         {
             boundBoxOffsetZ += 16;
@@ -752,7 +802,7 @@ static void viewport_surface_draw_tile_side_bottom(paint_session * session, enum
             session, image_id, offset.x, offset.y, tunnelBounds.x, tunnelBounds.y, boundBoxLength - 1, curHeight * 16,
             tunnelTopBoundBoxOffset.x, tunnelTopBoundBoxOffset.y, boundBoxOffsetZ);
 
-        curHeight += stru_97B570[tunnelType][0];
+        curHeight += _tunnelHeights[tunnelType][0];
         tunnelIndex++;
     }
 }

--- a/src/openrct2/paint/tile_element/TileElement.h
+++ b/src/openrct2/paint/tile_element/TileElement.h
@@ -65,6 +65,16 @@ enum
     TUNNEL_13 = 0x0D,
     TUNNEL_14 = 0x0E,
     TUNNEL_15 = 0x0F,
+    // Ghost train doors
+    TUNNEL_DOORS_0 = 16,
+    TUNNEL_DOORS_1 = 17,
+    TUNNEL_DOORS_2 = 18,
+    TUNNEL_DOORS_3 = 19,
+    TUNNEL_DOORS_4 = 20,
+    TUNNEL_DOORS_5 = 21,
+    TUNNEL_DOORS_6 = 22,
+
+    TUNNEL_TYPE_COUNT
 };
 
 enum

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -1232,6 +1232,12 @@ enum {
     RCT1_SCENERY_GEOMETRIC_SCULPTURE_5 = 171, // TGE5
 };
 
+enum {
+    RCT1_LANDSCAPE_DOOR_CLOSED = 0,
+    RCT1_LANDSCAPE_DOOR_HALF_OPEN = 2,
+    RCT1_LANDSCAPE_DOOR_OPEN = 3,
+};
+
 ParkLoadResult * load_from_sv4(const char *path);
 ParkLoadResult * load_from_sc4(const char *path);
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -2405,3 +2405,13 @@ void track_element_set_type(rct_tile_element * tileElement, uint8 type)
 {
     tileElement->properties.track.type = type;
 }
+
+uint8 track_element_get_door_a_state(const rct_tile_element * tileElement)
+{
+    return (tileElement->properties.track.colour & TRACK_ELEMENT_DOOR_A_MASK) >> 2;
+}
+
+uint8 track_element_get_door_b_state(const rct_tile_element * tileElement)
+{
+    return (tileElement->properties.track.colour & TRACK_ELEMENT_DOOR_B_MASK) >> 5;
+}

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -80,6 +80,9 @@ enum
 
     // Used for giga coaster
     TRACK_ELEMENT_COLOUR_FLAG_CABLE_LIFT = (1 << 3),
+
+    TRACK_ELEMENT_DOOR_A_MASK = 0b00011100,
+    TRACK_ELEMENT_DOOR_B_MASK = 0b11100000,
 };
 
 #define TRACK_ELEMENT_FLAG_MAGNITUDE_MASK 0x0F
@@ -586,3 +589,6 @@ uint8 track_element_get_ride_index(const rct_tile_element * tileElement);
 void track_element_set_ride_index(rct_tile_element * tileElement, uint8 rideIndex);
 uint8 track_element_get_type(const rct_tile_element * tileElement);
 void track_element_set_type(rct_tile_element * tileElement, uint8 rideIndex);
+
+uint8 track_element_get_door_a_state(const rct_tile_element * tileElement);
+uint8 track_element_get_door_b_state(const rct_tile_element * tileElement);


### PR DESCRIPTION
When investigating how tunnel doors in RCT1 work, I named some variables and updated some other code as well. The door drawing itself is not finished (and might only be implemented after increasing tile element size), but the rest is.

Also see #7059.