### PR TITLE
Use new canGrow property on surface objects

### DIFF
--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -59,23 +59,17 @@ int32_t day_spinner_value = 1;
 static void cheat_set_grass_length(int32_t length)
 {
     int32_t x, y;
-    TileElement* tileElement;
 
     for (y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
         for (x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            tileElement = map_get_surface_element_at(x, y);
-            if (!(tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED))
-                continue;
-
-            if (tileElement->AsSurface()->GetSurfaceStyle() != TERRAIN_GRASS)
-                continue;
-
-            if (tileElement->AsSurface()->GetWaterHeight() > 0)
-                continue;
-
-            tileElement->AsSurface()->SetGrassLength(length);
+            auto surfaceElement = map_get_surface_element_at(x, y)->AsSurface();
+            if (surfaceElement != nullptr && (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
+                && surfaceElement->GetWaterHeight() == 0 && surfaceElement->CanGrassGrow())
+            {
+                surfaceElement->SetGrassLength(length);
+            }
         }
     }
 

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -81,7 +81,8 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, const json_t* r
     Flags = ObjectJsonHelpers::GetFlags<TERRAIN_SURFACE_FLAGS>(
         properties,
         { { "smoothWithSelf", TERRAIN_SURFACE_FLAGS::SMOOTH_WITH_SELF },
-          { "smoothWithOther", TERRAIN_SURFACE_FLAGS::SMOOTH_WITH_OTHER } });
+          { "smoothWithOther", TERRAIN_SURFACE_FLAGS::SMOOTH_WITH_OTHER },
+          { "canGrow", TERRAIN_SURFACE_FLAGS::CAN_GROW } });
 
     auto jDefault = json_object_get(root, "default");
     if (json_is_object(jDefault))

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -17,6 +17,7 @@ enum TERRAIN_SURFACE_FLAGS
     NONE = 0,
     SMOOTH_WITH_SELF = 1 << 0,
     SMOOTH_WITH_OTHER = 1 << 1,
+    CAN_GROW = 1 << 2,
 };
 
 class TerrainSurfaceObject final : public Object

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1284,11 +1284,15 @@ static money32 map_change_surface_style(
                     continue;
             }
 
-            TileElement* tileElement = map_get_surface_element_at({ x, y });
+            auto surfaceElement = map_get_surface_element_at({ x, y })->AsSurface();
+            if (surfaceElement == nullptr)
+            {
+                continue;
+            }
 
             if (surfaceStyle != 0xFF)
             {
-                uint8_t cur_terrain = tileElement->AsSurface()->GetSurfaceStyle();
+                uint8_t cur_terrain = surfaceElement->GetSurfaceStyle();
 
                 if (surfaceStyle != cur_terrain)
                 {
@@ -1305,7 +1309,7 @@ static money32 map_change_surface_style(
 
                     if (flags & GAME_COMMAND_FLAG_APPLY)
                     {
-                        tileElement->AsSurface()->SetSurfaceStyle(surfaceStyle);
+                        surfaceElement->SetSurfaceStyle(surfaceStyle);
 
                         map_invalidate_tile_full(x, y);
                         footpath_remove_litter(x, y, tile_element_height(x, y));
@@ -1315,7 +1319,7 @@ static money32 map_change_surface_style(
 
             if (edgeStyle != 0xFF)
             {
-                uint8_t currentEdge = tileElement->AsSurface()->GetEdgeStyle();
+                uint8_t currentEdge = surfaceElement->GetEdgeStyle();
 
                 if (edgeStyle != currentEdge)
                 {
@@ -1323,7 +1327,7 @@ static money32 map_change_surface_style(
 
                     if (flags & GAME_COMMAND_FLAG_APPLY)
                     {
-                        tileElement->AsSurface()->SetEdgeStyle(edgeStyle);
+                        surfaceElement->SetEdgeStyle(edgeStyle);
                         map_invalidate_tile_full(x, y);
                     }
                 }
@@ -1331,13 +1335,10 @@ static money32 map_change_surface_style(
 
             if (flags & GAME_COMMAND_FLAG_APPLY)
             {
-                if (tileElement->AsSurface()->GetSurfaceStyle() == TERRAIN_GRASS)
+                if (surfaceElement->CanGrassGrow() && (surfaceElement->GetGrassLength() & 7) != GRASS_LENGTH_CLEAR_0)
                 {
-                    if ((tileElement->AsSurface()->GetGrassLength() & 7) != GRASS_LENGTH_CLEAR_0)
-                    {
-                        tileElement->AsSurface()->SetGrassLength(GRASS_LENGTH_CLEAR_0);
-                        map_invalidate_tile_full(x, y);
-                    }
+                    surfaceElement->SetGrassLength(GRASS_LENGTH_CLEAR_0);
+                    map_invalidate_tile_full(x, y);
                 }
             }
         }

--- a/src/openrct2/world/Surface.cpp
+++ b/src/openrct2/world/Surface.cpp
@@ -9,6 +9,9 @@
 
 #include "Surface.h"
 
+#include "../Context.h"
+#include "../object/ObjectManager.h"
+#include "../object/TerrainSurfaceObject.h"
 #include "../scenario/Scenario.h"
 #include "Location.hpp"
 #include "Map.h"
@@ -67,6 +70,22 @@ void SurfaceElement::SetWaterHeight(uint32_t newWaterHeight)
     terrain |= newWaterHeight;
 }
 
+bool SurfaceElement::CanGrassGrow() const
+{
+    auto surfaceStyle = GetSurfaceStyle();
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_TERRAIN_SURFACE, surfaceStyle);
+    if (obj != nullptr)
+    {
+        auto surfaceObject = static_cast<TerrainSurfaceObject*>(obj);
+        if (surfaceObject->Flags & TERRAIN_SURFACE_FLAGS::CAN_GROW)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 uint8_t SurfaceElement::GetGrassLength() const
 {
     return grass_length;
@@ -108,7 +127,7 @@ void SurfaceElement::SetGrassLengthAndInvalidate(uint8_t length, CoordsXY coords
 void SurfaceElement::UpdateGrassLength(CoordsXY coords)
 {
     // Check if tile is grass
-    if (GetSurfaceStyle() != TERRAIN_GRASS)
+    if (!CanGrassGrow())
         return;
 
     uint8_t grassLengthTmp = grass_length & 7;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -143,6 +143,7 @@ public:
     uint32_t GetEdgeStyle() const;
     void SetEdgeStyle(uint32_t newStyle);
 
+    bool CanGrassGrow() const;
     uint8_t GetGrassLength() const;
     void SetGrassLength(uint8_t newLength);
     void SetGrassLengthAndInvalidate(uint8_t newLength, CoordsXY coords);


### PR DESCRIPTION
Solves #8405 by replacing all hard coded uses of `TERRAIN_GRASS` when checking the length of the grass with the new object property.