### PR TITLE
Fix for #8662 paint_haunted_house_structure crash

### DIFF
--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -57,6 +57,11 @@ static void paint_ferris_wheel_structure(
     Ride* ride = get_ride(rideIndex);
     rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
     rct_vehicle* vehicle = nullptr;
+    if (rideEntry == nullptr)
+    {
+        log_error("Error drawing Ferris Wheel, rideEntry is NULL.");
+        return;
+    }
 
     int8_t xOffset = !(direction & 1) ? axisOffset : 0;
     int8_t yOffset = (direction & 1) ? axisOffset : 0;

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -41,6 +41,11 @@ static void paint_haunted_house_structure(
     Ride* ride = get_ride(rideIndex);
     rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
 
+    if (rideEntry == nullptr)
+    {
+        log_error("Error drawing haunted house, rideEntry is NULL.");
+        return;
+    }
     uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -185,6 +185,9 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
             continue;
 
         sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
+        if (sceneryEntry == nullptr)
+            continue;
+
         if (scenery_small_entry_has_flag(
                 sceneryEntry,
                 SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO


### PR DESCRIPTION
This series of commits fixes #8662 (as well as two additional crashes that came up after resolving the original one).

There are four commits; the first three abort if `rideEntry` is `NULL`, the final one instead avoids calls that would have used the `baseImageId` derived from it.

I'm not sure exactly what this park is _supposed_ to look like (and it seems like it's still missing things), but at least you can look around and it doesn't crash any more.

![2019-02-05-11 11 12-openrct2](https://user-images.githubusercontent.com/1077535/52299401-23625680-293a-11e9-8905-0e3f91118284.png)
