### PR TITLE
Decouple network updates from game ticks.

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -861,9 +861,14 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
+            network_update();
+
             if (_accumulator < GAME_UPDATE_TIME_MS)
             {
-                platform_sleep(GAME_UPDATE_TIME_MS - _accumulator - 1);
+                network_process_pending();
+                network_flush();
+
+                platform_sleep(1);
                 return;
             }
 
@@ -872,6 +877,9 @@ namespace OpenRCT2
                 Update();
                 _accumulator -= GAME_UPDATE_TIME_MS;
             }
+
+            network_process_pending();
+            network_flush();
 
             if (!_isWindowMinimised && !gOpenRCT2Headless)
             {
@@ -900,6 +908,8 @@ namespace OpenRCT2
 
             _uiContext->ProcessMessages();
 
+            network_update();
+
             while (_accumulator >= GAME_UPDATE_TIME_MS)
             {
                 // Get the original position of each sprite
@@ -914,6 +924,9 @@ namespace OpenRCT2
                 if (draw)
                     sprite_position_tween_store_b();
             }
+
+            network_process_pending();
+            network_flush();
 
             if (draw)
             {

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -137,11 +137,6 @@ void GameState::Update()
             // Update the animation list. Note this does not
             // increment the map animation.
             map_animation_invalidate_all();
-
-            // Special case because we set numUpdates to 0, otherwise in game_logic_update.
-            network_update();
-
-            network_process_pending();
         }
     }
 
@@ -221,8 +216,6 @@ void GameState::UpdateLogic()
     if (gScreenAge == 0)
         gScreenAge--;
 
-    network_update();
-
     GetContext()->GetReplayManager()->Update();
 
     if (network_get_mode() == NETWORK_MODE_CLIENT && network_get_status() == NETWORK_STATUS_CONNECTED
@@ -300,12 +293,6 @@ void GameState::UpdateLogic()
     {
         gLastAutoSaveUpdate = Platform::GetTicks();
     }
-
-    // Separated out processing commands in network_update which could call scenario_rand where gInUpdateCode is false.
-    // All commands that are received are first queued and then executed where gInUpdateCode is set to true.
-    network_process_pending();
-
-    network_flush();
 
     gCurrentTicks++;
     gScenarioTicks++;


### PR DESCRIPTION
This greatly reduces the delay on every action by allowing the network to queue up multiple commands/actions for the next tick instead of waiting for the next tick to happen before the messages actually go out.