### PR TITLE
Fix OpenGL renderer causing infinite loop on hacked surfaces.

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
@@ -179,7 +179,7 @@ int32_t MaxTransparencyDepth(const RectCommandBatch& transparent)
             /*
              * Increment the depth for endpoings that intersect this interval
              */
-            for (IntervalTree::iterator it = std::next(top_it); it != bottom_it; ++it)
+            for (IntervalTree::iterator it = std::next(top_it); it != bottom_it && it != std::end(y_intersect); ++it)
             {
                 max_depth = std::max(max_depth, ++it->second.depth);
             }
@@ -192,7 +192,7 @@ int32_t MaxTransparencyDepth(const RectCommandBatch& transparent)
             /*
              * Decrement the depth for endpoings that intersected this interval
              */
-            for (IntervalTree::iterator it = std::next(top_it); it != bottom_it; ++it)
+            for (IntervalTree::iterator it = std::next(top_it); it != bottom_it && it != std::end(y_intersect); ++it)
             {
                 --it->second.depth;
             }


### PR DESCRIPTION
I just found this while playing around with the tile inspector and removing surface, after that I was messing around with the base height and it froze. It seems that the first iterator points to y_intersect::end() and wasn't considered.