### PR TITLE
Fix #8062: Unstable cheat warning only shown when disabled

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
 - Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.
 - Fix: [#8045] Crash when switching between languages.
+- Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -1043,31 +1043,31 @@ static void window_cheats_rides_mouseup(rct_window* w, rct_widgetindex widgetInd
             game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_10MINUTEINSPECTIONS, 0, GAME_COMMAND_CHEAT, 0, 0);
             break;
         case WIDX_SHOW_ALL_OPERATING_MODES:
+            if (!gCheatsShowAllOperatingModes)
+            {
+                context_show_error(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
+            }
             game_do_command(
                 0, GAME_COMMAND_FLAG_APPLY, CHEAT_SHOWALLOPERATINGMODES, !gCheatsShowAllOperatingModes, GAME_COMMAND_CHEAT, 0,
                 0);
-            if (gCheatsShowAllOperatingModes)
+            break;
+        case WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES:
+            if (!gCheatsShowVehiclesFromOtherTrackTypes)
             {
                 context_show_error(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
             }
-            break;
-        case WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES:
             game_do_command(
                 0, GAME_COMMAND_FLAG_APPLY, CHEAT_SHOWVEHICLESFROMOTHERTRACKTYPES, !gCheatsShowVehiclesFromOtherTrackTypes,
                 GAME_COMMAND_CHEAT, 0, 0);
-            if (gCheatsShowVehiclesFromOtherTrackTypes)
+            break;
+        case WIDX_DISABLE_TRAIN_LENGTH_LIMITS:
+            if (!gCheatsDisableTrainLengthLimit)
             {
                 context_show_error(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
             }
-            break;
-        case WIDX_DISABLE_TRAIN_LENGTH_LIMITS:
             game_do_command(
                 0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLETRAINLENGTHLIMIT, !gCheatsDisableTrainLengthLimit, GAME_COMMAND_CHEAT,
                 0, 0);
-            if (gCheatsDisableTrainLengthLimit)
-            {
-                context_show_error(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
-            }
             break;
         case WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK:
             game_do_command(
@@ -1075,13 +1075,13 @@ static void window_cheats_rides_mouseup(rct_window* w, rct_widgetindex widgetInd
                 GAME_COMMAND_CHEAT, 0, 0);
             break;
         case WIDX_ENABLE_ARBITRARY_RIDE_TYPE_CHANGES:
-            game_do_command(
-                0, GAME_COMMAND_FLAG_APPLY, CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES, !gCheatsAllowArbitraryRideTypeChanges,
-                GAME_COMMAND_CHEAT, 0, 0);
-            if (gCheatsAllowArbitraryRideTypeChanges)
+            if (!gCheatsAllowArbitraryRideTypeChanges)
             {
                 context_show_error(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE);
             }
+            game_do_command(
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES, !gCheatsAllowArbitraryRideTypeChanges,
+                GAME_COMMAND_CHEAT, 0, 0);
             break;
         case WIDX_DISABLE_RIDE_VALUE_AGING:
             game_do_command(


### PR DESCRIPTION
This moves the check for showing a warning to be above the `game_do_command` function.