### PR TITLE
Fix for Issue #8151

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -51,6 +51,7 @@
 - Fix: [#8139] Buying land costs money when the game is in "no money" mode.
 - Fix: [#8141] Attempting to build entrance/exit on station 2 does not work.
 - Fix: [#8142] Reliability of mazes and crooked houses can go below 100%.
+- Fix: [#8151] Game freezes upon demolishing mazes at odd heights.
 - Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
 - Fix: [#8200] Incorrect behaviour when removing entrances and exits that are on the same tile.
 - Fix: [#8204] Crash when tile element has no surface elements.

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -93,6 +93,18 @@ public:
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
         res->ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 
+        if (_mode == GC_SET_MAZE_TRACK_BUILD)
+        {
+            return QueryBuild(std::move(res));
+        }
+        else
+        {
+            return QueryOther(std::move(res));
+        }
+    }
+
+    GameActionResult::Ptr QueryBuild(GameActionResult::Ptr res) const
+    {
         if (!map_check_free_elements_and_reorganise(1))
         {
             res->Error = GA_ERROR::NO_FREE_ELEMENTS;
@@ -141,13 +153,6 @@ public:
         tileElement = map_get_track_element_at_of_type_from_ride(_x, _y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
         if (tileElement == nullptr)
         {
-            if (_mode != GC_SET_MAZE_TRACK_BUILD)
-            {
-                res->Error = GA_ERROR::UNKNOWN;
-                res->ErrorMessage = STR_INVALID_SELECTION_OF_OBJECTS;
-                return res;
-            }
-
             if (!map_can_construct_at(floor2(_x, 32), floor2(_y, 32), baseHeight, clearanceHeight, { 0b1111, 0 }))
             {
                 res->Error = GA_ERROR::NO_CLEARANCE;
@@ -180,6 +185,28 @@ public:
             money32 price = (((RideTrackCosts[ride->type].track_price * TrackPricing[TRACK_ELEM_MAZE]) >> 16));
             res->Cost = price / 2 * 10;
 
+            return res;
+        }
+
+        return std::make_unique<GameActionResult>();
+    }
+
+    GameActionResult::Ptr QueryOther(GameActionResult::Ptr res) const
+    {
+        TileElement* tileElement = map_get_surface_element_at(_x / 32, _y / 32);
+        if (tileElement == nullptr)
+        {
+            res->Error = GA_ERROR::UNKNOWN;
+            res->ErrorMessage = STR_INVALID_SELECTION_OF_OBJECTS;
+            return res;
+        }
+
+        uint8_t baseHeight = _z >> 3;
+        tileElement = map_get_track_element_at_of_type_from_ride(_x, _y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+        if (tileElement == nullptr)
+        {
+            res->Error = GA_ERROR::UNKNOWN;
+            res->ErrorMessage = STR_INVALID_SELECTION_OF_OBJECTS;
             return res;
         }
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "53"
+#define NETWORK_STREAM_VERSION "54"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Issue #8151
First PR here! Open to all comments if I messed something up.

Added a check to allow filling/demolishing a maze track that was previously built at a half-step.
Normally, the track can only be built at a half-step through the Tile Inspector.
Building a new track on a half-step is still disallowed.
In any case, it seems reasonable to let the player edit a maze track, even thought it was wrongly built.

