### PR TITLE
Change log_error to log_verbose on map_get_first_element_at

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -217,7 +217,7 @@ TileElement* map_get_first_element_at(int32_t x, int32_t y)
 {
     if (x < 0 || y < 0 || x > (MAXIMUM_MAP_SIZE_TECHNICAL - 1) || y > (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
     {
-        log_error("Trying to access element outside of range");
+        log_verbose("Trying to access element outside of range");
         return nullptr;
     }
     return gTileElementTilePointers[x + y * MAXIMUM_MAP_SIZE_TECHNICAL];


### PR DESCRIPTION
Theres a lot of spam when I build ORCT2 locally and run bpb.sv6 test park, while its probably handy when it actually crashes due to null dereferencing this is not happening at all. It seems that most callees deal with it.