### PR TITLE
Add a "current_rotation" variable to the console

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -984,7 +984,7 @@ STR_1600    :{SMALLFONT}“This cookie from {STRINGID} is really good value”
 STR_1601    :
 STR_1602    :
 STR_1603    :
-STR_1604    :{SMALLFONT}“This roast sausage from {STRINGID} are really good value”
+STR_1604    :{SMALLFONT}“This roast sausage from {STRINGID} is really good value”
 STR_1605    :
 STR_1606    :
 STR_1607    :

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Feature: [#7971] Toolbox option to open custom content folder.
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
-- Feature: New console variable "current_rotation" to get or set view rotation
+- Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7945] Client IP address is logged as `(null)` in server logs.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Feature: [#7971] Toolbox option to open custom content folder.
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
+- Feature: New console variable "current_rotation" to get or set view rotation
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7945] Client IP address is logged as `(null)` in server logs.

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1374,7 +1374,7 @@ static constexpr const console_command console_command_table[] = {
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
     { "remove_park_fences", cc_remove_park_fences, "Removes all park fences from the surface", "remove_park_fences"},
     { "show_limits", cc_show_limits, "Shows the map data counts and limits.", "show_limits" },
-    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."},
+    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."}
 };
 // clang-format on
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -946,9 +946,11 @@ static int32_t cc_set(InteractiveConsole& console, const utf8** argv, int32_t ar
         {
             uint8_t currentRotation = get_current_rotation();
             rct_window* mainWindow = window_get_main();
-            // there are only 4 possible rotations (0-3)
-            int32_t newRotation = int_val[0] & 3;
-            if (newRotation != currentRotation && mainWindow != nullptr)
+            int32_t newRotation = int_val[0];
+            if(newRotation < 0 || newRotation > 3) {
+                console.WriteLineError("Invalid argument. Valid rotations are 0-3.");
+            }
+            else if (newRotation != currentRotation && mainWindow != nullptr)
             {
                 window_rotate_camera(mainWindow, newRotation - currentRotation);
             }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -626,6 +626,10 @@ static int32_t cc_get(InteractiveConsole& console, const utf8** argv, int32_t ar
         {
             console.WriteFormatLine("cheat_disable_support_limits %d", gCheatsDisableSupportLimits);
         }
+        else if (strcmp(argv[0], "current_rotation") == 0)
+        {
+            console.WriteFormatLine("current_rotation %d", get_current_rotation);
+        }
 #ifndef NO_TTF
         else if (strcmp(argv[0], "enable_hinting") == 0)
         {
@@ -937,6 +941,34 @@ static int32_t cc_set(InteractiveConsole& console, const utf8** argv, int32_t ar
                 }
             }
             console.Execute("get cheat_disable_support_limits");
+        }
+        else if (strcmp(argv[0], "current_rotation") == 0 && invalidArguments(&invalidArgs, int_valid[0]))
+        {
+            uint8_t currentRotation = get_current_rotation();
+            rct_window* mainWindow = window_get_main();
+            // as there are only 4 possible rotations, make any input go to 0-3 to avoid unneccessary work
+            int32_t newRotation = int_val[0] % 4;
+            if (newRotation != currentRotation && mainWindow != nullptr)
+            {
+                // if desired rotation is less than current, move counter-clockwise
+                if (newRotation < currentRotation)
+                {
+                    while (newRotation != currentRotation)
+                    {
+                        window_rotate_camera(mainWindow, -1);
+                        newRotation++;
+                    }
+                }
+                // otherwise move clockwise
+                else if (newRotation > currentRotation)
+                {
+                    while (newRotation != currentRotation)
+                    {
+                        window_rotate_camera(mainWindow, 1);
+                        newRotation--;
+                    }
+                }
+            }
         }
 #ifndef NO_TTF
         else if (strcmp(argv[0], "enable_hinting") == 0 && invalidArguments(&invalidArgs, int_valid[0]))
@@ -1306,6 +1338,7 @@ static constexpr const utf8* console_variable_table[] = {
     "cheat_sandbox_mode",
     "cheat_disable_clearance_checks",
     "cheat_disable_support_limits",
+    "current_rotation",
 };
 static constexpr const utf8* console_window_table[] = {
     "object_selection",
@@ -1341,7 +1374,7 @@ static constexpr const console_command console_command_table[] = {
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
     { "remove_park_fences", cc_remove_park_fences, "Removes all park fences from the surface", "remove_park_fences"},
     { "show_limits", cc_show_limits, "Shows the map data counts and limits.", "show_limits" },
-    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."}
+    { "date", cc_for_date, "Sets the date to a given date.", "Format <year>[ <month>[ <day>]]."},
 };
 // clang-format on
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -947,7 +947,8 @@ static int32_t cc_set(InteractiveConsole& console, const utf8** argv, int32_t ar
             uint8_t currentRotation = get_current_rotation();
             rct_window* mainWindow = window_get_main();
             int32_t newRotation = int_val[0];
-            if(newRotation < 0 || newRotation > 3) {
+            if (newRotation < 0 || newRotation > 3)
+            {
                 console.WriteLineError("Invalid argument. Valid rotations are 0-3.");
             }
             else if (newRotation != currentRotation && mainWindow != nullptr)

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -628,7 +628,7 @@ static int32_t cc_get(InteractiveConsole& console, const utf8** argv, int32_t ar
         }
         else if (strcmp(argv[0], "current_rotation") == 0)
         {
-            console.WriteFormatLine("current_rotation %d", get_current_rotation);
+            console.WriteFormatLine("current_rotation %d", get_current_rotation());
         }
 #ifndef NO_TTF
         else if (strcmp(argv[0], "enable_hinting") == 0)
@@ -946,29 +946,13 @@ static int32_t cc_set(InteractiveConsole& console, const utf8** argv, int32_t ar
         {
             uint8_t currentRotation = get_current_rotation();
             rct_window* mainWindow = window_get_main();
-            // as there are only 4 possible rotations, make any input go to 0-3 to avoid unneccessary work
-            int32_t newRotation = int_val[0] % 4;
+            // there are only 4 possible rotations (0-3)
+            int32_t newRotation = int_val[0] & 3;
             if (newRotation != currentRotation && mainWindow != nullptr)
             {
-                // if desired rotation is less than current, move counter-clockwise
-                if (newRotation < currentRotation)
-                {
-                    while (newRotation != currentRotation)
-                    {
-                        window_rotate_camera(mainWindow, -1);
-                        newRotation++;
-                    }
-                }
-                // otherwise move clockwise
-                else if (newRotation > currentRotation)
-                {
-                    while (newRotation != currentRotation)
-                    {
-                        window_rotate_camera(mainWindow, 1);
-                        newRotation--;
-                    }
-                }
+                window_rotate_camera(mainWindow, newRotation - currentRotation);
             }
+            console.Execute("get current_rotation");
         }
 #ifndef NO_TTF
         else if (strcmp(argv[0], "enable_hinting") == 0 && invalidArguments(&invalidArgs, int_valid[0]))


### PR DESCRIPTION
This is an implementation of this feature request https://openrct2.org/forums/topic/3404-console-addition/

It adds a current_rotation variable whose get is equal to `get_current_rotation()` and set uses `window_rotate_camera` to rotate it to the desired value (from 0-3, although it works for any value it's just % 4) 

This is my first github pull request and everything and I'm kind of rusty with C++ stuff too so obviously appreciate criticism of style and everything. 