### PR TITLE
Adjust the thresholds for color change to red for G-forces 

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1203,8 +1203,8 @@ static constexpr const rct_window_graphs_y_axis window_graphs_y_axi[] = {
 };
 
 static constexpr auto RIDE_G_FORCES_RED_POS_VERTICAL = FIXED_2DP(5, 00);
-static constexpr auto RIDE_G_FORCES_RED_NEG_VERTICAL = -FIXED_2DP(2, 00);
-static constexpr auto RIDE_G_FORCES_RED_LATERAL = FIXED_2DP(2, 80);
+static constexpr auto RIDE_G_FORCES_RED_NEG_VERTICAL = -FIXED_2DP(2, 50);
+static constexpr auto RIDE_G_FORCES_RED_LATERAL = FIXED_2DP(2, 81);
 
 // Used for sorting the ride type cheat dropdown.
 struct RideTypeLabel


### PR DESCRIPTION
This partially addresses https://github.com/OpenRCT2/OpenRCT2/issues/7983, but I wasn't sure how to address the last point they raised regarding G-forces in excess of 5, as it's not clear what the revised value should be.