### PR TITLE
#7930 automatically create custom user content folders

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -76,6 +76,7 @@ The following people are not part of the development team, but have been contrib
 * Nicolas Hawrysh (xp4xbox) - Various (ride) sprite improvements.
 * Albert Morgese (Fusxfaranto) - Shop auto-rotation, unicode uppercasing.
 * Olivier Wervers (oli414) - Remove unused objects command, various bugfixes
+* Christian Schubert (Osmodium) - Ensuring custom user content folders.
 
 ## Bug fixes
 * (halfbro)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -962,12 +962,11 @@ namespace OpenRCT2
                 });
         }
 
-        void EnsureDirectoriesExist(const DIRBASE dirBase, const std::vector<DIRID> dirIds)
+        void EnsureDirectoriesExist(const DIRBASE dirBase, const std::initializer_list<DIRID>& dirIds)
         {
-            std::string path;
             for (const auto& dirId : dirIds)
             {
-                path = _env->GetDirectoryPath(dirBase, dirId);
+                auto path = _env->GetDirectoryPath(dirBase, dirId);
                 if (!platform_ensure_directory_exists(path.c_str()))
                     log_error("Unable to create directory '%s'.", path.c_str());
             }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -353,6 +353,8 @@ namespace OpenRCT2
                 _uiContext->CreateWindow();
             }
 
+            EnsureCustomUserContentDirectories();
+
             // TODO Ideally we want to delay this until we show the title so that we can
             //      still open the game window and draw a progress screen for the creation
             //      of the object cache.
@@ -941,6 +943,36 @@ namespace OpenRCT2
             _uiContext->Update();
         }
 
+        /**
+         * Ensure that the custom user content folders are present
+         */
+        void EnsureCustomUserContentDirectories()
+        {
+            EnsureDirectories(
+                DIRBASE::USER,
+                {
+                    DIRID::OBJECT,
+                    DIRID::SAVE,
+                    DIRID::SCENARIO,
+                    DIRID::TRACK,
+                    DIRID::LANDSCAPE,
+                    DIRID::HEIGHTMAP,
+                    DIRID::THEME,
+                    DIRID::SEQUENCE,
+                });
+        }
+
+        void EnsureDirectories(const DIRBASE dirBase, const std::vector<DIRID> dirIds)
+        {
+            std::string path;
+            for (const auto& dirId : dirIds)
+            {
+                path = _env->GetDirectoryPath(dirBase, dirId);
+                if (!platform_ensure_directory_exists(path.c_str()))
+                    log_error("Unable to create directory '%s'.", path.c_str());
+            }
+        }
+       
         /**
          * Copy saved games and landscapes to user directory
          */

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -353,7 +353,7 @@ namespace OpenRCT2
                 _uiContext->CreateWindow();
             }
 
-            EnsureCustomUserContentDirectories();
+            EnsureUserContentDirectoriesExist();
 
             // TODO Ideally we want to delay this until we show the title so that we can
             //      still open the game window and draw a progress screen for the creation
@@ -946,9 +946,9 @@ namespace OpenRCT2
         /**
          * Ensure that the custom user content folders are present
          */
-        void EnsureCustomUserContentDirectories()
+        void EnsureUserContentDirectoriesExist()
         {
-            EnsureDirectories(
+            EnsureDirectoriesExist(
                 DIRBASE::USER,
                 {
                     DIRID::OBJECT,
@@ -962,7 +962,7 @@ namespace OpenRCT2
                 });
         }
 
-        void EnsureDirectories(const DIRBASE dirBase, const std::vector<DIRID> dirIds)
+        void EnsureDirectoriesExist(const DIRBASE dirBase, const std::vector<DIRID> dirIds)
         {
             std::string path;
             for (const auto& dirId : dirIds)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -972,7 +972,7 @@ namespace OpenRCT2
                     log_error("Unable to create directory '%s'.", path.c_str());
             }
         }
-       
+
         /**
          * Copy saved games and landscapes to user directory
          */

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -209,6 +209,7 @@ const char * PlatformEnvironment::DirectoryNamesOpenRCT2[] =
     "shaders",              // SHADER
     "themes",               // THEME
     "track",                // TRACK
+    "heightmap",            // HEIGHTMAP
 };
 
 const char * PlatformEnvironment::FileNames[] =

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -45,6 +45,7 @@ namespace OpenRCT2
         SHADER,      // Contains OpenGL shaders.
         THEME,       // Contains interface themes.
         TRACK,       // Contains track designs.
+        HEIGHTMAP    // Contains heightmap data.
     };
 
     enum class PATHID

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -45,7 +45,7 @@ namespace OpenRCT2
         SHADER,      // Contains OpenGL shaders.
         THEME,       // Contains interface themes.
         TRACK,       // Contains track designs.
-        HEIGHTMAP    // Contains heightmap data.
+        HEIGHTMAP,   // Contains heightmap data.
     };
 
     enum class PATHID


### PR DESCRIPTION
Added `heightmap` to list of `DIRID` for consistency of the user specific folders.
Added ensuring of following custom user content folders:
- `object`
- `save`
- `scenario`
- `track`
- `landscape`
- `heightmap`
- `theme`
- `sequence`