### PR TITLE
Resizeable invention list window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4536,7 +4536,7 @@ STR_6226    :Enable early scenario completion
 STR_6227    :{SMALLFONT}{BLACK}Triggers scenario completion when all scenario goals are met before the target date.
 STR_6228    :Scenario Options
 STR_6229    :{WINDOW_COLOUR_2}{STRINGID}: {STRINGID}
-STR_6230    :{STRINGID}: {MOVE_X}{185}{STRINGID}
+STR_6230    :{STRINGID}:
 STR_6231    :{WINDOW_COLOUR_2}{STRINGID}: {MOVE_X}{185}{STRINGID}
 STR_6232    :Frozen
 STR_6233    :Cut-away view

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
+- Improved: [#6221] The scenario editor's invention list is now resizeable.
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 - Improved: [#7435] Object indexing now supports multi-threading.
 - Improved: [#7510] Add horizontal clipping to cut-away view options.


### PR DESCRIPTION
This PR makes the invention list window resizeable. Fixes #6221.

I'd like to horizontally divide the text in the scrollable lists on resize, too, but it appears to be painted using a `{MOVE_X}` formatting code. We should probably split that into two `gfx_draw_string` calls instead.