### PR TITLE
Put boundaries on target coordinates for ducks 

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "23"
+#define NETWORK_STREAM_VERSION "24"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -432,10 +432,10 @@ static int32_t scenario_create_ducks()
     // To spawn ducks safely, the generated coordinates should not be in the outer 3 tiles of the map.
 
     r = scenario_rand();
-    x = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE +
-        ((r >> 16) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
-    y = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE +
-        ((r & 0xFFFF) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
+    x = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE
+        + ((r >> 16) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
+    y = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE
+        + ((r & 0xFFFF) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
     x = x * 32;
     y = y * 32;
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -427,10 +427,15 @@ static int32_t scenario_create_ducks()
     int32_t i, j, r, c, x, y, waterZ, centreWaterZ, x2, y2;
 
     // Originally, this function generated coordinates from 64 to 191.
-    // It now generates coordinates from 0 to 255, so smaller maps may also spawn ducks.
+    // The duck create function is called with 2 tiles of randomness to the target coordinate.
+    // The duck create function itself adds approximately 1 tile of randomness.
+    // To spawn ducks safely, the generated coordinates should not be in the outer 3 tiles of the map.
+
     r = scenario_rand();
-    x = ((r >> 16) & 0xFFFF) % MAXIMUM_MAP_SIZE_TECHNICAL;
-    y = (r & 0xFFFF) % MAXIMUM_MAP_SIZE_TECHNICAL;
+    x = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE +
+        ((r >> 16) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
+    y = 1 + DUCK_TARGET_TILES_AWAY_FROM_EDGE +
+        ((r & 0xFFFF) % (MAXIMUM_MAP_SIZE_PRACTICAL - (DUCK_TARGET_TILES_AWAY_FROM_EDGE * 2)));
     x = x * 32;
     y = y * 32;
 

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -363,6 +363,9 @@ enum
 #define AUTOSAVE_PAUSE 0
 #define DEFAULT_NUM_AUTOSAVES_TO_KEEP 10
 
+// Defines how many tiles from the edge duck target coordinates should be generated
+#define DUCK_TARGET_TILES_AWAY_FROM_EDGE 3
+
 extern const rct_string_id ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT];
 
 extern uint32_t gScenarioTicks;


### PR DESCRIPTION
Should fix the crashes caused by #8614

-Lowest tile coordinate is 1
-Highest tile coordinate is 254
-Create duck is called with 2 tiles of randomness.
-Create duck function itself also adds a random offset of maximum 30 (a little bit less than 1 tile)

If we limit the generated coordinates to be between 4 and 251, we should always get a valid tile.