### PR TITLE
Scale mouse delta by zoom when using shift.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#7713] The virtual floor now takes land ownership rights into account.
 - Feature: [#7771] Danish translation.
 - Feature: [#7797, #7802, #7821, #7830] Add sprite font glyphs for Danish, Norwegian, Russian, Turkish, Catalan and Romanian.
+- Feature: [#7868] Placing scenery while holding shift now scales appropriately with zoom levels.
 - Fix: [#3177] Wrong keys displayed in shortcut menu.
 - Fix: [#4039] No sprite font glyph for German opening quotation mark.
 - Fix: [#7462] Guest window goes beyond the map edge on a spiral slide.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -31,6 +31,7 @@
 #include <openrct2/world/Entrance.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
+#include <limits>
 
 #pragma region Widgets
 
@@ -2069,8 +2070,10 @@ static bool ride_get_place_position_from_screen_position(int32_t screenX, int32_
     {
         if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
         {
-            _trackPlaceShiftZ = _trackPlaceShiftStartScreenY - screenY + 4;
+            constexpr uint16_t maxHeight = (std::numeric_limits<decltype(rct_tile_element::base_height)>::max() - 32)
+                << MAX_ZOOM_LEVEL;
 
+            _trackPlaceShiftZ = _trackPlaceShiftStartScreenY - screenY + 4;
             // Scale delta by zoom to match mouse position.
             auto* mainWnd = window_get_main();
             if (mainWnd && mainWnd->viewport)
@@ -2078,6 +2081,9 @@ static bool ride_get_place_position_from_screen_position(int32_t screenX, int32_
                 _trackPlaceShiftZ <<= mainWnd->viewport->zoom;
             }
             _trackPlaceShiftZ = floor2(_trackPlaceShiftZ, 8);
+
+            // Clamp to maximum possible value of base_height can offer.
+            _trackPlaceShiftZ = std::min<int16_t>(_trackPlaceShiftZ, maxHeight);
 
             screenX = _trackPlaceShiftStartScreenX;
             screenY = _trackPlaceShiftStartScreenY;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2069,7 +2069,16 @@ static bool ride_get_place_position_from_screen_position(int32_t screenX, int32_
     {
         if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
         {
-            _trackPlaceShiftZ = floor2(_trackPlaceShiftStartScreenY - screenY + 4, 8);
+            _trackPlaceShiftZ = _trackPlaceShiftStartScreenY - screenY + 4;
+
+            // Scale delta by zoom to match mouse position.
+            auto* mainWnd = window_get_main();
+            if (mainWnd && mainWnd->viewport)
+            {
+                _trackPlaceShiftZ <<= mainWnd->viewport->zoom;
+            }
+            _trackPlaceShiftZ = floor2(_trackPlaceShiftZ, 8);
+
             screenX = _trackPlaceShiftStartScreenX;
             screenY = _trackPlaceShiftStartScreenY;
         }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <limits>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
@@ -31,7 +32,6 @@
 #include <openrct2/world/Entrance.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
-#include <limits>
 
 #pragma region Widgets
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1232,7 +1232,15 @@ static void sub_6E1F34(
             if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
             {
                 // SHIFT pressed
-                gSceneryShiftPressZOffset = (gSceneryShiftPressY - y + 4) & 0xFFF8;
+                gSceneryShiftPressZOffset = (gSceneryShiftPressY - y + 4);
+
+                // Scale delta by zoom to match mouse position.
+                auto *mainWnd = window_get_main();
+                if (mainWnd && mainWnd->viewport)
+                {
+                    gSceneryShiftPressZOffset <<= mainWnd->viewport->zoom;
+                }
+                gSceneryShiftPressZOffset = floor2(gSceneryShiftPressZOffset, 8);
 
                 x = gSceneryShiftPressX;
                 y = gSceneryShiftPressY;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1308,8 +1308,7 @@ static void sub_6E1F34(
                         int16_t z = (tile_element->base_height * 8) & 0xFFF0;
                         z += gSceneryShiftPressZOffset;
 
-                        z = std::max<int16_t>(z, 16);
-                        z = std::min<int16_t>(z, maxPossibleHeight);
+                        z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                         gSceneryPlaceZ = z;
                     }
@@ -1326,8 +1325,7 @@ static void sub_6E1F34(
                         z += gSceneryShiftPressZOffset;
                     }
 
-                    z = std::max<int16_t>(z, 16);
-                    z = std::min<int16_t>(z, maxPossibleHeight);
+                    z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                     gSceneryPlaceZ = z;
                 }
@@ -1394,8 +1392,7 @@ static void sub_6E1F34(
                     int16_t z = (tile_element->base_height * 8) & 0xFFF0;
                     z += gSceneryShiftPressZOffset;
 
-                    z = std::max<int16_t>(z, 16);
-                    z = std::min<int16_t>(z, maxPossibleHeight);
+                    z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                     gSceneryPlaceZ = z;
                 }
@@ -1411,8 +1408,7 @@ static void sub_6E1F34(
                     z += gSceneryShiftPressZOffset;
                 }
 
-                z = std::max<int16_t>(z, 16);
-                z = std::min<int16_t>(z, maxPossibleHeight);
+                z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                 gSceneryPlaceZ = z;
             }
@@ -1493,8 +1489,7 @@ static void sub_6E1F34(
                     int16_t z = (tile_element->base_height * 8) & 0xFFF0;
                     z += gSceneryShiftPressZOffset;
 
-                    z = std::max<int16_t>(z, 16);
-                    z = std::min<int16_t>(z, maxPossibleHeight);
+                    z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                     gSceneryPlaceZ = z;
                 }
@@ -1510,8 +1505,7 @@ static void sub_6E1F34(
                     z += gSceneryShiftPressZOffset;
                 }
 
-                z = std::max<int16_t>(z, 16);
-                z = std::min<int16_t>(z, maxPossibleHeight);
+                z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                 gSceneryPlaceZ = z;
             }
@@ -1554,8 +1548,7 @@ static void sub_6E1F34(
                     int16_t z = (tile_element->base_height * 8) & 0xFFF0;
                     z += gSceneryShiftPressZOffset;
 
-                    z = std::max<int16_t>(z, 16);
-                    z = std::min<int16_t>(z, maxPossibleHeight);
+                    z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                     gSceneryPlaceZ = z;
                 }
@@ -1571,8 +1564,7 @@ static void sub_6E1F34(
                     z += gSceneryShiftPressZOffset;
                 }
 
-                z = std::max<int16_t>(z, 16);
-                z = std::min<int16_t>(z, maxPossibleHeight);
+                z = std::clamp<int16_t>(z, 16, maxPossibleHeight);
 
                 gSceneryPlaceZ = z;
             }


### PR DESCRIPTION
This is something that bothered me for a while, the current behavior is this:
![2018-08-10_01-14-14bc0f9f495f44ff7e1](https://user-images.githubusercontent.com/5415177/43930656-e1742f28-9c3a-11e8-91e5-d0aa5795310d.gif)
Which clearly does not consider the zoom.

Thats what I believe it should look like:
![2018-08-10_01-13-03190527e718915af29](https://user-images.githubusercontent.com/5415177/43930675-f7d52e66-9c3a-11e8-97d8-7ee6d929e5dd.gif)

