### PR TITLE
Add ride type check

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1718,6 +1718,7 @@ bool rct_peep::ShouldGoOnRide(int32_t rideIndex, int32_t entranceNum, bool atQue
     if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
     {
         // Peeps that are leaving the park will refuse to go on any rides, with the exception of free transport rides.
+        assert(ride->type < std::size(RideData4));
         if (!(RideData4[ride->type].flags & RIDE_TYPE_FLAG4_TRANSPORT_RIDE) || ride->value == 0xFFFF
             || ride_get_price(ride) != 0)
         {


### PR DESCRIPTION
In the attached park delete `Bizarro-delete-me` ride and within a moment it will hit the assert.

[park-delete-bizarro.sv6.gz](https://github.com/OpenRCT2/OpenRCT2/files/2700591/park-delete-bizarro.sv6.gz)
![image](https://user-images.githubusercontent.com/550290/50311891-01566700-04a7-11e9-88b9-92b3682cb30f.png)
(in the screenshot the ride is not renamed yet)