### PR TITLE
Fix #7689: Deleting 0-tile maze gives a MONEY32_UNDEFINED (negative) refund.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Change: [#8222] The climate setting has been moved from objective options to scenario options.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7473] Disabling sound effects also disables "Disable audio on focus loss".
+- Fix: [#7689] Deleting 0-tile maze gives a MONEY32_UNDEFINED (negative) refund.
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
 - Fix: [#7945] Client IP address is logged as `(null)` in server logs.
 - Fix: [#7952] Performance drop caused by code refactor.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5989,8 +5989,7 @@ int32_t ride_get_refund_price(int32_t ride_id)
 
     if (!ride_try_get_origin_element(ride_id, &trackElement))
     {
-        gGameCommandErrorText = STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
-        return MONEY32_UNDEFINED;
+        return 0; // Ride has no track to refund
     }
 
     // Find the start in case it is not a complete circuit


### PR DESCRIPTION
#7689 
When deleting, a function is called to get the origin of a ride in order to delete it track by track.
If the ride has no tracks a STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY error was declared and MONEY32_UNDEFINED was returned.

Looking at the code for ride_try_get_origin_element() it can be found that this error can't really happen, and the only reason it could return false is that the ride has no tracks. Therefore, the refund should be 0.