### PR TITLE
Fix AddRange to avoid duplicates in EntryList

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#7674] Rides show up as random numbers in guest's ride list.
 - Fix: [#7678] Crash when loading or starting a new game while having object selection window open.
 - Fix: [#7683] 'Arbitrary ride type' dropdown state is shared between windows.
+- Fix: [#7697] Some scenery groups in RCT1 saves are never invented.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------
@@ -35,7 +36,7 @@
 - Fix: [#6938] Banner do not correctly capitalise non-ASCII characters.
 - Fix: [#7176] Mechanics sometimes fall down from rides.
 - Fix: [#7303] Visual glitch with virtual floor near map edges.
-- Fix: [#7313] Loading an invalid path with openrct2 produces results different than expected.
+- Fix: [#7313] Loading an invalid path with OpenRCT2 produces results different than expected.
 - Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
 - Fix: [#7331] Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries.
 - Fix: [#7341] Staff may auto-spawn on guests walking outside of paths.

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -95,7 +95,10 @@ public:
 
     void AddRange(std::initializer_list<const char *> initializerList)
     {
-        Collections::AddRange(_entries, initializerList);
+        for (auto entry : initializerList)
+        {
+            GetOrAddEntry(entry);
+        }
     }
 };
 


### PR DESCRIPTION
I had some trouble importing RCT1 parks with a lot of scenery groups. It turned out that the required scenery groups (of which there are six) were added _twice_ to \_sceneryGroupEntries. While `GetOrAddEntry()` checks for already existing values, `AddRange` did not, but now does. This also fixes strange behaviour in research that resulted from this bug (where several scenery groups _did_ end up in the game, but not in research).