### PR TITLE
Fix #8121: Crash renaming park with server logging enabled.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#8090] Maze designs saved incorrectly.
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
+- Fix: [#8121] Crash Renaming park with server logging enabled.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/actions/ParkSetNameAction.hpp
+++ b/src/openrct2/actions/ParkSetNameAction.hpp
@@ -109,7 +109,7 @@ private:
     void LogAction(const std::string& oldName) const
     {
         // Get player name
-        auto playerIndex = network_get_player_index(game_command_playerid);
+        auto playerIndex = network_get_player_index(GetPlayer());
         auto playerName = network_get_player_name(playerIndex);
 
         char logMessage[256];


### PR DESCRIPTION
This was caused by reading the wrong player id from game_command_playerid which is never assigned with the new game actions and must use GetPlayer() instead. Basically the PR https://github.com/OpenRCT2/OpenRCT2/pull/8138 would already fix this issue but for the time being this is a much smaller change.