### PR TITLE
Add debug option to visualize wide path flags.

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4567,6 +4567,7 @@ STR_6257    :Glassy (translucent)
 STR_6258    :Clear (transparent)
 STR_6259    :Disabled
 STR_6260    :Show blocked tiles
+STR_6261    :Show wide paths
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#5993] Ride window prices can now be set via text input.
 - Feature: [#6998] Guests now wait for passing vehicles before crossing railway tracks.
+- Feature: [#7694] Debug option to visualize paths that the game detects as wide.
 - Fix: [#7628] Always-researched items can be modified in the inventory list.
 - Fix: [#7643] No Money scenarios with funding set to zero.
 - Fix: [#7653] Finances money spinner is too narrow for big loans.

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -27,6 +27,7 @@
 enum WINDOW_DEBUG_PAINT_WIDGET_IDX
 {
     WIDX_BACKGROUND,
+    WIDX_TOGGLE_SHOW_WIDE_PATHS,
     WIDX_TOGGLE_SHOW_BLOCKED_TILES,
     WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS,
     WIDX_TOGGLE_SHOW_BOUND_BOXES,
@@ -34,14 +35,15 @@ enum WINDOW_DEBUG_PAINT_WIDGET_IDX
 };
 
 #define WINDOW_WIDTH    (200)
-#define WINDOW_HEIGHT   (8 + 15 + 15 + 15 + 11 + 8)
+#define WINDOW_HEIGHT   (8 + 15 + 15 + 15 + 15 + 11 + 8)
 
 static rct_widget window_debug_paint_widgets[] = {
-    { WWT_FRAME,    0,  0,  WINDOW_WIDTH - 1,   0,                  WINDOW_HEIGHT - 1,      0xFFFFFFFF,                             STR_NONE },
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8,                  8 + 11,                 STR_DEBUG_PAINT_SHOW_BLOCKED_TILES,     STR_NONE },
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15,             8 + 15 + 11,            STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS,   STR_NONE },
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 + 15,        8 + 15 + 15 + 11,       STR_DEBUG_PAINT_SHOW_BOUND_BOXES,       STR_NONE },
-    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 + 15 + 15,   8 + 15 + 15 + 15 + 11,  STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS,     STR_NONE },
+    { WWT_FRAME,    0,  0,  WINDOW_WIDTH - 1,   0,              WINDOW_HEIGHT - 1,  STR_NONE,                               STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 * 0,     8 + 15 * 0 + 11,    STR_DEBUG_PAINT_SHOW_WIDE_PATHS,        STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 * 1,     8 + 15 * 1 + 11,    STR_DEBUG_PAINT_SHOW_BLOCKED_TILES,     STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 * 2,     8 + 15 * 2 + 11,    STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS,   STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 * 3,     8 + 15 * 3 + 11,    STR_DEBUG_PAINT_SHOW_BOUND_BOXES,       STR_NONE },
+    { WWT_CHECKBOX, 1,  8,  WINDOW_WIDTH - 8,   8 + 15 * 4,     8 + 15 * 4 + 11,    STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS,     STR_NONE },
     { WIDGETS_END },
 };
 
@@ -102,6 +104,7 @@ rct_window * window_debug_paint_open()
 
     window->widgets = window_debug_paint_widgets;
     window->enabled_widgets =
+        (1 << WIDX_TOGGLE_SHOW_WIDE_PATHS) |
         (1 << WIDX_TOGGLE_SHOW_BLOCKED_TILES) |
         (1 << WIDX_TOGGLE_SHOW_BOUND_BOXES) |
         (1 << WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS) |
@@ -118,6 +121,11 @@ rct_window * window_debug_paint_open()
 static void window_debug_paint_mouseup([[maybe_unused]] rct_window * w, rct_widgetindex widgetIndex)
 {
     switch (widgetIndex) {
+        case WIDX_TOGGLE_SHOW_WIDE_PATHS:
+            gPaintWidePathsAsGhost = !gPaintWidePathsAsGhost;
+            gfx_invalidate_screen();
+            break;
+
         case WIDX_TOGGLE_SHOW_BLOCKED_TILES:
             gPaintBlockedTiles = !gPaintBlockedTiles;
             gfx_invalidate_screen();
@@ -142,6 +150,7 @@ static void window_debug_paint_mouseup([[maybe_unused]] rct_window * w, rct_widg
 
 static void window_debug_paint_invalidate(rct_window * w)
 {
+    widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_WIDE_PATHS, gPaintWidePathsAsGhost);
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_BLOCKED_TILES, gPaintBlockedTiles);
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS, gShowSupportSegmentHeights);
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3931,6 +3931,7 @@ enum {
     STR_VIRTUAL_FLOOR_STYLE_DISABLED = 6259,
 
     STR_DEBUG_PAINT_SHOW_BLOCKED_TILES = 6260,
+    STR_DEBUG_PAINT_SHOW_WIDE_PATHS = 6261,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -180,6 +180,7 @@ extern LocationXY8 gClipSelectionB;
 extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;
 extern bool gPaintBlockedTiles;
+extern bool gPaintWidePathsAsGhost;
 
 paint_struct * sub_98196C(
     paint_session * session,

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -34,6 +34,8 @@
 #include "../../world/Map.h"
 #include "../../drawing/LightFX.h"
 
+bool gPaintWidePathsAsGhost = false;
+
 // clang-format off
 const uint8 byte_98D800[] = {
     12, 9, 3, 6
@@ -800,6 +802,13 @@ void path_paint(paint_session * session, uint16 height, const rct_tile_element *
     if (gPaintBlockedTiles && (tile_element->flags & TILE_ELEMENT_FLAG_BLOCKED_BY_VEHICLE))
     {
         imageFlags = COLOUR_BRIGHT_GREEN << 19 | COLOUR_GREY << 24 | IMAGE_TYPE_REMAP;
+    }
+
+    // Draw wide flags as ghosts, leaving only the "walkable" paths to be drawn normally
+    if (gPaintWidePathsAsGhost && footpath_element_is_wide(tile_element))
+    {
+        imageFlags &= 0x7FFFF;
+        imageFlags |= CONSTRUCTION_MARKER;
     }
 
     sint16 x = session->MapPosition.x, y = session->MapPosition.y;


### PR DESCRIPTION
This implements #7694 

![dynamite dunes 2018-06-15 13-47-17](https://user-images.githubusercontent.com/9705046/41467702-c6c448c0-70a7-11e8-87f7-086b8c37aff7.png)