### PR TITLE
Fix #7766: Found ICU include directories being unused

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -162,6 +162,9 @@ if (NOT DISABLE_TTF)
         target_include_directories(${PROJECT} PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
     endif ()
 endif ()
+if (NOT MINGW AND NOT MSVC)
+    target_include_directories(${PROJECT} SYSTEM PRIVATE ${ICU_INCLUDE_DIRS})
+endif ()
 
 # To avoid unnecessary rebuilds set the current branch and
 # short sha1 only for the two files that use these


### PR DESCRIPTION
When ICU is installed separately from the system and paths configured in
CMake then the detected include directories should also be used for
compilation instead of blindly using unconfigured system includes.
SYSTEM flag ignores suggest-override warnings in ICU headers.