### PR TITLE
Fixed weekly profit graph. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,4 @@ discord-rpc
 
 # Cmake
 cmake-build-debug/
+*.favdoc

--- a/contributors.md
+++ b/contributors.md
@@ -76,6 +76,7 @@ The following people are not part of the development team, but have been contrib
 * Nicolas Hawrysh (xp4xbox) - Various (ride) sprite improvements.
 * Albert Morgese (Fusxfaranto) - Shop auto-rotation, unicode uppercasing.
 * Olivier Wervers (oli414) - Remove unused objects command, various bugfixes
+* (qqkookie) - Slow game speed.
 
 ## Bug fixes
 * (halfbro)

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -4568,6 +4568,8 @@ STR_6258    :Clear (transparent)
 STR_6259    :Disabled
 STR_6260    :Show blocked tiles
 STR_6261    :Show wide paths
+STR_6262    :Slow Speed
+STR_6263    :Slower Speed
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#7694] Debug option to visualize paths that the game detects as wide.
 - Feature: [#7771] Danish translation.
 - Feature: [#7802] Add sprite font glyphs for Russian.
+- Feature: [#7809] Slow speed step.
 - Fix: [#3177] Wrong keys displayed in shortcut menu.
 - Fix: [#4039] Add sprite font glyph for German opening quotation mark.
 - Fix: [#7533] Screenshot is incorrectly named/file is not generated in CJK language.

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -510,7 +510,7 @@ private:
         news_item_init_queue();
         load_palette();
         gScreenAge = 0;
-        gGameSpeed = 1;
+        gGameSpeed = GAMESPEED_NORMAL;
     }
 
     /**

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -533,6 +533,8 @@ rct_window* window_finances_open()
 
         research_update_uncompleted_types();
     }
+    else
+        window_close(w);
 
     w->page = WINDOW_FINANCES_PAGE_SUMMARY;
     window_invalidate(w);
@@ -1048,8 +1050,9 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     graphRight = w->x + pageWidget->right - 4;
     graphBottom = w->y + pageWidget->bottom - 4;
 
-    // Weekly profit
-    money32 weeklyPofit = gCurrentProfit;
+    // Weekly profit approximation
+    money32 weeklyPofit = ( gWeeklyProfitAverageDivisor != 0 ?
+        (7 * gWeeklyProfitAverageDividend / gWeeklyProfitAverageDivisor) : gWeeklyProfitAverageDividend);
     gfx_draw_string_left(
         dpi, weeklyPofit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE : STR_FINANCES_WEEKLY_PROFIT_LOSS, &weeklyPofit,
         COLOUR_BLACK, graphLeft, graphTop - 11);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -884,13 +884,27 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         imgId = SPR_G2_FASTFORWARD;
         gfx_draw_sprite(dpi, imgId, x + 6, y + 3, 0);
 
-        for (int32_t i = 0; i < gGameSpeed && gGameSpeed <= 4; i++)
+        if (gGameSpeed == GAMESPEED_SLOW)
         {
-            gfx_draw_sprite(dpi, SPR_G2_SPEED_ARROW, x + 5 + i * 5, y + 15, 0);
+            gfx_draw_sprite(dpi, SPR_G2_RCT1_TEST_BUTTON_2, x+3 , y + 12, 0);
         }
-        for (int32_t i = 0; i < 3 && i < gGameSpeed - 4 && gGameSpeed >= 5; i++)
+        else if (gGameSpeed == GAMESPEED_PAUSED)
         {
-            gfx_draw_sprite(dpi, SPR_G2_HYPER_ARROW, x + 5 + i * 6, y + 15, 0);
+            gfx_draw_sprite(dpi, SPR_G2_RCT1_CLOSE_BUTTON_2, x+3 , y + 12, 0);
+        }
+        else if (gGameSpeed == GAMESPEED_HYPER)
+        {
+            for (int32_t i = 0; i < 3; i++) 
+			{
+                gfx_draw_sprite(dpi, SPR_G2_HYPER_ARROW, x + 5 + i * 5, y + 15, 0);
+            }
+        }
+        else 
+		{
+            for (int32_t i = 0; i <= gGameSpeed - GAMESPEED_NORMAL; i++)
+			{
+                gfx_draw_sprite(dpi, SPR_G2_SPEED_ARROW, x + 5 + i * 5, y + 15, 0);
+            }
         }
     }
 
@@ -3061,63 +3075,40 @@ static void window_top_toolbar_tool_abort(rct_window* w, rct_widgetindex widgetI
 
 static void top_toolbar_init_fastforward_menu(rct_window* w, rct_widget* widget)
 {
-    int32_t num_items = 4;
-    gDropdownItemsFormat[0] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[1] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[2] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[3] = STR_TOGGLE_OPTION;
+    int32_t num_menu;
+    extern const rct_string_id SpeedNames[];
+
+    for (num_menu = 0; num_menu < GAMESPEED_TURBO; num_menu++)
+    {
+        gDropdownItemsFormat[num_menu] = STR_TOGGLE_OPTION;
+        gDropdownItemsArgs[num_menu] = SpeedNames[num_menu];
+    }
     if (gConfigGeneral.debugging_tools)
     {
-        gDropdownItemsFormat[4] = STR_EMPTY;
-        gDropdownItemsFormat[5] = STR_TOGGLE_OPTION;
-        gDropdownItemsArgs[5] = STR_SPEED_HYPER;
-        num_items = 6;
+        gDropdownItemsFormat[num_menu] = STR_EMPTY;
+        num_menu++;
+        gDropdownItemsFormat[num_menu] = STR_TOGGLE_OPTION;
+        gDropdownItemsArgs[num_menu] = STR_SPEED_HYPER;
+        num_menu++;
     }
-
-    gDropdownItemsArgs[0] = STR_SPEED_NORMAL;
-    gDropdownItemsArgs[1] = STR_SPEED_QUICK;
-    gDropdownItemsArgs[2] = STR_SPEED_FAST;
-    gDropdownItemsArgs[3] = STR_SPEED_TURBO;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, num_items);
+        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, num_menu);
 
     // Set checkmarks
-    if (gGameSpeed <= 4)
-    {
-        dropdown_set_checked(gGameSpeed - 1, true);
-    }
-    if (gGameSpeed == 8)
-    {
-        dropdown_set_checked(5, true);
-    }
-
-    if (gConfigGeneral.debugging_tools)
-    {
-        gDropdownDefaultIndex = (gGameSpeed == 8 ? 0 : gGameSpeed);
-    }
-    else
-    {
-        gDropdownDefaultIndex = (gGameSpeed >= 4 ? 0 : gGameSpeed);
-    }
-    if (gDropdownDefaultIndex == 4)
-    {
-        gDropdownDefaultIndex = 5;
-    }
+    gDropdownDefaultIndex = gGameSpeed - 1;
+    if (gConfigGeneral.debugging_tools && gGameSpeed == GAMESPEED_HYPER)
+        gDropdownDefaultIndex++;
+    dropdown_set_checked(gDropdownDefaultIndex, true);
 }
 
 static void top_toolbar_fastforward_menu_dropdown(int16_t dropdownIndex)
 {
     rct_window* w = window_get_main();
-    if (w)
+    if (w && dropdownIndex >= 0 && dropdownIndex <= 6)
     {
-        if (dropdownIndex >= 0 && dropdownIndex <= 5)
-        {
-            gGameSpeed = dropdownIndex + 1;
-            if (gGameSpeed >= 5)
-                gGameSpeed = 8;
+        gGameSpeed = (dropdownIndex == 6) ? GAMESPEED_HYPER : (dropdownIndex + 1);
             window_invalidate(w);
-        }
     }
 }
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -764,7 +764,7 @@ namespace OpenRCT2
         {
             if (!gConfigGeneral.uncap_fps)
                 return false;
-            if (gGameSpeed > 4)
+             if (gGameSpeed > GAMESPEED_HYPER)
                 return false;
             if (gOpenRCT2Headless)
                 return false;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -67,7 +67,7 @@
 
 uint16_t gTicksSinceLastUpdate;
 uint8_t gGamePaused = 0;
-int32_t gGameSpeed = 1;
+int32_t gGameSpeed = GAMESPEED_NORMAL;     // initial, normal speed ;
 float gDayNightCycle = 0;
 bool gInUpdateCode = false;
 bool gInMapInitCode = false;
@@ -129,17 +129,21 @@ GAME_COMMAND_CALLBACK_POINTER* game_command_callback_get_callback(uint32_t index
 
 void game_increase_game_speed()
 {
-    gGameSpeed = std::min(gConfigGeneral.debugging_tools ? 5 : 4, gGameSpeed + 1);
-    if (gGameSpeed == 5)
-        gGameSpeed = 8;
+    if (gGameSpeed < (gConfigGeneral.debugging_tools ? GAMESPEED_HYPER : GAMESPEED_TURBO))
+        gGameSpeed++;
+
+    if (game_is_paused())
+        pause_toggle();
     window_invalidate_by_class(WC_TOP_TOOLBAR);
 }
 
 void game_reduce_game_speed()
 {
-    gGameSpeed = std::max(1, gGameSpeed - 1);
-    if (gGameSpeed == 7)
-        gGameSpeed = 4;
+    if (gGameSpeed > GAMESPEED_PAUSED)
+        gGameSpeed--;
+
+    if (gGameSpeed == GAMESPEED_PAUSED && game_is_not_paused() )
+        pause_toggle();
     window_invalidate_by_class(WC_TOP_TOOLBAR);
 }
 
@@ -822,6 +826,10 @@ void pause_toggle()
     {
         audio_stop_all_music_and_sounds();
     }
+    else if (gGameSpeed == GAMESPEED_PAUSED)
+    {
+        gGameSpeed = GAMESPEED_NORMAL;
+    }
 }
 
 bool game_is_paused()
@@ -1147,7 +1155,7 @@ void game_load_init()
     }
 
     audio_stop_title_music();
-    gGameSpeed = 1;
+    gGameSpeed = GAMESPEED_NORMAL;
 }
 
 /**

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -140,6 +140,13 @@ extern uint32_t gCurrentTicks;
 extern uint16_t gTicksSinceLastUpdate;
 extern uint8_t gGamePaused;
 extern int32_t gGameSpeed;
+enum GAMESPEED {
+    GAMESPEED_PAUSED = 0,
+    GAMESPEED_SLOW = 1,
+    GAMESPEED_NORMAL = 2,
+    GAMESPEED_TURBO = 5,
+    GAMESPEED_HYPER = 6,
+};
 extern float gDayNightCycle;
 extern bool gInUpdateCode;
 extern bool gInMapInitCode;

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -47,6 +47,7 @@ bool gDebugStringFormatting = false;
 
 // clang-format off
 const rct_string_id SpeedNames[] = {
+    STR_SPEED_SLOW,
     STR_SPEED_NORMAL,
     STR_SPEED_QUICK,
     STR_SPEED_FAST,

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3928,6 +3928,9 @@ enum
     STR_DEBUG_PAINT_SHOW_BLOCKED_TILES = 6260,
     STR_DEBUG_PAINT_SHOW_WIDE_PATHS = 6261,
 
+    STR_SPEED_SLOW = 6262,
+    STR_SPEED_SLOWER = 6263,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -163,9 +163,9 @@ void TitleScreen::Update()
         _sequencePlayer->Update();
 
         int32_t numUpdates = 1;
-        if (gGameSpeed > 1)
+        if (gGameSpeed > GAMESPEED_NORMAL)
         {
-            numUpdates = 1 << (gGameSpeed - 1);
+            numUpdates <<= (gGameSpeed - GAMESPEED_NORMAL );
         }
         for (int32_t i = 0; i < numUpdates; i++)
         {

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -1066,13 +1066,8 @@ void Park::UpdateHistories()
     HistoryPushRecord<money32, 128>(gCashHistory, finance_get_current_cash() - gBankLoan);
 
     // Update weekly profit history
-    money32 currentWeeklyProfit = gWeeklyProfitAverageDividend;
-    if (gWeeklyProfitAverageDivisor != 0)
-    {
-        currentWeeklyProfit /= gWeeklyProfitAverageDivisor;
-    }
-    HistoryPushRecord<money32, 128>(gWeeklyProfitHistory, currentWeeklyProfit);
-    gWeeklyProfitAverageDividend = 0;
+    HistoryPushRecord<money32, 128>(gWeeklyProfitHistory, gCurrentProfit);
+    gCurrentProfit = 0; // Weekly sum is reset here.
     gWeeklyProfitAverageDivisor = 0;
 
     // Update park value history


### PR DESCRIPTION
Fixed Finance  > Weekly Profit Graph for inconsistency with monthly profit amount and not helpful graph scaling issue. It was due to bad design and bug. Now ride construction cost is not weekly expense. And the weekly profit is calculated correctly. Displayed weekly profit amount is now consistent with monthly profit. 