### PR TITLE
Fix number of free sprites on SV6 import

### DIFF
--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -223,6 +223,9 @@ public:
             gSpriteListHead[i] = _s6.sprite_lists_head[i];
             gSpriteListCount[i] = _s6.sprite_lists_count[i];
         }
+        // This list contains the number of free slots. Increase it according to our own sprite limit.
+        gSpriteListCount[SPRITE_LIST_NULL] += (MAX_SPRITES - RCT2_MAX_SPRITES);
+
         gParkName = _s6.park_name;
         // pad_013573D6
         gParkNameArgs = _s6.park_name_args;


### PR DESCRIPTION
When doing a test with an increased sprite limit, I noticed that `gSpriteListCount[SPRITE_LIST_NULL]`, which contains the number of free slots, was not updated accordingly.

This code ensures that, when we increase our limit, it will also be available in imported SV6 files.