### PR TITLE
GameAction cleanup part 1

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -332,17 +332,16 @@ void update_palette_effects()
  *
  * @param cost (ebp)
  */
-static int32_t game_check_affordability(int32_t cost)
+static int32_t game_check_affordability(int32_t cost, uint32_t flags)
 {
-    if (cost <= 0)
-        return cost;
+    // Only checked for game commands.
     if (gUnk141F568 & 0xF0)
         return cost;
-    if (cost <= gCash)
+
+    if (finance_check_affordability(cost, flags))
         return cost;
 
     set_format_arg(0, uint32_t, cost);
-
     gGameCommandErrorText = STR_NOT_ENOUGH_CASH_REQUIRES;
     return MONEY32_UNDEFINED;
 }
@@ -447,7 +446,7 @@ int32_t game_do_command_p(
         // Check funds
         int32_t insufficientFunds = 0;
         if (gGameCommandNestLevel == 1 && !(flags & GAME_COMMAND_FLAG_2) && !(flags & GAME_COMMAND_FLAG_5) && cost != 0)
-            insufficientFunds = game_check_affordability(cost);
+            insufficientFunds = game_check_affordability(cost, flags);
 
         if (insufficientFunds != MONEY32_UNDEFINED)
         {
@@ -531,8 +530,8 @@ int32_t game_do_command_p(
             if (gGameCommandNestLevel != 0)
                 return cost;
 
-            //
-            if (!(flags & 0x20))
+            // Check if money is required.
+            if (finance_check_money_required(flags))
             {
                 // Update money balance
                 finance_payment(cost, gCommandExpenditureType);

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -138,16 +138,6 @@ private:
     money32 GetRefundPrice(TileElement * footpathElement) const
     {
         money32 cost = -MONEY(10, 00);
-
-        bool isNotOwnedByPark = (GetFlags() & GAME_COMMAND_FLAG_5);
-        bool moneyDisabled = (gParkFlags & PARK_FLAGS_NO_MONEY);
-        bool isGhost = (footpathElement == nullptr) || (footpathElement->IsGhost());
-
-        if (isNotOwnedByPark || moneyDisabled || isGhost)
-        {
-            cost = 0;
-        }
-
         return cost;
     }
 };

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -126,17 +126,6 @@ namespace GameActions
         return false;
     }
 
-    static bool CheckActionAffordability(const GameActionResult* result)
-    {
-        if (gParkFlags & PARK_FLAGS_NO_MONEY)
-            return true;
-        if (result->Cost <= 0)
-            return true;
-        if (result->Cost <= gCash)
-            return true;
-        return false;
-    }
-
     static GameActionResult::Ptr QueryInternal(const GameAction* action, bool topLevel)
     {
         Guard::ArgumentNotNull(action);
@@ -165,7 +154,7 @@ namespace GameActions
 
         if (result->Error == GA_ERROR::OK)
         {
-            if (!CheckActionAffordability(result.get()))
+            if (finance_check_affordability(result->Cost, action->GetFlags()))
             {
                 result->Error = GA_ERROR::INSUFFICIENT_FUNDS;
                 result->ErrorMessage = STR_NOT_ENOUGH_CASH_REQUIRES;
@@ -309,8 +298,7 @@ namespace GameActions
             gCommandPosition.z = result->Position.z;
 
             // Update money balance
-            if (!(gParkFlags & PARK_FLAGS_NO_MONEY) && !(flags & GAME_COMMAND_FLAG_GHOST) && !(flags & GAME_COMMAND_FLAG_5)
-                && result->Cost != 0)
+            if (finance_check_money_required(flags) && result->Cost != 0)
             {
                 finance_payment(result->Cost, result->ExpenditureType);
                 money_effect_create(result->Cost);

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -154,7 +154,7 @@ namespace GameActions
 
         if (result->Error == GA_ERROR::OK)
         {
-            if (finance_check_affordability(result->Cost, action->GetFlags()))
+            if (finance_check_affordability(result->Cost, action->GetFlags()) == false)
             {
                 result->Error = GA_ERROR::INSUFFICIENT_FUNDS;
                 result->ErrorMessage = STR_NOT_ENOUGH_CASH_REQUIRES;
@@ -298,7 +298,7 @@ namespace GameActions
             gCommandPosition.z = result->Position.z;
 
             // Update money balance
-            if (finance_check_money_required(flags) && result->Cost != 0)
+            if (result->Error == GA_ERROR::OK && finance_check_money_required(flags) && result->Cost != 0)
             {
                 finance_payment(result->Cost, result->ExpenditureType);
                 money_effect_create(result->Cost);

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -134,11 +134,7 @@ public:
             }
         }
         auto res = std::make_unique<GameActionResult>();
-        res->Cost = 0;
-        if (!(gScreenFlags & SCREEN_FLAGS_EDITOR) && !(gParkFlags & PARK_FLAGS_NO_MONEY))
-        {
-            res->Cost = sceneryRemovalCost + GetSurfaceHeightChangeCost(surfaceElement);
-        }
+        res->Cost = sceneryRemovalCost + GetSurfaceHeightChangeCost(surfaceElement);
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
         return res;
     }

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -91,11 +91,9 @@ bool finance_check_affordability(money32 cost, uint32_t flags)
 {
     if (finance_check_money_required(flags) == false)
         return true;
-    if (cost <= 0)
-        return true;
-    if (cost <= gCash)
-        return true;
-    return false;
+    if (cost > gCash)
+        return false;
+    return true;
 }
 
 /**

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../OpenRCT2.h"
 #include "../interface/Window.h"
 #include "../localisation/Date.h"
 #include "../localisation/Localisation.h"
@@ -63,6 +64,39 @@ money32 gParkValueHistory[FINANCE_GRAPH_SIZE];
 money32 gExpenditureTable[EXPENDITURE_TABLE_MONTH_COUNT][RCT_EXPENDITURE_TYPE_COUNT];
 
 uint8_t gCommandExpenditureType;
+
+/**
+ * Checks the condition if the game is required to use money.
+ * @param flags game command flags.
+ */
+bool finance_check_money_required(uint32_t flags)
+{
+    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+        return false;
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
+        return false;
+    if (flags & GAME_COMMAND_FLAG_5)
+        return false;
+    if (flags & GAME_COMMAND_FLAG_GHOST)
+        return false;
+    return true;
+}
+
+/**
+ * Checks if enough money is available.
+ * @param cost.
+ * @param flags game command flags.
+ */
+bool finance_check_affordability(money32 cost, uint32_t flags)
+{
+    if (finance_check_money_required(flags) == false)
+        return true;
+    if (cost <= 0)
+        return true;
+    if (cost <= gCash)
+        return true;
+    return false;
+}
 
 /**
  * Pay an amount of money.

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -63,6 +63,8 @@ extern money32 gExpenditureTable[EXPENDITURE_TABLE_MONTH_COUNT][RCT_EXPENDITURE_
 
 extern uint8_t gCommandExpenditureType;
 
+bool finance_check_money_required(uint32_t flags);
+bool finance_check_affordability(money32 cost, uint32_t flags);
 void finance_payment(money32 amount, rct_expenditure_type type);
 void finance_pay_wages();
 void finance_pay_research();

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "38"
+#define NETWORK_STREAM_VERSION "39"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Part 1 of the cleanup, this is only for the money quirks.

This ensures that no money is ever used under given conditions:
- Scenario Editor
- No Money scenario
- Ghost piece
- Preview piece.

This applies to game actions and legacy game commands. I moved the function from GameActions.cpp to Finance.cpp so game commands can use the same logic. Also invoking game actions from game commands will no longer consume any money as well, no need to worry in further GA porting.