### PR TITLE
Add master volume slider and checkbox

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -1149,7 +1149,7 @@ STR_1770    :{SMALLFONT}{BLACK}Number of complete swings
 STR_1771    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{COMMA16}
 STR_1773    :Only one on-ride photo section allowed per ride
 STR_1774    :Only one cable lift hill allowed per ride
-STR_1777    :{WINDOW_COLOUR_2}Ride music
+STR_1777    :Ride music
 STR_1778    :{STRINGID} - - 
 STR_1779    :{INLINE_SPRITE}{254}{19}{00}{00} Panda costume
 STR_1780    :{INLINE_SPRITE}{255}{19}{00}{00} Tiger costume

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3722,6 +3722,8 @@ STR_6258    :Clear (transparent)
 STR_6259    :Disabled
 STR_6260    :Show blocked tiles
 STR_6261    :Show wide paths
+STR_6262    :Master volume
+STR_6263    :{SMALLFONT}{BLACK}Toggle all sound on/off
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#7713] The virtual floor now takes land ownership rights into account.
 - Feature: [#7771] Danish translation.
 - Feature: [#7797, #7802, #7821, #7830] Add sprite font glyphs for Danish, Norwegian, Russian, Turkish, Catalan and Romanian.
+- Feature: [#7848] Add a master volume slider to audio options screen.
 - Feature: [#7868] Placing scenery while holding shift now scales appropriately with zoom levels.
 - Feature: [#7882] Auto-detect Steam and GOG installations of RCT1.
 - Feature: [#7885] Turkish translation.

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -380,7 +380,8 @@ namespace OpenRCT2::Audio
         int32_t ApplyVolume(const IAudioChannel* channel, void* buffer, size_t len)
         {
             float volumeAdjust = _volume;
-            volumeAdjust *= (gConfigSound.master_volume / 100.0f);
+            volumeAdjust *= gConfigSound.master_sound_enabled ? (gConfigSound.master_volume / 100.0f) : 0;
+
             switch (channel->GetGroup())
             {
                 case MIXER_GROUP_SOUND:

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -696,19 +696,29 @@ static void widget_hscrollbar_draw(
     gfx_fill_rect(dpi, l + 10, t + 8, r - 10, t + 8, ColourMapA[colour].lighter);
 
     // Left button
-    gfx_fill_rect_inset(
-        dpi, l, t, l + 9, b, colour, ((scroll->flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, (char*)BlackLeftArrowString, COLOUR_BLACK, l + 1, t);
+    {
+        uint8_t flags = (scroll->flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+
+        gfx_fill_rect_inset(dpi, l, t, l + 9, b, colour, flags);
+        gfx_draw_string(dpi, (char*)BlackLeftArrowString, COLOUR_BLACK, l + 1, t);
+    }
 
     // Thumb
-    gfx_fill_rect_inset(
-        dpi, std::max(l + 10, l + scroll->h_thumb_left - 1), t, std::min(r - 10, l + scroll->h_thumb_right - 1), b, colour,
-        ((scroll->flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
+    {
+        int16_t left = std::max(l + 10, l + scroll->h_thumb_left - 1);
+        int16_t right = std::min(r - 10, l + scroll->h_thumb_right - 1);
+        uint8_t flags = (scroll->flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+
+        gfx_fill_rect_inset(dpi, left, t, right, b, colour, flags);
+    }
 
     // Right button
-    gfx_fill_rect_inset(
-        dpi, r - 9, t, r, b, colour, ((scroll->flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, (char*)BlackRightArrowString, COLOUR_BLACK, r - 6, t);
+    {
+        uint8_t flags = (scroll->flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+
+        gfx_fill_rect_inset(dpi, r - 9, t, r, b, colour, flags);
+        gfx_draw_string(dpi, (char*)BlackRightArrowString, COLOUR_BLACK, r - 6, t);
+    }
 }
 
 static void widget_vscrollbar_draw(

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -862,14 +862,12 @@ void widget_scroll_get_part(
     rct_window* w, rct_widget* widget, int32_t x, int32_t y, int32_t* output_x, int32_t* output_y, int32_t* output_scroll_area,
     int32_t* scroll_id)
 {
-    rct_widget* iterator = w->widgets;
     *scroll_id = 0;
-    while (++iterator != widget)
+    for (rct_widget* iterator = w->widgets; iterator != widget; iterator++)
     {
         if (iterator->type == WWT_SCROLL)
         {
-            (*scroll_id)++;
-            break;
+            *scroll_id += 1;
         }
     }
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -593,6 +593,11 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     // checkbox
     gfx_fill_rect_inset(dpi, l, yMid - 5, l + 9, yMid + 4, colour, INSET_RECT_F_60);
 
+    if (widget_is_disabled(w, widgetIndex))
+    {
+        colour |= COLOUR_FLAG_INSET;
+    }
+
     // fill it when checkbox is pressed
     if (widget_is_pressed(w, widgetIndex))
     {
@@ -603,11 +608,6 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     // draw the text
     if (widget->text == STR_NONE)
         return;
-
-    if (widget_is_disabled(w, widgetIndex))
-    {
-        colour |= COLOUR_FLAG_INSET;
-    }
 
     gfx_draw_string_left_centred(dpi, widget->text, gCommonFormatArgs, colour, l + 14, yMid);
 }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1798,23 +1798,17 @@ static void window_options_invalidate(rct_window* w)
             {
                 widget = &window_options_audio_widgets[WIDX_MASTER_VOLUME];
                 w->scrolls[0].h_left = ceil(
-                    (gConfigSound.master_volume / 100.0f) * 
-                    (w->scrolls[0].h_right - ((widget->right - widget->left) - 1))
-                );
+                    (gConfigSound.master_volume / 100.0f) * (w->scrolls[0].h_right - ((widget->right - widget->left) - 1)));
                 widget_scroll_update_thumbs(w, WIDX_MASTER_VOLUME);
 
                 widget = &window_options_audio_widgets[WIDX_SOUND_VOLUME];
                 w->scrolls[1].h_left = ceil(
-                    (gConfigSound.sound_volume / 100.0f) *
-                    (w->scrolls[1].h_right - ((widget->right - widget->left) - 1))
-                );
+                    (gConfigSound.sound_volume / 100.0f) * (w->scrolls[1].h_right - ((widget->right - widget->left) - 1)));
                 widget_scroll_update_thumbs(w, WIDX_SOUND_VOLUME);
 
                 widget = &window_options_audio_widgets[WIDX_MUSIC_VOLUME];
                 w->scrolls[2].h_left = ceil(
-                    (gConfigSound.ride_music_volume / 100.0f) *
-                    (w->scrolls[2].h_right - ((widget->right - widget->left) - 1))
-                );
+                    (gConfigSound.ride_music_volume / 100.0f) * (w->scrolls[2].h_right - ((widget->right - widget->left) - 1)));
                 widget_scroll_update_thumbs(w, WIDX_MUSIC_VOLUME);
             }
         }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -768,11 +768,6 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 case WIDX_SOUND_CHECKBOX:
                     gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
-                    if (!gConfigSound.sound_enabled)
-                        audio_pause_sounds();
-                    else
-                        audio_unpause_sounds();
-                    window_invalidate_by_class(WC_TOP_TOOLBAR);
                     config_save_default();
                     window_invalidate(w);
                     break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -768,12 +768,22 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 case WIDX_SOUND_CHECKBOX:
                     gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
+                    if (!gConfigSound.sound_enabled)
+                        audio_pause_sounds();
+                    else
+                        audio_unpause_sounds();
+                    window_invalidate_by_class(WC_TOP_TOOLBAR);
                     config_save_default();
                     window_invalidate(w);
                     break;
 
                 case WIDX_MASTER_SOUND_CHECKBOX:
                     gConfigSound.master_sound_enabled = !gConfigSound.master_sound_enabled;
+                    if (!gConfigSound.master_sound_enabled)
+                        audio_pause_sounds();
+                    else
+                        audio_unpause_sounds();
+                    window_invalidate_by_class(WC_TOP_TOOLBAR);
                     config_save_default();
                     window_invalidate(w);
                     break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1808,6 +1808,8 @@ static void window_options_invalidate(rct_window* w)
             widget_set_checkbox_value(w, WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
             widget_set_checkbox_value(w, WIDX_MUSIC_CHECKBOX, gConfigSound.ride_music_enabled);
             widget_set_checkbox_value(w, WIDX_AUDIO_FOCUS_CHECKBOX, gConfigSound.audio_focus);
+            widget_set_enabled(w, WIDX_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
+            widget_set_enabled(w, WIDX_MUSIC_CHECKBOX, gConfigSound.master_sound_enabled);
 
             // Initialize only on first frame, otherwise the scrollbars wont be able to be modified
             if (w->frame_no == 0)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1584,10 +1584,10 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
     }
 }
 
-static void initialize_scroll_position(rct_window* w, size_t widget_index, size_t scroll_index, uint8_t volume)
+static void initialize_scroll_position(rct_window* w, rct_widgetindex widget_index, int32_t scroll_id, uint8_t volume)
 {
     rct_widget* widget = &window_options_audio_widgets[widget_index];
-    rct_scroll* scroll = &w->scrolls[scroll_index];
+    rct_scroll* scroll = &w->scrolls[scroll_id];
 
     int widget_size = scroll->h_right - (widget->right - widget->left - 1);
     scroll->h_left = ceil(volume / 100.0f * widget_size);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1584,6 +1584,17 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
     }
 }
 
+static void initialize_scroll_position(rct_window* w, size_t widget_index, size_t scroll_index, uint8_t volume)
+{
+    rct_widget* widget = &window_options_audio_widgets[widget_index];
+    rct_scroll* scroll = &w->scrolls[scroll_index];
+
+    int widget_size = scroll->h_right - (widget->right - widget->left - 1);
+    scroll->h_left = ceil(volume / 100.0f * widget_size);
+
+    widget_scroll_update_thumbs(w, widget_index);
+}
+
 /**
  *
  *  rct2: 0x006BAD48
@@ -1796,23 +1807,13 @@ static void window_options_invalidate(rct_window* w)
             // Initialize only on first frame, otherwise the scrollbars wont be able to be modified
             if (w->frame_no == 0)
             {
-                widget = &window_options_audio_widgets[WIDX_MASTER_VOLUME];
-                w->scrolls[0].h_left = ceil(
-                    (gConfigSound.master_volume / 100.0f) * (w->scrolls[0].h_right - ((widget->right - widget->left) - 1)));
-                widget_scroll_update_thumbs(w, WIDX_MASTER_VOLUME);
-
-                widget = &window_options_audio_widgets[WIDX_SOUND_VOLUME];
-                w->scrolls[1].h_left = ceil(
-                    (gConfigSound.sound_volume / 100.0f) * (w->scrolls[1].h_right - ((widget->right - widget->left) - 1)));
-                widget_scroll_update_thumbs(w, WIDX_SOUND_VOLUME);
-
-                widget = &window_options_audio_widgets[WIDX_MUSIC_VOLUME];
-                w->scrolls[2].h_left = ceil(
-                    (gConfigSound.ride_music_volume / 100.0f) * (w->scrolls[2].h_right - ((widget->right - widget->left) - 1)));
-                widget_scroll_update_thumbs(w, WIDX_MUSIC_VOLUME);
+                initialize_scroll_position(w, WIDX_MASTER_VOLUME, 0, gConfigSound.master_volume);
+                initialize_scroll_position(w, WIDX_SOUND_VOLUME, 1, gConfigSound.sound_volume);
+                initialize_scroll_position(w, WIDX_MUSIC_VOLUME, 2, gConfigSound.ride_music_volume);
             }
+
+            break;
         }
-        break;
 
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
         {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2093,7 +2093,7 @@ static void window_options_scrollgetsize(rct_window* w, int32_t scrollIndex, int
 {
     if (w->page == WINDOW_OPTIONS_PAGE_AUDIO)
     {
-        *width = 1000;
+        *width = 500;
     }
 }
 

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -394,8 +394,8 @@ void audio_close()
 
 void audio_toggle_all_sounds()
 {
-    gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
-    if (gConfigSound.sound_enabled)
+    gConfigSound.master_sound_enabled = !gConfigSound.master_sound_enabled;
+    if (gConfigSound.master_sound_enabled)
     {
         audio_unpause_sounds();
     }
@@ -404,6 +404,8 @@ void audio_toggle_all_sounds()
         audio_stop_title_music();
         audio_pause_sounds();
     }
+
+    window_invalidate_by_class(WC_OPTIONS);
 }
 
 void audio_pause_sounds()

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -320,6 +320,8 @@ namespace Config
         if (reader->ReadSection("sound"))
         {
             auto model = &gConfigSound;
+            model->device = reader->GetCString("audio_device", nullptr);
+            model->master_sound_enabled = reader->GetBoolean("master_sound", true);
             model->master_volume = reader->GetInt32("master_volume", 100);
             model->title_music = reader->GetInt32("title_music", 2);
             model->sound_enabled = reader->GetBoolean("sound", true);
@@ -327,7 +329,6 @@ namespace Config
             model->ride_music_enabled = reader->GetBoolean("ride_music", true);
             model->ride_music_volume = reader->GetInt32("ride_music_volume", 100);
             model->audio_focus = reader->GetBoolean("audio_focus", false);
-            model->device = reader->GetCString("audio_device", nullptr);
         }
     }
 
@@ -335,6 +336,8 @@ namespace Config
     {
         auto model = &gConfigSound;
         writer->WriteSection("sound");
+        writer->WriteString("audio_device", model->device);
+        writer->WriteBoolean("master_sound", model->master_sound_enabled);
         writer->WriteInt32("master_volume", model->master_volume);
         writer->WriteInt32("title_music", model->title_music);
         writer->WriteBoolean("sound", model->sound_enabled);
@@ -342,7 +345,6 @@ namespace Config
         writer->WriteBoolean("ride_music", model->ride_music_enabled);
         writer->WriteInt32("ride_music_volume", model->ride_music_volume);
         writer->WriteBoolean("audio_focus", model->audio_focus);
-        writer->WriteString("audio_device", model->device);
     }
 
     static void ReadNetwork(IIniReader* reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -108,6 +108,7 @@ struct InterfaceConfiguration
 struct SoundConfiguration
 {
     utf8* device;
+    bool master_sound_enabled;
     uint8_t master_volume;
     uint8_t title_music;
     bool sound_enabled;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3885,6 +3885,9 @@ enum
     STR_DEBUG_PAINT_SHOW_BLOCKED_TILES = 6260,
     STR_DEBUG_PAINT_SHOW_WIDE_PATHS = 6261,
 
+    STR_MASTER_VOLUME = 6262,
+    STR_MASTER_VOLUME_TIP = 6263,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
Fixes #6720 and the issues discussed in PR #3001.

Also fixes a stubborn bug with `widget_scroll_get_part` not supporting more than two scroll widgets.

This PR includes some rewriting of rct_scroll code that I did while debugging the issue with more than two rct_scrolls in one window. I decided to leave it in.