### PR TITLE
Fix interactive console staff set costume command.

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -444,6 +444,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
 
                 uint8_t costume = int_val[1];
                 auto staffSetCostumeAction = StaffSetCostumeAction(int_val[0], costume);
+                GameActions::Execute(&staffSetCostumeAction);
             }
         }
     }


### PR DESCRIPTION
After the refactor to GameActions, forgot to actually issue the command after generating it.