### PR TITLE
Fix #8200: Incorrect behaviour when removing entrances and exits on the same tile

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#8121] Crash Renaming park with server logging enabled.
 - Fix: [#8142] Reliability of mazes and crooked houses can go below 100%.
 - Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
+- Fix: [#8200] Incorrect behaviour when removing entrances and exits that are on the same tile.
 - Fix: [#8204] Crash when tile element has no surface elements.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -210,7 +210,7 @@ static money32 RideEntranceExitPlace(
         if (requiresRemove)
         {
             money32 success = game_do_command(
-                removeCoord.x, flags, removeCoord.y, rideIndex, GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT, stationNum, 0);
+                removeCoord.x, flags, removeCoord.y, rideIndex, GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT, stationNum, isExit);
 
             if (success == MONEY32_UNDEFINED)
             {
@@ -307,7 +307,7 @@ static money32 RideEntranceExitPlace(
     return cost;
 }
 
-static money32 RideEntranceExitRemove(int16_t x, int16_t y, uint8_t rideIndex, uint8_t stationNum, uint8_t flags)
+static money32 RideEntranceExitRemove(int16_t x, int16_t y, uint8_t rideIndex, uint8_t stationNum, uint8_t flags, bool isExit)
 {
     if (rideIndex >= MAX_RIDES)
     {
@@ -371,6 +371,15 @@ static money32 RideEntranceExitRemove(int16_t x, int16_t y, uint8_t rideIndex, u
             if (flags & GAME_COMMAND_FLAG_5 && !(tileElement->flags & TILE_ELEMENT_FLAG_GHOST))
                 continue;
 
+            if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
+                continue;
+
+            if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE && isExit)
+                continue;
+
+            if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT && !isExit)
+                continue;
+
             found = true;
             break;
         } while (!(tileElement++)->IsLastForTile());
@@ -389,8 +398,6 @@ static money32 RideEntranceExitRemove(int16_t x, int16_t y, uint8_t rideIndex, u
         footpath_queue_chain_reset();
         maze_entrance_hedge_replacement(x, y, tileElement);
         footpath_remove_edges_at(x, y, tileElement);
-
-        bool isExit = tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT;
 
         tile_element_remove(tileElement);
 
@@ -535,7 +542,7 @@ void game_command_remove_ride_entrance_or_exit(
     int32_t* eax, int32_t* ebx, int32_t* ecx, int32_t* edx, [[maybe_unused]] int32_t* esi, int32_t* edi,
     [[maybe_unused]] int32_t* ebp)
 {
-    *ebx = RideEntranceExitRemove(*eax & 0xFFFF, *ecx & 0xFFFF, *edx & 0xFF, *edi & 0xFF, *ebx & 0xFF);
+    *ebx = RideEntranceExitRemove(*eax & 0xFFFF, *ecx & 0xFFFF, *edx & 0xFF, *edi & 0xFF, *ebx & 0xFF, *ebp & 1);
 }
 
 /**


### PR DESCRIPTION
Previously, it would just remove the first entrance or exit of the ride it encountered on that tile and height.