### PR TITLE
Fix #8102: Create new title sequence dialog is named 'Duplicate'

### DIFF
--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -293,9 +293,8 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
         case WIDX_TITLE_EDITOR_NEW_BUTTON:
             if (!commandEditorOpen)
             {
-                // TODO: This should probably be 'NEW'
                 window_text_input_open(
-                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_NONE, 0,
+                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_CREATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_NONE, 0,
                     64);
             }
             break;


### PR DESCRIPTION
Not sure why it was done like this is the first place, considering the necessary string already existed.