### PR TITLE
Auto-download missing objects

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3747,6 +3747,7 @@ STR_6296    :GiB
 STR_6297    :TiB
 STR_6298    :{STRING}/sec
 STR_6299    :Download all
+STR_6300    :Downloading object ({COMMA16} / {COMMA16}): [{STRING}]
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3576,7 +3576,7 @@ STR_6125    :Object type
 STR_6126    :Unknown type
 STR_6127    :File: {STRING}
 STR_6128    :The file could not be loaded as some of the objects referenced in it are missing or corrupt. A list of these objects is given below.
-STR_6129    :Copy selected item to clipboard
+STR_6129    :Copy item to clipboard
 STR_6130    :Copy entire list to clipboard
 STR_6131    :Object source
 STR_6132    :Ignore research status

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3746,6 +3746,7 @@ STR_6295    :MiB
 STR_6296    :GiB
 STR_6297    :TiB
 STR_6298    :{STRING}/sec
+STR_6299    :Download all
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3576,8 +3576,8 @@ STR_6125    :Object type
 STR_6126    :Unknown type
 STR_6127    :File: {STRING}
 STR_6128    :The file could not be loaded as some of the objects referenced in it are missing or corrupt. A list of these objects is given below.
-STR_6129    :Copy item to clipboard
-STR_6130    :Copy entire list to clipboard
+STR_6129    :Copy
+STR_6130    :Copy all
 STR_6131    :Object source
 STR_6132    :Ignore research status
 STR_6133    :{SMALLFONT}{BLACK}Access rides and scenery that have not yet been invented
@@ -3747,7 +3747,10 @@ STR_6296    :GiB
 STR_6297    :TiB
 STR_6298    :{STRING}/sec
 STR_6299    :Download all
-STR_6300    :Downloading object ({COMMA16} / {COMMA16}): [{STRING}]
+STR_6300    :{SMALLFONT}{BLACK}Download all missing objects if available online.
+STR_6301    :{SMALLFONT}{BLACK}Copy the selected object name to the clipboard.
+STR_6302    :{SMALLFONT}{BLACK}Copy the entire list of missing objects to the clipboard.
+STR_6303    :Downloading object ({COMMA16} / {COMMA16}): [{STRING}]
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -200,10 +200,10 @@ static rct_widget window_object_load_error_widgets[] = {
     { WWT_TABLE_HEADER,      0, SOURCE_COL_LEFT, TYPE_COL_LEFT - 1,     57,         70,         STR_OBJECT_SOURCE,              STR_NONE },                // 'Object source' header
     { WWT_TABLE_HEADER,      0, TYPE_COL_LEFT,   WW_LESS_PADDING - 1,   57,         70,         STR_OBJECT_TYPE,                STR_NONE },                // 'Object type' header
     { WWT_SCROLL,            0, 4,               WW_LESS_PADDING,       70,         WH - 33,    SCROLL_VERTICAL,                STR_NONE },                // Scrollable list area
-    { WWT_BUTTON,            0, 4,               148,                   WH - 23,    WH - 10,    STR_COPY_SELECTED,              STR_NONE },                // Copy selected btn
-    { WWT_BUTTON,            0, 152,             296,                   WH - 23,    WH - 10,    STR_COPY_ALL,                   STR_NONE },                // Copy all btn
+    { WWT_BUTTON,            0, 4,               148,                   WH - 23,    WH - 10,    STR_COPY_SELECTED,              STR_COPY_SELECTED_TIP },   // Copy selected button
+    { WWT_BUTTON,            0, 152,             296,                   WH - 23,    WH - 10,    STR_COPY_ALL,                   STR_COPY_ALL_TIP },        // Copy all button
 #ifndef DISABLE_HTTP
-    { WWT_BUTTON,            0, 300,             WW_LESS_PADDING,       WH - 23,    WH - 10,    STR_DOWNLOAD_ALL,               STR_NONE },                // Download all
+    { WWT_BUTTON,            0, 300,             WW_LESS_PADDING,       WH - 23,    WH - 10,    STR_DOWNLOAD_ALL,               STR_DOWNLOAD_ALL_TIP },    // Download all button
 #endif
     { WIDGETS_END },
 };

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#ifndef DISABLE_HTTP
+
 class ObjectDownloader
 {
 private:
@@ -166,6 +168,8 @@ private:
     }
 };
 
+#endif
+
 // clang-format off
 enum WINDOW_OBJECT_LOAD_ERROR_WIDGET_IDX {
     WIDX_BACKGROUND,
@@ -198,7 +202,9 @@ static rct_widget window_object_load_error_widgets[] = {
     { WWT_SCROLL,            0, 4,               WW_LESS_PADDING,       70,         WH - 33,    SCROLL_VERTICAL,                STR_NONE },                // Scrollable list area
     { WWT_BUTTON,            0, 4,               148,                   WH - 23,    WH - 10,    STR_COPY_SELECTED,              STR_NONE },                // Copy selected btn
     { WWT_BUTTON,            0, 152,             296,                   WH - 23,    WH - 10,    STR_COPY_ALL,                   STR_NONE },                // Copy all btn
+#ifndef DISABLE_HTTP
     { WWT_BUTTON,            0, 300,             WW_LESS_PADDING,       WH - 23,    WH - 10,    STR_DOWNLOAD_ALL,               STR_NONE },                // Download all
+#endif
     { WIDGETS_END },
 };
 
@@ -211,8 +217,10 @@ static void window_object_load_error_scrollmouseover(rct_window *w, int32_t scro
 static void window_object_load_error_scrollmousedown(rct_window *w, int32_t scrollIndex, int32_t x, int32_t y);
 static void window_object_load_error_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_object_load_error_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
+#ifndef DISABLE_HTTP
 static void window_object_load_error_download_all(rct_window* w);
 static void window_object_load_error_update_list(rct_window* w);
+#endif
 
 static rct_window_event_list window_object_load_error_events = {
     window_object_load_error_close,
@@ -249,8 +257,10 @@ static rct_window_event_list window_object_load_error_events = {
 static std::vector<rct_object_entry> _invalid_entries;
 static int32_t highlighted_index = -1;
 static std::string file_path;
+#ifndef DISABLE_HTTP
 static ObjectDownloader _objDownloader;
 static bool _updatedListAfterDownload;
+#endif
 
 /**
  *  Returns an rct_string_id that represents an rct_object_entry's type.
@@ -381,6 +391,7 @@ static void window_object_load_error_update(rct_window* w)
         widget_invalidate(w, WIDX_SCROLL);
     }
 
+#ifndef DISABLE_HTTP
     // Remove downloaded objects from our invalid entry list
     if (_objDownloader.IsDownloading())
     {
@@ -395,6 +406,7 @@ static void window_object_load_error_update(rct_window* w)
         window_object_load_error_update_list(w);
         _updatedListAfterDownload = true;
     }
+#endif
 }
 
 static void window_object_load_error_mouseup(rct_window* w, rct_widgetindex widgetIndex)
@@ -419,9 +431,11 @@ static void window_object_load_error_mouseup(rct_window* w, rct_widgetindex widg
         case WIDX_COPY_ALL:
             copy_object_names_to_clipboard(w);
             break;
+#ifndef DISABLE_HTTP
         case WIDX_DOWNLOAD_ALL:
             window_object_load_error_download_all(w);
             break;
+#endif
     }
 }
 
@@ -513,6 +527,8 @@ static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinf
     }
 }
 
+#ifndef DISABLE_HTTP
+
 static void window_object_load_error_download_all(rct_window* w)
 {
     if (!_objDownloader.IsDownloading())
@@ -535,3 +551,5 @@ static void window_object_load_error_update_list(rct_window* w)
         w->no_list_items = (uint16_t)_invalid_entries.size();
     }
 }
+
+#endif

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -30,7 +30,7 @@ private:
 
     std::vector<rct_object_entry> _entries;
     std::vector<rct_object_entry> _downloadedEntries;
-    int32_t _currentDownloadIndex{};
+    size_t _currentDownloadIndex{};
     std::mutex _downloadedEntriesMutex;
 
     // TODO static due to INTENT_EXTRA_CALLBACK not allowing a std::function
@@ -57,7 +57,7 @@ public:
     }
 
 private:
-    void UpdateProgress(const std::string& name, int32_t count, int32_t total)
+    void UpdateProgress(const std::string& name, size_t count, size_t total)
     {
         char str_downloading_objects[256];
         set_format_arg(0, int16_t, count);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3928,6 +3928,7 @@ enum
     STR_NETWORK_SPEED_SEC = 6298,
 
     STR_DOWNLOAD_ALL = 6299,
+    STR_DOWNLOADING_OBJECTS = 6300,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3927,6 +3927,8 @@ enum
 
     STR_NETWORK_SPEED_SEC = 6298,
 
+    STR_DOWNLOAD_ALL = 6299,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3928,7 +3928,10 @@ enum
     STR_NETWORK_SPEED_SEC = 6298,
 
     STR_DOWNLOAD_ALL = 6299,
-    STR_DOWNLOADING_OBJECTS = 6300,
+    STR_DOWNLOAD_ALL_TIP = 6300,
+    STR_COPY_SELECTED_TIP = 6301,
+    STR_COPY_ALL_TIP = 6302,
+    STR_DOWNLOADING_OBJECTS = 6303,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -160,7 +160,10 @@ namespace OpenRCT2::Network::Http
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
         curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &content_type);
         res.status = static_cast<Status>(code);
-        res.content_type = std::string(content_type);
+        if (content_type != nullptr)
+        {
+            res.content_type = std::string(content_type);
+        }
 
         return res;
     }

--- a/src/openrct2/network/Http.h
+++ b/src/openrct2/network/Http.h
@@ -21,7 +21,8 @@ namespace OpenRCT2::Network::Http
 {
     enum class Status
     {
-        OK = 200
+        OK = 200,
+        NotFound = 404
     };
 
     enum class Method

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -339,6 +339,23 @@ public:
         }
     }
 
+    void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) override
+    {
+        utf8 path[MAX_PATH];
+        GetPathForNewObject(path, sizeof(path), std::string(objectName).c_str());
+
+        log_verbose("Adding object: [%s]", objectName);
+        try
+        {
+            File::WriteAllBytes(path, data, dataSize);
+            ScanObject(path);
+        }
+        catch (const std::exception&)
+        {
+            Console::Error::WriteLine("Failed saving object: [%s] to '%s'.", objectName, path);
+        }
+    }
+
     void ExportPackedObject(IStream* stream) override
     {
         auto chunkReader = SawyerChunkReader(stream);

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -75,6 +75,7 @@ interface IObjectRepository
     virtual void UnregisterLoadedObject(const ObjectRepositoryItem* ori, Object* object) abstract;
 
     virtual void AddObject(const rct_object_entry* objectEntry, const void* data, size_t dataSize) abstract;
+    virtual void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) abstract;
 
     virtual void ExportPackedObject(IStream * stream) abstract;
     virtual void WritePackedObjects(IStream * stream, std::vector<const ObjectRepositoryItem*> & objects) abstract;


### PR DESCRIPTION
This adds a new button to the missing object window to automatically download the missing objects.

Sometimes I get a chain of 502 errors when querying for objects I am wondering whether that is me, curl or the API. Would anyone be able to test this and let me know if they hit the same issue?

This downloads objects synchronously, this can be improved but I don't want to over-complicate the initial feature PR.

![image](https://user-images.githubusercontent.com/1482259/52292249-355ced00-296c-11e9-8267-25b245e63be5.png)