### PR TITLE
Fix 7760: Touchscreen presses are handled twice

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -379,6 +379,10 @@ public:
                     break;
                 case SDL_MOUSEBUTTONDOWN:
                 {
+                    if (e.button.which == SDL_TOUCH_MOUSEID)
+                    {
+                        break;
+                    }
                     int32_t x = (int32_t)(e.button.x / gConfigGeneral.window_scale);
                     int32_t y = (int32_t)(e.button.y / gConfigGeneral.window_scale);
                     switch (e.button.button)
@@ -401,6 +405,10 @@ public:
                 }
                 case SDL_MOUSEBUTTONUP:
                 {
+                    if (e.button.which == SDL_TOUCH_MOUSEID)
+                    {
+                        break;
+                    }
                     int32_t x = (int32_t)(e.button.x / gConfigGeneral.window_scale);
                     int32_t y = (int32_t)(e.button.y / gConfigGeneral.window_scale);
                     switch (e.button.button)


### PR DESCRIPTION
As far as I can tell this resolves the issue of the game registering a single touch input as two clicks on Windows (Issue #7760 ).

The thing I'm not sure about is whether this will affect MacBooks--I see the comments in there about how OSX sends trackpad input as a touch event, so if somebody knows or can test whether this will break support for trackpads on Macs that would be well appreciated.

Also please let me know if there's anything wrong with this pull request--I'm a little new to the game.