### PR TITLE
GameAction fixes.

### DIFF
--- a/src/openrct2/actions/ClearAction.hpp
+++ b/src/openrct2/actions/ClearAction.hpp
@@ -158,11 +158,11 @@ private:
                             auto res = executing ? GameActions::ExecuteNested(&footpathRemoveAction)
                                                  : GameActions::QueryNested(&footpathRemoveAction);
 
-                            if (res->Error != GA_ERROR::OK)
-                                return MONEY32_UNDEFINED;
-
-                            totalCost += res->Cost;
-                            tileEdited = executing;
+                            if (res->Error == GA_ERROR::OK)
+                            {
+                                totalCost += res->Cost;
+                                tileEdited = executing;
+                            }
                         }
                         break;
                     case TILE_ELEMENT_TYPE_SMALL_SCENERY:
@@ -176,11 +176,11 @@ private:
                             auto res = executing ? GameActions::ExecuteNested(&removeSceneryAction)
                                                  : GameActions::QueryNested(&removeSceneryAction);
 
-                            if (res->Error != GA_ERROR::OK)
-                                return MONEY32_UNDEFINED;
-
-                            totalCost += res->Cost;
-                            tileEdited = executing;
+                            if (res->Error == GA_ERROR::OK)
+                            {
+                                totalCost += res->Cost;
+                                tileEdited = executing;
+                            }
                         }
                         break;
                     case TILE_ELEMENT_TYPE_WALL:
@@ -193,11 +193,11 @@ private:
                             auto res = executing ? GameActions::ExecuteNested(&wallRemoveAction)
                                                  : GameActions::QueryNested(&wallRemoveAction);
 
-                            if (res->Error != GA_ERROR::OK)
-                                return MONEY32_UNDEFINED;
-
-                            totalCost += res->Cost;
-                            tileEdited = executing;
+                            if (res->Error == GA_ERROR::OK)
+                            {
+                                totalCost += res->Cost;
+                                tileEdited = executing;
+                            }
                         }
                         break;
                     case TILE_ELEMENT_TYPE_LARGE_SCENERY:
@@ -211,11 +211,11 @@ private:
                             auto res = executing ? GameActions::ExecuteNested(&removeSceneryAction)
                                                  : GameActions::QueryNested(&removeSceneryAction);
 
-                            if (res->Error != GA_ERROR::OK)
-                                return MONEY32_UNDEFINED;
-
-                            totalCost += res->Cost;
-                            tileEdited = executing;
+                            if (res->Error == GA_ERROR::OK)
+                            {
+                                totalCost += res->Cost;
+                                tileEdited = executing;
+                            }
                         }
                         break;
                 }

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -62,6 +62,11 @@ public:
         }
 
         TileElement* footpathElement = GetFootpathElement();
+        if (footpathElement == nullptr)
+        {
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_FOOTPATH_FROM_HERE);
+        }
+
         res->Cost = GetRefundPrice(footpathElement);
 
         return res;
@@ -89,6 +94,10 @@ public:
             map_invalidate_tile_full(_x, _y);
             tile_element_remove(footpathElement);
             footpath_update_queue_chains();
+        }
+        else
+        {
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_FOOTPATH_FROM_HERE);
         }
 
         res->Cost = GetRefundPrice(footpathElement);

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -261,7 +261,7 @@ namespace GameActions
             }
         }
 
-        GameActionResult::Ptr result = Query(action);
+        GameActionResult::Ptr result = QueryInternal(action, topLevel);
         if (result->Error == GA_ERROR::OK)
         {
             if (topLevel)

--- a/src/openrct2/actions/SmallSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.hpp
@@ -104,8 +104,7 @@ public:
         TileElement* tileElement = FindSceneryElement();
         if (tileElement == nullptr)
         {
-            res->Cost = 0;
-            return res;
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_THIS, STR_INVALID_SELECTION_OF_OBJECTS);
         }
 
         return res;
@@ -130,8 +129,7 @@ public:
         TileElement* tileElement = FindSceneryElement();
         if (tileElement == nullptr)
         {
-            res->Cost = 0;
-            return res;
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_THIS, STR_INVALID_SELECTION_OF_OBJECTS);
         }
 
         res->Position.z = tile_element_height(res->Position.x, res->Position.y);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -30,7 +30,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "37"
+#define NETWORK_STREAM_VERSION "38"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
This PR fixes some small details.
1. FootpathRemoveAction did not check if a valid path could be obtained.
2. SmallSceneryRemoveAction did not result an error when no tile could be found, letting the top level action believe it succeeds.
3. ExecuteNested would not call Query instead of QueryNested.
4. ClearAction was changed to not abort the loop if a nested action would fail, I checked RCT2 and it seems to be just clearing whats possible without aborting it.

This should also fix infinite loop in ClearAction as before some of the nested actions did not result errors while no tile was modified so it kept going over and over the same element.