### PR TITLE
Improve portable builds

### DIFF
--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -15,6 +15,7 @@ utf8 gOpenRCT2StartupActionPath[512] = { 0 };
 utf8 gExePath[MAX_PATH];
 utf8 gCustomUserDataPath[MAX_PATH] = { 0 };
 utf8 gCustomOpenrctDataPath[MAX_PATH] = { 0 };
+utf8 gCustomRCT1DataPath[MAX_PATH] = { 0 };
 utf8 gCustomRCT2DataPath[MAX_PATH] = { 0 };
 utf8 gCustomPassword[MAX_PATH] = { 0 };
 

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -40,6 +40,7 @@ extern utf8 gOpenRCT2StartupActionPath[512];
 extern utf8 gExePath[MAX_PATH];
 extern utf8 gCustomUserDataPath[MAX_PATH];
 extern utf8 gCustomOpenrctDataPath[MAX_PATH];
+extern utf8 gCustomRCT1DataPath[MAX_PATH];
 extern utf8 gCustomRCT2DataPath[MAX_PATH];
 extern utf8 gCustomPassword[MAX_PATH];
 extern bool gOpenRCT2Headless;

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -131,6 +131,10 @@ std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment()
     basePaths[(size_t)DIRBASE::DOCUMENTATION] = Platform::GetDocsPath();
 
     // Override paths that have been specified via the command line
+    if (!String::IsNullOrEmpty(gCustomRCT1DataPath))
+    {
+        basePaths[(size_t)DIRBASE::RCT1] = gCustomRCT1DataPath;
+    }
     if (!String::IsNullOrEmpty(gCustomRCT2DataPath))
     {
         basePaths[(size_t)DIRBASE::RCT2] = gCustomRCT2DataPath;
@@ -160,8 +164,14 @@ std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment()
     {
         config_save(configPath.c_str());
     }
-    env->SetBasePath(DIRBASE::RCT1, String::ToStd(gConfigGeneral.rct1_path));
-    env->SetBasePath(DIRBASE::RCT2, String::ToStd(gConfigGeneral.rct2_path));
+    if (String::IsNullOrEmpty(gCustomRCT1DataPath))
+    {
+        env->SetBasePath(DIRBASE::RCT1, String::ToStd(gConfigGeneral.rct1_path));
+    }
+    if (String::IsNullOrEmpty(gCustomRCT2DataPath))
+    {
+        env->SetBasePath(DIRBASE::RCT2, String::ToStd(gConfigGeneral.rct2_path));
+    }
 
     // Log base paths
     log_verbose("DIRBASE::RCT1    : %s", env->GetDirectoryPath(DIRBASE::RCT1).c_str());

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -54,6 +54,7 @@ static bool _headless = false;
 static utf8* _password = nullptr;
 static utf8* _userDataPath = nullptr;
 static utf8* _openrctDataPath = nullptr;
+static utf8* _rct1DataPath = nullptr;
 static utf8* _rct2DataPath = nullptr;
 static bool _silentBreakpad = false;
 
@@ -74,6 +75,7 @@ static constexpr const CommandLineOptionDefinition StandardOptions[]
     { CMDLINE_TYPE_STRING,  &_password,        NAC, "password",          "password needed to join the server"                         },
     { CMDLINE_TYPE_STRING,  &_userDataPath,    NAC, "user-data-path",    "path to the user data directory (containing config.ini)"    },
     { CMDLINE_TYPE_STRING,  &_openrctDataPath, NAC, "openrct-data-path", "path to the OpenRCT2 data directory (containing languages)" },
+    { CMDLINE_TYPE_STRING,  &_rct1DataPath,    NAC, "rct1-data-path",    "path to the RollerCoaster Tycoon 1 data directory (containing data/csg1.dat)" },
     { CMDLINE_TYPE_STRING,  &_rct2DataPath,    NAC, "rct2-data-path",    "path to the RollerCoaster Tycoon 2 data directory (containing data/g1.dat)" },
 #ifdef USE_BREAKPAD
     { CMDLINE_TYPE_SWITCH,  &_silentBreakpad,  NAC, "silent-breakpad",   "make breakpad crash reporting silent"                       },
@@ -206,6 +208,12 @@ exitcode_t CommandLine::HandleCommandDefault()
         Path::GetAbsolute(absolutePath, Util::CountOf(absolutePath), _openrctDataPath);
         String::Set(gCustomOpenrctDataPath, Util::CountOf(gCustomOpenrctDataPath), absolutePath);
         Memory::Free(_openrctDataPath);
+    }
+
+    if (_rct1DataPath != nullptr)
+    {
+        String::Set(gCustomRCT1DataPath, Util::CountOf(gCustomRCT1DataPath), _rct1DataPath);
+        Memory::Free(_rct1DataPath);
     }
 
     if (_rct2DataPath != nullptr)

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -146,9 +146,10 @@ private:
         std::vector<std::string> files;
         for (const auto& directory : SearchPaths)
         {
-            log_verbose("FileIndex:Scanning for %s in '%s'", _pattern.c_str(), directory.c_str());
+            auto absoluteDirectory = Path::GetAbsolute(directory);
+            log_verbose("FileIndex:Scanning for %s in '%s'", _pattern.c_str(), absoluteDirectory.c_str());
 
-            auto pattern = Path::Combine(directory, _pattern);
+            auto pattern = Path::Combine(absoluteDirectory, _pattern);
             auto scanner = Path::ScanDirectory(pattern, true);
             while (scanner->Next())
             {


### PR DESCRIPTION
When testing out running OpenRCT2 on a flash drive I picked up a couple of things I wanted to improve:
* Allow RCT1 data path to be specified via command line like RCT2 can.
* Show the full path of the scenario in the scenario select screen.