### PR TITLE
Fix #8870: Use player index instead of id.

### DIFF
--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -400,6 +400,12 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
 void window_player_overview_invalidate(rct_window* w)
 {
+    int32_t playerIndex = network_get_player_index((uint8_t)w->number);
+    if (playerIndex == -1)
+    {
+        return;
+    }
+
     if (window_player_page_widgets[w->page] != w->widgets)
     {
         w->widgets = window_player_page_widgets[w->page];
@@ -449,7 +455,7 @@ void window_player_overview_invalidate(rct_window* w)
 
     // Only enable kick button for other players
     const bool canKick = network_can_perform_action(network_get_current_player_group_index(), NETWORK_PERMISSION_KICK_PLAYER);
-    const bool isServer = network_get_player_flags(w->number) & NETWORK_PLAYER_FLAG_ISSERVER;
+    const bool isServer = network_get_player_flags(playerIndex) & NETWORK_PLAYER_FLAG_ISSERVER;
     const bool isOwnWindow = (network_get_current_player_id() == w->number);
     widget_set_enabled(w, WIDX_KICK, canKick && !isOwnWindow && !isServer);
 }


### PR DESCRIPTION
Regression from #8734, small oversight on using id vs index. Also made sure the window gets closed in case the player no longer exists.