### PR TITLE
Remove logic for required objects

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -198,48 +198,6 @@ static void research_rides_setup()
 
 /**
  *
- *  rct2: 0x0068590C
- * Sets the critical scenery sets to always researched
- */
-static void research_scenery_groups_setup()
-{
-    for (size_t i = 0; i < std::size(RequiredSelectedObjects); i++)
-    {
-        const rct_object_entry* object = &RequiredSelectedObjects[i];
-
-        uint8_t entry_type, entryIndex;
-        if (!find_object_in_entry_group(object, &entry_type, &entryIndex))
-            continue;
-
-        if (entry_type != OBJECT_TYPE_SCENERY_GROUP)
-            continue;
-
-        rct_research_item* research = gResearchItems;
-        for (; research->rawValue != RESEARCHED_ITEMS_END; research++)
-        {
-            if ((research->rawValue & 0xFFFFFF) != entryIndex)
-                continue;
-
-            research->flags |= RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED;
-            _editorInventionsListDraggedItem = research;
-            move_research_item(gResearchItems);
-            _editorInventionsListDraggedItem = nullptr;
-        }
-    }
-}
-
-/**
- *
- *  rct2: 0x00685901
- */
-static void research_always_researched_setup()
-{
-    research_rides_setup();
-    research_scenery_groups_setup();
-}
-
-/**
- *
  *  rct2: 0x006855E7
  */
 static void move_research_item(rct_research_item* beforeItem)
@@ -383,7 +341,7 @@ rct_window* window_editor_inventions_list_open()
     if (w != nullptr)
         return w;
 
-    research_always_researched_setup();
+    research_rides_setup();
 
     w = window_create_centred(
         WW, WH, &window_editor_inventions_list_events, WC_EDITOR_INVENTION_LIST, WF_NO_SCROLLING | WF_RESIZABLE);

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -35,7 +35,6 @@ static int32_t _numAvailableObjectsForType[OBJECT_TYPE_COUNT];
 static void setup_in_use_selection_flags();
 static void setup_track_designer_objects();
 static void setup_track_manager_objects();
-static void window_editor_object_selection_select_required_objects();
 static void window_editor_object_selection_select_default_objects();
 
 /**
@@ -253,8 +252,6 @@ void sub_6AB211()
 
     if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
     {
-        window_editor_object_selection_select_required_objects();
-
         // To prevent it breaking in scenario mode.
         if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
         {
@@ -347,16 +344,6 @@ static void window_editor_object_selection_select_default_objects()
             window_editor_object_selection_select_object(0, 7, &defaultSelectedObject);
         }
     }
-}
-
-/**
- *
- *  rct2: 0x006AA7E9
- */
-static void window_editor_object_selection_select_required_objects()
-{
-    for (size_t i = 0; i < std::size(RequiredSelectedObjects); i++)
-        window_editor_object_selection_select_object(0, 0xF, &RequiredSelectedObjects[i]);
 }
 
 /**

--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -11,9 +11,8 @@
 
 #include "Object.h"
 
-/** rct2: 0x0098DA74 */
-const rct_object_entry RequiredSelectedObjects[7] = {
-    // Objects that are always required
+const rct_object_entry DefaultSelectedObjects[] = {
+    // An initial default selection
     { 0x00000087, { "SCGTREES" } }, // Scenery: Trees
     { 0x00000087, { "SCGSHRUB" } }, // Scenery: Shrubs and Ornaments
     { 0x00000087, { "SCGGARDN" } }, // Scenery: Gardens
@@ -21,10 +20,6 @@ const rct_object_entry RequiredSelectedObjects[7] = {
     { 0x00000087, { "SCGWALLS" } }, // Scenery: Walls and Roofs
     { 0x00000087, { "SCGPATHX" } }, // Scenery: Signs and Items for Footpaths
     { 0x00000085, { "TARMAC  " } }, // Footpath: Tarmac
-};
-
-const rct_object_entry DefaultSelectedObjects[26] = {
-    // An initial default selection
     { 0x00000080, { "TWIST1  " } }, // Ride: Twist
     { 0x00000080, { "PTCT1   " } }, // Ride: Wooden Roller Coaster (Wooden Roller Coaster Trains)
     { 0x00000080, { "ZLDB    " } }, // Ride: Junior Roller Coaster (Ladybird Trains)

--- a/src/openrct2/object/DefaultObjects.h
+++ b/src/openrct2/object/DefaultObjects.h
@@ -11,5 +11,4 @@
 
 #include "Object.h"
 
-extern const rct_object_entry RequiredSelectedObjects[7];
-extern const rct_object_entry DefaultSelectedObjects[26];
+extern const rct_object_entry DefaultSelectedObjects[33];


### PR DESCRIPTION
This allows TARMAC to be removed when `remove_unused_objects` is called.