### PR TITLE
Add easter-egg config that makes balloons explode when they pop

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -211,6 +211,7 @@ namespace Config
             model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
             model->show_real_names_of_guests = reader->GetBoolean("show_real_names_of_guests", true);
             model->allow_early_completion = reader->GetBoolean("allow_early_completion", false);
+            model->balloons_explode = reader->GetBoolean("balloons_explode", false);
         }
     }
 
@@ -283,6 +284,7 @@ namespace Config
         writer->WriteBoolean("show_real_names_of_guests", model->show_real_names_of_guests);
         writer->WriteBoolean("use_virtual_floor", model->use_virtual_floor);
         writer->WriteBoolean("allow_early_completion", model->allow_early_completion);
+        writer->WriteBoolean("balloons_explode", model->balloons_explode);
     }
 
     static void ReadInterface(IIniReader * reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -89,6 +89,7 @@ struct GeneralConfiguration
     bool        steam_overlay_pause;
     bool        show_real_names_of_guests;
     bool        allow_early_completion;
+    bool        balloons_explode;
 
     bool        confirmation_prompt;
     sint32      load_save_sort;

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -17,6 +17,7 @@
 #include "../network/network.h"
 
 #include "../audio/audio.h"
+#include "../config/Config.h"
 #include "../scenario/Scenario.h"
 #include "../util/Util.h"
 #include "Sprite.h"
@@ -89,7 +90,17 @@ void rct_balloon::Pop()
 {
     popped = 1;
     frame = 0;
-    audio_play_sound_at_location(SOUND_BALLOON_POP, x, y, z);
+
+    if (!gConfigGeneral.balloons_explode)
+    {
+        audio_play_sound_at_location(SOUND_BALLOON_POP, x, y, z);
+    }
+    else
+    {
+        audio_play_sound_at_location(SOUND_CRASH, x, y, z + 12);
+        sprite_misc_explosion_cloud_create(x, y, z + 14);
+        sprite_misc_explosion_flare_create(x, y, z + 14);
+    }
 }
 
 static money32 game_command_balloon_press(uint16 spriteIndex, uint8 flags)


### PR DESCRIPTION
This implements #7237.

I nearly forgot about this until @deurklink mentioned it again. We had some discussion wether or not this should be in the cheat window. Personally I'm leaning more towards keeping this a setting in the config file over clustering the cheat window with a fun cheat. It should be changeable through a console command or something for now, until this can be moved to a plug-in system.

Now it's only a line in `config.ini` that the user has to change: `balloons_explode = true/false`.

![2018-05-21_02-12-22](https://user-images.githubusercontent.com/9705046/40285467-844740b6-5c9c-11e8-8c84-e19a4f866e0c.gif)
(It also plays sound, but my capture framerate is really low for some reason)