### PR TITLE
Fix #8120: Crash trying to place peep spawn outside of map.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
 - Fix: [#8101] Title sequences window flashes after opening.
+- Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1332,7 +1332,7 @@ static void window_map_set_peep_spawn_tool_down(int32_t x, int32_t y)
 
     // Verify footpath exists at location, and retrieve coordinates
     footpath_get_coordinates_from_pos(x, y, &mapX, &mapY, &direction, &tileElement);
-    if (mapX == 0x8000)
+    if (mapX == LOCATION_NULL)
         return;
 
     mapZ = tileElement->base_height * 8;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -342,7 +342,7 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
         int32_t direction;
         rct_tile_element* tileElement;
         footpath_get_coordinates_from_pos(x, y, &x, &y, &direction, &tileElement);
-        if (x == 0x8000)
+        if (x == LOCATION_NULL)
             return;
 
         bool isPatrolAreaSet = staff_is_patrol_area_set(200 + selectedPeepType, x, y);


### PR DESCRIPTION
For some reason it was compared against a hardcoded value of 0x8000 instead of LOCATION_NULL. I also replaced another occurrence where it would result the wrong behavior.