### PR TITLE
Use unicode dingbats for +/- buttons in CJK languages

### DIFF
--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -112,6 +112,9 @@ sint32 font_sprite_get_codepoint_offset(sint32 codepoint)
     case UNICODE_Z_DOT: return RCT2_Z_DOT - 32;
     case UNICODE_Z_ACUTE: return RCT2_Z_ACUTE - 32;
 
+    // Render capital sharp-S (ẞ) with lowercase sprite (ß)
+    case UNICODE_CAPITAL_SHARP_S: return 223 - 32;
+
     case UNICODE_DINGBATS_PLUS: return 11;
     case UNICODE_DINGBATS_MINUS: return 13;
 

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -112,6 +112,9 @@ sint32 font_sprite_get_codepoint_offset(sint32 codepoint)
     case UNICODE_Z_DOT: return RCT2_Z_DOT - 32;
     case UNICODE_Z_ACUTE: return RCT2_Z_ACUTE - 32;
 
+    case UNICODE_DINGBATS_PLUS: return 11;
+    case UNICODE_DINGBATS_MINUS: return 13;
+
     default:
         if (codepoint < 32 || codepoint >= 256) codepoint = '?';
         return codepoint - 32;

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -137,6 +137,8 @@ bool utf8_should_use_sprite_for_codepoint(sint32 codepoint)
     case FORMAT_LEFT:
     case FORMAT_OPENQUOTES:
     case FORMAT_ENDQUOTES:
+    case UNICODE_DINGBATS_PLUS:
+    case UNICODE_DINGBATS_MINUS:
         return true;
     default:
         return false;

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -181,6 +181,11 @@ enum UnicodePolish
     UNICODE_Z_ACUTE = 378,
 };
 
+enum UnicodeGerman
+{
+    UNICODE_CAPITAL_SHARP_S = 0x1E9E,
+};
+
 enum UnicodeDingbats
 {
     UNICODE_DINGBATS_PLUS = 0x2795,

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -181,4 +181,10 @@ enum UnicodePolish
     UNICODE_Z_ACUTE = 378,
 };
 
+enum UnicodeDingbats
+{
+    UNICODE_DINGBATS_PLUS = 0x2795,
+    UNICODE_DINGBATS_MINUS = 0x2796,
+};
+
 #endif


### PR DESCRIPTION
As of #7579, we use +/- buttons instead of the up/down spinners to make value increments more easy. This does not look very aesthetically pleasing for languages using TTF fonts, however, as reported in #7616: 
![image](https://user-images.githubusercontent.com/10726524/40877577-3039ec72-66be-11e8-9869-08b6558d16ff.png)

This PR addresses this by allowing these languages to use dingbat glyphs ➕ (0x2795) and ➖ (0x2796) to use the sprite glyphs in these situations.
![screenshot_20180611_223601](https://user-images.githubusercontent.com/604665/41255749-d8348a80-6dc7-11e8-8159-9083e0870bcb.png)

Other plus and minus signs in texts will still be rendered with the TTF glyphs.

The language files for the languages in question will still need to be changed after this PR is merged:
```diff
-STR_1218    :{BLACK}+
-STR_1219    :{BLACK}-
+STR_1218    :{BLACK}➕
+STR_1219    :{BLACK}➖
```

As an added bonus, I've also tackled the rendering of U+1E9E ẞ (LATIN CAPITAL LETTER SHARP S) as U+00DF ß (LATIN SMALL LETTER SHARP S) if the sprite font is being used.