### PR TITLE
Fix #3177: Wrong keys displayed in shortcut menu

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#5993] Ride window prices can now be set via text input.
 - Feature: [#6998] Guests now wait for passing vehicles before crossing railway tracks.
 - Feature: [#7694] Debug option to visualize paths that the game detects as wide.
+- Fix: [#3177] Wrong keys displayed in shortcut menu.
 - Fix: [#7533] Screenshot is incorrectly named/file is not generated in CJK language.
 - Fix: [#7628] Always-researched items can be modified in the inventory list.
 - Fix: [#7643] No Money scenarios with funding set to zero.

--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -151,7 +151,7 @@ std::string KeyboardShortcuts::GetShortcutString(int32_t shortcut) const
         format_string(formatBuffer, sizeof(formatBuffer), STR_CMD_PLUS, nullptr);
         String::Append(buffer, sizeof(buffer), formatBuffer);
     }
-    String::Append(buffer, sizeof(buffer), SDL_GetScancodeName((SDL_Scancode)(shortcutKey & 0xFF)));
+    String::Append(buffer, sizeof(buffer), SDL_GetKeyName(SDL_GetKeyFromScancode((SDL_Scancode)(shortcutKey & 0xFF))));
     return std::string(buffer);
 }
 


### PR DESCRIPTION
SDL_GetScancodeName doesn't actually translate the scancode to the physical key, so first we need to convert the scancode to a keycode and then turn the keycode into a string.
I have a QWERTZ keyboard, and with this the strings in the shortcut menu are correct.