### PR TITLE
Fix #8101: Title Sequences window flashes on opening

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
+- Fix: [#8101] Title sequences window flashes after opening.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -508,7 +508,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
 static void window_title_editor_resize(rct_window* w)
 {
     if (w->selected_tab == WINDOW_TITLE_EDITOR_TAB_PRESETS)
-        window_set_resize(w, WW, WH, 500, WH2);
+        window_set_resize(w, WW, WH2, 500, WH2);
     else
         window_set_resize(w, WW, WH, 500, 580);
 }


### PR DESCRIPTION
Previously a max value lower than min value was being passed to clamp, which caused an assert in debug and weird stuttering on release.
WH2 seems the correct height for both min and max (tab doesn't change).

The defined height constants are a little bit obscure but by context it seems like what was intended and gives the right looking result.
![image](https://user-images.githubusercontent.com/43040194/47085126-8bffb900-d20d-11e8-8280-00afa63f34a1.png)
