### PR TITLE
Keep "Save track design" dropdown open

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 - Improved: [#7435] Object indexing now supports multi-threading.
 - Improved: [#7510] Add horizontal clipping to cut-away view options.
+- Improved: [#7531] "Save track design" dropdown now stays open.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5111,6 +5111,7 @@ static void window_ride_measurements_mousedown(rct_window *w, rct_widgetindex wi
     {
         // Disable saving without scenery if we're a flat ride
         dropdown_set_disabled(0, true);
+        gDropdownDefaultIndex = 1;
     }
 }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5099,7 +5099,7 @@ static void window_ride_measurements_mousedown(rct_window *w, rct_widgetindex wi
         w->y + widget->top,
         widget->bottom - widget->top + 1,
         w->colours[1],
-        0,
+        DROPDOWN_FLAG_STAY_OPEN,
         2
     );
     gDropdownDefaultIndex = 0;


### PR DESCRIPTION
When testing the "Save flat rides with scenery to td6", I overlooked a fairly small glitch that causes the "Save track design without scenery" to still get triggered when pressing and releasing the save track design icon. This fixes it by setting the default to "Save track design with scenery".

Edit: After discussion about the preferences of the dropdown staying open, I've changed this branches main purpose to keeping it open, the correct highlighting for flat rides is just extra icing for the cake.