### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -92,6 +92,11 @@ public:
 
     void Resize(uint32_t width, uint32_t height) override
     {
+        if (width == 0 || height == 0)
+        {
+            return;
+        }
+
         if (_screenTexture != nullptr)
         {
             SDL_DestroyTexture(_screenTexture);

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -34,11 +34,11 @@ std::vector<server_entry> server_list_read()
             for (size_t i = 0; i < numEntries; i++)
             {
                 server_entry serverInfo;
-                serverInfo.address = fs.ReadString();
-                serverInfo.name = fs.ReadString();
+                serverInfo.address = fs.ReadStdString();
+                serverInfo.name = fs.ReadStdString();
                 serverInfo.requiresPassword = false;
-                serverInfo.description = fs.ReadString();
-                serverInfo.version = String::Duplicate("");
+                serverInfo.description = fs.ReadStdString();
+                serverInfo.version = "";
                 serverInfo.favourite = true;
                 serverInfo.players = 0;
                 serverInfo.maxplayers = 0;

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -110,7 +110,7 @@ void StringTable::SetString(uint8_t id, uint8_t language, const std::string& tex
     StringTableEntry entry;
     entry.Id = id;
     entry.LanguageId = language;
-    entry.Text = String::Duplicate(text);
+    entry.Text = text;
     _strings.push_back(entry);
 }
 


### PR DESCRIPTION
The memory leaks I found were all about functions returning strings as `utf8 *` (or `char *`) that were manually allocated, but were used as assignments to `std::string` and not free'd. This caused immediate memory leaks. Two fixes involved removing a call to `String::Duplicate`, and the other two involved using the alternative that returned a `std::string`.

(I'm starting to think that pointers in C++ are an anti-pattern, and this project is half the reason why)

I also made a quick change in HardwareDisplayDrawingEngine.cpp. I realized a few days ago that building a Debug build in Visual Studio and running it caused an assert in SDL2, so I added an if statement to avoid that.