### PR TITLE
Added save_park command

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1172,20 +1172,38 @@ void save_game()
 {
     if (!gFirstTimeSaving)
     {
-        log_verbose("Saving to %s", gScenarioSavePath);
-        if (scenario_save(gScenarioSavePath, 0x80000000 | (gConfigGeneral.save_plugin_data ? 1 : 0)))
-        {
-            log_verbose("Saved to %s", gScenarioSavePath);
-            safe_strcpy(gCurrentLoadedPath, gScenarioSavePath, MAX_PATH);
-
-            // Setting screen age to zero, so no prompt will pop up when closing the
-            // game shortly after saving.
-            gScreenAge = 0;
-        }
+        save_game_with_name(gScenarioSavePath);
     }
     else
     {
         save_game_as();
+    }
+}
+
+void save_game_cmd(const utf8* name /* = nullptr */)
+{
+    if (name == nullptr)
+    {
+        save_game_with_name(gScenarioSavePath);
+    }
+    else
+    {
+        char savePath[MAX_PATH];
+        platform_get_user_directory(savePath, "save", sizeof(savePath));
+        safe_strcat_path(savePath, name, sizeof(savePath));
+        path_append_extension(savePath, ".sv6", sizeof(savePath));
+        save_game_with_name(savePath);
+    }
+}
+
+void save_game_with_name(const utf8* name)
+{
+    log_verbose("Saving to %s", name);
+    if (scenario_save(name, 0x80000000 | (gConfigGeneral.save_plugin_data ? 1 : 0)))
+    {
+        log_verbose("Saved to %s", name);
+        safe_strcpy(gCurrentLoadedPath, name, MAX_PATH);
+        gScreenAge = 0;
     }
 }
 

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -175,6 +175,8 @@ bool game_is_not_paused();
 void save_game();
 void* create_save_game_as_intent();
 void save_game_as();
+void save_game_cmd(const utf8* name = nullptr);
+void save_game_with_name(const utf8* name);
 void game_autosave();
 void game_convert_strings_to_utf8();
 void game_convert_news_items_to_utf8();

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1258,6 +1258,21 @@ static int32_t cc_for_date(
     return 1;
 }
 
+static int32_t cc_save_park(
+    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const utf8** argv, [[maybe_unused]] int32_t argc)
+{
+    if (argc < 1)
+    {
+        save_game_cmd();
+    }
+    else
+    {
+        save_game_cmd(argv[0]);
+    }
+    
+    return 1;
+}
+
 using console_command_func = int32_t (*)(InteractiveConsole& console, const utf8** argv, int32_t argc);
 struct console_command
 {
@@ -1341,7 +1356,8 @@ static constexpr const console_command console_command_table[] = {
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
     { "remove_park_fences", cc_remove_park_fences, "Removes all park fences from the surface", "remove_park_fences"},
     { "show_limits", cc_show_limits, "Shows the map data counts and limits.", "show_limits" },
-    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."}
+    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."},
+    { "save_park", cc_save_park, "Save current state of park. If no name specified default path will be used.", "save_park [name]"}
 };
 // clang-format on
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1269,7 +1269,6 @@ static int32_t cc_save_park(
     {
         save_game_cmd(argv[0]);
     }
-    
     return 1;
 }
 
@@ -1357,7 +1356,7 @@ static constexpr const console_command console_command_table[] = {
     { "remove_park_fences", cc_remove_park_fences, "Removes all park fences from the surface", "remove_park_fences"},
     { "show_limits", cc_show_limits, "Shows the map data counts and limits.", "show_limits" },
     { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."},
-    { "save_park", cc_save_park, "Save current state of park. If no name specified default path will be used.", "save_park [name]"}
+    { "save_park", cc_save_park, "Save current state of park. If no name specified default path will be used.", "save_park [name]"},
 };
 // clang-format on
 


### PR DESCRIPTION
Added `save_park` command that enable user to save current state of game using command line. This pull request is related to issue #7549 