### PR TITLE
Fix #8402: callback on already closed window

### DIFF
--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1470,7 +1470,7 @@ void window_event_update_call(rct_window* w)
 
 void window_event_unknown_07_call(rct_window* w)
 {
-    if (w->event_handlers->unknown_07 != nullptr)
+    if (w != nullptr && w->event_handlers->unknown_07 != nullptr)
         w->event_handlers->unknown_07(w);
 }
 


### PR DESCRIPTION
According to https://github.com/OpenRCT2/OpenRCT2/issues/8402 it's possible to have a window call execute on already deleted window. It's fairly easy to trigger, but doesn't always happen.

To reproduce:
1. Open a park with rides in it
2. Click on a ride
3. Open the ride rename box and leave it open
4. Demolish the ride

The call comes from https://github.com/OpenRCT2/OpenRCT2/blob/d9806305b0ae71fec59357139bc2cd817fdb0f3e/src/openrct2-ui/input/MouseInput.cpp#L106-L111