### PR TITLE
GameAction cleanup part 2

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -318,6 +318,11 @@ namespace GameActions
                     {
                         network_add_player_money_spent(playerIndex, result->Cost);
                     }
+
+                    if (result->Position.x != LOCATION_NULL)
+                    {
+                        network_set_player_last_action_coord(playerId, gCommandPosition);
+                    }
                 }
                 else if (network_get_mode() == NETWORK_MODE_NONE)
                 {

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -156,12 +156,6 @@ public:
         cost += GetSurfaceHeightChangeCost(surfaceElement);
         SetSurfaceHeight(surfaceElement);
 
-        LocationXYZ16 coord;
-        coord.x = _coords.x + 16;
-        coord.y = _coords.y + 16;
-        coord.z = surfaceHeight;
-        network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
-
         auto res = std::make_unique<GameActionResult>();
         res->Position = { _coords.x + 16, _coords.y + 16, surfaceHeight };
         res->Cost = cost;

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -62,11 +62,9 @@ public:
                 GA_ERROR::NOT_IN_EDITOR_MODE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
         }
 
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
-
-        gCommandPosition.x = _x;
-        gCommandPosition.y = _y;
-        gCommandPosition.z = _z * 16;
+        auto res = std::make_unique<GameActionResult>();
+        res->ExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
+        res->Position = CoordsXYZ{ _x, _y, _z * 16 };
 
         if (!map_check_free_elements_and_reorganise(3))
         {
@@ -119,18 +117,16 @@ public:
             }
         }
 
-        return std::make_unique<GameActionResult>();
+        return res;
     }
 
     GameActionResult::Ptr Execute() const override
     {
+        auto res = std::make_unique<GameActionResult>();
+        res->ExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
+        res->Position = CoordsXYZ{ _x, _y, _z * 16 };
+
         uint32_t flags = GetFlags();
-
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
-
-        gCommandPosition.x = _x;
-        gCommandPosition.y = _y;
-        gCommandPosition.z = _z * 16;
 
         CoordsXYZD parkEntrance;
         parkEntrance.x = _x;
@@ -201,6 +197,6 @@ public:
             }
         }
 
-        return std::make_unique<GameActionResult>();
+        return res;
     }
 };

--- a/src/openrct2/actions/PlacePeepSpawnAction.hpp
+++ b/src/openrct2/actions/PlacePeepSpawnAction.hpp
@@ -55,11 +55,9 @@ public:
                 GA_ERROR::NOT_IN_EDITOR_MODE, STR_ERR_CANT_PLACE_PEEP_SPAWN_HERE, STR_NONE);
         }
 
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
-
-        gCommandPosition.x = _location.x;
-        gCommandPosition.y = _location.y;
-        gCommandPosition.z = _location.z / 8;
+        auto res = std::make_unique<GameActionResult>();
+        res->ExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
+        res->Position = CoordsXYZ{ _location.x, _location.y, _location.z / 8 };
 
         if (!map_check_free_elements_and_reorganise(3))
         {
@@ -94,16 +92,14 @@ public:
                 GA_ERROR::INVALID_PARAMETERS, STR_ERR_CANT_PLACE_PEEP_SPAWN_HERE, STR_ERR_MUST_BE_OUTSIDE_PARK_BOUNDARIES);
         }
 
-        return std::make_unique<GameActionResult>();
+        return res;
     }
 
     GameActionResult::Ptr Execute() const override
     {
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
-
-        gCommandPosition.x = _location.x;
-        gCommandPosition.y = _location.y;
-        gCommandPosition.z = _location.z / 8;
+        auto res = std::make_unique<GameActionResult>();
+        res->ExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
+        res->Position = CoordsXYZ{ _location.x, _location.y, _location.z / 8 };
 
         // If we have reached our max peep spawns, use peep spawn next to last one set.
         if (gPeepSpawns.size() >= MAX_PEEP_SPAWNS)
@@ -134,6 +130,6 @@ public:
         // Invalidate tile
         map_invalidate_tile_full(_location.x, _location.y);
 
-        return std::make_unique<GameActionResult>();
+        return res;
     }
 };

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -307,7 +307,6 @@ public:
         window_invalidate_by_class(WC_RIDE_LIST);
 
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
-        res->Position.x = 0x8000;
 
         return std::move(res);
     }

--- a/src/openrct2/actions/RideSetAppearanceAction.hpp
+++ b/src/openrct2/actions/RideSetAppearanceAction.hpp
@@ -167,15 +167,11 @@ public:
         auto res = std::make_unique<GameActionResult>();
         if (ride->overall_view.xy != RCT_XY8_UNDEFINED)
         {
-            LocationXYZ16 coord;
-            coord.x = ride->overall_view.x * 32 + 16;
-            coord.y = ride->overall_view.y * 32 + 16;
-            coord.z = tile_element_height(coord.x, coord.y);
-            res->Position.x = coord.x;
-            res->Position.y = coord.y;
-            res->Position.z = coord.z;
-            network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+            res->Position.x = ride->overall_view.x * 32 + 16;
+            res->Position.y = ride->overall_view.y * 32 + 16;
+            res->Position.z = tile_element_height(res->Position.x, res->Position.y);
         }
+
         return res;
     }
 };

--- a/src/openrct2/actions/RideSetPriceAction.hpp
+++ b/src/openrct2/actions/RideSetPriceAction.hpp
@@ -101,11 +101,9 @@ public:
 
         if (ride->overall_view.xy != RCT_XY8_UNDEFINED)
         {
-            LocationXYZ16 coord;
-            coord.x = ride->overall_view.x * 32 + 16;
-            coord.y = ride->overall_view.y * 32 + 16;
-            coord.z = tile_element_height(coord.x, coord.y);
-            network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
+            res->Position.x = ride->overall_view.x * 32 + 16;
+            res->Position.y = ride->overall_view.y * 32 + 16;
+            res->Position.z = tile_element_height(res->Position.x, res->Position.y);
         }
 
         uint32_t shopItem;

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -97,12 +97,7 @@ public:
         res->Position.x = _origin.x + 16;
         res->Position.y = _origin.y + 16;
         res->Position.z = _origin.z;
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
-        gCommandPosition.x = res->Position.x;
-        gCommandPosition.y = res->Position.y;
-        gCommandPosition.z = res->Position.z;
 
-        int16_t trackpieceZ = _origin.z;
         gTrackGroundFlags = 0;
 
         uint32_t rideTypeFlags = RideProperties[ride->type].flags;
@@ -245,8 +240,6 @@ public:
             }
 
             mapLoc.z += trackBlock->z;
-
-            trackpieceZ = mapLoc.z;
 
             if (mapLoc.z < 16)
             {
@@ -443,12 +436,6 @@ public:
             cost += ((supportHeight / 2) * RideTrackCosts[ride->type].support_price) * 5;
         }
 
-        LocationXYZ16 coord;
-        coord.x = res->Position.x;
-        coord.y = res->Position.y;
-        coord.z = trackpieceZ;
-        network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
-
         money32 price = RideTrackCosts[ride->type].track_price;
         price *= (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ? FlatRideTrackPricing[_trackType] : TrackPricing[_trackType];
 
@@ -480,12 +467,7 @@ public:
         res->Position.x = _origin.x + 16;
         res->Position.y = _origin.y + 16;
         res->Position.z = _origin.z;
-        gCommandExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
-        gCommandPosition.x = res->Position.x;
-        gCommandPosition.y = res->Position.y;
-        gCommandPosition.z = res->Position.z;
 
-        int16_t trackpieceZ = _origin.z;
         gTrackGroundFlags = 0;
 
         uint32_t rideTypeFlags = RideProperties[ride->type].flags;
@@ -546,8 +528,6 @@ public:
             }
 
             mapLoc.z += trackBlock->z;
-
-            trackpieceZ = mapLoc.z;
 
             int32_t baseZ = mapLoc.z / 8;
 
@@ -788,12 +768,6 @@ public:
             }
             map_invalidate_tile_full(mapLoc.x, mapLoc.y);
         }
-
-        LocationXYZ16 coord;
-        coord.x = res->Position.x;
-        coord.y = res->Position.y;
-        coord.z = trackpieceZ;
-        network_set_player_last_action_coord(network_get_player_index(game_command_playerid), coord);
 
         money32 price = RideTrackCosts[ride->type].track_price;
         price *= (rideTypeFlags & RIDE_TYPE_FLAG_FLAT_RIDE) ? FlatRideTrackPricing[_trackType] : TrackPricing[_trackType];


### PR DESCRIPTION
This will eliminate the need to always call network_set_player_last_action_coord. It includes the commits from part 1 so I won't run into conflicts later, I'll rebase this once part 1 is merged.