### PR TITLE
Do not print which(1) errors to the console.

### DIFF
--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -243,12 +243,15 @@ namespace OpenRCT2::Ui
         static DIALOG_TYPE GetDialogApp(std::string * executablePath)
         {
             // Prefer zenity as it offers more required features, e.g., overwrite
-            // confirmation and selecting only existing files
-            if (Execute("which zenity", executablePath) == 0)
+            // confirmation and selecting only existing files.
+            // Silence error output with 2> /dev/null to avoid confusion in the
+            // case where a user does not have zenity and/or kdialog.
+            // OpenRCT2 will fall back to an SDL pop-up if the user has neither.
+            if (Execute("which zenity 2> /dev/null", executablePath) == 0)
             {
                 return DIALOG_TYPE::ZENITY;
             }
-            if (Execute("which kdialog", executablePath) == 0)
+            if (Execute("which kdialog 2> /dev/null", executablePath) == 0)
             {
                 return DIALOG_TYPE::KDIALOG;
             }


### PR DESCRIPTION
On first launch of the game, OpenRCT2 tries to find Gnome or KDE eyecandy dialog programs zenity and kdialog to inform the user to set the `game_path`. It will fall back to an SDL popup with manual instructions if neither is found, which looks fine. However, if OpenRCT2 is launched from the command line, which will print "file not found" errors if you don't have zenity and/or kdialog installed, which might potentially confuse the user.

This patch routes the error messages to `/dev/null`, as we don't really care if those programs are not found.

See this thread on the OpenBSD mailing list: https://marc.info/?l=openbsd-ports&m=153020454402268&w=2

[ci skip]