### PR TITLE
[feedback] Add RCT2 obj. dir. to ObjectRepository search path

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -83,6 +83,7 @@ public:
               std::vector<std::string>{
                   env.GetDirectoryPath(DIRBASE::OPENRCT2, DIRID::OBJECT),
                   env.GetDirectoryPath(DIRBASE::USER, DIRID::OBJECT),
+                  env.GetDirectoryPath(DIRBASE::RCT2, DIRID::OBJECT),
               })
         , _objectRepository(objectRepository)
     {


### PR DESCRIPTION
I followed the installation instructions for MacOS but I ended up with an error about missing objects. After some debugging, I found that the `ObjectRepository` did not look for objects in the original RCT2 `ObjDir` folder.

**Do I correctly assume that objects should be searched in the RCT2 game folder?**

![Issue](https://user-images.githubusercontent.com/675432/51372858-d7707e80-1afe-11e9-9906-9b8253fa6de3.png)

So, I added it to the repository, solving the issue. Still, it leaves me with some missing textures so something is still not alright on Mac OS <develop>.

![Texture](https://user-images.githubusercontent.com/675432/51377309-e1987a00-1b0a-11e9-977f-9cd63ac51eed.png)