### PR TITLE
Fix #8134: Only check originZ for alignment.

### DIFF
--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1173,7 +1173,7 @@ static money32 track_place(
 
             if (trackFlags[type] & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
             {
-                if ((z & 0x0F) != 8)
+                if ((originZ & 0x0F) != 8)
                 {
                     gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
                     return MONEY32_UNDEFINED;
@@ -1181,7 +1181,7 @@ static money32 track_place(
             }
             else
             {
-                if ((z & 0x0F) != 0)
+                if ((originZ & 0x0F) != 0)
                 {
                     gGameCommandErrorText = STR_CONSTRUCTION_ERR_UNKNOWN;
                     return MONEY32_UNDEFINED;


### PR DESCRIPTION
Small regression introduced by #8130. I don't quite fully understand why it has to be this way at least this will check the alignment after trying to check if the track piece can be built providing an actual meaningful error.