### PR TITLE
Fully reproducible dev environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,9 +12,6 @@
   import pinnedPkgs {}
  )
 }:
-let
-  a = "d";
-in
 pkgs.stdenv.mkDerivation {
   name = "openrct";
   src = builtins.filterSource

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,6 @@
     pinnedPkgs = hostPkgs.fetchFromGitHub {
       owner = "NixOS";
       repo = "nixpkgs-channels";
-      # nixos-unstable as of 2017-11-13T08:53:10-00:00
       rev = "08d245eb31a3de0ad73719372190ce84c1bf3aee";
       sha256 = "1g22f8r3l03753s67faja1r0dq0w88723kkfagskzg9xy3qs8yw8";
     };

--- a/shell.nix
+++ b/shell.nix
@@ -36,7 +36,8 @@ pkgs.stdenv.mkDerivation {
 	pkgs.pkgconfig
 	pkgs.xorg.libpthreadstubs
 ] ++ (pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.Foundation # osX hacks
+    pkgs.darwin.apple_sdk.frameworks.Foundation # osX hacks
+    pkgs.darwin.apple_sdk.frameworks.AppKit
     pkgs.libobjc ]
   );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@
  )
 }:
 pkgs.stdenv.mkDerivation {
-  name = "openrct";
+  name = "openrct2";
   src = builtins.filterSource
     (path: type:
       baseNameOf path != ".git" &&

--- a/shell.nix
+++ b/shell.nix
@@ -35,5 +35,8 @@ pkgs.stdenv.mkDerivation {
 	pkgs.cmake
 	pkgs.pkgconfig
 	pkgs.xorg.libpthreadstubs
-  ];
+] ++ (pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.Foundation # osX hacks
+    pkgs.libobjc ]
+  );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,43 @@
+{ pkgs ? (
+   let 
+    hostPkgs = import <nixpkgs> {};
+    pinnedPkgs = hostPkgs.fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nixpkgs-channels";
+      # nixos-unstable as of 2017-11-13T08:53:10-00:00
+      rev = "08d245eb31a3de0ad73719372190ce84c1bf3aee";
+      sha256 = "1g22f8r3l03753s67faja1r0dq0w88723kkfagskzg9xy3qs8yw8";
+    };
+  in
+  import pinnedPkgs {}
+ )
+}:
+let
+  a = "d";
+in
+pkgs.stdenv.mkDerivation {
+  name = "openrct";
+  src = builtins.filterSource
+    (path: type:
+      baseNameOf path != ".git" &&
+      baseNameOf path != "output" &&
+      baseNameOf path != "result")
+    ./.;
+  buildInputs = [
+	pkgs.gcc
+	pkgs.SDL2
+	pkgs.freetype
+	pkgs.fontconfig
+	pkgs.libzip
+	pkgs.speexdsp
+	pkgs.curl
+	pkgs.jansson
+	pkgs.openssl
+	pkgs.icu
+	pkgs.zlib
+	pkgs.libGL
+	pkgs.cmake
+	pkgs.pkgconfig
+	pkgs.xorg.libpthreadstubs
+  ];
+}


### PR DESCRIPTION
This file allows one to develop within a nix shell environment.
It isolates the build inputs to just the ones specified in here. Making sure that everyone builds against the same system libraries (or else they are not found). In the nix shell it is also guaranteed the same build tools are used.

Doesn't work on windows I believe, but osx is supported (albeit I can't test that, cause poor).

To use this, get nix: https://nixos.org/nix/, then go to root of project, `nix-shell --pure`, then do the regular build setup, `mkdir build`, `cd build`, `cmake ../`, `make`.