### PR TITLE
Add "simulate" command.

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4C3B4236205914F7000C5BB7 /* InGameConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B4234205914F7000C5BB7 /* InGameConsole.cpp */; };
 		4C93F1AD1F8CD9F000A9330D /* Input.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C93F1AC1F8CD9F000A9330D /* Input.cpp */; };
 		4C93F1AF1F8CD9F600A9330D /* KeyboardShortcut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C93F1AE1F8CD9F600A9330D /* KeyboardShortcut.cpp */; };
+		4CB1375621C2E9F80029FCDA /* SimulateCommands.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CB1375521C2E9F80029FCDA /* SimulateCommands.cpp */; };
 		4CF67197206B7E720034ADDD /* object in Resources */ = {isa = PBXBuildFile; fileRef = 4CF67196206B7E720034ADDD /* object */; };
 		9308D9FE209908090079EE96 /* TileElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308D9FA209908080079EE96 /* TileElement.cpp */; };
 		9308D9FF209908090079EE96 /* TileElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308D9FA209908080079EE96 /* TileElement.cpp */; };
@@ -830,6 +831,7 @@
 		4C93F1B71F8E185600A9330D /* NewsItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NewsItem.h; sourceTree = "<group>"; };
 		4C93F1B81F8E185600A9330D /* Research.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Research.cpp; sourceTree = "<group>"; };
 		4C93F1B91F8E185600A9330D /* Research.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Research.h; sourceTree = "<group>"; };
+		4CB1375521C2E9F80029FCDA /* SimulateCommands.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SimulateCommands.cpp; sourceTree = "<group>"; };
 		4CB832AA1EFFB8D100B88761 /* ttf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ttf.h; sourceTree = "<group>"; };
 		4CC4B8E21FE00C4100660D62 /* CmdlineSprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CmdlineSprite.cpp; sourceTree = "<group>"; };
 		4CC4B8E31FE00C4200660D62 /* CmdlineSprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CmdlineSprite.h; sourceTree = "<group>"; };
@@ -2400,6 +2402,7 @@
 				F76C83651EC4E7CC00FA49E2 /* ConvertCommand.cpp */,
 				F76C83661EC4E7CC00FA49E2 /* RootCommands.cpp */,
 				F76C83671EC4E7CC00FA49E2 /* ScreenshotCommands.cpp */,
+				4CB1375521C2E9F80029FCDA /* SimulateCommands.cpp */,
 				F76C83681EC4E7CC00FA49E2 /* SpriteCommands.cpp */,
 				F76C83691EC4E7CC00FA49E2 /* UriHandler.cpp */,
 			);
@@ -3568,6 +3571,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C68313CB1FDB4EEC006DB3D8 /* Tooltip.cpp in Sources */,
+				4CB1375621C2E9F80029FCDA /* SimulateCommands.cpp in Sources */,
 				C654DF2F1F69C0430040F43D /* Error.cpp in Sources */,
 				C64644F81F3FA4120026AC2D /* ClearScenery.cpp in Sources */,
 				C654DF2E1F69C0430040F43D /* DemolishRidePrompt.cpp in Sources */,

--- a/src/openrct2/cmdline/CommandLine.hpp
+++ b/src/openrct2/cmdline/CommandLine.hpp
@@ -117,6 +117,7 @@ namespace CommandLine
     extern const CommandLineCommand ScreenshotCommands[];
     extern const CommandLineCommand SpriteCommands[];
     extern const CommandLineCommand BenchGfxCommands[];
+    extern const CommandLineCommand SimulateCommands[];
 
     extern const CommandLineExample RootExamples[];
 

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -138,7 +138,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     DefineSubCommand("screenshot", CommandLine::ScreenshotCommands),
     DefineSubCommand("sprite",     CommandLine::SpriteCommands    ),
     DefineSubCommand("benchgfx",   CommandLine::BenchGfxCommands  ),
-
+    DefineSubCommand("simulate",   CommandLine::SimulateCommands  ),
     CommandTableEnd
 };
 

--- a/src/openrct2/cmdline/SimulateCommands.cpp
+++ b/src/openrct2/cmdline/SimulateCommands.cpp
@@ -1,0 +1,75 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2018 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../Context.h"
+#include "../Game.h"
+#include "../GameState.h"
+#include "../OpenRCT2.h"
+#include "../core/Console.hpp"
+#include "../network/network.h"
+#include "../platform/platform.h"
+#include "../world/Sprite.h"
+#include "CommandLine.hpp"
+
+#include <cstdlib>
+#include <memory>
+
+using namespace OpenRCT2;
+
+static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator);
+
+const CommandLineCommand CommandLine::SimulateCommands[]{ // Main commands
+                                                          DefineCommand("", "<ticks>", nullptr, HandleSimulate), CommandTableEnd
+};
+
+static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator)
+{
+    const char** argv = (const char**)argEnumerator->GetArguments() + argEnumerator->GetIndex();
+    int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
+
+    if (argc < 2)
+    {
+        Console::Error::WriteLine("Missing arguments <sv6-file> <ticks>.");
+        return EXITCODE_FAIL;
+    }
+
+    core_init();
+
+    const char* inputPath = argv[0];
+    uint32_t ticks = atol(argv[1]);
+
+    gOpenRCT2Headless = true;
+
+#ifndef DISABLE_NETWORK
+    gNetworkStart = NETWORK_MODE_SERVER;
+#endif
+
+    std::unique_ptr<IContext> context(CreateContext());
+    if (context->Initialise())
+    {
+        if (!context->LoadParkFromFile(inputPath))
+        {
+            return EXITCODE_FAIL;
+        }
+
+        Console::WriteLine("Running %d ticks...", ticks);
+        for (uint32_t i = 0; i < ticks; i++)
+        {
+            context->GetGameState()->UpdateLogic();
+        }
+        Console::WriteLine("Completed: %s", sprite_checksum());
+    }
+    else
+    {
+        Console::Error::WriteLine("Context initialization failed.");
+        return EXITCODE_FAIL;
+    }
+
+    return EXITCODE_OK;
+}


### PR DESCRIPTION
Before I forget about it again. 
This a basic command to simulate the game for a certain amount of ticks resulting the same network hash we use to identify desyncs. I used this to compare game logic across multiple builds and perhaps someone could actually put that to the CI to see if a PR will actually change the game logic and warn us about it.
