### PR TITLE
Refactor remaining number values to RideStation::NO_TRAIN

### DIFF
--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -152,7 +152,7 @@ public:
             ride->stations[i].Start.xy = RCT_XY8_UNDEFINED;
             ride_clear_entrance_location(ride, i);
             ride_clear_exit_location(ride, i);
-            ride->stations[i].TrainAtStation = 255;
+            ride->stations[i].TrainAtStation = RideStation::NO_TRAIN;
             ride->stations[i].QueueTime = 0;
         }
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2323,7 +2323,7 @@ static void peep_go_to_ride_entrance(rct_peep* peep, Ride* ride)
 
 static bool peep_find_vehicle_to_enter(rct_peep* peep, Ride* ride, std::vector<uint8_t>& car_array)
 {
-    uint8_t chosen_train = 0xFF;
+    uint8_t chosen_train = RideStation::NO_TRAIN;
 
     if (ride->mode == RIDE_MODE_BUMPERCAR || ride->mode == RIDE_MODE_RACE)
     {
@@ -2347,7 +2347,7 @@ static bool peep_find_vehicle_to_enter(rct_peep* peep, Ride* ride, std::vector<u
     {
         chosen_train = ride->stations[peep->current_ride_station].TrainAtStation;
     }
-    if (chosen_train == 0xFF || chosen_train >= MAX_VEHICLES_PER_RIDE)
+    if (chosen_train == RideStation::NO_TRAIN || chosen_train >= MAX_VEHICLES_PER_RIDE)
     {
         return false;
     }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -839,7 +839,7 @@ private:
         for (int32_t i = RCT12_MAX_STATIONS_PER_RIDE; i < MAX_STATIONS; i++)
         {
             dst->stations[i].Start.xy = RCT_XY8_UNDEFINED;
-            dst->stations[i].TrainAtStation = 255;
+            dst->stations[i].TrainAtStation = RideStation::NO_TRAIN;
             ride_clear_entrance_location(dst, i);
             ride_clear_exit_location(dst, i);
             dst->stations[i].LastPeepInQueue = SPRITE_INDEX_NULL;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -565,7 +565,7 @@ public:
         for (int32_t i = RCT12_MAX_STATIONS_PER_RIDE; i < MAX_STATIONS; i++)
         {
             dst->stations[i].Start.xy = RCT_XY8_UNDEFINED;
-            dst->stations[i].TrainAtStation = 255;
+            dst->stations[i].TrainAtStation = RideStation::NO_TRAIN;
             ride_clear_entrance_location(dst, i);
             ride_clear_exit_location(dst, i);
             dst->stations[i].LastPeepInQueue = SPRITE_INDEX_NULL;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2169,7 +2169,7 @@ static void train_ready_to_depart(rct_vehicle* vehicle, uint8_t num_peeps_on_tra
         uint8_t peep = ((-vehicle->vehicle_sprite_type) / 8) & 0xF;
         if (vehicle->peep[peep] != SPRITE_INDEX_NULL)
         {
-            ride->stations[vehicle->current_station].TrainAtStation = 0xFF;
+            ride->stations[vehicle->current_station].TrainAtStation = RideStation::NO_TRAIN;
             vehicle->status = VEHICLE_STATUS_UNLOADING_PASSENGERS;
             vehicle->sub_state = 0;
             vehicle_invalidate_window(vehicle);
@@ -2179,7 +2179,7 @@ static void train_ready_to_depart(rct_vehicle* vehicle, uint8_t num_peeps_on_tra
         if (vehicle->num_peeps == 0)
             return;
 
-        ride->stations[vehicle->current_station].TrainAtStation = 0xFF;
+        ride->stations[vehicle->current_station].TrainAtStation = RideStation::NO_TRAIN;
         vehicle->sub_state = 2;
         return;
     }
@@ -2187,7 +2187,7 @@ static void train_ready_to_depart(rct_vehicle* vehicle, uint8_t num_peeps_on_tra
     if (num_peeps_on_train == 0)
         return;
 
-    ride->stations[vehicle->current_station].TrainAtStation = 0xFF;
+    ride->stations[vehicle->current_station].TrainAtStation = RideStation::NO_TRAIN;
     vehicle->status = VEHICLE_STATUS_WAITING_FOR_PASSENGERS;
     vehicle->sub_state = 0;
     vehicle_invalidate_window(vehicle);
@@ -2231,7 +2231,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle* vehicle)
 
         if (ride_get_entrance_location(ride, vehicle->current_station).isNull())
         {
-            ride->stations[vehicle->current_station].TrainAtStation = 0xFF;
+            ride->stations[vehicle->current_station].TrainAtStation = RideStation::NO_TRAIN;
             vehicle->sub_state = 2;
             return;
         }
@@ -2242,7 +2242,7 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle* vehicle)
             return;
         }
 
-        if (ride->stations[vehicle->current_station].TrainAtStation != 0xFF)
+        if (ride->stations[vehicle->current_station].TrainAtStation != RideStation::NO_TRAIN)
             return;
 
         ride->stations[vehicle->current_station].TrainAtStation = trainIndex;


### PR DESCRIPTION
As a follow up on #8654, this should leave no remaining number value for the train index.