### PR TITLE
Drop xc-pretty due to Travis formatting issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ script:
     # Android jobs are triggered from cron and overwrite `script` part
     - if [[ "$OPENRCT2_ANDROID" == "true" ]] ; then exit 0 ; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/build.sh ; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild | xcpretty -f `xcpretty-travis-formatter`; fi
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild ; fi
 
 notifications:
     on_failure: change


### PR DESCRIPTION
Currently, `xc-pretty` is a bit too quiet about errors. 
Though the output is nice (due to colours and all), the debugging experience is awful. 

So, for the time being, just use the plain xcodebuild output, containing all the details. 

See for example this [build](https://travis-ci.org/OpenRCT2/OpenRCT2/jobs/499013497#L460) for #8481.