### PR TITLE
Fix #7473: Disable audio on focus loss not correct

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Feature: [#8078] Add save_park command to in-game console.
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
+- Fix: [#7473] Disabling sound effects also disables "Disable audio on focus loss".
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7945] Client IP address is logged as `(null)` in server logs.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -352,7 +352,7 @@ public:
                         }
                     }
 
-                    if (gConfigSound.audio_focus && gConfigSound.sound_enabled)
+                    if (gConfigSound.audio_focus)
                     {
                         if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
                         {


### PR DESCRIPTION
Previously only muted the volume if sound effects was enabled, but ride music is also a possible source of sound.

I just removed the check because I don't see a particular reason why it matters what sound options are enabled, it should always just mute, but maybe I'm wrong.