### PR TITLE
[Feedback] Inlining of frequently called functions

### DIFF
--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -24,14 +24,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-void openrct2_assert_fwd(bool expression, const char* message, ...)
-{
-    va_list va;
-    va_start(va, message);
-    Guard::Assert_VA(expression, message, va);
-    va_end(va);
-}
-
 namespace Guard
 {
     constexpr const utf8* ASSERTION_MESSAGE = "An assertion failed, please report this to the OpenRCT2 developers.";

--- a/src/openrct2/core/Guard.hpp
+++ b/src/openrct2/core/Guard.hpp
@@ -13,8 +13,6 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
-void openrct2_assert_fwd(bool expression, const char* message, ...);
-
 #define openrct2_assert(expr, msg, ...)                                                                                        \
     if (!(expr))                                                                                                               \
     {                                                                                                                          \
@@ -67,3 +65,11 @@ namespace Guard
 } // namespace Guard
 
 #define GUARD_LINE "Location: %s:%d", __func__, __LINE__
+
+inline void openrct2_assert_fwd(bool expression, const char* message, ...)
+{
+    va_list va;
+    va_start(va, message);
+    Guard::Assert_VA(expression, message, va);
+    va_end(va);
+}

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1886,27 +1886,6 @@ void screen_get_map_xy_side_with_z(int16_t screenX, int16_t screenY, int16_t z, 
     *mapY = floor2(*mapY, 32);
 }
 
-/**
- * Get current viewport rotation.
- *
- * If an invalid rotation is detected and DEBUG_LEVEL_1 is enabled, an error
- * will be reported.
- *
- * @returns rotation in range 0-3 (inclusive)
- */
-uint8_t get_current_rotation()
-{
-    uint8_t rotation = gCurrentRotation;
-    uint8_t rotation_masked = rotation & 3;
-#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-    if (rotation != rotation_masked)
-    {
-        log_error("Found wrong rotation %d! Will return %d instead.", (uint32_t)rotation, (uint32_t)rotation_masked);
-    }
-#endif // DEBUG_LEVEL_1
-    return rotation_masked;
-}
-
 int16_t get_height_marker_offset()
 {
     // Height labels in units

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -177,7 +177,25 @@ void screen_get_map_xy_quadrant_with_z(
 void screen_get_map_xy_side(int16_t screenX, int16_t screenY, int16_t* mapX, int16_t* mapY, uint8_t* side);
 void screen_get_map_xy_side_with_z(int16_t screenX, int16_t screenY, int16_t z, int16_t* mapX, int16_t* mapY, uint8_t* side);
 
-uint8_t get_current_rotation();
+/**
+ * Get current viewport rotation.
+ *
+ * If an invalid rotation is detected and DEBUG_LEVEL_1 is enabled, an error
+ * will be reported.
+ *
+ * @returns rotation in range 0-3 (inclusive)
+ */
+inline uint8_t get_current_rotation()
+{
+    auto rotation_masked = static_cast<uint8_t>(gCurrentRotation & 3);
+#if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
+    if (gCurrentRotation != rotation_masked)
+    {
+        log_error("Found wrong rotation %d! Will return %d instead.", (uint32_t)gCurrentRotation, (uint32_t)rotation_masked);
+    }
+#endif // DEBUG_LEVEL_1
+    return rotation_masked;
+}
 int16_t get_height_marker_offset();
 
 void viewport_set_saved_view();

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -120,22 +120,4 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, const json_t* r
     ObjectJsonHelpers::LoadImages(context, root, GetImageTable());
 }
 
-uint32_t TerrainSurfaceObject::GetImageId(
-    const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const
-{
-    uint32_t result = (underground ? DefaultUndergroundEntry : (grid ? DefaultGridEntry : DefaultEntry));
 
-    // Look for a matching special
-    auto variation = ((position.x << 1) & 0b10) | (position.y & 0b01);
-    for (const auto& special : SpecialEntries)
-    {
-        if ((special.Length == -1 || special.Length == length) && (special.Rotation == -1 || special.Rotation == rotation)
-            && (special.Variation == -1 || special.Variation == variation) && special.Grid == grid
-            && special.Underground == underground)
-        {
-            result = special.Index;
-            break;
-        }
-    }
-    return EntryBaseImageId + (result * NUM_IMAGES_IN_ENTRY) + offset;
-}

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -64,6 +64,23 @@ public:
 
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
 
-    uint32_t GetImageId(
-        const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const;
+    inline int32_t GetImageId(const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const
+    {
+        uint32_t result = (underground ? DefaultUndergroundEntry : (grid ? DefaultGridEntry : DefaultEntry));
+
+        // Look for a matching special
+        auto variation = ((position.x << 1) & 0b10) | (position.y & 0b01);
+        for (const auto& special : SpecialEntries)
+        {
+            if ((special.Length == -1 || special.Length == length) && (special.Rotation == -1 || special.Rotation == rotation)
+                && (special.Variation == -1 || special.Variation == variation) && special.Grid == grid
+                && special.Underground == underground)
+            {
+                result = special.Index;
+                break;
+            }
+        }
+        return EntryBaseImageId + (result * NUM_IMAGES_IN_ENTRY) + offset;
+    }
+
 };

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -36,32 +36,8 @@
 uint16_t testPaintVerticalTunnelHeight;
 #endif
 
-static void blank_tiles_paint(paint_session* session, int32_t x, int32_t y);
-static void sub_68B3FB(paint_session* session, int32_t x, int32_t y);
-
 const int32_t SEGMENTS_ALL = SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC
     | SEGMENT_D0 | SEGMENT_D4;
-
-/**
- *
- *  rct2: 0x0068B35F
- */
-void tile_element_paint_setup(paint_session* session, int32_t x, int32_t y)
-{
-    if (x < gMapSizeUnits && y < gMapSizeUnits && x >= 32 && y >= 32)
-    {
-        paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
-        paint_util_force_set_general_support_height(session, -1, 0);
-        session->Unk141E9DB = 0;
-        session->WaterHeight = 0xFFFF;
-
-        sub_68B3FB(session, x, y);
-    }
-    else
-    {
-        blank_tiles_paint(session, x, y);
-    }
-}
 
 /**
  *
@@ -88,7 +64,7 @@ void sub_68B2B7(paint_session* session, int32_t x, int32_t y)
  *
  *  rct2: 0x0068B60E
  */
-static void blank_tiles_paint(paint_session* session, int32_t x, int32_t y)
+void blank_tiles_paint(paint_session* session, int32_t x, int32_t y)
 {
     int32_t dx = 0;
     switch (session->CurrentRotation)
@@ -134,7 +110,7 @@ bool gShowSupportSegmentHeights = false;
  *
  *  rct2: 0x0068B3FB
  */
-static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
+void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
 {
     rct_drawpixelinfo* dpi = session->DPI;
 

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -12,6 +12,7 @@
 
 #include "../../common.h"
 #include "../../world/Map.h"
+#include "../../paint/Paint.h"
 
 struct paint_session;
 
@@ -98,7 +99,28 @@ void paint_util_force_set_general_support_height(paint_session* session, int16_t
 void paint_util_set_segment_support_height(paint_session* session, int32_t segments, uint16_t height, uint8_t slope);
 uint16_t paint_util_rotate_segments(uint16_t segments, uint8_t rotation);
 
-void tile_element_paint_setup(paint_session* session, int32_t x, int32_t y);
+void blank_tiles_paint(paint_session* session, int32_t x, int32_t y);
+void sub_68B3FB(paint_session* session, int32_t x, int32_t y);
+
+/**
+ *  rct2: 0x0068B35F
+ */
+inline void tile_element_paint_setup(paint_session* session, int32_t x, int32_t y)
+{
+    if (x < gMapSizeUnits && y < gMapSizeUnits && x >= 32 && y >= 32)
+    {
+        paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
+        paint_util_force_set_general_support_height(session, -1, 0);
+        session->Unk141E9DB = 0;
+        session->WaterHeight = 0xFFFF;
+
+        sub_68B3FB(session, x, y);
+    }
+    else
+    {
+        blank_tiles_paint(session, x, y);
+    }
+}
 
 void entrance_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tile_element);
 void banner_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tile_element);

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -161,28 +161,6 @@ void path_end_with_separator(utf8* path, size_t size)
     }
 }
 
-int32_t bitscanforward(int32_t source)
-{
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) // Visual Studio 2005
-    DWORD i;
-    uint8_t success = _BitScanForward(&i, (uint32_t)source);
-    return success != 0 ? i : -1;
-#elif defined(__GNUC__)
-    int32_t success = __builtin_ffs(source);
-    return success - 1;
-#else
-#    pragma message "Falling back to iterative bitscan forward, consider using intrinsics"
-    // This is a low-hanging optimisation boost, check if your compiler offers
-    // any intrinsic.
-    // cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
-    for (int32_t i = 0; i < 32; i++)
-        if (source & (1u << i))
-            return i;
-
-    return -1;
-#endif
-}
-
 #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
 #    include <cpuid.h>
 #    define OpenRCT2_CPUID_GNUC_X86

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -34,7 +34,28 @@ bool writeentirefile(const utf8* path, const void* buffer, size_t length);
 bool sse41_available();
 bool avx2_available();
 
-int32_t bitscanforward(int32_t source);
+inline int32_t bitscanforward(int32_t source)
+{
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) // Visual Studio 2005
+    DWORD i;
+    uint8_t success = _BitScanForward(&i, (uint32_t)source);
+    return success != 0 ? i : -1;
+#elif defined(__GNUC__)
+    int32_t success = __builtin_ffs(source);
+    return success - 1;
+#else
+#    pragma message "Falling back to iterative bitscan forward, consider using intrinsics"
+    // This is a low-hanging optimisation boost, check if your compiler offers
+    // any intrinsic.
+    // cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
+    for (int32_t i = 0; i < 32; i++)
+        if (source & (1u << i))
+            return i;
+
+    return -1;
+#endif
+}
+
 void bitcount_init();
 int32_t bitcount(uint32_t source);
 bool strequals(const char* a, const char* b, int32_t length, bool caseInsensitive);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1986,11 +1986,6 @@ int32_t footpath_is_connected_to_map_edge(int32_t x, int32_t y, int32_t z, int32
     return footpath_is_connected_to_map_edge_recurse(x, y, z, direction, flags, 0, 0, 16);
 }
 
-bool PathElement::IsSloped() const
-{
-    return (entryIndex & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) != 0;
-}
-
 void PathElement::SetSloped(bool isSloped)
 {
     entryIndex &= ~FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
@@ -2102,16 +2097,6 @@ uint8_t PathElement::GetPathEntryIndex() const
 uint8_t PathElement::GetRailingEntryIndex() const
 {
     return GetPathEntryIndex();
-}
-
-PathSurfaceEntry* PathElement::GetPathEntry() const
-{
-    return get_path_surface_entry(GetPathEntryIndex());
-}
-
-PathRailingsEntry* PathElement::GetRailingEntry() const
-{
-    return get_path_railings_entry(GetRailingEntryIndex());
 }
 
 void PathElement::SetPathEntryIndex(uint8_t newEntryIndex)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -105,31 +105,6 @@ bool gMapLandRightsUpdateSuccess;
 static void clear_elements_at(int32_t x, int32_t y);
 static void translate_3d_to_2d(int32_t rotation, int32_t* x, int32_t* y);
 
-void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation)
-{
-    int32_t temp;
-
-    switch (rotation)
-    {
-        case TILE_ELEMENT_DIRECTION_WEST:
-            break;
-        case TILE_ELEMENT_DIRECTION_NORTH:
-            temp = *x;
-            *x = *y;
-            *y = -temp;
-            break;
-        case TILE_ELEMENT_DIRECTION_EAST:
-            *x = -*x;
-            *y = -*y;
-            break;
-        case TILE_ELEMENT_DIRECTION_SOUTH:
-            temp = *y;
-            *y = *x;
-            *x = -temp;
-            break;
-    }
-}
-
 void tile_element_iterator_begin(tile_element_iterator* it)
 {
     it->x = 0;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -130,33 +130,6 @@ void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation)
     }
 }
 
-LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, int32_t rotation)
-{
-    LocationXY16 coordinate_2d;
-
-    switch (rotation)
-    {
-        default:
-        case 0:
-            coordinate_2d.x = coordinate_3d->y - coordinate_3d->x;
-            coordinate_2d.y = ((coordinate_3d->y + coordinate_3d->x) >> 1) - coordinate_3d->z;
-            break;
-        case 1:
-            coordinate_2d.x = -coordinate_3d->y - coordinate_3d->x;
-            coordinate_2d.y = ((coordinate_3d->y - coordinate_3d->x) >> 1) - coordinate_3d->z;
-            break;
-        case 2:
-            coordinate_2d.x = -coordinate_3d->y + coordinate_3d->x;
-            coordinate_2d.y = ((-coordinate_3d->y - coordinate_3d->x) >> 1) - coordinate_3d->z;
-            break;
-        case 3:
-            coordinate_2d.x = coordinate_3d->y + coordinate_3d->x;
-            coordinate_2d.y = ((-coordinate_3d->y + coordinate_3d->x) >> 1) - coordinate_3d->z;
-            break;
-    }
-    return coordinate_2d;
-}
-
 void tile_element_iterator_begin(tile_element_iterator* it)
 {
     it->x = 0;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -174,7 +174,32 @@ bool map_can_construct_with_clear_at(
     int32_t x, int32_t y, int32_t zLow, int32_t zHigh, CLEAR_FUNC clearFunc, uint8_t bl, uint8_t flags, money32* price,
     uint8_t crossingMode);
 int32_t map_can_construct_at(int32_t x, int32_t y, int32_t zLow, int32_t zHigh, uint8_t bl);
-void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation);
+inline void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation)
+{
+    int32_t temp;
+
+    switch (rotation)
+    {
+        case TILE_ELEMENT_DIRECTION_WEST:
+            break;
+        case TILE_ELEMENT_DIRECTION_NORTH:
+            temp = *x;
+            *x = *y;
+            *y = (uint16_t)-temp;
+            break;
+        case TILE_ELEMENT_DIRECTION_EAST:
+            *x = -*x;
+            *y = -*y;
+            break;
+        case TILE_ELEMENT_DIRECTION_SOUTH:
+            temp = *y;
+            *y = *x;
+            *x = (uint16_t)-temp;
+            break;
+        default:
+            break;
+    }
+}
 inline LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, int32_t rotation)
 {
     LocationXY16 coordinate_2d = { 0, 0 };

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -175,7 +175,32 @@ bool map_can_construct_with_clear_at(
     uint8_t crossingMode);
 int32_t map_can_construct_at(int32_t x, int32_t y, int32_t zLow, int32_t zHigh, uint8_t bl);
 void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation);
-LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, int32_t rotation);
+inline LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, int32_t rotation)
+{
+    LocationXY16 coordinate_2d = { 0, 0 };
+
+    switch (rotation)
+    {
+        default:
+        case 0:
+            coordinate_2d.x = coordinate_3d->y - coordinate_3d->x;
+            coordinate_2d.y = ((coordinate_3d->y + coordinate_3d->x) >> 1) - coordinate_3d->z;
+            break;
+        case 1:
+            coordinate_2d.x = -coordinate_3d->y - coordinate_3d->x;
+            coordinate_2d.y = ((coordinate_3d->y - coordinate_3d->x) >> 1) - coordinate_3d->z;
+            break;
+        case 2:
+            coordinate_2d.x = -coordinate_3d->y + coordinate_3d->x;
+            coordinate_2d.y = ((-coordinate_3d->y - coordinate_3d->x) >> 1) - coordinate_3d->z;
+            break;
+        case 3:
+            coordinate_2d.x = coordinate_3d->y + coordinate_3d->x;
+            coordinate_2d.y = ((-coordinate_3d->y + coordinate_3d->x) >> 1) - coordinate_3d->z;
+            break;
+    }
+    return coordinate_2d;
+}
 money32 map_clear_scenery(int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t clear, int32_t flags);
 money32 lower_water(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint8_t flags);
 money32 raise_water(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint8_t flags);

--- a/src/openrct2/world/Surface.cpp
+++ b/src/openrct2/world/Surface.cpp
@@ -16,14 +16,6 @@
 #include "Location.hpp"
 #include "Map.h"
 
-uint32_t SurfaceElement::GetSurfaceStyle() const
-{
-    uint32_t retVal = (terrain >> 5) & 7;
-    if (type & 1)
-        retVal |= (1 << 3);
-    return retVal;
-}
-
 uint32_t SurfaceElement::GetEdgeStyle() const
 {
     uint32_t terrain_edge = (slope >> 5) & 7;
@@ -222,11 +214,6 @@ void SurfaceElement::SetParkFences(uint8_t newParkFences)
 {
     ownership &= ~TILE_ELEMENT_SURFACE_PARK_FENCE_MASK;
     ownership |= (newParkFences & TILE_ELEMENT_SURFACE_PARK_FENCE_MASK);
-}
-
-uint8_t SurfaceElement::GetSlope() const
-{
-    return (slope & TILE_ELEMENT_SURFACE_SLOPE_MASK);
 }
 
 void SurfaceElement::SetSlope(uint8_t newSlope)

--- a/src/openrct2/world/Surface.h
+++ b/src/openrct2/world/Surface.h
@@ -102,14 +102,3 @@ enum
     TILE_ELEMENT_SLOPE_N_S_VALLEY = TILE_ELEMENT_SLOPE_N_CORNER_UP | TILE_ELEMENT_SLOPE_S_CORNER_UP
 };
 
-// Surface
-#define TILE_ELEMENT_SURFACE_DIAGONAL_FLAG 0x10       // in TileElement.properties.surface.slope
-#define TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK 0x0F // in TileElement.properties.surface.slope
-#define TILE_ELEMENT_SURFACE_SLOPE_MASK                                                                                        \
-    (TILE_ELEMENT_SURFACE_DIAGONAL_FLAG | TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK) // in TileElement.properties.surface.slope
-#define TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK 0xE0                                   // in TileElement.properties.surface.slope
-#define TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK 0x1F                                 // in TileElement.properties.surface.terrain
-#define TILE_ELEMENT_SURFACE_TERRAIN_MASK 0xE0                                      // in TileElement.properties.surface.terrain
-
-#define TILE_ELEMENT_SURFACE_OWNERSHIP_MASK 0xF0
-#define TILE_ELEMENT_SURFACE_PARK_FENCE_MASK 0x0F

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -17,11 +17,6 @@
 #include "LargeScenery.h"
 #include "Scenery.h"
 
-uint8_t TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
 void TileElementBase::SetType(uint8_t newType)
 {
     this->type &= ~TILE_ELEMENT_TYPE_MASK;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -12,6 +12,7 @@
 #include "../common.h"
 #include "../ride/RideTypes.h"
 #include "Footpath.h"
+#include "Surface.h"
 #include "Location.hpp"
 
 struct rct_scenery_entry;
@@ -202,10 +203,20 @@ private:
     uint8_t grass_length; // 6
     uint8_t ownership;    // 7
 public:
-    uint8_t GetSlope() const;
+    inline uint8_t GetSlope() const
+    {
+        return (slope & (uint8_t)TILE_ELEMENT_SURFACE_SLOPE_MASK);
+    }
     void SetSlope(uint8_t newSlope);
 
-    uint32_t GetSurfaceStyle() const;
+    inline uint32_t GetSurfaceStyle() const
+    {
+        uint32_t retVal = (uint8_t)((terrain >> 5) & 7);
+        if (type & 1)
+            retVal |= (1 << 3);
+        return retVal;
+    }
+
     void SetSurfaceStyle(uint32_t newStyle);
     uint32_t GetEdgeStyle() const;
     void SetEdgeStyle(uint32_t newStyle);

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -255,17 +255,27 @@ private:
 
 public:
     uint8_t GetPathEntryIndex() const;
-    PathSurfaceEntry* GetPathEntry() const;
+    inline PathSurfaceEntry* GetPathEntry() const
+    {
+        return get_path_surface_entry(GetPathEntryIndex());
+    }
     void SetPathEntryIndex(uint8_t newIndex);
 
     uint8_t GetRailingEntryIndex() const;
-    PathRailingsEntry* GetRailingEntry() const;
+
+    PathRailingsEntry* GetRailingEntry() const
+    {
+        return get_path_railings_entry(GetRailingEntryIndex());
+    }
     void SetRailingEntryIndex(uint8_t newIndex);
 
     uint8_t GetQueueBannerDirection() const;
     void SetQueueBannerDirection(uint8_t direction);
 
-    bool IsSloped() const;
+    inline bool IsSloped() const
+    {
+        return (entryIndex & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED) != 0;
+    }
     void SetSloped(bool isSloped);
 
     uint8_t GetSlopeDirection() const;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -12,7 +12,6 @@
 #include "../common.h"
 #include "../ride/RideTypes.h"
 #include "Footpath.h"
-#include "Surface.h"
 #include "Location.hpp"
 
 struct rct_scenery_entry;
@@ -78,6 +77,18 @@ enum
 #define MAP_ELEM_TRACK_SEQUENCE_STATION_INDEX_MASK 0b01110000
 #define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0b00001111
 #define MAP_ELEM_TRACK_SEQUENCE_TAKING_PHOTO_MASK 0b11110000
+
+// Surface
+#define TILE_ELEMENT_SURFACE_DIAGONAL_FLAG 0x10       // in TileElement.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK 0x0F // in TileElement.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_SLOPE_MASK                                                                                        \
+    (TILE_ELEMENT_SURFACE_DIAGONAL_FLAG | TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK) // in TileElement.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_EDGE_STYLE_MASK 0xE0                                   // in TileElement.properties.surface.slope
+#define TILE_ELEMENT_SURFACE_WATER_HEIGHT_MASK 0x1F                                 // in TileElement.properties.surface.terrain
+#define TILE_ELEMENT_SURFACE_TERRAIN_MASK 0xE0                                      // in TileElement.properties.surface.terrain
+
+#define TILE_ELEMENT_SURFACE_OWNERSHIP_MASK 0xF0
+#define TILE_ELEMENT_SURFACE_PARK_FENCE_MASK 0x0F
 
 #pragma pack(push, 1)
 

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -17,6 +17,67 @@
 struct rct_scenery_entry;
 struct rct_footpath_entry;
 
+enum
+{
+    TILE_ELEMENT_QUADRANT_SW,
+    TILE_ELEMENT_QUADRANT_NW,
+    TILE_ELEMENT_QUADRANT_NE,
+    TILE_ELEMENT_QUADRANT_SE
+};
+
+enum
+{
+    TILE_ELEMENT_TYPE_FLAG_HIGHLIGHT = (1 << 6),
+    SURFACE_ELEMENT_HAS_TRACK_THAT_NEEDS_WATER = (1 << 6),
+};
+
+enum
+{
+    TILE_ELEMENT_DIRECTION_WEST,
+    TILE_ELEMENT_DIRECTION_NORTH,
+    TILE_ELEMENT_DIRECTION_EAST,
+    TILE_ELEMENT_DIRECTION_SOUTH
+};
+
+enum
+{
+    TILE_ELEMENT_FLAG_GHOST = (1 << 4),
+    TILE_ELEMENT_FLAG_BROKEN = (1 << 5),
+    TILE_ELEMENT_FLAG_BLOCK_BRAKE_CLOSED = (1 << 5),
+    TILE_ELEMENT_FLAG_INDESTRUCTIBLE_TRACK_PIECE = (1 << 6),
+    TILE_ELEMENT_FLAG_BLOCKED_BY_VEHICLE = (1 << 6),
+    TILE_ELEMENT_FLAG_LAST_TILE = (1 << 7)
+};
+
+enum
+{
+    ENTRANCE_TYPE_RIDE_ENTRANCE,
+    ENTRANCE_TYPE_RIDE_EXIT,
+    ENTRANCE_TYPE_PARK_ENTRANCE
+};
+
+enum
+{
+    ELEMENT_IS_ABOVE_GROUND = 1 << 0,
+    ELEMENT_IS_UNDERGROUND = 1 << 1,
+    ELEMENT_IS_UNDERWATER = 1 << 2,
+};
+
+enum
+{
+    MAP_ELEM_TRACK_SEQUENCE_GREEN_LIGHT = (1 << 7),
+};
+
+#define TILE_ELEMENT_QUADRANT_MASK 0b11000000
+#define TILE_ELEMENT_TYPE_MASK 0b00111100
+#define TILE_ELEMENT_DIRECTION_MASK 0b00000011
+
+#define TILE_ELEMENT_COLOUR_MASK 0b00011111
+
+#define MAP_ELEM_TRACK_SEQUENCE_STATION_INDEX_MASK 0b01110000
+#define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0b00001111
+#define MAP_ELEM_TRACK_SEQUENCE_TAKING_PHOTO_MASK 0b11110000
+
 #pragma pack(push, 1)
 
 enum
@@ -64,7 +125,11 @@ struct TileElementBase
     uint8_t base_height;      // 2
     uint8_t clearance_height; // 3
 
-    uint8_t GetType() const;
+    inline uint8_t GetType() const
+    {
+        return this->type & (uint8_t)TILE_ELEMENT_TYPE_MASK;
+    }
+
     void SetType(uint8_t newType);
     uint8_t GetDirection() const;
     void SetDirection(uint8_t direction);
@@ -461,67 +526,6 @@ struct CorruptElement : TileElementBase
 };
 assert_struct_size(CorruptElement, 8);
 #pragma pack(pop)
-
-enum
-{
-    TILE_ELEMENT_QUADRANT_SW,
-    TILE_ELEMENT_QUADRANT_NW,
-    TILE_ELEMENT_QUADRANT_NE,
-    TILE_ELEMENT_QUADRANT_SE
-};
-
-enum
-{
-    TILE_ELEMENT_TYPE_FLAG_HIGHLIGHT = (1 << 6),
-    SURFACE_ELEMENT_HAS_TRACK_THAT_NEEDS_WATER = (1 << 6),
-};
-
-enum
-{
-    TILE_ELEMENT_DIRECTION_WEST,
-    TILE_ELEMENT_DIRECTION_NORTH,
-    TILE_ELEMENT_DIRECTION_EAST,
-    TILE_ELEMENT_DIRECTION_SOUTH
-};
-
-enum
-{
-    TILE_ELEMENT_FLAG_GHOST = (1 << 4),
-    TILE_ELEMENT_FLAG_BROKEN = (1 << 5),
-    TILE_ELEMENT_FLAG_BLOCK_BRAKE_CLOSED = (1 << 5),
-    TILE_ELEMENT_FLAG_INDESTRUCTIBLE_TRACK_PIECE = (1 << 6),
-    TILE_ELEMENT_FLAG_BLOCKED_BY_VEHICLE = (1 << 6),
-    TILE_ELEMENT_FLAG_LAST_TILE = (1 << 7)
-};
-
-enum
-{
-    ENTRANCE_TYPE_RIDE_ENTRANCE,
-    ENTRANCE_TYPE_RIDE_EXIT,
-    ENTRANCE_TYPE_PARK_ENTRANCE
-};
-
-enum
-{
-    ELEMENT_IS_ABOVE_GROUND = 1 << 0,
-    ELEMENT_IS_UNDERGROUND = 1 << 1,
-    ELEMENT_IS_UNDERWATER = 1 << 2,
-};
-
-enum
-{
-    MAP_ELEM_TRACK_SEQUENCE_GREEN_LIGHT = (1 << 7),
-};
-
-#define TILE_ELEMENT_QUADRANT_MASK 0b11000000
-#define TILE_ELEMENT_TYPE_MASK 0b00111100
-#define TILE_ELEMENT_DIRECTION_MASK 0b00000011
-
-#define TILE_ELEMENT_COLOUR_MASK 0b00011111
-
-#define MAP_ELEM_TRACK_SEQUENCE_STATION_INDEX_MASK 0b01110000
-#define MAP_ELEM_TRACK_SEQUENCE_SEQUENCE_MASK 0b00001111
-#define MAP_ELEM_TRACK_SEQUENCE_TAKING_PHOTO_MASK 0b11110000
 
 BannerIndex tile_element_get_banner_index(TileElement* tileElement);
 bool tile_element_is_underground(TileElement* tileElement);

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -160,11 +160,6 @@ bool TileElementBase::IsLastForTile() const
     return (this->flags & TILE_ELEMENT_FLAG_LAST_TILE) != 0;
 }
 
-uint8_t TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
 TileElement* map_get_first_element_at(int x, int y)
 {
     if (x < 0 || y < 0 || x > 255 || y > 255)


### PR DESCRIPTION
Frequently called simple functions like `TileElement->GetType` cannot be inlined because their definition is not available at compile time. I've identified a number of functions in the paint subroutines:

- `get_current_rotation`
- `TerrainSurfaceObject::GetImageId`
- `tile_element_paint_setup`
- `bitscanforward`
- `PathElement::IsSloped`
- `PathElement::GetPathEntry`
- `PathElement::GetRailingEntry`
- `rotate_map_coordinates`
- `TileElementBase::GetType`
- `SurfaceElement::GetSurfaceStyle`
- `openrct2_assert_fwd`

I've checked `llvm`'s optimization output to validate that these functions will indeed be inlined. 
I've ran the `gfxbench` and `benchspritesort` between `devel` and this branch, compiled with `-O2`. 

|            | gfxbench (rep.40) | spritesort (rep.8) |
|------------|-------------------|--------------------|
| devel      | 323.6 k/s         | 7.49 s             |
| inlined    | 346.8 k/s         | 7.37 s             |
| difference | +7.1%             | +1.6% (1/s)        |

There seems to be quite some performance to gain. What do you think about this? Should we extend this to all kinds of getters and setters throughout the code, only do this for simple functions (getters, arithmetic, etc.) that are often called or not at all? 