### PR TITLE
Fix #8064: Check clearance height before alignment on correct z.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,7 +18,7 @@
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
-- Fix: [#8064] Check clearance height before alignment on correct z.
+- Fix: [#8064] Error about prohibited high construction is sometimes shown as (undefined string).
 - Fix: [#8101] Title sequences window flashes after opening.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
+- Fix: [#8064] Check clearance height before alignment on correct z.
 - Fix: [#8101] Title sequences window flashes after opening.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -28,7 +28,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1077,23 +1077,8 @@ static money32 track_place(
     {
         return MONEY32_UNDEFINED;
     }
+
     const uint16_t* trackFlags = (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ? FlatTrackFlags : TrackFlags;
-    if (trackFlags[type] & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
-    {
-        if ((originZ & 0x0F) != 8)
-        {
-            gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
-            return MONEY32_UNDEFINED;
-        }
-    }
-    else
-    {
-        if ((originZ & 0x0F) != 0)
-        {
-            gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
-            return MONEY32_UNDEFINED;
-        }
-    }
 
     // If that is not the case, then perform the remaining checks
     trackBlock = get_track_def_from_ride(ride, type);
@@ -1144,7 +1129,6 @@ static money32 track_place(
         int32_t x = originX + offsetX;
         int32_t y = originY + offsetY;
         int32_t z = originZ + trackBlock->z;
-
         trackpieceZ = z;
 
         if (z < 16)
@@ -1183,7 +1167,26 @@ static money32 track_place(
                 : CREATE_CROSSING_MODE_NONE;
             if (!map_can_construct_with_clear_at(
                     x, y, baseZ, clearanceZ, &map_place_non_scenery_clear_func, bl, flags, &cost, crossingMode))
+            {
                 return MONEY32_UNDEFINED;
+            }
+
+            if (trackFlags[type] & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
+            {
+                if ((z & 0x0F) != 8)
+                {
+                    gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
+                    return MONEY32_UNDEFINED;
+                }
+            }
+            else
+            {
+                if ((z & 0x0F) != 0)
+                {
+                    gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
+                    return MONEY32_UNDEFINED;
+                }
+            }
         }
 
         // 6c53dc


### PR DESCRIPTION
The checks did not consider the the actual Z where the piece would be placed, also I made sure that it first checks if construction is possible before the alignment checks to avoid the unknown error string.