### PR TITLE
Fix #8099: Inverted RC should have Powered Launch available (from RCT1)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -115,6 +115,7 @@ The following people are not part of the development team, but have been contrib
 * Matthew Beaudin (mattbeaudin)
 * Øystein Dale (oystedal)
 * Christian Schubert (Osmodium)
+* James Lord (RCTMASTA)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
 - Feature: [#8078] Add save_park command to in-game console.
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
+- Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7473] Disabling sound effects also disables "Disable audio on focus loss".
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
@@ -18,7 +19,6 @@
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
-- Fix: [#8099] Inverted RC missing Powered Launch mode from RCT1.
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.
 - Fix: [#8090] Maze designs saved incorrectly.
+- Fix: [#8099] Inverted RC missing Powered Launch mode from RCT1.
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -916,7 +916,7 @@ const uint8_t RideAvailableModes[] = {
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, 0xFF,                                                                       // 00 Spiral Roller coaster
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, 0xFF,                                                                       // 01 Stand Up Coaster
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, 0xFF,                                                                       // 02 Suspended Swinging
-    RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, 0xFF,                                                                       // 03 Inverted
+    RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, RIDE_MODE_POWERED_LAUNCH_PASSTROUGH, RIDE_MODE_POWERED_LAUNCH, 0xFF,        // 03 Inverted
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED, RIDE_MODE_REVERSE_INCLINE_LAUNCHED_SHUTTLE, 0xFF,                           // 04 Steel Mini Coaster
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_SHUTTLE, 0xFF,                                                                                                  // 05 Mini Railway
     RIDE_MODE_CONTINUOUS_CIRCUIT, RIDE_MODE_SHUTTLE, 0xFF,                                                                                                  // 06 Monorail


### PR DESCRIPTION
I'm aware the issue this is fixing ( #8099 ) wasn't even marked as valid due to incompleteness of the initial report but a quick check on my LL copy confirms that this is vanilla behavior from RCT1 that was removed in RCT2.
First time contributing but I peeked through the code and contrib guidelines and this seemed like the right way to implement this, unless I'm missing something.