### PR TITLE
Scenario description typo in en-US.txt

### DIFF
--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -1563,7 +1563,7 @@ STR_DTLS    :The people of Hawaii are bored of surfing and are looking for somet
 <North America - Grand Canyon>
 STR_SCNR    :North America - Grand Canyon
 STR_PARK    :Canyon Calamities
-STR_DTLS    :You have to build a park on limited land either side of this natural treasure - you do have the opportunity to buy neighbouring land from the Native American Indians. You need to complete the objective to sustain the local town's population.
+STR_DTLS    :You have to build a park on limited land either side of this natural treasure - you do have the opportunity to buy neighboring land from the Native American Indians. You need to complete the objective to sustain the local town's population.
 
 <North America - Rollercoaster Heaven>
 STR_SCNR    :North America - Rollercoaster Heaven


### PR DESCRIPTION
The scenario description for North America - Grand Canyon uses the UK version of the word neighbouring instead of the US version of the word neighboring.