### PR TITLE
Fix #8653: crash when peeps attempt to enter a ride with no vehicles.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -61,6 +61,7 @@
 - Fix: [#8585] Part of track missing on air powered vertical coaster.
 - Fix: [#8588] Guest list scrolling breaks above ~2000 guests.
 - Fix: [#8591] Game loop does not run at a consistent tick rate of 40 Hz.
+- Fix: [#8653] Crash when peeps attempt to enter a ride with no vehicles.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
 - Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
 - Improved: [#7930] Automatically create folders for custom content.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "25"
+#define NETWORK_STREAM_VERSION "26"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2347,7 +2347,7 @@ static bool peep_find_vehicle_to_enter(rct_peep* peep, Ride* ride, std::vector<u
     {
         chosen_train = ride->stations[peep->current_ride_station].TrainAtStation;
     }
-    if (chosen_train == 0xFF)
+    if (chosen_train == 0xFF || chosen_train >= MAX_VEHICLES_PER_RIDE)
     {
         return false;
     }
@@ -2357,7 +2357,7 @@ static bool peep_find_vehicle_to_enter(rct_peep* peep, Ride* ride, std::vector<u
     int32_t i = 0;
 
     uint16_t vehicle_id = ride->vehicles[chosen_train];
-    rct_vehicle* vehicle = GET_VEHICLE(vehicle_id);
+    rct_vehicle* vehicle = nullptr;
 
     for (; vehicle_id != SPRITE_INDEX_NULL; vehicle_id = vehicle->next_vehicle_on_train, i++)
     {


### PR DESCRIPTION
This removes the double assignment of vehicle and also adds a bounds check to the chosen train index so no invalid read can also happen.