### PR TITLE
Fix #7987: Broken track designs increase money by MONEY32_UNDEFINED

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (Original bug).
 - Fix: [#7985] Giant Screenshot ignores 'Map rendering' settings.
+- Fix: [#7987] Broken track designs increase money by MONEY32_UNDEFINED.
 - Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.
 - Fix: [#8045] Crash when switching between languages.
 - Fix: [#8062] In multiplayer warnings for unstable cheats are shown when disabling them.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "28"
+#define NETWORK_STREAM_VERSION "29"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1093,6 +1093,11 @@ static int32_t track_design_place_scenery(
                             cost = game_do_command(
                                 mapCoord.x, flags | (bh << 8), mapCoord.y, z | (entry_index << 8),
                                 GAME_COMMAND_PLACE_PATH_FROM_TRACK, 0, 0);
+
+                            if (cost == MONEY32_UNDEFINED)
+                            {
+                                cost = 0;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Check that money is valid before adding it during track place.