### PR TITLE
Fix #8207: ride_create_command ignoring game action result.

### DIFF
--- a/src/openrct2/actions/GameActionCompat.cpp
+++ b/src/openrct2/actions/GameActionCompat.cpp
@@ -122,6 +122,12 @@ money32 ride_create_command(int32_t type, int32_t subType, int32_t flags, uint8_
     auto r = GameActions::Execute(&gameAction);
     const RideCreateGameActionResult* res = static_cast<RideCreateGameActionResult*>(r.get());
 
+    // Callee's of this function expect MONEY32_UNDEFINED in case of failure.
+    if (res->Error != GA_ERROR::OK)
+    {
+        return MONEY32_UNDEFINED;
+    }
+
     *outRideIndex = res->rideIndex;
     *outRideColour = colour1;
 


### PR DESCRIPTION
This was probably my fault when porting ride creation to game actions. It never considered that action result may not be ok and used uninitialized variables afterwards.