### PR TITLE
Fix memory leaks related to pointer assignment to std::string

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -112,6 +112,7 @@ The following people are not part of the development team, but have been contrib
 * Patrick Martinez (martip23)
 * Andy Ford (AndyTWF)
 * Matthew Beaudin (mattbeaudin)
+* Øystein Dale (oystedal)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -354,7 +354,7 @@ private:
                 sb.Append(&c, 1);
             }
         }
-        return std::string(sb.GetString());
+        return sb.GetStdString();
     }
 
     std::string GetLine(size_t index)

--- a/src/openrct2/core/StringBuilder.hpp
+++ b/src/openrct2/core/StringBuilder.hpp
@@ -138,13 +138,7 @@ public:
      */
     std::string GetStdString() const
     {
-        std::string result;
-        result.reserve(_length);
-        for (std::size_t i = 0U; i < _length; i++)
-        {
-            result.push_back(_buffer[i]);
-        }
-        return result;
+        return std::string(_buffer, _length);
     }
 
     /**

--- a/src/openrct2/core/StringBuilder.hpp
+++ b/src/openrct2/core/StringBuilder.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <algorithm>
+#include <string>
 #include "../common.h"
 
 #include "Math.hpp"
@@ -129,6 +130,20 @@ public:
         utf8 * result = Memory::AllocateArray<utf8>(_length + 1);
         std::copy_n(_buffer, _length, result);
         result[_length] = 0;
+        return result;
+    }
+
+    /**
+     * Returns the current string buffer as a standard string.
+     */
+    std::string GetStdString() const
+    {
+        std::string result;
+        result.reserve(_length);
+        for (std::size_t i = 0U; i < _length; i++)
+        {
+            result.push_back(_buffer[i]);
+        }
         return result;
     }
 

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -389,7 +389,7 @@ private:
             }
             if (sb.GetLength() == 8)
             {
-                _currentGroup = sb.GetString();
+                _currentGroup = sb.GetStdString();
                 _currentObjectOverride = GetObjectOverride(_currentGroup);
                 _currentScenarioOverride = nullptr;
                 if (_currentObjectOverride == nullptr)
@@ -432,7 +432,7 @@ private:
 
         if (closedCorrectly)
         {
-            _currentGroup = sb.GetString();
+            _currentGroup = sb.GetStdString();
             _currentObjectOverride = nullptr;
             _currentScenarioOverride = GetScenarioOverride(_currentGroup);
             if (_currentScenarioOverride == nullptr)

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -156,8 +156,8 @@ protected:
         ObjectRepositoryItem item;
 
         item.ObjectEntry = stream->ReadValue<rct_object_entry>();
-        item.Path = stream->ReadString();
-        item.Name = stream->ReadString();
+        item.Path = stream->ReadStdString();
+        item.Name = stream->ReadStdString();
 
         switch (object_entry_get_type(&item.ObjectEntry)) {
         case OBJECT_TYPE_RIDE:


### PR DESCRIPTION

In a few places a pointer to 0-terminated memory is assigned to an std::string. Assigning a pointer to std::string appears to only perform a copy, it does not transfer ownership of the pointer. As such, the allocated memory will never be freed.

The leaks were discovered by running `openrct2-cli` with `valgrind` and quitting once the prompt appears.

`valgrind` output before patches:

~~~
==25454== Memcheck, a memory error detector
==25454== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25454== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==25454== Command: ./build/openrct2-cli --verbose --openrct-data-path=/usr/local/share/openrct2
==25454== 
OpenRCT2, v0.2.0-149 (934e53869 on oystedal/string-memleaks)
<snip>
VERBOSE: begin openrct2 loop
openrct2 $ quit
VERBOSE: finish openrct2 loop
<snip>
==25454== HEAP SUMMARY:
==25454==     in use at exit: 206,944 bytes in 4,370 blocks
==25454==   total heap usage: 161,426 allocs, 157,056 frees, 11,083,884 bytes allocated
==25454== 
==25454== 142 bytes in 2 blocks are possibly lost in loss record 10 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4D8B1A: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4D8B1A: IStream::ReadString() (IStream.cpp:26)
==25454==    by 0x273D6D: ObjectFileIndex::Deserialise(IStream*) const (ObjectRepository.cpp:159)
==25454==    by 0x27D234: ReadIndexFile (FileIndex.hpp:297)
==25454==    by 0x27D234: LoadOrBuild (FileIndex.hpp:107)
==25454==    by 0x27D234: ObjectRepository::LoadOrConstruct(int) (ObjectRepository.cpp:220)
==25454==    by 0x1FAAD6: OpenRCT2::Context::Initialise() (Context.cpp:402)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 234 bytes in 26 blocks are definitely lost in loss record 11 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4E28BB: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4E28BB: GetString (StringBuilder.hpp:129)
==25454==    by 0x4E28BB: ParseGroupObject (LanguagePack.cpp:392)
==25454==    by 0x4E28BB: ParseLine (LanguagePack.cpp:344)
==25454==    by 0x4E28BB: LanguagePack (LanguagePack.cpp:111)
==25454==    by 0x4E28BB: FromText (LanguagePack.cpp:100)
==25454==    by 0x4E28BB: LanguagePack::FromFile(unsigned short, char const*) (LanguagePack.cpp:92)
==25454==    by 0x2497AC: OpenRCT2::Localisation::LocalisationService::OpenLanguage(int, IObjectManager&) (LocalisationService.cpp:86)
==25454==    by 0x1FAAA8: OpenRCT2::Context::Initialise() (Context.cpp:365)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 320 bytes in 1 blocks are possibly lost in loss record 12 of 18
==25454==    at 0x4C2EEF5: calloc (vg_replace_malloc.c:711)
==25454==    by 0x4011462: allocate_dtv (in /usr/lib/ld-2.27.so)
==25454==    by 0x4011DED: _dl_allocate_tls (in /usr/lib/ld-2.27.so)
==25454==    by 0x4E40C38: pthread_create@@GLIBC_2.2.5 (in /usr/lib/libpthread-2.27.so)
==25454==    by 0x6FCF015: __gthread_create (gthr-default.h:662)
==25454==    by 0x6FCF015: std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (thread.cc:135)
==25454==    by 0x232C46: thread<StdInOutConsole::Start()::<lambda()> > (thread:126)
==25454==    by 0x232C46: StdInOutConsole::Start() (StdInOutConsole.cpp:49)
==25454==    by 0x1FCDF9: OpenRCT2::Context::Launch() (Context.cpp:804)
==25454==    by 0x1FDCB7: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:211)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 1,217 bytes in 86 blocks are definitely lost in loss record 13 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4E269C: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4E269C: GetString (StringBuilder.hpp:129)
==25454==    by 0x4E269C: ParseGroupScenario (LanguagePack.cpp:435)
==25454==    by 0x4E269C: ParseLine (LanguagePack.cpp:347)
==25454==    by 0x4E269C: LanguagePack (LanguagePack.cpp:111)
==25454==    by 0x4E269C: FromText (LanguagePack.cpp:100)
==25454==    by 0x4E269C: LanguagePack::FromFile(unsigned short, char const*) (LanguagePack.cpp:92)
==25454==    by 0x249851: OpenRCT2::Localisation::LocalisationService::OpenLanguage(int, IObjectManager&) (LocalisationService.cpp:90)
==25454==    by 0x1FAAA8: OpenRCT2::Context::Initialise() (Context.cpp:365)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 2,672 bytes in 143 blocks are definitely lost in loss record 15 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4E269C: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4E269C: GetString (StringBuilder.hpp:129)
==25454==    by 0x4E269C: ParseGroupScenario (LanguagePack.cpp:435)
==25454==    by 0x4E269C: ParseLine (LanguagePack.cpp:347)
==25454==    by 0x4E269C: LanguagePack (LanguagePack.cpp:111)
==25454==    by 0x4E269C: FromText (LanguagePack.cpp:100)
==25454==    by 0x4E269C: LanguagePack::FromFile(unsigned short, char const*) (LanguagePack.cpp:92)
==25454==    by 0x2497AC: OpenRCT2::Localisation::LocalisationService::OpenLanguage(int, IObjectManager&) (LocalisationService.cpp:86)
==25454==    by 0x1FAAA8: OpenRCT2::Context::Initialise() (Context.cpp:365)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 36,684 bytes in 2,051 blocks are definitely lost in loss record 17 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4D8B1A: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4D8B1A: IStream::ReadString() (IStream.cpp:26)
==25454==    by 0x273D95: ObjectFileIndex::Deserialise(IStream*) const (ObjectRepository.cpp:160)
==25454==    by 0x27D234: ReadIndexFile (FileIndex.hpp:297)
==25454==    by 0x27D234: LoadOrBuild (FileIndex.hpp:107)
==25454==    by 0x27D234: ObjectRepository::LoadOrConstruct(int) (ObjectRepository.cpp:220)
==25454==    by 0x1FAAD6: OpenRCT2::Context::Initialise() (Context.cpp:402)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== 146,992 bytes in 2,050 blocks are definitely lost in loss record 18 of 18
==25454==    at 0x4C2CEDF: malloc (vg_replace_malloc.c:299)
==25454==    by 0x4D8B1A: AllocateArray<char> (Memory.hpp:42)
==25454==    by 0x4D8B1A: IStream::ReadString() (IStream.cpp:26)
==25454==    by 0x273D6D: ObjectFileIndex::Deserialise(IStream*) const (ObjectRepository.cpp:159)
==25454==    by 0x27D234: ReadIndexFile (FileIndex.hpp:297)
==25454==    by 0x27D234: LoadOrBuild (FileIndex.hpp:107)
==25454==    by 0x27D234: ObjectRepository::LoadOrConstruct(int) (ObjectRepository.cpp:220)
==25454==    by 0x1FAAD6: OpenRCT2::Context::Initialise() (Context.cpp:402)
==25454==    by 0x1FDC98: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:209)
==25454==    by 0x1EE7F8: main (Cli.cpp:31)
==25454== 
==25454== LEAK SUMMARY:
==25454==    definitely lost: 187,799 bytes in 4,356 blocks
==25454==    indirectly lost: 0 bytes in 0 blocks
==25454==      possibly lost: 462 bytes in 3 blocks
==25454==    still reachable: 18,683 bytes in 11 blocks
==25454==         suppressed: 0 bytes in 0 blocks
==25454== Reachable blocks (those to which a pointer was found) are not shown.
==25454== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==25454== 
==25454== For counts of detected and suppressed errors, rerun with: -v
==25454== Use --track-origins=yes to see where uninitialised values come from
==25454== ERROR SUMMARY: 32 errors from 23 contexts (suppressed: 0 from 0)
~~~

`valgrind` output after patches:

~~~
==26953== Memcheck, a memory error detector
==26953== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26953== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==26953== Command: ./build/openrct2-cli --verbose --openrct-data-path=/usr/local/share/openrct2
==26953== 
OpenRCT2, v0.2.0-149 (934e53869 on oystedal/string-memleaks)
<snip>
VERBOSE: begin openrct2 loop
openrct2 $ quit
VERBOSE: finish openrct2 loop
<snip>
==26953== HEAP SUMMARY:
==26953==     in use at exit: 19,047 bytes in 13 blocks
==26953==   total heap usage: 134,121 allocs, 134,108 frees, 10,578,636 bytes allocated
==26953== 
==26953== 320 bytes in 1 blocks are possibly lost in loss record 11 of 13
==26953==    at 0x4C2EEF5: calloc (vg_replace_malloc.c:711)
==26953==    by 0x4011462: allocate_dtv (in /usr/lib/ld-2.27.so)
==26953==    by 0x4011DED: _dl_allocate_tls (in /usr/lib/ld-2.27.so)
==26953==    by 0x4E40C38: pthread_create@@GLIBC_2.2.5 (in /usr/lib/libpthread-2.27.so)
==26953==    by 0x6FCF015: __gthread_create (gthr-default.h:662)
==26953==    by 0x6FCF015: std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (thread.cc:135)
==26953==    by 0x232C86: thread<StdInOutConsole::Start()::<lambda()> > (thread:126)
==26953==    by 0x232C86: StdInOutConsole::Start() (StdInOutConsole.cpp:49)
==26953==    by 0x1FCE39: OpenRCT2::Context::Launch() (Context.cpp:804)
==26953==    by 0x1FDCF7: OpenRCT2::Context::RunOpenRCT2(int, char const**) (Context.cpp:211)
==26953==    by 0x1EE838: main (Cli.cpp:31)
==26953== 
==26953== LEAK SUMMARY:
==26953==    definitely lost: 0 bytes in 0 blocks
==26953==    indirectly lost: 0 bytes in 0 blocks
==26953==      possibly lost: 320 bytes in 1 blocks
==26953==    still reachable: 18,727 bytes in 12 blocks
==26953==         suppressed: 0 bytes in 0 blocks
==26953== Reachable blocks (those to which a pointer was found) are not shown.
==26953== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==26953== 
==26953== For counts of detected and suppressed errors, rerun with: -v
==26953== Use --track-origins=yes to see where uninitialised values come from
==26953== ERROR SUMMARY: 32 errors from 17 contexts (suppressed: 0 from 0)
~~~