### PR TITLE
Quiet CMake find package 'benchmark'

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT DISABLE_NETWORK)
     find_package(OpenSSL 1.0.0 REQUIRED)
 endif ()
 
-find_package(benchmark)
+find_package(benchmark QUIET)
 
 if (NOT DISABLE_TTF)
     if (UNIX AND NOT APPLE AND NOT MSVC)


### PR DESCRIPTION
`benchmark` is an optional package. CMake can be quiet about not finding it.