### PR TITLE
Synchronize player info

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "49"
+#define NETWORK_STREAM_VERSION "50"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static rct_peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -26,13 +26,15 @@ void NetworkPlayer::Read(NetworkPacket& packet)
 {
     const utf8* name = packet.ReadString();
     SetName(name);
-    packet >> Id >> Flags >> Group;
+    packet >> Id >> Flags >> Group >> LastAction >> LastActionCoord.x >> LastActionCoord.y >> LastActionCoord.z >> MoneySpent
+        >> CommandsRan;
 }
 
 void NetworkPlayer::Write(NetworkPacket& packet)
 {
     packet.WriteString((const char*)Name.c_str());
-    packet << Id << Flags << Group;
+    packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z << MoneySpent
+           << CommandsRan;
 }
 
 void NetworkPlayer::AddMoneySpent(money32 cost)


### PR DESCRIPTION
Turns out this was never properly done, even the old game commands didn't do it right. Every client would maintain their own info about each player which should be the job of the server to send each client the correct data of the other players rather than handling such data locally.