### PR TITLE
Fix #7701: Strings overflow in drawing debug windows

### DIFF
--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -157,7 +157,7 @@ static void window_debug_paint_invalidate(rct_window * w)
 
         // Find the width of the longest string
         sint16 newWidth = 0;
-        for (size_t widgetIndex = WIDX_TOGGLE_SHOW_WIDE_PATHS; widgetIndex < WIDX_TOGGLE_SHOW_DIRTY_VISUALS; widgetIndex++)
+        for (size_t widgetIndex = WIDX_TOGGLE_SHOW_WIDE_PATHS; widgetIndex <= WIDX_TOGGLE_SHOW_DIRTY_VISUALS; widgetIndex++)
         {
             auto stringIdx = w->widgets[widgetIndex].text;
             auto string = ls.GetString(stringIdx);


### PR DESCRIPTION
The last widget was not taken into account.