### PR TITLE
Only provide strcasestr for WIN32 toolchains

### DIFF
--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -483,7 +483,7 @@ char* safe_strtrimleft(char* destination, const char* source, size_t size)
     return safe_strcpy(destination, source, size);
 }
 
-#if !(defined(_GNU_SOURCE) || (defined(__DARWIN_C_LEVEL) && __DARWIN_C_LEVEL >= 200809L))
+#if defined(_WIN32)
 char* strcasestr(const char* haystack, const char* needle)
 {
     const char* p1 = haystack;

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -44,7 +44,7 @@ char* safe_strcpy(char* destination, const char* source, size_t num);
 char* safe_strcat(char* destination, const char* source, size_t size);
 char* safe_strcat_path(char* destination, const char* source, size_t size);
 char* safe_strtrimleft(char* destination, const char* source, size_t size);
-#if !(defined(_GNU_SOURCE) || (defined(__DARWIN_C_LEVEL) && __DARWIN_C_LEVEL >= 200809L))
+#if defined(_WIN32)
 char* strcasestr(const char* haystack, const char* needle);
 #endif
 


### PR DESCRIPTION
All the other toolchains appear to be providing this function and only
MSVC+mingw are missing out.

cf. https://github.com/OpenRCT2/OpenRCT2/pull/7942