### PR TITLE
Fix loading of 4-byte UTF-8 codepoints

### DIFF
--- a/src/openrct2/localisation/UTF8.cpp
+++ b/src/openrct2/localisation/UTF8.cpp
@@ -33,8 +33,8 @@ uint32_t utf8_get_next(const utf8* char_ptr, const utf8** nextchar_ptr)
     }
     else if ((char_ptr[0] & 0xF8) == 0xF0)
     {
-        result = ((char_ptr[0] & 0x07) << 18) | ((char_ptr[1] & 0x3F) << 12) | ((char_ptr[1] & 0x3F) << 6)
-            | (char_ptr[2] & 0x3F);
+        result = ((char_ptr[0] & 0x07) << 18) | ((char_ptr[1] & 0x3F) << 12) | ((char_ptr[2] & 0x3F) << 6)
+            | (char_ptr[3] & 0x3F);
         numBytes = 4;
     }
     else


### PR DESCRIPTION
We're not using any of these characters in OpenRCT2 yet, to my knowledge, but the code to do so has been in the codebase for a while.

I noticed the bug when loading emoji as symbols in OpenLoco: https://github.com/OpenRCT2/OpenLoco/pull/203