### PR TITLE
Include stdexcept instead of exception

### DIFF
--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -10,8 +10,8 @@
 #include "Http.h"
 
 #include <cstring>
-#include <exception>
 #include <memory>
+#include <stdexcept>
 #include <thread>
 
 #ifndef DISABLE_HTTP


### PR DESCRIPTION
Fix build when using Windows 10 SDK 10.0.17763.0.