### PR TITLE
Fix #7828: Copied entrances and exits stay when demolishing ride

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -114,6 +114,7 @@ The following people are not part of the development team, but have been contrib
 * Andy Ford (AndyTWF)
 * Matthew Beaudin (mattbeaudin)
 * Øystein Dale (oystedal)
+* Christian Schubert (Osmodium)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
+- Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,9 +3,9 @@
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Feature: [#7971] Toolbox option to open custom content folder.
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
+- Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
-- Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -284,7 +284,24 @@ private:
         tile_element_iterator_begin(&it);
         while (tile_element_iterator_next(&it))
         {
-            if (it.element->GetType() != TILE_ELEMENT_TYPE_TRACK)
+            uint8_t tile_type = it.element->GetType();
+
+            if (tile_type == TILE_ELEMENT_TYPE_ENTRANCE)
+            {
+                uint8_t type = track_element_get_type(it.element);
+                if (type == ENTRANCE_TYPE_PARK_ENTRANCE)
+                    continue;
+
+                if (track_element_get_ride_index(it.element) == _rideIndex)
+                {
+                    tile_element_remove(it.element);
+                    tile_element_iterator_restart_for_tile(&it);
+                }
+
+                continue;
+            }
+
+            if (tile_type != TILE_ELEMENT_TYPE_TRACK)
                 continue;
 
             if (track_element_get_ride_index(it.element) != _rideIndex)


### PR DESCRIPTION
Implemented so its not necessary to loop over all tiles once more.
We can do this since entrances and exists doesn't add to the refund.