### PR TITLE
Correct client IP address not being propagated/stored

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
+- Fix: [#7945] Client IP address is logged as `(null)` in server logs.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
 - Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.

--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -210,10 +210,13 @@ public:
                     (struct sockaddr*)&client_addr, client_len, hostName, sizeof(hostName), nullptr, 0,
                     NI_NUMERICHOST | NI_NUMERICSERV);
                 SetTCPNoDelay(socket, true);
-                tcpSocket = new TcpSocket(socket);
                 if (rc == 0)
                 {
-                    _hostName = std::string(hostName);
+                    tcpSocket = new TcpSocket(socket, hostName);
+                }
+                else
+                {
+                    tcpSocket = new TcpSocket(socket, "");
                 }
             }
         }
@@ -427,9 +430,10 @@ public:
     }
 
 private:
-    explicit TcpSocket(SOCKET socket)
+    explicit TcpSocket(SOCKET socket, const std::string& hostName)
     {
         _socket = socket;
+        _hostName = hostName;
         _status = SOCKET_STATUS_CONNECTED;
     }
 


### PR DESCRIPTION
This allows to fix log messages like:
>[_timestamp_] Client joined from (null)
>[_timestamp_] Player has joined the game

with `null` becoming the proper client IP address