### PR TITLE
Fix #8585: Part of track missing on air powered vertical coaster

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -57,6 +57,7 @@
 - Fix: [#8555] Multiplayer window text limits are not computed properly.
 - Fix: [#8572] Steel Twister track pieces ID 64 and 65 drawn incorrectly.
 - Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..63 (original bug).
+- Fix: [#8585] Part of track missing on air powered vertical coaster.
 - Fix: [#8588] Guest list scrolling breaks above ~2000 guests.
 - Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -657,20 +657,16 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
     switch (trackSequence)
     {
         case 0:
-            // HACK this might be a mistake in original code
-            if (direction & 1)
-            {
-                bbHeight = bbHeights12[trackSequence];
-                sub_98197C_rotated(session, direction, supportsImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
-                sub_98199C_rotated(session, direction, trackImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
+            bbHeight = bbHeights12[trackSequence];
+            sub_98197C_rotated(session, direction, supportsImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
+            sub_98199C_rotated(session, direction, trackImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
 
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-                paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
+            paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
 
-                paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
-                paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
-            }
+            paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
+            paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
             break;
         case 1:
         case 2:


### PR DESCRIPTION
Test park: [FF-testAirPowered.zip](https://github.com/OpenRCT2/OpenRCT2/files/2797524/FF-testAirPowered.zip)
