### PR TITLE
Use different colours for entrance/exit on track design previews.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -53,6 +53,7 @@
 - Improved: [#7980] Show the full path of the scenario in the scenario select window.
 - Improved: [#7993] Allow assigning a keyboard shortcut for opening the tile inspector.
 - Improved: [#8107] Support Discord release of RCT2.
+- Improved: [#8491] Highlight entrance and exit with different colours in track design previews.
 - Improved: Almost completely new Hungarian translation.
 - Removed: [#7929] Support for scenario text objects.
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -31,14 +31,12 @@
 #define TRACK_MINI_PREVIEW_HEIGHT 78
 #define TRACK_MINI_PREVIEW_SIZE (TRACK_MINI_PREVIEW_WIDTH * TRACK_MINI_PREVIEW_HEIGHT)
 
-#define PALETTE_INDEX_TRANSPARENT (0)
-#define PALETTE_INDEX_PRIMARY_MID_DARK (248)
-#define PALETTE_INDEX_PRIMARY_LIGHTEST (252)
-
 struct rct_track_td6;
 
 static constexpr uint8_t _PaletteIndexColourEntrance = PALETTE_INDEX_20; // White
 static constexpr uint8_t _PaletteIndexColourExit = PALETTE_INDEX_10;     // Black
+static constexpr uint8_t _PaletteIndexColourTrack = PALETTE_INDEX_248;   // Grey (dark)
+static constexpr uint8_t _PaletteIndexColourStation = PALETTE_INDEX_252; // Grey (light)
 
 // clang-format off
 enum {
@@ -140,7 +138,8 @@ static uint8_t* draw_mini_preview_get_pixel_ptr(LocationXY16 pixel);
  */
 static void window_track_place_clear_mini_preview()
 {
-    std::fill(_window_track_place_mini_preview.begin(), _window_track_place_mini_preview.end(), PALETTE_INDEX_TRANSPARENT);
+    // Fill with transparent colour.
+    std::fill(_window_track_place_mini_preview.begin(), _window_track_place_mini_preview.end(), PALETTE_INDEX_0);
 }
 
 /**
@@ -562,8 +561,8 @@ static void window_track_place_draw_mini_preview_track(
 
                     // Station track is a lighter colour
                     uint8_t colour = (TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN)
-                        ? PALETTE_INDEX_PRIMARY_LIGHTEST
-                        : PALETTE_INDEX_PRIMARY_MID_DARK;
+                        ? _PaletteIndexColourStation
+                        : _PaletteIndexColourTrack;
 
                     for (int32_t i = 0; i < 4; i++)
                     {
@@ -670,7 +669,7 @@ static void window_track_place_draw_mini_preview_maze(
             {
                 uint8_t* pixel = draw_mini_preview_get_pixel_ptr(pixelPosition);
 
-                uint8_t colour = PALETTE_INDEX_PRIMARY_MID_DARK;
+                uint8_t colour = _PaletteIndexColourTrack;
 
                 // Draw entrance and exit with different colours.
                 if (mazeElement->type == MAZE_ELEMENT_TYPE_ENTRANCE)

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -64,7 +64,7 @@ enum
 
 enum
 {
-    PALETTE_INDEX_0 = 0,     //
+    PALETTE_INDEX_0 = 0,     // Transparent
     PALETTE_INDEX_10 = 10,   // Black (0-dark), Dark gray (0)
     PALETTE_INDEX_11 = 11,   // Black (middark)
     PALETTE_INDEX_12 = 12,   // Black (midlight), Dark gray (1-darkest)
@@ -106,6 +106,8 @@ enum
     PALETTE_INDEX_222 = 222, //
     PALETTE_INDEX_230 = 230, //
     PALETTE_INDEX_245 = 245, //
+    PALETTE_INDEX_248 = 248, // Grey (dark)
+    PALETTE_INDEX_252 = 252, // Grey (light)
 
     PALETTE_COUNT = 256,
 };


### PR DESCRIPTION
Something that bothered me from the very beginning, it was hard to tell how to place track designs if you aren't aware where the exit and entrances are. 

Heres what it looks like, Green = Entrance, Red = Exit.
![applicationframehost_2018-12-19_12-25-19](https://user-images.githubusercontent.com/5415177/50217513-294fa880-0389-11e9-9057-60472bcb63d7.jpg) ![applicationframehost_2018-12-19_12-24-14](https://user-images.githubusercontent.com/5415177/50217530-310f4d00-0389-11e9-8fb7-a83a731c9a93.jpg)
![applicationframehost_2018-12-19_12-26-17](https://user-images.githubusercontent.com/5415177/50217565-4be1c180-0389-11e9-95fb-3ed20fb1932b.jpg) ![applicationframehost_2018-12-19_12-24-00](https://user-images.githubusercontent.com/5415177/50217596-67e56300-0389-11e9-99cc-ac87bba62991.jpg)
![applicationframehost_2018-12-19_12-27-40](https://user-images.githubusercontent.com/5415177/50217629-7e8bba00-0389-11e9-992f-4866a350f9d7.jpg) ![applicationframehost_2018-12-19_12-24-30](https://user-images.githubusercontent.com/5415177/50217639-864b5e80-0389-11e9-8b37-72335291af32.jpg)

