### PR TITLE
Store ride idx inside ride struct

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1774,7 +1774,7 @@ static void window_ride_set_page(rct_window* w, int32_t page)
     w->var_492 = 0;
 
     // There doesn't seem to be any need for this call, and it can sometimes modify the reported number of cars per train, so
-    // I've removed it if (page == WINDOW_RIDE_PAGE_VEHICLE) { ride_update_max_vehicles(w->number);
+    // I've removed it if (page == WINDOW_RIDE_PAGE_VEHICLE) { ride_update_max_vehicles(ride);
     //}
 
     if (w->viewport != nullptr)

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -148,21 +148,19 @@ static void cheat_fix_rides()
 {
     ride_id_t rideIndex;
     Ride* ride;
-    rct_peep* mechanic;
 
     FOR_ALL_RIDES (rideIndex, ride)
     {
         if ((ride->mechanic_status != RIDE_MECHANIC_STATUS_FIXING)
             && (ride->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
         {
-            mechanic = ride_get_assigned_mechanic(ride);
-
+            auto mechanic = ride_get_assigned_mechanic(ride);
             if (mechanic != nullptr)
             {
                 mechanic->RemoveFromRide();
             }
 
-            ride_fix_breakdown(rideIndex, 0);
+            ride_fix_breakdown(ride, 0);
             ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
         }
     }

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -131,6 +131,7 @@ public:
             return std::move(res);
         }
 
+        ride->id = rideIndex;
         ride->type = _rideType;
         ride->subtype = rideEntryIndex;
         ride_set_colour_preset(ride, _colour1);

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -121,8 +121,8 @@ private:
     {
         money32 refundPrice = DemolishTracks();
 
-        ride_clear_for_construction(_rideIndex);
-        ride_remove_peeps(_rideIndex);
+        ride_clear_for_construction(ride);
+        ride_remove_peeps(ride);
         ride_stop_peeps_queuing(_rideIndex);
 
         sub_6CB945(_rideIndex);

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -128,8 +128,8 @@ public:
                     if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
                     {
                         ride->lifecycle_flags &= ~RIDE_LIFECYCLE_CRASHED;
-                        ride_clear_for_construction(_rideIndex);
-                        ride_remove_peeps(_rideIndex);
+                        ride_clear_for_construction(ride);
+                        ride_remove_peeps(ride);
                     }
                 }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -218,7 +218,7 @@ static int32_t cc_rides(InteractiveConsole& console, const utf8** argv, int32_t 
                     else
                     {
                         ride->mode = mode;
-                        invalidate_test_results(ride_index);
+                        invalidate_test_results(ride);
                     }
                 }
             }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -3097,7 +3097,7 @@ bool rct_peep::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride
         return false;
     }
 
-    ride_fix_breakdown(current_ride, steps);
+    ride_fix_breakdown(ride, steps);
 
     return true;
 }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -737,14 +737,15 @@ private:
         {
             if (_s4.rides[i].type != RIDE_TYPE_NULL)
             {
-                ImportRide(get_ride(i), &_s4.rides[i]);
+                ImportRide(get_ride(i), &_s4.rides[i], i);
             }
         }
     }
 
-    void ImportRide(Ride* dst, rct1_ride* src)
+    void ImportRide(Ride* dst, rct1_ride* src, ride_id_t rideIndex)
     {
-        std::memset(dst, 0x00, sizeof(Ride));
+        *dst = {};
+        dst->id = rideIndex;
 
         // This is a peculiarity of this exact version number, which only Heide-Park seems to use.
         if (_s4.game_version == 110018 && src->type == RCT1_RIDE_TYPE_INVERTED_ROLLER_COASTER)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -502,14 +502,9 @@ public:
         for (uint8_t index = 0; index < RCT12_MAX_RIDES_IN_PARK; index++)
         {
             auto src = &_s6.rides[index];
-            auto dst = get_ride(index);
-            *dst = {};
-            if (src->type == RIDE_TYPE_NULL)
+            if (src->type != RIDE_TYPE_NULL)
             {
-                dst->type = RIDE_TYPE_NULL;
-            }
-            else
-            {
+                auto dst = get_ride(index);
                 ImportRide(dst, src, index);
             }
         }
@@ -517,8 +512,8 @@ public:
 
     void ImportRide(Ride* dst, const rct2_ride* src, const ride_id_t rideIndex)
     {
-        std::memset(dst, 0, sizeof(Ride));
-
+        *dst = {};
+        dst->id = rideIndex;
         dst->type = src->type;
         dst->subtype = src->subtype;
         // pad_002;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -163,6 +163,7 @@ struct RideStation
  */
 struct Ride
 {
+    ride_id_t id;
     uint8_t type;
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
     // 0x4c.
@@ -1019,8 +1020,8 @@ int32_t ride_find_track_gap(ride_id_t rideIndex, CoordsXYE* input, CoordsXYE* ou
 void ride_construct_new(ride_list_item listItem);
 void ride_construct(ride_id_t rideIndex);
 int32_t ride_modify(CoordsXYE* input);
-void ride_remove_peeps(ride_id_t rideIndex);
-void ride_clear_blocked_tiles(ride_id_t rideIndex);
+void ride_remove_peeps(Ride* ride);
+void ride_clear_blocked_tiles(Ride* ride);
 void ride_get_status(ride_id_t rideIndex, rct_string_id* formatSecondary, int32_t* argument);
 rct_peep* ride_get_assigned_mechanic(Ride* ride);
 int32_t ride_get_total_length(Ride* ride);
@@ -1084,13 +1085,13 @@ money32 ride_create_command(int32_t type, int32_t subType, int32_t flags, ride_i
 void ride_set_name_to_default(Ride* ride, rct_ride_entry* rideEntry);
 
 void ride_set_name_to_track_default(Ride* ride, rct_ride_entry* rideEntry);
-void ride_clear_for_construction(ride_id_t rideIndex);
+void ride_clear_for_construction(Ride* ride);
 void ride_entrance_exit_place_provisional_ghost();
 void ride_entrance_exit_remove_ghost();
 void ride_restore_provisional_track_piece();
 void ride_remove_provisional_track_piece();
 void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int32_t num_images);
-void invalidate_test_results(ride_id_t rideIndex);
+void invalidate_test_results(Ride* ride);
 
 void ride_select_next_section();
 void ride_select_previous_section();
@@ -1144,11 +1145,11 @@ bool ride_select_forwards_from_back();
 money32 ride_remove_track_piece(int32_t x, int32_t y, int32_t z, int32_t direction, int32_t type, uint8_t flags);
 
 bool ride_are_all_possible_entrances_and_exits_built(Ride* ride);
-void ride_fix_breakdown(ride_id_t rideIndex, int32_t reliabilityIncreaseFactor);
+void ride_fix_breakdown(Ride* ride, int32_t reliabilityIncreaseFactor);
 
 void ride_entry_get_train_layout(int32_t rideEntryIndex, int32_t numCarsPerTrain, uint8_t* trainLayout);
 uint8_t ride_entry_get_vehicle_at_position(int32_t rideEntryIndex, int32_t numCarsPerTrain, int32_t position);
-void ride_update_max_vehicles(ride_id_t rideIndex);
+void ride_update_max_vehicles(Ride* ride);
 uint64_t ride_entry_get_supported_track_pieces(const rct_ride_entry* rideEntry);
 
 void ride_set_ride_entry(ride_id_t rideIndex, int32_t rideEntry);

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -1382,7 +1382,7 @@ static money32 track_place(
         if (!(flags & GAME_COMMAND_FLAG_APPLY))
             continue;
 
-        invalidate_test_results(rideIndex);
+        invalidate_test_results(ride);
         switch (type)
         {
             case TRACK_ELEM_ON_RIDE_PHOTO:
@@ -1510,7 +1510,7 @@ static money32 track_place(
                 track_add_station_element(x, y, baseZ, direction, rideIndex, GAME_COMMAND_FLAG_APPLY);
             }
             sub_6CB945(rideIndex);
-            ride_update_max_vehicles(rideIndex);
+            ride_update_max_vehicles(ride);
         }
 
         if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER)
@@ -1787,7 +1787,7 @@ static money32 track_remove(
             surfaceElement->AsSurface()->SetHasTrackThatNeedsWater(false);
         }
 
-        invalidate_test_results(rideIndex);
+        invalidate_test_results(ride);
         footpath_queue_chain_reset();
         if (!gCheatsDisableClearanceChecks || !(tileElement->flags & TILE_ELEMENT_FLAG_GHOST))
         {
@@ -1797,7 +1797,7 @@ static money32 track_remove(
         if (!(flags & GAME_COMMAND_FLAG_GHOST))
         {
             sub_6CB945(rideIndex);
-            ride_update_max_vehicles(rideIndex);
+            ride_update_max_vehicles(ride);
         }
     }
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -168,8 +168,8 @@ static money32 RideEntranceExitPlace(
             return MONEY32_UNDEFINED;
         }
 
-        ride_clear_for_construction(rideIndex);
-        ride_remove_peeps(rideIndex);
+        ride_clear_for_construction(ride);
+        ride_remove_peeps(ride);
 
         bool requiresRemove = false;
         LocationXY16 removeCoord = { 0, 0 };
@@ -345,9 +345,9 @@ static money32 RideEntranceExitRemove(int16_t x, int16_t y, ride_id_t rideIndex,
 
     if (flags & GAME_COMMAND_FLAG_APPLY)
     {
-        ride_clear_for_construction(rideIndex);
-        ride_remove_peeps(rideIndex);
-        invalidate_test_results(rideIndex);
+        ride_clear_for_construction(ride);
+        ride_remove_peeps(ride);
+        invalidate_test_results(ride);
 
         bool found = false;
         TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -825,7 +825,7 @@ int32_t tile_inspector_track_base_height_offset(int32_t x, int32_t y, int32_t el
                 map_get_surface_element_at({ elemX, elemY }) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
 
             // Keep?
-            // invalidate_test_results(rideIndex);
+            // invalidate_test_results(ride);
 
             tileElement->base_height += offset;
             tileElement->clearance_height += offset;
@@ -958,7 +958,7 @@ int32_t tile_inspector_track_set_chain(
                 map_get_surface_element_at({ elemX, elemY }) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
 
             // Keep?
-            // invalidate_test_results(rideIndex);
+            // invalidate_test_results(ride);
 
             if (tileElement->AsTrack()->HasChain() != setChain)
             {


### PR DESCRIPTION
Because the ride struct never stored the ID / index of the ride, many of the functions that need to pass a ride as an argument would pass the ride index instead and re-acquire the ride pointer or in some cases pass the ride pointer and the index.

This changes adds id as a field to `Ride` and makes a start on removing some of the now redundant ride index parameters, making everything consistently pass `Ride*`. This also optimises the code slightly as we don't have to call `get_ride` as often.