### PR TITLE
Allow loading CSS17.DAT and MP.DAT on all three RCT1 sources

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -35,6 +35,7 @@
 - Fix: [#7823] You can build mazes in pause mode.
 - Fix: [#7804] Russian ride descriptions are cut off.
 - Fix: [#7872] CJK tooltips are often cut off.
+- Fix: [#7895] Import of Mega Park and the RCT1 title music do not work on some RCT1 sources.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -246,12 +246,18 @@ namespace OpenRCT2
                 if (!(_env->GetDirectoryPath(DIRBASE::RCT1).empty()))
                 {
                     auto dataPath = _env->GetDirectoryPath(DIRBASE::RCT1, DIRID::DATA);
-                    result = Path::Combine(dataPath, "css17.dat");
+                    result = Path::ResolveCasing(Path::Combine(dataPath, "css17.dat"));
+
+                    if (!File::Exists(result))
+                    {
+                        auto rct1Path = _env->GetDirectoryPath(DIRBASE::RCT1);
+                        result = Path::ResolveCasing(Path::Combine(rct1Path, "RCTdeluxe_install", "Data", "css17.dat"));
+                    }
                 }
                 else
                 {
                     auto dataPath = _env->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA);
-                    result = Path::Combine(dataPath, "css50.dat");
+                    result = Path::ResolveCasing(Path::Combine(dataPath, "css50.dat"));
                 }
             }
             else if (pathId >= 0 && pathId < PATH_ID_END)

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -218,7 +218,7 @@ const char * PlatformEnvironment::FileNames[] =
     "objects.idx",          // CACHE_OBJECTS
     "tracks.idx",           // CACHE_TRACKS
     "scenarios.idx",        // CACHE_SCENARIOS
-    "RCTdeluxe_install" PATH_SEPARATOR "Data" PATH_SEPARATOR "mp.dat", // MP_DAT
+    "Data" PATH_SEPARATOR "mp.dat", // MP_DAT
     "groups.json",          // NETWORK_GROUPS
     "servers.cfg",          // NETWORK_SERVERS
     "users.json",           // NETWORK_USERS

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -486,7 +486,15 @@ private:
     {
         auto mpdatPath = _env->GetFilePath(PATHID::MP_DAT);
         auto scenarioDirectory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::SCENARIO);
-        auto sc21Path = Path::Combine(scenarioDirectory, "sc21.sc4");
+        auto sc21Path = Path::ResolveCasing(Path::Combine(scenarioDirectory, "sc21.sc4"));
+
+        // If the user has a Steam installation.
+        if (!File::Exists(mpdatPath))
+        {
+            mpdatPath = Path::ResolveCasing(
+                Path::Combine(_env->GetDirectoryPath(DIRBASE::RCT1), "RCTdeluxe_install", "Data", "mp.dat"));
+        }
+
         if (File::Exists(mpdatPath) && !File::Exists(sc21Path))
         {
             ConvertMegaPark(mpdatPath, sc21Path);


### PR DESCRIPTION
This should equalise the three in terms of supported features.