### PR TITLE
Fix #8338: Game actions using player id instead of index

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -253,10 +253,13 @@ namespace GameActions
                 {
                     NetworkPlayerId_t playerId = action->GetPlayer();
 
-                    network_set_player_last_action(network_get_player_index(playerId.id), action->GetType());
+                    int32_t playerIndex = network_get_player_index(playerId.id);
+                    Guard::Assert(playerIndex != -1);
+
+                    network_set_player_last_action(playerIndex, action->GetType());
                     if (result->Cost != 0)
                     {
-                        network_add_player_money_spent(playerId.id, result->Cost);
+                        network_add_player_money_spent(playerIndex, result->Cost);
                     }
                 }
             }


### PR DESCRIPTION
I feel like I have fixed this before, but here it is again I guess.