### PR TITLE
Fix Steam path for Linux and macOS

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#7697] Some scenery groups in RCT1 saves are never invented.
 - Fix: [#7711] Inverted Hairpin Coaster allows building invisible banked pieces.
 - Fix: [#7734] Title sequence not included in macOS builds as of 0.2.0 release.
+- Fix: [#7756] Steam RCT2 path not correctly checked on macOS and Linux.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -634,7 +634,7 @@ namespace Config
         utf8 steamPath[2048] = { 0 };
         if (platform_get_steam_path(steamPath, sizeof(steamPath)))
         {
-            std::string location = Path::Combine(steamPath, "Rollercoaster Tycoon 2");
+            std::string location = Path::Combine(steamPath, platform_get_rct2_steam_dir());
             if (platform_original_game_data_exists(location.c_str()))
             {
                 return location;

--- a/src/openrct2/platform/Linux.cpp
+++ b/src/openrct2/platform/Linux.cpp
@@ -131,7 +131,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
     if (steamRoot != nullptr)
     {
         safe_strcpy(outPath, steamRoot, outSize);
-        safe_strcat_path(outPath, "steamapps/common", outSize);
+        safe_strcat_path(outPath, "ubuntu12_32/steamapps/content", outSize);
         return true;
     }
 
@@ -140,7 +140,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
     if (localSharePath != nullptr)
     {
         safe_strcpy(steamPath, localSharePath, sizeof(steamPath));
-        safe_strcat_path(steamPath, "Steam/steamapps/common", sizeof(steamPath));
+        safe_strcat_path(steamPath, "Steam/ubuntu12_32/steamapps/content", sizeof(steamPath));
         if (platform_directory_exists(steamPath))
         {
             safe_strcpy(outPath, steamPath, outSize);
@@ -152,7 +152,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
     if (homeDir != nullptr)
     {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));
-        safe_strcat_path(steamPath, ".local/share/Steam/steamapps/common", sizeof(steamPath));
+        safe_strcat_path(steamPath, ".local/share/Steam/ubuntu12_32/steamapps/content", sizeof(steamPath));
         if (platform_directory_exists(steamPath))
         {
             safe_strcpy(outPath, steamPath, outSize);
@@ -161,7 +161,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
 
         memset(steamPath, 0, sizeof(steamPath));
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));
-        safe_strcat_path(steamPath, ".steam/steam/steamapps/common", sizeof(steamPath));
+        safe_strcat_path(steamPath, ".steam/steam/ubuntu12_32/steamapps/content", sizeof(steamPath));
         if (platform_directory_exists(steamPath))
         {
             safe_strcpy(outPath, steamPath, outSize);

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -433,4 +433,9 @@ bool platform_process_is_elevated()
 #endif // __EMSCRIPTEN__
 }
 
+std::string platform_get_rct2_steam_dir()
+{
+    return "app_285330" PATH_SEPARATOR "depot_285331";
+}
+
 #endif

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -224,6 +224,11 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
     return result == ERROR_SUCCESS;
 }
 
+std::string platform_get_rct2_steam_dir()
+{
+    return "Rollercoaster Tycoon 2";
+}
+
 uint16_t platform_get_locale_language()
 {
     CHAR langCode[4];

--- a/src/openrct2/platform/macos.mm
+++ b/src/openrct2/platform/macos.mm
@@ -153,7 +153,7 @@ bool platform_get_steam_path(utf8 * outPath, size_t outSize)
     if (homeDir != NULL)
     {
         safe_strcpy(steamPath, homeDir, sizeof(steamPath));
-        safe_strcat_path(steamPath, "Library/Application Support/Steam/steamapps/common", sizeof(steamPath));
+        safe_strcat_path(steamPath, "Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/steamapps", sizeof(steamPath));
         if (platform_directory_exists(steamPath))
         {
             safe_strcpy(outPath, steamPath, outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -10,6 +10,7 @@
 #ifndef _PLATFORM_H_
 #define _PLATFORM_H_
 
+#include <string>
 #include <time.h>
 #include "../common.h"
 
@@ -111,6 +112,7 @@ uint8_t platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();
 bool platform_get_steam_path(utf8 * outPath, size_t outSize);
+std::string platform_get_rct2_steam_dir();
 
 #ifndef NO_TTF
 bool platform_get_font_path(TTFFontDescriptor *font, utf8 *buffer, size_t size);


### PR DESCRIPTION
This needs testing by someone on Windows to check if I didn't accidentally break it. macOS still needs adjusting.

While OpenRCT2 already had code to look up the Steam path, it didn't look in the correct directory. This meant that it wouldn't detect the presence of RCT2, even if the user had downloaded it via the Steam Console.