### PR TITLE
Paint refactor

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2333,12 +2333,9 @@ static void sub_6CBCE2(
 {
     Ride* ride;
     const rct_preview_track* trackBlock;
-    int32_t preserve_current_viewport_flags;
     int32_t offsetX, offsetY;
 
-    paint_session* session = paint_session_alloc(dpi);
-    preserve_current_viewport_flags = gCurrentViewportFlags;
-    gCurrentViewportFlags = 0;
+    paint_session* session = paint_session_alloc(dpi, 0);
     trackDirection &= 3;
 
     ride = get_ride(rideIndex);
@@ -2450,10 +2447,8 @@ static void sub_6CBCE2(
     gMapSizeMaxXY = preserveMapSizeMaxXY;
 
     paint_session_arrange(session);
-    paint_draw_structs(session, gCurrentViewportFlags);
+    paint_draw_structs(session);
     paint_session_free(session);
-
-    gCurrentViewportFlags = preserve_current_viewport_flags;
 }
 
 /**

--- a/src/openrct2/drawing/Rain.cpp
+++ b/src/openrct2/drawing/Rain.cpp
@@ -42,10 +42,15 @@ void DrawRain(rct_drawpixelinfo* dpi, IRainDrawer* rainDrawer)
 {
     if (gConfigGeneral.render_weather_effects)
     {
+        uint32_t viewFlags = 0;
+
+        rct_viewport* viewport = window_get_viewport(window_get_main());
+        if (viewport != nullptr)
+            viewFlags = viewport->flags;
+
         // Get rain draw function and draw rain
         uint32_t rainType = gClimateCurrent.RainLevel;
-        if (rainType != RAIN_LEVEL_NONE && !gTrackDesignSaveMode
-            && !(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+        if (rainType != RAIN_LEVEL_NONE && !gTrackDesignSaveMode && !(viewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
         {
             auto drawFunc = DrawRainFunctions[rainType];
             auto uiContext = GetContext()->GetUiContext();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -50,7 +50,6 @@ uint8_t gSavedViewRotation;
 
 paint_entry* gNextFreePaintStruct;
 uint8_t gCurrentRotation;
-uint32_t gCurrentViewportFlags = 0;
 
 static uint32_t _currentImageType;
 
@@ -906,8 +905,6 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int16_t left
 
 static void viewport_paint_column(rct_drawpixelinfo* dpi, uint32_t viewFlags)
 {
-    gCurrentViewportFlags = viewFlags;
-
     if (viewFlags
         & (VIEWPORT_FLAG_HIDE_VERTICAL | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_CLIP_VIEW))
     {
@@ -919,10 +916,10 @@ static void viewport_paint_column(rct_drawpixelinfo* dpi, uint32_t viewFlags)
         gfx_clear(dpi, colour);
     }
 
-    paint_session* session = paint_session_alloc(dpi);
+    paint_session* session = paint_session_alloc(dpi, viewFlags);
     paint_session_generate(session);
     paint_session_arrange(session);
-    paint_draw_structs(session, viewFlags);
+    paint_draw_structs(session);
     paint_session_free(session);
 
     if (gConfigGeneral.render_weather_gloom && !gTrackDesignSaveMode && !(viewFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)
@@ -1644,7 +1641,7 @@ void get_map_coordinates_from_pos_window(
             dpi->x = _viewportDpi1.x;
             dpi->width = 1;
 
-            paint_session* session = paint_session_alloc(dpi);
+            paint_session* session = paint_session_alloc(dpi, myviewport->flags);
             paint_session_generate(session);
             paint_session_arrange(session);
             sub_68862C(session);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -115,7 +115,6 @@ extern uint8_t gSavedViewRotation;
 
 extern paint_entry* gNextFreePaintStruct;
 extern uint8_t gCurrentRotation;
-extern uint32_t gCurrentViewportFlags;
 
 void viewport_init_all();
 void centre_2d_coordinates(int32_t x, int32_t y, int32_t z, int32_t* out_x, int32_t* out_y, rct_viewport* viewport);

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -149,7 +149,7 @@ struct paint_session
     paint_entry* EndOfPaintStructArray;
     paint_entry* NextFreePaintStruct;
     LocationXY16 SpritePosition;
-    paint_struct* UnkF1AD28;
+    paint_struct* LastRootPS;
     attached_paint_struct* UnkF1AD2C;
     uint8_t InteractionType;
     uint8_t CurrentRotation;

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -149,7 +149,6 @@ struct paint_session
     paint_entry* EndOfPaintStructArray;
     paint_entry* NextFreePaintStruct;
     LocationXY16 SpritePosition;
-    paint_struct UnkF1A4CC;
     paint_struct* UnkF1AD28;
     attached_paint_struct* UnkF1AD2C;
     uint8_t InteractionType;

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -143,6 +143,7 @@ struct paint_session
     paint_entry PaintStructs[4000];
     paint_struct* Quadrants[MAX_PAINT_QUADRANTS];
     paint_struct PaintHead;
+    uint32_t ViewFlags;
     uint32_t QuadrantBackIndex;
     uint32_t QuadrantFrontIndex;
     const void* CurrentlyDrawnItem;
@@ -223,12 +224,12 @@ void paint_floating_money_effect(
     paint_session* session, money32 amount, rct_string_id string_id, int16_t y, int16_t z, int8_t y_offsets[], int16_t offset_x,
     uint32_t rotation);
 
-paint_session* paint_session_alloc(rct_drawpixelinfo* dpi);
-void paint_session_free(paint_session*);
+paint_session* paint_session_alloc(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+void paint_session_free(paint_session* session);
 void paint_session_generate(paint_session* session);
 void paint_session_arrange(paint_session* session);
 paint_struct* paint_arrange_structs_helper(paint_struct* ps_next, uint16_t quadrantIndex, uint8_t flag, uint8_t rotation);
-void paint_draw_structs(paint_session* session, uint32_t viewFlags);
+void paint_draw_structs(paint_session* session);
 void paint_draw_money_structs(rct_drawpixelinfo* dpi, paint_string_struct* ps);
 
 // TESTING

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -344,7 +344,7 @@ bool wooden_a_supports_paint_setup(
         *underground = false;
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false;
     }
@@ -522,7 +522,7 @@ bool wooden_b_supports_paint_setup(
 {
     bool _9E32B1 = false;
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         if (underground != nullptr)
             *underground = false; // AND
@@ -702,7 +702,7 @@ bool metal_a_supports_paint_setup(
 {
     support_height* supportSegments = session->SupportSegments;
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false;
     }
@@ -907,7 +907,7 @@ bool metal_b_supports_paint_setup(
     support_height* supportSegments = session->SupportSegments;
     uint8_t originalSegment = segment;
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false; // AND
     }
@@ -1090,7 +1090,7 @@ bool path_a_supports_paint_setup(
         *underground = false; // AND
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false;
     }
@@ -1234,7 +1234,7 @@ bool path_b_supports_paint_setup(
 {
     support_height* supportSegments = session->SupportSegments;
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false; // AND
     }

--- a/src/openrct2/paint/sprite/Paint.Peep.cpp
+++ b/src/openrct2/paint/sprite/Paint.Peep.cpp
@@ -62,7 +62,7 @@ void peep_paint(paint_session* session, const rct_peep* peep, int32_t imageDirec
         return;
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
     {
         return;
     }

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -29,7 +29,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         return;
     }
 
-    if (gTrackDesignSaveMode || (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES))
+    if (gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES))
     {
         return;
     }
@@ -46,7 +46,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         return;
     }
 
-    const bool highlightPathIssues = (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES);
+    const bool highlightPathIssues = (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES);
 
     for (const rct_sprite* spr = get_sprite(sprite_idx); sprite_idx != SPRITE_INDEX_NULL;
          sprite_idx = spr->generic.next_in_quadrant)
@@ -73,7 +73,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         // Here converting from land/path/etc height scale to pixel height scale.
         // Note: peeps/scenery on slopes will be above the base
         // height of the slope element, and consequently clipped.
-        if ((gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW))
+        if ((session->ViewFlags & VIEWPORT_FLAG_CLIP_VIEW))
         {
             if (spr->generic.z > (gClipHeight * 8))
             {

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -38,7 +38,7 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
 
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_BANNER;
 
-    if (dpi->zoom_level > 1 || gTrackDesignSaveMode || (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+    if (dpi->zoom_level > 1 || gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
         return;
 
     height -= 16;

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -31,7 +31,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
 {
     uint8_t is_exit = tile_element->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT;
 
-    if (gTrackDesignSaveMode || (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+    if (gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
     {
         if (tile_element->AsEntrance()->GetRideIndex() != gTrackDesignSaveRideIndex)
             return;
@@ -208,7 +208,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
  */
 static void park_entrance_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tile_element)
 {
-    if (gTrackDesignSaveMode || (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+    if (gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
         return;
 
 #ifdef __ENABLE_LIGHTFX__
@@ -332,7 +332,7 @@ void entrance_paint(paint_session* session, uint8_t direction, int32_t height, c
 
     rct_drawpixelinfo* dpi = session->DPI;
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_PATH_HEIGHTS && dpi->zoom_level == 0)
+    if (session->ViewFlags & VIEWPORT_FLAG_PATH_HEIGHTS && dpi->zoom_level == 0)
     {
         if (entrance_get_directions(tile_element) & 0xF)
         {

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -221,7 +221,7 @@ static constexpr const boundbox s98E3C4[] = {
  */
 void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t height, const TileElement* tileElement)
 {
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
+    if (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
     {
         return;
     }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -171,7 +171,7 @@ static void path_bit_bins_paint(
                 imageId += 8;
         }
 
-        if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
+        if (!(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
             sub_98197C(session, imageId, 7, 16, 1, 1, 7, height, 7, 16, height + 2);
     }
     if (!(edges & EDGE_SE))
@@ -192,7 +192,7 @@ static void path_bit_bins_paint(
                 imageId += 8;
         }
 
-        if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
+        if (!(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
             sub_98197C(session, imageId, 16, 25, 1, 1, 7, height, 16, 25, height + 2);
     }
 
@@ -214,7 +214,7 @@ static void path_bit_bins_paint(
                 imageId += 8;
         }
 
-        if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
+        if (!(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
             sub_98197C(session, imageId, 25, 16, 1, 1, 7, height, 25, 16, height + 2);
     }
 
@@ -236,7 +236,7 @@ static void path_bit_bins_paint(
                 imageId += 8;
         }
 
-        if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
+        if (!(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) || binIsFull || binsAreVandalised)
             sub_98197C(session, imageId, 16, 7, 1, 1, 7, height, 16, 7, height + 2);
     }
 }
@@ -697,7 +697,7 @@ static void sub_6A3F61(
                 if (sceneryEntry == nullptr)
                     return;
 
-                if ((gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
+                if ((session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
                     && !(tile_element->flags & TILE_ELEMENT_FLAG_BROKEN)
                     && !(sceneryEntry->path_bit.draw_type == PATH_BIT_DRAW_TYPE_BINS))
                 {
@@ -815,7 +815,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
         }
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
+    if (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
     {
         imageFlags = SPRITE_ID_PALETTE_COLOUR_1(PALETTE_46);
     }
@@ -911,7 +911,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
         }
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_PATH_HEIGHTS)
+    if (session->ViewFlags & VIEWPORT_FLAG_PATH_HEIGHTS)
     {
         uint16_t height2 = 3 + tile_element->base_height * 8;
         if (tile_element->AsPath()->IsSloped())

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -32,7 +32,7 @@ static constexpr const LocationXY16 lengths[] = {
  */
 void scenery_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tileElement)
 {
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
+    if (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
     {
         return;
     }

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -680,7 +680,7 @@ static void viewport_surface_draw_tile_side_bottom(
             return;
     }
 
-    bool neighbourIsClippedAway = (gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW) && !tile_is_inside_clip_view(neighbour);
+    bool neighbourIsClippedAway = (session->ViewFlags & VIEWPORT_FLAG_CLIP_VIEW) && !tile_is_inside_clip_view(neighbour);
 
     if (neighbour.tile_element == nullptr || neighbourIsClippedAway)
     {
@@ -712,7 +712,7 @@ static void viewport_surface_draw_tile_side_bottom(
         edgeStyle = TERRAIN_EDGE_ROCK;
 
     uint32_t base_image_id = get_edge_image(edgeStyle, 0);
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
+    if (session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
     {
         base_image_id = get_edge_image(edgeStyle, 1);
     }
@@ -921,7 +921,7 @@ static void viewport_surface_draw_tile_side_top(
     if (isWater)
     {
         base_image_id = get_edge_image(terrain, 2); // var_08
-        if (gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
+        if (session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
         {
             base_image_id = get_edge_image(terrain, 1); // var_04
         }
@@ -929,7 +929,7 @@ static void viewport_surface_draw_tile_side_top(
     }
     else
     {
-        if (!(gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE))
+        if (!(session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE))
         {
             const uint8_t incline = (cl - al) + 1;
             const uint32_t image_id = get_edge_image(terrain, 3) + (edge == EDGE_TOPLEFT ? 3 : 0) + incline; // var_c;
@@ -1076,7 +1076,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         descriptor.corner_heights.left = baseHeight + ch.left;
     }
 
-    if ((gCurrentViewportFlags & VIEWPORT_FLAG_LAND_HEIGHTS) && (zoomLevel == 0))
+    if ((session->ViewFlags & VIEWPORT_FLAG_LAND_HEIGHTS) && (zoomLevel == 0))
     {
         const int16_t x = session->MapPosition.x;
         const int16_t y = session->MapPosition.y;
@@ -1102,7 +1102,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
     }
     else
     {
-        const bool showGridlines = (gCurrentViewportFlags & VIEWPORT_FLAG_GRIDLINES);
+        const bool showGridlines = (session->ViewFlags & VIEWPORT_FLAG_GRIDLINES);
 
         int32_t branch = -1;
         if (tileElement->AsSurface()->GetSurfaceStyle() == TERRAIN_GRASS)
@@ -1111,7 +1111,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
             {
                 if (zoomLevel == 0)
                 {
-                    if ((gCurrentViewportFlags & (VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE)) == 0)
+                    if ((session->ViewFlags & (VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE)) == 0)
                     {
                         branch = tileElement->AsSurface()->GetGrassLength() & 0x7;
                     }
@@ -1149,7 +1149,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
                     image_id = SPR_TERRAIN_TRACK_DESIGNER;
                 }
 
-                if (gCurrentViewportFlags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE))
+                if (session->ViewFlags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE))
                 {
                     image_id &= 0xDC07FFFF; // remove colour
                     image_id |= 0x41880000;
@@ -1216,7 +1216,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
 
     // Draw Peep Spawns
     if (((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode)
-        && gCurrentViewportFlags & VIEWPORT_FLAG_LAND_OWNERSHIP)
+        && session->ViewFlags & VIEWPORT_FLAG_LAND_OWNERSHIP)
     {
         const LocationXY16& pos = session->MapPosition;
         for (auto& spawn : gPeepSpawns)
@@ -1232,7 +1232,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         }
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_LAND_OWNERSHIP)
+    if (session->ViewFlags & VIEWPORT_FLAG_LAND_OWNERSHIP)
     {
         // loc_660E9A:
         if (tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED)
@@ -1244,14 +1244,13 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         {
             const LocationXY16& pos = session->MapPosition;
             const int32_t height2 = (tile_element_height(pos.x + 16, pos.y + 16) & 0xFFFF) + 3;
-            paint_struct* backup = session->UnkF1AD28;
+            paint_struct* backup = session->LastRootPS;
             sub_98196C(session, SPR_LAND_OWNERSHIP_AVAILABLE, 16, 16, 1, 1, 0, height2);
-            session->UnkF1AD28 = backup;
+            session->LastRootPS = backup;
         }
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS
-        && !(tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED))
+    if (session->ViewFlags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS && !(tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED))
     {
         if (tileElement->AsSurface()->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
         {
@@ -1262,9 +1261,9 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         {
             const LocationXY16& pos = session->MapPosition;
             const int32_t height2 = tile_element_height(pos.x + 16, pos.y + 16) & 0xFFFF;
-            paint_struct* backup = session->UnkF1AD28;
+            paint_struct* backup = session->LastRootPS;
             sub_98196C(session, SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE, 16, 16, 1, 1, 0, height2 + 3);
-            session->UnkF1AD28 = backup;
+            session->LastRootPS = backup;
         }
     }
 
@@ -1339,9 +1338,9 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
 
                 const int32_t image_id = (SPR_TERRAIN_SELECTION_CORNER + byte_97B444[local_surfaceShape]) | 0x21300000;
 
-                paint_struct* backup = session->UnkF1AD28;
+                paint_struct* backup = session->LastRootPS;
                 sub_98196C(session, image_id, 0, 0, 32, 32, 1, local_height);
-                session->UnkF1AD28 = backup;
+                session->LastRootPS = backup;
             }
         }
     }
@@ -1369,8 +1368,8 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         }
     }
 
-    if (zoomLevel == 0 && has_surface && !(gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
-        && !(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_BASE) && gConfigGeneral.landscape_smoothing)
+    if (zoomLevel == 0 && has_surface && !(session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE)
+        && !(session->ViewFlags & VIEWPORT_FLAG_HIDE_BASE) && gConfigGeneral.landscape_smoothing)
     {
         viewport_surface_smoothen_edge(session, EDGE_TOPLEFT, tileDescriptors[0], tileDescriptors[3]);
         viewport_surface_smoothen_edge(session, EDGE_TOPRIGHT, tileDescriptors[0], tileDescriptors[4]);
@@ -1378,7 +1377,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         viewport_surface_smoothen_edge(session, EDGE_BOTTOMRIGHT, tileDescriptors[0], tileDescriptors[2]);
     }
 
-    if ((gCurrentViewportFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE) && !(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_BASE)
+    if ((session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE) && !(session->ViewFlags & VIEWPORT_FLAG_HIDE_BASE)
         && !(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
     {
         const uint8_t image_offset = byte_97B444[surfaceShape];
@@ -1391,7 +1390,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         paint_attach_to_previous_ps(session, image_id, 0, 0);
     }
 
-    if (!(gCurrentViewportFlags & VIEWPORT_FLAG_HIDE_VERTICAL))
+    if (!(session->ViewFlags & VIEWPORT_FLAG_HIDE_VERTICAL))
     {
         const uint32_t edgeStyle = tileElement->AsSurface()->GetEdgeStyle();
         if (edgeStyle >= TERRAIN_EDGE_COUNT)

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -138,7 +138,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
 {
     rct_drawpixelinfo* dpi = session->DPI;
 
-    if ((gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW))
+    if ((session->ViewFlags & VIEWPORT_FLAG_CLIP_VIEW))
     {
         if (x / 32 < gClipSelectionA.x || x / 32 > gClipSelectionB.x)
             return;
@@ -245,7 +245,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
     do
     {
         // Only paint tile_elements below the clip height.
-        if ((gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW) && (tile_element->base_height > gClipHeight))
+        if ((session->ViewFlags & VIEWPORT_FLAG_CLIP_VIEW) && (tile_element->base_height > gClipHeight))
             continue;
 
         int32_t direction = tile_element->GetDirectionWithOffset(rotation);
@@ -366,7 +366,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
             }
 
             // Only draw supports below the clipping height.
-            if ((gCurrentViewportFlags & VIEWPORT_FLAG_CLIP_VIEW) && (segmentHeight > gClipHeight))
+            if ((session->ViewFlags & VIEWPORT_FLAG_CLIP_VIEW) && (segmentHeight > gClipHeight))
                 continue;
 
             int32_t xOffset = sy * 10;

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -190,7 +190,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     paint_util_set_general_support_height(session, height, 0x20);
 
     uint32_t dword_141F710 = 0;
-    if (gTrackDesignSaveMode || (gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+    if (gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
     {
         if (!track_design_save_contains_tile_element(tile_element))
         {

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2160,13 +2160,13 @@ void track_paint(paint_session* session, uint8_t direction, int32_t height, cons
     rct_drawpixelinfo* dpi = session->DPI;
 
     if ((!gTrackDesignSaveMode || rideIndex == gTrackDesignSaveRideIndex)
-        && !(gCurrentViewportFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+        && !(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
     {
         int32_t trackType = tileElement->AsTrack()->GetTrackType();
         int32_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
         int32_t trackColourScheme = tileElement->AsTrack()->GetColourScheme();
 
-        if ((gCurrentViewportFlags & VIEWPORT_FLAG_TRACK_HEIGHTS) && dpi->zoom_level == 0)
+        if ((session->ViewFlags & VIEWPORT_FLAG_TRACK_HEIGHTS) && dpi->zoom_level == 0)
         {
             session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             if (TrackHeightMarkerPositions[trackType] & (1 << trackSequence))

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1199,7 +1199,7 @@ void vehicle_visual_mini_golf_player(
         return;
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
     {
         return;
     }
@@ -1232,7 +1232,7 @@ void vehicle_visual_mini_golf_ball(
         return;
     }
 
-    if (gCurrentViewportFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
+    if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_PEEPS)
     {
         return;
     }

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -32,7 +32,6 @@ uint8_t gTrackDesignSaveRideIndex = 255;
 uint8_t gClipHeight = 255;
 LocationXY8 gClipSelectionA = { 0, 0 };
 LocationXY8 gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
-uint32_t gCurrentViewportFlags;
 uint32_t gScenarioTicks;
 uint8_t gCurrentRotation;
 

--- a/test/testpaint/TestPaint.cpp
+++ b/test/testpaint/TestPaint.cpp
@@ -64,7 +64,6 @@ namespace TestPaint
         g141E9DB = G141E9DB_FLAG_1 | G141E9DB_FLAG_2;
         gPaintSession.Unk141E9DB = G141E9DB_FLAG_1 | G141E9DB_FLAG_2;
 
-        gCurrentViewportFlags = 0;
         RCT2_CurrentViewportFlags = 0;
 
         gScenarioTicks = 0;


### PR DESCRIPTION
Small refactor that renames one unknown field and eliminates the need for gCurrentViewportFlags as its passed along the paint_session now. This gets us one step closer to actual multithreaded rendering.