### PR TITLE
Refactor/s4 tile element

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -610,7 +610,7 @@ struct rct1_s4
     uint32_t ticks;
     uint32_t random_a;
     uint32_t random_b;
-    TileElement tile_elements[RCT1_MAX_TILE_ELEMENTS];
+    RCT12TileElement tile_elements[RCT1_MAX_TILE_ELEMENTS];
     uint32_t unk_counter;
     rct1_sprite sprites[RCT1_MAX_SPRITES];
     uint16_t next_sprite_index;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2060,7 +2060,7 @@ private:
                 dst2->SetColourScheme(src2->GetColourScheme());
                 dst2->SetStationIndex(src2->GetStationIndex());
                 dst2->SetHasChain(src2->HasChain());
-                dst2->SetHasCableLift(src2->HasCableLift());
+                dst2->SetHasCableLift(false);
                 dst2->SetInverted(src2->IsInverted());
                 dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
                 dst2->SetHasGreenLight(src2->HasGreenLight());
@@ -2134,13 +2134,8 @@ private:
 
                 dst2->SetEntryIndex(src2->GetEntryIndex());
                 dst2->SetSlope(src2->GetSlope());
-                dst2->SetPrimaryColour(src2->GetPrimaryColour());
-                dst2->SetSecondaryColour(src2->GetSecondaryColour());
-                dst2->SetTertiaryColour(src2->GetTertiaryColour());
-                dst2->SetAnimationFrame(src2->GetAnimationFrame());
-                dst2->SetBannerIndex(src2->GetBannerIndex());
-                dst2->SetAcrossTrack(src2->IsAcrossTrack());
-                dst2->SetAnimationIsBackwards(src2->AnimationIsBackwards());
+                dst2->SetPrimaryColour(RCT1::GetColour(src2->GetRCT1WallColour()));
+                dst2->SetRawRCT1Data(src2->GetRawRCT1WallTypeData());
 
                 break;
             }
@@ -2154,7 +2149,6 @@ private:
                 dst2->SetSequenceIndex(src2->GetSequenceIndex());
                 dst2->SetPrimaryColour(RCT1::GetColour(src2->GetPrimaryColour()));
                 dst2->SetSecondaryColour(RCT1::GetColour(src2->GetSecondaryColour()));
-                dst2->SetBannerIndex(src2->GetBannerIndex());
 
                 break;
             }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1973,9 +1973,7 @@ private:
 
         ClearExtraTileEntries();
         FixWalls();
-        FixBanners();
         FixEntrancePositions();
-        FixTileElementEntryTypes();
     }
 
     void ImportTileElement(TileElement* dst, const RCT12TileElement* src)
@@ -2080,7 +2078,8 @@ private:
                 auto dst2 = dst->AsSmallScenery();
                 auto src2 = src->AsSmallScenery();
 
-                dst2->SetEntryIndex(src2->GetEntryIndex());
+                uint8_t entryIndex = _smallSceneryTypeToEntryMap[src2->GetEntryIndex()];
+                dst2->SetEntryIndex(entryIndex);
                 dst2->SetAge(src2->GetAge());
                 dst2->SetSceneryQuadrant(src2->GetSceneryQuadrant());
                 dst2->SetPrimaryColour(RCT1::GetColour(src2->GetPrimaryColour()));
@@ -2164,9 +2163,14 @@ private:
                 auto dst2 = dst->AsBanner();
                 auto src2 = src->AsBanner();
 
-                dst2->SetIndex(src2->GetIndex());
+                uint8_t index = src2->GetIndex();
+                dst2->SetIndex(index);
                 dst2->SetPosition(src2->GetPosition());
                 dst2->SetAllowedEdges(src2->GetAllowedEdges());
+
+                rct_banner* srcBanner = &_s4.banners[index];
+                rct_banner* dstBanner = &gBanners[index];
+                ImportBanner(dstBanner, srcBanner);
 
                 break;
             }
@@ -2720,27 +2724,6 @@ private:
         }
     }
 
-    void FixBanners()
-    {
-        for (int32_t x = 0; x < RCT1_MAX_MAP_SIZE; x++)
-        {
-            for (int32_t y = 0; y < RCT1_MAX_MAP_SIZE; y++)
-            {
-                TileElement* tileElement = map_get_first_element_at(x, y);
-                do
-                {
-                    if (tileElement->GetType() == TILE_ELEMENT_TYPE_BANNER)
-                    {
-                        uint8_t index = tileElement->AsBanner()->GetIndex();
-                        rct_banner* src = &_s4.banners[index];
-                        rct_banner* dst = &gBanners[index];
-                        ImportBanner(dst, src);
-                    }
-                } while (!(tileElement++)->IsLastForTile());
-            }
-        }
-    }
-
     void ImportBanner(rct_banner* dst, rct_banner* src)
     {
         *dst = *src;
@@ -2788,25 +2771,6 @@ private:
             gParkEntrances[entranceIndex].z = element->base_height * 8;
             gParkEntrances[entranceIndex].direction = element->GetDirection();
             entranceIndex++;
-        }
-    }
-
-    void FixTileElementEntryTypes()
-    {
-        tile_element_iterator it;
-        tile_element_iterator_begin(&it);
-        while (tile_element_iterator_next(&it))
-        {
-            TileElement* tileElement = it.element;
-            switch (tileElement->GetType())
-            {
-                case TILE_ELEMENT_TYPE_SMALL_SCENERY:
-                {
-                    uint8_t entryIndex = _smallSceneryTypeToEntryMap[tileElement->AsSmallScenery()->GetEntryIndex()];
-                    tileElement->AsSmallScenery()->SetEntryIndex(entryIndex);
-                    break;
-                }
-            }
         }
     }
 

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -332,6 +332,11 @@ bool RCT12WallElement::AnimationIsBackwards() const
     return (animation & WALL_ANIMATION_FLAG_DIRECTION_BACKWARD) != 0;
 }
 
+uint32_t RCT12WallElement::GetRawRCT1WallTypeData() const
+{
+    return colour_3 | (colour_1 << 8) | (animation << 16);
+}
+
 int32_t RCT12WallElement::GetRCT1WallType(int32_t edge) const
 {
     uint8_t var_05 = colour_3;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -310,6 +310,7 @@ public:
     BannerIndex GetBannerIndex() const;
     bool IsAcrossTrack() const;
     bool AnimationIsBackwards() const;
+    uint32_t GetRawRCT1WallTypeData() const;
     int32_t GetRCT1WallType(int32_t edge) const;
     colour_t GetRCT1WallColour() const;
 };

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -390,6 +390,7 @@ public:
     bool AnimationIsBackwards() const;
     void SetAnimationIsBackwards(bool isBackwards);
 
+    void SetRawRCT1Data(uint32_t rawData);
     int32_t GetRCT1WallType(int32_t edge) const;
     colour_t GetRCT1WallColour() const;
 };

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -811,3 +811,10 @@ void WallElement::SetAnimationIsBackwards(bool isBackwards)
     if (isBackwards)
         animation |= WALL_ANIMATION_FLAG_DIRECTION_BACKWARD;
 }
+
+void WallElement::SetRawRCT1Data(uint32_t rawData)
+{
+    colour_3 = rawData & 0xFF;
+    colour_1 = (rawData >> 8) & 0xFF;
+    animation = (rawData >> 16) & 0xFF;
+}


### PR DESCRIPTION
This makes the S4 importer mostly file format independent. By importing the tile elements this way, I could also get rid of many FixABC() methods. (The wall stuff is as dirty as ever.)