### PR TITLE
Fix #8345: crash with deleted surface when using "Own all land" cheat

### DIFF
--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -459,6 +459,8 @@ static void cheat_own_all_land()
         for (coords.x = min; coords.x <= max; coords.x += 32)
         {
             TileElement* surfaceElement = map_get_surface_element_at(coords);
+            if (!surfaceElement)
+                continue;
 
             // Ignore already owned tiles.
             if (surfaceElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED)


### PR DESCRIPTION
Just a missing nullptr check.
Step to reproduce the crash:
1. Copy footpath outside of the park on any surface with the tile editor.
2. Remove the surface and raise the footpath.
3. "Own all land" cheat.