### PR TITLE
Add missing trailing semicolon

### DIFF
--- a/distribution/linux/openrct2-uri.desktop
+++ b/distribution/linux/openrct2-uri.desktop
@@ -7,4 +7,4 @@ Icon=openrct2
 Name=OpenRCT2
 Terminal=false
 NoDisplay=true
-MimeType=x-scheme-handler/openrct2
+MimeType=x-scheme-handler/openrct2;


### PR DESCRIPTION
The AppImage build script complains about the missing semicolon (it uses `desktop-file-validate` to check conformity).