### PR TITLE
Fix compilation on Linux, macOS

### DIFF
--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -309,7 +309,7 @@ namespace Imaging
                 return ReadFromFile(path, GetImageFormatFromPath(path));
             default:
             {
-#if _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
                 auto pathW = String::ToUtf16(path);
                 std::ifstream fs(pathW, std::ios::binary);
 #else
@@ -335,7 +335,7 @@ namespace Imaging
                 break;
             case IMAGE_FORMAT::PNG:
             {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
                 auto pathW = String::ToUtf16(path);
                 std::ofstream fs(pathW, std::ios::binary);
 #else


### PR DESCRIPTION
Compilation on Linux and macOS is broken as a result of 0f2ccebfe726f3c3048c5a04ba485cf43d77ba65.