### PR TITLE
Fix #7653: Loan spinner too small for big loans

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.2.0+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#6998] Guests now wait for passing vehicles before crossing railway tracks.
-- Fix: [#7653] Finances money spinner is to narrow for big loans.
+- Fix: [#7653] Finances money spinner is too narrow for big loans.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.2.0+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#6998] Guests now wait for passing vehicles before crossing railway tracks.
+- Fix: [#7653] Finances money spinner is to narrow for big loans.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -101,7 +101,7 @@ static rct_widget _windowFinancesSummaryWidgets[] =
     { WWT_RESIZE,           1,  0,      529,    43, 309,    0xFFFFFFFF,                 STR_NONE                                }, \
     TAB_WIDGETS,
     { WWT_SCROLL,           1,  130,    520,     50,    260,    SCROLL_HORIZONTAL,                  STR_NONE },
-      SPINNER_WIDGETS      (1,  64,     153,    279,    290,    STR_FINANCES_SUMMARY_LOAN_VALUE,    STR_NONE), // NB: 3 widgets.
+      SPINNER_WIDGETS      (1,  64,     160,    279,    290,    STR_FINANCES_SUMMARY_LOAN_VALUE,    STR_NONE), // NB: 3 widgets.
     { WIDGETS_END },
 };
 
@@ -698,7 +698,7 @@ static void window_finances_summary_paint(rct_window *w, rct_drawpixelinfo *dpi)
     // Loan and interest rate
     gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_LOAN, nullptr, COLOUR_BLACK, w->x + 8, w->y + 279);
     set_format_arg(0, uint16, gBankLoanInterestRate);
-    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, gCommonFormatArgs, COLOUR_BLACK, w->x + 160, w->y + 279);
+    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, gCommonFormatArgs, COLOUR_BLACK, w->x + 167, w->y + 279);
 
     // Current cash
     rct_string_id stringId = gCash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;


### PR DESCRIPTION
On large loans in the millions (e.g. Alton Towers / BPB), the loan
amount can extend so far that it runs over the spinner widget.
This change makes the loan box slightly larger on the right side to
accommodate larger loans.