### PR TITLE
Fix #8090: Bug with maze design saving

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
+- Fix: [#8090] Maze designs saved incorrectly.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -944,7 +944,7 @@ static bool track_design_save_to_td6_for_maze(uint8_t rideIndex, rct_track_td6* 
     maze++;
     numMazeElements++;
 
-    location = ride_get_entrance_location(rideIndex, 0);
+    location = ride_get_exit_location(rideIndex, 0);
     if (location.isNull())
     {
         gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;


### PR DESCRIPTION
The exit wasn't being saved - ride_get_entrance_location was mistakenly called twice and ride_get_exit_location not at all. Presumably a typo along the way. I've tested and this fixes the bug - mazes can be saved and loaded fine (although obviously maze designs saved before are still broken)