### PR TITLE
Fix Ride Entrance Exit Removal Network Issue

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -331,9 +331,9 @@ template<> struct DataSerializerTraits<CoordsXY>
     }
     static void decode(IStream* stream, CoordsXY& coords)
     {
-        auto x = ByteSwapBE(stream->ReadValue<int16_t>());
-        auto y = ByteSwapBE(stream->ReadValue<int16_t>());
-        coords = CoordsXY(x, y);
+        auto x = ByteSwapBE(stream->ReadValue<int32_t>());
+        auto y = ByteSwapBE(stream->ReadValue<int32_t>());
+        coords = CoordsXY{x, y};
     }
     static void log(IStream* stream, const CoordsXY& coords)
     {

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -333,7 +333,7 @@ template<> struct DataSerializerTraits<CoordsXY>
     {
         auto x = ByteSwapBE(stream->ReadValue<int32_t>());
         auto y = ByteSwapBE(stream->ReadValue<int32_t>());
-        coords = CoordsXY{x, y};
+        coords = CoordsXY{ x, y };
     }
     static void log(IStream* stream, const CoordsXY& coords)
     {

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "49"
+#define NETWORK_STREAM_VERSION "50"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Wrong sized parameters used in DataSerialiser caused bad data to be input into game action.