### PR TITLE
Improve checks for object files

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -71,7 +71,7 @@ class ObjectFileIndex final : public FileIndex<ObjectRepositoryItem>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x5844494F; // OIDX
-    static constexpr uint16_t VERSION = 18;
+    static constexpr uint16_t VERSION = 19;
     static constexpr auto PATTERN = "*.dat;*.pob;*.json;*.parkobj";
 
     IObjectRepository& _objectRepository;

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -195,6 +195,10 @@ size_t SawyerChunkReader::DecodeChunkRLE(void* dst, size_t dstCapacity, const vo
             {
                 throw SawyerChunkException(EXCEPTION_MSG_DESTINATION_TOO_SMALL);
             }
+            if (i + 1 + rleCodeByte + 1 > srcLength)
+            {
+                throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_RLE);
+            }
 
             std::memcpy(dst8, src8 + i + 1, rleCodeByte + 1);
             dst8 += rleCodeByte + 1;


### PR DESCRIPTION
object failing this check: [Mbsteily.DAT.gz](https://github.com/OpenRCT2/OpenRCT2/files/2665175/Mbsteily.DAT.gz)
