### PR TITLE
Allow building footpaths on 'corner down' terrain

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [#8078] Add save_park command to in-game console.
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).
+- Feature: [#8190] Allow building footpaths on 'corner down' terrain.
 - Feature: [#8191] Allow building on-ride photos and water S-bends on the Water Coaster.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7473] Disabling sound effects also disables "Disable audio on focus loss".

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -154,14 +154,14 @@ static constexpr const uint8_t DefaultPathSlope[] = {
     SLOPE_IS_IRREGULAR_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
     FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 3,
-    SLOPE_IS_IRREGULAR_FLAG,
+    RAISE_FOOTPATH_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
     FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 1,
     SLOPE_IS_IRREGULAR_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
+    RAISE_FOOTPATH_FLAG,
     FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 0,
-    SLOPE_IS_IRREGULAR_FLAG,
-    SLOPE_IS_IRREGULAR_FLAG,
+    RAISE_FOOTPATH_FLAG,
+    RAISE_FOOTPATH_FLAG,
     SLOPE_IS_IRREGULAR_FLAG,
 };
 
@@ -763,9 +763,15 @@ static void window_footpath_set_provisional_path_at_point(int32_t x, int32_t y)
                     slope |= FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
                 break;
         }
+        uint8_t z = tileElement->base_height;
+        if (slope & RAISE_FOOTPATH_FLAG)
+        {
+            slope &= ~RAISE_FOOTPATH_FLAG;
+            z += 2;
+        }
         int32_t pathType = (gFootpathSelectedType << 7) + (gFootpathSelectedId & 0xFF);
 
-        _window_footpath_cost = footpath_provisional_set(pathType, x, y, tileElement->base_height, slope);
+        _window_footpath_cost = footpath_provisional_set(pathType, x, y, z, slope);
         window_invalidate_by_class(WC_FOOTPATH);
     }
 }
@@ -863,6 +869,11 @@ static void window_footpath_place_path_at_point(int32_t x, int32_t y)
             break;
     }
     z = tileElement->base_height;
+    if (currentType & RAISE_FOOTPATH_FLAG)
+    {
+        currentType &= ~RAISE_FOOTPATH_FLAG;
+        z += 2;
+    }
     selectedType = (gFootpathSelectedType << 7) + (gFootpathSelectedId & 0xFF);
 
     // Try and place path

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -28,7 +28,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -103,7 +103,8 @@ enum
 
 enum
 {
-    SLOPE_IS_IRREGULAR_FLAG = (1 << 3), // Flag set in `defaultPathSlope[]` and checked in `footpath_place_real`
+    SLOPE_IS_IRREGULAR_FLAG = (1 << 3), // Flag set in `DefaultPathSlope[]` and checked in `footpath_place_real`
+    RAISE_FOOTPATH_FLAG = (1 << 4)
 };
 
 extern uint8_t gFootpathProvisionalFlags;


### PR DESCRIPTION
This PR allows building footpaths on corner-down land pieces without using bridge mode.

![six flags 2018-10-31 13-48-48](https://user-images.githubusercontent.com/1478678/47789036-be340f00-dd13-11e8-993a-b6e28761851f.png)
