### PR TITLE
Fix #7528: Tab changing in park pricing window happens on mousedown

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: [#7480] Graphs skip values of 0.
+- Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1212,15 +1212,6 @@ static void window_park_price_mousedown(rct_window *w, rct_widgetindex widgetInd
     case WIDX_CLOSE:
         window_close(w);
         break;
-    case WIDX_TAB_1:
-    case WIDX_TAB_2:
-    case WIDX_TAB_3:
-    case WIDX_TAB_4:
-    case WIDX_TAB_5:
-    case WIDX_TAB_6:
-    case WIDX_TAB_7:
-        window_park_set_page(w, widgetIndex - WIDX_TAB_1);
-        break;
     case WIDX_INCREASE_PRICE:
         newFee = Math::Min(MAX_ENTRANCE_FEE, gParkEntranceFee + MONEY(1,00));
         park_set_entrance_fee(newFee);


### PR DESCRIPTION
Tab changing should happen on mouse up instead of mouse down. Found some code in the tab for park pricing that messed with the behaviour on that tab. Now the behaviour is same for all tabs in park window.