### PR TITLE
Improve quoted strings in console

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1559,6 +1559,9 @@ void InteractiveConsole::Execute(const std::string& s)
             argc++;
         }
 
+        // Move ahead to prevent next token from being interpreted as quoted
+        if (inQuotes) end++;
+
         start = end;
     } while (*end != 0);
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1569,7 +1569,7 @@ void InteractiveConsole::Execute(const std::string& s)
 
         if (length > 0)
         {
-            utf8* arg = (utf8*)malloc(length - countEscapeChars + 1);
+            utf8* arg = (utf8*)malloc(length - (size_t)countEscapeChars + 1);
 
             size_t escapeOffset = 0;
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1559,6 +1559,12 @@ void InteractiveConsole::Execute(const std::string& s)
             end++;
         }
         size_t length = end - start - (size_t)countEscapeChars;
+
+        // Display error for trailing slash at the end of a token
+        if (inEscape) {
+            WriteLineError("[console] trailing slash on token is not allowed");
+            return;
+        }
         inEscape = false;
 
         if (length > 0)


### PR DESCRIPTION
This PR
- Fixes a problem with quoted strings
- Adds support for backslash-escaping quotes inside strings.

The console currently supports the use of quotes so that tokens may contain spaces. In the current implementation, this produces unexpected behavior for consecutive tokens, which are interpreted as if surrounded by quotes.

For example:
- `echo hello there` outputs `hello` as expected
- `echo "hello there"` outputs `hello there` as expected
- `echo "hello" there` also outputs `hello there`
- `"echo" hello there` outputs ` hello there` (note the leading space)

This happens because, after a quoted token, the console believes the next token(s) is/are also quoted, and doesn't stop until observing another quote.

This PR fixes the issue above, producing the following behavior:
For example:
- `echo "hello" there`outputs `hello`
- `"echo" hello there` outputs `hello`

I believe this behavior is more correct because the `echo` command takes only one parameter and ignores the rest.

This PR also adds quote escaping so that parameters to commands may contain quotes. This could be useful if, for example, there's a command to set the text on a sign or the title of a ride (something I may try to tackle later if it's a welcome addition).

For example:
- `echo "why \"hello\" there"` outputs `why "hello" there`
- `echo why\ hello\ there` outputs `why hello there`
- `echo why\ hello\ there "\` outputs `[console] trailing slash on token is not allowed`
- `echo c:\\windows` outputs `c:\windows`

Additionally, this change does not create a new buffer, and does not do byte-by-byte copying. Instead, it intelligently copies text between escape characters. This is, I believe, the most optimal solution, and wasn't very complicated to implement either.