### PR TITLE
Show command descriptions even if only -a is passed

### DIFF
--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -181,7 +181,7 @@ exitcode_t CommandLine::HandleCommandDefault()
         }
     }
 
-    if (_help)
+    if (_help || _all)
     {
         CommandLine::PrintHelp(_all);
         result = EXITCODE_OK;


### PR DESCRIPTION
OpenRCT2 lists `-a` as an option to show help for all commands.
```
$ openrct2 -h
[...]
    -a, --all                    show help for all commands
[...]
```
But if you only pass `-a` the game still starts as if nothing was passed at all. Apparently you have to pass `-h -a` to show the help for all commands. This PR changes that behavior so it is also shown when only `-a` is passed.