### PR TITLE
Use vector<string> in InteractiveConsole

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -59,7 +59,7 @@
 
 using arguments_t = std::vector<std::string>;
 
-static constexpr const utf8* ClimateNames[] = {
+static constexpr const char* ClimateNames[] = {
     "cool_and_wet",
     "warm",
     "hot_and_dry",
@@ -67,9 +67,6 @@ static constexpr const utf8* ClimateNames[] = {
 };
 
 static void console_write_all_commands(InteractiveConsole& console);
-static int32_t console_parse_int(const utf8* src, bool* valid);
-static double console_parse_double(const utf8* src, bool* valid);
-
 static int32_t cc_variables(InteractiveConsole& console, const arguments_t& argv);
 static int32_t cc_windows(InteractiveConsole& console, const arguments_t& argv);
 static int32_t cc_help(InteractiveConsole& console, const arguments_t& argv);
@@ -84,20 +81,20 @@ static bool invalidArguments(bool* invalid, bool arguments);
             variable &= ~(flag);                                                                                               \
     }
 
-int32_t console_parse_int(const utf8* src, bool* valid)
+int32_t console_parse_int(const std::string& src, bool* valid)
 {
     utf8* end;
     int32_t value;
-    value = strtol(src, &end, 10);
+    value = static_cast<int32_t>(strtol(src.c_str(), &end, 10));
     *valid = (*end == '\0');
     return value;
 }
 
-double console_parse_double(const utf8* src, bool* valid)
+double console_parse_double(const std::string& src, bool* valid)
 {
     utf8* end;
     double value;
-    value = strtod(src, &end);
+    value = strtod(src.c_str(), &end);
     *valid = (*end == '\0');
     return value;
 }
@@ -173,8 +170,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             if (argv[1] == "type")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                int32_t type = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                int32_t type = console_parse_int(argv[3], &int_valid[1]);
                 if (!int_valid[0] || !int_valid[1])
                 {
                     console.WriteFormatLine("This command expects integer arguments");
@@ -197,8 +194,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "mode")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                int32_t mode = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                int32_t mode = console_parse_int(argv[3], &int_valid[1]);
                 if (!int_valid[0] || !int_valid[1])
                 {
                     console.WriteFormatLine("This command expects integer arguments");
@@ -228,8 +225,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "mass")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                int32_t mass = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                int32_t mass = console_parse_int(argv[3], &int_valid[1]);
 
                 if (ride_index < 0)
                 {
@@ -268,8 +265,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "excitement")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                ride_rating excitement = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                ride_rating excitement = console_parse_int(argv[3], &int_valid[1]);
 
                 if (ride_index < 0)
                 {
@@ -299,8 +296,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "intensity")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                ride_rating intensity = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                ride_rating intensity = console_parse_int(argv[3], &int_valid[1]);
 
                 if (ride_index < 0)
                 {
@@ -330,8 +327,8 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "nausea")
             {
                 bool int_valid[2] = { 0 };
-                int32_t ride_index = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                ride_rating nausea = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
+                ride_rating nausea = console_parse_int(argv[3], &int_valid[1]);
 
                 if (ride_index < 0)
                 {
@@ -404,8 +401,8 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             {
                 int32_t int_val[3];
                 bool int_valid[3] = { 0 };
-                int_val[0] = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                int_val[1] = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int_val[0] = console_parse_int(argv[2], &int_valid[0]);
+                int_val[1] = console_parse_int(argv[3], &int_valid[1]);
 
                 if (int_valid[0] && int_valid[1] && ((GET_PEEP(int_val[0])) != nullptr))
                 {
@@ -419,8 +416,8 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             {
                 int32_t int_val[2];
                 bool int_valid[2] = { 0 };
-                int_val[0] = console_parse_int(argv[2].c_str(), &int_valid[0]);
-                int_val[1] = console_parse_int(argv[3].c_str(), &int_valid[1]);
+                int_val[0] = console_parse_int(argv[2], &int_valid[0]);
+                int_val[1] = console_parse_int(argv[3], &int_valid[1]);
                 rct_peep* peep = nullptr;
                 if (!int_valid[0])
                 {
@@ -671,8 +668,8 @@ static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
         {
             if (i + 1 < argv.size())
             {
-                int_val[i] = console_parse_int(argv[i + 1].c_str(), &int_valid[i]);
-                double_val[i] = console_parse_double(argv[i + 1].c_str(), &double_valid[i]);
+                int_val[i] = console_parse_int(argv[i + 1], &int_valid[i]);
+                double_val[i] = console_parse_double(argv[i + 1], &double_valid[i]);
             }
             else
             {

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -169,7 +169,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             if (argv[1] == "type")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 int32_t type = console_parse_int(argv[3], &int_valid[1]);
                 if (!int_valid[0] || !int_valid[1])
@@ -193,7 +193,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (argv[1] == "mode")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 int32_t mode = console_parse_int(argv[3], &int_valid[1]);
                 if (!int_valid[0] || !int_valid[1])
@@ -224,7 +224,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (argv[1] == "mass")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 int32_t mass = console_parse_int(argv[3], &int_valid[1]);
 
@@ -264,7 +264,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (argv[1] == "excitement")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 ride_rating excitement = console_parse_int(argv[3], &int_valid[1]);
 
@@ -295,7 +295,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (argv[1] == "intensity")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 ride_rating intensity = console_parse_int(argv[3], &int_valid[1]);
 
@@ -326,7 +326,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (argv[1] == "nausea")
             {
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int32_t ride_index = console_parse_int(argv[2], &int_valid[0]);
                 ride_rating nausea = console_parse_int(argv[3], &int_valid[1]);
 
@@ -400,7 +400,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             if (argv[1] == "energy")
             {
                 int32_t int_val[3];
-                bool int_valid[3] = { 0 };
+                bool int_valid[3] = { false };
                 int_val[0] = console_parse_int(argv[2], &int_valid[0]);
                 int_val[1] = console_parse_int(argv[3], &int_valid[1]);
 
@@ -415,7 +415,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             else if (argv[1] == "costume")
             {
                 int32_t int_val[2];
-                bool int_valid[2] = { 0 };
+                bool int_valid[2] = { false };
                 int_val[0] = console_parse_int(argv[2], &int_valid[0]);
                 int_val[1] = console_parse_int(argv[3], &int_valid[1]);
                 rct_peep* peep = nullptr;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -66,8 +66,8 @@ static constexpr const char* ClimateNames[] = {
     "cold",
 };
 
-int32_t console_parse_int(const std::string& src, bool* valid);
-double console_parse_double(const std::string& src, bool* valid);
+static int32_t console_parse_int(const std::string& src, bool* valid);
+static double console_parse_double(const std::string& src, bool* valid);
 
 static void console_write_all_commands(InteractiveConsole& console);
 static int32_t cc_variables(InteractiveConsole& console, const arguments_t& argv);
@@ -84,7 +84,7 @@ static bool invalidArguments(bool* invalid, bool arguments);
             variable &= ~(flag);                                                                                               \
     }
 
-int32_t console_parse_int(const std::string& src, bool* valid)
+static int32_t console_parse_int(const std::string& src, bool* valid)
 {
     utf8* end;
     int32_t value;
@@ -93,7 +93,7 @@ int32_t console_parse_int(const std::string& src, bool* valid)
     return value;
 }
 
-double console_parse_double(const std::string& src, bool* valid)
+static double console_parse_double(const std::string& src, bool* valid)
 {
     utf8* end;
     double value;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -66,6 +66,9 @@ static constexpr const char* ClimateNames[] = {
     "cold",
 };
 
+int32_t console_parse_int(const std::string& src, bool* valid);
+double console_parse_double(const std::string& src, bool* valid);
+
 static void console_write_all_commands(InteractiveConsole& console);
 static int32_t cc_variables(InteractiveConsole& console, const arguments_t& argv);
 static int32_t cc_windows(InteractiveConsole& console, const arguments_t& argv);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -57,7 +57,7 @@
 #    include "../drawing/TTF.h"
 #endif
 
-using argv_t = std::vector<std::string>;
+using arguments_t = std::vector<std::string>;
 
 static constexpr const utf8* ClimateNames[] = {
     "cool_and_wet",
@@ -70,9 +70,9 @@ static void console_write_all_commands(InteractiveConsole& console);
 static int32_t console_parse_int(const utf8* src, bool* valid);
 static double console_parse_double(const utf8* src, bool* valid);
 
-static int32_t cc_variables(InteractiveConsole& console, const argv_t& argv);
-static int32_t cc_windows(InteractiveConsole& console, const argv_t& argv);
-static int32_t cc_help(InteractiveConsole& console, const argv_t& argv);
+static int32_t cc_variables(InteractiveConsole& console, const arguments_t& argv);
+static int32_t cc_windows(InteractiveConsole& console, const arguments_t& argv);
+static int32_t cc_help(InteractiveConsole& console, const arguments_t& argv);
 
 static bool invalidArguments(bool* invalid, bool arguments);
 
@@ -102,32 +102,32 @@ double console_parse_double(const utf8* src, bool* valid)
     return value;
 }
 
-static int32_t cc_clear(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_clear(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Clear();
     return 0;
 }
 
-static int32_t cc_close(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_close(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Close();
     return 0;
 }
 
-static int32_t cc_hide(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_hide(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     console.Hide();
     return 0;
 }
 
-static int32_t cc_echo(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_echo(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
         console.WriteLine(argv[0]);
     return 0;
 }
 
-static int32_t cc_rides(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -367,7 +367,7 @@ static int32_t cc_rides(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_staff(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -453,7 +453,7 @@ static int32_t cc_staff(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_get(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_get(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -656,7 +656,7 @@ static int32_t cc_get(InteractiveConsole& console, const argv_t& argv)
     }
     return 0;
 }
-static int32_t cc_set(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
 {
     uint32_t i;
     if (argv.size() > 1)
@@ -1006,7 +1006,7 @@ static int32_t cc_set(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_twitch([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_twitch([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
 #ifdef DISABLE_TWITCH
     console.WriteLineError("OpenRCT2 build not compiled with Twitch integration.");
@@ -1018,7 +1018,7 @@ static int32_t cc_twitch([[maybe_unused]] InteractiveConsole& console, [[maybe_u
     return 0;
 }
 
-static int32_t cc_load_object(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -1094,7 +1094,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_object_count(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_object_count(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     const utf8* object_type_names[] = {
         "Rides", "Small scenery",  "Large scenery",  "Walls",          "Banners",
@@ -1117,13 +1117,13 @@ static int32_t cc_object_count(InteractiveConsole& console, [[maybe_unused]] con
     return 0;
 }
 
-static int32_t cc_reset_user_strings([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_reset_user_strings([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     reset_user_strings();
     return 0;
 }
 
-static int32_t cc_open(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_open(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -1167,14 +1167,14 @@ static int32_t cc_open(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_remove_unused_objects(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_remove_unused_objects(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     int32_t result = editor_remove_unused_objects();
     console.WriteFormatLine("%d unused object entries have been removed.", result);
     return 0;
 }
 
-static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     tile_element_iterator it;
     tile_element_iterator_begin(&it);
@@ -1191,7 +1191,7 @@ static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused
     return 0;
 }
 
-static int32_t cc_show_limits(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_show_limits(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     map_reorganise_elements();
     int32_t tileElementCount = gNextFreeTileElement - gTileElements - 1;
@@ -1238,7 +1238,7 @@ static int32_t cc_show_limits(InteractiveConsole& console, [[maybe_unused]] cons
     return 0;
 }
 
-static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     int32_t year = 0;
     int32_t month = 0;
@@ -1294,7 +1294,7 @@ static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe
     return 1;
 }
 
-static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
     {
@@ -1307,7 +1307,7 @@ static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[mayb
     return 1;
 }
 
-static int32_t cc_say(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_say(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() == NETWORK_MODE_NONE || network_get_status() != NETWORK_STATUS_CONNECTED
         || network_get_authstatus() != NETWORK_AUTH_OK)
@@ -1330,7 +1330,7 @@ static int32_t cc_say(InteractiveConsole& console, const argv_t& argv)
     }
 }
 
-static int32_t cc_replay_startrecord(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_replay_startrecord(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -1369,7 +1369,7 @@ static int32_t cc_replay_startrecord(InteractiveConsole& console, const argv_t& 
     return 0;
 }
 
-static int32_t cc_replay_stoprecord(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_replay_stoprecord(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -1404,7 +1404,7 @@ static int32_t cc_replay_stoprecord(InteractiveConsole& console, const argv_t& a
     return 0;
 }
 
-static int32_t cc_replay_start(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_replay_start(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -1446,7 +1446,7 @@ static int32_t cc_replay_start(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_replay_stop(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_replay_stop(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -1464,7 +1464,7 @@ static int32_t cc_replay_stop(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_replay_normalise(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_replay_normalise(InteractiveConsole& console, const arguments_t& argv)
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -1493,13 +1493,13 @@ static int32_t cc_replay_normalise(InteractiveConsole& console, const argv_t& ar
 
 #pragma warning(push)
 #pragma warning(disable : 4702) // unreachable code
-static int32_t cc_abort([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_abort([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     std::abort();
     return 0;
 }
 
-static int32_t cc_dereference([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_dereference([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"
@@ -1510,14 +1510,14 @@ static int32_t cc_dereference([[maybe_unused]] InteractiveConsole& console, [[ma
 #pragma GCC diagnostic pop
 }
 
-static int32_t cc_terminate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_terminate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     std::terminate();
     return 0;
 }
 #pragma warning(pop)
 
-using console_command_func = int32_t (*)(InteractiveConsole& console, const argv_t& argv);
+using console_command_func = int32_t (*)(InteractiveConsole& console, const arguments_t& argv);
 struct console_command
 {
     const utf8* command;
@@ -1616,7 +1616,7 @@ static constexpr const console_command console_command_table[] = {
 };
 // clang-format on
 
-static int32_t cc_windows(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_windows(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     for (auto s : console_window_table)
     {
@@ -1625,7 +1625,7 @@ static int32_t cc_windows(InteractiveConsole& console, [[maybe_unused]] const ar
     return 0;
 }
 
-static int32_t cc_variables(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_variables(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     for (auto s : console_variable_table)
     {
@@ -1634,7 +1634,7 @@ static int32_t cc_variables(InteractiveConsole& console, [[maybe_unused]] const 
     return 0;
 }
 
-static int32_t cc_help(InteractiveConsole& console, const argv_t& argv)
+static int32_t cc_help(InteractiveConsole& console, const arguments_t& argv)
 {
     if (!argv.empty())
     {
@@ -1674,7 +1674,7 @@ static bool invalidArguments(bool* invalid, bool arguments)
 
 void InteractiveConsole::Execute(const std::string& s)
 {
-    argv_t argv;
+    arguments_t argv;
     argv.reserve(8);
 
     const utf8* start = s.c_str();

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -57,7 +57,7 @@
 #    include "../drawing/TTF.h"
 #endif
 
-using argv_t = std::vector<std::basic_string<utf8>>;
+using argv_t = std::vector<std::string>;
 
 static constexpr const utf8* ClimateNames[] = {
     "cool_and_wet",

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1721,7 +1721,7 @@ void InteractiveConsole::Execute(const std::string& s)
 
     for (const auto& c : console_command_table)
     {
-        if (argv[0] == std::string(c.command))
+        if (argv[0] == c.command)
         {
             argv.erase(argv.begin());
             c.func(*this, argv);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1714,7 +1714,7 @@ void InteractiveConsole::Execute(const std::string& s)
         start = end;
     } while (*end != 0);
 
-    if( argv.empty())
+    if (argv.empty())
         return;
 
     bool validCommand = false;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1006,8 +1006,7 @@ static int32_t cc_set(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_twitch(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_twitch([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
 #ifdef DISABLE_TWITCH
     console.WriteLineError("OpenRCT2 build not compiled with Twitch integration.");
@@ -1118,8 +1117,7 @@ static int32_t cc_object_count(InteractiveConsole& console, [[maybe_unused]] con
     return 0;
 }
 
-static int32_t cc_reset_user_strings(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_reset_user_strings([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     reset_user_strings();
     return 0;
@@ -1169,16 +1167,14 @@ static int32_t cc_open(InteractiveConsole& console, const argv_t& argv)
     return 0;
 }
 
-static int32_t cc_remove_unused_objects(
-    InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_remove_unused_objects(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     int32_t result = editor_remove_unused_objects();
     console.WriteFormatLine("%d unused object entries have been removed.", result);
     return 0;
 }
 
-static int32_t cc_remove_park_fences(
-    InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     tile_element_iterator it;
     tile_element_iterator_begin(&it);
@@ -1242,8 +1238,7 @@ static int32_t cc_show_limits(InteractiveConsole& console, [[maybe_unused]] cons
     return 0;
 }
 
-static int32_t cc_for_date(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     int32_t year = 0;
     int32_t month = 0;
@@ -1299,8 +1294,7 @@ static int32_t cc_for_date(
     return 1;
 }
 
-static int32_t cc_save_park(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     if (argv.size() < 1)
     {
@@ -1499,15 +1493,13 @@ static int32_t cc_replay_normalise(InteractiveConsole& console, const argv_t& ar
 
 #pragma warning(push)
 #pragma warning(disable : 4702) // unreachable code
-static int32_t cc_abort(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_abort([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     std::abort();
     return 0;
 }
 
-static int32_t cc_dereference(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_dereference([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"
@@ -1518,8 +1510,7 @@ static int32_t cc_dereference(
 #pragma GCC diagnostic pop
 }
 
-static int32_t cc_terminate(
-    [[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
+static int32_t cc_terminate([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const argv_t& argv)
 {
     std::terminate();
     return 0;
@@ -1723,7 +1714,7 @@ void InteractiveConsole::Execute(const std::string& s)
         start = end;
     } while (*end != 0);
 
-    if(argv.empty())
+    if( argv.empty())
         return;
 
     bool validCommand = false;


### PR DESCRIPTION
Taking #8619 a step further

Issue #8597 shows Valgrind result indicating memory leak in
InteractiveConsole. This is fixed in #8619 by ensuring that free() is
called appropriately.
This commit takes that a step further by removing all manual memory
management in favour of using vector<string>.

- argc is now gone in favour of argv.empty()/argv.size()
- argv_t is a vector of strings of utf8's
- console_command_func's signature is changed accordingly