### PR TITLE
Temporary fix for false desyncs.

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -947,6 +947,7 @@ namespace OpenRCT2
             }
 
             date_update_real_time_of_day();
+            network_update();
 
             if (gIntroState != INTRO_STATE_NONE)
             {
@@ -970,6 +971,8 @@ namespace OpenRCT2
 
             twitch_update();
             chat_update();
+            network_flush();
+
             _stdInOutConsole.ProcessEvalQueue();
             _uiContext->Update();
         }

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -221,8 +221,6 @@ void GameState::UpdateLogic()
     if (gScreenAge == 0)
         gScreenAge--;
 
-    network_update();
-
     GetContext()->GetReplayManager()->Update();
 
     if (network_get_mode() == NETWORK_MODE_CLIENT && network_get_status() == NETWORK_STATUS_CONNECTED
@@ -304,8 +302,6 @@ void GameState::UpdateLogic()
     // Separated out processing commands in network_update which could call scenario_rand where gInUpdateCode is false.
     // All commands that are received are first queued and then executed where gInUpdateCode is set to true.
     network_process_pending();
-
-    network_flush();
 
     gCurrentTicks++;
     gScenarioTicks++;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -294,7 +294,6 @@ private:
     std::unique_ptr<INetworkServerAdvertiser> _advertiser;
     uint16_t listening_port = 0;
     SOCKET_STATUS _lastConnectStatus = SOCKET_STATUS_CLOSED;
-    uint32_t last_tick_sent_time = 0;
     uint32_t last_ping_sent_time = 0;
     uint32_t server_tick = 0;
     uint32_t server_srand0 = 0;
@@ -363,7 +362,6 @@ Network::Network()
     wsa_initialized = false;
     mode = NETWORK_MODE_NONE;
     status = NETWORK_STATUS_NONE;
-    last_tick_sent_time = 0;
     last_ping_sent_time = 0;
     _commandId = 0;
     _actionId = 0;
@@ -1631,14 +1629,6 @@ void Network::Server_Send_GAME_ACTION(const GameAction* action)
 
 void Network::Server_Send_TICK()
 {
-    uint32_t ticks = platform_get_ticks();
-    if (ticks < last_tick_sent_time + 25)
-    {
-        return;
-    }
-
-    last_tick_sent_time = ticks;
-
     std::unique_ptr<NetworkPacket> packet(NetworkPacket::Allocate());
     *packet << (uint32_t)NETWORK_COMMAND_TICK << gCurrentTicks << scenario_rand_state().s0;
     uint32_t flags = 0;


### PR DESCRIPTION
One issue has been that the network_update was called from within LogicUpdate which might be used from the TitleScreen->Update, so after the map load it would be still on the title screen state and desyncs. Thats why network_update was moved out from there. The other reason for the desync remains unknown, in this PR it is required to have two ticks mismatch before its considered fully desynced which seems to solve the issue of #8055 
I also removed some unnecessary code, the function NETWORK_SEND_TICK is only called from game ticks, no need to double time it.

I have to yet figure out why its doing the false ones, for now this seems to do the job to hide the false positives.