### PR TITLE
Allow scrolling on spinners/steppers

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -52,6 +52,7 @@
 - Improved: [#7577] Allow fine-tuning the virtual floor style.
 - Improved: [#7608] The vehicle selection dropdown is now sorted orthographically.
 - Improved: [#7613] Resizing the staff window now resizes the name and action columns too.
+- Improved: [#7627] Allow scrolling up and down on steppers to change their values.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -36,8 +36,6 @@ enum WINDOW_CLEAR_SCENERY_WIDGET_IDX {
     WIDX_FOOTPATH
 };
 
-validate_global_widx(WC_CLEAR_SCENERY, WIDX_PREVIEW);
-
 static rct_widget window_clear_scenery_widgets[] = {
     { WWT_FRAME,    0,  0,  97, 0,  93, 0xFFFFFFFF,                                 STR_NONE },                         // panel / background
     { WWT_CAPTION,  0,  1,  96, 1,  14, STR_CLEAR_SCENERY,                          STR_WINDOW_TITLE_TIP },             // title bar

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -40,8 +40,6 @@ enum WINDOW_LAND_WIDGET_IDX {
     WIDX_WALL,
 };
 
-validate_global_widx(WC_LAND, WIDX_PREVIEW);
-
 static rct_widget window_land_widgets[] = {
     { WWT_FRAME,    0,  0,  97, 0,  159,        0xFFFFFFFF,                             STR_NONE },                     // panel / background
     { WWT_CAPTION,  0,  1,  96, 1,  14,         STR_LAND,                               STR_WINDOW_TITLE_TIP },         // title bar

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -39,8 +39,6 @@ enum WINDOW_WATER_WIDGET_IDX {
     WIDX_BUY_CONSTRUCTION_RIGHTS
 };
 
-validate_global_widx(WC_LAND_RIGHTS, WIDX_PREVIEW);
-
 static rct_widget window_land_rights_widgets[] = {
     { WWT_FRAME,    0,  0,  97, 0,  93, 0xFFFFFFFF,                                 STR_NONE },                             // panel / background
     { WWT_CAPTION,  0,  1,  96, 1,  14, STR_LAND_RIGHTS,                            STR_WINDOW_TITLE_TIP },                 // title bar

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -77,7 +77,6 @@ enum WINDOW_MAP_WIDGET_IDX {
     WIDX_MAP_GENERATOR = 21
 };
 
-validate_global_widx(WC_MAP, WIDX_LAND_TOOL);
 validate_global_widx(WC_MAP, WIDX_ROTATE_90);
 
 static rct_widget window_map_widgets[] = {

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -84,6 +84,7 @@ static bool _dragging;
 
 static void window_view_clipping_close_button(rct_window* w);
 static void window_view_clipping_mouseup(rct_window* w, rct_widgetindex widgetIndex);
+static void window_view_clipping_mousedown(rct_window*w, rct_widgetindex widgetIndex, rct_widget *widget);
 static void window_view_clipping_update(rct_window* w);
 static void window_view_clipping_tool_update(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
 static void window_view_clipping_tool_down(rct_window* w, rct_widgetindex widgetIndex, sint32 x, sint32 y);
@@ -98,7 +99,7 @@ static rct_window_event_list window_view_clipping_events = {
     window_view_clipping_close_button,
     window_view_clipping_mouseup,
     nullptr,
-    nullptr,
+    window_view_clipping_mousedown,
     nullptr,
     nullptr,
     window_view_clipping_update,
@@ -160,6 +161,7 @@ rct_window * window_view_clipping_open()
         (1ULL << WIDX_CLIP_HEIGHT_SLIDER) |
         (1ULL << WIDX_CLIP_SELECTOR) |
         (1ULL << WIDX_CLIP_CLEAR);
+    window->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
 
     window_init_scroll_widgets(window);
 
@@ -224,20 +226,6 @@ static void window_view_clipping_mouseup(rct_window *w, rct_widgetindex widgetIn
         }
         window_invalidate(w);
         break;
-    case WIDX_CLIP_HEIGHT_INCREASE:
-        if (gClipHeight < 255)
-            window_view_clipping_set_clipheight(w, gClipHeight + 1);
-        mainWindow = window_get_main();
-        if (mainWindow != nullptr)
-            window_invalidate(mainWindow);
-        break;
-    case WIDX_CLIP_HEIGHT_DECREASE:
-        if (gClipHeight > 0)
-            window_view_clipping_set_clipheight(w, gClipHeight - 1);
-        mainWindow = window_get_main();
-        if (mainWindow != nullptr)
-            window_invalidate(mainWindow);
-        break;
     case WIDX_CLIP_HEIGHT_VALUE:
         // Toggle display of the cut height value in RAW vs UNITS
         if (gClipHeightDisplayType == DISPLAY_TYPE::DISPLAY_RAW)
@@ -273,6 +261,29 @@ static void window_view_clipping_mouseup(rct_window *w, rct_widgetindex widgetIn
         gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
         gfx_invalidate_screen();
         break;
+    }
+}
+
+static void window_view_clipping_mousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
+{
+    rct_window* mainWindow = window_get_main();
+
+    switch (widgetIndex)
+    {
+        case WIDX_CLIP_HEIGHT_INCREASE:
+            if (gClipHeight < 255)
+                window_view_clipping_set_clipheight(w, gClipHeight + 1);
+            mainWindow = window_get_main();
+            if (mainWindow != nullptr)
+                window_invalidate(mainWindow);
+            break;
+        case WIDX_CLIP_HEIGHT_DECREASE:
+            if (gClipHeight > 0)
+                window_view_clipping_set_clipheight(w, gClipHeight - 1);
+            mainWindow = window_get_main();
+            if (mainWindow != nullptr)
+                window_invalidate(mainWindow);
+            break;
     }
 }
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -33,8 +33,6 @@ enum WINDOW_WATER_WIDGET_IDX {
     WIDX_INCREMENT
 };
 
-validate_global_widx(WC_WATER, WIDX_PREVIEW);
-
 static rct_widget window_water_widgets[] = {
     { WWT_FRAME,    0,  0,  75, 0,  76, 0xFFFFFFFF,                             STR_NONE },                         // panel / background
     { WWT_CAPTION,  0,  1,  74, 1,  14, STR_WATER,                              STR_WINDOW_TITLE_TIP },             // title bar

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -32,6 +32,7 @@
 #include "../OpenRCT2.h"
 #include "../platform/platform.h"
 #include "../scenario/Scenario.h"
+#include "../sprites.h"
 #include "../world/Map.h"
 #include "../world/Sprite.h"
 #include "Viewport.h"
@@ -292,34 +293,36 @@ static bool window_other_wheel_input(rct_window* w, rct_widgetindex widgetIndex,
     }
 
     rct_widgetindex buttonWidgetIndex;
-    if (widgetType == WWT_IMGBTN)
+    uint16 expectedType;
+    uint32 expectedContent[2];
+    switch (widgetType)
     {
-        buttonWidgetIndex = wheel < 0 ? widgetIndex + 2 : widgetIndex + 1;
-
-        // For previews, the - and + buttons are expected to be of type WWT_TRNBTN
-        auto buttonType = w->widgets[buttonWidgetIndex].type;
-        if (buttonType != WWT_TRNBTN)
-        {
-            return false;
-        }
+        case WWT_IMGBTN:
+            buttonWidgetIndex = wheel < 0 ? widgetIndex + 2 : widgetIndex + 1;
+            expectedType = WWT_TRNBTN;
+            expectedContent[0] = IMAGE_TYPE_REMAP | SPR_LAND_TOOL_DECREASE;
+            expectedContent[1] = IMAGE_TYPE_REMAP | SPR_LAND_TOOL_INCREASE;
+            break;
+        case WWT_STEPPER:
+            buttonWidgetIndex = wheel < 0 ? widgetIndex + 1 : widgetIndex + 2;
+            expectedType = WWT_BUTTON;
+            expectedContent[0] = STR_NUMERIC_UP;
+            expectedContent[1] = STR_NUMERIC_DOWN;
+            break;
+        default: return false;
     }
-    else if (widgetType == WWT_STEPPER)
-    {
-        buttonWidgetIndex = wheel < 0 ? widgetIndex + 1 : widgetIndex + 2;
 
-        // For steppers, the - and + buttons are expected to be of type WWT_BUTTON
-        auto buttonType = w->widgets[buttonWidgetIndex].type;
-        if (buttonType != WWT_BUTTON)
-        {
-            return false;
-        }
-    }
-    else
+    if (widget_is_disabled(w, buttonWidgetIndex))
     {
         return false;
     }
 
-    if (widget_is_disabled(w, buttonWidgetIndex))
+    auto button1Type = w->widgets[widgetIndex + 1].type;
+    auto button1Image = w->widgets[widgetIndex + 1].image;
+    auto button2Type = w->widgets[widgetIndex + 2].type;
+    auto button2Image = w->widgets[widgetIndex + 2].image;
+    if (button1Type != expectedType || button2Type != expectedType || button1Image != expectedContent[0]
+        || button2Image != expectedContent[1])
     {
         return false;
     }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -303,7 +303,7 @@ static bool window_other_wheel_input(rct_window* w, rct_widgetindex widgetIndex,
             return false;
         }
     }
-    else
+    else if (widgetType == WWT_STEPPER)
     {
         buttonWidgetIndex = wheel < 0 ? widgetIndex + 1 : widgetIndex + 2;
 
@@ -313,6 +313,10 @@ static bool window_other_wheel_input(rct_window* w, rct_widgetindex widgetIndex,
         {
             return false;
         }
+    }
+    else
+    {
+        return false;
     }
 
     if (widget_is_disabled(w, buttonWidgetIndex))

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -457,18 +457,13 @@ enum {
 #define WC_RIDE_CONSTRUCTION__WIDX_ROTATE               32
 #define WC_SCENERY__WIDX_SCENERY_TAB_1                  4
 #define WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON  25
-#define WC_LAND__WIDX_PREVIEW                           5
-#define WC_WATER__WIDX_PREVIEW                          3
 #define WC_PEEP__WIDX_PATROL                            11
 #define WC_PEEP__WIDX_ACTION_LBL                        12
 #define WC_PEEP__WIDX_PICKUP                            13
 #define WC_TRACK_DESIGN_LIST__WIDX_ROTATE               8
 #define WC_TRACK_DESIGN_PLACE__WIDX_ROTATE              3
-#define WC_MAP__WIDX_LAND_TOOL                          13
 #define WC_MAP__WIDX_ROTATE_90                          20
 #define WC_EDITOR_OBJECT_SELECTION__WIDX_TAB_1          21
-#define WC_CLEAR_SCENERY__WIDX_PREVIEW                  3
-#define WC_LAND_RIGHTS__WIDX_PREVIEW                    3
 #define WC_STAFF__WIDX_PICKUP                           10
 
 enum PROMPT_MODE {


### PR DESCRIPTION
This implementes an idea that I got from https://github.com/OpenRCT2/OpenRCT2/pull/7579

Just like scrolling while over preview images for the land-, watertool and some others, you can now scroll while hovering over a stepper.
I've changed the behaviour of the `window_other_wheel_input` function to, instead of checking for semi-hardcoded widgets IDs and window classes, make performs a few checks to make sure the widget that is scrolled on belongs to a tool-size preview widget or to a stepper widget. With the new behaviour, you can also scroll while hovering over the + and - buttons of the previews, which was previously not possible.

n.b. I've used the term 'stepper' everywhere because that's currently used in the code.