### PR TITLE
Link targets with platform specific libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ endif()
 
 project(openrct2 CXX)
 
+include(cmake/platform.cmake)
+
 if (NOT MSVC)
     include(FindPkgConfig)
 endif ()

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -1,0 +1,11 @@
+# Helpers for linking platform specific libraries
+
+function(target_link_platform_libraries target)
+
+if (APPLE)
+    target_link_libraries(${target} "-framework Cocoa")
+elseif(WIN32)
+    target_link_libraries(${target} gdi32)
+endif ()
+
+endfunction()

--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -1,28 +1,20 @@
-# CMAKE project for openrct2-cli (CLI-only build of OpenRCT2)
 cmake_minimum_required(VERSION 3.9)
+project(openrct2-cli CXX)
 
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif ()
 
-# Sources
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/*.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/*.h"
     "${CMAKE_CURRENT_LIST_DIR}/*.hpp")
 
-# Outputs
-set (PROJECT openrct2-cli)
-project(${PROJECT} CXX)
-add_executable(${PROJECT} ${OPENRCT2_CLI_SOURCES})
-ipo_set_target_properties(${PROJECT})
-target_link_libraries(${PROJECT} "libopenrct2")
-target_link_platform_libraries(${PROJECT})
-
-# Needed for interactive console
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-target_link_libraries(${PROJECT} Threads::Threads)
-target_link_platform_libraries(${PROJECT})
-# Includes
-target_include_directories(${PROJECT} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
+add_executable(${PROJECT_NAME} ${OPENRCT2_CLI_SOURCES})
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")
+ipo_set_target_properties(${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME} libopenrct2 Threads::Threads)
+target_link_platform_libraries(${PROJECT_NAME})

--- a/src/openrct2-cli/CMakeLists.txt
+++ b/src/openrct2-cli/CMakeLists.txt
@@ -1,5 +1,6 @@
 # CMAKE project for openrct2-cli (CLI-only build of OpenRCT2)
 cmake_minimum_required(VERSION 3.9)
+
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif ()
@@ -15,21 +16,13 @@ set (PROJECT openrct2-cli)
 project(${PROJECT} CXX)
 add_executable(${PROJECT} ${OPENRCT2_CLI_SOURCES})
 ipo_set_target_properties(${PROJECT})
-
 target_link_libraries(${PROJECT} "libopenrct2")
+target_link_platform_libraries(${PROJECT})
 
 # Needed for interactive console
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT} Threads::Threads)
-
-if (APPLE)
-    target_link_libraries(${PROJECT} "-framework Cocoa")
-endif ()
-
-if (WIN32)
-    target_link_libraries(${PROJECT} gdi32)
-endif ()
-
+target_link_platform_libraries(${PROJECT})
 # Includes
 target_include_directories(${PROJECT} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/..")

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -48,10 +48,7 @@ ipo_set_target_properties(${PROJECT})
 target_link_libraries(${PROJECT} "libopenrct2"
                                  ${SDL2_LDFLAGS}
                                  ${SPEEX_LDFLAGS})
-
-if (APPLE)
-    target_link_libraries(${PROJECT} "-framework Cocoa")
-endif ()
+target_link_platform_libraries(${PROJECT})
 
 if (NOT DISABLE_OPENGL)
     if (WIN32)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ set(SAWYERCODING_TEST_SOURCES
         )
 add_executable(test_sawyercoding ${SAWYERCODING_TEST_SOURCES})
 target_link_libraries(test_sawyercoding ${GTEST_LIBRARIES} test-common ${LDL} z)
+target_link_platform_libraries(test_sawyercoding)
 add_test(NAME sawyercoding COMMAND test_sawyercoding)
 
 # LanguagePack test
@@ -125,6 +126,7 @@ if (UNIX AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
     set(LDL dl)
 endif ()
 target_link_libraries(test_languagepack ${GTEST_LIBRARIES} test-common ${LDL} z)
+target_link_platform_libraries(test_languagepack)
 add_test(NAME languagepack COMMAND test_languagepack)
 
 # INI test
@@ -139,6 +141,7 @@ set(INI_TEST_SOURCES
 add_executable(test_ini ${INI_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_ini)
 target_link_libraries(test_ini ${GTEST_LIBRARIES} test-common ${LDL} z)
+target_link_platform_libraries(test_ini)
 add_test(NAME ini COMMAND test_ini)
 
 # String test
@@ -148,6 +151,7 @@ set(STRING_TEST_SOURCES
 add_executable(test_string ${STRING_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_string)
 target_link_libraries(test_string ${GTEST_LIBRARIES} test-common ${LDL} z)
+target_link_platform_libraries(test_string)
 add_test(NAME string COMMAND test_string)
 
 # Localisation test
@@ -155,6 +159,7 @@ set(STRING_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Localisation.cpp")
 add_executable(test_localisation ${STRING_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_localisation)
 target_link_libraries(test_localisation ${GTEST_LIBRARIES} test-common ${LDL} z)
+target_link_platform_libraries(test_localisation)
 add_test(NAME localisation COMMAND test_localisation)
 
 if (NOT DISABLE_NETWORK)
@@ -163,6 +168,7 @@ if (NOT DISABLE_NETWORK)
                               "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
     SET_CHECK_CXX_FLAGS(test_crypt)
     target_link_libraries(test_crypt ${GTEST_LIBRARIES} libopenrct2)
+    target_link_platform_libraries(test_crypt)
     add_test(NAME Crypt COMMAND test_crypt)
 endif ()
 
@@ -171,6 +177,7 @@ add_executable(test_imageimporter "${CMAKE_CURRENT_LIST_DIR}/ImageImporterTests.
                                   "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
 SET_CHECK_CXX_FLAGS(test_imageimporter)
 target_link_libraries(test_imageimporter ${GTEST_LIBRARIES} libopenrct2)
+target_link_platform_libraries(test_imageimporter)
 add_test(NAME ImageImporter COMMAND test_imageimporter)
 
 # Ride ratings test
@@ -179,6 +186,7 @@ set(RIDE_RATINGS_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/RideRatings.cpp"
 add_executable(test_ride_ratings ${RIDE_RATINGS_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_ride_ratings)
 target_link_libraries(test_ride_ratings ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+target_link_platform_libraries(test_ride_ratings)
 add_test(NAME ride_ratings COMMAND test_ride_ratings)
 
 # Multi-launch test
@@ -187,6 +195,7 @@ set(MULTILAUNCH_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/MultiLaunch.cpp"
 add_executable(test_multilaunch ${MULTILAUNCH_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_multilaunch)
 target_link_libraries(test_multilaunch ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+target_link_platform_libraries(test_multilaunch)
 add_test(NAME multilaunch COMMAND test_multilaunch)
 
 # Tile element test
@@ -195,6 +204,7 @@ set(TILE_ELEMENT_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/TileElements.cpp"
 add_executable(test_tile_elements ${TILE_ELEMENT_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_tile_elements)
 target_link_libraries(test_tile_elements ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+target_link_platform_libraries(test_tile_elements)
 add_test(NAME tile_elements COMMAND test_tile_elements)
 
 if (NOT DISABLE_NETWORK)
@@ -204,6 +214,7 @@ if (NOT DISABLE_NETWORK)
     add_executable(test_replays ${REPLAY_TEST_SOURCES})
     SET_CHECK_CXX_FLAGS(test_replays)
     target_link_libraries(test_replays ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+    target_link_platform_libraries(test_replays)
     add_test(NAME replay_tests COMMAND test_replays)
 endif ()
 
@@ -213,4 +224,5 @@ set(PATHFINDING_TEST_SOURCES  "${CMAKE_CURRENT_LIST_DIR}/Pathfinding.cpp"
 add_executable(test_pathfinding ${PATHFINDING_TEST_SOURCES})
 SET_CHECK_CXX_FLAGS(test_pathfinding)
 target_link_libraries(test_pathfinding ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+target_link_platform_libraries(test_pathfinding)
 add_test(NAME pathfinding COMMAND test_pathfinding)


### PR DESCRIPTION
The 'platform' codebase might require linking with some shared libs / frameworks of the OS. I've tried to centralize this in a function such that it's also easy applied to tests and the like. 

This gets test working on MacOS when using CMake. 