### PR TITLE
Fix tile inspector errors for banner

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1654,6 +1654,14 @@ static void window_tile_inspector_invalidate(rct_window *w)
         w->widgets[WIDX_BANNER_SPINNER_HEIGHT_INCREASE].bottom = GBBB(propertiesAnchor, 0) - 4;
         w->widgets[WIDX_BANNER_SPINNER_HEIGHT_DECREASE].top = GBBT(propertiesAnchor, 0) + 4;
         w->widgets[WIDX_BANNER_SPINNER_HEIGHT_DECREASE].bottom = GBBB(propertiesAnchor, 0) - 4;
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_NE].top = GBBT(propertiesAnchor, 1);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_NE].bottom = GBBB(propertiesAnchor, 1);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_SE].top = GBBT(propertiesAnchor, 2);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_SE].bottom = GBBB(propertiesAnchor, 2);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_SW].top = GBBT(propertiesAnchor, 2);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_SW].bottom = GBBB(propertiesAnchor, 2);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_NW].top = GBBT(propertiesAnchor, 1);
+        w->widgets[WIDX_BANNER_CHECK_BLOCK_NW].bottom = GBBB(propertiesAnchor, 1);
         widget_set_checkbox_value(w, WIDX_BANNER_CHECK_BLOCK_NE, !(tileElement->properties.banner.flags & (1 << ((0 - get_current_rotation()) & 3))));
         widget_set_checkbox_value(w, WIDX_BANNER_CHECK_BLOCK_SE, !(tileElement->properties.banner.flags & (1 << ((1 - get_current_rotation()) & 3))));
         widget_set_checkbox_value(w, WIDX_BANNER_CHECK_BLOCK_SW, !(tileElement->properties.banner.flags & (1 << ((2 - get_current_rotation()) & 3))));

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -267,11 +267,15 @@ sint32 tile_inspector_rotate_element_at(sint32 x, sint32 y, sint32 elementIndex,
             tileElement->type |= newRotation;
             break;
         case TILE_ELEMENT_TYPE_BANNER:
-            tileElement->properties.banner.flags ^= 1 << tileElement->properties.banner.position;
+        {
+            uint8 unblockedEdges = tileElement->properties.banner.flags & 0xF;
+            unblockedEdges = (unblockedEdges << 1 | unblockedEdges >> 3) & 0xF;
+            tileElement->properties.banner.flags &= ~0xF;
+            tileElement->properties.banner.flags |= unblockedEdges;
             tileElement->properties.banner.position++;
             tileElement->properties.banner.position &= 3;
-            tileElement->properties.banner.flags ^= 1 << tileElement->properties.banner.position;
             break;
+        }
         }
 
         map_invalidate_tile_full(x << 5, y << 5);


### PR DESCRIPTION
This is likely the least used page of the tile inspector, since two things have been broken for months apparently.

- The checkboxes for the blocked edges weren't being positioned correctly
- Rotating a banner that has either 0 or more than 1 edges blocked, the blocked edges weren't updated correctly