### PR TITLE
Fix #7804: Russian ride descriptions cut off

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,6 +34,7 @@
 - Fix: [#7817] No sprite font glyph for interpunct.
 - Fix: [#7823] You can build mazes in pause mode.
 - Fix: [#7804] Russian ride descriptions are cut off.
+- Fix: [#7872] CJK tooltips are often cut off.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#7793] Duplicate private keys generated.
 - Fix: [#7817] No sprite font glyph for interpunct.
 - Fix: [#7823] You can build mazes in pause mode.
+- Fix: [#7804] Russian ride descriptions are cut off.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -84,7 +84,7 @@ void window_tooltip_show(rct_string_id id, int32_t x, int32_t y)
 
     char* buffer = gCommonStringFormatBuffer;
 
-    format_string(buffer, 256, id, gCommonFormatArgs);
+    format_string(buffer, sizeof(gCommonStringFormatBuffer), id, gCommonFormatArgs);
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
     int32_t tooltip_text_width;

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -107,7 +107,7 @@ static void DrawText(rct_drawpixelinfo* dpi, int32_t x, int32_t y, TextPaint* pa
 
 static void DrawText(rct_drawpixelinfo* dpi, int32_t x, int32_t y, TextPaint* paint, rct_string_id format, void* args)
 {
-    utf8 buffer[256];
+    utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
     DrawText(dpi, x, y, paint, buffer);
 }
@@ -134,7 +134,7 @@ static void DrawTextEllipsisedCompat(
     _legacyPaint.SpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    utf8 buffer[256];
+    utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
     gfx_clip_string(buffer, width);
 
@@ -206,7 +206,7 @@ void gfx_draw_string_right_clipped(
 int32_t gfx_draw_string_left_wrapped(
     rct_drawpixelinfo* dpi, void* args, int32_t x, int32_t y, int32_t width, rct_string_id format, uint8_t colour)
 {
-    utf8 buffer[256];
+    utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
@@ -225,7 +225,7 @@ int32_t gfx_draw_string_left_wrapped(
 int32_t gfx_draw_string_centred_wrapped(
     rct_drawpixelinfo* dpi, void* args, int32_t x, int32_t y, int32_t width, rct_string_id format, uint8_t colour)
 {
-    utf8 buffer[256];
+    utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -35,7 +35,7 @@
 #include "Date.h"
 #include "Localisation.h"
 
-char gCommonStringFormatBuffer[256];
+char gCommonStringFormatBuffer[512];
 uint8_t gCommonFormatArgs[80];
 uint8_t gMapTooltipFormatArgs[40];
 

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -63,7 +63,7 @@ extern const char real_name_initials[16];
 extern const char* real_names[1024];
 
 extern utf8 gUserStrings[MAX_USER_STRINGS][USER_STRING_MAX_LENGTH];
-extern char gCommonStringFormatBuffer[256];
+extern char gCommonStringFormatBuffer[512];
 extern uint8_t gCommonFormatArgs[80];
 extern uint8_t gMapTooltipFormatArgs[40];
 extern bool gDebugStringFormatting;

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -103,11 +103,11 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
     }
     if (gConfigGeneral.upper_case_banners)
     {
-        format_string_to_upper(gCommonStringFormatBuffer, 256, string_id, gCommonFormatArgs);
+        format_string_to_upper(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
     }
     else
     {
-        format_string(gCommonStringFormatBuffer, 256, string_id, gCommonFormatArgs);
+        format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
     }
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -454,11 +454,12 @@ static void sub_6A4101(
             }
             if (gConfigGeneral.upper_case_banners)
             {
-                format_string_to_upper(gCommonStringFormatBuffer, 256, string_id, gCommonFormatArgs);
+                format_string_to_upper(
+                    gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
             }
             else
             {
-                format_string(gCommonStringFormatBuffer, 256, string_id, gCommonFormatArgs);
+                format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
             }
 
             gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;


### PR DESCRIPTION
Before:

![](https://camo.githubusercontent.com/4eaa7782969226be024e0aa675bb9b415477793e/68747470733a2f2f66696c65732e6769747465722e696d2f4f70656e524354322f4c6f63616c69736174696f6e2f5039696b2f426c61636b706f6f6c2d506c6561737572652d42656163682d323031382d30372d32302d32312d30342d30332e706e67)

After:

![blackpool pleasure beach 2018-08-13 20-33-45](https://user-images.githubusercontent.com/1478678/44051357-ed1651ec-9f39-11e8-9af1-49d02ed217cf.png)
