### PR TITLE
Fix #7569: Assertion hit when using the XY spinners

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -991,7 +991,7 @@ static void window_tile_inspector_mouseup(rct_window *w, rct_widgetindex widgetI
     }
 
     // Only element-specific widgets from now on
-    if (w->page == TILE_INSPECTOR_PAGE_DEFAULT) {
+    if (w->selected_list_item == TILE_INSPECTOR_PAGE_DEFAULT || w->selected_list_item == -1) {
         return;
     }
 


### PR DESCRIPTION
The X/Y spinners change the currently tile selected, and reset the element selection index. Previously this would also set the page to default immediately, but since that's now done on invalidation instead, the page would not be correct. This is fixed by checking the index of the selected element too, instead of only the selected page, in the mouse_up event.