### PR TITLE
Git-ignore typical CMake build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,5 +306,5 @@ discord-rpc
 !.vscode/launch.json
 !.vscode/extensions.json
 
-# Cmake
-cmake-build-debug/
+# CMake
+cmake-build-*/


### PR DESCRIPTION
It's useful to have a range of git-ignored directories at your disposal. 
This replaces the original 'cmake-build-debug' for a more generalized version. 

I needed this in #8641 and comparable. 

This also integrates nicely with the build-dir conventions of CLion. 