### PR TITLE
Introduce parkobj and json object .png support

### DIFF
--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -161,7 +161,7 @@ private:
         if (!path.empty())
         {
             // Convert back slashes to forward slashes
-            result = std::move(std::string(path));
+            result = std::string(path);
             for (auto ch = result.data(); *ch != '\0'; ch++)
             {
                 if (*ch == '\\')

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -15,6 +15,7 @@
 #pragma endregion
 
 #include <string_view>
+#include <tuple>
 #include "../core/Imaging.h"
 #include "Drawing.h"
 
@@ -58,6 +59,10 @@ namespace OpenRCT2::Drawing
 
     private:
         static const PaletteBGRA StandardPalette[256];
+
+        static std::vector<sint32> GetPixels(const uint8 * pixels, uint32 width, uint32 height, IMPORT_FLAGS flags, IMPORT_MODE mode);
+        static std::tuple<void *, size_t> EncodeRaw(const sint32 * pixels, uint32 width, uint32 height);
+        static std::tuple<void *, size_t> EncodeRLE(const sint32 * pixels, uint32 width, uint32 height);
 
         static sint32 CalculatePaletteIndex(IMPORT_MODE mode, sint16 * rgbaSrc, sint32 x, sint32 y, sint32 width, sint32 height);
         static sint32 GetPaletteIndex(const PaletteBGRA * palette, sint16 * colour);

--- a/src/openrct2/drawing/Sprite.cpp
+++ b/src/openrct2/drawing/Sprite.cpp
@@ -736,8 +736,12 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(rct_drawpixelinfo *dpi, sint32
         return;
     }
 
-    assert(imgMask->flags & G1_FLAG_BMP);
-    assert(imgColour->flags & G1_FLAG_BMP);
+    // Only BMP format is supported for masking
+    if (!(imgMask->flags & G1_FLAG_BMP) || !(imgColour->flags & G1_FLAG_BMP))
+    {
+        gfx_draw_sprite_software(dpi, colourImage, x, y, 0);
+        return;
+    }
 
     if (dpi->zoom_level != 0) {
         // TODO: Implement other zoom levels (probably not used though)

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <string_view>
+#include <vector>
 #include "../common.h"
 #include "../core/Json.hpp"
 #include "ImageTable.h"
@@ -122,6 +124,7 @@ interface IReadObjectContext
 
     virtual IObjectRepository& GetObjectRepository() abstract;
     virtual bool ShouldLoadImages() abstract;
+    virtual std::vector<uint8> GetData(const std::string_view& path) abstract;
 
     virtual void LogWarning(uint32 code, const utf8 * text) abstract;
     virtual void LogError(uint32 code, const utf8 * text) abstract;

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -104,9 +104,9 @@ public:
         bool loadImages,
         const IFileDataRetriever * fileDataRetriever)
         : _objectRepository(objectRepository),
+          _fileDataRetriever(fileDataRetriever),
           _objectName(objectName),
-          _loadImages(loadImages),
-          _fileDataRetriever(fileDataRetriever)
+          _loadImages(loadImages)
     {
     }
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -270,7 +270,7 @@ namespace ObjectFactory
         try
         {
             auto jRoot = Json::ReadFromFile(path.c_str());
-            CreateObjectFromJson(objectRepository, jRoot);
+            result = CreateObjectFromJson(objectRepository, jRoot);
             json_decref(jRoot);
         }
         catch (const std::runtime_error &err)

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <string_view>
 #include "../common.h"
 
 interface IObjectRepository;
@@ -26,6 +27,7 @@ namespace ObjectFactory
 {
     Object * CreateObjectFromLegacyFile(IObjectRepository& objectRepository, const utf8 * path);
     Object * CreateObjectFromLegacyData(IObjectRepository& objectRepository, const rct_object_entry * entry, const void * data, size_t dataSize);
+    Object * CreateObjectFromZipFile(IObjectRepository& objectRepository, const std::string_view& path);
     Object * CreateObject(const rct_object_entry &entry);
 
     Object * CreateObjectFromJsonFile(IObjectRepository& objectRepository, const std::string &path);

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -26,6 +26,7 @@
 #include "../core/Memory.hpp"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
+#include "../drawing/ImageImporter.h"
 #include "../interface/Cursors.h"
 #include "../localisation/Language.h"
 #include "../PlatformEnvironment.h"
@@ -35,6 +36,7 @@
 #include "ObjectJsonHelpers.h"
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::Drawing;
 
 namespace ObjectJsonHelpers
 {
@@ -314,6 +316,27 @@ namespace ObjectJsonHelpers
                 auto range = ParseRange(name.substr(rangeStart));
                 name = name.substr(0, rangeStart);
                 result = LoadObjectImages(context, name, range);
+            }
+        }
+        else
+        {
+            try
+            {
+                auto imageData = context->GetData(s);
+                auto image = Imaging::ReadFromBuffer(imageData, IMAGE_FORMAT::PNG_32);
+
+                ImageImporter importer;
+                auto importResult = importer.Import(image, 0, 0, ImageImporter::IMPORT_FLAGS::RLE);
+
+                result.push_back(importResult.Element);
+            }
+            catch (const std::exception& e)
+            {
+                auto msg = String::StdFormat("Unable to load image '%s': %s", s.c_str(), e.what());
+                context->LogWarning(OBJECT_ERROR_BAD_IMAGE_TABLE, msg.c_str());
+
+                rct_g1_element emptyg1 = { 0 };
+                result.push_back(emptyg1);
             }
         }
         return result;

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -426,11 +426,11 @@ namespace ObjectJsonHelpers
                 if (json_is_string(el))
                 {
                     auto s = json_string_value(el);
-                    images = std::move(ParseImages(context, s));
+                    images = ParseImages(context, s);
                 }
                 else if (json_is_object(el))
                 {
-                    images = std::move(ParseImages(context, el));
+                    images = ParseImages(context, el);
                 }
                 for (const auto &g1 : images)
                 {

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -347,15 +347,21 @@ namespace ObjectJsonHelpers
         auto path = GetString(el, "path");
         auto x = GetInteger(el, "x");
         auto y = GetInteger(el, "y");
+        auto raw = (GetString(el, "format") == "raw");
 
         std::vector<rct_g1_element> result;
         try
         {
+            auto flags = ImageImporter::IMPORT_FLAGS::NONE;
+            if (!raw)
+            {
+                flags = (ImageImporter::IMPORT_FLAGS)(flags | ImageImporter::IMPORT_FLAGS::RLE);
+            }
             auto imageData = context->GetData(path);
             auto image = Imaging::ReadFromBuffer(imageData, IMAGE_FORMAT::PNG_32);
 
             ImageImporter importer;
-            auto importResult = importer.Import(image, 0, 0, ImageImporter::IMPORT_FLAGS::RLE);
+            auto importResult = importer.Import(image, 0, 0, flags);
             auto g1Element = importResult.Element;
             g1Element.x_offset = x;
             g1Element.y_offset = y;

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -103,34 +103,29 @@ public:
 public:
     std::tuple<bool, ObjectRepositoryItem> Create(sint32 language, const std::string &path) const override
     {
+        Object * object = nullptr;
         auto extension = Path::GetExtension(path);
         if (String::Equals(extension, ".json", true))
         {
-            auto object = ObjectFactory::CreateObjectFromJsonFile(_objectRepository, path);
-            if (object != nullptr)
-            {
-                ObjectRepositoryItem item = { 0 };
-                item.ObjectEntry = *object->GetObjectEntry();
-                item.Path = String::Duplicate(path);
-                item.Name = String::Duplicate(object->GetName(language));
-                object->SetRepositoryItem(&item);
-                delete object;
-                return std::make_tuple(true, item);
-            }
+            object = ObjectFactory::CreateObjectFromJsonFile(_objectRepository, path);
+        }
+        else if (String::Equals(extension, ".parkobj", true))
+        {
+            object = ObjectFactory::CreateObjectFromZipFile(_objectRepository, path);
         }
         else
         {
-            auto object = ObjectFactory::CreateObjectFromLegacyFile(_objectRepository, path.c_str());
-            if (object != nullptr)
-            {
-                ObjectRepositoryItem item = { 0 };
-                item.ObjectEntry = *object->GetObjectEntry();
-                item.Path = String::Duplicate(path);
-                item.Name = String::Duplicate(object->GetName());
-                object->SetRepositoryItem(&item);
-                delete object;
-                return std::make_tuple(true, item);
-            }
+            object = ObjectFactory::CreateObjectFromLegacyFile(_objectRepository, path.c_str());
+        }
+        if (object != nullptr)
+        {
+            ObjectRepositoryItem item = { 0 };
+            item.ObjectEntry = *object->GetObjectEntry();
+            item.Path = String::Duplicate(path);
+            item.Name = String::Duplicate(object->GetName());
+            object->SetRepositoryItem(&item);
+            delete object;
+            return std::make_tuple(true, item);
         }
         return std::make_tuple(false, ObjectRepositoryItem());
     }
@@ -284,6 +279,10 @@ public:
         if (String::Equals(extension, ".json", true))
         {
             return ObjectFactory::CreateObjectFromJsonFile(*this, ori->Path);
+        }
+        else if (String::Equals(extension, ".parkobj", true))
+        {
+            return ObjectFactory::CreateObjectFromZipFile(*this, ori->Path);
         }
         else
         {

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -82,7 +82,7 @@ class ObjectFileIndex final : public FileIndex<ObjectRepositoryItem>
 private:
     static constexpr uint32 MAGIC_NUMBER = 0x5844494F; // OIDX
     static constexpr uint16 VERSION = 17;
-    static constexpr auto PATTERN = "*.dat;*.pob;*.json";
+    static constexpr auto PATTERN = "*.dat;*.pob;*.json;*.parkobj";
 
     IObjectRepository& _objectRepository;
 


### PR DESCRIPTION
New objects can now be zip files (with .parkobj extension) containing `object.json` and png images references from the json.

png loading is also supported for json files not contained with zip files which is useful for object development.

**Example:**
[rct1.toilets.parkobj.zip](https://github.com/OpenRCT2/OpenRCT2/files/1998355/rct1.toilets.parkobj.zip) (remove zip extension)

**object.json:**
```json
    ...
    "images": [
        { "path": "images/64231.png", "format": "raw" },
        "",
        "",
        { "path": "images/61289.png", "x": -32, "y": -18 },
        { "path": "images/61290.png", "x": -32, "y": -27 },
        { "path": "images/61291.png", "x": -32, "y": -27 },
        { "path": "images/61292.png", "x": 11, "y": -17 },
        { "path": "images/61293.png", "x": -20, "y": -27 },
        { "path": "images/61294.png", "x": -32, "y": -27 }
    ],
    ...
```

