### PR TITLE
Fix dereferencing nullptr when game objects are missing.

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -269,10 +269,10 @@ void window_scenery_init()
     // small scenery
     for (uint16_t sceneryId = SCENERY_SMALL_SCENERY_ID_MIN; sceneryId < SCENERY_SMALL_SCENERY_ID_MAX; sceneryId++)
     {
-        if (get_small_scenery_entry(sceneryId) == nullptr)
+        rct_scenery_entry* sceneryEntry = get_small_scenery_entry(sceneryId);
+        if (sceneryEntry == nullptr)
             continue;
 
-        rct_scenery_entry* sceneryEntry = get_small_scenery_entry(sceneryId);
         init_scenery_entry(sceneryEntry, sceneryId, sceneryEntry->small_scenery.scenery_tab_id);
     }
 
@@ -281,10 +281,10 @@ void window_scenery_init()
     {
         int32_t largeSceneryIndex = sceneryId - SCENERY_LARGE_SCENERY_ID_MIN;
 
-        if (get_large_scenery_entry(largeSceneryIndex) == nullptr)
+        rct_scenery_entry* sceneryEntry = get_large_scenery_entry(largeSceneryIndex);
+        if (sceneryEntry == nullptr)
             continue;
 
-        rct_scenery_entry* sceneryEntry = get_large_scenery_entry(largeSceneryIndex);
         init_scenery_entry(sceneryEntry, sceneryId, sceneryEntry->large_scenery.scenery_tab_id);
     }
 
@@ -293,10 +293,10 @@ void window_scenery_init()
     {
         int32_t wallSceneryIndex = sceneryId - SCENERY_WALLS_ID_MIN;
 
-        if (get_wall_entry(wallSceneryIndex) == nullptr)
+        rct_scenery_entry* sceneryEntry = get_wall_entry(wallSceneryIndex);
+        if (sceneryEntry == nullptr)
             continue;
 
-        rct_scenery_entry* sceneryEntry = get_wall_entry(wallSceneryIndex);
         init_scenery_entry(sceneryEntry, sceneryId, sceneryEntry->wall.scenery_tab_id);
     }
 
@@ -305,10 +305,10 @@ void window_scenery_init()
     {
         int32_t bannerIndex = sceneryId - SCENERY_BANNERS_ID_MIN;
 
-        if (get_banner_entry(bannerIndex) == nullptr)
+        rct_scenery_entry* sceneryEntry = get_banner_entry(bannerIndex);
+        if (sceneryEntry == nullptr)
             continue;
 
-        rct_scenery_entry* sceneryEntry = get_banner_entry(bannerIndex);
         init_scenery_entry(sceneryEntry, sceneryId, sceneryEntry->banner.scenery_tab_id);
     }
 
@@ -317,10 +317,10 @@ void window_scenery_init()
     {
         int32_t pathBitIndex = sceneryId - SCENERY_PATH_SCENERY_ID_MIN;
 
-        if (get_footpath_item_entry(pathBitIndex) == nullptr)
+        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathBitIndex);
+        if (sceneryEntry == nullptr)
             continue;
 
-        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathBitIndex);
         init_scenery_entry(sceneryEntry, sceneryId, sceneryEntry->path_bit.scenery_tab_id);
     }
 
@@ -1174,7 +1174,7 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
             dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK, w->x + w->width - 0x1A, w->y + w->height - 13);
     }
 
-    set_format_arg(0, rct_string_id, sceneryEntry->name);
+    set_format_arg(0, rct_string_id, sceneryEntry != nullptr ? sceneryEntry->name : STR_UNKNOWN_OBJECT_TYPE);
     gfx_draw_string_left_clipped(
         dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + 3, w->y + w->height - 13, w->width - 19);
 }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1811,7 +1811,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 if (tileElement->AsPath()->HasAddition())
                 {
                     const uint8_t pathAdditionType = tileElement->AsPath()->GetAdditionEntryIndex();
-                    rct_string_id additionNameId = get_footpath_item_entry(pathAdditionType)->name;
+                    const auto* sceneryElement = get_footpath_item_entry(pathAdditionType);
+                    rct_string_id additionNameId = sceneryElement != nullptr ? sceneryElement->name : STR_UNKNOWN_OBJECT_TYPE;
                     gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_PATH_ADDITIONS, &additionNameId, COLOUR_DARK_GREEN, x, y + 11);
                 }
                 else

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -693,6 +693,10 @@ static void sub_6A3F61(
                 // Draw additional path bits (bins, benches, lamps, queue screens)
                 rct_scenery_entry* sceneryEntry = tile_element->AsPath()->GetAdditionEntry();
 
+                // Can be null if the object is not loaded.
+                if (sceneryEntry == nullptr)
+                    return;
+
                 if ((gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
                     && !(tile_element->flags & TILE_ELEMENT_FLAG_BROKEN)
                     && !(sceneryEntry->path_bit.draw_type == PATH_BIT_DRAW_TYPE_BINS))
@@ -940,7 +944,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
         if (tile_element->AsPath()->HasAddition() && !(tile_element->flags & TILE_ELEMENT_FLAG_BROKEN))
         {
             rct_scenery_entry* sceneryEntry = tile_element->AsPath()->GetAdditionEntry();
-            if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP)
+            if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP)
             {
                 if (!(tile_element->AsPath()->GetEdges() & EDGE_NE))
                 {

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -644,7 +644,7 @@ void rct_peep::Tick128UpdateGuest(int32_t index)
                         {
                             uint8_t pathSceneryIndex = tileElement->AsPath()->GetAdditionEntryIndex();
                             rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathSceneryIndex);
-                            if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN)
+                            if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN)
                             {
                                 found = true;
                             }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -391,7 +391,7 @@ static money32 footpath_element_update(
         if (pathItemType != 0)
         {
             rct_scenery_entry* scenery_entry = get_footpath_item_entry(pathItemType - 1);
-            if (scenery_entry->path_bit.flags & PATH_BIT_FLAG_IS_BIN)
+            if (scenery_entry != nullptr && scenery_entry->path_bit.flags & PATH_BIT_FLAG_IS_BIN)
             {
                 tileElement->AsPath()->SetAdditionStatus(255);
             }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -266,7 +266,7 @@ static bool is_jumping_fountain(int32_t type, int32_t x, int32_t y, int32_t z)
 
         uint8_t additionIndex = tileElement->AsPath()->GetAdditionEntryIndex();
         rct_scenery_entry* sceneryEntry = get_footpath_item_entry(additionIndex);
-        if (sceneryEntry != reinterpret_cast<void*>(-1) && sceneryEntry->path_bit.flags & pathBitFlagMask)
+        if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & pathBitFlagMask)
         {
             return true;
         }


### PR DESCRIPTION
Added a few nullptr guards to places that access scenery objects and removed unnecessary calls where it would get the object twice. Also fixes #8340