### PR TITLE
Fix #7911: Unable to save new scenarios

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -216,19 +216,19 @@ static const char* getFilterPatternByType(const int32_t type, const bool isSave)
     switch (type & 0x0E)
     {
         case LOADSAVETYPE_GAME:
-            return isSave ? "*.sv6" : "*.sv6;*.sc6;*.sc4;*.sv4;*.sv7";
+            return isSave ? ".sv6" : ".sv6;.sc6;.sc4;.sv4;.sv7";
 
         case LOADSAVETYPE_LANDSCAPE:
-            return isSave ? "*.sc6" : "*.sc6;*.sv6;*.sc4;*.sv4;*.sv7";
+            return isSave ? ".sc6" : ".sc6;.sv6;.sc4;.sv4;.sv7";
 
         case LOADSAVETYPE_SCENARIO:
-            return "*.sc6";
+            return ".sc6";
 
         case LOADSAVETYPE_TRACK:
-            return isSave ? "*.td6" : "*.td6;*.td4";
+            return isSave ? ".td6" : ".td6;.td4";
 
         case LOADSAVETYPE_HEIGHTMAP:
-            return "*.bmp;*.png";
+            return ".bmp;.png";
 
         default:
             openrct2_assert(true, "Unsupported load/save directory type.");
@@ -907,7 +907,8 @@ static void window_loadsave_populate_list(rct_window* w, int32_t includeNewItem,
         while (extToken != nullptr)
         {
             safe_strcpy(filter, directory, Util::CountOf(filter));
-            safe_strcat_path(filter, extToken, Util::CountOf(filter));
+            safe_strcat_path(filter, "*", Util::CountOf(filter));
+            path_append_extension(filter, extToken, Util::CountOf(filter));
 
             auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(filter, false));
             while (scanner->Next())


### PR DESCRIPTION
The problem was that the filters have changed so they included the '*' character. This got appended to the path, which caused the check for valid filenames to fail.

This commit reverts the offending strings and code lines to how it was before.