### PR TITLE
Text height computation for multiplayer information

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -51,6 +51,7 @@
 - Fix: [#8464] Crash on game shutdown.
 - Fix: [#8469] Crash modifying colour on hacked rides.
 - Fix: [#8508] Underground roto-drop is not going up.
+- Fix: [#8555] Multiplayer window text limits are not computed properly.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -412,18 +412,47 @@ static LocationXY16 window_multiplayer_information_get_size()
         return _windowInformationSize;
     }
 
-    int32_t width = 450;
-    int32_t height = 60;
-    int32_t minNumLines = 5;
-    int32_t descNumLines, fontSpriteBase;
-
+    // Reset font sprite base and compute line height
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    utf8* buffer = _strdup(network_get_server_description());
-    gfx_wrap_string(buffer, width, &descNumLines, &fontSpriteBase);
-    free(buffer);
+    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
-    int32_t lineHeight = font_get_line_height(fontSpriteBase);
-    height += (minNumLines + descNumLines) * lineHeight;
+    // Base dimensions. Assuming three lines of provider info, and one line of white space.
+    const int32_t width = 450;
+    int32_t height = 55;
+    int32_t numLines, fontSpriteBase;
+
+    // Server name is displayed word-wrapped, so figure out how high it will be.
+    {
+        utf8* buffer = _strdup(network_get_server_name());
+        gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
+        free(buffer);
+        height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
+    }
+
+    // Likewise, for the optional server description -- which can be a little longer.
+    const utf8* descString = network_get_server_description();
+    if (!str_is_null_or_empty(descString))
+    {
+        utf8* buffer = _strdup(descString);
+        gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
+        free(buffer);
+        height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
+    }
+
+    // Finally, account for provider info, if present.
+    {
+        const utf8* providerName = network_get_server_provider_name();
+        if (!str_is_null_or_empty(providerName))
+            height += LIST_ROW_HEIGHT;
+
+        const utf8* providerEmail = network_get_server_provider_email();
+        if (!str_is_null_or_empty(providerEmail))
+            height += LIST_ROW_HEIGHT;
+
+        const utf8* providerWebsite = network_get_server_provider_website();
+        if (!str_is_null_or_empty(providerWebsite))
+            height += LIST_ROW_HEIGHT;
+    }
 
     _windowInformationSizeDirty = false;
     _windowInformationSize = { (int16_t)width, (int16_t)height };
@@ -465,10 +494,9 @@ static void window_multiplayer_information_paint(rct_window* w, rct_drawpixelinf
 
         const utf8* name = network_get_server_name();
         {
-            gfx_draw_string_left_wrapped(dpi, (void*)&name, x, y, width, STR_STRING, w->colours[1]);
-            y += LIST_ROW_HEIGHT;
+            y += gfx_draw_string_left_wrapped(dpi, (void*)&name, x, y, width, STR_STRING, w->colours[1]);
+            y += LIST_ROW_HEIGHT / 2;
         }
-        y += LIST_ROW_HEIGHT / 2;
 
         const utf8* description = network_get_server_description();
         if (!str_is_null_or_empty(description))

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -416,7 +416,7 @@ static LocationXY16 window_multiplayer_information_get_size()
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
-    // Base dimensions. Assuming three lines of provider info, and one line of white space.
+    // Base dimensions.
     const int32_t width = 450;
     int32_t height = 55;
     int32_t numLines, fontSpriteBase;


### PR DESCRIPTION
The height for the information tab in the multiplayer window is currently not being computed correctly. This PR addresses this, fixing #8555.

Changes:

* Server names are displayed with word-wrapping, while it was assumed to take up one line.
* Provider name/email/website now only take up space when present.
* Effectively, there is `LIST_ROW_HEIGHT` spacing between server name and description, previously not taken into account.