### PR TITLE
Fix #8584: Ducks spawning function doesnt check tiles 0..63 (original bug)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,8 +54,8 @@
 - Fix: [#8469] Crash modifying colour on hacked rides.
 - Fix: [#8508] Underground roto-drop is not going up.
 - Fix: [#8555] Multiplayer window text limits are not computed properly.
-- Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
 - Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..63 (Original bug)
+- Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -55,6 +55,7 @@
 - Fix: [#8508] Underground roto-drop is not going up.
 - Fix: [#8555] Multiplayer window text limits are not computed properly.
 - Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
+- Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..64 (Original bug)
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -55,7 +55,7 @@
 - Fix: [#8508] Underground roto-drop is not going up.
 - Fix: [#8555] Multiplayer window text limits are not computed properly.
 - Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
-- Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..64 (Original bug)
+- Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..63 (Original bug)
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "22"
+#define NETWORK_STREAM_VERSION "23"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -429,8 +429,8 @@ static int32_t scenario_create_ducks()
     // Originally, this function generated coordinates from 64 to 191.
     // It now generates coordinates from 0 to 255, so smaller maps may also spawn ducks.
     r = scenario_rand();
-    x = ((r >> 16) & 0xFFFF) & 0xFF;
-    y = (r & 0xFFFF) & 0xFF;
+    x = ((r >> 16) & 0xFFFF) % MAXIMUM_MAP_SIZE_TECHNICAL;
+    y = (r & 0xFFFF) % MAXIMUM_MAP_SIZE_TECHNICAL;
     x = x * 32;
     y = y * 32;
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -426,11 +426,13 @@ static int32_t scenario_create_ducks()
 {
     int32_t i, j, r, c, x, y, waterZ, centreWaterZ, x2, y2;
 
+    // Originally, this function generated coordinates from 64 to 191.
+    // It now generates coordinates from 0 to 255, so smaller maps may also spawn ducks.
     r = scenario_rand();
-    x = ((r >> 16) & 0xFFFF) & 0x7F;
-    y = (r & 0xFFFF) & 0x7F;
-    x = (x + 64) * 32;
-    y = (y + 64) * 32;
+    x = ((r >> 16) & 0xFFFF) & 0xFF;
+    y = (r & 0xFFFF) & 0xFF;
+    x = x * 32;
+    y = y * 32;
 
     if (!map_is_location_in_park({ x, y }))
         return 0;


### PR DESCRIPTION
Originally, the function that checks for water on tiles to spawn ducks only generated coordinates from 64 to 191. This meant that in small maps like Leafy Lake or Forest Frontiers, ducks will normally not spawn, or only in a corner of the map if all land is owned.

I tested this in vanilla RCT2 on Crazy Castle, and it seems ducks only stick to a small corner of the map with coordinates bigger than 63,63 as well, so it seems to be an original bug (or intended behavior).

This pull modifies the function to consider every tile coordinate from 0 to 255. I tested this on several maps with water inside the park area, and they now all spawn a good amount of ducks every year.