### PR TITLE
Add random walk jump event for peeps when they are happy.

### DIFF
--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -489,7 +489,7 @@ bool rct_peep::CheckForPath()
     path_check_optimisation++;
     if ((path_check_optimisation & 0xF) != (sprite_index & 0xF))
     {
-        // This condition makes the check happen less often 
+        // This condition makes the check happen less often
         // As a side effect peeps hover for a short,
         // random time when a path below them has been deleted
         return true;
@@ -626,7 +626,11 @@ bool rct_peep::UpdateAction(sint16 * actionX, sint16 * actionY, sint16 * xy_dist
 
     *xy_distance = x_delta + y_delta;
 
-    if (action == PEEP_ACTION_NONE_1 || action == PEEP_ACTION_NONE_2)
+    bool allowPeepMovement = (action == PEEP_ACTION_NONE_1) ||
+        (action == PEEP_ACTION_NONE_2) ||
+        (state == PEEP_STATE_WALKING && action == PEEP_ACTION_JUMP);
+
+    if (allowPeepMovement)
     {
         if (*xy_distance <= destination_tolerance)
         {
@@ -649,6 +653,7 @@ bool rct_peep::UpdateAction(sint16 * actionX, sint16 * actionY, sint16 * xy_dist
                 nextDirection = 0;
             }
         }
+
         sprite_direction = nextDirection;
         *actionX                     = x + word_981D7C[nextDirection / 8].x;
         *actionY                     = y + word_981D7C[nextDirection / 8].y;
@@ -658,6 +663,16 @@ bool rct_peep::UpdateAction(sint16 * actionX, sint16 * actionY, sint16 * xy_dist
         if (no_action_frame_num >= peepAnimation[action_sprite_type].num_frames)
         {
             no_action_frame_num = 0;
+            if (action == PEEP_ACTION_JUMP)
+            {
+                // No longer jumping, reset state.
+                action_sprite_image_offset = 0;
+                action = 0xFF;
+                UpdateCurrentActionSpriteType();
+                Invalidate();
+                *actionX = x;
+                *actionY = y;
+            }
         }
         action_sprite_image_offset = imageOffset[no_action_frame_num];
         return true;
@@ -1780,7 +1795,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
     if (intensityHighest >= 7)
         intensityHighest = 15;
 
-    /* Check which intensity boxes are enabled 
+    /* Check which intensity boxes are enabled
      * and apply the appropriate intensity settings. */
     if (gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
     {
@@ -1789,7 +1804,7 @@ rct_peep * peep_generate(sint32 x, sint32 y, sint32 z)
             intensityLowest = 0;
             intensityHighest = 15;
         }
-        else 
+        else
         {
             intensityLowest = 0;
             intensityHighest = 4;


### PR DESCRIPTION
As the title suggests this, this will make peeps randomly jump while walking if their happiness is >128, energy >= 64, nausea <= 32. They will also not jump if they are on a sloped path or carry an item.

I think this adds some new breath to the game as each jump also costs the peep 1 energy which should slightly change the game dynamics.

Small video showing the feature: https://share.epic-domain.com/2018-05-13_11-40-19.webm