### PR TITLE
Enable gzip-compression of minidumps, update information

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@
 2. 
 
 **Dump file**
-<!-- If you have a dump file: zip it before you drag & drop it here. -->
+<!-- If you have a dump file: .dmp.gz will be accepted directly, otherwise zip it before you drag & drop it here. -->
 
 **Screenshots / Video:**
 <!-- Drag & drop screenshots here. You can use https://youtube.com to upload video. -->

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Feature: [#7971] Toolbox option to open custom content folder.
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
-- Feature: [#8073] Auto-upload minidumps to backtrace.io (MSVC/Windows only)
+- Feature: [#8073] Auto-upload minidumps to backtrace.io (optional, MSVC/Windows only)
 - Feature: [#8078] Add save_park command to in-game console.
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#7956, #7964] Add sprite font glyphs for Hungarian and some Czech letters.
 - Feature: [#7971] Toolbox option to open custom content folder.
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
+- Feature: [#8073] Auto-upload minidumps to backtrace.io (MSVC/Windows only)
 - Feature: [#8078] Add save_park command to in-game console.
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).

--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -103,18 +103,22 @@ static bool OnCrash(
     wchar_t dumpFilePathGZIP[MAX_PATH];
     swprintf_s(dumpFilePathGZIP, sizeof(dumpFilePathGZIP), L"%s.gz", dumpFilePathNew);
 
-    // TODO: enable gzip compression once supported on backtrace.io
-    /*
     FILE* input = _wfopen(dumpFilePath, L"rb");
     FILE* dest = _wfopen(dumpFilePathGZIP, L"wb");
 
     if (util_gzip_compress(input, dest))
     {
+        // TODO: enable upload of gzip-compressed dumps once supported on
+        // backtrace.io (uncomment the line below). For now leave compression
+        // on, as GitHub will accept .gz files, even though it does not
+        // advertise it officially.
+
+        /*
         minidumpToUpload = dumpFilePathGZIP;
+        */
     }
     fclose(input);
     fclose(dest);
-    */
 
     // Try to rename the files
     if (_wrename(dumpFilePath, dumpFilePathNew) == 0)


### PR DESCRIPTION
Enable gzip, but only for local save, as GitHub will accept
gzip-compressed files even if they don't advertise it explicitly. Update
changelog and GitHub issue template to relfect that.