### PR TITLE
Fix #1496: scrolling on touch devices

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -302,7 +302,6 @@ public:
         _cursorState.middle &= ~CURSOR_CHANGED;
         _cursorState.right &= ~CURSOR_CHANGED;
         _cursorState.old = 0;
-        _cursorState.touch = false;
 
         SDL_Event e;
         while (SDL_PollEvent(&e))
@@ -401,6 +400,7 @@ public:
                             _cursorState.old = 2;
                             break;
                     }
+                    _cursorState.touch = false;
                     break;
                 }
                 case SDL_MOUSEBUTTONUP:
@@ -427,6 +427,7 @@ public:
                             _cursorState.old = 4;
                             break;
                     }
+                    _cursorState.touch = false;
                     break;
                 }
                 // Apple sends touchscreen events for trackpads, so ignore these events on macOS

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -537,6 +537,7 @@ static void input_viewport_drag_continue()
     rct_viewport* viewport;
 
     context_get_cursor_position(&newDragX, &newDragY);
+    const CursorState *cursorState = context_get_cursor_state();
 
     dx = newDragX - gInputDragLastX;
     dy = newDragY - gInputDragLastY;
@@ -582,7 +583,13 @@ static void input_viewport_drag_continue()
         }
     }
 
-    context_set_cursor_position(gInputDragLastX, gInputDragLastY);
+    if (cursorState->touch) {
+        gInputDragLastX = newDragX;
+        gInputDragLastY = newDragY;
+    }
+    else {
+        context_set_cursor_position(gInputDragLastX, gInputDragLastY);
+    }
 }
 
 static void input_viewport_drag_end()

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -537,7 +537,7 @@ static void input_viewport_drag_continue()
     rct_viewport* viewport;
 
     context_get_cursor_position(&newDragX, &newDragY);
-    const CursorState *cursorState = context_get_cursor_state();
+    const CursorState* cursorState = context_get_cursor_state();
 
     dx = newDragX - gInputDragLastX;
     dy = newDragY - gInputDragLastY;
@@ -583,11 +583,13 @@ static void input_viewport_drag_continue()
         }
     }
 
-    if (cursorState->touch) {
+    if (cursorState->touch)
+    {
         gInputDragLastX = newDragX;
         gInputDragLastY = newDragY;
     }
-    else {
+    else
+    {
         context_set_cursor_position(gInputDragLastX, gInputDragLastY);
     }
 }


### PR DESCRIPTION
Another fix for touch input. This one for #1496 where scrolling by double tapping and then dragging causes the viewport to scroll incredibly fast. It seems to be because the behavior is dependent on being able to reset the cursor to the starting position of the drag in order to calculate the cursor movement. But since you can't do that with a touchscreen, the cursor doesn't get reset and it doesn't calculate cursor movement correctly.

Here I've had it check first if the viewport dragging is because of touchscreen input. If it is, instead of moving the cursor just set `gInputDragLast` to the current cursor position.

The thing I'm not sure about here is that this required a change in how `_cursorState.touch` is set in UiContext.cpp. Instead of setting it to false every time the game checks for input, it's set to false when input received from an actual mouse. This makes it possible to check whether the viewport drag is caused by mouse or touch. I don't _think_ this would break anything because it doesn't look like `_cursorState.touch` is used anywhere else. Is there a particular reason for the way that value is set now?