### PR TITLE
fix #8034 screenshot command outputs broken sprites

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
+- Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -487,6 +487,7 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
         }
     }
 
+    gOpenRCT2Headless = true;
     auto context = CreateContext();
     if (context->Initialise())
     {

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -487,7 +487,6 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
         }
     }
 
-    gOpenRCT2Headless = true;
     auto context = CreateContext();
     if (context->Initialise())
     {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -212,7 +212,7 @@ namespace ObjectFactory
                 log_verbose("  size: %zu", chunk->GetLength());
 
                 auto chunkStream = MemoryStream(chunk->GetData(), chunk->GetLength());
-                auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2Headless, nullptr);
+                auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2NoGraphics, nullptr);
                 ReadObjectLegacy(result, &readContext, &chunkStream);
                 if (readContext.WasError())
                 {
@@ -241,7 +241,7 @@ namespace ObjectFactory
             utf8 objectName[DAT_NAME_LENGTH + 1];
             object_entry_get_name_fixed(objectName, sizeof(objectName), entry);
 
-            auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2Headless, nullptr);
+            auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2NoGraphics, nullptr);
             auto chunkStream = MemoryStream(data, dataSize);
             ReadObjectLegacy(result, &readContext, &chunkStream);
 
@@ -409,7 +409,7 @@ namespace ObjectFactory
                 memcpy(entry.name, originalName.c_str(), minLength);
 
                 result = CreateObject(entry);
-                auto readContext = ReadObjectContext(objectRepository, id, !gOpenRCT2Headless, fileRetriever);
+                auto readContext = ReadObjectContext(objectRepository, id, !gOpenRCT2NoGraphics, fileRetriever);
                 result->ReadJson(&readContext, jRoot);
                 if (readContext.WasError())
                 {


### PR DESCRIPTION
I wasn't sure if this is the proper way of fixing the issue, but I've tested this on both Windows 10 (openrct2.com) and Ubuntu Server (openrct2-cli), and everything seem to work fine now.

I'd like someone who knows what `gHeadless` is supposed to do better than me to review this. afaik headless-mode both disables loading graphics and opening a window. For the screenshot command we need graphics, but no window.

Before and after:

![out](https://user-images.githubusercontent.com/9705046/46313810-208cd900-c5c9-11e8-8b70-e385080bc9c3.png)
![out](https://user-images.githubusercontent.com/9705046/46313814-24206000-c5c9-11e8-9415-6305bc7b8082.png)