### PR TITLE
Fix some IPv6 problems

### DIFF
--- a/src/openrct2/network/TcpSocket.cpp
+++ b/src/openrct2/network/TcpSocket.cpp
@@ -451,6 +451,7 @@ private:
         hints.ai_family = AF_UNSPEC;
         if (address == nullptr)
         {
+            hints.ai_family = AF_INET6;
             hints.ai_flags = AI_PASSIVE;
         }
 


### PR DESCRIPTION
This is an experimental fix for some of the IPv6 issues we have with the master server. The problem is that OpenRCT2 only opens an IPv4 socket but the master server apparently tries to connect using IPv6. This fix opens the socket for both protocols.

## Technical notes
By specifying `AF_INET6` instead of `AF_UNSPEC`, `getaddrinfo` resolves `IN6ADDR_ANY`, which according to https://stackoverflow.com/a/2357111 also contains the IPv4 addresses.

## Testing
Without the fix applied, you can only connect to OpenRCT2 on the specified port using IPv4:

    telnet -4 127.0.0.1 11753
    Trying 127.0.0.1...
    Connected to 127.0.0.1.
    Escape character is '^]'.

A connection using IPv6 fails:

    telnet -6 ::1 11753
    Trying ::1...
    telnet: Unable to connect to remote host: Connection refused

With this fix applied both methods work. I also started the master-server on my development machine and with the fix it also works with IPv6.

Can someone who has only IPv4 check if it still works?

## Problems
This is an ugly fix. When hosting it will still show the 500-error on the console and then "Retry with ipv4 only". Also the master-server still only reports the IPv4-address back when listing servers, so this only fixes the problems for users with BOTH IPv4 AND IPv6 (which are most users atm but the number of IPv6-only users is rising).