### PR TITLE
Fix scrolling banner drawing invalid text.

### DIFF
--- a/src/openrct2/actions/BannerSetNameAction.hpp
+++ b/src/openrct2/actions/BannerSetNameAction.hpp
@@ -92,6 +92,9 @@ public:
         intent.putExtra(INTENT_EXTRA_BANNER_INDEX, _bannerIndex);
         context_broadcast_intent(&intent);
 
+        scrolling_text_invalidate();
+        gfx_invalidate_screen();
+
         return MakeResult();
     }
 };

--- a/src/openrct2/actions/ParkSetNameAction.hpp
+++ b/src/openrct2/actions/ParkSetNameAction.hpp
@@ -92,7 +92,9 @@ public:
             LogAction(oldName);
         }
 
+        scrolling_text_invalidate();
         gfx_invalidate_screen();
+
         return MakeResult();
     }
 

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -13,6 +13,7 @@
 #include "../Context.h"
 #include "../GameState.h"
 #include "../core/MemoryStream.h"
+#include "../drawing/Drawing.h"
 #include "../interface/Window.h"
 #include "../localisation/Localisation.h"
 #include "../management/NewsItem.h"
@@ -250,6 +251,9 @@ private:
         auto windowManager = OpenRCT2::GetContext()->GetUiContext()->GetWindowManager();
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_RIDE_LIST));
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_REFRESH_GUEST_LIST));
+
+        scrolling_text_invalidate();
+        gfx_invalidate_screen();
 
         return res;
     }

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -92,6 +92,7 @@ public:
         user_string_free(ride->name);
         ride->name = newUserStringId;
 
+        scrolling_text_invalidate();
         gfx_invalidate_screen();
 
         // Refresh windows that display ride name

--- a/src/openrct2/actions/SignSetNameAction.hpp
+++ b/src/openrct2/actions/SignSetNameAction.hpp
@@ -85,6 +85,8 @@ public:
                 user_string_free(prev_string_id);
 
                 banner->flags &= ~(BANNER_FLAG_LINKED_TO_RIDE);
+
+                scrolling_text_invalidate();
                 gfx_invalidate_screen();
             }
             else
@@ -108,6 +110,7 @@ public:
             banner->string_idx = STR_DEFAULT_SIGN;
             user_string_free(prev_string_id);
 
+            scrolling_text_invalidate();
             gfx_invalidate_screen();
         }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -368,6 +368,7 @@ void ttf_draw_string(rct_drawpixelinfo* dpi, const_utf8string text, int32_t colo
 
 // scrolling text
 void scrolling_text_initialise_bitmaps();
+void scrolling_text_invalidate();
 int32_t scrolling_text_setup(struct paint_session* session, rct_string_id stringId, uint16_t scroll, uint16_t scrollingMode);
 
 rct_size16 FASTCALL gfx_get_sprite_size(uint32_t image_id);

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1451,6 +1451,17 @@ static constexpr const int16_t* _scrollPositions[MAX_SCROLLING_TEXT_MODES] = {
 };
 // clang-format on
 
+void scrolling_text_invalidate()
+{
+    for (int32_t i = 0; i < MAX_SCROLLING_TEXT_ENTRIES; i++)
+    {
+        rct_draw_scroll_text& scrollText = _drawScrollTextList[i];
+        scrollText.string_id = 0;
+        scrollText.string_args_0 = 0;
+        scrollText.string_args_1 = 0;
+    }
+}
+
 /**
  *
  *  rct2: 0x006C42D9


### PR DESCRIPTION
This fixes a rather rare issue that would have been caused by cached scrolling text where the text arguments would fit an old string_id entry but with different text, demonstration below:

![2018-10-20_08-59-05703fe0716a8087b25](https://user-images.githubusercontent.com/5415177/47253071-b8564800-d44e-11e8-8062-8743cc024030.gif)

This could be also a possible fix for #8121, I never managed to get it to crash so I can't verify it, its possible that on some platforms the use after free is handled differently.