### PR TITLE
Disable kick button when unable to use it + slight refactor

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Change: [#8222] The climate setting has been moved from objective options to scenario options.
 - Change: [#8718] Allow TARMAC object to be removed when running the `remove_unused_objects` command.
 - Change: [#8718] No longer require the generic scenery groups and tarmac footpath to be checked when creating a scenario.
+- Change: [#8734] Disable kick button in multiplayer window when unable to use it.
 - Fix: [#3832] Changing the colour scheme of track pieces does not work in multiplayer.
 - Fix: [#5684] Player list can desync between clients and server and can crash.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -445,6 +445,12 @@ void window_player_overview_invalidate(rct_window* w)
         viewport->view_width = viewport->width << viewport->zoom;
         viewport->view_height = viewport->height << viewport->zoom;
     }
+
+    // Only enable kick button for other players
+    const bool canKick = network_can_perform_action(network_get_current_player_group_index(), 15);
+    const bool isServer = network_get_player_flags(w->number) & NETWORK_PLAYER_FLAG_ISSERVER;
+    const bool isOwnWindow = (network_get_current_player_id() == w->number);
+    widget_set_enabled(w, WIDX_KICK, canKick && !isOwnWindow && !isServer);
 }
 
 void window_player_statistics_close(rct_window* w)

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Colour.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/network/NetworkAction.h>
 #include <openrct2/network/network.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
@@ -447,7 +448,7 @@ void window_player_overview_invalidate(rct_window* w)
     }
 
     // Only enable kick button for other players
-    const bool canKick = network_can_perform_action(network_get_current_player_group_index(), 15);
+    const bool canKick = network_can_perform_action(network_get_current_player_group_index(), NETWORK_PERMISSION_KICK_PLAYER);
     const bool isServer = network_get_player_flags(w->number) & NETWORK_PLAYER_FLAG_ISSERVER;
     const bool isOwnWindow = (network_get_current_player_id() == w->number);
     widget_set_enabled(w, WIDX_KICK, canKick && !isOwnWindow && !isServer);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1149,28 +1149,34 @@ void Network::SaveGroups()
 
 void Network::SetupDefaultGroups()
 {
+    // Admin group
     auto admin = std::make_unique<NetworkGroup>();
     admin->SetName("Admin");
     admin->ActionsAllowed.fill(0xFF);
     admin->Id = 0;
     group_list.push_back(std::move(admin));
+
+    // Spectator group
     auto spectator = std::make_unique<NetworkGroup>();
     spectator->SetName("Spectator");
-    spectator->ToggleActionPermission(0); // Chat
+    spectator->ToggleActionPermission(NETWORK_PERMISSION_CHAT);
     spectator->Id = 1;
     group_list.push_back(std::move(spectator));
+
+    // User group
     auto user = std::make_unique<NetworkGroup>();
     user->SetName("User");
     user->ActionsAllowed.fill(0xFF);
-    user->ToggleActionPermission(15); // Kick Player
-    user->ToggleActionPermission(16); // Modify Groups
-    user->ToggleActionPermission(17); // Set Player Group
-    user->ToggleActionPermission(18); // Cheat
-    user->ToggleActionPermission(20); // Passwordless login
-    user->ToggleActionPermission(21); // Modify Tile
-    user->ToggleActionPermission(22); // Edit Scenario Options
+    user->ToggleActionPermission(NETWORK_PERMISSION_KICK_PLAYER);
+    user->ToggleActionPermission(NETWORK_PERMISSION_MODIFY_GROUPS);
+    user->ToggleActionPermission(NETWORK_PERMISSION_SET_PLAYER_GROUP);
+    user->ToggleActionPermission(NETWORK_PERMISSION_CHEAT);
+    user->ToggleActionPermission(NETWORK_PERMISSION_PASSWORDLESS_LOGIN);
+    user->ToggleActionPermission(NETWORK_PERMISSION_MODIFY_TILE);
+    user->ToggleActionPermission(NETWORK_PERMISSION_EDIT_SCENARIO_OPTIONS);
     user->Id = 2;
     group_list.push_back(std::move(user));
+
     SetDefaultGroup(1);
 }
 

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -47,15 +47,15 @@ int32_t NetworkActions::FindCommandByPermissionName(const std::string& permissio
     return -1;
 }
 
-const std::vector<NetworkAction> NetworkActions::Actions = {
-    {
+const std::array<NetworkAction, NETWORK_PERMISSION_COUNT> NetworkActions::Actions = {
+    NetworkAction{
         STR_ACTION_CHAT,
         "PERMISSION_CHAT",
         {
             MISC_COMMAND_CHAT,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_TERRAFORM,
         "PERMISSION_TERRAFORM",
         {
@@ -66,7 +66,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_CHANGE_SURFACE_STYLE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_SET_WATER_LEVEL,
         "PERMISSION_SET_WATER_LEVEL",
         {
@@ -75,28 +75,28 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_LOWER_WATER,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_TOGGLE_PAUSE,
         "PERMISSION_TOGGLE_PAUSE",
         {
             GAME_COMMAND_TOGGLE_PAUSE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_CREATE_RIDE,
         "PERMISSION_CREATE_RIDE",
         {
             GAME_COMMAND_CREATE_RIDE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_REMOVE_RIDE,
         "PERMISSION_REMOVE_RIDE",
         {
             GAME_COMMAND_DEMOLISH_RIDE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_BUILD_RIDE,
         "PERMISSION_BUILD_RIDE",
         {
@@ -109,7 +109,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_RIDE_PROPERTIES,
         "PERMISSION_RIDE_PROPERTIES",
         {
@@ -123,7 +123,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_SET_COLOUR_SCHEME,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_SCENERY,
         "PERMISSION_SCENERY",
         {
@@ -146,7 +146,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_SET_SIGN_STYLE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_PATH,
         "PERMISSION_PATH",
         {
@@ -155,14 +155,14 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_REMOVE_PATH,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_CLEAR_LANDSCAPE,
         "PERMISSION_CLEAR_LANDSCAPE",
         {
             GAME_COMMAND_CLEAR_SCENERY,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_GUEST,
         "PERMISSION_GUEST",
         {
@@ -171,7 +171,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_BALLOON_PRESS,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_STAFF,
         "PERMISSION_STAFF",
         {
@@ -185,7 +185,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_PICKUP_STAFF,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_PARK_PROPERTIES,
         "PERMISSION_PARK_PROPERTIES",
         {
@@ -199,7 +199,7 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_PLACE_PEEP_SPAWN,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_PARK_FUNDING,
         "PERMISSION_PARK_FUNDING",
         {
@@ -208,56 +208,56 @@ const std::vector<NetworkAction> NetworkActions::Actions = {
             GAME_COMMAND_START_MARKETING_CAMPAIGN,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_KICK_PLAYER,
         "PERMISSION_KICK_PLAYER",
         {
             GAME_COMMAND_KICK_PLAYER,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_MODIFY_GROUPS,
         "PERMISSION_MODIFY_GROUPS",
         {
             GAME_COMMAND_MODIFY_GROUPS,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_SET_PLAYER_GROUP,
         "PERMISSION_SET_PLAYER_GROUP",
         {
             GAME_COMMAND_SET_PLAYER_GROUP,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_CHEAT,
         "PERMISSION_CHEAT",
         {
             GAME_COMMAND_CHEAT,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_TOGGLE_SCENERY_CLUSTER,
         "PERMISSION_TOGGLE_SCENERY_CLUSTER",
         {
             MISC_COMMAND_TOGGLE_SCENERY_CLUSTER,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_PASSWORDLESS_LOGIN,
         "PERMISSION_PASSWORDLESS_LOGIN",
         {
             MISC_COMMAND_PASSWORDLESS_LOGIN,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_MODIFY_TILE,
         "PERMISSION_MODIFY_TILE",
         {
             GAME_COMMAND_MODIFY_TILE,
         },
     },
-    {
+    NetworkAction{
         STR_ACTION_EDIT_SCENARIO_OPTIONS,
         "PERMISSION_EDIT_SCENARIO_OPTIONS",
         {

--- a/src/openrct2/network/NetworkAction.h
+++ b/src/openrct2/network/NetworkAction.h
@@ -11,8 +11,8 @@
 
 #include "../common.h"
 
+#include <array>
 #include <string>
-#include <vector>
 
 enum MISC_COMMAND
 {
@@ -21,18 +21,47 @@ enum MISC_COMMAND
     MISC_COMMAND_PASSWORDLESS_LOGIN = -3,
 };
 
+enum NETWORK_PERMISSION
+{
+    NETWORK_PERMISSION_CHAT,
+    NETWORK_PERMISSION_TERRAFORM,
+    NETWORK_PERMISSION_SET_WATER_LEVEL,
+    NETWORK_PERMISSION_TOGGLE_PAUSE,
+    NETWORK_PERMISSION_CREATE_RIDE,
+    NETWORK_PERMISSION_REMOVE_RIDE,
+    NETWORK_PERMISSION_BUILD_RIDE,
+    NETWORK_PERMISSION_RIDE_PROPERTIES,
+    NETWORK_PERMISSION_SCENERY,
+    NETWORK_PERMISSION_PATH,
+    NETWORK_PERMISSION_CLEAR_LANDSCAPE,
+    NETWORK_PERMISSION_GUEST,
+    NETWORK_PERMISSION_STAFF,
+    NETWORK_PERMISSION_PARK_PROPERTIES,
+    NETWORK_PERMISSION_PARK_FUNDING,
+    NETWORK_PERMISSION_KICK_PLAYER,
+    NETWORK_PERMISSION_MODIFY_GROUPS,
+    NETWORK_PERMISSION_SET_PLAYER_GROUP,
+    NETWORK_PERMISSION_CHEAT,
+    NETWORK_PERMISSION_TOGGLE_SCENERY_CLUSTER,
+    NETWORK_PERMISSION_PASSWORDLESS_LOGIN,
+    NETWORK_PERMISSION_MODIFY_TILE,
+    NETWORK_PERMISSION_EDIT_SCENARIO_OPTIONS,
+
+    NETWORK_PERMISSION_COUNT,
+};
+
 class NetworkAction final
 {
 public:
     rct_string_id Name;
     std::string PermissionName;
-    std::vector<int32_t> Commands;
+    std::array<int32_t, NETWORK_PERMISSION_COUNT> Commands;
 };
 
 class NetworkActions final
 {
 public:
-    static const std::vector<NetworkAction> Actions;
+    static const std::array<NetworkAction, NETWORK_PERMISSION_COUNT> Actions;
 
     static int32_t FindCommand(int32_t command);
     static int32_t FindCommandByPermissionName(const std::string& permission_name);


### PR DESCRIPTION
This PR makes it so that the kick button in the multiplayer window is disabled when either you don't have the kick permission, the window is for the host, or the window is for yourself.

When trying to find how to read the permissions, I found hardcoded numbers that correspond with the `NetworkActions::Actions` vector. To reduce these hardcoded numbers a new enum is introduced, and the vector is now an `std::array` to have compile-time changes when this collection gets changed.

This does not require a network version increase, as all of this is client-side.