### PR TITLE
Make Twitch integration API URL configurable

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4558,6 +4558,10 @@ STR_6248    :{WINDOW_COLOUR_1}Do you want to refurbish {STRINGID} for {CURRENCY}
 STR_6249    :{WINDOW_COLOUR_1}Do you want to refurbish {STRINGID}?
 STR_6250    :{WINDOW_COLOUR_1}Are you sure you want to completely demolish {STRINGID} and gain {CURRENCY}?
 STR_6251    :Ride is not empty yet
+STR_6252    :Twitch API URL
+STR_6253    :{SMALLFONT}{BLACK}Provide URL of Twitch integration API. Must be required in order to enable Twitch integration.
+STR_6254    :Please input URL of Twitch integration API.
+STR_6255    :URL is not valid.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 - Improved: [#7510] Add horizontal clipping to cut-away view options.
 - Improved: [#7531] "Save track design" dropdown now stays open.
 - Improved: [#7548] Ctrl-clicking with the tile inspector open now directly selects an element and its tile.
+- Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -29,6 +29,7 @@
 #include <openrct2/title/TitleScreen.h>
 #include <openrct2/title/TitleSequenceManager.h>
 #include <openrct2/core/Math.hpp>
+#include <openrct2/core/String.hpp>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2-ui/windows/Window.h>
 
@@ -185,6 +186,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 
     // Twitch
     WIDX_CHANNEL_BUTTON = WIDX_PAGE_START,
+    WIDX_API_URL_BUTTON,
     WIDX_FOLLOWER_PEEP_NAMES_CHECKBOX,
     WIDX_FOLLOWER_PEEP_TRACKING_CHECKBOX,
     WIDX_CHAT_PEEP_NAMES_CHECKBOX,
@@ -371,11 +373,12 @@ static rct_widget window_options_advanced_widgets[] = {
 static rct_widget window_options_twitch_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
     { WWT_BUTTON,           1,  10,     299,    54,     66,     STR_TWITCH_NAME,            STR_TWITCH_NAME_TIP },              // Twitch channel name
-    { WWT_CHECKBOX,         2,  10,     299,    71,     86,     STR_TWITCH_PEEP_FOLLOWERS,  STR_TWITCH_PEEP_FOLLOWERS_TIP },    // Twitch name peeps by follows
-    { WWT_CHECKBOX,         2,  10,     299,    87,     102,    STR_TWITCH_FOLLOWERS_TRACK, STR_TWITCH_FOLLOWERS_TRACK_TIP },   // Twitch information on for follows
-    { WWT_CHECKBOX,         2,  10,     299,    103,    118,    STR_TWITCH_PEEP_CHAT,       STR_TWITCH_PEEP_CHAT_TIP },         // Twitch name peeps by chat
-    { WWT_CHECKBOX,         2,  10,     299,    119,    134,    STR_TWITCH_CHAT_TRACK,      STR_TWITCH_CHAT_TRACK_TIP  },       // Twitch information on for chat
-    { WWT_CHECKBOX,         2,  10,     299,    135,    150,    STR_TWITCH_CHAT_NEWS,       STR_TWITCH_CHAT_NEWS_TIP },         // Twitch chat !news as notifications in game
+    { WWT_BUTTON,           1,  10,     299,    71,     83,     STR_TWITCH_API_URL,         STR_TWITCH_API_URL_TIP },           // Twitch API name
+    { WWT_CHECKBOX,         2,  10,     299,    88,     103,    STR_TWITCH_PEEP_FOLLOWERS,  STR_TWITCH_PEEP_FOLLOWERS_TIP },    // Twitch name peeps by follows
+    { WWT_CHECKBOX,         2,  10,     299,    104,    119,    STR_TWITCH_FOLLOWERS_TRACK, STR_TWITCH_FOLLOWERS_TRACK_TIP },   // Twitch information on for follows
+    { WWT_CHECKBOX,         2,  10,     299,    120,    135,    STR_TWITCH_PEEP_CHAT,       STR_TWITCH_PEEP_CHAT_TIP },         // Twitch name peeps by chat
+    { WWT_CHECKBOX,         2,  10,     299,    136,    151,    STR_TWITCH_CHAT_TRACK,      STR_TWITCH_CHAT_TRACK_TIP  },       // Twitch information on for chat
+    { WWT_CHECKBOX,         2,  10,     299,    152,    167,    STR_TWITCH_CHAT_NEWS,       STR_TWITCH_CHAT_NEWS_TIP },         // Twitch chat !news as notifications in game
     { WIDGETS_END },
 };
 
@@ -604,6 +607,7 @@ static uint64 window_options_page_enabled_widgets[] = {
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_CHANNEL_BUTTON) |
+    (1 << WIDX_API_URL_BUTTON) |
     (1 << WIDX_FOLLOWER_PEEP_NAMES_CHECKBOX) |
     (1 << WIDX_FOLLOWER_PEEP_TRACKING_CHECKBOX) |
     (1 << WIDX_CHAT_PEEP_NAMES_CHECKBOX) |
@@ -986,6 +990,9 @@ static void window_options_mouseup(rct_window *w, rct_widgetindex widgetIndex)
             gConfigTwitch.enable_news ^= 1;
             config_save_default();
             window_invalidate(w);
+            break;
+        case WIDX_API_URL_BUTTON:
+            window_text_input_raw_open(w, widgetIndex, STR_TWITCH_API_URL, STR_TWITCH_API_URL_DESC, gConfigTwitch.api_url, 256);
             break;
         }
         break;
@@ -1953,9 +1960,24 @@ static void window_options_text_input(rct_window *w, rct_widgetindex widgetIndex
     if (text == nullptr)
         return;
 
-    if (widgetIndex == WIDX_CHANNEL_BUTTON) {
+    if (widgetIndex == WIDX_CHANNEL_BUTTON)
+    {
         free(gConfigTwitch.channel);
         gConfigTwitch.channel = _strdup(text);
+        config_save_default();
+    }
+    else if (widgetIndex == WIDX_API_URL_BUTTON)
+    {
+        if (!String::StartsWith(text, "http://", false) && !String::StartsWith(text, "https://", false))
+        {
+            context_show_error(STR_INVALID_URL, STR_NONE);
+            return;
+        }
+        if (gConfigTwitch.api_url != nullptr)
+        {
+            free(gConfigTwitch.api_url);
+        }
+        gConfigTwitch.api_url = _strdup(text);
         config_save_default();
     }
 }

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -466,6 +466,7 @@ namespace Config
         if (reader->ReadSection("twitch"))
         {
             auto model = &gConfigTwitch;
+            model->api_url = reader->GetCString("api_url", nullptr);
             model->channel = reader->GetCString("channel", nullptr);
             model->enable_follower_peep_names = reader->GetBoolean("follower_peep_names", true);
             model->enable_follower_peep_tracking = reader->GetBoolean("follower_peep_tracking", false);
@@ -479,6 +480,7 @@ namespace Config
     {
         auto model = &gConfigTwitch;
         writer->WriteSection("twitch");
+        writer->WriteString("api_url", model->api_url);
         writer->WriteString("channel", model->channel);
         writer->WriteBoolean("follower_peep_names", model->enable_follower_peep_names);
         writer->WriteBoolean("follower_peep_tracking", model->enable_follower_peep_tracking);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -127,6 +127,7 @@ struct SoundConfiguration
 struct TwitchConfiguration
 {
     utf8 *      channel;
+    utf8 *      api_url;
     bool        enable_follower_peep_names;
     bool        enable_follower_peep_tracking;
     bool        enable_chat_peep_names;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3920,6 +3920,11 @@ enum {
     STR_DEMOLISH_RIDE_ID_MONEY = 6250,
     STR_RIDE_NOT_YET_EMPTY = 6251,
 
+    STR_TWITCH_API_URL = 6252,
+    STR_TWITCH_API_URL_TIP = 6253,
+    STR_TWITCH_API_URL_DESC = 6254,
+    STR_INVALID_URL = 6255,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -102,7 +102,6 @@ namespace Twitch
      * have a lower latency.
      */
     constexpr uint32 PulseTime = 10 * 1000;
-    constexpr const char * TwitchExtendedBaseUrl = "http://openrct.ursalabs.co/api/1/";
 
     static sint32               _twitchState = TWITCH_STATE_LEFT;
     static bool              _twitchIdle = true;
@@ -192,7 +191,14 @@ namespace Twitch
     static void Join()
     {
         char url[256];
-        snprintf(url, sizeof(url), "%sjoin/%s", TwitchExtendedBaseUrl, gConfigTwitch.channel);
+
+        if (gConfigTwitch.api_url == nullptr || strlen(gConfigTwitch.api_url) == 0)
+        {
+            auto context = GetContext();
+            context->WriteLine("API URL is empty! skipping request...");
+            return;
+        }
+        snprintf(url, sizeof(url), "%s/join/%s", gConfigTwitch.api_url, gConfigTwitch.channel);
 
         _twitchState = TWITCH_STATE_JOINING;
         _twitchIdle = false;
@@ -270,7 +276,14 @@ namespace Twitch
     static void GetFollowers()
     {
         char url[256];
-        snprintf(url, sizeof(url), "%schannel/%s/audience", TwitchExtendedBaseUrl, gConfigTwitch.channel);
+
+        if (gConfigTwitch.api_url == nullptr || strlen(gConfigTwitch.api_url) == 0)
+        {
+            auto context = GetContext();
+            context->WriteLine("API URL is empty! skipping request...");
+            return;
+        }
+        snprintf(url, sizeof(url), "%s/channel/%s/audience", gConfigTwitch.api_url, gConfigTwitch.channel);
 
         _twitchState = TWITCH_STATE_WAITING;
         _twitchIdle = false;
@@ -301,7 +314,14 @@ namespace Twitch
     static void GetMessages()
     {
         char url[256];
-        snprintf(url, sizeof(url), "%schannel/%s/messages", TwitchExtendedBaseUrl, gConfigTwitch.channel);
+
+        if (gConfigTwitch.api_url == nullptr || strlen(gConfigTwitch.api_url) == 0)
+        {
+            auto context = GetContext();
+            context->WriteLine("API URL is empty! skipping request...");
+            return;
+        }
+        snprintf(url, sizeof(url), "%s/channel/%s/messages", gConfigTwitch.api_url, gConfigTwitch.channel);
 
         _twitchState = TWITCH_STATE_WAITING;
         _twitchIdle = false;


### PR DESCRIPTION
This change tries to fix broken Twitch integration.

As you may already aware, Twitch integration is broken. It's because the API server is no longer active and the URL (http://openrct.ursalabs.co) is hardcoded into the code.

There's [server](https://github.com/BenediktMagnus/OpenRCT2TwitchServer) out there you can run by yourself, but the URL is hardcoded so you have to modify `/etc/hosts` to make it work.

This patch lets you to configure the server URL manually. I know this wouldn't effectively bring back the Twitch integration in a whole. You still need the running server. But I think it's better than leaving it in utterly broken state.

![image](https://user-images.githubusercontent.com/424089/40476330-bfec3682-5f7e-11e8-8f47-010f3546a4ac.png)

![image](https://user-images.githubusercontent.com/424089/40476384-daeee3e4-5f7e-11e8-9d68-3e2117d389b3.png)
