### PR TITLE
Refactor scenario_rand() to use c++11 <random>

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -47,6 +47,7 @@ void GameState::InitAll(int32_t mapSize)
 {
     gInMapInitCode = true;
 
+    scenario_init();
     map_init(mapSize);
     _park->Initialise();
     finance_init();

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -960,7 +960,7 @@ bool Network::CheckSRAND(uint32_t tick, uint32_t srand0)
 void Network::CheckDesynchronizaton()
 {
     // Check synchronisation
-    if (GetMode() == NETWORK_MODE_CLIENT && !_desynchronised && !CheckSRAND(gCurrentTicks, gScenarioSrand0))
+    if (GetMode() == NETWORK_MODE_CLIENT && !_desynchronised && !CheckSRAND(gCurrentTicks, scenario_rand_state()))
     {
         _desynchronised = true;
 
@@ -1596,7 +1596,7 @@ void Network::Server_Send_TICK()
     last_tick_sent_time = ticks;
 
     std::unique_ptr<NetworkPacket> packet(NetworkPacket::Allocate());
-    *packet << (uint32_t)NETWORK_COMMAND_TICK << gCurrentTicks << gScenarioSrand0;
+    *packet << (uint32_t)NETWORK_COMMAND_TICK << gCurrentTicks << scenario_rand_state();
     uint32_t flags = 0;
     // Simple counter which limits how often a sprite checksum gets sent.
     // This can get somewhat expensive, so we don't want to push it every tick in release,

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2451,8 +2451,7 @@ private:
     {
         // Date and srand
         gScenarioTicks = _s4.ticks;
-        gScenarioSrand0 = _s4.random_a;
-        gScenarioSrand1 = _s4.random_b;
+        scenario_rand_seed(_s4.random_a);
         gDateMonthsElapsed = _s4.month;
         gDateMonthTicks = _s4.day;
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -188,8 +188,7 @@ void S6Exporter::Export()
     _s6.elapsed_months = gDateMonthsElapsed;
     _s6.current_day = gDateMonthTicks;
     _s6.scenario_ticks = gScenarioTicks;
-    _s6.scenario_srand_0 = gScenarioSrand0;
-    _s6.scenario_srand_1 = gScenarioSrand1;
+    _s6.scenario_srand_0 = _s6.scenario_srand_1 = scenario_rand_state();
 
     std::memcpy(_s6.tile_elements, gTileElements, sizeof(_s6.tile_elements));
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -207,8 +207,7 @@ public:
         gDateMonthsElapsed = _s6.elapsed_months;
         gDateMonthTicks = _s6.current_day;
         gScenarioTicks = _s6.scenario_ticks;
-        gScenarioSrand0 = _s6.scenario_srand_0;
-        gScenarioSrand1 = _s6.scenario_srand_1;
+        scenario_rand_seed(_s6.scenario_srand_0);
 
         ImportTileElements();
 

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -389,6 +389,7 @@ extern uint32_t gLastAutoSaveUpdate;
 extern char gScenarioFileName[260];
 
 void load_from_sc6(const char* path);
+void scenario_init();
 void scenario_begin();
 void scenario_update();
 void scenario_rand_seed(uint32_t seed);

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -366,8 +366,6 @@ enum
 extern const rct_string_id ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT];
 
 extern uint32_t gScenarioTicks;
-extern uint32_t gScenarioSrand0;
-extern uint32_t gScenarioSrand1;
 
 extern uint8_t gScenarioObjectiveType;
 extern uint8_t gScenarioObjectiveYear;
@@ -393,6 +391,8 @@ extern char gScenarioFileName[260];
 void load_from_sc6(const char* path);
 void scenario_begin();
 void scenario_update();
+void scenario_rand_seed(uint32_t seed);
+uint32_t scenario_rand_state();
 
 #ifdef DEBUG_DESYNC
 uint32_t dbg_scenario_rand(const char* file, const char* function, const uint32_t line, const void* data);

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -41,8 +41,7 @@ public:
     void SetUp() override
     {
         // Use a consistent random seed in every test
-        gScenarioSrand0 = 0x12345678;
-        gScenarioSrand1 = 0x87654321;
+        scenario_rand_seed(0x12345678);
     }
 
     static void TearDownTestCase()


### PR DESCRIPTION
Currently implements a simple `linear_congruential_engine` but could be changed later to another one.  Chose this engine because its very small state size (single int) so that the state fits in existing save files, scenarios etc. 