### PR TITLE
Simplify sprite structs

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -71,7 +71,7 @@ int32_t viewport_interaction_get_item_left(int32_t x, int32_t y, viewport_intera
     switch (info->type)
     {
         case VIEWPORT_INTERACTION_ITEM_SPRITE:
-            switch (sprite->unknown.sprite_identifier)
+            switch (sprite->generic.sprite_identifier)
             {
                 case SPRITE_IDENTIFIER_VEHICLE:
                     vehicle = &(sprite->vehicle);
@@ -135,7 +135,7 @@ int32_t viewport_interaction_left_click(int32_t x, int32_t y)
     switch (viewport_interaction_get_item_left(x, y, &info))
     {
         case VIEWPORT_INTERACTION_ITEM_SPRITE:
-            switch (info.sprite->unknown.sprite_identifier)
+            switch (info.sprite->generic.sprite_identifier)
             {
                 case SPRITE_IDENTIFIER_VEHICLE:
                 {
@@ -154,7 +154,7 @@ int32_t viewport_interaction_left_click(int32_t x, int32_t y)
                 case SPRITE_IDENTIFIER_MISC:
                     if (game_is_not_paused())
                     {
-                        switch (info.sprite->unknown.misc_identifier)
+                        switch (info.sprite->generic.type)
                         {
                             case SPRITE_MISC_BALLOON:
                                 game_do_command(
@@ -420,7 +420,7 @@ int32_t viewport_interaction_right_click(int32_t x, int32_t y)
             return 0;
 
         case VIEWPORT_INTERACTION_ITEM_SPRITE:
-            if (info.sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
+            if (info.sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
                 ride_construct(info.sprite->vehicle.ride);
             break;
         case VIEWPORT_INTERACTION_ITEM_RIDE:

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -616,8 +616,8 @@ static void window_title_command_editor_tool_down(rct_window* w, rct_widgetindex
 
     if (info.type == VIEWPORT_INTERACTION_ITEM_SPRITE)
     {
-        uint16_t spriteIndex = info.sprite->unknown.sprite_index;
-        uint16_t spriteIdentifier = info.sprite->unknown.sprite_identifier;
+        uint16_t spriteIndex = info.sprite->generic.sprite_index;
+        uint16_t spriteIdentifier = info.sprite->generic.sprite_identifier;
         bool validSprite = false;
         if (spriteIdentifier == SPRITE_IDENTIFIER_PEEP)
         {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -294,7 +294,7 @@ namespace Editor
         for (int32_t i = 0; i < MAX_SPRITES; i++)
         {
             rct_sprite* sprite = get_sprite(i);
-            user_string_free(sprite->unknown.name_string_idx);
+            user_string_free(sprite->generic.name_string_idx);
         }
 
         reset_sprite_list();

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1160,9 +1160,9 @@ void reset_all_sprite_quadrant_placements()
     for (size_t i = 0; i < MAX_SPRITES; i++)
     {
         rct_sprite* spr = get_sprite(i);
-        if (spr->unknown.sprite_identifier != SPRITE_IDENTIFIER_NULL)
+        if (spr->generic.sprite_identifier != SPRITE_IDENTIFIER_NULL)
         {
-            sprite_move(spr->unknown.x, spr->unknown.y, spr->unknown.z, spr);
+            sprite_move(spr->generic.x, spr->generic.y, spr->generic.z, spr);
         }
     }
 }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -186,9 +186,9 @@ void viewport_create(
     {
         w->viewport_target_sprite = sprite;
         rct_sprite* centre_sprite = get_sprite(sprite);
-        centre_x = centre_sprite->unknown.x;
-        centre_y = centre_sprite->unknown.y;
-        centre_z = centre_sprite->unknown.z;
+        centre_x = centre_sprite->generic.x;
+        centre_y = centre_sprite->generic.y;
+        centre_z = centre_sprite->generic.z;
     }
     else
     {
@@ -638,13 +638,13 @@ void viewport_update_sprite_follow(rct_window* window)
     {
         rct_sprite* sprite = get_sprite(window->viewport_target_sprite);
 
-        int32_t height = (tile_element_height(0xFFFF & sprite->unknown.x, 0xFFFF & sprite->unknown.y) & 0xFFFF) - 16;
-        int32_t underground = sprite->unknown.z < height;
+        int32_t height = (tile_element_height(0xFFFF & sprite->generic.x, 0xFFFF & sprite->generic.y) & 0xFFFF) - 16;
+        int32_t underground = sprite->generic.z < height;
 
         viewport_set_underground_flag(underground, window, window->viewport);
 
         int32_t centre_x, centre_y;
-        centre_2d_coordinates(sprite->unknown.x, sprite->unknown.y, sprite->unknown.z, &centre_x, &centre_y, window->viewport);
+        centre_2d_coordinates(sprite->generic.x, sprite->generic.y, sprite->generic.z, &centre_x, &centre_y, window->viewport);
 
         window->saved_view_x = centre_x;
         window->saved_view_y = centre_y;
@@ -660,7 +660,7 @@ void viewport_update_smart_sprite_follow(rct_window* window)
         window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
         window->viewport_target_sprite = SPRITE_INDEX_NULL;
     }
-    else if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+    else if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
     {
         rct_peep* peep = GET_PEEP(window->viewport_smart_follow_sprite);
 
@@ -669,13 +669,13 @@ void viewport_update_smart_sprite_follow(rct_window* window)
         else if (peep->type == PEEP_TYPE_STAFF)
             viewport_update_smart_staff_follow(window, peep);
     }
-    else if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
+    else if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
     {
         viewport_update_smart_vehicle_follow(window);
     }
     else if (
-        sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_MISC
-        || sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
+        sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_MISC
+        || sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
     {
         window->viewport_focus_sprite.sprite_id = window->viewport_smart_follow_sprite;
         window->viewport_target_sprite = window->viewport_smart_follow_sprite;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -822,9 +822,9 @@ void window_scroll_to_viewport(rct_window* w)
     if (w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_SPRITE)
     {
         rct_sprite* sprite = get_sprite(w->viewport_focus_sprite.sprite_id);
-        x = sprite->unknown.x;
-        y = sprite->unknown.y;
-        z = sprite->unknown.z;
+        x = sprite->generic.x;
+        y = sprite->generic.y;
+        z = sprite->generic.z;
     }
     else
     {

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -32,12 +32,12 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
 {
     rct_drawpixelinfo* dpi = session->DPI;
 
-    switch (misc->steam_particle.misc_identifier)
+    switch (misc->steam_particle.type)
     {
         case SPRITE_MISC_STEAM_PARTICLE: // 0
         {
             uint32_t imageId = 22637 + (misc->steam_particle.frame / 256);
-            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->unknown.z);
+            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->generic.z);
             break;
         }
 
@@ -68,14 +68,14 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
             uint32_t imageId = vehicle_particle_base_sprites[particle.crashed_sprite_base] + particle.frame / 256;
             imageId = imageId | (particle.colour[0] << 19) | (particle.colour[1] << 24) | IMAGE_TYPE_REMAP
                 | IMAGE_TYPE_REMAP_2_PLUS;
-            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->unknown.z);
+            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->generic.z);
             break;
         }
 
         case SPRITE_MISC_EXPLOSION_CLOUD: // 3
         {
-            uint32_t imageId = 22878 + (misc->unknown.frame / 256);
-            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->unknown.z);
+            uint32_t imageId = 22878 + (misc->generic.frame / 256);
+            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->generic.z);
             break;
         }
 
@@ -90,8 +90,8 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
         case SPRITE_MISC_EXPLOSION_FLARE: // 5
         {
             // Like a flare
-            uint32_t imageId = 22896 + (misc->unknown.frame / 256);
-            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->unknown.z);
+            uint32_t imageId = 22896 + (misc->generic.frame / 256);
+            sub_98196C(session, imageId, 0, 0, 1, 1, 0, misc->generic.z);
             break;
         }
 
@@ -121,7 +121,7 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
                 al = al ^ 1;
             }
 
-            uint32_t baseImageId = (jumpingFountain.misc_identifier == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW) ? 23037 : 22973;
+            uint32_t baseImageId = (jumpingFountain.type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW) ? 23037 : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain.frame;
             if (al & 1)
             {

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -49,13 +49,13 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
     const bool highlightPathIssues = (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES);
 
     for (const rct_sprite* spr = get_sprite(sprite_idx); sprite_idx != SPRITE_INDEX_NULL;
-         sprite_idx = spr->unknown.next_in_quadrant)
+         sprite_idx = spr->generic.next_in_quadrant)
     {
         spr = get_sprite(sprite_idx);
 
         if (highlightPathIssues)
         {
-            if (spr->unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+            if (spr->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
             {
                 rct_peep* peep = (rct_peep*)spr;
                 if (!(peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_HANDYMAN))
@@ -63,7 +63,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
                     continue;
                 }
             }
-            else if (spr->unknown.sprite_identifier != SPRITE_IDENTIFIER_LITTER)
+            else if (spr->generic.sprite_identifier != SPRITE_IDENTIFIER_LITTER)
             {
                 continue;
             }
@@ -75,15 +75,15 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         // height of the slope element, and consequently clipped.
         if ((gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW))
         {
-            if (spr->unknown.z > (gClipHeight * 8))
+            if (spr->generic.z > (gClipHeight * 8))
             {
                 continue;
             }
-            if (spr->unknown.x / 32 < gClipSelectionA.x || spr->unknown.x / 32 > gClipSelectionB.x)
+            if (spr->generic.x / 32 < gClipSelectionA.x || spr->generic.x / 32 > gClipSelectionB.x)
             {
                 continue;
             }
-            if (spr->unknown.y / 32 < gClipSelectionA.y || spr->unknown.y / 32 > gClipSelectionB.y)
+            if (spr->generic.y / 32 < gClipSelectionA.y || spr->generic.y / 32 > gClipSelectionB.y)
             {
                 continue;
             }
@@ -91,23 +91,23 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 
         dpi = session->DPI;
 
-        if (dpi->y + dpi->height <= spr->unknown.sprite_top || spr->unknown.sprite_bottom <= dpi->y
-            || dpi->x + dpi->width <= spr->unknown.sprite_left || spr->unknown.sprite_right <= dpi->x)
+        if (dpi->y + dpi->height <= spr->generic.sprite_top || spr->generic.sprite_bottom <= dpi->y
+            || dpi->x + dpi->width <= spr->generic.sprite_left || spr->generic.sprite_right <= dpi->x)
         {
             continue;
         }
 
         int32_t image_direction = session->CurrentRotation;
         image_direction <<= 3;
-        image_direction += spr->unknown.sprite_direction;
+        image_direction += spr->generic.sprite_direction;
         image_direction &= 0x1F;
 
         session->CurrentlyDrawnItem = spr;
-        session->SpritePosition.x = spr->unknown.x;
-        session->SpritePosition.y = spr->unknown.y;
+        session->SpritePosition.x = spr->generic.x;
+        session->SpritePosition.y = spr->generic.y;
         session->InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
 
-        switch (spr->unknown.sprite_identifier)
+        switch (spr->generic.sprite_identifier)
         {
             case SPRITE_IDENTIFIER_VEHICLE:
                 vehicle_paint(session, (rct_vehicle*)spr, image_direction);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5348,11 +5348,11 @@ void rct_peep::UpdateWalking()
 
     // Check if there is a peep watching (and if there is place for us)
     uint16_t sprite_id = sprite_get_first_in_quadrant(x, y);
-    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant)
+    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -5946,11 +5946,11 @@ bool rct_peep::UpdateWalkingFindBench()
     uint8_t free_edge = 3;
 
     // Check if there is no peep sitting in chosen_edge
-    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant)
+    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6136,11 +6136,11 @@ static void peep_update_walking_break_scenery(rct_peep* peep)
     uint16_t sprite_id = sprite_get_first_in_quadrant(peep->x, peep->y);
 
     // Check if a peep is already sitting on the bench. If so, do not vandalise it.
-    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant)
+    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
 
-        if ((sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2) || (sprite->peep.state != PEEP_STATE_SITTING)
+        if ((sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2) || (sprite->peep.state != PEEP_STATE_SITTING)
             || (peep->z != sprite->peep.z))
         {
             continue;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -396,7 +396,7 @@ rct_peep* try_get_guest(uint16_t spriteIndex)
     rct_sprite* sprite = try_get_sprite(spriteIndex);
     if (sprite == nullptr)
         return nullptr;
-    if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
+    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
         return nullptr;
     if (sprite->peep.type != PEEP_TYPE_GUEST)
         return nullptr;
@@ -2775,10 +2775,10 @@ static void peep_footpath_move_forward(rct_peep* peep, int16_t x, int16_t y, rct
     uint8_t litter_count = 0;
     uint8_t sick_count = 0;
     uint16_t sprite_id = sprite_get_first_in_quadrant(x, y);
-    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant)
+    for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
-        if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+        if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
         {
             rct_peep* other_peep = (rct_peep*)sprite;
             if (other_peep->state != PEEP_STATE_WALKING)
@@ -2789,7 +2789,7 @@ static void peep_footpath_move_forward(rct_peep* peep, int16_t x, int16_t y, rct
             crowded++;
             continue;
         }
-        else if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
+        else if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
         {
             rct_litter* litter = (rct_litter*)sprite;
             if (abs(litter->z - peep->next_z * 8) > 16)

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -467,7 +467,7 @@ void game_command_set_staff_patrol(
             return;
         }
         rct_sprite* sprite = get_sprite(sprite_id);
-        if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_PEEP || sprite->peep.type != PEEP_TYPE_STAFF)
+        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP || sprite->peep.type != PEEP_TYPE_STAFF)
         {
             *ebx = MONEY32_UNDEFINED;
             log_warning("Invalid type of sprite %u for game command", sprite_id);
@@ -2292,11 +2292,11 @@ static int32_t peep_update_patrolling_find_sweeping(rct_peep* peep)
 
     uint16_t sprite_id = sprite_get_first_in_quadrant(peep->x, peep->y);
 
-    for (rct_sprite* sprite = nullptr; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->unknown.next_in_quadrant)
+    for (rct_sprite* sprite = nullptr; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_LITTER * 2)
+        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_LITTER * 2)
             continue;
 
         uint16_t z_diff = abs(peep->z - sprite->litter.z);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1322,7 +1322,7 @@ private:
         for (size_t i = 0; i < MAX_SPRITES; i++)
         {
             rct_sprite* sprite = get_sprite(i);
-            if (sprite->unknown.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
+            if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_VEHICLE)
             {
                 rct_vehicle* vehicle = (rct_vehicle*)sprite;
                 FixVehiclePeepLinks(vehicle, spriteIndexMap);
@@ -1650,11 +1650,11 @@ private:
             if (sprite.unknown.sprite_identifier == SPRITE_IDENTIFIER_MISC)
             {
                 rct1_unk_sprite* src = &sprite.unknown;
-                rct_unk_sprite* dst = (rct_unk_sprite*)create_sprite(SPRITE_IDENTIFIER_MISC);
+                rct_sprite_generic* dst = (rct_sprite_generic*)create_sprite(SPRITE_IDENTIFIER_MISC);
                 move_sprite_to_list((rct_sprite*)dst, SPRITE_LIST_MISC * 2);
 
                 dst->sprite_identifier = src->sprite_identifier;
-                dst->misc_identifier = src->misc_identifier;
+                dst->type = src->misc_identifier;
                 dst->flags = src->flags;
                 dst->sprite_direction = src->sprite_direction;
                 dst->sprite_width = src->sprite_width;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -832,7 +832,7 @@ public:
         uint16_t numRiders = 0;
         for (const rct_sprite sprite : _s6.sprites)
         {
-            if (sprite.unknown.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+            if (sprite.generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
             {
                 if (sprite.peep.current_ride == rideIndex
                     && (sprite.peep.state == PEEP_STATE_ON_RIDE || sprite.peep.state == PEEP_STATE_ENTERING_RIDE))

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -830,7 +830,7 @@ public:
     {
         // The number of riders might have overflown or underflown. Re-calculate the value.
         uint16_t numRiders = 0;
-        for (const rct_sprite sprite : _s6.sprites)
+        for (const rct_sprite& sprite : _s6.sprites)
         {
             if (sprite.generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
             {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -834,7 +834,7 @@ rct_vehicle* try_get_vehicle(uint16_t spriteIndex)
     rct_sprite* sprite = try_get_sprite(spriteIndex);
     if (sprite == nullptr)
         return nullptr;
-    if (sprite->unknown.sprite_identifier != SPRITE_IDENTIFIER_VEHICLE)
+    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_VEHICLE)
         return nullptr;
     return &sprite->vehicle;
 }
@@ -7235,7 +7235,7 @@ static void steam_particle_create(int16_t x, int16_t y, int16_t z)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SPRITE_IDENTIFIER_MISC;
-        steam->misc_identifier = SPRITE_MISC_STEAM_PARTICLE;
+        steam->type = SPRITE_MISC_STEAM_PARTICLE;
         steam->frame = 256;
         steam->time_to_move = 0;
         sprite_move(x, y, z, (rct_sprite*)steam);

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -15,7 +15,7 @@
 
 bool rct_sprite::IsBalloon()
 {
-    return this->balloon.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->balloon.misc_identifier == SPRITE_MISC_BALLOON;
+    return this->balloon.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->balloon.type == SPRITE_MISC_BALLOON;
 }
 
 rct_balloon* rct_sprite::AsBalloon()
@@ -111,7 +111,7 @@ void create_balloon(int32_t x, int32_t y, int32_t z, int32_t colour, bool isPopp
         sprite->balloon.sprite_height_positive = 11;
         sprite->balloon.sprite_identifier = SPRITE_IDENTIFIER_MISC;
         sprite_move(x, y, z, sprite);
-        sprite->balloon.misc_identifier = SPRITE_MISC_BALLOON;
+        sprite->balloon.type = SPRITE_MISC_BALLOON;
         sprite->balloon.time_to_move = 0;
         sprite->balloon.frame = 0;
         sprite->balloon.colour = colour;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -76,7 +76,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 
 bool rct_sprite::IsDuck()
 {
-    return this->duck.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->duck.misc_identifier == SPRITE_MISC_DUCK;
+    return this->duck.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->duck.type == SPRITE_MISC_DUCK;
 }
 
 rct_duck* rct_sprite::AsDuck()
@@ -313,7 +313,7 @@ void create_duck(int32_t targetX, int32_t targetY)
     if (sprite != nullptr)
     {
         sprite->duck.sprite_identifier = SPRITE_IDENTIFIER_MISC;
-        sprite->duck.misc_identifier = SPRITE_MISC_DUCK;
+        sprite->duck.type = SPRITE_MISC_DUCK;
         sprite->duck.sprite_width = 9;
         sprite->duck.sprite_height_negative = 12;
         sprite->duck.sprite_height_positive = 9;
@@ -378,9 +378,9 @@ void duck_remove_all()
     for (uint16_t spriteIndex = gSpriteListHead[SPRITE_LIST_MISC]; spriteIndex != SPRITE_INDEX_NULL;
          spriteIndex = nextSpriteIndex)
     {
-        rct_unk_sprite* sprite = &(get_sprite(spriteIndex)->unknown);
+        rct_sprite_generic* sprite = &(get_sprite(spriteIndex)->generic);
         nextSpriteIndex = sprite->next;
-        if (sprite->misc_identifier == SPRITE_MISC_DUCK)
+        if (sprite->type == SPRITE_MISC_DUCK)
         {
             sprite_remove((rct_sprite*)sprite);
         }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -142,7 +142,7 @@ void jumping_fountain_create(int32_t type, int32_t x, int32_t y, int32_t z, int3
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SPRITE_IDENTIFIER_MISC;
         sprite_move(x, y, z, (rct_sprite*)jumpingFountain);
-        jumpingFountain->misc_identifier = type == JUMPING_FOUNTAIN_TYPE_SNOW ? SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
+        jumpingFountain->type = type == JUMPING_FOUNTAIN_TYPE_SNOW ? SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
                                                                               : SPRITE_MISC_JUMPING_FOUNTAIN_WATER;
         jumpingFountain->num_ticks_alive = 0;
         jumpingFountain->frame = 0;
@@ -164,7 +164,7 @@ void jumping_fountain_update(rct_jumping_fountain* jumpingFountain)
     invalidate_sprite_0((rct_sprite*)jumpingFountain);
     jumpingFountain->frame++;
 
-    switch (jumpingFountain->misc_identifier)
+    switch (jumpingFountain->type)
     {
         case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
             if (jumpingFountain->frame == 11 && (jumpingFountain->fountain_flags & FOUNTAIN_FLAG::FAST))
@@ -192,7 +192,7 @@ void jumping_fountain_update(rct_jumping_fountain* jumpingFountain)
 
 static int32_t jumping_fountain_get_type(const rct_jumping_fountain* jumpingFountain)
 {
-    int32_t type = jumpingFountain->misc_identifier == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW ? JUMPING_FOUNTAIN_TYPE_SNOW
+    int32_t type = jumpingFountain->type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW ? JUMPING_FOUNTAIN_TYPE_SNOW
                                                                                          : JUMPING_FOUNTAIN_TYPE_WATER;
     return type;
 }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -143,7 +143,7 @@ void jumping_fountain_create(int32_t type, int32_t x, int32_t y, int32_t z, int3
         jumpingFountain->sprite_identifier = SPRITE_IDENTIFIER_MISC;
         sprite_move(x, y, z, (rct_sprite*)jumpingFountain);
         jumpingFountain->type = type == JUMPING_FOUNTAIN_TYPE_SNOW ? SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
-                                                                              : SPRITE_MISC_JUMPING_FOUNTAIN_WATER;
+                                                                   : SPRITE_MISC_JUMPING_FOUNTAIN_WATER;
         jumpingFountain->num_ticks_alive = 0;
         jumpingFountain->frame = 0;
     }
@@ -193,7 +193,7 @@ void jumping_fountain_update(rct_jumping_fountain* jumpingFountain)
 static int32_t jumping_fountain_get_type(const rct_jumping_fountain* jumpingFountain)
 {
     int32_t type = jumpingFountain->type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW ? JUMPING_FOUNTAIN_TYPE_SNOW
-                                                                                         : JUMPING_FOUNTAIN_TYPE_WATER;
+                                                                              : JUMPING_FOUNTAIN_TYPE_WATER;
     return type;
 }
 

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -200,10 +200,10 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
                 int32_t y2 = y - CoordsDirectionDelta[direction].y;
 
                 uint16_t spriteIdx = sprite_get_first_in_quadrant(x2, y2);
-                for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->unknown.next_in_quadrant)
+                for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (sprite->unknown.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+                    if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -37,7 +37,7 @@ void money_effect_create_at(money32 value, int32_t x, int32_t y, int32_t z, bool
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SPRITE_IDENTIFIER_MISC;
     sprite_move(x, y, z, (rct_sprite*)moneyEffect);
-    moneyEffect->misc_identifier = SPRITE_MISC_MONEY_EFFECT;
+    moneyEffect->type = SPRITE_MISC_MONEY_EFFECT;
     moneyEffect->num_movements = 0;
     moneyEffect->move_delay = 0;
 

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -29,7 +29,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, int32_t x, int3
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SPRITE_IDENTIFIER_MISC;
         sprite_move(x, y, z, (rct_sprite*)sprite);
-        sprite->misc_identifier = SPRITE_MISC_CRASHED_VEHICLE_PARTICLE;
+        sprite->type = SPRITE_MISC_CRASHED_VEHICLE_PARTICLE;
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -114,7 +114,7 @@ void crashed_vehicle_particle_update(rct_crashed_vehicle_particle* particle)
  */
 void crash_splash_create(int32_t x, int32_t y, int32_t z)
 {
-    rct_unk_sprite* sprite = (rct_unk_sprite*)create_sprite(2);
+    rct_sprite_generic* sprite = (rct_sprite_generic*)create_sprite(2);
     if (sprite != nullptr)
     {
         sprite->sprite_width = 33;
@@ -122,7 +122,7 @@ void crash_splash_create(int32_t x, int32_t y, int32_t z)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SPRITE_IDENTIFIER_MISC;
         sprite_move(x, y, z + 3, (rct_sprite*)sprite);
-        sprite->misc_identifier = SPRITE_MISC_CRASH_SPLASH;
+        sprite->type = SPRITE_MISC_CRASH_SPLASH;
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -41,7 +41,7 @@ enum SPRITE_LIST
 struct rct_sprite_common
 {
     uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
+    uint8_t type;                   // 0x01
     uint16_t next_in_quadrant;       // 0x02
     uint16_t next;                   // 0x04
     uint16_t previous;               // 0x06
@@ -62,27 +62,25 @@ struct rct_sprite_common
     int16_t sprite_right;           // 0x1A
     int16_t sprite_bottom;          // 0x1C
     uint8_t sprite_direction;       // 0x1e
-};
-
-struct rct_unk_sprite : rct_sprite_common
-{
     uint8_t pad_1F[3];
     rct_string_id name_string_idx; // 0x22
+};
+
+struct rct_sprite_generic : rct_sprite_common
+{
     uint16_t pad_24;
     uint16_t frame; // 0x26
 };
-assert_struct_size(rct_unk_sprite, 0x28); // 9 bytes
+assert_struct_size(rct_sprite_generic, 0x28); // 9 bytes
 
 struct rct_litter : rct_sprite_common
 {
-    uint8_t pad_1F[5];
     uint32_t creationTick; // 0x24
 };
 assert_struct_size(rct_litter, 0x28);
 
 struct rct_balloon : rct_sprite_common
 {
-    uint8_t pad_16[0x05];
     uint16_t popped;      // 0x24
     uint8_t time_to_move; // 0x26
 
@@ -98,7 +96,7 @@ assert_struct_size(rct_balloon, 0x2D);
 
 struct rct_duck : rct_sprite_common
 {
-    uint8_t pad_1F[0x7];
+    uint8_t pad_1F[0x2];
     uint16_t frame;
     uint8_t pad_28[0x8];
     int16_t target_x; // 0x30
@@ -120,7 +118,7 @@ assert_struct_size(rct_duck, 0x49);
 
 struct rct_jumping_fountain : rct_sprite_common
 {
-    uint8_t pad_1F[0x7];
+    uint8_t pad_1F[0x2];
     uint8_t num_ticks_alive; // 0x26
     uint8_t frame;           // 0x27
     uint8_t pad_28[0x7];     // 0x28 Originally var_2E was set to direction but it was unused.
@@ -134,7 +132,6 @@ assert_struct_size(rct_jumping_fountain, 0x48);
 
 struct rct_money_effect : rct_sprite_common
 {
-    uint8_t pad_16[0x5];
     uint16_t move_delay;   // 0x24
     uint8_t num_movements; // 0x26
     uint8_t vertical;
@@ -147,8 +144,6 @@ assert_struct_size(rct_money_effect, 0x48);
 
 struct rct_crashed_vehicle_particle : rct_sprite_common
 {
-    uint8_t pad_1F[3];              // 0x1f
-    uint16_t name_string_idx;       // 0x22
     uint16_t time_to_live;          // 0x24
     uint16_t frame;                 // 0x26
     uint8_t pad_28[4];
@@ -166,8 +161,6 @@ assert_struct_size(rct_crashed_vehicle_particle, 0x44);
 
 struct rct_crash_splash : rct_sprite_common
 {
-    uint8_t pad_1F[3];              // 0x1f
-    uint16_t name_string_idx;       // 0x22
     uint16_t pad_24;
     uint16_t frame; // 0x26
 };
@@ -175,8 +168,6 @@ assert_struct_size(rct_crash_splash, 0x28);
 
 struct rct_steam_particle : rct_sprite_common
 {
-    uint8_t pad_1F[3];              // 0x1F
-    uint16_t name_string_idx;       // 0x22
     uint16_t time_to_move;          // 0x24 Moves +1 z every 3 ticks after intitial 4 ticks
     uint16_t frame;                 // 0x26
 };
@@ -189,7 +180,7 @@ assert_struct_size(rct_steam_particle, 0x28);
 union rct_sprite
 {
     uint8_t pad_00[0x100];
-    rct_unk_sprite unknown;
+    rct_sprite_generic generic;
     rct_peep peep;
     rct_litter litter;
     rct_vehicle vehicle;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -38,7 +38,7 @@ enum SPRITE_LIST
 };
 
 #pragma pack(push, 1)
-struct rct_unk_sprite
+struct rct_sprite_common
 {
     uint8_t sprite_identifier;       // 0x00
     uint8_t misc_identifier;         // 0x01
@@ -62,55 +62,30 @@ struct rct_unk_sprite
     int16_t sprite_right;           // 0x1A
     int16_t sprite_bottom;          // 0x1C
     uint8_t sprite_direction;       // 0x1e
+};
+
+struct rct_unk_sprite : rct_sprite_common
+{
     uint8_t pad_1F[3];
     rct_string_id name_string_idx; // 0x22
     uint16_t pad_24;
     uint16_t frame; // 0x26
 };
-assert_struct_size(rct_unk_sprite, 0x28);
+assert_struct_size(rct_unk_sprite, 0x28); // 9 bytes
 
-struct rct_litter
+struct rct_litter : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t type;                    // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t sprite_height_negative;  // 0x09
-    uint16_t sprite_index;           // 0x0A
-    uint16_t flags;                  // 0x0C
-    int16_t x;                       // 0x0E
-    int16_t y;                       // 0x10
-    int16_t z;                       // 0x12
-    uint8_t sprite_width;            // 0x14
-    uint8_t sprite_height_positive;  // 0x15
-    uint8_t pad_16[8];
-    uint8_t sprite_direction; // 0x1E
     uint8_t pad_1F[5];
     uint32_t creationTick; // 0x24
 };
 assert_struct_size(rct_litter, 0x28);
 
-struct rct_balloon
+struct rct_balloon : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t sprite_height_negative;  // 0x09
-    uint16_t sprite_index;           // 0x0A
-    uint16_t flags;                  // 0x0C
-    int16_t x;                       // 0x0E
-    int16_t y;                       // 0x10
-    int16_t z;                       // 0x12
-    uint8_t sprite_width;            // 0x14
-    uint8_t sprite_height_positive;  // 0x15
-    uint8_t pad_16[0xE];
+    uint8_t pad_16[0x05];
     uint16_t popped;      // 0x24
     uint8_t time_to_move; // 0x26
+
     uint8_t frame;        // 0x27
     uint8_t pad_28[4];
     uint8_t colour; // 0x2C
@@ -121,24 +96,8 @@ struct rct_balloon
 };
 assert_struct_size(rct_balloon, 0x2D);
 
-struct rct_duck
+struct rct_duck : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t sprite_height_negative;  // 0x09
-    uint16_t sprite_index;           // 0x0A
-    uint16_t flags;                  // 0x0C
-    int16_t x;                       // 0x0E
-    int16_t y;                       // 0x10
-    int16_t z;                       // 0x12
-    uint8_t sprite_width;            // 0x14
-    uint8_t sprite_height_positive;  // 0x15
-    uint8_t pad_16[0x8];
-    uint8_t sprite_direction; // 0x1E
     uint8_t pad_1F[0x7];
     uint16_t frame;
     uint8_t pad_28[0x8];
@@ -159,24 +118,8 @@ struct rct_duck
 };
 assert_struct_size(rct_duck, 0x49);
 
-struct rct_jumping_fountain
+struct rct_jumping_fountain : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t sprite_height_negative;
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    uint8_t sprite_width;           // 0x14
-    uint8_t sprite_height_positive; // 0x15
-    uint8_t pad_16[0x8];
-    uint8_t sprite_direction; // 0x1E
     uint8_t pad_1F[0x7];
     uint8_t num_ticks_alive; // 0x26
     uint8_t frame;           // 0x27
@@ -189,23 +132,9 @@ struct rct_jumping_fountain
 };
 assert_struct_size(rct_jumping_fountain, 0x48);
 
-struct rct_money_effect
+struct rct_money_effect : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t sprite_height_negative;
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    uint8_t sprite_width;           // 0x14
-    uint8_t sprite_height_positive; // 0x15
-    uint8_t pad_16[0xE];
+    uint8_t pad_16[0x5];
     uint16_t move_delay;   // 0x24
     uint8_t num_movements; // 0x26
     uint8_t vertical;
@@ -216,30 +145,8 @@ struct rct_money_effect
 };
 assert_struct_size(rct_money_effect, 0x48);
 
-struct rct_crashed_vehicle_particle
+struct rct_crashed_vehicle_particle : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    // Height from centre of sprite to bottom
-    uint8_t sprite_height_negative; // 0x09
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    // Width from centre of sprite to edge
-    uint8_t sprite_width; // 0x14
-    // Height from centre of sprite to top
-    uint8_t sprite_height_positive; // 0x15
-    int16_t sprite_left;            // 0x16
-    int16_t sprite_top;             // 0x18
-    int16_t sprite_right;           // 0x1A
-    int16_t sprite_bottom;          // 0x1C
-    uint8_t sprite_direction;       // direction of sprite? 0x1e
     uint8_t pad_1F[3];              // 0x1f
     uint16_t name_string_idx;       // 0x22
     uint16_t time_to_live;          // 0x24
@@ -257,30 +164,8 @@ struct rct_crashed_vehicle_particle
 };
 assert_struct_size(rct_crashed_vehicle_particle, 0x44);
 
-struct rct_crash_splash
+struct rct_crash_splash : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    // Height from centre of sprite to bottom
-    uint8_t sprite_height_negative; // 0x09
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    // Width from centre of sprite to edge
-    uint8_t sprite_width; // 0x14
-    // Height from centre of sprite to top
-    uint8_t sprite_height_positive; // 0x15
-    int16_t sprite_left;            // 0x16
-    int16_t sprite_top;             // 0x18
-    int16_t sprite_right;           // 0x1A
-    int16_t sprite_bottom;          // 0x1C
-    uint8_t sprite_direction;       // direction of sprite? 0x1e
     uint8_t pad_1F[3];              // 0x1f
     uint16_t name_string_idx;       // 0x22
     uint16_t pad_24;
@@ -288,30 +173,8 @@ struct rct_crash_splash
 };
 assert_struct_size(rct_crash_splash, 0x28);
 
-struct rct_steam_particle
+struct rct_steam_particle : rct_sprite_common
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t misc_identifier;         // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08 Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    // Height from centre of sprite to bottom
-    uint8_t sprite_height_negative; // 0x09
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    // Width from centre of sprite to edge
-    uint8_t sprite_width; // 0x14
-    // Height from centre of sprite to top
-    uint8_t sprite_height_positive; // 0x15
-    int16_t sprite_left;            // 0x16
-    int16_t sprite_top;             // 0x18
-    int16_t sprite_right;           // 0x1A
-    int16_t sprite_bottom;          // 0x1C
-    uint8_t sprite_direction;       // 0x1E
     uint8_t pad_1F[3];              // 0x1F
     uint16_t name_string_idx;       // 0x22
     uint16_t time_to_move;          // 0x24 Moves +1 z every 3 ticks after intitial 4 ticks

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -41,7 +41,7 @@ enum SPRITE_LIST
 struct rct_sprite_common
 {
     uint8_t sprite_identifier;       // 0x00
-    uint8_t type;                   // 0x01
+    uint8_t type;                    // 0x01
     uint16_t next_in_quadrant;       // 0x02
     uint16_t next;                   // 0x04
     uint16_t previous;               // 0x06
@@ -84,7 +84,7 @@ struct rct_balloon : rct_sprite_common
     uint16_t popped;      // 0x24
     uint8_t time_to_move; // 0x26
 
-    uint8_t frame;        // 0x27
+    uint8_t frame; // 0x27
     uint8_t pad_28[4];
     uint8_t colour; // 0x2C
 
@@ -144,8 +144,8 @@ assert_struct_size(rct_money_effect, 0x48);
 
 struct rct_crashed_vehicle_particle : rct_sprite_common
 {
-    uint16_t time_to_live;          // 0x24
-    uint16_t frame;                 // 0x26
+    uint16_t time_to_live; // 0x24
+    uint16_t frame;        // 0x26
     uint8_t pad_28[4];
     uint8_t colour[2];
     uint16_t crashed_sprite_base; // 0x2E
@@ -168,8 +168,8 @@ assert_struct_size(rct_crash_splash, 0x28);
 
 struct rct_steam_particle : rct_sprite_common
 {
-    uint16_t time_to_move;          // 0x24 Moves +1 z every 3 ticks after intitial 4 ticks
-    uint16_t frame;                 // 0x26
+    uint16_t time_to_move; // 0x24 Moves +1 z every 3 ticks after intitial 4 ticks
+    uint16_t frame;        // 0x26
 };
 assert_struct_size(rct_steam_particle, 0x28);
 


### PR DESCRIPTION
Some small refactoring to make the structs smaller in readable code size, also the first fields are usually identical in each struct so I introduced a common struct.