### PR TITLE
Disable SSE4 and AVX2 for 32-bit builds

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
 - Fix: [#8101] Title sequences window flashes after opening.
+- Fix: [#8117] OpenRCT2 freezes at start due to AVX2 instructions running on unsupported CPU.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -209,7 +209,7 @@ static bool cpuid_x86(uint32_t* cpuid_outdata, int32_t eax)
 
 bool sse41_available()
 {
-#ifdef OPENRCT2_X86
+#if defined(OPENRCT2_X86) && !defined(PLATFORM_X86)
     // SSE4.1 support is declared as the 19th bit of ECX with CPUID(EAX = 1).
     uint32_t regs[4] = { 0 };
     if (cpuid_x86(regs, 1))
@@ -222,7 +222,7 @@ bool sse41_available()
 
 bool avx2_available()
 {
-#ifdef OPENRCT2_X86
+#if defined(OPENRCT2_X86) && !defined(PLATFORM_X86)
 // For GCC and similar use the builtin function, as cpuid changed its semantics in
 // https://github.com/gcc-mirror/gcc/commit/132fa33ce998df69a9f793d63785785f4b93e6f1
 // which causes it to ignore subleafs, but the new function is unavailable on Ubuntu's


### PR DESCRIPTION
As a preliminary measure for #8117 I am disabling SSE4 and AVX2 for 32-bit builds. This will ensure 32-bit builds cater for lowest common denominator CPUs.