### PR TITLE
Implement game action logging.

### DIFF
--- a/src/openrct2/actions/BannerSetNameAction.hpp
+++ b/src/openrct2/actions/BannerSetNameAction.hpp
@@ -44,7 +44,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _bannerIndex << _name;
+        stream << DS_TAG(_bannerIndex) << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/ClimateSetAction.hpp
+++ b/src/openrct2/actions/ClimateSetAction.hpp
@@ -35,7 +35,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _climate;
+        stream << DS_TAG(_climate);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -46,7 +46,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _x << _y << _z;
+        stream << DS_TAG(_x) << DS_TAG(_y) << DS_TAG(_z);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -90,8 +90,8 @@ public:
 private:
     uint32_t const _type;
 
-    uint32_t _playerId = 0; // Callee
-    uint32_t _flags = 0;    // GAME_COMMAND_FLAGS
+    NetworkPlayerId_t _playerId = { 0 }; // Callee
+    uint32_t _flags = 0;                 // GAME_COMMAND_FLAGS
     uint32_t _networkId = 0;
     Callback_t _callback;
 
@@ -103,12 +103,12 @@ public:
 
     virtual ~GameAction() = default;
 
-    uint32_t GetPlayer() const
+    NetworkPlayerId_t GetPlayer() const
     {
         return _playerId;
     }
 
-    void SetPlayer(uint32_t playerId)
+    void SetPlayer(NetworkPlayerId_t playerId)
     {
         _playerId = playerId;
     }
@@ -174,9 +174,7 @@ public:
 
     virtual void Serialise(DataSerialiser& stream)
     {
-        stream << _networkId;
-        stream << _flags;
-        stream << _playerId;
+        stream << DS_TAG(_networkId) << DS_TAG(_flags) << DS_TAG(_playerId);
     }
 
     // Helper function, allows const Objects to still serialize into DataSerialiser while being const.

--- a/src/openrct2/actions/GuestSetNameAction.hpp
+++ b/src/openrct2/actions/GuestSetNameAction.hpp
@@ -46,7 +46,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _spriteIndex << _name;
+        stream << DS_TAG(_spriteIndex) << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -56,7 +56,7 @@ private:
     uint16_t _z;
     bool _initialPlacement;
     uint8_t _direction;
-    uint8_t _rideIndex;
+    NetworkRideId_t _rideIndex;
     uint8_t _mode;
 
 public:
@@ -64,7 +64,7 @@ public:
     {
     }
     MazeSetTrackAction(
-        uint16_t x, uint16_t y, uint16_t z, bool initialPlacement, uint8_t direction, uint8_t rideIndex, uint8_t mode)
+        uint16_t x, uint16_t y, uint16_t z, bool initialPlacement, uint8_t direction, NetworkRideId_t rideIndex, uint8_t mode)
         : _x(x)
         , _y(y)
         , _z(z)
@@ -79,7 +79,8 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _x << _y << _z << _initialPlacement << _direction << _rideIndex << _mode;
+        stream << DS_TAG(_x) << DS_TAG(_y) << DS_TAG(_z) << DS_TAG(_initialPlacement) << DS_TAG(_direction)
+               << DS_TAG(_rideIndex) << DS_TAG(_mode);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/ParkMarketingAction.hpp
+++ b/src/openrct2/actions/ParkMarketingAction.hpp
@@ -47,7 +47,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _type << _item << _numWeeks;
+        stream << DS_TAG(_type) << DS_TAG(_item) << DS_TAG(_numWeeks);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/ParkSetLoanAction.hpp
+++ b/src/openrct2/actions/ParkSetLoanAction.hpp
@@ -40,7 +40,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _value;
+        stream << DS_TAG(_value);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/ParkSetNameAction.hpp
+++ b/src/openrct2/actions/ParkSetNameAction.hpp
@@ -44,7 +44,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _name;
+        stream << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override
@@ -85,13 +85,6 @@ public:
         user_string_free(gParkName);
         gParkName = newNameId;
 
-        // Log park rename command if we are in multiplayer and logging is enabled
-        if ((network_get_mode() == NETWORK_MODE_CLIENT || network_get_mode() == NETWORK_MODE_SERVER)
-            && gConfigNetwork.log_server_actions)
-        {
-            LogAction(oldName);
-        }
-
         scrolling_text_invalidate();
         gfx_invalidate_screen();
 
@@ -104,17 +97,5 @@ private:
         char buffer[128];
         format_string(buffer, sizeof(buffer), gParkName, &gParkNameArgs);
         return buffer;
-    }
-
-    void LogAction(const std::string& oldName) const
-    {
-        // Get player name
-        auto playerIndex = network_get_player_index(GetPlayer());
-        auto playerName = network_get_player_name(playerIndex);
-
-        char logMessage[256];
-        const char* args[3] = { playerName, oldName.c_str(), _name.c_str() };
-        format_string(logMessage, sizeof(logMessage), STR_LOG_PARK_NAME, (void*)args);
-        network_append_server_log(logMessage);
     }
 };

--- a/src/openrct2/actions/ParkSetResearchFundingAction.hpp
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.hpp
@@ -43,7 +43,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _priorities << _fundingAmount;
+        stream << DS_TAG(_priorities) << DS_TAG(_fundingAmount);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -51,7 +51,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _x << _y << _z << _direction;
+        stream << DS_TAG(_x) << DS_TAG(_y) << DS_TAG(_z) << DS_TAG(_direction);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/PlacePeepSpawnAction.hpp
+++ b/src/openrct2/actions/PlacePeepSpawnAction.hpp
@@ -44,7 +44,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _location.x << _location.y << _location.z << _location.direction;
+        stream << DS_TAG(_location.x) << DS_TAG(_location.y) << DS_TAG(_location.z) << DS_TAG(_location.direction);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -64,14 +64,13 @@ public:
     uint16_t GetActionFlags() const override
     {
         return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
-        ;
     }
 
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
 
-        stream << _rideType << _subType << _colour1 << _colour2;
+        stream << DS_TAG(_rideType) << DS_TAG(_subType) << DS_TAG(_colour1) << DS_TAG(_colour2);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -31,7 +31,7 @@ using namespace OpenRCT2;
 struct RideDemolishAction : public GameActionBase<GAME_COMMAND_DEMOLISH_RIDE, GameActionResult>
 {
 private:
-    int32_t _rideIndex = -1;
+    NetworkRideId_t _rideIndex{ -1 };
     uint8_t _modifyType = RIDE_MODIFY_DEMOLISH;
 
 public:
@@ -48,7 +48,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _rideIndex << _modifyType;
+        stream << DS_TAG(_rideIndex) << DS_TAG(_modifyType);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -25,7 +25,7 @@
 struct RideSetNameAction : public GameActionBase<GAME_COMMAND_SET_RIDE_NAME, GameActionResult>
 {
 private:
-    int32_t _rideIndex = -1;
+    NetworkRideId_t _rideIndex{ -1 };
     std::string _name;
 
 public:
@@ -47,7 +47,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _rideIndex << _name;
+        stream << DS_TAG(_rideIndex) << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -30,7 +30,7 @@ static rct_string_id _StatusErrorTitles[] = {
 struct RideSetStatusAction : public GameActionBase<GAME_COMMAND_SET_RIDE_STATUS, GameActionResult>
 {
 private:
-    int32_t _rideIndex = -1;
+    NetworkRideId_t _rideIndex{ -1 };
     uint8_t _status = RIDE_STATUS_CLOSED;
 
 public:
@@ -52,7 +52,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _rideIndex << _status;
+        stream << DS_TAG(_rideIndex) << DS_TAG(_status);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/SetParkEntranceFeeAction.hpp
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.hpp
@@ -39,7 +39,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _fee;
+        stream << DS_TAG(_fee);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/SignSetNameAction.hpp
+++ b/src/openrct2/actions/SignSetNameAction.hpp
@@ -43,7 +43,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _bannerIndex << _name;
+        stream << DS_TAG(_bannerIndex) << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/StaffSetColourAction.hpp
+++ b/src/openrct2/actions/StaffSetColourAction.hpp
@@ -44,7 +44,7 @@ public:
     void Serialise(DataSerialiser& stream) override
     {
         GameAction::Serialise(stream);
-        stream << _staffType << _colour;
+        stream << DS_TAG(_staffType) << DS_TAG(_colour);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/StaffSetNameAction.hpp
+++ b/src/openrct2/actions/StaffSetNameAction.hpp
@@ -47,7 +47,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _spriteIndex << _name;
+        stream << DS_TAG(_spriteIndex) << DS_TAG(_name);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/actions/WallRemoveAction.hpp
+++ b/src/openrct2/actions/WallRemoveAction.hpp
@@ -35,7 +35,7 @@ public:
     {
         GameAction::Serialise(stream);
 
-        stream << _location.x << _location.y << _location.z << _location.direction;
+        stream << DS_TAG(_location.x) << DS_TAG(_location.y) << DS_TAG(_location.z) << DS_TAG(_location.direction);
     }
 
     GameActionResult::Ptr Query() const override

--- a/src/openrct2/core/DataSerialiserTag.h
+++ b/src/openrct2/core/DataSerialiserTag.h
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2018 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+template<typename T> class DataSerialiserTag
+{
+public:
+    DataSerialiserTag(const char* name, T& data)
+        : _name(name)
+        , _data(data)
+    {
+    }
+
+    const char* Name() const
+    {
+        return _name;
+    }
+
+    T& Data() const
+    {
+        return _data;
+    }
+
+private:
+    const char* _name = nullptr;
+    T& _data;
+};
+
+template<typename T> inline DataSerialiserTag<T> CreateDataSerialiserTag(const char* name, T& data)
+{
+    DataSerialiserTag<T> r(name, data);
+    return r;
+}
+
+#define DS_TAG(var) CreateDataSerialiserTag(#var, var)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2635,7 +2635,7 @@ void Network::Client_Handle_GAME_ACTION([[maybe_unused]] NetworkConnection& conn
     }
     action->Serialise(ds);
 
-    if (player_id == action->GetPlayer())
+    if (player_id == action->GetPlayer().id)
     {
         // Only execute callbacks that belong to us,
         // clients can have identical network ids assigned.
@@ -2721,7 +2721,7 @@ void Network::Server_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPa
 
     ga->Serialise(stream);
     // Set player to sender, should be 0 if sent from client.
-    ga->SetPlayer(connection.Player->Id);
+    ga->SetPlayer(NetworkPlayerId_t{ connection.Player->Id });
 
     game_command_queue.emplace(tick, std::move(ga), _commandId++);
 }
@@ -3143,7 +3143,7 @@ uint32_t network_get_player_commands_ran(uint32_t index)
     return gNetwork.player_list[index]->CommandsRan;
 }
 
-int32_t network_get_player_index(uint8_t id)
+int32_t network_get_player_index(uint32_t id)
 {
     auto it = gNetwork.GetPlayerIteratorByID(id);
     if (it == gNetwork.player_list.end())
@@ -3915,7 +3915,7 @@ uint32_t network_get_player_commands_ran(uint32_t index)
 {
     return 0;
 }
-int32_t network_get_player_index(uint8_t id)
+int32_t network_get_player_index(uint32_t id)
 {
     return -1;
 }

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -68,3 +68,30 @@ enum NETWORK_COMMAND
     NETWORK_COMMAND_MAX,
     NETWORK_COMMAND_INVALID = -1
 };
+
+// Structure is used for networking specific fields with meaning,
+// this structure can be used in combination with DataSerialiser
+// to provide extra details with template specialization.
+#pragma pack(push, 1)
+template<typename T, size_t _TypeID> struct NetworkObjectId_t
+{
+    NetworkObjectId_t(T v)
+        : id(v)
+    {
+    }
+    NetworkObjectId_t()
+        : id(T(-1))
+    {
+    }
+    operator T() const
+    {
+        return id;
+    }
+    T id;
+};
+#pragma pack(pop)
+
+// NOTE: When adding new types make sure to have no duplicate _TypeID's otherwise
+// there is no way to specialize templates if they have the exact symbol.
+using NetworkPlayerId_t = NetworkObjectId_t<int32_t, 0>;
+using NetworkRideId_t = NetworkObjectId_t<int32_t, 1>;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -57,7 +57,7 @@ void network_set_player_last_action(uint32_t index, int32_t command);
 LocationXYZ16 network_get_player_last_action_coord(uint32_t index);
 void network_set_player_last_action_coord(uint32_t index, LocationXYZ16 coord);
 uint32_t network_get_player_commands_ran(uint32_t index);
-int32_t network_get_player_index(uint8_t id);
+int32_t network_get_player_index(uint32_t id);
 uint8_t network_get_player_group(uint32_t index);
 void network_set_player_group(uint32_t index, uint32_t groupindex);
 int32_t network_get_group_index(uint8_t id);


### PR DESCRIPTION
This will use the underlying serialization routines to also output a readable version. I've introduced a new class called DataSerialiserTag which is just a small proxy for the variables to include a name which the serializer can use to format the output. I've also specialized some types for the network such as Player Id and Ride Id which also the serializer uses to print more data into the log.

Heres some example output of a server log:
```[2018/10/23 18:35:18] [sv] Game Action 00000006 (_networkId = 00000000; _flags = 80000000; _playerId = 0 "Matt"; _rideType = 0000002E; _subType = 0000000D; _colour1 = 00; _colour2 = 00; ) OK
[2018/10/23 18:35:24] [sv] Game Action 00000008 (_networkId = 00000000; _flags = 80000000; _playerId = 0 "Matt"; _rideIndex = 2 "Twist 1"; _status = 02; ) OK
[2018/10/23 18:35:26] [sv] Game Action 00000008 (_networkId = 00000000; _flags = 80000000; _playerId = 0 "Matt"; _rideIndex = 2 "Twist 1"; _status = 01; ) OK
[2018/10/23 18:37:16] [sv] Game Action 00000007 (_networkId = 00000001; _flags = 80000001; _playerId = 1 "Matt #2"; _rideIndex = 2 "Twist 1"; _modifyType = 00; ) OK
[2018/10/23 18:46:39] [sv] Game Action 0000000A (_networkId = 00000000; _flags = 80000000; _playerId = 0 "Matt"; _rideIndex = 2 "Twist 1"; _name = "Better Twister"; ) OK
```
I think we could add a lot more detail but this should provide enough for some groundwork considering game actions currently don't log anything exception with renaming the park.