### PR TITLE
Fix rendering of text shadows with TTF

### DIFF
--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -588,10 +588,26 @@ static void ttf_draw_string_raw_ttf(rct_drawpixelinfo* dpi, const utf8* text, te
                 {
                     if (*src != 0)
                     {
-                        *(dst + 1) = info->palette[3];                   // right
-                        *(dst - 1) = info->palette[3];                   // left
-                        *(dst - width - dstScanSkip) = info->palette[3]; // top
-                        *(dst + width + dstScanSkip) = info->palette[3]; // bottom
+                        // right
+                        if (xx + skipX < dpi->width + dpi->pitch - 1)
+                        {
+                            *(dst + 1) = info->palette[3];
+                        }
+                        // left
+                        if (xx + skipX > 1)
+                        {
+                            *(dst - 1) = info->palette[3];
+                        }
+                        // top
+                        if (yy + skipY > 1)
+                        {
+                            *(dst - width - dstScanSkip) = info->palette[3];
+                        }
+                        // bottom
+                        if (yy + skipY < dpi->height - 1)
+                        {
+                            *(dst + width + dstScanSkip) = info->palette[3];
+                        }
                     }
                     src++;
                     dst++;


### PR DESCRIPTION
Only render shadow if it is within the bounds of allocated buffer.
This fixes most if not all crashes seen with rendering TTF. The cause of
the problem is rendering of shadows which is done by taking a solid
rendered text and moving it by one pixel to up, left, right and *down*.
In some cases rendering the shadow in the one-down offset will write
past the allocated surface (see
https://github.com/OpenRCT2/OpenRCT2/blob/8d9fcb7f982e7fc60aab45a71e5a8f915866564e/src/openrct2/drawing/Drawing.String.cpp#L594)
it can easily happen when trying to render a shadowed text (e.g. map
tooltip) on a peep that's just above the bottom of the viewport.