### PR TITLE
Demolish entrance fix

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -49,6 +49,7 @@
 - Fix: [#7823] You can build mazes in pause mode.
 - Fix: [#7804] Russian ride descriptions are cut off.
 - Fix: [#7872] CJK tooltips are often cut off.
+- Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7895] Import of Mega Park and the RCT1 title music do not work on some RCT1 sources.
 - Improved: [#7899] Timestamps in the load/save screen are now displayed using local timezone instead of GMT.
 - Improved: [#7918] Better RCT2 detection if both disc and GOG/Steam versions are installed.

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -284,8 +284,12 @@ private:
         tile_element_iterator_begin(&it);
         while (tile_element_iterator_next(&it))
         {
+            // Check if tile is a track type.
             if (it.element->GetType() != TILE_ELEMENT_TYPE_TRACK)
-                continue;
+                // If tile is not a track type, check if it's an entrance.
+                if (it.element->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
+                    // If not an entrance, continue.
+                    continue;
 
             if (track_element_get_ride_index(it.element) != _rideIndex)
                 continue;

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -272,6 +272,7 @@ private:
         return MONEY32_UNDEFINED;
     }
 
+    // Demolishes the track and returns the refund price
     money32 DemolishTracks() const
     {
         money32 refundPrice = 0;
@@ -281,15 +282,13 @@ private:
 
         tile_element_iterator it;
 
+        // Check for track pieces to delete.
         tile_element_iterator_begin(&it);
         while (tile_element_iterator_next(&it))
         {
             // Check if tile is a track type.
             if (it.element->GetType() != TILE_ELEMENT_TYPE_TRACK)
-                // If tile is not a track type, check if it's an entrance.
-                if (it.element->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
-                    // If not an entrance, continue.
-                    continue;
+                continue;
 
             if (track_element_get_ride_index(it.element) != _rideIndex)
                 continue;
@@ -332,6 +331,23 @@ private:
                     break;
             }
 
+            tile_element_iterator_restart_for_tile(&it);
+        }
+
+        // Check for entrances to delete.
+        tile_element_iterator_begin(&it);
+        while (tile_element_iterator_next(&it))
+        {
+            if (it.element->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
+                continue;
+
+            if (entrance_element_get_type(it.element) == ENTRANCE_TYPE_PARK_ENTRANCE)
+                continue;
+
+            if (track_element_get_ride_index(it.element) != _rideIndex)
+                continue;
+
+            tile_element_remove(it.element);
             tile_element_iterator_restart_for_tile(&it);
         }
 


### PR DESCRIPTION
I'm having a bit of an issue I've added an if statement within != track to check for station entrance but I now get an error every time a ride is demolished 

![image](https://user-images.githubusercontent.com/16685010/44491323-82e7d680-a626-11e8-8f8b-3f4aec98f3ff.png)

I am trying to modify the code on 314 by wrapping it in an if statement and creating two game_do_command for track or park entrance but it seems to be introducing more bugs. 

Assistance in fixing this issue would be appreciated!