### PR TITLE
Fix #7571 Track design ghost generates money

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,7 +33,7 @@
 - Fix: [#7480] Graphs skip values of 0.
 - Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Fix: [#7544] Starting a headless server with no arguments causes the game to freeze.
-- Fix: [#7571] Hovering a ride design over scenery will give tons of money.
+- Fix: [#7571] Hovering a ride design over scenery or tracks will give tons of money.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
@@ -46,6 +46,7 @@
 - Improved: [#7548] Ctrl-clicking with the tile inspector open now directly selects an element and its tile.
 - Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
 - Improved: [#7567] Improve the performance of loading parks and the title sequence.
+- Improved: [#7577] Allow fine-tuning the virtual floor style.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#7480] Graphs skip values of 0.
 - Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Fix: [#7544] Starting a headless server with no arguments causes the game to freeze.
+- Fix: [#7571] Hovering a ride design over scenery will give tons of money.
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -3328,7 +3328,7 @@ void map_obstruction_set_error_text(rct_tile_element *tileElement)
  *  ebp = clearFunc
  *  bl = bl
  */
-sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode)
+bool map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode)
 {
     sint32 al, ah, bh, cl, ch, water_height;
     al = ah = bh = cl = ch = water_height = 0;
@@ -3336,10 +3336,17 @@ sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 z
 
     gMapGroundFlags = ELEMENT_IS_ABOVE_GROUND;
     bool canBuildCrossing = false;
-    if (x >= gMapSizeUnits || y >= gMapSizeUnits || x < 32 || y < 32) {
+    if (x >= gMapSizeUnits || y >= gMapSizeUnits || x < 32 || y < 32)
+    {
         gGameCommandErrorText = STR_OFF_EDGE_OF_MAP;
         return false;
     }
+
+    if (gCheatsDisableClearanceChecks)
+    {
+        return true;
+    }
+
     rct_tile_element* tileElement = map_get_first_element_at(x / 32, y / 32);
     do {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_SURFACE) {
@@ -3351,7 +3358,7 @@ sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 z
             continue;
         }
         water_height = surface_get_water_height(tileElement) * 2;
-        if (water_height && water_height > zLow && tileElement->base_height < zHigh && !gCheatsDisableClearanceChecks) {
+        if (water_height && water_height > zLow && tileElement->base_height < zHigh) {
             gMapGroundFlags |= ELEMENT_IS_UNDERWATER;
             if (water_height < zHigh) {
                 goto loc_68BAE6;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -173,7 +173,7 @@ using CLEAR_FUNC = sint32(*)(rct_tile_element** tile_element, sint32 x, sint32 y
 
 sint32 map_place_non_scenery_clear_func(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
 sint32 map_place_scenery_clear_func(rct_tile_element** tile_element, sint32 x, sint32 y, uint8 flags, money32* price);
-sint32 map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode);
+bool map_can_construct_with_clear_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, CLEAR_FUNC clearFunc, uint8 bl, uint8 flags, money32 *price, uint8 crossingMode);
 sint32 map_can_construct_at(sint32 x, sint32 y, sint32 zLow, sint32 zHigh, uint8 bl);
 void rotate_map_coordinates(sint16 *x, sint16 *y, sint32 rotation);
 LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, sint32 rotation);


### PR DESCRIPTION
The problem was that when placing a ride ghost, some clearance checks are performed to see if nothing stands in the way, and if it does, it tries to raise the ride to a height where it's possible to place. When this happens, it removes all track pieces that have already been placed, and tries again at the next height. With clearance checks disabled, this check was still performed, while it should ignore clearance altogether.