### PR TITLE
Fix #8142: Freeze reliability of unbreakable rides to 100%

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Fix: [#8121] Crash Renaming park with server logging enabled.
+- Fix: [#8142] Reliability of mazes and crooked houses can go below 100%.
 - Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -28,7 +28,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -210,7 +210,6 @@ static void ride_call_mechanic(int32_t rideIndex, rct_peep* mechanic, int32_t fo
 static void ride_chairlift_update(Ride* ride);
 static void ride_entrance_exit_connected(Ride* ride, int32_t ride_idx);
 static void ride_set_name_to_vehicle_default(Ride* ride, rct_ride_entry* rideEntry);
-static bool ride_can_breakdown(Ride* ride);
 static int32_t ride_get_new_breakdown_problem(Ride* ride);
 static void ride_inspection_update(Ride* ride);
 static void ride_mechanic_status_update(int32_t rideIndex, int32_t mechanicStatus);
@@ -263,7 +262,7 @@ rct_ride_measurement* get_ride_measurement(int32_t index)
     return &gRideMeasurements[index];
 }
 
-rct_ride_entry* get_ride_entry_by_ride(Ride* ride)
+rct_ride_entry* get_ride_entry_by_ride(const Ride* ride)
 {
     rct_ride_entry* type = get_ride_entry(ride->subtype);
     if (type == nullptr)
@@ -2480,7 +2479,7 @@ static void ride_breakdown_update(int32_t rideIndex)
     if (ride->status == RIDE_STATUS_CLOSED)
         return;
 
-    if (!ride_can_breakdown(ride))
+    if (!ride->CanBreakDown())
     {
         ride->reliability = RIDE_INITIAL_RELIABILITY;
         return;
@@ -2517,7 +2516,7 @@ static int32_t ride_get_new_breakdown_problem(Ride* ride)
     // Brake failure is more likely when it's raining
     _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE] = climate_is_raining() ? 20 : 3;
 
-    if (!ride_can_breakdown(ride))
+    if (!ride->CanBreakDown())
         return -1;
 
     availableBreakdownProblems = RideAvailableBreakdowns[ride->type];
@@ -2567,14 +2566,14 @@ static int32_t ride_get_new_breakdown_problem(Ride* ride)
     return BREAKDOWN_BRAKES_FAILURE;
 }
 
-static bool ride_can_breakdown(Ride* ride)
+bool Ride::CanBreakDown() const
 {
-    if (RideAvailableBreakdowns[ride->type] == 0)
+    if (RideAvailableBreakdowns[this->type] == 0)
     {
         return false;
     }
 
-    rct_ride_entry* entry = get_ride_entry_by_ride(ride);
+    rct_ride_entry* entry = get_ride_entry_by_ride(this);
     if (entry == nullptr || entry->flags & RIDE_ENTRY_FLAG_CANNOT_BREAK_DOWN)
     {
         return false;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -210,6 +210,7 @@ static void ride_call_mechanic(int32_t rideIndex, rct_peep* mechanic, int32_t fo
 static void ride_chairlift_update(Ride* ride);
 static void ride_entrance_exit_connected(Ride* ride, int32_t ride_idx);
 static void ride_set_name_to_vehicle_default(Ride* ride, rct_ride_entry* rideEntry);
+static bool ride_can_breakdown(Ride* ride);
 static int32_t ride_get_new_breakdown_problem(Ride* ride);
 static void ride_inspection_update(Ride* ride);
 static void ride_mechanic_status_update(int32_t rideIndex, int32_t mechanicStatus);
@@ -2479,6 +2480,12 @@ static void ride_breakdown_update(int32_t rideIndex)
     if (ride->status == RIDE_STATUS_CLOSED)
         return;
 
+    if (!ride_can_breakdown(ride))
+    {
+        ride->reliability = RIDE_INITIAL_RELIABILITY;
+        return;
+    }
+
     // Calculate breakdown probability?
     int32_t unreliabilityAccumulator = ride->unreliability_factor + get_age_penalty(ride);
     ride->reliability = (uint16_t)std::max(0, (ride->reliability - unreliabilityAccumulator));
@@ -2506,13 +2513,11 @@ static void ride_breakdown_update(int32_t rideIndex)
 static int32_t ride_get_new_breakdown_problem(Ride* ride)
 {
     int32_t availableBreakdownProblems, monthsOld, totalProbability, randomProbability, problemBits, breakdownProblem;
-    rct_ride_entry* entry;
 
     // Brake failure is more likely when it's raining
     _breakdownProblemProbabilities[BREAKDOWN_BRAKES_FAILURE] = climate_is_raining() ? 20 : 3;
 
-    entry = get_ride_entry_by_ride(ride);
-    if (entry == nullptr || entry->flags & RIDE_ENTRY_FLAG_CANNOT_BREAK_DOWN)
+    if (!ride_can_breakdown(ride))
         return -1;
 
     availableBreakdownProblems = RideAvailableBreakdowns[ride->type];
@@ -2560,6 +2565,22 @@ static int32_t ride_get_new_breakdown_problem(Ride* ride)
         return -1;
 
     return BREAKDOWN_BRAKES_FAILURE;
+}
+
+static bool ride_can_breakdown(Ride* ride)
+{
+    if (RideAvailableBreakdowns[ride->type] == 0)
+    {
+        return false;
+    }
+
+    rct_ride_entry* entry = get_ride_entry_by_ride(ride);
+    if (entry == nullptr || entry->flags & RIDE_ENTRY_FLAG_CANNOT_BREAK_DOWN)
+    {
+        return false;
+    }
+
+    return true;
 }
 
 static void choose_random_train_to_breakdown_safe(Ride* ride)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -341,6 +341,7 @@ struct Ride
     uint8_t cable_lift_z;
     uint16_t cable_lift;
     uint16_t queue_length[MAX_STATIONS];
+    bool CanBreakDown() const;
 };
 
 #pragma pack(push, 1)
@@ -1032,7 +1033,7 @@ track_colour ride_get_track_colour(Ride* ride, int32_t colourScheme);
 vehicle_colour ride_get_vehicle_colour(Ride* ride, int32_t vehicleIndex);
 int32_t ride_get_unused_preset_vehicle_colour(uint8_t ride_sub_type);
 void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index);
-rct_ride_entry* get_ride_entry_by_ride(Ride* ride);
+rct_ride_entry* get_ride_entry_by_ride(const Ride* ride);
 uint8_t* get_ride_entry_indices_for_ride_type(uint8_t rideType);
 void reset_type_to_ride_entry_index_map(IObjectManager& objectManager);
 void ride_measurement_clear(Ride* ride);

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -138,7 +138,7 @@ rct_ride_entry* get_ride_entry(int index)
     return gRideEntries[index];
 }
 
-rct_ride_entry* get_ride_entry_by_ride(Ride* ride)
+rct_ride_entry* get_ride_entry_by_ride(const Ride* ride)
 {
     rct_ride_entry* type = get_ride_entry(ride->subtype);
     if (type == nullptr)


### PR DESCRIPTION
#8142 
It is my understanding that the "RIDE_ENTRY_FLAG_CANNOT_BREAK_DOWN" flag is not the sole "unbreakable" indicator (it doesn't seem to be set for mazes for example). 
We need to check that there are no breakdowns available.

I don't know the "legacy data" part of the game. Whould it be sufficient to only check for RideAvailableBreakdowns?