### PR TITLE
Mark unused arguments in the libopenrct2 project

### DIFF
--- a/src/openrct2/audio/DummyAudioContext.cpp
+++ b/src/openrct2/audio/DummyAudioContext.cpp
@@ -23,15 +23,15 @@ namespace OpenRCT2::Audio
         IAudioMixer * GetMixer() override { return nullptr; }
 
         std::vector<std::string> GetOutputDevices() override { return std::vector<std::string>(); }
-        void SetOutputDevice(const std::string &deviceName) override { }
+        void SetOutputDevice(const std::string &/*deviceName*/) override { }
 
-        IAudioSource * CreateStreamFromWAV(const std::string &path) override { return nullptr; }
+        IAudioSource * CreateStreamFromWAV(const std::string &/*path*/) override { return nullptr; }
 
         void StartTitleMusic() override { }
 
-        IAudioChannel * PlaySound(sint32 soundId, sint32 volume, sint32 pan) override { return nullptr; }
-        IAudioChannel * PlaySoundAtLocation(sint32 soundId, sint16 x, sint16 y, sint16 z) override { return nullptr; }
-        IAudioChannel * PlaySoundPanned(sint32 soundId, sint32 pan, sint16 x, sint16 y, sint16 z) override { return nullptr; }
+        IAudioChannel * PlaySound(sint32 /*soundId*/, sint32 /*volume*/, sint32 /*pan*/) override { return nullptr; }
+        IAudioChannel * PlaySoundAtLocation(sint32 /*soundId*/, sint16 /*x*/, sint16 /*y*/, sint16 /*z*/) override { return nullptr; }
+        IAudioChannel * PlaySoundPanned(sint32 /*soundId*/, sint32 /*pan*/, sint16 /*x*/, sint16 /*y*/, sint16 /*z*/) override { return nullptr; }
 
         void ToggleAllSounds() override { }
         void PauseSounds() override { }

--- a/src/openrct2/audio/NullAudioSource.cpp
+++ b/src/openrct2/audio/NullAudioSource.cpp
@@ -29,7 +29,7 @@ namespace OpenRCT2::Audio
             return 0;
         }
 
-        size_t Read(void * dst, uint64 offset, size_t len) override
+        size_t Read([[maybe_unused]] void* dst, [[maybe_unused]] uint64 offset, [[maybe_unused]] size_t len) override
         {
             return 0;
         }

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -376,32 +376,32 @@ private:
 class DefaultIniReader final : public IIniReader
 {
 public:
-    bool ReadSection(const std::string &name) override
+    bool ReadSection([[maybe_unused]] const std::string& name) override
     {
         return true;
     }
 
-    bool GetBoolean(const std::string &name, bool defaultValue) const override
+    bool GetBoolean([[maybe_unused]] const std::string& name, bool defaultValue) const override
     {
         return defaultValue;
     }
 
-    sint32 GetSint32(const std::string &name, sint32 defaultValue) const override
+    sint32 GetSint32([[maybe_unused]] const std::string& name, sint32 defaultValue) const override
     {
         return defaultValue;
     }
 
-    float GetFloat(const std::string &name, float defaultValue) const override
+    float GetFloat([[maybe_unused]] const std::string& name, float defaultValue) const override
     {
         return defaultValue;
     }
 
-    std::string GetString(const std::string &name, const std::string &defaultValue) const override
+    std::string GetString([[maybe_unused]] const std::string& name, const std::string& defaultValue) const override
     {
         return defaultValue;
     }
 
-    bool TryGetString(const std::string &name, std::string * outValue) const override
+    bool TryGetString([[maybe_unused]] const std::string& name, [[maybe_unused]] std::string* outValue) const override
     {
         return false;
     }

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -253,7 +253,7 @@ static void TTF_drawLine_Shaded(const TTF_Font *font, const TTFSurface *textbuf,
     }
 }
 
-static void TTF_SetFTError(const char *msg, FT_Error error)
+static void TTF_SetFTError(const char* msg, [[maybe_unused]] FT_Error error)
 {
 #ifdef USE_FREETYPE_ERRORS
 #undef FTERRORS_H
@@ -1125,8 +1125,7 @@ int TTF_SizeUTF8(TTF_Font *font, const char *text, int *w, int *h)
     return status;
 }
 
-TTFSurface *TTF_RenderUTF8_Solid(TTF_Font *font,
-    const char *text, uint32 colour)
+TTFSurface* TTF_RenderUTF8_Solid(TTF_Font* font, const char* text, [[maybe_unused]] uint32 colour)
 {
     bool first;
     int xstart;
@@ -1246,8 +1245,7 @@ TTFSurface *TTF_RenderUTF8_Solid(TTF_Font *font,
     return textbuf;
 }
 
-TTFSurface *TTF_RenderUTF8_Shaded(TTF_Font *font,
-                const char *text, uint32 fg, uint32 bg)
+TTFSurface* TTF_RenderUTF8_Shaded(TTF_Font* font, const char* text, [[maybe_unused]] uint32 fg, [[maybe_unused]] uint32 bg)
 {
     bool first;
     int xstart;

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -135,7 +135,7 @@ void X8RainDrawer::Restore()
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #endif
 
-X8DrawingEngine::X8DrawingEngine(const std::shared_ptr<Ui::IUiContext>& uiContext)
+X8DrawingEngine::X8DrawingEngine([[maybe_unused]] const std::shared_ptr<Ui::IUiContext>& uiContext)
 {
     _drawingContext = new X8DrawingContext(this);
 #ifdef __ENABLE_LIGHTFX__
@@ -161,11 +161,11 @@ void X8DrawingEngine::Resize(uint32 width, uint32 height)
     ConfigureBits(width, height, pitch);
 }
 
-void X8DrawingEngine::SetPalette(const rct_palette_entry * palette)
+void X8DrawingEngine::SetPalette([[maybe_unused]] const rct_palette_entry* palette)
 {
 }
 
-void X8DrawingEngine::SetVSync(bool vsync)
+void X8DrawingEngine::SetVSync([[maybe_unused]] bool vsync)
 {
     // Not applicable for this engine
 }
@@ -299,7 +299,7 @@ DRAWING_ENGINE_FLAGS X8DrawingEngine::GetFlags()
     return DEF_DIRTY_OPTIMISATIONS;
 }
 
-void X8DrawingEngine::InvalidateImage(uint32 image)
+void X8DrawingEngine::InvalidateImage([[maybe_unused]] uint32 image)
 {
     // Not applicable for this engine
 }
@@ -368,7 +368,8 @@ void X8DrawingEngine::ConfigureBits(uint32 width, uint32 height, uint32 pitch)
 #endif
 }
 
-void X8DrawingEngine::OnDrawDirtyBlock(uint32 x, uint32 y, uint32 columns, uint32 rows)
+void X8DrawingEngine::OnDrawDirtyBlock(
+    [[maybe_unused]] uint32 x, [[maybe_unused]] uint32 y, [[maybe_unused]] uint32 columns, [[maybe_unused]] uint32 rows)
 {
 }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -968,7 +968,8 @@ static sint32 cc_show_limits(InteractiveConsole & console, [[maybe_unused]] cons
     return 0;
 }
 
-static sint32 cc_for_date(InteractiveConsole & console, [[maybe_unused]] const utf8 ** argv, [[maybe_unused]] sint32 argc)
+static sint32
+    cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const utf8** argv, [[maybe_unused]] sint32 argc)
 {
     sint32 year = 0;
     sint32 month = 0;

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -30,7 +30,7 @@ constexpr const char * APPLICATION_ID = "378612438200877056";
 constexpr const char * STEAM_APP_ID = nullptr;
 constexpr const uint32 REFRESH_INTERVAL = 5 * GAME_UPDATE_FPS; // 5 seconds
 
-static void OnReady(const DiscordUser * request)
+static void OnReady([[maybe_unused]] const DiscordUser* request)
 {
     log_verbose("DiscordService::OnReady()");
 }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1800,7 +1800,7 @@ void Network::Server_Client_Joined(const char* name, const std::string &keyhash,
     }
 }
 
-void Network::Server_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Server_Handle_TOKEN(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
 {
     uint8 token_size = 10 + (rand() & 0x7f);
     connection.Challenge.resize(token_size);
@@ -1976,7 +1976,7 @@ void Network::Server_Handle_AUTH(NetworkConnection& connection, NetworkPacket& p
     }
 }
 
-void Network::Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint32 size, offset;
     packet >> size >> offset;
@@ -2149,7 +2149,7 @@ bool Network::SaveMap(IStream * stream, const std::vector<const ObjectRepository
     return result;
 }
 
-void Network::Client_Handle_CHAT(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_CHAT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     const char* text = packet.ReadString();
     if (text) {
@@ -2173,7 +2173,7 @@ void Network::Server_Handle_CHAT(NetworkConnection& connection, NetworkPacket& p
     }
 }
 
-void Network::Client_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_GAMECMD([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint32 tick;
     uint32 args[7];
@@ -2184,7 +2184,7 @@ void Network::Client_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
     game_command_queue.emplace(tick, args, playerid, callback, _commandId++);
 }
 
-void Network::Client_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_GAME_ACTION([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint32 tick;
     uint32 type;
@@ -2356,7 +2356,7 @@ void Network::Server_Handle_GAMECMD(NetworkConnection& connection, NetworkPacket
     game_command_queue.emplace(tick, args, playerid, callback, _commandId++);
 }
 
-void Network::Client_Handle_TICK(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_TICK([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint32 srand0;
     uint32 flags;
@@ -2382,7 +2382,7 @@ void Network::Client_Handle_TICK(NetworkConnection& connection, NetworkPacket& p
     game_commands_processed_this_tick = 0;
 }
 
-void Network::Client_Handle_PLAYERLIST(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_PLAYERLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint8 size;
     packet >> size;
@@ -2412,12 +2412,12 @@ void Network::Client_Handle_PLAYERLIST(NetworkConnection& connection, NetworkPac
     }
 }
 
-void Network::Client_Handle_PING(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_PING([[maybe_unused]] NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
 {
     Client_Send_PING();
 }
 
-void Network::Server_Handle_PING(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Server_Handle_PING(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
 {
     sint32 ping = platform_get_ticks() - connection.PingTime;
     if (ping < 0) {
@@ -2429,7 +2429,7 @@ void Network::Server_Handle_PING(NetworkConnection& connection, NetworkPacket& p
     }
 }
 
-void Network::Client_Handle_PINGLIST(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_PINGLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     uint8 size;
     packet >> size;
@@ -2455,19 +2455,19 @@ void Network::Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, Netw
     }
 }
 
-void Network::Server_Handle_GAMEINFO(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Server_Handle_GAMEINFO(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
 {
     Server_Send_GAMEINFO(connection);
 }
 
-void Network::Client_Handle_SHOWERROR(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_SHOWERROR([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     rct_string_id title, message;
     packet >> title >> message;
     context_show_error(title, message);
 }
 
-void Network::Client_Handle_GROUPLIST(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_GROUPLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     group_list.clear();
     uint8 size;
@@ -2480,7 +2480,7 @@ void Network::Client_Handle_GROUPLIST(NetworkConnection& connection, NetworkPack
     }
 }
 
-void Network::Client_Handle_EVENT(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_EVENT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     char text[256];
     uint16 eventType;
@@ -2523,7 +2523,7 @@ static std::string json_stdstring_value(const json_t * string)
     return cstr == nullptr ? std::string() : std::string(cstr);
 }
 
-void Network::Client_Handle_GAMEINFO(NetworkConnection& connection, NetworkPacket& packet)
+void Network::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
 {
     const char * jsonString = packet.ReadString();
 

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -100,7 +100,7 @@ rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint
     return header;
 }
 
-void Object::SetSourceGame(const uint8 sourceGame)
+void Object::SetSourceGame([[maybe_unused]] const uint8 sourceGame)
 {
     // FIXME: Temporary disabled because it breaks exporting to vanilla.
     /*_objectEntry.flags &= 0x0F;

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -100,7 +100,7 @@ rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint
     return header;
 }
 
-void Object::SetSourceGame([[maybe_unused]] const uint8 sourceGame)
+void Object::SetSourceGame(const uint8 sourceGame)
 {
     // FIXME: Temporary disabled because it breaks exporting to vanilla.
     /*_objectEntry.flags &= 0x0F;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -180,18 +180,18 @@ public:
     const rct_object_entry *    GetObjectEntry() const { return &_objectEntry; }
     virtual void *              GetLegacyData() abstract;
 
-    virtual void ReadJson(IReadObjectContext * context, const json_t * root) { }
+    virtual void ReadJson(IReadObjectContext * /*context*/, const json_t * /*root*/) { }
     virtual void ReadLegacy(IReadObjectContext * context, IStream * stream) abstract;
     virtual void Load() abstract;
     virtual void Unload() abstract;
 
-    virtual void DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint32 height) const { }
+    virtual void DrawPreview(rct_drawpixelinfo * /*dpi*/, sint32 /*width*/, sint32 /*height*/) const { }
 
     virtual uint8           GetObjectType() const final { return _objectEntry.flags & 0x0F; }
     virtual std::string     GetName() const;
     virtual std::string     GetName(sint32 language) const;
 
-    virtual void SetRepositoryItem(ObjectRepositoryItem * item) const { }
+    virtual void SetRepositoryItem(ObjectRepositoryItem * /*item*/) const { }
 
     const ImageTable & GetImageTable() const { return _imageTable; }
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -129,23 +129,23 @@ public:
         return {};
     }
 
-    void LogWarning([[maybe_unused]] uint32 code, const utf8* text) override
+    void LogWarning(uint32 code, const utf8* text) override
     {
         _wasWarning = true;
 
         if (!String::IsNullOrEmpty(text))
         {
-            Console::Error::WriteLine("[%s] Warning: %s", _objectName.c_str(), text);
+            Console::Error::WriteLine("[%s] Warning (%d): %s", _objectName.c_str(), code, text);
         }
     }
 
-    void LogError([[maybe_unused]] uint32 code, const utf8* text) override
+    void LogError(uint32 code, const utf8* text) override
     {
         _wasError = true;
 
         if (!String::IsNullOrEmpty(text))
         {
-            Console::Error::WriteLine("[%s] Error: %s", _objectName.c_str(), text);
+            Console::Error::WriteLine("[%s] Error (%d): %s", _objectName.c_str(), code, text);
         }
     }
 };

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -129,7 +129,7 @@ public:
         return {};
     }
 
-    void LogWarning(uint32 code, const utf8 * text) override
+    void LogWarning([[maybe_unused]] uint32 code, const utf8* text) override
     {
         _wasWarning = true;
 
@@ -139,7 +139,7 @@ public:
         }
     }
 
-    void LogError(uint32 code, const utf8 * text) override
+    void LogError([[maybe_unused]] uint32 code, const utf8* text) override
     {
         _wasError = true;
 

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -99,7 +99,7 @@ public:
     }
 
 public:
-    std::tuple<bool, ObjectRepositoryItem> Create(sint32 language, const std::string &path) const override
+    std::tuple<bool, ObjectRepositoryItem> Create([[maybe_unused]] sint32 language, const std::string& path) const override
     {
         Object * object = nullptr;
         auto extension = Path::GetExtension(path);

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -343,7 +343,7 @@ void RideObject::Unload()
     _legacyType.images_offset = 0;
 }
 
-void RideObject::DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint32 height) const
+void RideObject::DrawPreview(rct_drawpixelinfo* dpi, [[maybe_unused]] sint32 width, [[maybe_unused]] sint32 height) const
 {
     uint32 imageId = _legacyType.images_offset;
 
@@ -411,7 +411,8 @@ void RideObject::SetRepositoryItem(ObjectRepositoryItem * item) const
     item->RideInfo.RideGroupIndex = rideGroupIndex;
 }
 
-void RideObject::ReadLegacyVehicle(IReadObjectContext * context, IStream * stream, rct_ride_entry_vehicle * vehicle)
+void RideObject::ReadLegacyVehicle(
+    [[maybe_unused]] IReadObjectContext* context, IStream* stream, rct_ride_entry_vehicle* vehicle)
 {
     vehicle->rotation_frame_mask = stream->ReadValue<uint16>();
     stream->Seek(2 * 1, STREAM_SEEK_CURRENT);
@@ -644,7 +645,7 @@ void RideObject::ReadJson(IReadObjectContext * context, const json_t * root)
     ObjectJsonHelpers::LoadImages(context, root, GetImageTable());
 }
 
-void RideObject::ReadJsonVehicleInfo(IReadObjectContext * context, const json_t * properties)
+void RideObject::ReadJsonVehicleInfo([[maybe_unused]] IReadObjectContext* context, const json_t* properties)
 {
     _legacyType.min_cars_in_train = ObjectJsonHelpers::GetInteger(properties, "minCarsPerTrain", 1);
     _legacyType.max_cars_in_train = ObjectJsonHelpers::GetInteger(properties, "maxCarsPerTrain", 1);

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -60,7 +60,7 @@ void WaterObject::DrawPreview(rct_drawpixelinfo * dpi, sint32 width, sint32 heig
     gfx_draw_string_centred(dpi, STR_WINDOW_NO_IMAGE, x, y, COLOUR_BLACK, nullptr);
 }
 
-void WaterObject::ReadJson(IReadObjectContext * context, const json_t * root)
+void WaterObject::ReadJson([[maybe_unused]] IReadObjectContext* context, const json_t* root)
 {
     auto properties = json_object_get(root, "properties");
     _legacyType.flags = ObjectJsonHelpers::GetFlags<uint16>(properties, {

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -730,7 +730,7 @@ paint_session * paint_session_alloc(rct_drawpixelinfo * dpi)
     return session;
 }
 
-void paint_session_free(paint_session * session)
+void paint_session_free([[maybe_unused]] paint_session* session)
 {
     _paintSessionInUse = false;
 }

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -281,8 +281,12 @@ static uint8 footpath_element_next_in_direction(TileCoordsXYZ loc, rct_tile_elem
  *
  * This is the recursive portion of footpath_element_destination_in_direction().
  */
-static uint8 footpath_element_dest_in_dir(TileCoordsXYZ loc, rct_tile_element * inputTileElement,
-                                          uint8 chosenDirection, uint8 * outRideIndex, sint32 level)
+static uint8 footpath_element_dest_in_dir(
+    TileCoordsXYZ loc,
+    [[maybe_unused]] rct_tile_element* inputTileElement,
+    uint8 chosenDirection,
+    uint8* outRideIndex,
+    sint32 level)
 {
     rct_tile_element * tileElement;
     sint32            direction;
@@ -1560,7 +1564,7 @@ static uint8 get_nearest_park_entrance_index(uint16 x, uint16 y)
  *
  *  rct2: 0x006952C0
  */
-static sint32 guest_path_find_entering_park(rct_peep * peep, rct_tile_element * tile_element, uint8 edges)
+static sint32 guest_path_find_entering_park(rct_peep* peep, [[maybe_unused]] rct_tile_element* tile_element, uint8 edges)
 {
     // Send peeps to the nearest park entrance.
     uint8 chosenEntrance = get_nearest_park_entrance_index(peep->next_x, peep->next_y);
@@ -1615,7 +1619,7 @@ static uint8 get_nearest_peep_spawn_index(uint16 x, uint16 y)
  *
  *  rct2: 0x0069536C
  */
-static sint32 guest_path_find_leaving_park(rct_peep * peep, rct_tile_element * tile_element, uint8 edges)
+static sint32 guest_path_find_leaving_park(rct_peep* peep, [[maybe_unused]] rct_tile_element* tile_element, uint8 edges)
 {
     // Send peeps to the nearest spawn point.
     uint8 chosenSpawn = get_nearest_peep_spawn_index(peep->next_x, peep->next_y);
@@ -1650,7 +1654,7 @@ static sint32 guest_path_find_leaving_park(rct_peep * peep, rct_tile_element * t
  *
  *  rct2: 0x00695161
  */
-static sint32 guest_path_find_park_entrance(rct_peep * peep, rct_tile_element * tile_element, uint8 edges)
+static sint32 guest_path_find_park_entrance(rct_peep* peep, [[maybe_unused]] rct_tile_element* tile_element, uint8 edges)
 {
     uint8 entranceNum;
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -923,7 +923,8 @@ bool peep_pickup_command(uint32 peepnum, sint32 x, sint32 y, sint32 z, sint32 ac
     return true;
 }
 
-void game_command_pickup_guest(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+void game_command_pickup_guest(
+    sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, [[maybe_unused]] sint32* esi, sint32* edi, sint32* ebp)
 {
     sint32 peepnum = *eax;
     sint32 x       = *edi;
@@ -3357,7 +3358,7 @@ static void peep_apply_easter_egg_to_nearby_guests(rct_peep * peep, easter_egg_f
     }
 }
 
-static void peep_give_passing_peeps_purple_clothes(rct_peep * peep, rct_peep * otherPeep)
+static void peep_give_passing_peeps_purple_clothes([[maybe_unused]] rct_peep* peep, rct_peep* otherPeep)
 {
     otherPeep->tshirt_colour   = COLOUR_BRIGHT_PURPLE;
     otherPeep->trousers_colour = COLOUR_BRIGHT_PURPLE;
@@ -3843,7 +3844,7 @@ void peep_handle_easteregg_name(rct_peep * peep)
 }
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-void pathfind_logging_enable(rct_peep * peep)
+void pathfind_logging_enable([[maybe_unused]] rct_peep* peep)
 {
 #if defined(PATHFIND_DEBUG) && PATHFIND_DEBUG
     /* Determine if the pathfinding debugging is wanted for this peep. */

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -371,8 +371,8 @@ static money32 staff_hire_new_staff_member(uint8 staff_type, uint8 flags, sint16
  *
  *  rct2: 0x006BEFA1
  */
-void game_command_hire_new_staff_member(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                        sint32 * ebp)
+void game_command_hire_new_staff_member(
+    sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, [[maybe_unused]] sint32* esi, sint32* edi, [[maybe_unused]] sint32* ebp)
 {
     *ebx = staff_hire_new_staff_member((*ebx & 0xFF00) >> 8, *ebx & 0xFF, *eax & 0xFFFF, *ecx & 0xFFFF, *edx & 0xFFFF,
                                        (*ebx & 0xFF0000) >> 16, edi);
@@ -402,8 +402,14 @@ static constexpr const bool peep_slow_walking_types[] = {
  *
  *  rct2: 0x006C0BB5
  */
-void game_command_set_staff_order(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                  sint32 * ebp)
+void game_command_set_staff_order(
+    [[maybe_unused]] sint32* eax,
+    sint32* ebx,
+    [[maybe_unused]] sint32* ecx,
+    sint32* edx,
+    [[maybe_unused]] sint32* esi,
+    [[maybe_unused]] sint32* edi,
+    [[maybe_unused]] sint32* ebp)
 {
     gCommandExpenditureType = RCT_EXPENDITURE_TYPE_WAGES;
     uint8  order_id         = *ebx >> 8;
@@ -453,8 +459,14 @@ void game_command_set_staff_order(sint32 * eax, sint32 * ebx, sint32 * ecx, sint
  *
  *  rct2: 0x006C09D1
  */
-void game_command_set_staff_patrol(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                   sint32 * ebp)
+void game_command_set_staff_patrol(
+    sint32* eax,
+    sint32* ebx,
+    sint32* ecx,
+    sint32* edx,
+    [[maybe_unused]] sint32* esi,
+    [[maybe_unused]] sint32* edi,
+    [[maybe_unused]] sint32* ebp)
 {
     if (*ebx & GAME_COMMAND_FLAG_APPLY)
     {
@@ -507,8 +519,14 @@ void game_command_set_staff_patrol(sint32 * eax, sint32 * ebx, sint32 * ecx, sin
  *
  *  rct2: 0x006C0B83
  */
-void game_command_fire_staff_member(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi,
-                                    sint32 * ebp)
+void game_command_fire_staff_member(
+    [[maybe_unused]] sint32* eax,
+    sint32* ebx,
+    [[maybe_unused]] sint32* ecx,
+    sint32* edx,
+    [[maybe_unused]] sint32* esi,
+    [[maybe_unused]] sint32* edi,
+    [[maybe_unused]] sint32* ebp)
 {
     gCommandExpenditureType = RCT_EXPENDITURE_TYPE_WAGES;
     if (*ebx & GAME_COMMAND_FLAG_APPLY)
@@ -1540,7 +1558,8 @@ sint32 staff_path_finding(rct_peep * peep)
     }
 }
 
-void game_command_pickup_staff(sint32 * eax, sint32 * ebx, sint32 * ecx, sint32 * edx, sint32 * esi, sint32 * edi, sint32 * ebp)
+void game_command_pickup_staff(
+    sint32* eax, sint32* ebx, sint32* ecx, sint32* edx, [[maybe_unused]] sint32* esi, sint32* edi, sint32* ebp)
 {
     sint32 peepnum = *eax;
     sint32 x       = *edi;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -173,10 +173,8 @@ public:
         return result;
     }
 
-    ParkLoadResult LoadFromStream(IStream * stream,
-                                  bool isScenario,
-                                  bool skipObjectCheck,
-                                  const utf8 * path) override
+    ParkLoadResult
+        LoadFromStream(IStream* stream, bool isScenario, [[maybe_unused]] bool skipObjectCheck, const utf8* path) override
     {
         _s4 = *ReadAndDecodeS4(stream, isScenario);
         _s4Path = path;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -109,10 +109,11 @@ public:
         return result;
     }
 
-    ParkLoadResult LoadFromStream(IStream * stream,
-                                  bool isScenario,
-                                  bool skipObjectCheck = false,
-                                  const utf8 * path = String::Empty) override
+    ParkLoadResult LoadFromStream(
+        IStream* stream,
+        bool isScenario,
+        [[maybe_unused]] bool skipObjectCheck = false,
+        const utf8* path = String::Empty) override
     {
         if (isScenario && !gConfigGeneral.allow_loading_with_incorrect_checksum && !SawyerEncoding::ValidateChecksum(stream))
         {

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -32,7 +32,7 @@ namespace OpenRCT2::Ui
 
     public:
         void Update() override { }
-        void Draw(rct_drawpixelinfo * dpi) override { }
+        void Draw(rct_drawpixelinfo * /*dpi*/) override { }
 
         void CreateWindow() override { }
         void CloseWindow() override { }
@@ -41,7 +41,7 @@ namespace OpenRCT2::Ui
         sint32 GetWidth() override { return 0; }
         sint32 GetHeight() override { return 0; }
         sint32 GetScaleQuality() override { return 0; }
-        void SetFullscreenMode(FULLSCREEN_MODE mode) override { }
+        void SetFullscreenMode(FULLSCREEN_MODE /*mode*/) override { }
         std::vector<Resolution> GetFullscreenResolutions() override { return std::vector<Resolution>(); }
         bool HasFocus() override { return false; }
         bool IsMinimised() override { return false; }
@@ -49,26 +49,27 @@ namespace OpenRCT2::Ui
         void ProcessMessages() override { }
         void TriggerResize() override { }
 
-        void ShowMessageBox(const std::string &message) override { }
-        std::string ShowFileDialog(const FileDialogDesc &desc) override { return std::string(); }
-        std::string ShowDirectoryDialog(const std::string &title) override { return std::string(); }
+        void ShowMessageBox(const std::string &/*message*/) override { }
+        std::string ShowFileDialog(const FileDialogDesc &/*desc*/) override { return std::string(); }
+        std::string ShowDirectoryDialog(const std::string &/*title*/) override { return std::string(); }
 
         // Input
         const CursorState * GetCursorState() override { return nullptr; }
         CURSOR_ID GetCursor() override { return CURSOR_ARROW; }
-        void SetCursor(CURSOR_ID cursor) override { }
-        void SetCursorScale(uint8 scale) override  { }
-        void SetCursorVisible(bool value) override { }
-        void GetCursorPosition(sint32 * x, sint32 * y) override { }
-        void SetCursorPosition(sint32 x, sint32 y) override { }
-        void SetCursorTrap(bool value) override { }
+        void SetCursor(CURSOR_ID /*cursor*/) override { }
+        void SetCursorScale(uint8 /*scale*/) override  { }
+        void SetCursorVisible(bool /*value*/) override { }
+        void GetCursorPosition(sint32 * /*x*/, sint32 * /*y*/) override { }
+        void SetCursorPosition(sint32 /*x*/, sint32 /*y*/) override { }
+        void SetCursorTrap(bool /*value*/) override { }
         const uint8 * GetKeysState() override { return nullptr; }
         const uint8 * GetKeysPressed() override { return nullptr; }
-        void SetKeysPressed(uint32 keysym, uint8 scancode) override { }
+        void SetKeysPressed(uint32 /*keysym*/, uint8 /*scancode*/) override { }
 
         class X8DrawingEngineFactory final : public IDrawingEngineFactory
         {
-            std::unique_ptr<IDrawingEngine> Create(DRAWING_ENGINE_TYPE type, const std::shared_ptr<IUiContext>& uiContext) override
+            std::unique_ptr<IDrawingEngine>
+                Create([[maybe_unused]] DRAWING_ENGINE_TYPE type, const std::shared_ptr<IUiContext>& uiContext) override
             {
                 return std::make_unique<X8DrawingEngine>(uiContext);
             }
@@ -82,8 +83,14 @@ namespace OpenRCT2::Ui
 
         // Text input
         bool IsTextInputActive() override { return false; }
-        TextInputSession * StartTextInput(utf8 * buffer, size_t bufferSize) override { return nullptr; }
-        void StopTextInput() override { }
+        TextInputSession* StartTextInput([[maybe_unused]] utf8* buffer, [[maybe_unused]] size_t bufferSize) override
+        {
+            return nullptr;
+        }
+
+        void StopTextInput() override
+        {
+        }
 
         // In-game UI
         IWindowManager * GetWindowManager() override
@@ -92,7 +99,10 @@ namespace OpenRCT2::Ui
         }
 
         // Clipboard
-        bool SetClipboardText(const utf8* target) override { return false; }
+        bool SetClipboardText([[maybe_unused]] const utf8* target) override
+        {
+            return false;
+        }
 
         ~DummyUiContext() { delete _windowManager; }
     };

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -21,17 +21,17 @@ namespace OpenRCT2::Ui
     class DummyWindowManager final : public IWindowManager
     {
         void Init() override {};
-        rct_window * OpenWindow(rct_windowclass wc) override { return nullptr; }
-        rct_window * OpenView(uint8 view) override { return nullptr; }
-        rct_window * OpenDetails(uint8 type, sint32 id) override { return nullptr; }
-        rct_window * ShowError(rct_string_id title, rct_string_id message) override { return nullptr; }
-        rct_window * OpenIntent(Intent * intent) override { return nullptr; };
-        void BroadcastIntent(const Intent &intent) override { }
-        void ForceClose(rct_windowclass windowClass) override { }
+        rct_window * OpenWindow(rct_windowclass /*wc*/) override { return nullptr; }
+        rct_window * OpenView(uint8 /*view*/) override { return nullptr; }
+        rct_window * OpenDetails(uint8 /*type*/, sint32 /*id*/) override { return nullptr; }
+        rct_window * ShowError(rct_string_id /*title*/, rct_string_id /*message*/) override { return nullptr; }
+        rct_window * OpenIntent(Intent * /*intent*/) override { return nullptr; };
+        void BroadcastIntent(const Intent &/*intent*/) override { }
+        void ForceClose(rct_windowclass /*windowClass*/) override { }
         void UpdateMapTooltip() override { }
         void HandleInput() override { }
-        void HandleKeyboard(bool isTitle) override { }
-        std::string GetKeyboardShortcutString(sint32 shortcut) override { return std::string(); }
+        void HandleKeyboard(bool /*isTitle*/) override { }
+        std::string GetKeyboardShortcutString(sint32 /*shortcut*/) override { return std::string(); }
     };
 
     IWindowManager * CreateDummyWindowManager()

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -35,7 +35,14 @@
 
 bool gDisableErrorWindowSound = false;
 
-void game_command_callback_pickup_guest(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_pickup_guest(
+    sint32 eax,
+    sint32 ebx,
+    sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     switch (ecx)
     {
@@ -59,7 +66,14 @@ void game_command_callback_pickup_guest(sint32 eax, sint32 ebx, sint32 ecx, sint
     }
 }
 
-void game_command_callback_hire_new_staff_member(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_hire_new_staff_member(
+    [[maybe_unused]] sint32 eax,
+    [[maybe_unused]] sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     sint32 sprite_index = edi;
     if (sprite_index == SPRITE_INDEX_NULL)
@@ -76,7 +90,14 @@ void game_command_callback_hire_new_staff_member(sint32 eax, sint32 ebx, sint32 
     }
 }
 
-void game_command_callback_pickup_staff(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_pickup_staff(
+    sint32 eax,
+    sint32 ebx,
+    sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     switch (ecx)
     {
@@ -108,7 +129,14 @@ uint8 _rideConstructionState2;
 bool _stationConstructed;
 bool _deferClose;
 
-void game_command_callback_place_ride_entrance_or_exit(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_place_ride_entrance_or_exit(
+    [[maybe_unused]] sint32 eax,
+    [[maybe_unused]] sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    [[maybe_unused]] sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     audio_play_sound_at_location(
         SOUND_PLACE_ITEM,
@@ -555,7 +583,14 @@ void window_ride_construction_update_active_elements()
     context_broadcast_intent(&intent);
 }
 
-void game_command_callback_place_banner(sint32 eax, sint32 ebx, sint32 ecx, sint32 edx, sint32 esi, sint32 edi, sint32 ebp)
+void game_command_callback_place_banner(
+    [[maybe_unused]] sint32 eax,
+    sint32 ebx,
+    [[maybe_unused]] sint32 ecx,
+    [[maybe_unused]] sint32 edx,
+    [[maybe_unused]] sint32 esi,
+    sint32 edi,
+    [[maybe_unused]] sint32 ebp)
 {
     if (ebx != MONEY32_UNDEFINED) {
         sint32 bannerId = edi;


### PR DESCRIPTION
This is a continuation of #7426. This time I used clang-tidy with `misc-unused-parameters` to find all functions with unused arguments, and replaced the ones in the libopenrct2 project. I left the UI project as it is.

For dummy classes and functions with empty bodies I've only commented out the arguments, for all others I used C++17's `[[maybe_unused]]`.