### PR TITLE
Fix #8187: Cannot claim land over ride entrances/exits

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,7 +23,7 @@
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Fix: [#8121] Crash Renaming park with server logging enabled.
-- Fix: [#8187] Cannot claim land or set construction rights over ride entrances or exits
+- Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Fix: [#8121] Crash Renaming park with server logging enabled.
+- Fix: [#8187] Cannot claim land or set construction rights over ride entrances or exits
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -358,7 +358,8 @@ static money32 map_buy_land_rights_for_tile(int32_t x, int32_t y, int32_t settin
             rct_tile_element* tileElement = map_get_first_element_at(x / 32, y / 32);
             do
             {
-                if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
+                if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE
+                    && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                 {
                     // Do not allow ownership of park entrance.
                     if (newOwnership == OWNERSHIP_OWNED || newOwnership == OWNERSHIP_AVAILABLE)


### PR DESCRIPTION
Allows claiming land and construction rights over ride entrances and exits.