### PR TITLE
Fix crash when map window tries to plot a ride entrances

### DIFF
--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1589,7 +1589,9 @@ static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
             case TILE_ELEMENT_TYPE_ENTRANCE:
                 if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                     break;
-                // fall-through
+                ride = get_ride(tileElement->AsEntrance()->GetRideIndex());
+                colourA = RideKeyColours[RideColourKey[ride->type]];
+                break;
             case TILE_ELEMENT_TYPE_TRACK:
                 ride = get_ride(tileElement->AsTrack()->GetRideIndex());
                 colourA = RideKeyColours[RideColourKey[ride->type]];


### PR DESCRIPTION
The case block falls through into the ride element case block, which uses `AsTrack()`, which returned `nullptr` for the ride entrance.