### PR TITLE
Fix compilation on musl

### DIFF
--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -81,7 +81,7 @@ using colour_t = uint8_t;
 
 #if !(                                                                                                                         \
     (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L) || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)               \
-    || (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID_API__) || defined(__FreeBSD__))
+    || (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID_API__) || defined(__FreeBSD__) || !defined(__GLIBC__))
 char* strndup(const char* src, size_t size);
 #endif // !(POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700)
 

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -45,7 +45,7 @@ static mach_timebase_info_data_t _mach_base_info = {};
 
 #if !(                                                                                                                         \
     (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L) || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)               \
-    || (defined(__APPLE__) && defined(__MACH__)))
+    || (defined(__APPLE__) && defined(__MACH__)) || !defined(__GLIBC__))
 char* strndup(const char* src, size_t size)
 {
     size_t len = strnlen(src, size);


### PR DESCRIPTION
`strndup` is not available on Musl, so make sure it gets defined when glibc is not available.

Resolves #8065 