### PR TITLE
Fix #7949: Use unique_ptr vs shared_ptr for the Context

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -419,8 +419,8 @@ private:
                 auto parkImporter = ParkImporter::Create(path);
                 auto result = parkImporter->Load(path);
 
-                auto objectManager = GetContext()->GetObjectManager();
-                objectManager->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+                auto& objectManager = GetContext()->GetObjectManager();
+                objectManager.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
 
                 parkImporter->Import();
             }
@@ -458,8 +458,8 @@ private:
                 auto parkImporter = ParkImporter::Create(hintPath);
                 auto result = parkImporter->LoadFromStream(stream, isScenario);
 
-                auto objectManager = GetContext()->GetObjectManager();
-                objectManager->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+                auto& objectManager = GetContext()->GetObjectManager();
+                objectManager.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
 
                 parkImporter->Import();
             }

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -367,10 +367,10 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
                 auto hintPath = String::ToStd(handle->HintPath);
 
                 bool isScenario = ParkImporter::ExtensionIsScenario(hintPath);
-                auto objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+                auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
                 auto parkImporter = std::unique_ptr<IParkImporter>(ParkImporter::Create(hintPath));
                 auto result = parkImporter->LoadFromStream(stream, isScenario);
-                objectMgr->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+                objectMgr.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
                 parkImporter->Import();
 
                 if (isScenario)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -170,9 +170,9 @@ namespace OpenRCT2
             return *_localisationService;
         }
 
-        std::shared_ptr<IObjectManager> GetObjectManager() override
+        IObjectManager& GetObjectManager() override
         {
-            return _objectManager;
+            return *_objectManager;
         }
 
         std::shared_ptr<IObjectRepository> GetObjectRepository() override
@@ -496,7 +496,7 @@ namespace OpenRCT2
                     else
                     {
                         // Save is an S6 (RCT2 format)
-                        parkImporter = ParkImporter::CreateS6(_objectRepository, _objectManager);
+                        parkImporter = ParkImporter::CreateS6(_objectRepository, *_objectManager);
                     }
 
                     try

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -98,7 +98,7 @@ namespace OpenRCT2
         virtual GameState* GetGameState() abstract;
         virtual std::shared_ptr<IPlatformEnvironment> GetPlatformEnvironment() abstract;
         virtual Localisation::LocalisationService& GetLocalisationService() abstract;
-        virtual std::shared_ptr<IObjectManager> GetObjectManager() abstract;
+        virtual IObjectManager& GetObjectManager() abstract;
         virtual std::shared_ptr<IObjectRepository> GetObjectRepository() abstract;
         virtual ITrackDesignRepository* GetTrackDesignRepository() abstract;
         virtual IScenarioRepository* GetScenarioRepository() abstract;

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -65,8 +65,7 @@ namespace ParkImporter
 {
     std::unique_ptr<IParkImporter> Create(const std::string& hintPath);
     std::unique_ptr<IParkImporter> CreateS4();
-    std::unique_ptr<IParkImporter> CreateS6(
-        std::shared_ptr<IObjectRepository> objectRepository, std::shared_ptr<IObjectManager> objectManager);
+    std::unique_ptr<IParkImporter> CreateS6(std::shared_ptr<IObjectRepository> objectRepository, IObjectManager& objectManager);
 
     bool ExtensionIsRCT1(const std::string& extension);
     bool ExtensionIsScenario(const std::string& extension);

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -97,10 +97,10 @@ bool language_open(int32_t id)
 {
     auto context = OpenRCT2::GetContext();
     auto& localisationService = context->GetLocalisationService();
-    auto objectManager = context->GetObjectManager();
+    auto& objectManager = context->GetObjectManager();
     try
     {
-        localisationService.OpenLanguage(id, *objectManager);
+        localisationService.OpenLanguage(id, objectManager);
         return true;
     }
     catch (const std::exception&)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1181,8 +1181,8 @@ void Network::Server_Send_MAP(NetworkConnection* connection)
         // This will send all custom objects to connected clients
         // TODO: fix it so custom objects negotiation is performed even in this case.
         auto context = GetContext();
-        auto objManager = context->GetObjectManager();
-        objects = objManager->GetPackableObjects();
+        auto& objManager = context->GetObjectManager();
+        objects = objManager.GetPackableObjects();
     }
 
     size_t out_size;
@@ -1938,8 +1938,8 @@ void Network::Server_Client_Joined(const char* name, const std::string& keyhash,
         chat_history_add(text);
 
         auto context = GetContext();
-        auto objManager = context->GetObjectManager();
-        auto objects = objManager->GetPackableObjects();
+        auto& objManager = context->GetObjectManager();
+        auto objects = objManager.GetPackableObjects();
         Server_Send_OBJECTS(connection, objects);
 
         // Log player joining event
@@ -2230,10 +2230,10 @@ bool Network::LoadMap(IStream* stream)
     try
     {
         auto context = GetContext();
-        auto objManager = context->GetObjectManager();
+        auto& objManager = context->GetObjectManager();
         auto importer = ParkImporter::CreateS6(context->GetObjectRepository(), context->GetObjectManager());
         auto loadResult = importer->LoadFromStream(stream, false);
-        objManager->LoadObjects(loadResult.RequiredObjects.data(), loadResult.RequiredObjects.size());
+        objManager.LoadObjects(loadResult.RequiredObjects.data(), loadResult.RequiredObjects.size());
         importer->Import();
 
         sprite_position_tween_reset();

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -169,8 +169,8 @@ void* object_entry_get_chunk(int32_t objectType, size_t index)
     }
 
     void* result = nullptr;
-    auto objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objectMgr->GetLoadedObject(objectIndex);
+    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objectMgr.GetLoadedObject(objectIndex);
     if (obj != nullptr)
     {
         result = obj->GetLegacyData();
@@ -181,8 +181,8 @@ void* object_entry_get_chunk(int32_t objectType, size_t index)
 const rct_object_entry* object_entry_get_entry(int32_t objectType, size_t index)
 {
     const rct_object_entry* result = nullptr;
-    auto objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objectMgr->GetLoadedObject(objectType, index);
+    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objectMgr.GetLoadedObject(objectType, index);
     if (obj != nullptr)
     {
         result = obj->GetObjectEntry();

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -633,46 +633,43 @@ std::unique_ptr<IObjectManager> CreateObjectManager(std::shared_ptr<IObjectRepos
 
 void* object_manager_get_loaded_object_by_index(size_t index)
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    Object* loadedObject = objectManager->GetLoadedObject(index);
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    Object* loadedObject = objectManager.GetLoadedObject(index);
     return (void*)loadedObject;
 }
 
 void* object_manager_get_loaded_object(const rct_object_entry* entry)
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    Object* loadedObject = objectManager->GetLoadedObject(entry);
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    Object* loadedObject = objectManager.GetLoadedObject(entry);
     return (void*)loadedObject;
 }
 
 uint8_t object_manager_get_loaded_object_entry_index(const void* loadedObject)
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
     const Object* object = static_cast<const Object*>(loadedObject);
-    uint8_t entryIndex = objectManager->GetLoadedObjectEntryIndex(object);
+    uint8_t entryIndex = objectManager.GetLoadedObjectEntryIndex(object);
     return entryIndex;
 }
 
 void* object_manager_load_object(const rct_object_entry* entry)
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    Object* loadedObject = objectManager->LoadObject(entry);
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    Object* loadedObject = objectManager.LoadObject(entry);
     return (void*)loadedObject;
 }
 
 void object_manager_unload_objects(const rct_object_entry* entries, size_t count)
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    objectManager->UnloadObjects(entries, count);
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    objectManager.UnloadObjects(entries, count);
 }
 
 void object_manager_unload_all_objects()
 {
-    auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    if (objectManager != nullptr)
-    {
-        objectManager->UnloadAll();
-    }
+    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    objectManager.UnloadAll();
 }
 
 rct_string_id object_manager_get_source_game_string(const uint8_t sourceGame)

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -651,8 +651,8 @@ void object_list_load()
     auto objectRepository = context->GetObjectRepository();
     objectRepository->LoadOrConstruct(localisationService.GetCurrentLanguage());
 
-    auto objectManager = context->GetObjectManager();
-    objectManager->UnloadAll();
+    auto& objectManager = context->GetObjectManager();
+    objectManager.UnloadAll();
 }
 
 void* object_repository_load_object(const rct_object_entry* objectEntry)

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -71,7 +71,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
 {
     auto context = GetContext();
     auto objectRepository = context->GetObjectRepository();
-    auto objectManager = context->GetObjectManager();
+    auto& objectManager = context->GetObjectManager();
 
     _legacyType.entry_count = 0;
     for (const auto& objectEntry : _items)
@@ -82,7 +82,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         if (ori->LoadedObject == nullptr)
             continue;
 
-        uint16_t sceneryEntry = objectManager->GetLoadedObjectEntryIndex(ori->LoadedObject);
+        uint16_t sceneryEntry = objectManager.GetLoadedObjectEntryIndex(ori->LoadedObject);
         Guard::Assert(sceneryEntry != UINT8_MAX, GUARD_LINE);
 
         auto objectType = ori->ObjectEntry.flags & 0x0F;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -334,7 +334,7 @@ private:
 
         // Do map initialisation, same kind of stuff done when loading scenario editor
         auto context = OpenRCT2::GetContext();
-        context->GetObjectManager()->UnloadAll();
+        context->GetObjectManager().UnloadAll();
         context->GetGameState()->InitAll(mapSize);
         gS6Info.editor_step = EDITOR_STEP_OBJECT_SELECTION;
         gParkFlags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
@@ -1827,8 +1827,8 @@ private:
 
     void LoadObjects()
     {
-        auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
-        objectManager->LoadDefaultObjects();
+        auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+        objectManager.LoadDefaultObjects();
 
         LoadObjects(OBJECT_TYPE_RIDE, _rideEntries);
         LoadObjects(OBJECT_TYPE_SMALL_SCENERY, _smallSceneryEntries);
@@ -1861,7 +1861,7 @@ private:
 
     void LoadObjects(uint8_t objectType, const std::vector<const char*>& entries)
     {
-        auto objectManager = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
 
         uint32_t entryIndex = 0;
         for (const char* objectName : entries)
@@ -1871,7 +1871,7 @@ private:
             std::copy_n(objectName, 8, entry.name);
             entry.checksum = 0;
 
-            Object* object = objectManager->LoadObject(&entry);
+            Object* object = objectManager.LoadObject(&entry);
             if (object == nullptr && objectType != OBJECT_TYPE_SCENERY_GROUP)
             {
                 log_error("Failed to load %s.", objectName);
@@ -2865,19 +2865,19 @@ std::unique_ptr<IParkImporter> ParkImporter::CreateS4()
 
 void load_from_sv4(const utf8* path)
 {
-    auto objectMgr = GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     auto s4Importer = std::make_unique<S4Importer>();
     auto result = s4Importer->LoadSavedGame(path);
-    objectMgr->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+    objectMgr.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
     s4Importer->Import();
 }
 
 void load_from_sc4(const utf8* path)
 {
-    auto objectMgr = GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     auto s4Importer = std::make_unique<S4Importer>();
     auto result = s4Importer->LoadScenario(path);
-    objectMgr->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+    objectMgr.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
     s4Importer->Import();
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -768,8 +768,8 @@ int32_t scenario_save(const utf8* path, int32_t flags)
     {
         if (flags & S6_SAVE_FLAG_EXPORT)
         {
-            auto objManager = OpenRCT2::GetContext()->GetObjectManager();
-            s6exporter->ExportObjectsList = objManager->GetPackableObjects();
+            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+            s6exporter->ExportObjectsList = objManager.GetPackableObjects();
         }
         s6exporter->RemoveTracklessRides = true;
         s6exporter->Export();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -57,14 +57,14 @@ class S6Importer final : public IParkImporter
 {
 private:
     std::shared_ptr<IObjectRepository> const _objectRepository;
-    std::shared_ptr<IObjectManager> const _objectManager;
+    IObjectManager& _objectManager;
 
     const utf8* _s6Path = nullptr;
     rct_s6_data _s6{};
     uint8_t _gameVersion = 0;
 
 public:
-    S6Importer(std::shared_ptr<IObjectRepository> objectRepository, std::shared_ptr<IObjectManager> objectManager)
+    S6Importer(std::shared_ptr<IObjectRepository> objectRepository, IObjectManager& objectManager)
         : _objectRepository(objectRepository)
         , _objectManager(objectManager)
     {
@@ -846,7 +846,7 @@ public:
 };
 
 std::unique_ptr<IParkImporter> ParkImporter::CreateS6(
-    std::shared_ptr<IObjectRepository> objectRepository, std::shared_ptr<IObjectManager> objectManager)
+    std::shared_ptr<IObjectRepository> objectRepository, IObjectManager& objectManager)
 {
     return std::make_unique<S6Importer>(objectRepository, objectManager);
 }
@@ -857,9 +857,9 @@ void load_from_sv6(const char* path)
     auto s6Importer = std::make_unique<S6Importer>(context->GetObjectRepository(), context->GetObjectManager());
     try
     {
-        auto objectMgr = context->GetObjectManager();
+        auto& objectMgr = context->GetObjectManager();
         auto result = s6Importer->LoadSavedGame(path);
-        objectMgr->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+        objectMgr.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
         s6Importer->Import();
         game_fix_save_vars();
         sprite_position_tween_reset();
@@ -891,12 +891,12 @@ void load_from_sv6(const char* path)
 void load_from_sc6(const char* path)
 {
     auto context = OpenRCT2::GetContext();
-    auto objManager = context->GetObjectManager();
+    auto& objManager = context->GetObjectManager();
     auto s6Importer = std::make_unique<S6Importer>(context->GetObjectRepository(), context->GetObjectManager());
     try
     {
         auto result = s6Importer->LoadScenario(path);
-        objManager->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
+        objManager.LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
         s6Importer->Import();
         game_fix_save_vars();
         sprite_position_tween_reset();

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -233,14 +233,11 @@ Ride* get_ride(int32_t index)
 rct_ride_entry* get_ride_entry(int32_t index)
 {
     rct_ride_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_RIDE, index);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_RIDE, index);
-        if (obj != nullptr)
-        {
-            result = (rct_ride_entry*)obj->GetLegacyData();
-        }
+        result = (rct_ride_entry*)obj->GetLegacyData();
     }
     return result;
 }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2612,14 +2612,11 @@ void footpath_remove_edges_at(int32_t x, int32_t y, rct_tile_element* tileElemen
 rct_footpath_entry* get_footpath_entry(int32_t entryIndex)
 {
     rct_footpath_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_PATHS, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_PATHS, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_footpath_entry*)obj->GetLegacyData();
-        }
+        result = (rct_footpath_entry*)obj->GetLegacyData();
     }
     return result;
 }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -258,14 +258,11 @@ void scenery_remove_ghost_tool_placement()
 rct_scenery_entry* get_small_scenery_entry(int32_t entryIndex)
 {
     rct_scenery_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_SMALL_SCENERY, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_SMALL_SCENERY, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_entry*)obj->GetLegacyData();
     }
     return result;
 }
@@ -273,14 +270,11 @@ rct_scenery_entry* get_small_scenery_entry(int32_t entryIndex)
 rct_scenery_entry* get_large_scenery_entry(int32_t entryIndex)
 {
     rct_scenery_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_LARGE_SCENERY, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_LARGE_SCENERY, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_entry*)obj->GetLegacyData();
     }
     return result;
 }
@@ -288,14 +282,11 @@ rct_scenery_entry* get_large_scenery_entry(int32_t entryIndex)
 rct_scenery_entry* get_wall_entry(int32_t entryIndex)
 {
     rct_scenery_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_WALLS, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_WALLS, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_entry*)obj->GetLegacyData();
     }
     return result;
 }
@@ -303,14 +294,11 @@ rct_scenery_entry* get_wall_entry(int32_t entryIndex)
 rct_scenery_entry* get_banner_entry(int32_t entryIndex)
 {
     rct_scenery_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_BANNERS, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_BANNERS, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_entry*)obj->GetLegacyData();
     }
     return result;
 }
@@ -318,14 +306,11 @@ rct_scenery_entry* get_banner_entry(int32_t entryIndex)
 rct_scenery_entry* get_footpath_item_entry(int32_t entryIndex)
 {
     rct_scenery_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_PATH_BITS, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_PATH_BITS, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_entry*)obj->GetLegacyData();
     }
     return result;
 }
@@ -333,14 +318,11 @@ rct_scenery_entry* get_footpath_item_entry(int32_t entryIndex)
 rct_scenery_group_entry* get_scenery_group_entry(int32_t entryIndex)
 {
     rct_scenery_group_entry* result = nullptr;
-    auto objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    if (objMgr != nullptr)
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_SCENERY_GROUP, entryIndex);
+    if (obj != nullptr)
     {
-        auto obj = objMgr->GetLoadedObject(OBJECT_TYPE_SCENERY_GROUP, entryIndex);
-        if (obj != nullptr)
-        {
-            result = (rct_scenery_group_entry*)obj->GetLegacyData();
-        }
+        result = (rct_scenery_group_entry*)obj->GetLegacyData();
     }
     return result;
 }


### PR DESCRIPTION
Return reference instead of shared_ptr for ObjectManager.