### PR TITLE
Add RISC-V architecture information

### DIFF
--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -32,6 +32,8 @@
 #    define OPENRCT2_ARCHITECTURE "mips64"
 #elif defined(__mips__)
 #    define OPENRCT2_ARCHITECTURE "mips"
+#elif defined(__riscv)
+#    define OPENRCT2_ARCHITECTURE "RISC-V"
 #endif
 #ifdef __EMSCRIPTEN__
 #    define OPENRCT2_ARCHITECTURE "Emscripten"


### PR DESCRIPTION
![example](https://user-images.githubusercontent.com/550290/44960964-16fc4c80-af09-11e8-9ad7-f7272b7f5fb0.png)

```
[root@stage4 build]# ctest -V
UpdateCTestConfiguration  from :/root/OpenRCT2/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/root/OpenRCT2/build/DartConfiguration.tcl
Test project /root/OpenRCT2/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
      Start  1: sawyercoding

1: Test command: /root/OpenRCT2/build/test_sawyercoding
1: Test timeout computed to be: 9.99988e+06
1: Running main() from gtest_main.cc
1: [==========] Running 8 tests from 1 test case.
1: [----------] Global test environment set-up.
1: [----------] 8 tests from SawyerCodingTest
1: [ RUN      ] SawyerCodingTest.write_read_chunk_none
1: [       OK ] SawyerCodingTest.write_read_chunk_none (2 ms)
1: [ RUN      ] SawyerCodingTest.write_read_chunk_rle
1: [       OK ] SawyerCodingTest.write_read_chunk_rle (1 ms)
1: [ RUN      ] SawyerCodingTest.write_read_chunk_rle_compressed
1: [       OK ] SawyerCodingTest.write_read_chunk_rle_compressed (2 ms)
1: [ RUN      ] SawyerCodingTest.write_read_chunk_rotate
1: [       OK ] SawyerCodingTest.write_read_chunk_rotate (0 ms)
1: [ RUN      ] SawyerCodingTest.decode_chunk_none
1: [       OK ] SawyerCodingTest.decode_chunk_none (2 ms)
1: [ RUN      ] SawyerCodingTest.decode_chunk_rle
1: [       OK ] SawyerCodingTest.decode_chunk_rle (0 ms)
1: [ RUN      ] SawyerCodingTest.decode_chunk_rlecompressed
1: [       OK ] SawyerCodingTest.decode_chunk_rlecompressed (1 ms)
1: [ RUN      ] SawyerCodingTest.decode_chunk_rotate
1: [       OK ] SawyerCodingTest.decode_chunk_rotate (0 ms)
1: [----------] 8 tests from SawyerCodingTest (10 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 8 tests from 1 test case ran. (17 ms total)
1: [  PASSED  ] 8 tests.
 1/10 Test  #1: sawyercoding .....................   Passed    0.14 sec
test 2
      Start  2: languagepack

2: Test command: /root/OpenRCT2/build/test_languagepack
2: Test timeout computed to be: 9.99988e+06
2: Running main() from gtest_main.cc
2: [==========] Running 4 tests from 1 test case.
2: [----------] Global test environment set-up.
2: [----------] 4 tests from LanguagePackTest
2: [ RUN      ] LanguagePackTest.create_empty
2: [       OK ] LanguagePackTest.create_empty (3 ms)
2: [ RUN      ] LanguagePackTest.create_mutable_id_1
2: [       OK ] LanguagePackTest.create_mutable_id_1 (3 ms)
2: [ RUN      ] LanguagePackTest.language_pack_simple
2: [       OK ] LanguagePackTest.language_pack_simple (3 ms)
2: [ RUN      ] LanguagePackTest.language_pack_multibyte
2: [       OK ] LanguagePackTest.language_pack_multibyte (1 ms)
2: [----------] 4 tests from LanguagePackTest (14 ms total)
2: 
2: [----------] Global test environment tear-down
2: [==========] 4 tests from 1 test case ran. (22 ms total)
2: [  PASSED  ] 4 tests.
 2/10 Test  #2: languagepack .....................   Passed    0.11 sec
test 3
      Start  3: ini

3: Test command: /root/OpenRCT2/build/test_ini
3: Test timeout computed to be: 9.99988e+06
3: Running main() from gtest_main.cc
3: [==========] Running 15 tests from 2 test cases.
3: [----------] Global test environment set-up.
3: [----------] 10 tests from IniWriterTest
3: [ RUN      ] IniWriterTest.create_empty
3: [       OK ] IniWriterTest.create_empty (1 ms)
3: [ RUN      ] IniWriterTest.create_one_section
3: [       OK ] IniWriterTest.create_one_section (1 ms)
3: [ RUN      ] IniWriterTest.create_multiple_sections
3: [       OK ] IniWriterTest.create_multiple_sections (0 ms)
3: [ RUN      ] IniWriterTest.create_loose_bool_entry
3: [       OK ] IniWriterTest.create_loose_bool_entry (0 ms)
3: [ RUN      ] IniWriterTest.create_loose_enum_entry
3: [       OK ] IniWriterTest.create_loose_enum_entry (1 ms)
3: [ RUN      ] IniWriterTest.create_loose_float_entry
3: [       OK ] IniWriterTest.create_loose_float_entry (1 ms)
3: [ RUN      ] IniWriterTest.create_loose_int32_t_entry
3: [       OK ] IniWriterTest.create_loose_int32_t_entry (0 ms)
3: [ RUN      ] IniWriterTest.create_loose_string_entry
3: [       OK ] IniWriterTest.create_loose_string_entry (1 ms)
3: [ RUN      ] IniWriterTest.create_multiple_section_with_values
3: [       OK ] IniWriterTest.create_multiple_section_with_values (1 ms)
3: [ RUN      ] IniWriterTest.create_duplicate_sections
3: [       OK ] IniWriterTest.create_duplicate_sections (1 ms)
3: [----------] 10 tests from IniWriterTest (13 ms total)
3: 
3: [----------] 5 tests from IniReaderTest
3: [ RUN      ] IniReaderTest.create_empty
3: [       OK ] IniReaderTest.create_empty (1 ms)
3: [ RUN      ] IniReaderTest.read_prepared
3: [       OK ] IniReaderTest.read_prepared (29 ms)
3: [ RUN      ] IniReaderTest.read_duplicate
3: [       OK ] IniReaderTest.read_duplicate (2 ms)
3: [ RUN      ] IniReaderTest.read_untrimmed
3: [       OK ] IniReaderTest.read_untrimmed (1 ms)
3: [ RUN      ] IniReaderTest.read_case_insensitive
3: [       OK ] IniReaderTest.read_case_insensitive (0 ms)
3: [----------] 5 tests from IniReaderTest (35 ms total)
3: 
3: [----------] Global test environment tear-down
3: [==========] 15 tests from 2 test cases ran. (50 ms total)
3: [  PASSED  ] 15 tests.
 3/10 Test  #3: ini ..............................   Passed    0.16 sec
test 4
      Start  4: string

4: Test command: /root/OpenRCT2/build/test_string
4: Test timeout computed to be: 9.99988e+06
4: Running main() from gtest_main.cc
4: [==========] Running 40 tests from 2 test cases.
4: [----------] Global test environment set-up.
4: [----------] 14 tests from StringTest
4: [ RUN      ] StringTest.Split_ByComma
4: [       OK ] StringTest.Split_ByComma (2 ms)
4: [ RUN      ] StringTest.Split_ByColonColon
4: [       OK ] StringTest.Split_ByColonColon (0 ms)
4: [ RUN      ] StringTest.Split_Empty
4: [       OK ] StringTest.Split_Empty (0 ms)
4: [ RUN      ] StringTest.Split_ByEmpty
4: [       OK ] StringTest.Split_ByEmpty (16 ms)
4: [ RUN      ] StringTest.Convert_950_to_UTF8
4: [       OK ] StringTest.Convert_950_to_UTF8 (78 ms)
4: [ RUN      ] StringTest.Convert_UTF8_to_932
4: [       OK ] StringTest.Convert_UTF8_to_932 (32 ms)
4: [ RUN      ] StringTest.Convert_UTF8_to_UTF8
4: [       OK ] StringTest.Convert_UTF8_to_UTF8 (0 ms)
4: [ RUN      ] StringTest.Convert_Empty
4: [       OK ] StringTest.Convert_Empty (1 ms)
4: [ RUN      ] StringTest.ToUpper_Basic
4: [       OK ] StringTest.ToUpper_Basic (20 ms)
4: [ RUN      ] StringTest.ToUpper_Dutch
4: [       OK ] StringTest.ToUpper_Dutch (0 ms)
4: [ RUN      ] StringTest.ToUpper_French
4: [       OK ] StringTest.ToUpper_French (1 ms)
4: [ RUN      ] StringTest.ToUpper_Greek
4: [       OK ] StringTest.ToUpper_Greek (0 ms)
4: [ RUN      ] StringTest.ToUpper_Russian
4: [       OK ] StringTest.ToUpper_Russian (0 ms)
4: [ RUN      ] StringTest.ToUpper_Japanese
4: [       OK ] StringTest.ToUpper_Japanese (1 ms)
4: [----------] 14 tests from StringTest (156 ms total)
4: 
4: [----------] 26 tests from TrimData/StringTest
4: [ RUN      ] TrimData/StringTest.Trim/0
4: [       OK ] TrimData/StringTest.Trim/0 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/1
4: [       OK ] TrimData/StringTest.Trim/1 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/2
4: [       OK ] TrimData/StringTest.Trim/2 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/3
4: [       OK ] TrimData/StringTest.Trim/3 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/4
4: [       OK ] TrimData/StringTest.Trim/4 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/5
4: [       OK ] TrimData/StringTest.Trim/5 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/6
4: [       OK ] TrimData/StringTest.Trim/6 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/7
4: [       OK ] TrimData/StringTest.Trim/7 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/8
4: [       OK ] TrimData/StringTest.Trim/8 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/9
4: [       OK ] TrimData/StringTest.Trim/9 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/10
4: [       OK ] TrimData/StringTest.Trim/10 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/11
4: [       OK ] TrimData/StringTest.Trim/11 (0 ms)
4: [ RUN      ] TrimData/StringTest.Trim/12
4: [       OK ] TrimData/StringTest.Trim/12 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/0
4: [       OK ] TrimData/StringTest.TrimStart/0 (1 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/1
4: [       OK ] TrimData/StringTest.TrimStart/1 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/2
4: [       OK ] TrimData/StringTest.TrimStart/2 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/3
4: [       OK ] TrimData/StringTest.TrimStart/3 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/4
4: [       OK ] TrimData/StringTest.TrimStart/4 (1 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/5
4: [       OK ] TrimData/StringTest.TrimStart/5 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/6
4: [       OK ] TrimData/StringTest.TrimStart/6 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/7
4: [       OK ] TrimData/StringTest.TrimStart/7 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/8
4: [       OK ] TrimData/StringTest.TrimStart/8 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/9
4: [       OK ] TrimData/StringTest.TrimStart/9 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/10
4: [       OK ] TrimData/StringTest.TrimStart/10 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/11
4: [       OK ] TrimData/StringTest.TrimStart/11 (0 ms)
4: [ RUN      ] TrimData/StringTest.TrimStart/12
4: [       OK ] TrimData/StringTest.TrimStart/12 (0 ms)
4: [----------] 26 tests from TrimData/StringTest (8 ms total)
4: 
4: [----------] Global test environment tear-down
4: [==========] 40 tests from 2 test cases ran. (168 ms total)
4: [  PASSED  ] 40 tests.
 4/10 Test  #4: string ...........................   Passed    0.30 sec
test 5
      Start  5: localisation

5: Test command: /root/OpenRCT2/build/test_localisation
5: Test timeout computed to be: 9.99988e+06
5: Running main() from gtest_main.cc
5: [==========] Running 8 tests from 1 test case.
5: [----------] Global test environment set-up.
5: [----------] 8 tests from Localisation
5: [ RUN      ] Localisation.RCT2_to_UTF8_UK
5: [       OK ] Localisation.RCT2_to_UTF8_UK (4 ms)
5: [ RUN      ] Localisation.RCT2_to_UTF8_JP
5: [       OK ] Localisation.RCT2_to_UTF8_JP (5 ms)
5: [ RUN      ] Localisation.RCT2_to_UTF8_ZH_TW
5: [       OK ] Localisation.RCT2_to_UTF8_ZH_TW (1 ms)
5: [ RUN      ] Localisation.RCT2_to_UTF8_PL
5: [       OK ] Localisation.RCT2_to_UTF8_PL (0 ms)
5: [ RUN      ] Localisation.RCT2_to_UTF8_ZH_TW_PREMATURE_END
5: [       OK ] Localisation.RCT2_to_UTF8_ZH_TW_PREMATURE_END (6 ms)
5: [ RUN      ] Localisation.UTF8_to_RCT2_Basic
5: [       OK ] Localisation.UTF8_to_RCT2_Basic (1 ms)
5: [ RUN      ] Localisation.UTF8_to_RCT2_ChineseTraditional
5: [       OK ] Localisation.UTF8_to_RCT2_ChineseTraditional (1 ms)
5: [ RUN      ] Localisation.UTF8_to_RCT2_PL
5: [       OK ] Localisation.UTF8_to_RCT2_PL (0 ms)
5: [----------] 8 tests from Localisation (20 ms total)
5: 
5: [----------] Global test environment tear-down
5: [==========] 8 tests from 1 test case ran. (22 ms total)
5: [  PASSED  ] 8 tests.
 5/10 Test  #5: localisation .....................   Passed    0.13 sec
test 6
      Start  6: Crypt

6: Test command: /root/OpenRCT2/build/test_crypt
6: Test timeout computed to be: 9.99988e+06
6: Running main() from gtest_main.cc
6: [==========] Running 8 tests from 1 test case.
6: [----------] Global test environment set-up.
6: [----------] 8 tests from CryptTests
6: [ RUN      ] CryptTests.SHA1_Basic
6: [       OK ] CryptTests.SHA1_Basic (8 ms)
6: [ RUN      ] CryptTests.SHA1_Multiple
6: [       OK ] CryptTests.SHA1_Multiple (1 ms)
6: [ RUN      ] CryptTests.SHA1_WithClear
6: [       OK ] CryptTests.SHA1_WithClear (0 ms)
6: [ RUN      ] CryptTests.SHA1_Many
6: [       OK ] CryptTests.SHA1_Many (0 ms)
6: [ RUN      ] CryptTests.RSA_Basic
6: [       OK ] CryptTests.RSA_Basic (76 ms)
6: [ RUN      ] CryptTests.RSA_VerifyWithPublic
6: [       OK ] CryptTests.RSA_VerifyWithPublic (47 ms)
6: [ RUN      ] CryptTests.RSAKey_GetPublic
6: [       OK ] CryptTests.RSAKey_GetPublic (2 ms)
6: [ RUN      ] CryptTests.RSAKey_Generate
6: [       OK ] CryptTests.RSAKey_Generate (365 ms)
6: [----------] 8 tests from CryptTests (503 ms total)
6: 
6: [----------] Global test environment tear-down
6: [==========] 8 tests from 1 test case ran. (508 ms total)
6: [  PASSED  ] 8 tests.
 6/10 Test  #6: Crypt ............................   Passed    0.82 sec
test 7
      Start  7: ImageImporter

7: Test command: /root/OpenRCT2/build/test_imageimporter
7: Test timeout computed to be: 9.99988e+06
7: Running main() from gtest_main.cc
7: [==========] Running 1 test from 1 test case.
7: [----------] Global test environment set-up.
7: [----------] 1 test from ImageImporterTests
7: [ RUN      ] ImageImporterTests.Import_Logo
7: [       OK ] ImageImporterTests.Import_Logo (28 ms)
7: [----------] 1 test from ImageImporterTests (29 ms total)
7: 
7: [----------] Global test environment tear-down
7: [==========] 1 test from 1 test case ran. (33 ms total)
7: [  PASSED  ] 1 test.
 7/10 Test  #7: ImageImporter ....................   Passed    0.32 sec
test 8
      Start  8: ride_ratings

8: Test command: /root/OpenRCT2/build/test_ride_ratings
8: Test timeout computed to be: 9.99988e+06
8: Running main() from gtest_main.cc
8: [==========] Running 1 test from 1 test case.
8: [----------] Global test environment set-up.
8: [----------] 1 test from RideRatings
8: [ RUN      ] RideRatings.all
8: For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
8: Building object index (2052 items)
Finished building object index in 1.56 seconds.
8: Building track design index (0 items)
8: Finished building track design index in 0.00 seconds.
8: Building scenario index (0 items)
8: Finished building scenario index in 0.00 seconds.
8: [       OK ] RideRatings.all (6163 ms)
8: [----------] 1 test from RideRatings (6166 ms total)
8: 
8: [----------] Global test environment tear-down
8: [==========] 1 test from 1 test case ran. (6171 ms total)
8: [  PASSED  ] 1 test.
 8/10 Test  #8: ride_ratings .....................   Passed    6.45 sec
test 9
      Start  9: multilaunch

9: Test command: /root/OpenRCT2/build/test_multilaunch
9: Test timeout computed to be: 9.99988e+06
9: Running main() from gtest_main.cc
9: [==========] Running 1 test from 1 test case.
9: [----------] Global test environment set-up.
9: [----------] 1 test from MultiLaunchTest
9: [ RUN      ] MultiLaunchTest.all
9: For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
9: For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
9: For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
9: [       OK ] MultiLaunchTest.all (14770 ms)
9: [----------] 1 test from MultiLaunchTest (14771 ms total)
9: 
9: [----------] Global test environment tear-down
9: [==========] 1 test from 1 test case ran. (14775 ms total)
9: [  PASSED  ] 1 test.
 9/10 Test  #9: multilaunch ......................   Passed   14.99 sec
test 10
      Start 10: tile_elements

10: Test command: /root/OpenRCT2/build/test_tile_elements
10: Test timeout computed to be: 9.99988e+06
10: Running main() from gtest_main.cc
10: [==========] Running 6 tests from 1 test case.
10: [----------] Global test environment set-up.
10: [----------] 6 tests from TileElementWantsFootpathConnection
10: For security reasons, it is not recommended to run OpenRCT2 with elevated permissions.
10: [ RUN      ] TileElementWantsFootpathConnection.FlatPath
10: [       OK ] TileElementWantsFootpathConnection.FlatPath (1 ms)
10: [ RUN      ] TileElementWantsFootpathConnection.SlopedPath
10: [       OK ] TileElementWantsFootpathConnection.SlopedPath (1 ms)
10: [ RUN      ] TileElementWantsFootpathConnection.Stall
10: [       OK ] TileElementWantsFootpathConnection.Stall (8 ms)
10: [ RUN      ] TileElementWantsFootpathConnection.RideEntrance
10: [       OK ] TileElementWantsFootpathConnection.RideEntrance (0 ms)
10: [ RUN      ] TileElementWantsFootpathConnection.RideExit
10: [       OK ] TileElementWantsFootpathConnection.RideExit (1 ms)
10: [ RUN      ] TileElementWantsFootpathConnection.DifferentHeight
10: [       OK ] TileElementWantsFootpathConnection.DifferentHeight (0 ms)
10: [----------] 6 tests from TileElementWantsFootpathConnection (14 ms total)
10: 
10: [----------] Global test environment tear-down
10: [==========] 6 tests from 1 test case ran. (2376 ms total)
10: [  PASSED  ] 6 tests.
10/10 Test #10: tile_elements ....................   Passed    2.60 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =  26.18 sec
```