### PR TITLE
Minor format_string refactor.

### DIFF
--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -1284,7 +1284,7 @@ static void format_string_part(utf8** dest, size_t* size, rct_string_id format, 
  * format (ax)
  * args (ecx)
  */
-void format_string(utf8* dest, size_t size, rct_string_id format, void* args)
+void format_string(utf8* dest, size_t size, rct_string_id format, const void* args)
 {
 #ifdef DEBUG
     if (gDebugStringFormatting)
@@ -1319,7 +1319,7 @@ void format_string(utf8* dest, size_t size, rct_string_id format, void* args)
 #endif
 }
 
-void format_string_raw(utf8* dest, size_t size, utf8* src, void* args)
+void format_string_raw(utf8* dest, size_t size, const utf8* src, const void* args)
 {
 #ifdef DEBUG
     if (gDebugStringFormatting)
@@ -1361,7 +1361,7 @@ void format_string_raw(utf8* dest, size_t size, utf8* src, void* args)
  * format (ax)
  * args (ecx)
  */
-void format_string_to_upper(utf8* dest, size_t size, rct_string_id format, void* args)
+void format_string_to_upper(utf8* dest, size_t size, rct_string_id format, const void* args)
 {
 #ifdef DEBUG
     if (gDebugStringFormatting)

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -25,9 +25,9 @@ bool utf8_should_use_sprite_for_codepoint(int32_t codepoint);
 int32_t utf8_get_format_code_arg_length(int32_t codepoint);
 void utf8_remove_formatting(utf8* string, bool allowColours);
 
-void format_string(char* dest, size_t size, rct_string_id format, void* args);
-void format_string_raw(char* dest, size_t size, char* src, void* args);
-void format_string_to_upper(char* dest, size_t size, rct_string_id format, void* args);
+void format_string(char* dest, size_t size, rct_string_id format, const void* args);
+void format_string_raw(char* dest, size_t size, const char* src, const void* args);
+void format_string_to_upper(char* dest, size_t size, rct_string_id format, const void* args);
 void generate_string_file();
 utf8* get_string_end(const utf8* text);
 size_t get_string_size(const utf8* text);


### PR DESCRIPTION
Made arguments to format_string(...), format_string_raw(...) and format_string_to_upper(...) const where possible.