### PR TITLE
Order vehicle type dropdown orthographically

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -49,6 +49,7 @@
 - Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
 - Improved: [#7567] Improve the performance of loading parks and the title sequence.
 - Improved: [#7577] Allow fine-tuning the virtual floor style.
+- Improved: [#7608] The vehicle selection dropdown is now sorted orthographically.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------


### PR DESCRIPTION
As requested in #7606, this PR orders the vehicle type dropdown orthographically as well:

![screenshot_20180601_201314](https://user-images.githubusercontent.com/604665/40856525-82260854-65d8-11e8-871c-87b96c6fe5b2.png)
