### PR TITLE
Fix #8431: crash when game action logging is enabled.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#8433] Crash if master server response is not valid JSON.
 - Fix: [#8434] Crash if curl_easy_init fails.
 - Fix: [#8443] Crash when selecting the current vehicle for ride that has none available.
+- Fix: [#8431] Crash when game action logging is enabled.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -187,7 +187,8 @@ namespace GameActions
         output.Write(temp, strlen(temp) + 1);
 
         const char* text = (const char*)output.GetData();
-        log_info(text);
+        log_verbose("%s", text);
+
         network_append_server_log(text);
     }
 


### PR DESCRIPTION
My bad, user input should be never used as input format.