### PR TITLE
Fix #8204: Crash when tile element has no surface elements.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#8121] Crash Renaming park with server logging enabled.
 - Fix: [#8142] Reliability of mazes and crooked houses can go below 100%.
 - Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
+- Fix: [#8204] Crash when tile element has no surface elements.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1814,7 +1814,7 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
 
     TileElement* tile_element = map_get_surface_element_at({ x, y });
     // If vehicle above ground.
-    if (tile_element->base_height * 8 <= z)
+    if (tile_element != nullptr && tile_element->base_height * 8 <= z)
     {
         // Set tile_element to first element. Since elements aren't always ordered by base height,
         // we must start at the first element and iterate through each tile element.


### PR DESCRIPTION
Simply a missing null pointer check.