### PR TITLE
Ensure finances window's months don't overflow

### DIFF
--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -611,14 +611,14 @@ static void window_finances_summary_mousedown(rct_window* w, rct_widgetindex wid
     }
 }
 
-static uint16_t summary_num_months_available()
+static uint16_t summary_max_available_month()
 {
-    return std::min<uint16_t>(gDateMonthsElapsed, EXPENDITURE_TABLE_MONTH_COUNT);
+    return std::min<uint16_t>(gDateMonthsElapsed, EXPENDITURE_TABLE_MONTH_COUNT - 1);
 }
 
 static void window_finances_summary_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    *width = EXPENDITURE_COLUMN_WIDTH * (summary_num_months_available() + 1);
+    *width = EXPENDITURE_COLUMN_WIDTH * (summary_max_available_month() + 1);
 }
 
 static void window_finances_summary_invertscroll(rct_window* w)
@@ -737,7 +737,7 @@ static void window_finances_summary_scrollpaint(rct_window* w, rct_drawpixelinfo
 
     // Expenditure / Income values for each month
     int16_t currentMonthYear = gDateMonthsElapsed;
-    for (int32_t i = summary_num_months_available(); i >= 0; i--)
+    for (int32_t i = summary_max_available_month(); i >= 0; i--)
     {
         y = 0;
 


### PR DESCRIPTION
Some functions (e.g. window_finances_summary_scrollpaint) will try using
the returned index, which makes it overflow.