### PR TITLE
Introduce calls to check for research markers

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -223,7 +223,7 @@ static void research_scenery_groups_setup()
             continue;
 
         rct_research_item* research = gResearchItems;
-        for (; research->rawValue != RESEARCHED_ITEMS_END; research++)
+        for (; !research->IsUninventedEndMarker(); research++)
         {
             if ((research->rawValue & 0xFFFFFF) != entryIndex)
                 continue;
@@ -268,7 +268,7 @@ static void move_research_item(rct_research_item *beforeItem)
     do {
         *researchItem = *(researchItem + 1);
         researchItem++;
-    } while (researchItem->rawValue != RESEARCHED_ITEMS_END_2);
+    } while (!researchItem->IsRandomEndMarker());
     // At end of this researchItem points to the end of the list
 
     if (beforeItem > _editorInventionsListDraggedItem)
@@ -301,11 +301,11 @@ static rct_research_item *window_editor_inventions_list_get_item_from_scroll_y(s
 
     if (scrollIndex != 0) {
         // Skip pre-researched items
-        for (; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++) { }
+        for (; !researchItem->IsInventedEndMarker(); researchItem++) { }
         researchItem++;
     }
 
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR && researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !researchItem->IsInventedEndMarker() && !researchItem->IsUninventedEndMarker(); researchItem++)
     {
         y -= SCROLLABLE_ROW_HEIGHT;
         if (y < 0)
@@ -329,11 +329,11 @@ static rct_research_item *window_editor_inventions_list_get_item_from_scroll_y_i
 
     if (scrollIndex != 0) {
         // Skip pre-researched items
-        for (; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++) { }
+        for (; !researchItem->IsInventedEndMarker(); researchItem++) { }
         researchItem++;
     }
 
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR && researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !researchItem->IsInventedEndMarker() && !researchItem->IsUninventedEndMarker(); researchItem++)
     {
         y -= SCROLLABLE_ROW_HEIGHT;
         if (y < 0)
@@ -498,7 +498,7 @@ static void window_editor_inventions_list_scrollgetheight(rct_window *w, sint32 
     *height = 0;
 
     // Count / skip pre-researched items
-    for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
+    for (researchItem = gResearchItems; !researchItem->IsInventedEndMarker(); researchItem++)
         *height += SCROLLABLE_ROW_HEIGHT;
 
     if (scrollIndex == 1) {
@@ -506,7 +506,7 @@ static void window_editor_inventions_list_scrollgetheight(rct_window *w, sint32 
 
         // Count non pre-researched items
         *height = 0;
-        for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+        for (; !researchItem->IsUninventedEndMarker(); researchItem++)
             *height += SCROLLABLE_ROW_HEIGHT;
     }
 }
@@ -742,7 +742,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
     if (scrollIndex == 1)
     {
         // Skip pre-researched items
-        for (; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++) { }
+        for (; !researchItem->IsInventedEndMarker(); researchItem++) { }
         researchItem++;
         researchItemEndMarker = RESEARCHED_ITEMS_END;
     }
@@ -779,7 +779,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpix
             gfx_filter_rect(dpi, 0, top, boxWidth, bottom, PALETTE_DARKEN_1);
         }
 
-        if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR || researchItem->rawValue == RESEARCHED_ITEMS_END)
+        if (researchItem->IsInventedEndMarker() || researchItem->IsUninventedEndMarker())
             continue;
 
         if (researchItem == _editorInventionsListDraggedItem)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -809,7 +809,7 @@ static void window_new_ride_invalidate(rct_window *w)
 
     if (_windowNewRideCurrentTab == WINDOW_NEW_RIDE_PAGE_RESEARCH) {
         window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_EMPTY;
-        if (gResearchLastItem.rawValue != RESEARCHED_ITEMS_SEPARATOR)
+        if (!gResearchLastItem.IsInventedEndMarker())
         {
             uint8 type = gResearchLastItem.type;
             window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -317,7 +317,7 @@ static void window_research_development_invalidate(rct_window *w)
     window_research_set_pressed_tab(w);
 
     window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_EMPTY;
-    if (gResearchLastItem.rawValue != RESEARCHED_ITEMS_SEPARATOR)
+    if (!gResearchLastItem.IsInventedEndMarker())
     {
         uint8 type = gResearchLastItem.type;
         window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;
@@ -395,7 +395,7 @@ void window_research_development_page_paint(rct_window *w, rct_drawpixelinfo *dp
     y = w->y + w->widgets[WIDX_LAST_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
 
     rct_string_id lastDevelopmentFormat;
-    if (gResearchLastItem.rawValue != RESEARCHED_ITEMS_SEPARATOR)
+    if (!gResearchLastItem.IsInventedEndMarker())
     {
         stringId = research_item_get_name(&gResearchLastItem);
         uint8 type = gResearchLastItem.type;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -84,9 +84,9 @@ void research_update_uncompleted_types()
 {
     sint32 uncompletedResearchTypes = 0;
     rct_research_item * researchItem = gResearchItems;
-    while (researchItem++->rawValue != RESEARCHED_ITEMS_SEPARATOR);
+    while (!(researchItem++)->IsInventedEndMarker());
 
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !researchItem->IsUninventedEndMarker(); researchItem++)
     {
         uncompletedResearchTypes |= (1 << researchItem->category);
     }
@@ -139,7 +139,7 @@ static void research_next_design()
 
     // Skip already researched items
     firstUnresearchedItem = gResearchItems;
-    while (firstUnresearchedItem->rawValue != RESEARCHED_ITEMS_SEPARATOR)
+    while (!firstUnresearchedItem->IsInventedEndMarker())
     {
         firstUnresearchedItem++;
     }
@@ -149,7 +149,7 @@ static void research_next_design()
     for (;;)
     {
         researchItem++;
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
+        if (researchItem->IsUninventedEndMarker())
         {
             if (!ignoreActiveResearchTypes)
             {
@@ -186,7 +186,7 @@ static void research_next_design()
         *(researchItem - 1) = tmp;
         researchItem--;
     }
-    while ((researchItem + 1)->rawValue != RESEARCHED_ITEMS_SEPARATOR);
+    while (!(researchItem + 1)->IsInventedEndMarker());
 
     research_invalidate_related_windows();
 }
@@ -233,9 +233,9 @@ void research_finish_item(rct_research_item * researchItem)
             bool seenRideEntry[MAX_RIDE_OBJECTS];
 
             rct_research_item * researchItem2 = gResearchItems;
-            for (; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
+            for (; !researchItem2->IsUninventedEndMarker(); researchItem2++)
             {
-                if (researchItem2->rawValue != RESEARCHED_ITEMS_SEPARATOR &&
+                if (!researchItem2->IsInventedEndMarker() &&
                     researchItem2->type == RESEARCH_ENTRY_TYPE_RIDE)
                 {
                     uint8 index = researchItem2->entryIndex;
@@ -387,10 +387,10 @@ void research_update()
 void research_process_random_items()
 {
     rct_research_item * research = gResearchItems;
-    for (; research->rawValue != RESEARCHED_ITEMS_END; research++) { }
+    for (; !research->IsUninventedEndMarker(); research++) { }
 
     research++;
-    for (; research->rawValue != RESEARCHED_ITEMS_END_2; research += 2)
+    for (; !research->IsRandomEndMarker(); research += 2)
     {
         if (scenario_rand() & 1)
         {
@@ -411,7 +411,7 @@ void research_process_random_items()
                 ebp = inner_research;
             }
         }
-        while ((inner_research++)->rawValue != RESEARCHED_ITEMS_END);
+        while (!(inner_research++)->IsUninventedEndMarker());
         assert(edx != nullptr);
         edx->rawValue = research->rawValue;
         assert(ebp != nullptr);
@@ -439,7 +439,7 @@ void research_reset_current_item()
     set_all_scenery_groups_not_invented();
 
 
-    for (rct_research_item * research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_SEPARATOR; research++)
+    for (rct_research_item * research = gResearchItems; !research->IsInventedEndMarker(); research++)
     {
         research_finish_item(research);
     }
@@ -460,11 +460,11 @@ static void research_insert_unresearched(sint32 rawValue, sint32 category)
     researchItem = gResearchItems;
     do
     {
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
+        if (researchItem->IsUninventedEndMarker())
         {
             // Insert slot
             researchItem2 = researchItem;
-            while (researchItem2->rawValue != RESEARCHED_ITEMS_END_2)
+            while (!researchItem2->IsRandomEndMarker())
             {
                 researchItem2++;
             }
@@ -489,7 +489,7 @@ static void research_insert_researched(sint32 rawValue, uint8 category)
 
     researchItem = gResearchItems;
     // First check to make sure that entry is not already accounted for
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !researchItem->IsUninventedEndMarker(); researchItem++)
     {
         if ((researchItem->rawValue & 0xFFFFFF) == (rawValue & 0xFFFFFF))
         {
@@ -499,11 +499,11 @@ static void research_insert_researched(sint32 rawValue, uint8 category)
     researchItem = gResearchItems;
     do
     {
-        if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
+        if (researchItem->IsInventedEndMarker())
         {
             // Insert slot
             researchItem2 = researchItem;
-            while (researchItem2->rawValue != RESEARCHED_ITEMS_END_2)
+            while (!researchItem2->IsRandomEndMarker())
             {
                 researchItem2++;
             }
@@ -525,7 +525,7 @@ static void research_insert_researched(sint32 rawValue, uint8 category)
 void research_remove(rct_research_item * researchItem)
 {
     for (rct_research_item * researchItem2 = gResearchItems;
-         researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
+         !researchItem2->IsUninventedEndMarker(); researchItem2++)
     {
         if (researchItem2->rawValue == researchItem->rawValue)
         {
@@ -533,7 +533,7 @@ void research_remove(rct_research_item * researchItem)
             {
                 *researchItem2 = *(researchItem2 + 1);
             }
-            while (researchItem2++->rawValue != RESEARCHED_ITEMS_END_2);
+            while (!(researchItem2++)->IsRandomEndMarker());
             return;
         }
     }
@@ -845,7 +845,7 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8 trackType, rct_rid
  */
 void research_remove_flags()
 {
-    for (rct_research_item * research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_END_2; research++)
+    for (rct_research_item * research = gResearchItems; !research->IsRandomEndMarker(); research++)
     {
         // Clear the always researched flags.
         if (research->rawValue > RESEARCHED_ITEMS_SEPARATOR)
@@ -861,9 +861,9 @@ void research_fix()
     for (sint32 i = 0; i < MAX_RESEARCH_ITEMS; i++)
     {
         rct_research_item * researchItem = &gResearchItems[i];
-        if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
+        if (researchItem->IsInventedEndMarker())
             continue;
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
+        if (researchItem->IsUninventedEndMarker())
         {
             if (i == MAX_RESEARCH_ITEMS - 1)
             {
@@ -872,7 +872,7 @@ void research_fix()
             (++researchItem)->rawValue = RESEARCHED_ITEMS_END_2;
             break;
         }
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END_2)
+        if (researchItem->IsRandomEndMarker())
             break;
         if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE)
         {
@@ -940,13 +940,13 @@ void research_items_make_all_unresearched()
     sint32 sorted;
     do {
         sorted = 1;
-        for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
+        for (researchItem = gResearchItems; !researchItem->IsInventedEndMarker(); researchItem++)
         {
             if (research_item_is_always_researched(researchItem))
                 continue;
 
             nextResearchItem = researchItem + 1;
-            if (nextResearchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR || research_item_is_always_researched(nextResearchItem))
+            if (nextResearchItem->IsInventedEndMarker() || research_item_is_always_researched(nextResearchItem))
             {
                 // Bubble up always researched item or separator
                 researchItemTemp = *researchItem;
@@ -954,7 +954,7 @@ void research_items_make_all_unresearched()
                 *nextResearchItem = researchItemTemp;
                 sorted = 0;
 
-                if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
+                if (researchItem->IsInventedEndMarker())
                     break;
             }
         }
@@ -967,10 +967,10 @@ void research_items_make_all_researched()
     rct_research_item * researchItem, researchItemTemp;
 
     // Find separator
-    for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++) { }
+    for (researchItem = gResearchItems; !researchItem->IsInventedEndMarker(); researchItem++) { }
 
     // Move separator below all items
-    for (; (researchItem + 1)->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !(researchItem + 1)->IsUninventedEndMarker(); researchItem++)
     {
         // Swap separator with research item
         researchItemTemp = *researchItem;
@@ -989,13 +989,13 @@ void research_items_shuffle()
     sint32 i, numNonResearchedItems;
 
     // Skip pre-researched items
-    for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++) {}
+    for (researchItem = gResearchItems; !researchItem->IsInventedEndMarker(); researchItem++) {}
     researchItem++;
     researchOrderBase = researchItem;
 
     // Count non pre-researched items
     numNonResearchedItems = 0;
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (; !researchItem->IsUninventedEndMarker(); researchItem++)
         numNonResearchedItems++;
 
     // Shuffle list
@@ -1014,4 +1014,19 @@ void research_items_shuffle()
 bool research_item_is_always_researched(rct_research_item * researchItem)
 {
     return (researchItem->flags & (RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED | RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED)) != 0;
+}
+
+bool rct_research_item::IsInventedEndMarker() const
+{
+    return (rawValue == RESEARCHED_ITEMS_SEPARATOR);
+}
+
+bool rct_research_item::IsUninventedEndMarker() const
+{
+    return (rawValue == RESEARCHED_ITEMS_END);
+}
+
+bool rct_research_item::IsRandomEndMarker() const
+{
+    return (rawValue == RESEARCHED_ITEMS_END_2);
 }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -38,6 +38,12 @@ struct rct_research_item
         };
     };
     uint8 category;
+
+    bool IsInventedEndMarker() const;
+
+    bool IsRandomEndMarker() const;
+
+    bool IsUninventedEndMarker() const;
 };
 assert_struct_size(rct_research_item, 5);
 #pragma pack(pop)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2123,7 +2123,7 @@ private:
         gResearchExpectedMonth = _s4.next_research_expected_month;
 
         ConvertResearchEntry(&gResearchNextItem, _s4.next_research_item, _s4.next_research_type);
-        if (gResearchNextItem.rawValue == RESEARCHED_ITEMS_SEPARATOR)
+        if (gResearchNextItem.IsInventedEndMarker())
         {
             gResearchProgressStage     = RESEARCH_STAGE_INITIAL_RESEARCH;
             gResearchProgress          = 0;


### PR DESCRIPTION
Many of these will not be needed after we replace our current implementation with the one in #7522, but it's still useful for importing RCT1 and RCT2 saves/scenarios.