### PR TITLE
Increase network version to avoid conflicts

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -28,7 +28,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
#8053 bumped the network version to 3, which we already had before but [was reverted](https://github.com/OpenRCT2/OpenRCT2/commit/15490010e1e71311a5ce5eff728bc2beb1c3e75e#diff-4a91630fd1f8bc5a6e9d68f9fecea3c3).