### PR TITLE
Fix part of #7415: Korean scenario descriptions are mangled

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -742,7 +742,7 @@ namespace String
 #endif
     }
 
-    bool ContainsColourCode(std::string string)
+    bool ContainsColourCode(const std::string& string)
     {
         for (char c : string)
         {

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -33,6 +33,7 @@
 
 #include "../common.h"
 #include "../localisation/ConversionTables.h"
+#include "../localisation/FormatCodes.h"
 #include "../localisation/Language.h"
 #include "../util/Util.h"
 #include "Memory.hpp"
@@ -739,5 +740,17 @@ namespace String
 
         return res;
 #endif
+    }
+
+    bool ContainsColourCode(std::string string)
+    {
+        for (char c : string)
+        {
+            if (c >= (char)FORMAT_COLOUR_CODE_START && c <= (char)FORMAT_COLOUR_CODE_END)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 } // namespace String

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -744,9 +744,9 @@ namespace String
 
     bool ContainsColourCode(const std::string& string)
     {
-        for (char c : string)
+        for (unsigned char c : string)
         {
-            if (c >= (char)FORMAT_COLOUR_CODE_START && c <= (char)FORMAT_COLOUR_CODE_END)
+            if (c >= FORMAT_COLOUR_CODE_START && c <= FORMAT_COLOUR_CODE_END)
             {
                 return true;
             }

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -114,6 +114,6 @@ namespace String
     /**
      * Returns true if the string contains an RCT2 colour code.
      */
-    bool ContainsColourCode(std::string string);
+    bool ContainsColourCode(const std::string& string);
 
 } // namespace String

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -110,4 +110,10 @@ namespace String
      * Returns an uppercased version of a UTF-8 string.
      */
     std::string ToUpper(const std::string_view& src);
+
+    /**
+     * Returns true if the string contains an RCT2 colour code.
+     */
+    bool ContainsColourCode(std::string string);
+
 } // namespace String

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -184,13 +184,26 @@ public:
         // _s6.header
         gS6Info = _s6.info;
 
+        // Some scenarios have their scenario details in UTF-8, due to earlier bugs in OpenRCT2.
+        // This is hard to detect. Therefore, consider invalid characters like colour codes as a sign the text is in UTF-8.
+        bool alreadyInUTF8 = false;
+
+        if (String::ContainsColourCode(_s6.info.name) || String::ContainsColourCode(_s6.info.details))
+        {
+            alreadyInUTF8 = true;
+        }
+
+        if (!alreadyInUTF8)
         {
             auto temp = rct2_to_utf8(_s6.info.name, RCT2_LANGUAGE_ID_ENGLISH_UK);
             safe_strcpy(gS6Info.name, temp.data(), sizeof(gS6Info.name));
+            auto temp2 = rct2_to_utf8(_s6.info.details, RCT2_LANGUAGE_ID_ENGLISH_UK);
+            safe_strcpy(gS6Info.details, temp2.data(), sizeof(gS6Info.details));
         }
+        else
         {
-            auto temp = rct2_to_utf8(_s6.info.details, RCT2_LANGUAGE_ID_ENGLISH_UK);
-            safe_strcpy(gS6Info.details, temp.data(), sizeof(gS6Info.details));
+            safe_strcpy(gS6Info.name, _s6.info.name, sizeof(gS6Info.name));
+            safe_strcpy(gS6Info.details, _s6.info.details, sizeof(gS6Info.details));
         }
 
         gDateMonthsElapsed = _s6.elapsed_months;

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -243,8 +243,14 @@ private:
                 if (header.type == S6_TYPE_SCENARIO)
                 {
                     rct_s6_info info = chunkReader.ReadChunkAs<rct_s6_info>();
-                    rct2_to_utf8_self(info.name, sizeof(info.name));
-                    rct2_to_utf8_self(info.details, sizeof(info.details));
+                    // If the name or the details contain a colour code, they might be in UTF-8 already.
+                    // This is caused by a bug that was in OpenRCT2 for 3 years.
+                    if (!String::ContainsColourCode(info.name) && !String::ContainsColourCode(info.details))
+                    {
+                        rct2_to_utf8_self(info.name, sizeof(info.name));
+                        rct2_to_utf8_self(info.details, sizeof(info.details));
+                    }
+
                     *entry = CreateNewScenarioEntry(path, timestamp, &info);
                     return true;
                 }


### PR DESCRIPTION
OpenRCT2 used to incorrectly write UTF-8 to SV6 names and descriptions. This PR fixes reading such scenarios. It should also fix the game crashing when attempting to load such a scenario.

What this PR _doesn't_ do is add support for the encoding that vanilla used for CJK, or add support for creating scenarios with Korean descriptions. That will only be feasible when switching to our own format.

![king county amusements 2018-08-13 11-18-17](https://user-images.githubusercontent.com/1478678/44023470-b884b1d4-9eea-11e8-9ef3-67d8d12449a7.png)

@telk5093 @Lastorder-DC Could you test this PR and see if it solves your problems?