### PR TITLE
Fix #7975: Clear inspection due flag when interval set to Never

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.2.1+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
+- Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected.
 - Improved: [#7930] Automatically create folders for custom content.
 - Removed: [#7929] Support for scenario text objects.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.2.1+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
-- Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected.
+- Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
 - Improved: [#7930] Automatically create folders for custom content.
 - Removed: [#7929] Support for scenario text objects.
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -28,7 +28,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2386,6 +2386,7 @@ static void ride_inspection_update(Ride* ride)
         ride->last_inspection--;
 
     int32_t inspectionIntervalMinutes = RideInspectionInterval[ride->inspection_interval];
+    // An inspection interval of 0 minutes means the ride is set to never be inspected.
     if (inspectionIntervalMinutes == 0)
     {
         ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2386,8 +2386,10 @@ static void ride_inspection_update(Ride* ride)
         ride->last_inspection--;
 
     int32_t inspectionIntervalMinutes = RideInspectionInterval[ride->inspection_interval];
-    if (inspectionIntervalMinutes == 0)
+    if (inspectionIntervalMinutes == 0) {
+        ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
         return;
+    }
 
     if (RideAvailableBreakdowns[ride->type] == 0)
         return;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2386,7 +2386,8 @@ static void ride_inspection_update(Ride* ride)
         ride->last_inspection--;
 
     int32_t inspectionIntervalMinutes = RideInspectionInterval[ride->inspection_interval];
-    if (inspectionIntervalMinutes == 0) {
+    if (inspectionIntervalMinutes == 0)
+    {
         ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
         return;
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4111,6 +4111,11 @@ static money32 ride_set_setting(uint8_t rideIndex, uint8_t setting, uint8_t valu
                 return MONEY32_UNDEFINED;
             }
 
+            if (value == RIDE_INSPECTION_NEVER)
+            {
+                ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+            }
+
             if (flags & GAME_COMMAND_FLAG_APPLY)
             {
                 ride->inspection_interval = value;


### PR DESCRIPTION
The 'Inspection due' flag is now cleared when a ride's inspection interval is set to Never. Previously, the flag would only be cleared if a mechanic inspected it one last time.