### PR TITLE
Prevent changelog window from painting lines out of view

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.
 - Fix: [#6134] Scenarios incorrectly categorised when using Polish version of RCT2.
 - Fix: [#6141] CSS50.dat is never loaded.
+- Fix: [#6647] Changelog window causes FPS drop.
 - Fix: [#6938] Banner do not correctly capitalise non-ASCII characters.
 - Fix: [#7176] Mechanics sometimes fall down from rides.
 - Fix: [#7303] Visual glitch with virtual floor near map edges.

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -170,7 +170,9 @@ static void window_changelog_scrollgetsize(
     [[maybe_unused]] rct_window * w, [[maybe_unused]] sint32 scrollIndex, sint32 * width, sint32 * height)
 {
     *width = _changelogLongestLineWidth + 4;
-    *height = (sint32)(_changelogLines.size() * 11);
+
+    const sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    *height = (sint32)(_changelogLines.size() * lineHeight);
 }
 
 static void window_changelog_invalidate(rct_window *w)

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -196,12 +196,17 @@ static void window_changelog_scrollpaint(rct_window * w, rct_drawpixelinfo * dpi
     gCurrentFontFlags = 0;
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
+    const sint32 lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+
     sint32 x = 3;
-    sint32 y = 3;
+    sint32 y = 3 - lineHeight;
     for (auto line : _changelogLines)
     {
+        y += lineHeight;
+        if (y < dpi->y || y >= dpi->y + dpi->height)
+            continue;
+
         gfx_draw_string(dpi, (char *)line, w->colours[0], x, y);
-        y += 11;
     }
 }
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -203,7 +203,7 @@ static void window_changelog_scrollpaint(rct_window * w, rct_drawpixelinfo * dpi
     for (auto line : _changelogLines)
     {
         y += lineHeight;
-        if (y < dpi->y || y >= dpi->y + dpi->height)
+        if (y + lineHeight < dpi->y || y >= dpi->y + dpi->height)
             continue;
 
         gfx_draw_string(dpi, (char *)line, w->colours[0], x, y);


### PR DESCRIPTION
As raised in #6647, the changelog window currently repaints the entire changelog on every frame, including lines outside of the current viewport.

Ideally, we'd not repaint the scrollview when no change is required, though. Is this possible in the current widget system? I haven't found a way yet.

This changeset introduces a side effect in (inconsistent) flickering text. This will obviously need to be solved before merge. I wanted to open the PR for discussion, though.