### PR TITLE
Fix Game Actions Error Messages

### DIFF
--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -123,7 +123,7 @@ public:
                     _coords.x, _coords.y, _height, zCorner, &map_set_land_height_clear_func, { 0b1111, 0 }, 0, nullptr,
                     CREATE_CROSSING_MODE_NONE))
             {
-                return std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, gGameCommandErrorText);
+                return std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, STR_NONE, gGameCommandErrorText, gCommonFormatArgs);
             }
 
             tileElement = CheckUnremovableObstructions(surfaceElement, zCorner);

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -123,7 +123,8 @@ public:
                     _coords.x, _coords.y, _height, zCorner, &map_set_land_height_clear_func, { 0b1111, 0 }, 0, nullptr,
                     CREATE_CROSSING_MODE_NONE))
             {
-                return std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, STR_NONE, gGameCommandErrorText, gCommonFormatArgs);
+                return std::make_unique<GameActionResult>(
+                    GA_ERROR::DISALLOWED, STR_NONE, gGameCommandErrorText, gCommonFormatArgs);
             }
 
             tileElement = CheckUnremovableObstructions(surfaceElement, zCorner);

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -150,9 +150,7 @@ public:
 
             if (!map_can_construct_at(floor2(_x, 32), floor2(_y, 32), baseHeight, clearanceHeight, { 0b1111, 0 }))
             {
-                res->Error = GA_ERROR::NO_CLEARANCE;
-                res->ErrorMessage = STR_NONE;
-                return res;
+                return MakeResult(GA_ERROR::NO_CLEARANCE, res->ErrorTitle, gGameCommandErrorText, gCommonFormatArgs);
             }
 
             if (gMapGroundFlags & ELEMENT_IS_UNDERWATER)

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -101,7 +101,8 @@ public:
 
             if (!map_can_construct_at(entranceLoc.x, entranceLoc.y, zLow, zHigh, { 0b1111, 0 }))
             {
-                return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, gGameCommandErrorText, gCommonFormatArgs);
+                return std::make_unique<GameActionResult>(
+                    GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, gGameCommandErrorText, gCommonFormatArgs);
             }
 
             // Check that entrance element does not already exist at this location

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -101,7 +101,7 @@ public:
 
             if (!map_can_construct_at(entranceLoc.x, entranceLoc.y, zLow, zHigh, { 0b1111, 0 }))
             {
-                return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
+                return std::make_unique<GameActionResult>(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_PARK_ENTRANCE_HERE, gGameCommandErrorText, gCommonFormatArgs);
             }
 
             // Check that entrance element does not already exist at this location

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -34,7 +34,7 @@ public:
     {
     }
     RideCreateGameActionResult(GA_ERROR error, rct_string_id message)
-        : GameActionResult(error, message)
+        : GameActionResult(error, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, message)
     {
     }
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -186,7 +186,7 @@ public:
         int8_t clear_z = (z / 8) + (_isExit ? 5 : 7);
         auto cost = MONEY32_UNDEFINED;
         if (!map_can_construct_with_clear_at(
-                _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 }, GetFlags(), &cost,
+                _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 }, GetFlags() | GAME_COMMAND_FLAG_APPLY, &cost,
                 CREATE_CROSSING_MODE_NONE))
         {
             return MakeResult(GA_ERROR::NO_CLEARANCE, errorTitle, gGameCommandErrorText, gCommonFormatArgs);

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -186,8 +186,8 @@ public:
         int8_t clear_z = (z / 8) + (_isExit ? 5 : 7);
         auto cost = MONEY32_UNDEFINED;
         if (!map_can_construct_with_clear_at(
-                _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 }, GetFlags() | GAME_COMMAND_FLAG_APPLY, &cost,
-                CREATE_CROSSING_MODE_NONE))
+                _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 },
+                GetFlags() | GAME_COMMAND_FLAG_APPLY, &cost, CREATE_CROSSING_MODE_NONE))
         {
             return MakeResult(GA_ERROR::NO_CLEARANCE, errorTitle, gGameCommandErrorText, gCommonFormatArgs);
         }

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -375,7 +375,7 @@ public:
         money32 clearCost = 0;
 
         if (!map_can_construct_with_clear_at(
-                _loc.x, _loc.y, zLow, zHigh, &map_place_scenery_clear_func, quarterTile, GetFlags(), &clearCost,
+                _loc.x, _loc.y, zLow, zHigh, &map_place_scenery_clear_func, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY, &clearCost,
                 CREATE_CROSSING_MODE_NONE))
         {
             return MakeResult(GA_ERROR::DISALLOWED, STR_CANT_POSITION_THIS_HERE, gGameCommandErrorText, gCommonFormatArgs);

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -375,8 +375,8 @@ public:
         money32 clearCost = 0;
 
         if (!map_can_construct_with_clear_at(
-                _loc.x, _loc.y, zLow, zHigh, &map_place_scenery_clear_func, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY, &clearCost,
-                CREATE_CROSSING_MODE_NONE))
+                _loc.x, _loc.y, zLow, zHigh, &map_place_scenery_clear_func, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY,
+                &clearCost, CREATE_CROSSING_MODE_NONE))
         {
             return MakeResult(GA_ERROR::DISALLOWED, STR_CANT_POSITION_THIS_HERE, gGameCommandErrorText, gCommonFormatArgs);
         }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "55"
+#define NETWORK_STREAM_VERSION "56"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fix the error messages generated by `can_construct`. Pass the correct flags to `can_construct`. Note that may change network state. 

Fix #8736 the error title on ride create.