### PR TITLE
Report all the paint session data

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -453,6 +453,25 @@ paint_struct* paint_arrange_structs_helper(paint_struct* ps_next, uint16_t quadr
 void paint_session_arrange(paint_session* session)
 {
     paint_struct* psHead = &session->PaintHead;
+    static int session_count = 0;
+    printf("\n    { /* session %3d */\n        .PaintStructs = {\n", session_count++);
+    int i = 0;
+    for (auto& ps : session->PaintStructs)
+    {
+        printf(
+            "    /* %4d */ { .basic = { .bounds = { %5u, %5u, %5u, %5u, %5u, %5u }, .quadrant_index = %3u, .quadrant_flags = "
+            "0x%x, .next_quadrant_ps = (paint_struct*)%4d} },\n",
+            i++, ps.basic.bounds.x, ps.basic.bounds.y, ps.basic.bounds.z, ps.basic.bounds.x_end, ps.basic.bounds.y_end,
+            ps.basic.bounds.z_end, ps.basic.quadrant_index, ps.basic.quadrant_flags,
+            (ps.basic.next_quadrant_ps ? int(ps.basic.next_quadrant_ps - &session->PaintStructs[0].basic) : 4000));
+    }
+    printf("        },\n        .Quadrants = {\n");
+    i = 0;
+    for (auto& quad : session->Quadrants)
+    {
+        printf("    /* %4d */ (paint_struct*)%4d,\n", i++, (quad ? int(quad - &session->PaintStructs[0].basic) : 512));
+    }
+    printf("        }\n    },\n");
 
     paint_struct* ps = psHead;
     ps->next_quadrant_ps = nullptr;


### PR DESCRIPTION
See https://github.com/janisozaur/openrct2-sprite-benchmark
```
/*
 * Benchmark for paint session sorting code. Code extracted from OpenRCT2 as of cf44ea7e2
 *
 * Generate data file with OpenRCT2 PR: https://github.com/OpenRCT2/OpenRCT2/issues/8442
 * E.g.
 *
 *     ./openrct2 screenshot ~/.config/OpenRCT2/save/dome-roof-on_zoom1.sv6 /dev/null giant 0 0 > out
 *
 * Save results as a file and remove any errors there may have been reported there (e.g. stuff about invalid/duplicate objects)
 * Make sure you have Google benchmark installed and available.
 * Compile this with... Warning, the output of the screenshot command may be large and require lots of RAM to compile
 *
 *     g++ paint_struct_benchmark.cpp -Wall -Wextra -Wno-missing-field-initializers -lbenchmark \
 *         -g -O2 -o paint_struct_bench -DSESSION_FILE=\"out\" -std=c++17 -O2
 *
 * You can limit amount of data provided to compilation when not doing real benchmark, but just playing around by providing
 * only a few paint sessions. The provided data (out.gz) contains values extracted from the "dome" park
 * (https://github.com/OpenRCT2/OpenRCT2/issues/4388) and out-min file contains the first three sessions of said file.
 *
 * Run the benchmark... Make sure you observe benchmark's warning regarding CPU scaling, if emitted
 *
 *     ./paint_struct_bench
 *
 * Observe the results:
 *
 *     2018-12-14 22:35:48
 *     Running ./bench-gcc
 *     Run on (8 X 4400 MHz CPU s)
 *     CPU Caches:
 *     L1 Data 32K (x4)
 *     L1 Instruction 32K (x4)
 *     L2 Unified 256K (x4)
 *     L3 Unified 8192K (x1)
 *     ----------------------------------------------------------------
 *     Benchmark                         Time           CPU Iterations
 *     ----------------------------------------------------------------
 *     BM_paint_session_arrange        945 ns        825 ns     872513
 *
 * Play with code, compiler and benchmark options.
 */
```