### PR TITLE
Draw dangerous G forces in red on ride graph

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
+- Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.
 - Removed: [#7929] Support for scenario text objects.
 

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -97,6 +97,7 @@ enum
     PALETTE_INDEX_162 = 162, //
     PALETTE_INDEX_171 = 171, // Saturated Red (lightest) Bright Red (middark)
     PALETTE_INDEX_172 = 172, // Saturated Red (10-11), Bright Red (midlight)
+    PALETTE_INDEX_173 = 173, // Used to draw intense lines in the Ride Graphs window
     PALETTE_INDEX_183 = 183, // Used to draw rides in the Map window
     PALETTE_INDEX_186 = 186, //
     PALETTE_INDEX_194 = 194, //


### PR DESCRIPTION
This is an experimental project/idea. The goal is to take the g force caps that would usually draw the forces red in the ride details tab, and use them to draw the high g-forces as red in the graph tab.
https://i.imgur.com/cJp3SRx.png

https://i.imgur.com/HJMrWrF.png

If all is well, I'll add a changelog entry and whatnot. I just figured someone might be able to provide some improvements with the code such as better variable names or where to place the defines for the limits, etc..