### PR TITLE
[WIP] Leverage `constexpr` for compile-time evaluation and improved performance

### DIFF
--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -16,21 +16,6 @@
 #include "../world/TileElement.h"
 #include "../world/Wall.h"
 
-uint8_t RCT12TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
-uint8_t RCT12TileElementBase::GetDirection() const
-{
-    return this->type & TILE_ELEMENT_DIRECTION_MASK;
-}
-
-bool RCT12TileElementBase::IsLastForTile() const
-{
-    return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
-}
-
 uint8_t RCT12SurfaceElement::GetSlope() const
 {
     return (slope & TILE_ELEMENT_SURFACE_SLOPE_MASK);

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -13,6 +13,7 @@
 
 #include "../common.h"
 #include "../world/Location.hpp"
+#include "../world/TileElement.h"
 
 #define RCT12_MAX_RIDES_IN_PARK 255
 #define RCT12_MAX_AWARDS 4
@@ -110,10 +111,16 @@ struct RCT12TileElementBase
     uint8_t flags;            // 1
     uint8_t base_height;      // 2
     uint8_t clearance_height; // 3
-    uint8_t GetType() const;
-    uint8_t GetDirection() const;
-    bool IsLastForTile() const;
-    bool IsGhost() const;
+    constexpr uint8_t GetType() const {
+        return this->type & TILE_ELEMENT_TYPE_MASK;
+    }
+    constexpr uint8_t GetDirection() const {
+        return this->type & TILE_ELEMENT_DIRECTION_MASK;
+    }
+    constexpr bool IsLastForTile() const {
+        return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
+    }
+    constexpr bool IsGhost() const;
 };
 /**
  * Map element structure
@@ -122,40 +129,40 @@ struct RCT12TileElementBase
 struct RCT12TileElement : public RCT12TileElementBase
 {
     uint8_t pad_04[4];
-    template<typename TType, RCT12TileElementType TClass> TType* as() const
+    template<typename TType, RCT12TileElementType TClass> constexpr TType* as() const
     {
         return (RCT12TileElementType)GetType() == TClass ? (TType*)this : nullptr;
     }
 
-    RCT12SurfaceElement* AsSurface() const
+    constexpr RCT12SurfaceElement* AsSurface() const
     {
         return as<RCT12SurfaceElement, RCT12TileElementType::Surface>();
     }
-    RCT12PathElement* AsPath() const
+    constexpr RCT12PathElement* AsPath() const
     {
         return as<RCT12PathElement, RCT12TileElementType::Path>();
     }
-    RCT12TrackElement* AsTrack() const
+    constexpr RCT12TrackElement* AsTrack() const
     {
         return as<RCT12TrackElement, RCT12TileElementType::Track>();
     }
-    RCT12SmallSceneryElement* AsSmallScenery() const
+    constexpr RCT12SmallSceneryElement* AsSmallScenery() const
     {
         return as<RCT12SmallSceneryElement, RCT12TileElementType::SmallScenery>();
     }
-    RCT12LargeSceneryElement* AsLargeScenery() const
+    constexpr RCT12LargeSceneryElement* AsLargeScenery() const
     {
         return as<RCT12LargeSceneryElement, RCT12TileElementType::LargeScenery>();
     }
-    RCT12WallElement* AsWall() const
+    constexpr RCT12WallElement* AsWall() const
     {
         return as<RCT12WallElement, RCT12TileElementType::Wall>();
     }
-    RCT12EntranceElement* AsEntrance() const
+    constexpr RCT12EntranceElement* AsEntrance() const
     {
         return as<RCT12EntranceElement, RCT12TileElementType::Entrance>();
     }
-    RCT12BannerElement* AsBanner() const
+    constexpr RCT12BannerElement* AsBanner() const
     {
         return as<RCT12BannerElement, RCT12TileElementType::Banner>();
     }

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -111,13 +111,16 @@ struct RCT12TileElementBase
     uint8_t flags;            // 1
     uint8_t base_height;      // 2
     uint8_t clearance_height; // 3
-    constexpr uint8_t GetType() const {
+    constexpr uint8_t GetType() const
+    {
         return this->type & TILE_ELEMENT_TYPE_MASK;
     }
-    constexpr uint8_t GetDirection() const {
+    constexpr uint8_t GetDirection() const
+    {
         return this->type & TILE_ELEMENT_DIRECTION_MASK;
     }
-    constexpr bool IsLastForTile() const {
+    constexpr bool IsLastForTile() const
+    {
         return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
     }
     constexpr bool IsGhost() const;

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -2287,11 +2287,6 @@ uint8_t TrackElement::GetDoorBState() const
     return (colour & TRACK_ELEMENT_DOOR_B_MASK) >> 5;
 }
 
-ride_id_t TrackElement::GetRideIndex() const
-{
-    return rideIndex;
-}
-
 void TrackElement::SetRideIndex(ride_id_t newRideIndex)
 {
     rideIndex = newRideIndex;

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -652,11 +652,6 @@ void EntranceElement::SetEntranceType(uint8_t newType)
     entranceType = newType;
 }
 
-ride_id_t EntranceElement::GetRideIndex() const
-{
-    return rideIndex;
-}
-
 void EntranceElement::SetRideIndex(ride_id_t newRideIndex)
 {
     rideIndex = newRideIndex;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -961,9 +961,7 @@ void footpath_bridge_get_info_from_pos(
         if (directions & 0x0F)
         {
             int32_t bx = bitscanforward(directions);
-	    auto entrance = (*tileElement)->AsEntrance();
-	    if(entrance != nullptr)
-            	bx += entrance->GetDirection();
+            bx += (*tileElement)->AsEntrance()->GetDirection();
             bx &= 3;
             if (direction != nullptr)
                 *direction = bx;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1986,11 +1986,6 @@ int32_t footpath_is_connected_to_map_edge(int32_t x, int32_t y, int32_t z, int32
     return footpath_is_connected_to_map_edge_recurse(x, y, z, direction, flags, 0, 0, 16);
 }
 
-bool PathElement::IsSloped() const
-{
-    return (entryIndex & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) != 0;
-}
-
 void PathElement::SetSloped(bool isSloped)
 {
     entryIndex &= ~FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
@@ -2007,11 +2002,6 @@ void PathElement::SetSlopeDirection(uint8_t newSlope)
 {
     entryIndex &= ~FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
     entryIndex |= newSlope & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK;
-}
-
-bool PathElement::IsQueue() const
-{
-    return (type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) != 0;
 }
 
 void PathElement::SetIsQueue(bool isQueue)
@@ -2042,11 +2032,6 @@ void PathElement::SetStationIndex(uint8_t newStationIndex)
 {
     additions &= ~FOOTPATH_PROPERTIES_ADDITIONS_STATION_INDEX_MASK;
     additions |= ((newStationIndex << 4) & FOOTPATH_PROPERTIES_ADDITIONS_STATION_INDEX_MASK);
-}
-
-bool PathElement::IsWide() const
-{
-    return (type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_WIDE) != 0;
 }
 
 void PathElement::SetWide(bool isWide)
@@ -2712,29 +2697,14 @@ PathRailingsEntry* get_path_railings_entry(int32_t entryIndex)
     return result;
 }
 
-ride_id_t PathElement::GetRideIndex() const
-{
-    return rideIndex;
-}
-
 void PathElement::SetRideIndex(ride_id_t newRideIndex)
 {
     rideIndex = newRideIndex;
 }
 
-uint8_t PathElement::GetAdditionStatus() const
-{
-    return additionStatus;
-}
-
 void PathElement::SetAdditionStatus(uint8_t newStatus)
 {
     additionStatus = newStatus;
-}
-
-uint8_t PathElement::GetEdges() const
-{
-    return edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
 }
 
 void PathElement::SetEdges(uint8_t newEdges)
@@ -2743,20 +2713,10 @@ void PathElement::SetEdges(uint8_t newEdges)
     edges |= (newEdges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK);
 }
 
-uint8_t PathElement::GetCorners() const
-{
-    return edges >> 4;
-}
-
 void PathElement::SetCorners(uint8_t newCorners)
 {
     edges &= ~FOOTPATH_PROPERTIES_EDGES_CORNERS_MASK;
     edges |= (newCorners << 4);
-}
-
-uint8_t PathElement::GetEdgesAndCorners() const
-{
-    return edges;
 }
 
 void PathElement::SetEdgesAndCorners(uint8_t newEdgesAndCorners)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -961,7 +961,9 @@ void footpath_bridge_get_info_from_pos(
         if (directions & 0x0F)
         {
             int32_t bx = bitscanforward(directions);
-            bx += (*tileElement)->AsEntrance()->GetDirection();
+	    auto entrance = (*tileElement)->AsEntrance();
+	    if(entrance != nullptr)
+            	bx += entrance->GetDirection();
             bx &= 3;
             if (direction != nullptr)
                 *direction = bx;

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -17,41 +17,16 @@
 #include "LargeScenery.h"
 #include "Scenery.h"
 
-uint8_t TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
 void TileElementBase::SetType(uint8_t newType)
 {
     this->type &= ~TILE_ELEMENT_TYPE_MASK;
     this->type |= (newType & TILE_ELEMENT_TYPE_MASK);
 }
 
-uint8_t TileElementBase::GetDirection() const
-{
-    return this->type & TILE_ELEMENT_DIRECTION_MASK;
-}
-
 void TileElementBase::SetDirection(uint8_t direction)
 {
     this->type &= ~TILE_ELEMENT_DIRECTION_MASK;
     this->type |= (direction & TILE_ELEMENT_DIRECTION_MASK);
-}
-
-uint8_t TileElementBase::GetDirectionWithOffset(uint8_t offset) const
-{
-    return ((this->type & TILE_ELEMENT_DIRECTION_MASK) + offset) & TILE_ELEMENT_DIRECTION_MASK;
-}
-
-bool TileElementBase::IsLastForTile() const
-{
-    return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
-}
-
-bool TileElementBase::IsGhost() const
-{
-    return (this->flags & TILE_ELEMENT_FLAG_GHOST) != 0;
 }
 
 bool tile_element_is_underground(TileElement* tileElement)

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -157,7 +157,7 @@ struct TileElement : public TileElementBase
 
     template<typename TType, TileElementType TClass> constexpr TType* as() const
     {
-        return (TileElementType)GetType() == TClass ? (TType*)this : nullptr;
+        return (TType*)this;
     }
 
 public:

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -24,7 +24,6 @@
 #define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0b00001111
 #define MAP_ELEM_TRACK_SEQUENCE_TAKING_PHOTO_MASK 0b11110000
 
-
 enum
 {
     TILE_ELEMENT_QUADRANT_SW,
@@ -76,7 +75,6 @@ enum
     MAP_ELEM_TRACK_SEQUENCE_GREEN_LIGHT = (1 << 7),
 };
 
-
 struct rct_scenery_entry;
 struct rct_footpath_entry;
 
@@ -127,21 +125,26 @@ struct TileElementBase
     uint8_t base_height;      // 2
     uint8_t clearance_height; // 3
 
-    constexpr uint8_t GetType() const {
+    constexpr uint8_t GetType() const
+    {
         return this->type & TILE_ELEMENT_TYPE_MASK;
     }
     void SetType(uint8_t newType);
-    constexpr uint8_t GetDirection() const {
+    constexpr uint8_t GetDirection() const
+    {
         return this->type & TILE_ELEMENT_DIRECTION_MASK;
     }
     void SetDirection(uint8_t direction);
-    constexpr uint8_t GetDirectionWithOffset(uint8_t offset) const {
+    constexpr uint8_t GetDirectionWithOffset(uint8_t offset) const
+    {
         return ((this->type & TILE_ELEMENT_DIRECTION_MASK) + offset) & TILE_ELEMENT_DIRECTION_MASK;
     }
-    constexpr bool IsLastForTile() const {
+    constexpr bool IsLastForTile() const
+    {
         return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
     }
-    constexpr bool IsGhost() const {
+    constexpr bool IsGhost() const
+    {
         return (this->flags & TILE_ELEMENT_FLAG_GHOST) != 0;
     }
     void Remove();
@@ -262,7 +265,8 @@ public:
     uint8_t GetQueueBannerDirection() const;
     void SetQueueBannerDirection(uint8_t direction);
 
-    constexpr bool IsSloped() const {
+    constexpr bool IsSloped() const
+    {
         return (entryIndex & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) != 0;
     }
     void SetSloped(bool isSloped);
@@ -270,7 +274,8 @@ public:
     uint8_t GetSlopeDirection() const;
     void SetSlopeDirection(uint8_t newSlope);
 
-    constexpr ride_id_t GetRideIndex() const {
+    constexpr ride_id_t GetRideIndex() const
+    {
         return rideIndex;
     };
     void SetRideIndex(ride_id_t newRideIndex);
@@ -278,27 +283,32 @@ public:
     uint8_t GetStationIndex() const;
     void SetStationIndex(uint8_t newStationIndex);
 
-    constexpr bool IsWide() const {
+    constexpr bool IsWide() const
+    {
         return (type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_WIDE) != 0;
     }
     void SetWide(bool isWide);
 
-    constexpr bool IsQueue() const {
+    constexpr bool IsQueue() const
+    {
         return (type & FOOTPATH_ELEMENT_TYPE_FLAG_IS_QUEUE) != 0;
     }
     void SetIsQueue(bool isQueue);
     bool HasQueueBanner() const;
     void SetHasQueueBanner(bool hasQueueBanner);
 
-    constexpr uint8_t GetEdges() const {
+    constexpr uint8_t GetEdges() const
+    {
         return edges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
     }
     void SetEdges(uint8_t newEdges);
-    constexpr uint8_t GetCorners() const {
+    constexpr uint8_t GetCorners() const
+    {
         return edges >> 4;
     }
     void SetCorners(uint8_t newCorners);
-    constexpr uint8_t GetEdgesAndCorners() const {
+    constexpr uint8_t GetEdgesAndCorners() const
+    {
         return edges;
     }
     void SetEdgesAndCorners(uint8_t newEdgesAndCorners);
@@ -312,7 +322,8 @@ public:
     bool AdditionIsGhost() const;
     void SetAdditionIsGhost(bool isGhost);
 
-    constexpr uint8_t GetAdditionStatus() const {
+    constexpr uint8_t GetAdditionStatus() const
+    {
         return additionStatus;
     }
     void SetAdditionStatus(uint8_t newStatus);
@@ -356,7 +367,8 @@ public:
     uint8_t GetSequenceIndex() const;
     void SetSequenceIndex(uint8_t newSequenceIndex);
 
-    constexpr ride_id_t GetRideIndex() const {
+    constexpr ride_id_t GetRideIndex() const
+    {
         return rideIndex;
     };
     void SetRideIndex(ride_id_t newRideIndex);
@@ -509,7 +521,8 @@ public:
     uint8_t GetEntranceType() const;
     void SetEntranceType(uint8_t newType);
 
-    constexpr ride_id_t GetRideIndex() const {
+    constexpr ride_id_t GetRideIndex() const
+    {
         return rideIndex;
     };
     void SetRideIndex(ride_id_t newRideIndex);
@@ -554,8 +567,6 @@ struct CorruptElement : TileElementBase
 };
 assert_struct_size(CorruptElement, 8);
 #pragma pack(pop)
-
-
 
 BannerIndex tile_element_get_banner_index(TileElement* tileElement);
 bool tile_element_is_underground(TileElement* tileElement);

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -155,16 +155,6 @@ rct_sprite* get_sprite(size_t sprite_idx)
     return &sprite_list[sprite_idx];
 }
 
-bool TileElementBase::IsLastForTile() const
-{
-    return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
-}
-
-uint8_t TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
 TileElement* map_get_first_element_at(int x, int y)
 {
     if (x < 0 || y < 0 || x > 255 || y > 255)
@@ -283,11 +273,6 @@ uint8_t TrackElement::GetDoorBState() const
     return (colour & TRACK_ELEMENT_DOOR_B_MASK) >> 5;
 }
 
-uint8_t TrackElement::GetRideIndex() const
-{
-    return rideIndex;
-}
-
 void TrackElement::SetRideIndex(uint8_t newRideIndex)
 {
     rideIndex = newRideIndex;
@@ -391,16 +376,6 @@ void TileElementBase::SetType(uint8_t newType)
     this->type |= (newType & TILE_ELEMENT_TYPE_MASK);
 }
 
-uint8_t TileElementBase::GetDirection() const
-{
-    return this->type & TILE_ELEMENT_DIRECTION_MASK;
-}
-
-uint8_t TileElementBase::GetDirectionWithOffset(uint8_t offset) const
-{
-    return ((this->type & TILE_ELEMENT_DIRECTION_MASK) + offset) & TILE_ELEMENT_DIRECTION_MASK;
-}
-
 uint8_t SurfaceElement::GetSlope() const
 {
     return (slope & TILE_ELEMENT_SURFACE_SLOPE_MASK);
@@ -414,11 +389,6 @@ uint32_t SurfaceElement::GetWaterHeight() const
 bool TrackElement::IsHighlighted() const
 {
     return (type & TILE_ELEMENT_TYPE_FLAG_HIGHLIGHT);
-}
-
-uint8_t PathElement::GetEdges() const
-{
-    return edges & 0xF;
 }
 
 StationObject* ride_get_station_object(const Ride* ride)


### PR DESCRIPTION
I've run `callgrind` on `develop` and listed the called methods from most frequently called to least. 
Much time is spent on getter methods of tiles, so I started there. 

These are some early experiments that I wanted to run on CI ;). 