### PR TITLE
Fix #8385: Ghost objects rendered in minimap

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [#8963] Add missing Czech letters to sprite font, use sprite font for Czech.
 - Feature: [#9154] Change map toolbar icon with current viewport rotation.
 - Change: [#7877] Files are now sorted in logical rather than dictionary order.
+- Change: [#8427] Ghost elements now show up as white on the mini-map.
 - Change: [#8688] Move common actions from debug menu into cheats menu.
 - Fix: [#5103] OpenGL: ride track preview not rendered.
 - Fix: [#5889] Giant screenshot does not work while using OpenGL renderer.

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -877,6 +877,7 @@ static void window_map_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
     g1temp.x_offset = -8;
     g1temp.y_offset = -8;
     gfx_set_g1_element(SPR_TEMP, &g1temp);
+    drawing_engine_invalidate_image(SPR_TEMP);
     gfx_draw_sprite(dpi, SPR_TEMP, 0, 0, 0);
 
     if (w->selected_tab == PAGE_PEEPS)
@@ -1551,7 +1552,10 @@ static uint16_t map_window_get_pixel_colour_peep(CoordsXY c)
     while (!(tileElement++)->IsLastForTile())
     {
         if (tileElement->IsGhost())
-            continue;
+        {
+            colour = MAP_COLOUR(PALETTE_INDEX_21);
+            break;
+        }
 
         int32_t tileElementType = tileElement->GetType() >> 2;
         if (tileElementType >= maxSupportedTileElementType)
@@ -1568,7 +1572,6 @@ static uint16_t map_window_get_pixel_colour_peep(CoordsXY c)
 static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
 {
     Ride* ride;
-    // ~Mikroscopic: do we need two separate colour variables here?
     uint16_t colourA = 0;                            // highlight colour
     uint16_t colourB = MAP_COLOUR(PALETTE_INDEX_13); // surface colour (dark grey)
 
@@ -1577,7 +1580,10 @@ static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
     do
     {
         if (tileElement->IsGhost())
-            continue;
+        {
+            colourA = MAP_COLOUR(PALETTE_INDEX_21);
+            break;
+        }
 
         switch (tileElement->GetType())
         {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1550,6 +1550,9 @@ static uint16_t map_window_get_pixel_colour_peep(CoordsXY c)
     const int32_t maxSupportedTileElementType = (int32_t)std::size(ElementTypeAddColour);
     while (!(tileElement++)->IsLastForTile())
     {
+        if (tileElement->IsGhost())
+            continue;
+
         int32_t tileElementType = tileElement->GetType() >> 2;
         if (tileElementType >= maxSupportedTileElementType)
         {
@@ -1565,6 +1568,7 @@ static uint16_t map_window_get_pixel_colour_peep(CoordsXY c)
 static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
 {
     Ride* ride;
+    // ~Mikroscopic: do we need two separate colour variables here?
     uint16_t colourA = 0;                            // highlight colour
     uint16_t colourB = MAP_COLOUR(PALETTE_INDEX_13); // surface colour (dark grey)
 
@@ -1572,6 +1576,9 @@ static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
     TileElement* tileElement = map_get_surface_element_at(c);
     do
     {
+        if (tileElement->IsGhost())
+            continue;
+
         switch (tileElement->GetType())
         {
             case TILE_ELEMENT_TYPE_SURFACE:


### PR DESCRIPTION
Add a check for the ghost flag before changing map pixel color (First PR, please alert me to any mistakes)