### PR TITLE
Fix #5684: Refactor player list updates being bound on ticks.

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -131,7 +131,7 @@ void GameState::Update()
             // Special case because we set numUpdates to 0, otherwise in game_logic_update.
             network_update();
 
-            network_process_game_commands();
+            network_process_pending();
         }
     }
 
@@ -291,7 +291,7 @@ void GameState::UpdateLogic()
 
     // Separated out processing commands in network_update which could call scenario_rand where gInUpdateCode is false.
     // All commands that are received are first queued and then executed where gInUpdateCode is set to true.
-    network_process_game_commands();
+    network_process_pending();
 
     network_flush();
 

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -39,7 +39,7 @@ int32_t network_get_status();
 void network_check_desynchronization();
 void network_send_tick();
 void network_update();
-void network_process_game_commands();
+void network_process_pending();
 void network_flush();
 
 int32_t network_get_authstatus();


### PR DESCRIPTION
I think the issue has been open for too long, this was fairly easy to do. Now the player list should be identical on server and clients at all time. Currently its possible to crash the clients if the client issues a game command and quickly disconnects/gets kicked at nearly the same time.