### PR TITLE
Fix #7434: Allow deletion of isolated diagonal track

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -110,6 +110,7 @@ The following people are not part of the development team, but have been contrib
 * Nathan Zabriskie (NathanZabriskie)
 * Toby Hinloopen (tobyhinloopen)
 * Patrick Martinez (martip23)
+* Andy Ford (AndyTWF)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,7 +32,7 @@
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.
 - Fix: [#7418] Staff walk off paths with a connection but no adjacent path.
-- Fix: [#7434] Allow deletion of isolated diagonal track pieces
+- Fix: [#7434] Diagonal ride segments cannot be deleted if they are isolated.
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: [#7480] Graphs skip values of 0.
 - Fix: [#7505] Game crashes when trying to make path over map edge while having clearance checks disabled.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,13 +32,13 @@
 - Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.
 - Fix: [#7418] Staff walk off paths with a connection but no adjacent path.
+- Fix: [#7434] Allow deletion of isolated diagonal track pieces
 - Fix: [#7436] Only the first 32 vehicles of a train can be painted.
 - Fix: [#7480] Graphs skip values of 0.
 - Fix: [#7505] Game crashes when trying to make path over map edge while having clearance checks disabled.
 - Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Fix: [#7544] Starting a headless server with no arguments causes the game to freeze.
 - Fix: [#7571] Hovering a ride design over scenery or tracks will give tons of money.
-- Fix: [#7434] Allow deletion of isolated diagonal track pieces
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Fix: [#7544] Starting a headless server with no arguments causes the game to freeze.
 - Fix: [#7571] Hovering a ride design over scenery or tracks will give tons of money.
+- Fix: [#7434] Allow deletion of isolated diagonal track pieces
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1827,7 +1827,7 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
         direction = _currentTrackPieceDirection;
         type = _currentTrackPieceType;
 
-        if (sub_6C683D(&x, &y, &z, direction, type, 0, &tileElement, 0)) {
+        if (sub_6C683D(&x, &y, &z, direction & 3, type, 0, &tileElement, 0)) {
             window_ride_construction_update_active_elements();
             return;
         }

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -513,7 +513,7 @@ void window_ride_construction_mouseup_demolish_next_piece(sint32 x, sint32 y, si
         _rideConstructionState = RIDE_CONSTRUCTION_STATE_FRONT;
         _currentTrackSelectionFlags = 0;
         _rideConstructionArrowPulseTime = 0;
-        direction = _currentTrackPieceDirection;
+        _currentTrackPieceDirection = direction & 3;
         sint32 slope = _currentTrackCurve;
         sint32 slopeEnd = _previousTrackSlopeEnd;
         sint32 b2 = _currentTrackSlopeEnd;
@@ -525,7 +525,7 @@ void window_ride_construction_mouseup_demolish_next_piece(sint32 x, sint32 y, si
         window_ride_construction_update_active_elements();
         if (!ride_try_get_origin_element(_currentRideIndex, NULL)) {
             ride_initialise_construction_window(_currentRideIndex);
-            _currentTrackPieceDirection = direction;
+            _currentTrackPieceDirection = direction & 3;
             if (!(slope & 0x100)) {
                 _currentTrackCurve = slope;
                 _previousTrackSlopeEnd = slopeEnd;


### PR DESCRIPTION
Allow for the deletion of isolated diagonal track.

Mimic vanilla RCT2:

- If the isolated track is the last piece on the ride, delete and
set the construction mode to a straight piece. Rotate said piece
45 degrees counter-clockwise.
- If other track still exists, delete and rotate as above but
set the track type to station-platform.
- If banked, set track type to the turn that entered the previous
orientation. For example, north west banked track would continue
with a banked 45 degree turn starting facing west.