### PR TITLE
Fix #8212: Crash when opening rides with changed mode and no tracks.

### DIFF
--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1018,7 +1018,7 @@ void ride_check_all_reachable();
 void ride_update_satisfaction(Ride* ride, uint8_t happiness);
 void ride_update_popularity(Ride* ride, uint8_t pop_amount);
 bool ride_try_get_origin_element(int32_t rideIndex, CoordsXYE* output);
-int32_t ride_find_track_gap(CoordsXYE* input, CoordsXYE* output);
+int32_t ride_find_track_gap(int32_t rideIndex, CoordsXYE* input, CoordsXYE* output);
 void ride_construct_new(ride_list_item listItem);
 void ride_construct(int32_t rideIndex);
 int32_t ride_modify(CoordsXYE* input);


### PR DESCRIPTION
The crash is mainly if the mode is set to something that has no tracks such as the Maze that would try to access null given that in an earlier function it would assign input.element to null given that there are no tracks. Also instead of trying to find the ride index over the tile element I simply pass it down from the beginning which makes more sense in my opinion.