### PR TITLE
Automatically detect fts.h presence when compiling

### DIFF
--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -15,7 +15,7 @@
 #    include <errno.h>
 #    include <fcntl.h>
 #    include <fnmatch.h>
-#    ifndef __EMSCRIPTEN__
+#    if !defined(__EMSCRIPTEN__) && __has_include(<fts.h>)
 #        include <fts.h>
 #    endif
 #    include "../OpenRCT2.h"


### PR DESCRIPTION
This should support libc-s that don't ship with glibc-like fts.h, e.g.
musl