### PR TITLE
Better tooltips for banners and signs

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -551,8 +551,8 @@ STR_1167    :Can't raise water level here...
 STR_1168    :Options
 STR_1169    :(None)
 STR_1170    :{STRING}
-STR_1171    :{RED}Closed - - 
-STR_1172    :{YELLOW}{STRINGID} - - 
+STR_1171    :{RED}Closed
+STR_1172    :{YELLOW}{STRINGID}
 STR_1173    :{SMALLFONT}{BLACK}Build footpaths and queue lines
 STR_1174    :Banner sign in the way
 STR_1175    :Can't build this on sloped footpath
@@ -1108,7 +1108,7 @@ STR_1726    :Land not for sale!
 STR_1727    :Construction rights not for sale!
 STR_1728    :Can't buy construction rights here...
 STR_1729    :Land not owned by park!
-STR_1730    :{RED}Closed - - 
+STR_1730    :{RED}Closed
 STR_1731    :{WHITE}{STRINGID} - - 
 STR_1732    :Build
 STR_1733    :Mode
@@ -2237,7 +2237,7 @@ STR_2977    :Staff member name
 STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
-STR_2981    :{RED}No entry - - 
+STR_2981    :{RED}No entry
 STR_2982    :Banner text
 STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3756,7 +3756,6 @@ STR_6305    :Multithreading
 STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
 STR_6308    :“{STRINGID}{OUTLINE}{TOPAZ}”{NEWLINE}{STRINGID}
-STR_6309    :{RED}No entry
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3755,6 +3755,8 @@ STR_6304    :Open scenery picker
 STR_6305    :Multithreading
 STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
+STR_6308    :“{STRINGID}{OUTLINE}{TOPAZ}”{NEWLINE}{STRINGID}
+STR_6309    :{RED}No entry
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#7296] Allow assigning a keyboard shortcut for the scenery picker.
 - Feature: [#8029] Add the Hungarian Forint (HUF) to the list of available currencies.
 - Feature: [#8481] Multi-threaded rendering.
+- Feature: [#8659] Banner and sign texts are now shown in tooltips.
 - Feature: [#8919] Allow setting ride price from console.
 - Feature: [#8963] Add missing Czech letters to sprite font, use sprite font for Czech.
 - Change: [#7877] Files are now sorted in logical rather than dictionary order.

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -337,8 +337,15 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             banner = &gBanners[tileElement->AsBanner()->GetIndex()];
             sceneryEntry = get_banner_entry(banner->type);
 
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-            set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+            set_map_tooltip_format_arg( 0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+            if (banner->flags & BANNER_FLAG_NO_ENTRY)
+            {
+                set_map_tooltip_format_arg( 2, rct_string_id, STR_NO_ENTRY_TOOLTIP);
+            } else {
+                set_map_tooltip_format_arg( 2, rct_string_id, banner->string_idx);
+            }
+            set_map_tooltip_format_arg( 4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+            set_map_tooltip_format_arg( 6, rct_string_id, sceneryEntry->name);
             return info->type;
     }
 

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -338,12 +338,12 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             sceneryEntry = get_banner_entry(banner->type);
 
             set_map_tooltip_format_arg( 0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+            
             if (banner->flags & BANNER_FLAG_NO_ENTRY)
-            {
                 set_map_tooltip_format_arg( 2, rct_string_id, STR_NO_ENTRY_TOOLTIP);
-            } else {
+            else
                 set_map_tooltip_format_arg( 2, rct_string_id, banner->string_idx);
-            }
+
             set_map_tooltip_format_arg( 4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
             set_map_tooltip_format_arg( 6, rct_string_id, sceneryEntry->name);
             return info->type;

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -317,8 +317,11 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             sceneryEntry = tileElement->AsWall()->GetEntry();
             if (sceneryEntry->wall.scrolling_mode != SCROLLING_MODE_NONE)
             {
-                set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+                banner = &gBanners[tileElement->AsWall()->GetBannerIndex()];
+                set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+                set_map_tooltip_format_arg(2, rct_string_id, banner->string_idx);
+                set_map_tooltip_format_arg(4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+                set_map_tooltip_format_arg(6, rct_string_id, sceneryEntry->name);
                 return info->type;
             }
             break;
@@ -327,8 +330,12 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (sceneryEntry->large_scenery.scrolling_mode != SCROLLING_MODE_NONE)
             {
-                set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+
+                banner = &gBanners[tileElement->AsLargeScenery()->GetBannerIndex()];
+                set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+                set_map_tooltip_format_arg(2, rct_string_id, banner->string_idx);
+                set_map_tooltip_format_arg(4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+                set_map_tooltip_format_arg(6, rct_string_id, sceneryEntry->name);
                 return info->type;
             }
             break;
@@ -337,15 +344,15 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             banner = &gBanners[tileElement->AsBanner()->GetIndex()];
             sceneryEntry = get_banner_entry(banner->type);
 
-            set_map_tooltip_format_arg( 0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
             
             if (banner->flags & BANNER_FLAG_NO_ENTRY)
-                set_map_tooltip_format_arg( 2, rct_string_id, STR_NO_ENTRY);
+                set_map_tooltip_format_arg(2, rct_string_id, STR_NO_ENTRY);
             else
-                set_map_tooltip_format_arg( 2, rct_string_id, banner->string_idx);
+                set_map_tooltip_format_arg(2, rct_string_id, banner->string_idx);
 
-            set_map_tooltip_format_arg( 4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-            set_map_tooltip_format_arg( 6, rct_string_id, sceneryEntry->name);
+            set_map_tooltip_format_arg(4, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+            set_map_tooltip_format_arg(6, rct_string_id, sceneryEntry->name);
             return info->type;
     }
 

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -330,7 +330,6 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (sceneryEntry->large_scenery.scrolling_mode != SCROLLING_MODE_NONE)
             {
-
                 banner = &gBanners[tileElement->AsLargeScenery()->GetBannerIndex()];
                 set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
                 set_map_tooltip_format_arg(2, rct_string_id, banner->string_idx);
@@ -345,7 +344,7 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             sceneryEntry = get_banner_entry(banner->type);
 
             set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
-            
+
             if (banner->flags & BANNER_FLAG_NO_ENTRY)
                 set_map_tooltip_format_arg(2, rct_string_id, STR_NO_ENTRY);
             else

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -340,7 +340,7 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             set_map_tooltip_format_arg( 0, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
             
             if (banner->flags & BANNER_FLAG_NO_ENTRY)
-                set_map_tooltip_format_arg( 2, rct_string_id, STR_NO_ENTRY_TOOLTIP);
+                set_map_tooltip_format_arg( 2, rct_string_id, STR_NO_ENTRY);
             else
                 set_map_tooltip_format_arg( 2, rct_string_id, banner->string_idx);
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3939,6 +3939,9 @@ enum
 
     STR_TILE_INSPECTOR_COLOUR_SCHEME = 6307,
 
+    STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID = 6308,
+    STR_NO_ENTRY_TOOLTIP = 6309,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3940,7 +3940,6 @@ enum
     STR_TILE_INSPECTOR_COLOUR_SCHEME = 6307,
 
     STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID = 6308,
-    STR_NO_ENTRY_TOOLTIP = 6309,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -95,19 +95,23 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
     set_format_arg(0, uint32_t, 0);
     set_format_arg(4, uint32_t, 0);
 
-    rct_string_id string_id = STR_NO_ENTRY;
-    if (!(gBanners[tile_element->AsBanner()->GetIndex()].flags & BANNER_FLAG_NO_ENTRY))
+    if (gBanners[tile_element->AsBanner()->GetIndex()].flags & BANNER_FLAG_NO_ENTRY)
     {
-        set_format_arg(0, rct_string_id, gBanners[tile_element->AsBanner()->GetIndex()].string_idx);
-        string_id = STR_BANNER_TEXT_FORMAT;
-    }
-    if (gConfigGeneral.upper_case_banners)
-    {
-        format_string_to_upper(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
+        set_format_arg(0, rct_string_id, STR_NO_ENTRY);
     }
     else
     {
-        format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
+        set_format_arg(0, rct_string_id, gBanners[tile_element->AsBanner()->GetIndex()].string_idx);
+    }
+
+
+    if (gConfigGeneral.upper_case_banners)
+    {
+        format_string_to_upper(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
+    }
+    else
+    {
+        format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
     }
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
@@ -116,6 +120,6 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
     uint16_t scroll = (gCurrentTicks / 2) % string_width;
 
     sub_98199C(
-        session, scrolling_text_setup(session, string_id, scroll, scrollingMode), 0, 0, 1, 1, 0x15, height + 22,
+        session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, scrollingMode), 0, 0, 1, 1, 0x15, height + 22,
         boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ);
 }

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -104,10 +104,10 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
         set_format_arg(0, rct_string_id, gBanners[tile_element->AsBanner()->GetIndex()].string_idx);
     }
 
-
     if (gConfigGeneral.upper_case_banners)
     {
-        format_string_to_upper(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
+        format_string_to_upper(
+            gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
     }
     else
     {

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -158,27 +158,28 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
     if (!is_exit && !(tile_element->IsGhost()) && tile_element->AsEntrance()->GetRideIndex() != RIDE_ID_NULL
         && stationObj->ScrollingMode != SCROLLING_MODE_NONE)
     {
-        set_format_arg(0, uint32_t, 0);
+        set_format_arg(0, rct_string_id, STR_RIDE_ENTRANCE_NAME);
         set_format_arg(4, uint32_t, 0);
-
-        rct_string_id string_id = STR_RIDE_ENTRANCE_CLOSED;
 
         if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
         {
-            set_format_arg(0, rct_string_id, ride->name);
-            set_format_arg(2, uint32_t, ride->name_arguments);
-
-            string_id = STR_RIDE_ENTRANCE_NAME;
+            set_format_arg(2, rct_string_id, STR_RIDE_ENTRANCE_NAME);
+            set_format_arg(4, rct_string_id, ride->name);
+            set_format_arg(6, uint32_t, ride->name_arguments);
+        }
+        else
+        {
+            set_format_arg(2, rct_string_id, STR_RIDE_ENTRANCE_CLOSED);
         }
 
         utf8 entrance_string[256];
         if (gConfigGeneral.upper_case_banners)
         {
-            format_string_to_upper(entrance_string, sizeof(entrance_string), string_id, gCommonFormatArgs);
+            format_string_to_upper(entrance_string, sizeof(entrance_string), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
         }
         else
         {
-            format_string(entrance_string, sizeof(entrance_string), string_id, gCommonFormatArgs);
+            format_string(entrance_string, sizeof(entrance_string), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
         }
 
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
@@ -187,7 +188,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
         uint16_t scroll = (gCurrentTicks / 2) % string_width;
 
         sub_98199C(
-            session, scrolling_text_setup(session, string_id, scroll, stationObj->ScrollingMode), 0, 0, 0x1C, 0x1C, 0x33,
+            session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, stationObj->ScrollingMode), 0, 0, 0x1C, 0x1C, 0x33,
             height + stationObj->Height, 2, 2, height + stationObj->Height);
     }
 
@@ -264,7 +265,6 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                 break;
 
             {
-                rct_string_id park_text_id = STR_BANNER_TEXT_CLOSED;
                 set_format_arg(0, uint32_t, 0);
                 set_format_arg(4, uint32_t, 0);
 
@@ -272,18 +272,21 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                 {
                     set_format_arg(0, rct_string_id, gParkName);
                     set_format_arg(2, uint32_t, gParkNameArgs);
-
-                    park_text_id = STR_BANNER_TEXT_FORMAT;
+                }
+                else
+                {
+                    set_format_arg(0, rct_string_id, STR_BANNER_TEXT_CLOSED);
+                    set_format_arg(2, uint32_t, 0);
                 }
 
                 utf8 park_name[256];
                 if (gConfigGeneral.upper_case_banners)
                 {
-                    format_string_to_upper(park_name, sizeof(park_name), park_text_id, gCommonFormatArgs);
+                    format_string_to_upper(park_name, sizeof(park_name), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
                 }
                 else
                 {
-                    format_string(park_name, sizeof(park_name), park_text_id, gCommonFormatArgs);
+                    format_string(park_name, sizeof(park_name), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
                 }
 
                 gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
@@ -294,7 +297,7 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                 if (entrance->scrolling_mode == SCROLLING_MODE_NONE)
                     break;
 
-                int32_t stsetup = scrolling_text_setup(session, park_text_id, scroll, entrance->scrolling_mode + direction / 2);
+                int32_t stsetup = scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, entrance->scrolling_mode + direction / 2);
                 int32_t text_height = height + entrance->text_height;
                 sub_98199C(session, stsetup, 0, 0, 0x1C, 0x1C, 0x2F, text_height, 2, 2, text_height);
             }

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -188,8 +188,8 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
         uint16_t scroll = (gCurrentTicks / 2) % string_width;
 
         sub_98199C(
-            session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, stationObj->ScrollingMode), 0, 0, 0x1C, 0x1C, 0x33,
-            height + stationObj->Height, 2, 2, height + stationObj->Height);
+            session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, stationObj->ScrollingMode), 0, 0, 0x1C, 0x1C,
+            0x33, height + stationObj->Height, 2, 2, height + stationObj->Height);
     }
 
     image_id = entranceImageId;
@@ -297,7 +297,8 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                 if (entrance->scrolling_mode == SCROLLING_MODE_NONE)
                     break;
 
-                int32_t stsetup = scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, entrance->scrolling_mode + direction / 2);
+                int32_t stsetup = scrolling_text_setup(
+                    session, STR_BANNER_TEXT_FORMAT, scroll, entrance->scrolling_mode + direction / 2);
                 int32_t text_height = height + entrance->text_height;
                 sub_98199C(session, stsetup, 0, 0, 0x1C, 0x1C, 0x2F, text_height, 2, 2, text_height);
             }

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -163,9 +163,8 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
 
         if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
         {
-            set_format_arg(2, rct_string_id, STR_RIDE_ENTRANCE_NAME);
-            set_format_arg(4, rct_string_id, ride->name);
-            set_format_arg(6, uint32_t, ride->name_arguments);
+            set_format_arg(2, rct_string_id, ride->name);
+            set_format_arg(4, uint32_t, ride->name_arguments);
         }
         else
         {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -451,21 +451,24 @@ static void sub_6A4101(
             set_format_arg(4, uint32_t, 0);
 
             Ride* ride = get_ride(tile_element->AsPath()->GetRideIndex());
-            rct_string_id string_id = STR_RIDE_ENTRANCE_CLOSED;
             if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
             {
-                set_format_arg(0, rct_string_id, ride->name);
-                set_format_arg(2, uint32_t, ride->name_arguments);
-                string_id = STR_RIDE_ENTRANCE_NAME;
+                set_format_arg(0, rct_string_id, STR_RIDE_ENTRANCE_NAME);
+                set_format_arg(2, rct_string_id, ride->name);
+                set_format_arg(4, uint32_t, ride->name_arguments);
+            }
+            else
+            {
+                set_format_arg(0, rct_string_id, STR_RIDE_ENTRANCE_CLOSED);
             }
             if (gConfigGeneral.upper_case_banners)
             {
                 format_string_to_upper(
-                    gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
+                    gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
             }
             else
             {
-                format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), string_id, gCommonFormatArgs);
+                format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
             }
 
             gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
@@ -474,7 +477,7 @@ static void sub_6A4101(
             uint16_t scroll = (gCurrentTicks / 2) % string_width;
 
             sub_98199C(
-                session, scrolling_text_setup(session, string_id, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,
+                session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,
                 boundBoxOffsets.x, boundBoxOffsets.y, boundBoxOffsets.z);
         }
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -468,7 +468,8 @@ static void sub_6A4101(
             }
             else
             {
-                format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
+                format_string(
+                    gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, gCommonFormatArgs);
             }
 
             gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
@@ -477,8 +478,8 @@ static void sub_6A4101(
             uint16_t scroll = (gCurrentTicks / 2) % string_width;
 
             sub_98199C(
-                session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, scrollingMode), 0, 0, 1, 1, 21, height + 7,
-                boundBoxOffsets.x, boundBoxOffsets.y, boundBoxOffsets.z);
+                session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, scrollingMode), 0, 0, 1, 1, 21,
+                height + 7, boundBoxOffsets.x, boundBoxOffsets.y, boundBoxOffsets.z);
         }
 
         session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;


### PR DESCRIPTION
Here is an implementation of the request in issue #8593.

* Adds tooltips to signs that are visible on hover.
  * Scrolling signs that have colored text use the text's color.
  * No entry signs show "No entry".
  * 3D landscape signs and other scrolling signs display their text.
* Changes some of the localization strings.
  * Addition of a new string for sign tooltips that resets the tooltip formatting.
  * Banner messages that ended with ` - - ` have had that trimmed.
    * `STR_RIDE_ENTRANCE_NAME`, `STR_RIDE_ENTRANCE_CLOSED`, `STR_PARK_CLOSED`, `STR_NO_ENTRY` ...
  * Those banners now use `STR_BANNER_TEXT_FORMAT` or `STR_SCROLLING_SIGN_TEXT` to provide the final ` - - `.

One small issue is that new signs that _have not been edited yet_ will show the text "Sign" instead of the default nearby-ride name, but the tile inspector does this as well.

----

![Scrolling sign with colored text](https://user-images.githubusercontent.com/1077535/52092084-5b991c00-256b-11e9-9705-b0207a01af12.png)
![No Entry sign](https://user-images.githubusercontent.com/1077535/52092092-5dfb7600-256b-11e9-98bf-d7f468b55d1c.png)
![3D sign](https://user-images.githubusercontent.com/1077535/52092099-62279380-256b-11e9-8aaa-3f15a2e1310a.png)
