### PR TITLE
Add string include

### DIFF
--- a/src/openrct2-ui/SDLException.h
+++ b/src/openrct2-ui/SDLException.h
@@ -18,6 +18,7 @@
 
 #include <SDL2/SDL.h>
 #include <stdexcept>
+#include <string>
 
 /**
  * An exception which wraps an SDL error.


### PR DESCRIPTION
LLVM 6.0 on FreeBSD needs it for basic_string template.