### PR TITLE
Fix OpenGL renderer stuttering when loading new textures into atlas.

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -189,6 +189,7 @@ private:
 
     GLuint _atlasesTexture = 0;
     GLint _atlasesTextureDimensions = 0;
+    GLuint _atlasesTextureCapacity = 0;
     GLuint _atlasesTextureIndices = 0;
     GLint _atlasesTextureIndicesLimit = 0;
     std::vector<Atlas> _atlases;


### PR DESCRIPTION
I refactored the code to have a capacity on the atlas and it will only do a copy when it runs out of free preserved space which saves a lot of time for the CPU/GPU it seems. The framerate is now pretty stable from the beginning to the end even while I move the camera around in the park bpb.sv6