### PR TITLE
Properly fix maze building when paused

### DIFF
--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -499,7 +499,7 @@ static void window_maze_construction_construct(int32_t direction)
         default:
         case RIDE_CONSTRUCTION_STATE_MAZE_FILL:
             mode = GC_SET_MAZE_TRACK_FILL;
-            flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED;
+            flags = GAME_COMMAND_FLAG_APPLY;
             break;
     }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3782,6 +3782,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
 
             if (_trackPlaceCost == MONEY32_UNDEFINED)
             {
+                _rideConstructionState = RIDE_CONSTRUCTION_STATE_PLACE;
                 rct_string_id errorText = gGameCommandErrorText;
                 z -= 8;
                 if (errorText == STR_NOT_ENOUGH_CASH_REQUIRES || errorText == STR_CAN_ONLY_BUILD_THIS_UNDERWATER

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -116,6 +116,7 @@ namespace GameActions
             GameActionResult::Ptr result = std::make_unique<GameActionResult>();
 
             result->Error = GA_ERROR::GAME_PAUSED;
+            result->ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
             result->ErrorMessage = STR_CONSTRUCTION_NOT_POSSIBLE_WHILE_GAME_IS_PAUSED;
 
             return result;

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -77,7 +77,11 @@ public:
 
     uint16_t GetActionFlags() const override
     {
-        return GameAction::GetActionFlags();
+        uint16_t flags = GameAction::GetActionFlags();
+        if (GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED)
+            flags |= GA_FLAGS::ALLOW_WHILE_PAUSED;
+
+        return flags;
     }
 
     void Serialise(DataSerialiser& stream) override


### PR DESCRIPTION
I think I properly fixed the issue in `MazeSetTrackAction.hpp` now, please do confirm if I did it right this time.

Also fixes two relevant bugs:
- The error message having no title
- Fixes the controls in the construction window activating when the initial placement fails because of e.g. the game being paused.