### PR TITLE
Fix #8469: Crash modifying colour on hacked rides.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#8434] Crash if curl_easy_init fails.
 - Fix: [#8443] Crash when selecting the current vehicle for ride that has none available.
 - Fix: [#8431] Crash when game action logging is enabled.
+- Fix: [#8469] Crash modifying colour on hacked rides.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4777,6 +4777,8 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
         TileElement* tileElement = map_get_first_element_at((*position).x, (*position).y);
         do
         {
+            if (tileElement == nullptr)
+                break;
             if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
                 continue;
             if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE


### PR DESCRIPTION
Added a nullptr check.