### PR TITLE
Allow compilation of testpaint on non-x86 targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ add_custom_target(g2 DEPENDS ${PROJECT} g2.dat)
 # Include tests
 if (WITH_TESTS)
     enable_testing()
-    if (UNIX AND (NOT USE_MMAP) AND FORCE32)
+    if (UNIX AND (NOT USE_MMAP))
         include("${ROOT_DIR}/test/testpaint/CMakeLists.txt" NO_POLICY_SCOPE)
     endif ()
     include("${ROOT_DIR}/test/tests/CMakeLists.txt" NO_POLICY_SCOPE)

--- a/test/testpaint/CMakeLists.txt
+++ b/test/testpaint/CMakeLists.txt
@@ -18,7 +18,7 @@ add_custom_command(
     DEPENDS ${OPENRCT2_EXE}
 )
 add_custom_target(segfiles DEPENDS openrct2_text openrct2_data)
-if (NOT USE_MMAP)
+if (NOT USE_MMAP AND FORCE32)
     set(OBJ_FORMAT "elf32-i386")
     set(LINKER_SCRIPT "ld_script_i386.xc")
     if (APPLE)
@@ -92,6 +92,11 @@ if (NOT MINGW AND NOT MSVC)
     target_link_libraries(testpaint ${ICU_LIBRARIES})
 endif ()
 
-set_target_properties(testpaint PROPERTIES COMPILE_FLAGS "-DNO_VEHICLES -D__TESTPAINT__ -Wno-unused")
-set_target_properties(testpaint PROPERTIES LINK_FLAGS ${RCT2_SEGMENT_LINKER_FLAGS})
+# Only use custom linker script for 32 bit builds. For 64 bit builds, it should still _compile_.
+if (FORCE32)
+    set_target_properties(testpaint PROPERTIES LINK_FLAGS ${RCT2_SEGMENT_LINKER_FLAGS})
+else ()
+    set(TESTPAINT_64BIT_FLAGS "-Wno-int-to-pointer-cast -fpermissive -Wno-error")
+endif ()
+set_target_properties(testpaint PROPERTIES COMPILE_FLAGS "-DNO_VEHICLES -D__TESTPAINT__ -Wno-unused ${TESTPAINT_64BIT_FLAGS}")
 add_dependencies(testpaint segfiles)

--- a/test/testpaint/main.cpp
+++ b/test/testpaint/main.cpp
@@ -451,6 +451,10 @@ static void TestGeneralSupportHeightCall()
 
 int main(int argc, char* argv[])
 {
+#if !defined(__i386__)
+    fprintf(stderr, "Testpaint can only be properly executed on x86\n");
+    return 1;
+#else
     TestGeneralSupportHeightCall();
 
     std::vector<TestCase> testCases;
@@ -636,4 +640,5 @@ int main(int argc, char* argv[])
     }
 
     return 0;
+#endif
 }


### PR DESCRIPTION
This will enable compilation of testpaint on targets different than x86.
It won't function the way it does on x86, but it should provide a way of
tackling various compilation errors that can only be seen in the very
specific environment required by testpaint proper.