### PR TITLE
Fix #8851: Show only game action errors to the issuer.

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -357,7 +357,19 @@ namespace GameActions
             cb(action, result.get());
         }
 
-        if (result->Error != GA_ERROR::OK && !(flags & GAME_COMMAND_FLAG_GHOST) && !(flags & GAME_COMMAND_FLAG_5))
+        // Only show errors when its not a ghost and not a preview and also top level action.
+        bool shouldShowError = !(flags & GAME_COMMAND_FLAG_GHOST) && !(flags & GAME_COMMAND_FLAG_5) && topLevel == true;
+
+        // In network mode the error should be only shown to the issuer of the action.
+        if (network_get_mode() != NETWORK_MODE_NONE)
+        {
+            if (action->GetPlayer() != network_get_current_player_id())
+            {
+                shouldShowError = false;
+            }
+        }
+
+        if (result->Error != GA_ERROR::OK && shouldShowError == true)
         {
             // Show the error box
             std::copy(result->ErrorMessageArgs.begin(), result->ErrorMessageArgs.end(), gCommonFormatArgs);


### PR DESCRIPTION
While Query covers most of the cases before its even networked theres still a chance that Query/Execute will fail on the server and would show the error on every client. This makes sure only the client who requested the action gets to see the error.