### PR TITLE
Fix #7773: Stop research bill after all items have been researched.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -111,6 +111,7 @@ The following people are not part of the development team, but have been contrib
 * Toby Hinloopen (tobyhinloopen)
 * Patrick Martinez (martip23)
 * Andy Ford (AndyTWF)
+* Matthew Beaudin (mattbeaudin)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#7734] Title sequence not included in macOS builds as of 0.2.0 release.
 - Fix: [#7756] Steam RCT2 path not correctly checked on macOS and Linux.
 - Fix: [#7765] Crash when opening ride list window on Windows Vista.
+- Fix: [#7773] Once research has been completed, player is still charged for research.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -373,6 +373,9 @@ void research_update()
             research_update_uncompleted_types();
             research_invalidate_related_windows();
             break;
+        case RESEARCH_STAGE_FINISHED_ALL:
+            gResearchFundingLevel = RESEARCH_FUNDING_NONE;
+            break;
         }
     }
 }


### PR DESCRIPTION
Stops research from charging you every month by checking if gResearchProgressStage is RESEARCH_STAGE_FINISHED_ALL.

[#7773](https://github.com/OpenRCT2/OpenRCT2/issues/7773)