### PR TITLE
Fix #7765: Crash when opening ride list window on Windows Vista

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#7711] Inverted Hairpin Coaster allows building invisible banked pieces.
 - Fix: [#7734] Title sequence not included in macOS builds as of 0.2.0 release.
 - Fix: [#7756] Steam RCT2 path not correctly checked on macOS and Linux.
+- Fix: [#7765] Crash when opening ride list window on Windows Vista.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -703,7 +703,7 @@ namespace String
 
         // Measure how long the destination needs to be
         auto requiredSize = LCMapStringEx(
-            LOCALE_NAME_INVARIANT,
+            LOCALE_NAME_USER_DEFAULT,
             LCMAP_UPPERCASE | LCMAP_LINGUISTIC_CASING,
             srcW.c_str(),
             (int)srcW.length(),
@@ -718,7 +718,7 @@ namespace String
 
         // Transform the string
         auto result = LCMapStringEx(
-            LOCALE_NAME_INVARIANT,
+            LOCALE_NAME_USER_DEFAULT,
             LCMAP_UPPERCASE | LCMAP_LINGUISTIC_CASING,
             srcW.c_str(),
             (int)srcW.length(),


### PR DESCRIPTION
It has been reported that Windows Vista crashes in LCMapStringEx when
using LOCALE_NAME_INVARIANT even though it is documented as supported.

As a counter measure, use LOCALE_NAME_USER_DEFAULT for the time being.