### PR TITLE
Allow opening SV7 files

### DIFF
--- a/distribution/linux/openrct2-mimeinfo.xml
+++ b/distribution/linux/openrct2-mimeinfo.xml
@@ -24,6 +24,7 @@
     <comment xml:lang="zh-TW">OpenRCT2 遊戲存檔</comment>
     <glob weight="60" pattern="*.sv6"/>
     <glob weight="60" pattern="*.sv4"/>
+    <glob weight="60" pattern="*.sv7"/>
   </mime-type>
 
   <mime-type type="application/x-openrct2-scenario">

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -220,7 +220,7 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName)
             w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
             if (window_loadsave_get_dir(gConfigGeneral.last_save_game_directory, path, "save", sizeof(path)))
             {
-                window_loadsave_populate_list(w, isSave, path, isSave ? ".sv6" : ".sv6;.sc6;.sv4;.sc4");
+                window_loadsave_populate_list(w, isSave, path, isSave ? ".sv6" : ".sv6;.sc6;.sv4;.sc4;.sv7");
                 success = true;
             }
             break;
@@ -229,7 +229,7 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName)
             w->widgets[WIDX_TITLE].text = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
             if (window_loadsave_get_dir(gConfigGeneral.last_save_landscape_directory, path, "landscape", sizeof(path)))
             {
-                window_loadsave_populate_list(w, isSave, path, isSave ? ".sc6" : ".sc6;.sv6;.sc4;.sv4");
+                window_loadsave_populate_list(w, isSave, path, isSave ? ".sc6" : ".sc6;.sv6;.sc4;.sv4;.sv7");
                 success = true;
             }
             break;
@@ -313,7 +313,7 @@ static bool browse(bool isSave, char* path, size_t pathSize)
             fileType = FILE_EXTENSION_SV6;
             title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
             desc.filters[0].name = language_get_string(STR_OPENRCT2_SAVED_GAME);
-            desc.filters[0].pattern = isSave ? "*.sv6" : "*.sv6;*.sc6;*.sv4;*.sc4";
+            desc.filters[0].pattern = isSave ? "*.sv6" : "*.sv6;*.sc6;*.sv4;*.sc4;*.sv7";
             break;
 
         case LOADSAVETYPE_LANDSCAPE:
@@ -321,7 +321,7 @@ static bool browse(bool isSave, char* path, size_t pathSize)
             fileType = FILE_EXTENSION_SC6;
             title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
             desc.filters[0].name = language_get_string(STR_OPENRCT2_LANDSCAPE_FILE);
-            desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4";
+            desc.filters[0].pattern = isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4;*.sv7";
             break;
 
         case LOADSAVETYPE_SCENARIO:

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -249,7 +249,7 @@ namespace Editor
         {
             load_from_sc6(path);
         }
-        else if (_stricmp(extension, ".sv6") == 0)
+        else if (_stricmp(extension, ".sv6") == 0 || _stricmp(extension, ".sv7") == 0)
         {
             load_from_sv6(path);
         }

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -177,6 +177,8 @@ uint32_t get_file_extension_type(const utf8* path)
         return FILE_EXTENSION_SC6;
     if (String::Equals(extension, ".sv6", true))
         return FILE_EXTENSION_SV6;
+    if (String::Equals(extension, ".sv7", true))
+        return FILE_EXTENSION_SV6;
     if (String::Equals(extension, ".td6", true))
         return FILE_EXTENSION_TD6;
     return FILE_EXTENSION_UNKNOWN;

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -669,6 +669,7 @@ void platform_setup_file_associations()
     windows_setup_file_association(".sc6", "RCT2 Scenario (.sc6)", "Play", "\"%1\"", 0);
     windows_setup_file_association(".sv4", "RCT1 Saved Game (.sc4)", "Play", "\"%1\"", 0);
     windows_setup_file_association(".sv6", "RCT2 Saved Game (.sv6)", "Play", "\"%1\"", 0);
+    windows_setup_file_association(".sv7", "RCT Modified Saved Game (.sv7)", "Play", "\"%1\"", 0);
     windows_setup_file_association(".td4", "RCT1 Track Design (.td4)", "Install", "\"%1\"", 0);
     windows_setup_file_association(".td6", "RCT2 Track Design (.td6)", "Install", "\"%1\"", 0);
 
@@ -683,6 +684,7 @@ void platform_remove_file_associations()
     windows_remove_file_association(".sc6");
     windows_remove_file_association(".sv4");
     windows_remove_file_association(".sv6");
+    windows_remove_file_association(".sv7");
     windows_remove_file_association(".td4");
     windows_remove_file_association(".td6");
 


### PR DESCRIPTION
This makes .SV7 files (created with RCT Modified) show up in the Load window, as well as associate the extension with OpenRCT2 on Linux.

This is mostly for convenience, as no further modifications have been done to the import.