### PR TITLE
Auto-detect RCT1 files location

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -917,20 +917,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     if (rct1path)
                     {
                         // Check if this directory actually contains RCT1
-                        // The sprite file can be called either csg1.1 or csg1.dat, so check for both names.
-                        utf8 checkpath[MAX_PATH];
-                        safe_strcpy(checkpath, rct1path, MAX_PATH);
-                        safe_strcat_path(checkpath, "Data", MAX_PATH);
-                        safe_strcat_path(checkpath, "csg1.1", MAX_PATH);
-
-                        if (!platform_file_exists(checkpath))
-                        {
-                            safe_strcpy(checkpath, rct1path, MAX_PATH);
-                            safe_strcat_path(checkpath, "Data", MAX_PATH);
-                            safe_strcat_path(checkpath, "csg1.dat", MAX_PATH);
-                        }
-
-                        if (platform_file_exists(checkpath))
+                        if (platform_original_rct1_data_exists(rct1path))
                         {
                             SafeFree(gConfigGeneral.rct1_path);
                             gConfigGeneral.rct1_path = rct1path;

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -816,7 +816,7 @@ bool config_find_or_browse_install_directory()
     std::string rct1Path = Config::FindRCT1Path();
     if (!rct1Path.empty())
     {
-        Memory::Free(gConfigGeneral.rct1_path);
+        free(gConfigGeneral.rct1_path);
         gConfigGeneral.rct1_path = String::Duplicate(rct1Path.c_str());
     }
 

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -20,6 +20,7 @@
 #    endif
 #    include "../OpenRCT2.h"
 #    include "../config/Config.h"
+#    include "../core/Path.hpp"
 #    include "../localisation/Date.h"
 #    include "../localisation/Language.h"
 #    include "../util/Util.h"
@@ -142,6 +143,35 @@ bool platform_original_game_data_exists(const utf8* path)
     safe_strcat_path(checkPath, "Data", MAX_PATH);
     safe_strcat_path(checkPath, "g1.dat", MAX_PATH);
     return platform_file_exists(checkPath);
+}
+
+bool platform_original_rct1_data_exists(const utf8* path)
+{
+    char buffer[MAX_PATH], checkPath1[MAX_PATH], checkPath2[MAX_PATH];
+    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
+    safe_strcat_path(buffer, "Data", MAX_PATH);
+    safe_strcpy(checkPath1, buffer, MAX_PATH);
+    safe_strcpy(checkPath2, buffer, MAX_PATH);
+    safe_strcat_path(checkPath1, "CSG1.DAT", MAX_PATH);
+    safe_strcat_path(checkPath2, "CSG1.1", MAX_PATH);
+
+    // Since Linux is case sensitive (and macOS sometimes too), make sure we handle case properly.
+    std::string path1result = Path::ResolveCasing(checkPath1);
+    if (!path1result.empty())
+    {
+        return true;
+    }
+    else
+    {
+        std::string path2result = Path::ResolveCasing(checkPath2);
+
+        if (!path2result.empty())
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 // Implement our own version of getumask(), as it is documented being
@@ -459,6 +489,11 @@ bool platform_process_is_elevated()
 #    else
     return false;
 #    endif // __EMSCRIPTEN__
+}
+
+std::string platform_get_rct1_steam_dir()
+{
+    return "app_285310" PATH_SEPARATOR "depot_285311";
 }
 
 std::string platform_get_rct2_steam_dir()

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -106,6 +106,19 @@ bool platform_original_game_data_exists(const utf8* path)
     return platform_file_exists(checkPath);
 }
 
+bool platform_original_rct1_data_exists(const utf8* path)
+{
+    char checkPath[MAX_PATH];
+    char checkPath2[MAX_PATH];
+    safe_strcpy(checkPath, path, MAX_PATH);
+    safe_strcpy(checkPath2, path, MAX_PATH);
+    safe_strcat_path(checkPath, "Data", MAX_PATH);
+    safe_strcat_path(checkPath2, "Data", MAX_PATH);
+    safe_strcat_path(checkPath, "csg1.dat", MAX_PATH);
+    safe_strcat_path(checkPath2, "csg1.1", MAX_PATH);
+    return platform_file_exists(checkPath) || platform_file_exists(checkPath2);
+}
+
 bool platform_ensure_directory_exists(const utf8* path)
 {
     if (platform_directory_exists(path))
@@ -228,6 +241,11 @@ bool platform_get_steam_path(utf8* outPath, size_t outSize)
     free(wSteamPath);
     RegCloseKey(hKey);
     return result == ERROR_SUCCESS;
+}
+
+std::string platform_get_rct1_steam_dir()
+{
+    return "Rollercoaster Tycoon Deluxe";
 }
 
 std::string platform_get_rct2_steam_dir()

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -91,6 +91,7 @@ void platform_get_time_local(rct2_time* out_time);
 bool platform_file_exists(const utf8* path);
 bool platform_directory_exists(const utf8* path);
 bool platform_original_game_data_exists(const utf8* path);
+bool platform_original_rct1_data_exists(const utf8* path);
 time_t platform_file_get_modified_time(const utf8* path);
 bool platform_ensure_directory_exists(const utf8* path);
 bool platform_directory_delete(const utf8* path);
@@ -119,6 +120,7 @@ uint8_t platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();
 bool platform_get_steam_path(utf8* outPath, size_t outSize);
+std::string platform_get_rct1_steam_dir();
 std::string platform_get_rct2_steam_dir();
 
 #ifndef NO_TTF


### PR DESCRIPTION
This needs testing on Windows.

It works on Linux with the RCT1 files downloaded using the Steam console and `download_depot`.