### PR TITLE
Fix #8809. Check for valid colours ignored special cases

### DIFF
--- a/src/openrct2/actions/RideSetVehiclesAction.hpp
+++ b/src/openrct2/actions/RideSetVehiclesAction.hpp
@@ -118,7 +118,7 @@ public:
 
                 // Validate preset
                 vehicle_colour_preset_list* presetList = rideEntry->vehicle_preset_list;
-                if (_colour >= presetList->count)
+                if (_colour >= presetList->count && _colour != 255 && _colour != 0)
                 {
                     log_error("Unknown vehicle colour preset. colour = %d", _colour);
                     return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, errTitle);


### PR DESCRIPTION
Due to the special cases the colour check would fail and this would mean that the ride type could not be changed. 255 and 0 are both used to indicate that the ride should use different colours for each train.