### PR TITLE
Fix #8377: Change number of autosaves that are stored

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3725,6 +3725,8 @@ STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
 STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
+STR_6278    :Autosave-Amount
+STR_6279    :Amount of how many autosaves should be kept
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3725,7 +3725,7 @@ STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
 STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
-STR_6278    :Autosave-Amount
+STR_6278    :Autosave amount
 STR_6279    :Amount of how many autosaves should be kept
 
 #############

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3726,7 +3726,7 @@ STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
 STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
 STR_6278    :Autosave amount
-STR_6279    :Amount of how many autosaves should be kept
+STR_6279    :{SMALLFONT}{BLACK}Number of autosaves that should be kept
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Feature: [#8191] Allow building on-ride photos and water S-bends on the Water Coaster.
 - Feature: [#8259] Add say command to in-game console.
 - Feature: [#8374] Add replay system.
+- Feature: [#8377] Add option to adjust amount of how many autosaves are kept.
 - Feature: [#8583] Add boosters to water coaster.
 - Change: [#7961] Add new object types: station, terrain surface, and terrain edge.
 - Change: [#8222] The climate setting has been moved from objective options to scenario options.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Feature: [#8191] Allow building on-ride photos and water S-bends on the Water Coaster.
 - Feature: [#8259] Add say command to in-game console.
 - Feature: [#8374] Add replay system.
-- Feature: [#8377] Add option to adjust amount of how many autosaves are kept.
+- Feature: [#8377] Add option to adjust amount of autosaves to keep.
 - Feature: [#8583] Add boosters to water coaster.
 - Change: [#7961] Add new object types: station, terrain surface, and terrain edge.
 - Change: [#8222] The climate setting has been moved from objective options to scenario options.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -362,10 +362,10 @@ static rct_widget window_options_advanced_widgets[] = {
     { WWT_CHECKBOX,         1,  10,     299,    129,    140,    STR_ALWAYS_NATIVE_LOADSAVE,                 STR_ALWAYS_NATIVE_LOADSAVE_TIP },                   // Use native load/save window
     { WWT_DROPDOWN,         1,  165,    299,    145,    157,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
     { WWT_BUTTON,           1,  288,    298,    146,    156,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
-    SPINNER_WIDGETS        (1,  165,    299,    165,    180,    STR_NONE,                                   STR_AUTOSAVE_AMOUNT_TIP ),                          // Autosave amount spinner
-    { WWT_LABEL,            1,  23,     298,    180,    190,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
-    { WWT_BUTTON,           1,  24,     289,    195,    205,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
-    { WWT_BUTTON,           1,  289,    299,    195,    205,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
+    SPINNER_WIDGETS        (1,  165,    299,    165,    176,    STR_NONE,                                   STR_AUTOSAVE_AMOUNT_TIP ),                          // Autosave amount spinner
+    { WWT_LABEL,            1,  23,     298,    184,    195,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
+    { WWT_BUTTON,           1,  24,     289,    199,    212,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
+    { WWT_BUTTON,           1,  289,    299,    199,    212,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1328,14 +1328,18 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                 case WIDX_AUTOSAVE_AMOUNT_UP:
                     gConfigGeneral.autosave_amount += 1;
                     config_save_default();
-                    gfx_invalidate_screen();
+                    widget_invalidate(w, WIDX_AUTOSAVE);
+                    widget_invalidate(w, WIDX_AUTOSAVE_DROPDOWN);
+                    widget_invalidate(w, WIDX_AUTOSAVE_AMOUNT);
                     break;
                 case WIDX_AUTOSAVE_AMOUNT_DOWN:
                     if (gConfigGeneral.autosave_amount > 1)
                     {
                         gConfigGeneral.autosave_amount -= 1;
                         config_save_default();
-                        gfx_invalidate_screen();
+                        widget_invalidate(w, WIDX_AUTOSAVE);
+                        widget_invalidate(w, WIDX_AUTOSAVE_DROPDOWN);
+                        widget_invalidate(w, WIDX_AUTOSAVE_AMOUNT);
                     }
             }
             break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -362,7 +362,7 @@ static rct_widget window_options_advanced_widgets[] = {
     { WWT_CHECKBOX,         1,  10,     299,    129,    140,    STR_ALWAYS_NATIVE_LOADSAVE,                 STR_ALWAYS_NATIVE_LOADSAVE_TIP },                   // Use native load/save window
     { WWT_DROPDOWN,         1,  165,    299,    145,    157,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
     { WWT_BUTTON,           1,  288,    298,    146,    156,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
-    SPINNER_WIDGETS         (1,  165,    299,    165,    180,    STR_NONE,                                   STR_AUTOSAVE_AMOUNT_TIP ),                         // Autosave amount spinner
+    SPINNER_WIDGETS        (1,  165,    299,    165,    180,    STR_NONE,                                   STR_AUTOSAVE_AMOUNT_TIP ),                          // Autosave amount spinner
     { WWT_LABEL,            1,  23,     298,    180,    190,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
     { WWT_BUTTON,           1,  24,     289,    195,    205,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
     { WWT_BUTTON,           1,  289,    299,    195,    205,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
@@ -2088,9 +2088,9 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
             gfx_draw_string_left(
                 dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1], w->x + 24,
                 w->y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
-            int32_t autosave_amount = gConfigGeneral.autosave_amount*100;
+            int32_t autosavesToKeep = (int32_t)(gConfigGeneral.autosave_amount * 100);
             gfx_draw_string_left(
-                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosave_amount, w->colours[1], w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
+                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosavesToKeep, w->colours[1], w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
                 w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
 #ifdef __APPLE__

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1329,8 +1329,6 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     gConfigGeneral.autosave_amount += 1;
                     config_save_default();
                     gfx_invalidate_screen();
-                    context_trigger_resize();
-                    context_update_cursor_scale();
                     break;
                 case WIDX_AUTOSAVE_AMOUNT_DOWN:
                     if (gConfigGeneral.autosave_amount > 1)
@@ -1338,8 +1336,6 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                         gConfigGeneral.autosave_amount -= 1;
                         config_save_default();
                         gfx_invalidate_screen();
-                        context_trigger_resize();
-                        context_update_cursor_scale();
                     }
             }
             break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2090,8 +2090,8 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 w->y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
             int32_t autosavesToKeep = (int32_t)(gConfigGeneral.autosave_amount * 100);
             gfx_draw_string_left(
-                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosavesToKeep, w->colours[1], w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
-                w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
+                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosavesToKeep, w->colours[1],
+                w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
 #ifdef __APPLE__
             set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2088,9 +2088,9 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
             gfx_draw_string_left(
                 dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1], w->x + 24,
                 w->y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
-            int32_t autosavesToKeep = (int32_t)(gConfigGeneral.autosave_amount * 100);
+            int32_t autosavesToKeep = (int32_t)(gConfigGeneral.autosave_amount);
             gfx_draw_string_left(
-                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosavesToKeep, w->colours[1],
+                dpi, STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, &autosavesToKeep, w->colours[1],
                 w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
 #ifdef __APPLE__

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -178,6 +178,9 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_ALWAYS_NATIVE_LOADSAVE,
     WIDX_AUTOSAVE,
     WIDX_AUTOSAVE_DROPDOWN,
+    WIDX_AUTOSAVE_AMOUNT,
+    WIDX_AUTOSAVE_AMOUNT_UP,
+    WIDX_AUTOSAVE_AMOUNT_DOWN,
     WIDX_PATH_TO_RCT1_TEXT,
     WIDX_PATH_TO_RCT1_BUTTON,
     WIDX_PATH_TO_RCT1_CLEAR,
@@ -359,9 +362,10 @@ static rct_widget window_options_advanced_widgets[] = {
     { WWT_CHECKBOX,         1,  10,     299,    129,    140,    STR_ALWAYS_NATIVE_LOADSAVE,                 STR_ALWAYS_NATIVE_LOADSAVE_TIP },                   // Use native load/save window
     { WWT_DROPDOWN,         1,  165,    299,    145,    157,    STR_NONE,                                   STR_NONE },                                         // Autosave dropdown
     { WWT_BUTTON,           1,  288,    298,    146,    156,    STR_DROPDOWN_GLYPH,                         STR_AUTOSAVE_FREQUENCY_TIP },                       // Autosave dropdown button
-    { WWT_LABEL,            1,  23,     298,    165,    176,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
-    { WWT_BUTTON,           1,  24,     289,    180,    193,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
-    { WWT_BUTTON,           1,  289,    299,    180,    193,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
+    SPINNER_WIDGETS         (1,  165,    299,    165,    180,    STR_NONE,                                   STR_AUTOSAVE_AMOUNT_TIP ),                         // Autosave amount spinner
+    { WWT_LABEL,            1,  23,     298,    180,    190,    STR_PATH_TO_RCT1,                           STR_PATH_TO_RCT1_TIP },                             // RCT 1 path text
+    { WWT_BUTTON,           1,  24,     289,    195,    205,    STR_NONE,                                   STR_STRING_TOOLTIP },                               // RCT 1 path button
+    { WWT_BUTTON,           1,  289,    299,    195,    205,    STR_CLOSE_X,                                STR_PATH_TO_RCT1_CLEAR_TIP },                       // RCT 1 path clear button
     { WIDGETS_END },
 };
 
@@ -598,6 +602,9 @@ static uint64_t window_options_page_enabled_widgets[] = {
     (1 << WIDX_ALWAYS_NATIVE_LOADSAVE) |
     (1 << WIDX_AUTOSAVE) |
     (1 << WIDX_AUTOSAVE_DROPDOWN) |
+    (1 << WIDX_AUTOSAVE_AMOUNT) |
+    (1 << WIDX_AUTOSAVE_AMOUNT_UP) |
+    (1 << WIDX_AUTOSAVE_AMOUNT_DOWN) |
     (1 << WIDX_PATH_TO_RCT1_TEXT) |
     (1 << WIDX_PATH_TO_RCT1_BUTTON) |
     (1 << WIDX_PATH_TO_RCT1_CLEAR),
@@ -1318,6 +1325,22 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     window_options_show_dropdown(w, widget, AUTOSAVE_NEVER + 1);
                     dropdown_set_checked(gConfigGeneral.autosave_frequency, true);
                     break;
+                case WIDX_AUTOSAVE_AMOUNT_UP:
+                    gConfigGeneral.autosave_amount += 1;
+                    config_save_default();
+                    gfx_invalidate_screen();
+                    context_trigger_resize();
+                    context_update_cursor_scale();
+                    break;
+                case WIDX_AUTOSAVE_AMOUNT_DOWN:
+                    if (gConfigGeneral.autosave_amount > 1)
+                    {
+                        gConfigGeneral.autosave_amount -= 1;
+                        config_save_default();
+                        gfx_invalidate_screen();
+                        context_trigger_resize();
+                        context_update_cursor_scale();
+                    }
             }
             break;
 
@@ -2062,6 +2085,13 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, window_options_autosave_names[gConfigGeneral.autosave_frequency], nullptr, w->colours[1],
                 w->x + window_options_advanced_widgets[WIDX_AUTOSAVE].left + 1,
                 w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top);
+            gfx_draw_string_left(
+                dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1], w->x + 24,
+                w->y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
+            int32_t autosave_amount = gConfigGeneral.autosave_amount*100;
+            gfx_draw_string_left(
+                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &autosave_amount, w->colours[1], w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
+                w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
 #ifdef __APPLE__
             set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -64,8 +64,6 @@
 #include <iterator>
 #include <memory>
 
-#define NUMBER_OF_AUTOSAVES_TO_KEEP 9
-
 uint16_t gCurrentDeltaTime;
 uint8_t gGamePaused = 0;
 int32_t gGameSpeed = 1;
@@ -1384,7 +1382,8 @@ void game_autosave()
         timeName, sizeof(timeName), "autosave_%04u-%02u-%02u_%02u-%02u-%02u%s", currentDate.year, currentDate.month,
         currentDate.day, currentTime.hour, currentTime.minute, currentTime.second, fileExtension);
 
-    limit_autosave_count(NUMBER_OF_AUTOSAVES_TO_KEEP, (gScreenFlags & SCREEN_FLAGS_EDITOR));
+    int32_t autosave_amount = gConfigGeneral.autosave_amount;
+    limit_autosave_count(autosave_amount-1, (gScreenFlags & SCREEN_FLAGS_EDITOR));
 
     utf8 path[MAX_PATH];
     utf8 backupPath[MAX_PATH];

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -1382,8 +1382,8 @@ void game_autosave()
         timeName, sizeof(timeName), "autosave_%04u-%02u-%02u_%02u-%02u-%02u%s", currentDate.year, currentDate.month,
         currentDate.day, currentTime.hour, currentTime.minute, currentTime.second, fileExtension);
 
-    int32_t autosave_amount = gConfigGeneral.autosave_amount;
-    limit_autosave_count(autosave_amount-1, (gScreenFlags & SCREEN_FLAGS_EDITOR));
+    int32_t autosavesToKeep = gConfigGeneral.autosave_amount;
+    limit_autosave_count(autosavesToKeep - 1, (gScreenFlags & SCREEN_FLAGS_EDITOR));
 
     utf8 path[MAX_PATH];
     utf8 backupPath[MAX_PATH];

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -137,6 +137,7 @@ namespace Config
             auto model = &gConfigGeneral;
             model->always_show_gridlines = reader->GetBoolean("always_show_gridlines", false);
             model->autosave_frequency = reader->GetInt32("autosave", AUTOSAVE_EVERY_5MINUTES);
+            model->autosave_amount = reader->GetInt32("autosave_amount", 8);
             model->confirmation_prompt = reader->GetBoolean("confirmation_prompt", false);
             model->currency_format = reader->GetEnum<int32_t>("currency_format", platform_get_locale_currency(), Enum_Currency);
             model->custom_currency_rate = reader->GetInt32("custom_currency_rate", 10);
@@ -220,6 +221,7 @@ namespace Config
         writer->WriteSection("general");
         writer->WriteBoolean("always_show_gridlines", model->always_show_gridlines);
         writer->WriteInt32("autosave", model->autosave_frequency);
+        writer->WriteInt32("autosave_amount", model->autosave_amount);
         writer->WriteBoolean("confirmation_prompt", model->confirmation_prompt);
         writer->WriteEnum<int32_t>("currency_format", model->currency_format, Enum_Currency);
         writer->WriteInt32("custom_currency_rate", model->custom_currency_rate);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -34,8 +34,6 @@
 
 #include <memory>
 
-#define DEFAULT_NUM_AUTOSAVES_TO_KEEP 10
-
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui;
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -34,6 +34,8 @@
 
 #include <memory>
 
+#define DEFAULT_NUM_AUTOSAVES_TO_KEEP 10
+
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui;
 
@@ -137,7 +139,7 @@ namespace Config
             auto model = &gConfigGeneral;
             model->always_show_gridlines = reader->GetBoolean("always_show_gridlines", false);
             model->autosave_frequency = reader->GetInt32("autosave", AUTOSAVE_EVERY_5MINUTES);
-            model->autosave_amount = reader->GetInt32("autosave_amount", 10);
+            model->autosave_amount = reader->GetInt32("autosave_amount", DEFAULT_NUM_AUTOSAVES_TO_KEEP);
             model->confirmation_prompt = reader->GetBoolean("confirmation_prompt", false);
             model->currency_format = reader->GetEnum<int32_t>("currency_format", platform_get_locale_currency(), Enum_Currency);
             model->custom_currency_rate = reader->GetInt32("custom_currency_rate", 10);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -137,7 +137,7 @@ namespace Config
             auto model = &gConfigGeneral;
             model->always_show_gridlines = reader->GetBoolean("always_show_gridlines", false);
             model->autosave_frequency = reader->GetInt32("autosave", AUTOSAVE_EVERY_5MINUTES);
-            model->autosave_amount = reader->GetInt32("autosave_amount", 8);
+            model->autosave_amount = reader->GetInt32("autosave_amount", 10);
             model->confirmation_prompt = reader->GetBoolean("confirmation_prompt", false);
             model->currency_format = reader->GetEnum<int32_t>("currency_format", platform_get_locale_currency(), Enum_Currency);
             model->custom_currency_rate = reader->GetInt32("custom_currency_rate", 10);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -71,6 +71,7 @@ struct GeneralConfiguration
     bool no_test_crashes;
     bool debugging_tools;
     int32_t autosave_frequency;
+    int32_t autosave_amount;
     bool auto_staff_placement;
     bool handymen_mow_default;
     bool auto_open_shops;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3898,6 +3898,9 @@ enum
 
     STR_TILE_INSPECTOR_STATION_INDEX = 6277,
 
+    STR_AUTOSAVE_AMOUNT = 6278,
+    STR_AUTOSAVE_AMOUNT_TIP = 6279,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -361,6 +361,7 @@ enum
 };
 
 #define AUTOSAVE_PAUSE 0
+#define DEFAULT_NUM_AUTOSAVES_TO_KEEP 10
 
 extern const rct_string_id ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT];
 


### PR DESCRIPTION
Fixes #8377 

This adds a spinning widget in the advanced options tab to adjust the amount of autosaves to keep.

I'm not sure if the added strings are already completly implemented because within my build is displays undefined string. But this is perhaps only a build error.