### PR TITLE
Fix signed/unsigned mismatch warnings

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -32,7 +32,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>4068;4091;4100;4132;4200;4201;4204;4206;4221;4244;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4068;4091;4100;4132;4200;4201;4204;4206;4221;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Warnings:
              C4068: unknown pragma
              C4091: 'keyword': ignored on left of 'type' when no variable is declared
@@ -44,7 +44,6 @@
              C4206: nonstandard extension used: translation unit is empty
              C4221: nonstandard extension used: 'identifier': cannot be initialized using address of automatic variable 'identifier'
              C4244: 'conversion_type': conversion from 'type1' to 'type2', possible loss of data
-             C4245: 'conversion_type': conversion from 'type1' to 'type2', signed/unsigned mismatch
       -->
       <TreatSpecificWarningsAsErrors>4263;4265;4548;4549;4555</TreatSpecificWarningsAsErrors>
       <!-- Warnings, that have to be enabled manually:

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -724,7 +724,7 @@ static void window_footpath_show_footpath_types_dialog(rct_window * w, rct_widge
             image++;
         }
 
-        gDropdownItemsFormat[numPathTypes] = -1;
+        gDropdownItemsFormat[numPathTypes] = STR_NONE;
         gDropdownItemsArgs[numPathTypes]   = image;
         numPathTypes++;
     }

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -651,13 +651,13 @@ static void window_mapgen_base_mouseup(rct_window *w, rct_widgetindex widgetInde
         window_text_input_open(w, WIDX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, STR_FORMAT_INTEGER, _mapSize - 2, 4);
         break;
     case WIDX_BASE_HEIGHT:
-        TextInputDescriptionArgs[0] = (BASESIZE_MIN - 12) / 2;
-        TextInputDescriptionArgs[1] = (BASESIZE_MAX - 12) / 2;
+        TextInputDescriptionArgs[0] = (uint16)((BASESIZE_MIN - 12) / 2);
+        TextInputDescriptionArgs[1] = (uint16)((BASESIZE_MAX - 12) / 2);
         window_text_input_open(w, WIDX_BASE_HEIGHT, STR_BASE_HEIGHT, STR_ENTER_BASE_HEIGHT, STR_FORMAT_INTEGER, (_baseHeight - 12) / 2, 3);
         break;
     case WIDX_WATER_LEVEL:
-        TextInputDescriptionArgs[0] = (WATERLEVEL_MIN - 12) / 2;
-        TextInputDescriptionArgs[1] = (WATERLEVEL_MAX - 12) / 2;
+        TextInputDescriptionArgs[0] = (uint16)((WATERLEVEL_MIN - 12) / 2);
+        TextInputDescriptionArgs[1] = (uint16)((WATERLEVEL_MAX - 12) / 2);
         window_text_input_open(w, WIDX_WATER_LEVEL, STR_WATER_LEVEL, STR_ENTER_WATER_LEVEL, STR_FORMAT_INTEGER, (_waterLevel - 12) / 2, 3);
         break;
     }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <limits>
 #include <openrct2-ui/windows/Window.h>
 
 #include <openrct2/config/Config.h>
@@ -569,7 +570,7 @@ static void window_new_ride_set_page(rct_window *w, sint32 page)
     _windowNewRideCurrentTab = page;
     w->frame_no = 0;
     w->new_ride.highlighted_ride_id = -1;
-    w->new_ride.selected_ride_countdown = -1;
+    w->new_ride.selected_ride_countdown = std::numeric_limits<uint16>::max();
     window_new_ride_populate_list();
     if (page < WINDOW_NEW_RIDE_PAGE_RESEARCH) {
         w->new_ride.highlighted_ride_id = _windowNewRideHighlightedItem[page].ride_type_and_entry;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <limits>
 #include <openrct2/actions/ParkSetNameAction.hpp>
 #include <openrct2/config/Config.h>
 #include <openrct2/Context.h>
@@ -568,7 +569,7 @@ static rct_window *window_park_open()
     w->page = WINDOW_PARK_PAGE_ENTRANCE;
     w->viewport_focus_coordinates.y = 0;
     w->frame_no = 0;
-    w->list_information_type = -1;
+    w->list_information_type = std::numeric_limits<uint16>::max();
     w->numberOfStaff = -1;
     w->var_492 = 0;
     window_park_set_disabled_tabs(w);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -390,7 +390,7 @@ void window_scenery_set_default_placement_configuration()
     window_scenery_init();
 
     for (sint32 i = 0; i < SCENERY_WINDOW_TABS; i++)
-        gWindowSceneryTabSelections[i] = -1;
+        gWindowSceneryTabSelections[i] = WINDOW_SCENERY_TAB_SELECTION_UNDEFINED;
 
     for (sint32 i = 0; i < SCENERY_WINDOW_TABS; i++) {
         if (window_scenery_tab_entries[i][0] != -1) {
@@ -462,7 +462,7 @@ rct_window * window_scenery_open()
         (1 << WIDX_SCENERY_REPAINT_SCENERY_BUTTON) |
         (1 << WIDX_SCENERY_TERTIARY_COLOUR_BUTTON) |
         (1 << WIDX_SCENERY_EYEDROPPER_BUTTON) |
-        (1 << WIDX_SCENERY_BUILD_CLUSTER_BUTTON);
+        (1ULL << WIDX_SCENERY_BUILD_CLUSTER_BUTTON);
 
     window_init_scroll_widgets(window);
     window_scenery_update_scroll(window);
@@ -1275,6 +1275,6 @@ void window_scenery_reset_selected_scenery_items()
 {
     for (size_t i = 0; i < SCENERY_WINDOW_TABS; i++)
     {
-        gWindowSceneryTabSelections[i] = -1;
+        gWindowSceneryTabSelections[i] = WINDOW_SCENERY_TAB_SELECTION_UNDEFINED;
     }
 }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -950,7 +950,7 @@ static void repaint_scenery_tool_down(sint16 x, sint16 y, rct_widgetindex widget
     sint32 type;
     // edx
     rct_tile_element* tile_element;
-    uint16 flags =
+    auto flags =
         VIEWPORT_INTERACTION_MASK_SCENERY &
         VIEWPORT_INTERACTION_MASK_WALL &
         VIEWPORT_INTERACTION_MASK_LARGE_SCENERY &
@@ -1047,7 +1047,7 @@ static void repaint_scenery_tool_down(sint16 x, sint16 y, rct_widgetindex widget
 
 static void scenery_eyedropper_tool_down(sint16 x, sint16 y, rct_widgetindex widgetIndex)
 {
-    uint16 flags =
+    auto flags =
         VIEWPORT_INTERACTION_MASK_SCENERY &
         VIEWPORT_INTERACTION_MASK_WALL &
         VIEWPORT_INTERACTION_MASK_LARGE_SCENERY &
@@ -1182,7 +1182,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
             if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z)) {
                 // CTRL pressed
                 rct_tile_element* tile_element;
-                uint16 flags =
+                auto flags =
                     VIEWPORT_INTERACTION_MASK_TERRAIN &
                     VIEWPORT_INTERACTION_MASK_RIDE &
                     VIEWPORT_INTERACTION_MASK_SCENERY &
@@ -1307,7 +1307,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
 
         // If CTRL not pressed
         if (!gSceneryCtrlPressed) {
-            uint16 flags =
+            auto flags =
                 VIEWPORT_INTERACTION_MASK_TERRAIN &
                 VIEWPORT_INTERACTION_MASK_WATER;
             sint32 interaction_type = 0;
@@ -1381,7 +1381,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
     case SCENERY_TYPE_PATH_ITEM:
     {
         // Path bits
-        uint16 flags =
+        auto flags =
             VIEWPORT_INTERACTION_MASK_FOOTPATH &
             VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM;
         sint32 interaction_type = 0;
@@ -1519,7 +1519,7 @@ static void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid
     case SCENERY_TYPE_BANNER:
     {
         // Banner
-        uint16 flags =
+        auto flags =
             VIEWPORT_INTERACTION_MASK_FOOTPATH &
             VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM;
         sint32 interaction_type = 0;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1817,8 +1817,8 @@ void window_resize(rct_window *w, sint32 dw, sint32 dh)
 
     // Update scroll widgets
     for (i = 0; i < 3; i++) {
-        w->scrolls[i].h_right = -1;
-        w->scrolls[i].v_bottom = -1;
+        w->scrolls[i].h_right = WINDOW_SCROLL_UNDEFINED;
+        w->scrolls[i].v_bottom = WINDOW_SCROLL_UNDEFINED;
     }
     window_update_scroll_widgets(w);
 

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -17,6 +17,7 @@
 #ifndef _WINDOW_H_
 #define _WINDOW_H_
 
+#include <limits>
 #include "../common.h"
 
 struct rct_drawpixelinfo;
@@ -113,6 +114,8 @@ struct rct_scroll {
     uint16 v_thumb_top;         // 0x0E
     uint16 v_thumb_bottom;      // 0x10
 };
+
+constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<uint16>::max();
 
 /**
  * Viewport focus structure.

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -1110,12 +1110,12 @@ static void format_string_part(utf8 **dest, size_t *size, rct_string_id format, 
         if ((*size) > 0) *(*dest) = '\0';
     } else if (format <= REAL_NAME_END) {
         // Real name
-        format -= -REAL_NAME_START;
+        auto realNameIndex = format - REAL_NAME_START;
 
-        format_append_string(dest, size, real_names[format % Util::CountOf(real_names)]);
+        format_append_string(dest, size, real_names[realNameIndex % Util::CountOf(real_names)]);
         if ((*size) == 0) return;
         format_push_char(' ');
-        format_push_char(real_name_initials[(format >> 10) % Util::CountOf(real_name_initials)]);
+        format_push_char(real_name_initials[(realNameIndex >> 10) % Util::CountOf(real_name_initials)]);
         format_push_char('.');
         *(*dest) = '\0';
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -3088,7 +3088,7 @@ sint32 network_can_perform_action(uint32 groupindex, uint32 index)
     return gNetwork.group_list[groupindex]->CanPerformAction(index);
 }
 
-sint32 network_can_perform_command(uint32 groupindex, uint32 index)
+sint32 network_can_perform_command(uint32 groupindex, sint32 index)
 {
     return gNetwork.group_list[groupindex]->CanPerformCommand(index);
 }
@@ -3318,7 +3318,7 @@ uint8 network_get_default_group() { return 0; }
 sint32 network_get_num_actions() { return 0; }
 rct_string_id network_get_action_name_string_id(uint32 index) { return -1; }
 sint32 network_can_perform_action(uint32 groupindex, uint32 index) { return 0; }
-sint32 network_can_perform_command(uint32 groupindex, uint32 index) { return 0; }
+sint32 network_can_perform_command(uint32 groupindex, sint32 index) { return 0; }
 void network_set_pickup_peep(uint8 playerid, rct_peep* peep) { _pickup_peep = peep; }
 rct_peep* network_get_pickup_peep(uint8 playerid) { return _pickup_peep; }
 void network_set_pickup_peep_old_x(uint8 playerid, sint32 x) { _pickup_peep_old_x = x; }

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -36,7 +36,7 @@ uint8 * NetworkPacket::GetData()
     return &(*Data)[0];
 }
 
-uint32 NetworkPacket::GetCommand()
+sint32 NetworkPacket::GetCommand()
 {
     if (Data->size() >= sizeof(uint32))
     {

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -34,7 +34,7 @@ public:
     static std::unique_ptr<NetworkPacket> Duplicate(NetworkPacket& packet);
 
     uint8 * GetData();
-    uint32  GetCommand();
+    sint32  GetCommand();
 
     void Clear();
     bool CommandRequiresAuth();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -345,7 +345,7 @@ uint8 network_get_default_group();
 sint32 network_get_num_actions();
 rct_string_id network_get_action_name_string_id(uint32 index);
 sint32 network_can_perform_action(uint32 groupindex, uint32 index);
-sint32 network_can_perform_command(uint32 groupindex, uint32 index);
+sint32 network_can_perform_command(uint32 groupindex, sint32 index);
 void network_set_pickup_peep(uint8 playerid, rct_peep* peep);
 rct_peep* network_get_pickup_peep(uint8 playerid);
 void network_set_pickup_peep_old_x(uint8 playerid, sint32 x);

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -70,7 +70,7 @@ static void paint_session_init(paint_session * session, rct_drawpixelinfo * dpi)
     {
         quadrant = nullptr;
     }
-    session->QuadrantBackIndex = -1;
+    session->QuadrantBackIndex = std::numeric_limits<uint32>::max();
     session->QuadrantFrontIndex = 0;
     session->PSStringHead = nullptr;
     session->LastPSString = nullptr;

--- a/src/openrct2/paint/tile_element/Surface.cpp
+++ b/src/openrct2/paint/tile_element/Surface.cpp
@@ -852,8 +852,8 @@ static void viewport_surface_draw_tile_side_top(paint_session * session, enum ed
 
     sint16 al, ah, cl, ch, dl = 0, dh;
 
-    LocationXY8 offset = { 0, 0 };
-    LocationXY8 bounds = { 0, 0 };
+    sLocationXY8 offset = { 0, 0 };
+    sLocationXY8 bounds = { 0, 0 };
 
     switch (edge)
     {
@@ -959,7 +959,8 @@ static void viewport_surface_draw_tile_side_top(paint_session * session, enum ed
 
     if (isWater)
     {
-        offset.xy = 0;
+        offset.x = 0;
+        offset.y = 0;
     }
 
     while (cur_height < al && cur_height < ah)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3519,8 +3519,8 @@ sint32 ride_music_params_update(sint16 x, sint16 y, sint16 z, uint8 rideIndex, u
         }
         sint32 pan_y = ((y2 / screenheight) - 0x8000) >> 4;
 
-        uint8  vol1  = -1;
-        uint8  vol2  = -1;
+        uint8  vol1  = 255;
+        uint8  vol2  = 255;
         sint32 panx2 = pan_x;
         sint32 pany2 = pan_y;
         if (pany2 < 0)
@@ -3538,7 +3538,7 @@ sint32 ride_music_params_update(sint16 x, sint16 y, sint16 z, uint8 rideIndex, u
             vol1  = (uint8) pany2;
             if (pany2 >= 256)
             {
-                vol1 = -1;
+                vol1 = 255;
             }
         }
 
@@ -3557,7 +3557,7 @@ sint32 ride_music_params_update(sint16 x, sint16 y, sint16 z, uint8 rideIndex, u
             vol2  = (uint8) panx2;
             if (panx2 >= 256)
             {
-                vol2 = -1;
+                vol2 = 255;
             }
         }
         if (vol1 >= vol2)
@@ -3651,7 +3651,7 @@ void ride_music_update_final()
                 {
                     break;
                 }
-                edi->ride_id = -1;
+                edi->ride_id = RIDE_ID_NULL;
             }
 
             // stop currently playing music that is not in music params list or not playing?
@@ -6991,13 +6991,13 @@ uint64 ride_entry_get_supported_track_pieces(const rct_ride_entry * rideEntry)
 
 static sint32 ride_get_smallest_station_length(Ride *ride)
 {
-    uint32 result = -1;
+    sint32 result = -1;
     for (sint32 i = 0; i < MAX_STATIONS; i++) {
         if (ride->station_starts[i].xy != RCT_XY8_UNDEFINED) {
-            result = Math::Min(result, (uint32)(ride->station_length[i]));
+            result = std::min<sint32>(result, ride->station_length[i]);
         }
     }
-    return (sint32)result;
+    return result;
 }
 
 /**

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #pragma endregion
 
+#include <limits>
 #include "../core/Math.hpp"
 #include "../core/Util.hpp"
 #include "../sprites.h"
@@ -183,13 +184,13 @@ void rct_duck::UpdateSwim()
         if (randomNumber & 0x80000000)
         {
             state = DUCK_STATE::DOUBLE_DRINK;
-            frame = -1;
+            frame = std::numeric_limits<uint16>::max();
             UpdateDoubleDrink();
         }
         else
         {
             state = DUCK_STATE::DRINK;
-            frame = -1;
+            frame = std::numeric_limits<uint16>::max();
             UpdateDrink();
         }
     }

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -17,6 +17,7 @@
 #ifndef _SCENERY_H_
 #define _SCENERY_H_
 
+#include <limits>
 #include "../common.h"
 #include "../object/Object.h"
 #include "../world/Location.hpp"
@@ -239,6 +240,7 @@ enum
 };
 
 #define SCENERY_ENTRIES_BY_TAB 1024
+constexpr auto WINDOW_SCENERY_TAB_SELECTION_UNDEFINED = std::numeric_limits<uint16>::max();
 
 extern uint8 gWindowSceneryActiveTabIndex;
 extern uint16 gWindowSceneryTabSelections[20];


### PR DESCRIPTION
Unignore MSVC warning: C4245:
'conversion_type': conversion from 'type1' to 'type2', signed/unsigned mismatch