### PR TITLE
Fix #8349: Change argument passing for entrance type.

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1932,7 +1932,7 @@ static int32_t ride_modify_entrance_or_exit(TileElement* tileElement, int32_t x,
         // Remove entrance / exit
         game_do_command(
             x, (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_APPLY), y, rideIndex,
-            GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT, stationIndex, 0);
+            GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT, stationIndex, entranceType == ENTRANCE_TYPE_RIDE_EXIT);
         gCurrentToolWidget.widget_index = entranceType == ENTRANCE_TYPE_RIDE_ENTRANCE ? WC_RIDE_CONSTRUCTION__WIDX_ENTRANCE
                                                                                       : WC_RIDE_CONSTRUCTION__WIDX_EXIT;
         gRideEntranceExitPlaceType = entranceType;

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -496,7 +496,7 @@ void ride_entrance_exit_remove_ghost()
             gRideEntranceExitGhostPosition.x,
             (GAME_COMMAND_FLAG_5 | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_APPLY),
             gRideEntranceExitGhostPosition.y, _currentRideIndex, GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT,
-            gRideEntranceExitGhostStationIndex, 0);
+            gRideEntranceExitGhostStationIndex, gRideEntranceExitPlaceType == ENTRANCE_TYPE_RIDE_EXIT);
     }
 }
 


### PR DESCRIPTION
Most of the time the entrance type was already passed via edx starting at bit 8. I refactored this part to use the unused ebp variable instead. This PR also makes sure that its not left out. I also changed some lines where ride index was expected instead it was passing (z / 16) for some reason, that broke the Track designs of some mazes. Now it seems all okay.