### PR TITLE
Fix #8333: Replace assert with in-game error.

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3723,6 +3723,7 @@ STR_6272    :Stations
 STR_6273    :Music
 STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
+STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
 
 #############
 # Scenarios #

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -173,6 +173,8 @@ public:
 
                 ride->race_winner = SPRITE_INDEX_NULL;
                 ride->status = _status;
+                ride->current_issues = 0;
+                ride->last_issue_time = 0;
                 ride_get_measurement(_rideIndex, nullptr);
                 ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
                 window_invalidate_by_number(WC_RIDE, _rideIndex);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3894,6 +3894,7 @@ enum
     STR_CANT_SET_COLOUR_SCHEME = 6274,
 
     STR_STATION_STYLE = 6275,
+    STR_GUESTS_GETTING_STUCK_ON_RIDE = 6276,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3597,10 +3597,30 @@ void rct_peep::UpdateRideAdvanceThroughEntrance()
             peep_update_ride_leave_entrance_maze(this, ride, entranceLocation);
             return;
         }
-        Guard::Assert(ride->type == RIDE_TYPE_SPIRAL_SLIDE);
+        else if (ride->type == RIDE_TYPE_SPIRAL_SLIDE)
+        {
+            peep_update_ride_leave_entrance_spiral_slide(this, ride, entranceLocation);
+            return;
+        }
+        else
+        {
+            // If the ride type was changed guests will become stuck.
+            // Inform the player about this if its a new issue or hasn't been addressed within 120 seconds.
+            if ((ride->current_issues & RIDE_ISSUE_GUESTS_STUCK) == 0 || gCurrentTicks - ride->last_issue_time > 3000)
+            {
+                ride->current_issues |= RIDE_ISSUE_GUESTS_STUCK;
+                ride->last_issue_time = gCurrentTicks;
 
-        peep_update_ride_leave_entrance_spiral_slide(this, ride, entranceLocation);
-        return;
+                set_format_arg(0, rct_string_id, ride->name);
+                set_format_arg(2, uint32_t, ride->name_arguments);
+                if (gConfigNotifications.ride_warnings)
+                {
+                    news_item_add_to_queue(NEWS_ITEM_RIDE, STR_GUESTS_GETTING_STUCK_ON_RIDE, current_ride);
+                }
+            }
+
+            return;
+        }
     }
 
     rct_vehicle* vehicle = GET_VEHICLE(ride->vehicles[current_train]);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -342,6 +342,11 @@ struct Ride
     uint8_t cable_lift_z;
     uint16_t cable_lift;
     uint16_t queue_length[MAX_STATIONS];
+    // These fields are used to warn users about issues.
+    // Such issue can be hacked rides with incompatible options set.
+    // They don't require export/import.
+    uint8_t current_issues;
+    uint32_t last_issue_time;
     bool CanBreakDown() const;
 };
 
@@ -879,6 +884,12 @@ enum
 {
     RIDE_MODIFY_DEMOLISH,
     RIDE_MODIFY_RENEW
+};
+
+enum
+{
+    RIDE_ISSUE_NONE = 0,
+    RIDE_ISSUE_GUESTS_STUCK = (1 << 0),
 };
 
 struct rct_ride_properties


### PR DESCRIPTION
I feel like this makes more sense than a crash as long we offer the option to change the ride to any arbitrary type.

Affected Park: 
[park (4).sv6.gz](https://github.com/OpenRCT2/OpenRCT2/files/2700736/park.4.sv6.gz)
