### PR TITLE
Prevent peeps from spawning in the scenario editor

### DIFF
--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -579,6 +579,10 @@ void Park::Initialise()
 
 void Park::Update()
 {
+    // TODO: move when GameState class is introduced.
+    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+        return;
+
     // Every 5 seconds approximately
     if (gCurrentTicks % 512 == 0)
     {


### PR DESCRIPTION
This is a regression from 721dc007784734c550c8e0364c2d3b2e4dfa572c.

`Park::Update` replaces `park_update`, but no longer contains the check for `gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)`. This is because https://github.com/OpenRCT2/OpenRCT2/pull/5979 moved the check to `GameState::UpdateLogic`, which I didn't account for when I split off the Park class to its own PR.

This PR reintroduces the check in `Park::Update`, until GameState is merged into develop.