### PR TITLE
Fix #8426: Queue banner left behind after ride demolition

### DIFF
--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -126,6 +126,7 @@ private:
         ride_stop_peeps_queuing(_rideIndex);
 
         sub_6CB945(_rideIndex);
+        ride_clear_leftover_entrances(_rideIndex);
         news_item_disable_news(NEWS_ITEM_RIDE, _rideIndex);
 
         for (auto& banner : gBanners)
@@ -150,7 +151,7 @@ private:
             {
                 if (peep->current_ride == _rideIndex)
                 {
-                    peep->current_ride = MAX_RIDES;
+                    peep->current_ride = RIDE_ID_NULL;
                     if (peep->time_to_stand >= 50)
                     {
                         // make peep stop watching the ride
@@ -200,11 +201,11 @@ private:
 
             if (peep->guest_heading_to_ride_id == _rideIndex)
             {
-                peep->guest_heading_to_ride_id = MAX_RIDES;
+                peep->guest_heading_to_ride_id = RIDE_ID_NULL;
             }
             if (peep->favourite_ride == _rideIndex)
             {
-                peep->favourite_ride = MAX_RIDES;
+                peep->favourite_ride = RIDE_ID_NULL;
             }
 
             for (int32_t i = 0; i < PEEP_MAX_THOUGHTS; i++)
@@ -288,24 +289,7 @@ private:
         tile_element_iterator_begin(&it);
         while (tile_element_iterator_next(&it))
         {
-            uint8_t tile_type = it.element->GetType();
-
-            if (tile_type == TILE_ELEMENT_TYPE_ENTRANCE)
-            {
-                uint8_t type = it.element->AsEntrance()->GetEntranceType();
-                if (type == ENTRANCE_TYPE_PARK_ENTRANCE)
-                    continue;
-
-                if (it.element->AsEntrance()->GetRideIndex() == _rideIndex)
-                {
-                    tile_element_remove(it.element);
-                    tile_element_iterator_restart_for_tile(&it);
-                }
-
-                continue;
-            }
-
-            if (tile_type != TILE_ELEMENT_TYPE_TRACK)
+            if (it.element->GetType() != TILE_ELEMENT_TYPE_TRACK)
                 continue;
 
             if (it.element->AsTrack()->GetRideIndex() != _rideIndex)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -8990,3 +8990,20 @@ void determine_ride_entrance_and_exit_locations()
         }
     }
 }
+
+void ride_clear_leftover_entrances(uint8_t rideIndex)
+{
+    tile_element_iterator it;
+
+    tile_element_iterator_begin(&it);
+    while (tile_element_iterator_next(&it))
+    {
+        if (it.element->GetType() == TILE_ELEMENT_TYPE_ENTRANCE
+            && it.element->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE
+            && it.element->AsEntrance()->GetRideIndex() == rideIndex)
+        {
+            tile_element_remove(it.element);
+            tile_element_iterator_restart_for_tile(&it);
+        }
+    }
+}

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1195,5 +1195,6 @@ void ride_stop_peeps_queuing(int32_t rideIndex);
 LocationXY16 ride_get_rotated_coords(int16_t x, int16_t y, int16_t z);
 
 void determine_ride_entrance_and_exit_locations();
+void ride_clear_leftover_entrances(uint8_t rideIndex);
 
 #endif


### PR DESCRIPTION
This reverts https://github.com/OpenRCT2/OpenRCT2/commit/16936d4ea15fef55645313e0afcc4d64932238c2 , which aimed to remove duplicate entrances/exit, and replaces it with a new approach that is executed after the normal entrances and exits are removed (`sub_6CB945` removes entrances and exit cleanly, including removing the queue sign).