### PR TITLE
Split gResearchItems into separate vectors

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -33,6 +33,8 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/ride/RideGroupManager.h>
 
+#include <algorithm>
+
 #pragma region Widgets
 
 #define WW 600
@@ -162,14 +164,6 @@ static rct_window_event_list window_editor_inventions_list_drag_events = {
 
 #pragma endregion
 
-namespace
-{
-bool compare_research_items (const rct_research_item& First, const rct_research_item& Second)
-{
-    return First.rawValue == Second.rawValue && First.category == Second.category;
-}
-}
-
 static rct_research_item *_editorInventionsListDraggedItem;
 
 static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
@@ -185,6 +179,25 @@ static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
 
 static void window_editor_inventions_list_drag_open(rct_research_item *researchItem);
 static void move_research_item(rct_research_item *beforeItem);
+
+namespace
+{
+bool compare_research_items(const rct_research_item& First, const rct_research_item& Second)
+{
+    return First.rawValue == Second.rawValue && First.category == Second.category;
+}
+
+void research_set_always_researched_flag(const uint8 entryIndex, rct_research_item& researchItem)
+{
+    if ((researchItem.rawValue & 0xFFFFFF) == entryIndex)
+    {
+        researchItem.flags |= RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED;
+        _editorInventionsListDraggedItem = &researchItem;
+        move_research_item(gResearchedResearchItems.data());
+        _editorInventionsListDraggedItem = nullptr;
+    }
+}
+} // namespace
 
 /**
  *
@@ -211,17 +224,6 @@ static void research_rides_setup()
         {
             Editor::SetSelectedObject(OBJECT_TYPE_RIDE, ride->subtype, OBJECT_SELECTION_FLAG_SELECTED);
         }
-    }
-}
-
-void research_set_always_researched_flag(const uint8 entryIndex, rct_research_item& researchItem)
-{
-    if ((researchItem.rawValue & 0xFFFFFF) == entryIndex)
-    {
-        researchItem.flags |= RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED;
-        _editorInventionsListDraggedItem = &researchItem;
-        move_research_item(gResearchedResearchItems.data());
-        _editorInventionsListDraggedItem = nullptr;
     }
 }
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -193,7 +193,7 @@ void research_set_always_researched_flag(const uint8 entryIndex, rct_research_it
     {
         researchItem.flags |= RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED;
         _editorInventionsListDraggedItem = &researchItem;
-        move_research_item(gResearchedResearchItems.front());
+        move_research_item(ResearchItem::gResearched.front());
         _editorInventionsListDraggedItem = nullptr;
     }
 }
@@ -272,11 +272,11 @@ static void research_scenery_groups_setup()
         if (find_object_in_entry_group(object, &entry_type, &entryIndex) &&
             entry_type == OBJECT_TYPE_SCENERY_GROUP)
         {
-            for (rct_research_item& researchItem : gResearchedResearchItems)
+            for (rct_research_item& researchItem : ResearchItem::gResearched)
             {
                 research_set_always_researched_flag(entryIndex, researchItem);
             }
-            for (rct_research_item& researchItem : gUnResearchedResearchItems)
+            for (rct_research_item& researchItem : ResearchItem::gResearchable)
             {
                 research_set_always_researched_flag(entryIndex, researchItem);
             }
@@ -302,25 +302,25 @@ static void move_research_item(const rct_research_item& beforeItem)
 {
     const rct_research_item copy = *_editorInventionsListDraggedItem;
     
-    if (!remove(copy, gResearchedResearchItems))
+    if (!remove(copy, ResearchItem::gResearched))
     {
-        if (!remove(copy, gUnResearchedResearchItems))
+        if (!remove(copy, ResearchItem::gResearchable))
         {
             assert(0); // item not found
         }
     }
 
-    if (compare_research_items(beforeItem, gResearchItemSeparator))
+    if (compare_research_items(beforeItem, ResearchItem::gSeparator))
     {
-        gResearchedResearchItems.push_back(copy);
+        ResearchItem::gResearched.push_back(copy);
     }
-    else if (compare_research_items(beforeItem, gResearchItemEnd))
+    else if (compare_research_items(beforeItem, ResearchItem::gEnd))
     {
-        gUnResearchedResearchItems.push_back(copy);
+        ResearchItem::gResearchable.push_back(copy);
     }
-    else if (!insert(copy, beforeItem, gResearchedResearchItems))
+    else if (!insert(copy, beforeItem, ResearchItem::gResearched))
     {
-        if (!insert(copy, beforeItem, gUnResearchedResearchItems))
+        if (!insert(copy, beforeItem, ResearchItem::gResearchable))
         {
             assert(0); // item not inserted
         }
@@ -342,7 +342,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y(s
 {
     if (scrollIndex == 0)
     {
-        for (rct_research_item& researchItem : gResearchedResearchItems)
+        for (rct_research_item& researchItem : ResearchItem::gResearched)
         {
             y -= SCROLLABLE_ROW_HEIGHT;
             if (y < 0)
@@ -357,7 +357,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y(s
     }
     else
     {
-        for (rct_research_item& researchItem : gUnResearchedResearchItems)
+        for (rct_research_item& researchItem : ResearchItem::gResearchable)
         {
             y -= SCROLLABLE_ROW_HEIGHT;
             if (y < 0)
@@ -378,7 +378,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_i
 {
     if (scrollIndex == 0)
     {
-        for (rct_research_item& researchItem : gResearchedResearchItems)
+        for (rct_research_item& researchItem : ResearchItem::gResearched)
         {
             y -= SCROLLABLE_ROW_HEIGHT;
             if (y < 0)
@@ -386,10 +386,10 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_i
                 return &researchItem;
             }
         }
-        return &gResearchItemSeparator;
+        return &ResearchItem::gSeparator;
     }
 
-    for (rct_research_item& researchItem : gUnResearchedResearchItems)
+    for (rct_research_item& researchItem : ResearchItem::gResearchable)
     {
         y -= SCROLLABLE_ROW_HEIGHT;
         if (y < 0)
@@ -397,7 +397,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_i
             return &researchItem;
         }
     }
-    return &gResearchItemEnd;
+    return &ResearchItem::gEnd;
 }
 
 static rct_research_item *get_research_item_at(sint32 x, sint32 y)
@@ -551,12 +551,12 @@ static void window_editor_inventions_list_scrollgetheight(rct_window *w, sint32 
     if (scrollIndex == 1)
     {
         // Count non pre-researched items
-        *height = SCROLLABLE_ROW_HEIGHT * static_cast<sint32>(gUnResearchedResearchItems.size());
+        *height = SCROLLABLE_ROW_HEIGHT * static_cast<sint32>(ResearchItem::gResearchable.size());
     }
     else
     {
         // Count / skip pre-researched items
-        *height = SCROLLABLE_ROW_HEIGHT * static_cast<sint32>(gResearchedResearchItems.size());
+        *height = SCROLLABLE_ROW_HEIGHT * static_cast<sint32>(ResearchItem::gResearched.size());
     }
 }
 
@@ -783,9 +783,9 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
     {
         if (scrollIndex == 1)
         {
-            return gUnResearchedResearchItems;
+            return ResearchItem::gResearchable;
         }
-        return gResearchedResearchItems;
+        return ResearchItem::gResearched;
     }();
 
     itemY = -SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -374,7 +374,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y(s
  *
  *  rct2: 0x006855BB
  */
-static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_include_seps(sint32 scrollIndex, sint32 y)
+static const rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_include_seps(sint32 scrollIndex, sint32 y)
 {
     if (scrollIndex == 0)
     {
@@ -400,7 +400,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_i
     return &ResearchItem::gEnd;
 }
 
-static rct_research_item *get_research_item_at(sint32 x, sint32 y)
+static const rct_research_item *get_research_item_at(sint32 x, sint32 y)
 {
     rct_window *w = window_find_by_class(WC_EDITOR_INVENTION_LIST);
     if (w != nullptr && w->x <= x && w->y < y && w->x + w->width > x && w->y + w->height > y) {
@@ -922,7 +922,7 @@ static void window_editor_inventions_list_drag_cursor(rct_window *w, rct_widgeti
 {
     rct_window *inventionListWindow = window_find_by_class(WC_EDITOR_INVENTION_LIST);
     if (inventionListWindow != nullptr) {
-        rct_research_item *researchItem = get_research_item_at(x, y);
+        const rct_research_item *researchItem = get_research_item_at(x, y);
         if (researchItem != inventionListWindow->research_item) {
             inventionListWindow = (rct_window *)researchItem;
             window_invalidate(inventionListWindow);
@@ -938,7 +938,7 @@ static void window_editor_inventions_list_drag_cursor(rct_window *w, rct_widgeti
  */
 static void window_editor_inventions_list_drag_moved(rct_window* w, sint32 x, sint32 y)
 {
-    rct_research_item* researchItem = get_research_item_at(x, y);
+    const rct_research_item* researchItem = get_research_item_at(x, y);
     if (researchItem)
     {
         move_research_item(*researchItem);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -788,76 +788,75 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
     for (const rct_research_item& researchItem : listToPaint)
     {
         itemY += SCROLLABLE_ROW_HEIGHT;
-        if (itemY + SCROLLABLE_ROW_HEIGHT < dpi->y || itemY >= dpi->y + dpi->height)
+        if (itemY + SCROLLABLE_ROW_HEIGHT >= dpi->y || itemY < dpi->y + dpi->height)
         {
-            return;
-        }
-
-        uint8 colour = COLOUR_BRIGHT_GREEN | COLOUR_FLAG_TRANSLUCENT;
-        if (w->research_item && compare_research_items(*w->research_item, researchItem))
-        {
-            if (_editorInventionsListDraggedItem == nullptr)
+            uint8 colour = COLOUR_BRIGHT_GREEN | COLOUR_FLAG_TRANSLUCENT;
+            if (w->research_item && compare_research_items(*w->research_item, researchItem))
             {
-                // Highlight
-                top = itemY;
-                bottom = itemY + SCROLLABLE_ROW_HEIGHT - 1;
-            }
-            else
-            {
-                // Drop horizontal rule
-                top = itemY - 1;
-                bottom = itemY;
-            }
-
-            if (_editorInventionsListDraggedItem == nullptr)
-            {
-                colour = COLOUR_BRIGHT_GREEN;
-            }
-        }
-
-        if (&researchItem != _editorInventionsListDraggedItem)
-        {
-            disableItemMovement = research_item_is_always_researched(&researchItem);
-
-            stringId = research_item_get_name(&researchItem);
-
-            ptr = buffer;
-            if (!disableItemMovement)
-            {
-                ptr = utf8_write_codepoint(ptr, colour);
-            }
-
-            if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE
-                && !RideGroupManager::RideTypeIsIndependent(researchItem.baseRideType))
-            {
-                const rct_string_id rideGroupName
-                    = get_ride_naming(researchItem.baseRideType, get_ride_entry(researchItem.entryIndex)).name;
-                rct_string_id args[] = { rideGroupName, stringId };
-                format_string(ptr, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, &args);
-            }
-            else
-            {
-                format_string(ptr, 256, stringId, nullptr);
-            }
-
-            if (disableItemMovement)
-            {
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
-                if (colour == COLOUR_BRIGHT_GREEN && _editorInventionsListDraggedItem == nullptr)
+                if (_editorInventionsListDraggedItem == nullptr)
                 {
-                    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK;
+                    // Highlight
+                    top = itemY;
+                    bottom = itemY + SCROLLABLE_ROW_HEIGHT - 1;
                 }
-                colour = COLOUR_FLAG_INSET | w->colours[1];
-            }
-            else
-            {
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-                colour = COLOUR_BLACK;
+                else
+                {
+                    // Drop horizontal rule
+                    top = itemY - 1;
+                    bottom = itemY;
+                }
+                gfx_filter_rect(dpi, 0, top, w->width, bottom, PALETTE_DARKEN_1);
+
+                if (_editorInventionsListDraggedItem == nullptr)
+                {
+                    colour = COLOUR_BRIGHT_GREEN;
+                }
             }
 
-            left = 1;
-            top = itemY;
-            gfx_draw_string(dpi, buffer, colour, left, top);
+            if (&researchItem != _editorInventionsListDraggedItem)
+            {
+                disableItemMovement = research_item_is_always_researched(&researchItem);
+
+                stringId = research_item_get_name(&researchItem);
+
+                ptr = buffer;
+                if (!disableItemMovement)
+                {
+                    ptr = utf8_write_codepoint(ptr, colour);
+                }
+
+                if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE
+                    && !RideGroupManager::RideTypeIsIndependent(researchItem.baseRideType))
+                {
+                    const rct_string_id rideGroupName
+                        = get_ride_naming(researchItem.baseRideType, get_ride_entry(researchItem.entryIndex)).name;
+                    rct_string_id args[] = { rideGroupName, stringId };
+                    format_string(ptr, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, &args);
+                }
+                else
+                {
+                    format_string(ptr, 256, stringId, nullptr);
+                }
+
+                if (disableItemMovement)
+                {
+                    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                    if (colour == COLOUR_BRIGHT_GREEN && _editorInventionsListDraggedItem == nullptr)
+                    {
+                        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK;
+                    }
+                    colour = COLOUR_FLAG_INSET | w->colours[1];
+                }
+                else
+                {
+                    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+                    colour = COLOUR_BLACK;
+                }
+
+                left = 1;
+                top = itemY;
+                gfx_draw_string(dpi, buffer, colour, left, top);
+            }
         }
     }
 }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -285,7 +285,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
             tmp.type = RESEARCH_ENTRY_TYPE_RIDE;
             tmp.entryIndex = entry_index;
             tmp.baseRideType = rideType;
-            research_remove(&tmp);
+            research_remove(tmp);
         }
     }
     else if (entry_type == OBJECT_TYPE_SCENERY_GROUP)
@@ -293,7 +293,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
         rct_research_item tmp = {};
         tmp.type = RESEARCH_ENTRY_TYPE_SCENERY;
         tmp.entryIndex = entry_index;
-        research_remove(&tmp);
+        research_remove(tmp);
     }
 }
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -931,7 +931,7 @@ rct_widgetindex window_find_widget_from_point(rct_window *w, sint32 x, sint32 y)
  *
  * @param window The window to invalidate (esi).
  */
-void window_invalidate(rct_window *window)
+void window_invalidate(const rct_window *window)
 {
     if (window != nullptr)
         gfx_set_dirty_blocks(window->x, window->y, window->x + window->width, window->y + window->height);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -571,7 +571,7 @@ rct_window *window_find_by_class(rct_windowclass cls);
 rct_window *window_find_by_number(rct_windowclass cls, rct_windownumber number);
 rct_window *window_find_from_point(sint32 x, sint32 y);
 rct_widgetindex window_find_widget_from_point(rct_window *w, sint32 x, sint32 y);
-void window_invalidate(rct_window *window);
+void window_invalidate(const rct_window *window);
 void window_invalidate_by_class(rct_windowclass cls);
 void window_invalidate_by_number(rct_windowclass cls, rct_windownumber number);
 void window_invalidate_all();

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -54,9 +54,9 @@ rct_research_item gResearchNextItem;
 
 namespace ResearchItem
 {
-rct_research_item gSeparator = { RESEARCHED_ITEMS_SEPARATOR, 0 };
-rct_research_item gEnd = { RESEARCHED_ITEMS_END, 0 };
-rct_research_item gEnd2 = { RESEARCHED_ITEMS_END_2, 0 };
+const rct_research_item gSeparator = { RESEARCHED_ITEMS_SEPARATOR, 0 };
+const rct_research_item gEnd = { RESEARCHED_ITEMS_END, 0 };
+const rct_research_item gEnd2 = { RESEARCHED_ITEMS_END_2, 0 };
 std::vector<rct_research_item> gResearched;
 std::vector<rct_research_item> gResearchable;
 #ifdef _DEBUG

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -1,4 +1,4 @@
-#pragma region Copyright (c) 2014-2017 OpenRCT2 Developers
+#pragma region Copyright(c) 2014 - 2017 OpenRCT2 Developers
 /*****************************************************************************
  * OpenRCT2, an open source clone of Roller Coaster Tycoon 2.
  *
@@ -14,10 +14,14 @@
  *****************************************************************************/
 #pragma endregion
 
+#include "Research.h"
 #include <algorithm>
+#include <map>
+#include <random>
 #include "../actions/ParkSetResearchFundingAction.hpp"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
+#include "../core/Memory.hpp"
 #include "../core/Util.hpp"
 #include "../Game.h"
 #include "../interface/Window.h"
@@ -26,36 +30,40 @@
 #include "../localisation/StringIds.h"
 #include "../object/ObjectList.h"
 #include "../OpenRCT2.h"
-#include "../scenario/Scenario.h"
 #include "../rct1/RCT1.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/RideGroupManager.h"
 #include "../ride/TrackData.h"
-#include "../world/Scenery.h"
-#include "NewsItem.h"
-#include "Finance.h"
-#include "Research.h"
-#include "../core/Memory.hpp"
+#include "../scenario/Scenario.h"
 #include "../util/Util.h"
+#include "../world/Scenery.h"
+#include "Finance.h"
+#include "NewsItem.h"
 
-static constexpr const sint32 _researchRate[] = {0, 160, 250, 400};
+static constexpr const sint32 _researchRate[] = { 0, 160, 250, 400 };
 
-uint8  gResearchFundingLevel;
-uint8  gResearchPriorities;
+uint8 gResearchFundingLevel;
+uint8 gResearchPriorities;
 uint16 gResearchProgress;
-uint8  gResearchProgressStage;
+uint8 gResearchProgressStage;
 rct_research_item gResearchLastItem;
-uint8  gResearchExpectedMonth;
-uint8  gResearchExpectedDay;
+uint8 gResearchExpectedMonth;
+uint8 gResearchExpectedDay;
 rct_research_item gResearchNextItem;
 
-rct_research_item gResearchItemSeparator = { RESEARCHED_ITEMS_SEPARATOR, 0 };
-rct_research_item gResearchItemEnd = { RESEARCHED_ITEMS_END, 0 };
-rct_research_item gResearchItemEnd2 = { RESEARCHED_ITEMS_END_2, 0 };
-std::vector<rct_research_item> gResearchedResearchItems;
-std::vector<rct_research_item> gUnResearchedResearchItems;
-std::vector<rct_research_item> gUnresearchableResearchItems;
+namespace ResearchItem
+{
+rct_research_item gSeparator = { RESEARCHED_ITEMS_SEPARATOR, 0 };
+rct_research_item gEnd = { RESEARCHED_ITEMS_END, 0 };
+rct_research_item gEnd2 = { RESEARCHED_ITEMS_END_2, 0 };
+std::vector<rct_research_item> gResearched;
+std::vector<rct_research_item> gResearchable;
+#ifdef _DEBUG
+std::map<sint32, std::string> gNames;
+#endif
+} // namespace ResearchItem
+
 
 // 0x00EE787C
 uint8 gResearchUncompletedCategories;
@@ -72,7 +80,7 @@ bool compare_research_items(const rct_research_item& First, const rct_research_i
 {
     return First.rawValue == Second.rawValue;
 }
-}
+} // namespace
 
 /**
  *
@@ -80,8 +88,12 @@ bool compare_research_items(const rct_research_item& First, const rct_research_i
  */
 void research_reset_items()
 {
-    gResearchedResearchItems.clear();
-    gUnResearchedResearchItems.clear();
+    ResearchItem::gResearched.clear();
+    ResearchItem::gResearchable.clear();
+
+#ifdef _DEBUG
+    ResearchItem::gNames.clear();
+#endif
 }
 
 /**
@@ -91,7 +103,7 @@ void research_reset_items()
 void research_update_uncompleted_types()
 {
     sint32 uncompletedResearchTypes = 0;
-    for (const rct_research_item& researchItem : gUnResearchedResearchItems)
+    for (const rct_research_item& researchItem : ResearchItem::gResearchable)
     {
         uncompletedResearchTypes |= (1 << researchItem.category);
     }
@@ -115,14 +127,14 @@ static void research_calculate_expected_date()
         progressRemaining -= gResearchProgress;
         sint32 daysRemaining = (progressRemaining / _researchRate[gResearchFundingLevel]) * 128;
 
-        sint32 expectedDay  = gDateMonthTicks + (daysRemaining & 0xFFFF);
-        sint32 dayQuotient  = expectedDay / 0x10000;
+        sint32 expectedDay = gDateMonthTicks + (daysRemaining & 0xFFFF);
+        sint32 dayQuotient = expectedDay / 0x10000;
         sint32 dayRemainder = expectedDay % 0x10000;
 
         sint32 expectedMonth = date_get_month(gDateMonthsElapsed + dayQuotient + (daysRemaining >> 16));
         expectedDay = (dayRemainder * days_in_month[expectedMonth]) >> 16;
 
-        gResearchExpectedDay   = expectedDay;
+        gResearchExpectedDay = expectedDay;
         gResearchExpectedMonth = expectedMonth;
     }
 }
@@ -141,7 +153,7 @@ static void research_next_design()
 {
     gResearchProgress = 0;
 
-    if (gUnResearchedResearchItems.empty()) // Reset funding to 0 if no more rides.
+    if (ResearchItem::gResearchable.empty()) // Reset funding to 0 if no more rides.
     {
         gResearchProgressStage = RESEARCH_STAGE_FINISHED_ALL;
         research_invalidate_related_windows();
@@ -150,8 +162,8 @@ static void research_next_design()
     }
     else
     {
-        gResearchNextItem = gResearchItemEnd;
-        for (const rct_research_item& researchItem : gUnResearchedResearchItems)
+        gResearchNextItem = ResearchItem::gEnd;
+        for (const rct_research_item& researchItem : ResearchItem::gResearchable)
         {
             if (gResearchPriorities & (1 << researchItem.category))
             {
@@ -160,9 +172,9 @@ static void research_next_design()
             }
         }
 
-        if (! compare_research_items(gResearchNextItem, gResearchItemEnd))
+        if (!compare_research_items(gResearchNextItem, ResearchItem::gEnd))
         {
-            gResearchNextItem = gUnResearchedResearchItems.front();
+            gResearchNextItem = ResearchItem::gResearchable.front();
         }
 
         gResearchProgressStage = RESEARCH_STAGE_DESIGNING;
@@ -190,7 +202,7 @@ void research_finish_item(rct_research_item* researchItem)
         if (rideEntry != nullptr && base_ride_type != RIDE_TYPE_NULL)
         {
             bool ride_group_was_invented_before = false;
-            bool ride_type_was_invented_before  = ride_type_is_invented(base_ride_type);
+            bool ride_type_was_invented_before = ride_type_is_invented(base_ride_type);
             rct_string_id availabilityString;
 
             // Determine if the ride group this entry belongs to was invented before.
@@ -214,7 +226,7 @@ void research_finish_item(rct_research_item* researchItem)
 
             bool seenRideEntry[MAX_RIDE_OBJECTS];
 
-            for (rct_research_item& researchItem2 : gResearchedResearchItems)
+            for (rct_research_item& researchItem2 : ResearchItem::gResearched)
             {
                 if (researchItem2.type == RESEARCH_ENTRY_TYPE_RIDE)
                 {
@@ -361,43 +373,22 @@ void research_update()
 
 void research_process_random_items()
 {
-    /*
-    rct_research_item * research = gResearchItems;
-    for (; research->rawValue != RESEARCHED_ITEMS_END; research++) { }
-
-    research++;
-    for (; research->rawValue != RESEARCHED_ITEMS_END_2; research += 2)
+    for (rct_research_item& resesarchItem : ResearchItem::gResearchable)
     {
         if (scenario_rand() & 1)
         {
             continue;
         }
 
-        rct_research_item * edx            = nullptr;
-        rct_research_item * ebp            = nullptr;
-        rct_research_item * inner_research = gResearchItems;
-        do
+        for (rct_research_item& researchedResesarchItem : ResearchItem::gResearched)
         {
-            if (research->rawValue == inner_research->rawValue)
+            if (resesarchItem.rawValue == researchedResesarchItem.rawValue)
             {
-                edx = inner_research;
-            }
-            if ((research + 1)->rawValue == inner_research->rawValue)
-            {
-                ebp = inner_research;
+                std::swap(resesarchItem, researchedResesarchItem);
+                assert(0);
             }
         }
-        while ((inner_research++)->rawValue != RESEARCHED_ITEMS_END);
-        assert(edx != nullptr);
-        edx->rawValue = research->rawValue;
-        assert(ebp != nullptr);
-        ebp->rawValue = (research + 1)->rawValue;
-
-        uint8 cat = edx->category;
-        edx->category = ebp->category;
-        ebp->category = cat;
     }
-    */
 }
 
 /**
@@ -415,12 +406,12 @@ void research_reset_current_item()
     set_all_scenery_items_invented();
     set_all_scenery_groups_not_invented();
 
-    for (rct_research_item& research : gResearchedResearchItems)
+    for (rct_research_item& research : ResearchItem::gResearched)
     {
         research_finish_item(&research);
     }
 
-    gResearchLastItem = gResearchItemSeparator;
+    gResearchLastItem = ResearchItem::gSeparator;
     gResearchProgressStage = RESEARCH_STAGE_INITIAL_RESEARCH;
     gResearchProgress = 0;
 }
@@ -431,20 +422,24 @@ void research_reset_current_item()
  */
 void research_remove(const rct_research_item& researchItemToRemove)
 {
-    for (auto it = gResearchedResearchItems.begin(); it != gResearchedResearchItems.end(); ++it)
+#ifdef _DEBUG
+    ResearchItem::gNames.erase(researchItemToRemove.rawValue);
+#endif
+
+    for (auto it = ResearchItem::gResearched.begin(); it != ResearchItem::gResearched.end(); ++it)
     {
         if (compare_research_items(researchItemToRemove, *it))
         {
-            gResearchedResearchItems.erase(it);
+            ResearchItem::gResearched.erase(it);
             return;
         }
     }
 
-    for (auto it = gUnResearchedResearchItems.begin(); it != gUnResearchedResearchItems.end(); ++it)
+    for (auto it = ResearchItem::gResearchable.begin(); it != ResearchItem::gResearchable.end(); ++it)
     {
         if (compare_research_items(researchItemToRemove, *it))
         {
-            gUnResearchedResearchItems.erase(it);
+            ResearchItem::gResearchable.erase(it);
             return;
         }
     }
@@ -456,7 +451,7 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
     newResearchItem.rawValue = rawValue;
     newResearchItem.category = category;
 
-    for (const rct_research_item& researchItem : gResearchedResearchItems)
+    for (const rct_research_item& researchItem : ResearchItem::gResearched)
     {
         if (compare_research_items(researchItem, newResearchItem))
         {
@@ -465,7 +460,7 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
         }
     }
 
-    for (const rct_research_item& researchItem : gUnResearchedResearchItems)
+    for (const rct_research_item& researchItem : ResearchItem::gResearchable)
     {
         if (compare_research_items(researchItem, newResearchItem))
         {
@@ -473,14 +468,37 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
             return;
         }
     }
+
+    
+#ifdef _DEBUG
+    {
+        rct_string_id stringId = research_item_get_name(&newResearchItem);
+        utf8 buffer[256];
+
+        if (newResearchItem.type == RESEARCH_ENTRY_TYPE_RIDE
+            && !RideGroupManager::RideTypeIsIndependent(newResearchItem.baseRideType))
+        {
+            const rct_string_id rideGroupName
+                = get_ride_naming(newResearchItem.baseRideType, get_ride_entry(newResearchItem.entryIndex)).name;
+            rct_string_id args[] = { rideGroupName, stringId };
+            format_string(buffer, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, &args);
+        }
+        else
+        {
+            format_string(buffer, 256, stringId, nullptr);
+        }
+
+        ResearchItem::gNames[newResearchItem.rawValue] = buffer;
+    }
+#endif
 
     if (researched)
     {
-        gResearchedResearchItems.push_back(newResearchItem);
+        ResearchItem::gResearched.push_back(newResearchItem);
     }
     else
     {
-        gUnResearchedResearchItems.push_back(newResearchItem);
+        ResearchItem::gResearchable.push_back(newResearchItem);
     }
 }
 
@@ -757,12 +775,12 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8 trackType, rct_rid
  */
 void research_remove_flags()
 {
-    for (rct_research_item& researchItem : gResearchedResearchItems)
+    for (rct_research_item& researchItem : ResearchItem::gResearched)
     {
         researchItem.flags = 0;
     }
 
-    for (rct_research_item& researchItem : gUnResearchedResearchItems)
+    for (rct_research_item& researchItem : ResearchItem::gResearchable)
     {
         researchItem.flags = 0;
     }
@@ -773,7 +791,7 @@ void research_fix()
     std::vector<rct_research_item> researchItemsToRemove;
 
     // Fix invalid research items
-    for (rct_research_item& researchItem : gResearchedResearchItems)
+    for (rct_research_item& researchItem : ResearchItem::gResearched)
     {
         if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE)
         {
@@ -840,7 +858,7 @@ void research_fix()
 void research_items_make_all_unresearched()
 {
     std::vector<rct_research_item> alwaysResearchedItems;
-    for (const rct_research_item& researchItem : gResearchedResearchItems)
+    for (const rct_research_item& researchItem : ResearchItem::gResearched)
     {
         if (research_item_is_always_researched(&researchItem))
         {
@@ -848,18 +866,18 @@ void research_items_make_all_unresearched()
         }
         else
         {
-            gUnResearchedResearchItems.push_back(researchItem);
+            ResearchItem::gResearchable.push_back(researchItem);
         }
     }
 
-    gResearchedResearchItems = alwaysResearchedItems;
+    ResearchItem::gResearched = alwaysResearchedItems;
 }
 
 void research_items_make_all_researched()
 {
-    gResearchedResearchItems.insert(
-        gResearchedResearchItems.end(), gUnResearchedResearchItems.begin(), gUnResearchedResearchItems.end());
-    gUnResearchedResearchItems.clear();
+    ResearchItem::gResearched.insert(
+        ResearchItem::gResearched.end(), ResearchItem::gResearchable.begin(), ResearchItem::gResearchable.end());
+    ResearchItem::gResearchable.clear();
 }
 
 /**
@@ -869,7 +887,7 @@ void research_items_make_all_researched()
 void research_items_shuffle()
 {
     std::mt19937 g(util_rand());
-    std::shuffle(std::begin(gUnResearchedResearchItems), std::end(gUnResearchedResearchItems), g);
+    std::shuffle(std::begin(ResearchItem::gResearchable), std::end(ResearchItem::gResearchable), g);
 }
 
 bool research_item_is_always_researched(const rct_research_item* researchItem)

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -64,6 +64,14 @@ static bool _researchedSceneryItems[MAX_RESEARCHED_SCENERY_ITEMS];
 
 bool gSilentResearch = false;
 
+namespace
+{
+bool compare_research_items(const rct_research_item& First, const rct_research_item& Second)
+{
+    return First.rawValue == Second.rawValue;
+}
+}
+
 /**
  *
  *  rct2: 0x006671AD, part of 0x00667132
@@ -137,23 +145,28 @@ static void research_next_design()
         research_invalidate_related_windows();
         auto gameAction = ParkSetResearchFundingAction(gResearchPriorities, 0);
         GameActions::Execute(&gameAction);
-        return;
     }
-
-    auto nextResearchItem = std::find_if(
-        std::begin(gUnResearchedResearchItems),
-        std::end(gUnResearchedResearchItems),
-        [](const rct_research_item& researchItem) { return (gResearchPriorities & (1 << researchItem.category)); });
-
-    if (nextResearchItem == gUnResearchedResearchItems.end())
+    else
     {
-        nextResearchItem = gUnResearchedResearchItems.begin();
+        gResearchNextItem = gResearchItemEnd;
+        for (const rct_research_item& researchItem : gUnResearchedResearchItems)
+        {
+            if (gResearchPriorities & (1 << researchItem.category))
+            {
+                gResearchNextItem = researchItem;
+                break;
+            }
+        }
+
+        if (! compare_research_items(gResearchNextItem, gResearchItemEnd))
+        {
+            gResearchNextItem = gUnResearchedResearchItems.front();
+        }
+
+        gResearchProgressStage = RESEARCH_STAGE_DESIGNING;
+
+        research_invalidate_related_windows();
     }
-
-    gResearchNextItem = *nextResearchItem;
-    gResearchProgressStage = RESEARCH_STAGE_DESIGNING;
-
-    research_invalidate_related_windows();
 }
 
 /**
@@ -414,50 +427,56 @@ void research_reset_current_item()
  *
  *  rct2: 0x006857CF
  */
-void research_remove(rct_research_item* researchItemToRemove)
+void research_remove(const rct_research_item& researchItemToRemove)
 {
-    auto CompareResearchItems = [](const rct_research_item& First, const rct_research_item& Second) -> bool {
-        return First.rawValue == Second.rawValue;
-    };
-
-    auto RemoveItemIfFound = [&](std::vector<rct_research_item>& ResearchItems) {
-        auto Found = std::remove_if(
-            std::begin(ResearchItems), std::end(ResearchItems), [&](const rct_research_item& researchItem) -> bool {
-                return CompareResearchItems(*researchItemToRemove, researchItem);
-            });
-        if (Found != std::end(ResearchItems))
+    for (auto it = gResearchedResearchItems.begin(); it != gResearchedResearchItems.end(); ++it)
+    {
+        if (compare_research_items(researchItemToRemove, *it))
         {
-            ResearchItems.erase(Found);
+            gResearchedResearchItems.erase(it);
+            return;
         }
-    };
+    }
 
-    RemoveItemIfFound(gResearchedResearchItems);
-    RemoveItemIfFound(gUnResearchedResearchItems);
+    for (auto it = gUnResearchedResearchItems.begin(); it != gUnResearchedResearchItems.end(); ++it)
+    {
+        if (compare_research_items(researchItemToRemove, *it))
+        {
+            gUnResearchedResearchItems.erase(it);
+            return;
+        }
+    }
 }
 
 void research_insert(sint32 researched, sint32 rawValue, uint8 category)
 {
-    auto CompareRawValue = [rawValue](const rct_research_item& researchItem) { return researchItem.rawValue == rawValue; };
+    rct_research_item newResearchItem;
+    newResearchItem.rawValue = rawValue;
+    newResearchItem.category = category;
 
-    if (gResearchedResearchItems.end()
-            != std::find_if(std::begin(gResearchedResearchItems), std::end(gResearchedResearchItems), CompareRawValue)
-        || gUnResearchedResearchItems.end()
-            != std::find_if(std::begin(gUnResearchedResearchItems), std::end(gUnResearchedResearchItems), CompareRawValue))
+    for (const rct_research_item& researchItem : gResearchedResearchItems)
     {
-        return;
+        if (compare_research_items(researchItem, newResearchItem))
+        {
+            return;
+        }
     }
 
-    rct_research_item researchItem;
-    researchItem.rawValue = rawValue;
-    researchItem.category = category;
+    for (const rct_research_item& researchItem : gUnResearchedResearchItems)
+    {
+        if (compare_research_items(researchItem, newResearchItem))
+        {
+            return;
+        }
+    }
 
     if (researched)
     {
-        gResearchedResearchItems.push_back(researchItem);
+        gResearchedResearchItems.push_back(newResearchItem);
     }
     else
     {
-        gUnResearchedResearchItems.push_back(researchItem);
+        gUnResearchedResearchItems.push_back(newResearchItem);
     }
 }
 
@@ -734,10 +753,15 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8 trackType, rct_rid
  */
 void research_remove_flags()
 {
-    auto ClearAlwaysResearchedFlag = [](rct_research_item& researchItem) { researchItem.flags = 0; };
+    for (rct_research_item& researchItem : gResearchedResearchItems)
+    {
+        researchItem.flags = 0;
+    }
 
-    std::for_each(std::begin(gResearchedResearchItems), std::end(gResearchedResearchItems), ClearAlwaysResearchedFlag);
-    std::for_each(std::begin(gUnResearchedResearchItems), std::end(gUnResearchedResearchItems), ClearAlwaysResearchedFlag);
+    for (rct_research_item& researchItem : gUnResearchedResearchItems)
+    {
+        researchItem.flags = 0;
+    }
 }
 
 void research_fix()
@@ -767,7 +791,7 @@ void research_fix()
 
     for (rct_research_item& researchItemToRemove : researchItemsToRemove)
     {
-        research_remove(&researchItemToRemove);
+        research_remove(researchItemToRemove);
     }
 
     research_update_uncompleted_types();

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -50,10 +50,12 @@ uint8  gResearchExpectedMonth;
 uint8  gResearchExpectedDay;
 rct_research_item gResearchNextItem;
 
-rct_research_item gResearchItemSeparator = { RESEARCHED_ITEMS_SEPARATOR ,0};
+rct_research_item gResearchItemSeparator = { RESEARCHED_ITEMS_SEPARATOR, 0 };
 rct_research_item gResearchItemEnd = { RESEARCHED_ITEMS_END, 0 };
+rct_research_item gResearchItemEnd2 = { RESEARCHED_ITEMS_END_2, 0 };
 std::vector<rct_research_item> gResearchedResearchItems;
 std::vector<rct_research_item> gUnResearchedResearchItems;
+std::vector<rct_research_item> gUnresearchableResearchItems;
 
 // 0x00EE787C
 uint8 gResearchUncompletedCategories;
@@ -458,6 +460,7 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
     {
         if (compare_research_items(researchItem, newResearchItem))
         {
+            assert(0); // already researched.
             return;
         }
     }
@@ -466,6 +469,7 @@ void research_insert(sint32 researched, sint32 rawValue, uint8 category)
     {
         if (compare_research_items(researchItem, newResearchItem))
         {
+            assert(0); // already researched.
             return;
         }
     }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -108,8 +108,10 @@ extern bool gSilentResearch;
 
 extern rct_research_item gResearchItemSeparator;
 extern rct_research_item gResearchItemEnd;
+extern rct_research_item gResearchItemEnd2;
 extern std::vector<rct_research_item> gResearchedResearchItems;
 extern std::vector<rct_research_item> gUnResearchedResearchItems;
+extern std::vector<rct_research_item> gUnresearchableResearchItems;
 
 void research_reset_items();
 void research_update_uncompleted_types();

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -121,7 +121,7 @@ void research_process_random_items();
 
 void research_finish_item(rct_research_item * researchItem);
 void research_insert(sint32 researched, sint32 rawValue, uint8 category);
-void research_remove(rct_research_item * researchItem);
+void research_remove(const rct_research_item& researchItem);
 
 void research_insert_ride_entry(uint8 entryIndex, bool researched);
 void research_insert_scenery_group_entry(uint8 entryIndex, bool researched);

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -108,9 +108,9 @@ extern bool gSilentResearch;
 
 namespace ResearchItem
 {
-extern rct_research_item gSeparator;
-extern rct_research_item gEnd;
-extern rct_research_item gEnd2;
+extern const rct_research_item gSeparator;
+extern const rct_research_item gEnd;
+extern const rct_research_item gEnd2;
 extern std::vector<rct_research_item> gResearched;
 extern std::vector<rct_research_item> gResearchable;
 }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -106,12 +106,14 @@ extern rct_research_item gResearchNextItem;
 extern uint8 gResearchUncompletedCategories;
 extern bool gSilentResearch;
 
-extern rct_research_item gResearchItemSeparator;
-extern rct_research_item gResearchItemEnd;
-extern rct_research_item gResearchItemEnd2;
-extern std::vector<rct_research_item> gResearchedResearchItems;
-extern std::vector<rct_research_item> gUnResearchedResearchItems;
-extern std::vector<rct_research_item> gUnresearchableResearchItems;
+namespace ResearchItem
+{
+extern rct_research_item gSeparator;
+extern rct_research_item gEnd;
+extern rct_research_item gEnd2;
+extern std::vector<rct_research_item> gResearched;
+extern std::vector<rct_research_item> gResearchable;
+}
 
 void research_reset_items();
 void research_update_uncompleted_types();

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -103,9 +103,13 @@ extern uint8 gResearchExpectedDay;
 extern rct_research_item gResearchLastItem;
 extern rct_research_item gResearchNextItem;
 
-extern rct_research_item gResearchItems[MAX_RESEARCH_ITEMS];
 extern uint8 gResearchUncompletedCategories;
 extern bool gSilentResearch;
+
+extern rct_research_item gResearchItemSeparator;
+extern rct_research_item gResearchItemEnd;
+extern std::vector<rct_research_item> gResearchedResearchItems;
+extern std::vector<rct_research_item> gUnResearchedResearchItems;
 
 void research_reset_items();
 void research_update_uncompleted_types();
@@ -147,4 +151,4 @@ void research_fix();
 void research_items_make_all_unresearched();
 void research_items_make_all_researched();
 void research_items_shuffle();
-bool research_item_is_always_researched(rct_research_item * researchItem);
+bool research_item_is_always_researched(const rct_research_item * researchItem);

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -742,22 +742,25 @@ void S6Exporter::ExportResearchedSceneryItems()
 
 void S6Exporter::ExportResearchList()
 {
-    rct_research_item separator = {};
-
+    // concatenate the researchitems into one array.
     std::vector<rct_research_item> combinedResearchItems = gResearchedResearchItems;
 
-    separator.rawValue = RESEARCHED_ITEMS_SEPARATOR;
-    combinedResearchItems.push_back(separator);
+    combinedResearchItems.push_back(gResearchItemSeparator);
 
     combinedResearchItems.insert(
         combinedResearchItems.end(), gUnResearchedResearchItems.begin(), gUnResearchedResearchItems.end());
 
-    combinedResearchItems.resize(sizeof(_s6.research_items)-2);
+    combinedResearchItems.push_back(gResearchItemEnd);
 
-    separator.rawValue = RESEARCHED_ITEMS_END;
-    combinedResearchItems.push_back(separator);
-    separator.rawValue = RESEARCHED_ITEMS_END_2;
-    combinedResearchItems.push_back(separator);
+    combinedResearchItems.insert(
+        combinedResearchItems.end(), gUnresearchableResearchItems.begin(), gUnresearchableResearchItems.end());
+
+    combinedResearchItems.push_back(gResearchItemEnd2);
+
+    // ensure backwardscompatibility by restricting the exported items to MAX_RESEARCH_ITEMS
+    combinedResearchItems.resize(MAX_RESEARCH_ITEMS);
+    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 2) = gResearchItemEnd;
+    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 1) = gResearchItemEnd2;
 
     memcpy(_s6.research_items, combinedResearchItems.data(), sizeof(_s6.research_items));
 }

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -743,24 +743,21 @@ void S6Exporter::ExportResearchedSceneryItems()
 void S6Exporter::ExportResearchList()
 {
     // concatenate the researchitems into one array.
-    std::vector<rct_research_item> combinedResearchItems = gResearchedResearchItems;
+    std::vector<rct_research_item> combinedResearchItems = ResearchItem::gResearched;
 
-    combinedResearchItems.push_back(gResearchItemSeparator);
-
-    combinedResearchItems.insert(
-        combinedResearchItems.end(), gUnResearchedResearchItems.begin(), gUnResearchedResearchItems.end());
-
-    combinedResearchItems.push_back(gResearchItemEnd);
+    combinedResearchItems.push_back(ResearchItem::gSeparator);
 
     combinedResearchItems.insert(
-        combinedResearchItems.end(), gUnresearchableResearchItems.begin(), gUnresearchableResearchItems.end());
+        combinedResearchItems.end(), ResearchItem::gResearchable.begin(), ResearchItem::gResearchable.end());
 
-    combinedResearchItems.push_back(gResearchItemEnd2);
+    combinedResearchItems.push_back(ResearchItem::gEnd);
+    combinedResearchItems.push_back(ResearchItem::gEnd2);
 
     // ensure backwardscompatibility by restricting the exported items to MAX_RESEARCH_ITEMS
+    // and placing ending markers
     combinedResearchItems.resize(MAX_RESEARCH_ITEMS);
-    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 2) = gResearchItemEnd;
-    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 1) = gResearchItemEnd2;
+    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 2) = ResearchItem::gEnd;
+    combinedResearchItems.at(MAX_RESEARCH_ITEMS - 1) = ResearchItem::gEnd2;
 
     memcpy(_s6.research_items, combinedResearchItems.data(), sizeof(_s6.research_items));
 }

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -742,7 +742,24 @@ void S6Exporter::ExportResearchedSceneryItems()
 
 void S6Exporter::ExportResearchList()
 {
-    memcpy(_s6.research_items, gResearchItems, sizeof(_s6.research_items));
+    rct_research_item separator = {};
+
+    std::vector<rct_research_item> combinedResearchItems = gResearchedResearchItems;
+
+    separator.rawValue = RESEARCHED_ITEMS_SEPARATOR;
+    combinedResearchItems.push_back(separator);
+
+    combinedResearchItems.insert(
+        combinedResearchItems.end(), gUnResearchedResearchItems.begin(), gUnResearchedResearchItems.end());
+
+    combinedResearchItems.resize(sizeof(_s6.research_items)-2);
+
+    separator.rawValue = RESEARCHED_ITEMS_END;
+    combinedResearchItems.push_back(separator);
+    separator.rawValue = RESEARCHED_ITEMS_END_2;
+    combinedResearchItems.push_back(separator);
+
+    memcpy(_s6.research_items, combinedResearchItems.data(), sizeof(_s6.research_items));
 }
 
 enum : uint32

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -767,7 +767,29 @@ public:
 
     void ImportResearchList()
     {
-        memcpy(gResearchItems, _s6.research_items, sizeof(_s6.research_items));
+        sint32 researchedItems = 0, unResearchedItems = 0;
+        for (const rct_research_item* researchItem = _s6.research_items; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR;
+             ++researchItem)
+        {
+            researchedItems++;
+        }
+
+        gResearchedResearchItems.resize(researchedItems);
+        memcpy(gResearchedResearchItems.data(), _s6.research_items, sizeof(rct_research_item) * researchedItems);
+
+        researchedItems++;
+        for (const rct_research_item* researchItem = _s6.research_items + researchedItems;
+             researchItem->rawValue != RESEARCHED_ITEMS_END;
+             ++researchItem)
+        {
+            unResearchedItems++;
+        }
+
+        gUnResearchedResearchItems.resize(researchedItems);
+        memcpy(
+            gUnResearchedResearchItems.data(),
+            _s6.research_items + researchedItems,
+            sizeof(rct_research_item) * unResearchedItems);
     }
 
     void Initialise()

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -774,8 +774,8 @@ public:
             researchedItems++;
         }
 
-        gResearchedResearchItems.resize(researchedItems);
-        memcpy(gResearchedResearchItems.data(), _s6.research_items, sizeof(rct_research_item) * researchedItems);
+        ResearchItem::gResearched.resize(researchedItems);
+        memcpy(ResearchItem::gResearched.data(), _s6.research_items, sizeof(rct_research_item) * researchedItems);
 
         researchedItems++;
         for (const rct_research_item* researchItem = _s6.research_items + researchedItems;
@@ -785,9 +785,9 @@ public:
             unResearchedItems++;
         }
 
-        gUnResearchedResearchItems.resize(researchedItems);
+        ResearchItem::gResearchable.resize(researchedItems);
         memcpy(
-            gUnResearchedResearchItems.data(),
+            ResearchItem::gResearchable.data(),
             _s6.research_items + researchedItems,
             sizeof(rct_research_item) * unResearchedItems);
     }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -523,7 +523,7 @@ void Park::Initialise()
     gParkRating = 0;
     _guestGenerationProbability = 0;
     gTotalRideValueForMoney = 0;
-    gResearchLastItem = gResearchItemSeparator;;
+    gResearchLastItem = ResearchItem::gSeparator;
 
     for (size_t i = 0; i < 20; i++)
     {

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -523,7 +523,7 @@ void Park::Initialise()
     gParkRating = 0;
     _guestGenerationProbability = 0;
     gTotalRideValueForMoney = 0;
-    gResearchLastItem.rawValue = RESEARCHED_ITEMS_SEPARATOR;
+    gResearchLastItem = gResearchItemSeparator;;
 
     for (size_t i = 0; i < 20; i++)
     {


### PR DESCRIPTION
This will be a better fix for #7331, as this MR is able to successfully remove rides from the `gResearchItems`.

This MR also makes _always-researched-items_ unpickable, so they cannot be moved to the unresearched list.

~~Some debatable changes:~~
- ~~I still have combined `research_insert_researched()` and `research_insert_unresearched()` into a single function to reuse most of the code.~~
- ~~`research_reset_items()` resets the whole `gResearchItems` array to 0~~

gResearchItems is now separated into two vectors.
Some functions are still lambdas but may be converted to free functions as well.