### PR TITLE
Refactor direct calls to Query and Execute on game actions.

### DIFF
--- a/src/openrct2/actions/ClearAction.hpp
+++ b/src/openrct2/actions/ClearAction.hpp
@@ -155,7 +155,9 @@ private:
                             auto footpathRemoveAction = FootpathRemoveAction(x * 32, y * 32, tileElement->base_height);
                             footpathRemoveAction.SetFlags(GetFlags());
 
-                            auto res = executing ? footpathRemoveAction.Execute() : footpathRemoveAction.Query();
+                            auto res = executing ? GameActions::Execute(&footpathRemoveAction, false)
+                                                 : GameActions::Query(&footpathRemoveAction, false);
+
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
 
@@ -171,7 +173,9 @@ private:
                                 tileElement->AsSmallScenery()->GetEntryIndex());
                             removeSceneryAction.SetFlags(GetFlags());
 
-                            auto res = executing ? removeSceneryAction.Execute() : removeSceneryAction.Query();
+                            auto res = executing ? GameActions::Execute(&removeSceneryAction, false)
+                                                 : GameActions::Query(&removeSceneryAction, false);
+
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
 
@@ -186,7 +190,9 @@ private:
                             auto wallRemoveAction = WallRemoveAction(wallLocation);
                             wallRemoveAction.SetFlags(GetFlags());
 
-                            auto res = executing ? wallRemoveAction.Execute() : wallRemoveAction.Query();
+                            auto res = executing ? GameActions::Execute(&wallRemoveAction, false)
+                                                 : GameActions::Query(&wallRemoveAction, false);
+
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
 
@@ -202,7 +208,9 @@ private:
                                 tileElement->AsLargeScenery()->GetSequenceIndex());
                             removeSceneryAction.SetFlags(GetFlags() | GAME_COMMAND_FLAG_PATH_SCENERY);
 
-                            auto res = executing ? removeSceneryAction.Execute() : removeSceneryAction.Query();
+                            auto res = executing ? GameActions::Execute(&removeSceneryAction, false)
+                                                 : GameActions::Query(&removeSceneryAction, false);
+
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
 

--- a/src/openrct2/actions/ClearAction.hpp
+++ b/src/openrct2/actions/ClearAction.hpp
@@ -155,8 +155,8 @@ private:
                             auto footpathRemoveAction = FootpathRemoveAction(x * 32, y * 32, tileElement->base_height);
                             footpathRemoveAction.SetFlags(GetFlags());
 
-                            auto res = executing ? GameActions::Execute(&footpathRemoveAction, false)
-                                                 : GameActions::Query(&footpathRemoveAction, false);
+                            auto res = executing ? GameActions::ExecuteNested(&footpathRemoveAction)
+                                                 : GameActions::QueryNested(&footpathRemoveAction);
 
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
@@ -173,8 +173,8 @@ private:
                                 tileElement->AsSmallScenery()->GetEntryIndex());
                             removeSceneryAction.SetFlags(GetFlags());
 
-                            auto res = executing ? GameActions::Execute(&removeSceneryAction, false)
-                                                 : GameActions::Query(&removeSceneryAction, false);
+                            auto res = executing ? GameActions::ExecuteNested(&removeSceneryAction)
+                                                 : GameActions::QueryNested(&removeSceneryAction);
 
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
@@ -190,8 +190,8 @@ private:
                             auto wallRemoveAction = WallRemoveAction(wallLocation);
                             wallRemoveAction.SetFlags(GetFlags());
 
-                            auto res = executing ? GameActions::Execute(&wallRemoveAction, false)
-                                                 : GameActions::Query(&wallRemoveAction, false);
+                            auto res = executing ? GameActions::ExecuteNested(&wallRemoveAction)
+                                                 : GameActions::QueryNested(&wallRemoveAction);
 
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;
@@ -208,8 +208,8 @@ private:
                                 tileElement->AsLargeScenery()->GetSequenceIndex());
                             removeSceneryAction.SetFlags(GetFlags() | GAME_COMMAND_FLAG_PATH_SCENERY);
 
-                            auto res = executing ? GameActions::Execute(&removeSceneryAction, false)
-                                                 : GameActions::Query(&removeSceneryAction, false);
+                            auto res = executing ? GameActions::ExecuteNested(&removeSceneryAction)
+                                                 : GameActions::QueryNested(&removeSceneryAction);
 
                             if (res->Error != GA_ERROR::OK)
                                 return MONEY32_UNDEFINED;

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -137,7 +137,7 @@ namespace GameActions
         return false;
     }
 
-    GameActionResult::Ptr Query(const GameAction* action, bool topLevel /* = true */)
+    static GameActionResult::Ptr QueryInternal(const GameAction* action, bool topLevel)
     {
         Guard::ArgumentNotNull(action);
 
@@ -156,7 +156,7 @@ namespace GameActions
         auto result = action->Query();
 
         // Only top level actions affect the command position.
-        if (topLevel == true)
+        if (topLevel)
         {
             gCommandPosition.x = result->Position.x;
             gCommandPosition.y = result->Position.y;
@@ -173,6 +173,16 @@ namespace GameActions
             }
         }
         return result;
+    }
+
+    GameActionResult::Ptr Query(const GameAction* action)
+    {
+        return QueryInternal(action, true);
+    }
+
+    GameActionResult::Ptr QueryNested(const GameAction* action)
+    {
+        return QueryInternal(action, false);
     }
 
     static const char* GetRealm()
@@ -227,7 +237,7 @@ namespace GameActions
         network_append_server_log(text);
     }
 
-    GameActionResult::Ptr Execute(const GameAction* action, bool topLevel /* = true */)
+    static GameActionResult::Ptr ExecuteInternal(const GameAction* action, bool topLevel)
     {
         Guard::ArgumentNotNull(action);
 
@@ -251,7 +261,7 @@ namespace GameActions
             }
         }
 
-        GameActionResult::Ptr result = Query(action, topLevel);
+        GameActionResult::Ptr result = Query(action);
         if (result->Error == GA_ERROR::OK)
         {
             if (topLevel)
@@ -362,6 +372,16 @@ namespace GameActions
         }
 
         return result;
+    }
+
+    GameActionResult::Ptr Execute(const GameAction* action)
+    {
+        return ExecuteInternal(action, true);
+    }
+
+    GameActionResult::Ptr ExecuteNested(const GameAction* action)
+    {
+        return ExecuteInternal(action, false);
     }
 
 } // namespace GameActions

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -244,8 +244,15 @@ namespace GameActions
     bool IsValidId(uint32_t id);
     GameAction::Ptr Create(uint32_t id);
     GameAction::Ptr Clone(const GameAction* action);
-    GameActionResult::Ptr Query(const GameAction* action, bool topLevel = true);
-    GameActionResult::Ptr Execute(const GameAction* action, bool topLevel = true);
+
+    // This should be used if a round trip is to be expected.
+    GameActionResult::Ptr Query(const GameAction* action);
+    GameActionResult::Ptr Execute(const GameAction* action);
+
+    // This should be used from within game actions.
+    GameActionResult::Ptr QueryNested(const GameAction* action);
+    GameActionResult::Ptr ExecuteNested(const GameAction* action);
+
     GameActionFactory Register(uint32_t id, GameActionFactory action);
 
     template<typename T> static GameActionFactory Register()

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -244,8 +244,8 @@ namespace GameActions
     bool IsValidId(uint32_t id);
     GameAction::Ptr Create(uint32_t id);
     GameAction::Ptr Clone(const GameAction* action);
-    GameActionResult::Ptr Query(const GameAction* action);
-    GameActionResult::Ptr Execute(const GameAction* action);
+    GameActionResult::Ptr Query(const GameAction* action, bool topLevel = true);
+    GameActionResult::Ptr Execute(const GameAction* action, bool topLevel = true);
     GameActionFactory Register(uint32_t id, GameActionFactory action);
 
     template<typename T> static GameActionFactory Register()

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -264,7 +264,7 @@ private:
         auto setMazeTrack = MazeSetTrackAction(x, y, z, false, direction, _rideIndex, GC_SET_MAZE_TRACK_FILL);
         setMazeTrack.SetFlags(GetFlags());
 
-        auto execRes = GameActions::Execute(&setMazeTrack, false);
+        auto execRes = GameActions::ExecuteNested(&setMazeTrack);
         if (execRes->Error == GA_ERROR::OK)
         {
             return execRes->Cost;

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -264,14 +264,10 @@ private:
         auto setMazeTrack = MazeSetTrackAction(x, y, z, false, direction, _rideIndex, GC_SET_MAZE_TRACK_FILL);
         setMazeTrack.SetFlags(GetFlags());
 
-        auto queryRes = setMazeTrack.Query();
-        if (queryRes->Error == GA_ERROR::OK)
+        auto execRes = GameActions::Execute(&setMazeTrack, false);
+        if (execRes->Error == GA_ERROR::OK)
         {
-            auto execRes = setMazeTrack.Execute();
-            if (execRes->Error == GA_ERROR::OK)
-            {
-                return execRes->Cost;
-            }
+            return execRes->Cost;
         }
 
         return MONEY32_UNDEFINED;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "36"
+#define NETWORK_STREAM_VERSION "37"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1328,8 +1328,10 @@ static money32 lower_land(
                     newSlope &= TILE_ELEMENT_SURFACE_SLOPE_MASK;
 
                     auto landSetHeightAction = LandSetHeightAction({ x_coord, y_coord }, height, newSlope);
-                    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? landSetHeightAction.Execute() : landSetHeightAction.Query();
+                    landSetHeightAction.SetFlags(flags);
 
+                    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
+                                                                 : GameActions::Query(&landSetHeightAction, false);
                     if (res->Error != GA_ERROR::OK)
                     {
                         return MONEY32_UNDEFINED;
@@ -1580,7 +1582,9 @@ static money32 smooth_land_tile(
     }
 
     auto landSetHeightAction = LandSetHeightAction({ x, y }, targetBaseZ, slope);
-    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? landSetHeightAction.Execute() : landSetHeightAction.Query();
+    landSetHeightAction.SetFlags(flags);
+    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
+                                                 : GameActions::Query(&landSetHeightAction, false);
 
     if (res->Error == GA_ERROR::OK)
     {
@@ -1725,8 +1729,9 @@ static money32 smooth_land_row_by_edge(
             }
         }
         auto landSetHeightAction = LandSetHeightAction({ x, y }, targetBaseZ, slope);
-        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? landSetHeightAction.Execute() : landSetHeightAction.Query();
-
+        landSetHeightAction.SetFlags(flags);
+        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
+                                                     : GameActions::Query(&landSetHeightAction, false);
         if (res->Error == GA_ERROR::OK)
         {
             totalCost += res->Cost;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1330,8 +1330,8 @@ static money32 lower_land(
                     auto landSetHeightAction = LandSetHeightAction({ x_coord, y_coord }, height, newSlope);
                     landSetHeightAction.SetFlags(flags);
 
-                    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
-                                                                 : GameActions::Query(&landSetHeightAction, false);
+                    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::ExecuteNested(&landSetHeightAction)
+                                                                 : GameActions::QueryNested(&landSetHeightAction);
                     if (res->Error != GA_ERROR::OK)
                     {
                         return MONEY32_UNDEFINED;
@@ -1583,8 +1583,8 @@ static money32 smooth_land_tile(
 
     auto landSetHeightAction = LandSetHeightAction({ x, y }, targetBaseZ, slope);
     landSetHeightAction.SetFlags(flags);
-    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
-                                                 : GameActions::Query(&landSetHeightAction, false);
+    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::ExecuteNested(&landSetHeightAction)
+                                                 : GameActions::QueryNested(&landSetHeightAction);
 
     if (res->Error == GA_ERROR::OK)
     {
@@ -1730,8 +1730,8 @@ static money32 smooth_land_row_by_edge(
         }
         auto landSetHeightAction = LandSetHeightAction({ x, y }, targetBaseZ, slope);
         landSetHeightAction.SetFlags(flags);
-        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landSetHeightAction, false)
-                                                     : GameActions::Query(&landSetHeightAction, false);
+        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::ExecuteNested(&landSetHeightAction)
+                                                     : GameActions::QueryNested(&landSetHeightAction);
         if (res->Error == GA_ERROR::OK)
         {
             totalCost += res->Cost;


### PR DESCRIPTION
Previously it was unsafe to directly call Execute as Query would always validate the input and conditions. Instead of calling it directly I added an optional "topLevel" parameter to GameActions::Query/Execute which is by default set to true, meaning it is the root command and should obey network/queue, when set to false it will Query/Execute without the consideration of any round trips, this should be used when used within an action.

Now every Execute will also use Query before finally going to execute the action, this might solve a few crashes reported from backtrace, I would need to go over it.

This will also probably supersede #8707