### PR TITLE
Use get track element

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -4714,20 +4714,12 @@ void Guest::UpdateRideMazePathfinding()
     int16_t stationHeight = ride->stations[0].Height;
 
     // Find the station track element
-    TileElement* tileElement = map_get_first_element_at(actionX / 32, actionY / 32);
-    do
-    {
-        if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK && stationHeight == tileElement->base_height)
-            break;
-
-    } while (!(tileElement++)->IsLastForTile());
-
-    auto trackMazeEntry = tileElement->AsTrack();
-    if (trackMazeEntry == nullptr)
+    auto trackElement = map_get_track_element_at(actionX, actionY, stationHeight);
+    if (trackElement == nullptr)
     {
         return;
     }
-    uint16_t mazeEntry = trackMazeEntry->GetMazeEntry();
+    uint16_t mazeEntry = trackElement->GetMazeEntry();
     uint16_t openHedges = 0;
     // var_37 is 3, 7, 11 or 15
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -4772,7 +4772,7 @@ void Guest::UpdateRideMazePathfinding()
     };
     maze_type mazeType = maze_type::invalid;
 
-    tileElement = map_get_first_element_at(actionX / 32, actionY / 32);
+    auto tileElement = map_get_first_element_at(actionX / 32, actionY / 32);
     do
     {
         if (stationHeight != tileElement->base_height)

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2472,7 +2472,7 @@ bool Staff::UpdateFixingMoveToStationEnd(bool firstRun, Ride* ride)
         uint16_t stationX = stationPosition.x * 32;
         uint16_t stationY = stationPosition.y * 32;
 
-        TileElement* tileElement = map_get_track_element_at(stationX, stationY, stationZ);
+        auto tileElement = map_get_track_element_at(stationX, stationY, stationZ);
         if (tileElement == nullptr)
         {
             log_error("Couldn't find tile_element");

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4904,40 +4904,40 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
     int32_t firstX = vehicle->track_x;
     int32_t firstY = vehicle->track_y;
     int32_t firstZ = vehicle->track_z;
-    TileElement* firstElement = map_get_track_element_at(firstX, firstY, firstZ / 8);
+    auto firstElement = map_get_track_element_at(firstX, firstY, firstZ / 8);
 
     assert(firstElement != nullptr);
 
     int32_t x = firstX;
     int32_t y = firstY;
-    TileElement* trackElement = firstElement;
+    auto trackElement = firstElement;
     track_begin_end trackBeginEnd;
-    while (track_block_get_previous(x, y, trackElement, &trackBeginEnd))
+    while (track_block_get_previous(x, y, reinterpret_cast<TileElement*>(trackElement), &trackBeginEnd))
     {
         x = trackBeginEnd.end_x;
         y = trackBeginEnd.end_y;
-        trackElement = trackBeginEnd.begin_element;
+        trackElement = trackBeginEnd.begin_element->AsTrack();
         if (x == firstX && y == firstY && trackElement == firstElement)
         {
             break;
         }
 
-        int32_t trackType = trackElement->AsTrack()->GetTrackType();
+        int32_t trackType = trackElement->GetTrackType();
         switch (trackType)
         {
             case TRACK_ELEM_25_DEG_UP_TO_FLAT:
             case TRACK_ELEM_60_DEG_UP_TO_FLAT:
-                if (trackElement->AsTrack()->HasChain())
+                if (trackElement->HasChain())
                 {
                     outXYElement->x = x;
                     outXYElement->y = y;
-                    outXYElement->element = trackElement;
+                    outXYElement->element = reinterpret_cast<TileElement*>(trackElement);
                     return;
                 }
                 break;
             case TRACK_ELEM_DIAG_25_DEG_UP_TO_FLAT:
             case TRACK_ELEM_DIAG_60_DEG_UP_TO_FLAT:
-                if (trackElement->AsTrack()->HasChain())
+                if (trackElement->HasChain())
                 {
                     TileElement* tileElement = map_get_first_element_at(trackBeginEnd.begin_x >> 5, trackBeginEnd.begin_y >> 5);
                     do
@@ -4962,7 +4962,7 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
             case TRACK_ELEM_BLOCK_BRAKES:
                 outXYElement->x = x;
                 outXYElement->y = y;
-                outXYElement->element = trackElement;
+                outXYElement->element = reinterpret_cast<TileElement*>(trackElement);
                 return;
         }
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4939,22 +4939,16 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
             case TRACK_ELEM_DIAG_60_DEG_UP_TO_FLAT:
                 if (trackElement->HasChain())
                 {
-                    TileElement* tileElement = map_get_first_element_at(trackBeginEnd.begin_x >> 5, trackBeginEnd.begin_y >> 5);
-                    do
+                    TileElement* tileElement = map_get_track_element_at_of_type_seq(
+                        trackBeginEnd.begin_x, trackBeginEnd.begin_y, trackBeginEnd.begin_z / 8, trackType, 0);
+
+                    if (tileElement != nullptr)
                     {
-                        if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
-                            continue;
-                        if (tileElement->AsTrack()->GetTrackType() != trackType)
-                            continue;
-                        if (tileElement->AsTrack()->GetSequenceIndex() != 0)
-                            continue;
-                        if (tileElement->base_height != trackBeginEnd.begin_z / 8)
-                            continue;
                         outXYElement->x = trackBeginEnd.begin_x;
                         outXYElement->y = trackBeginEnd.begin_y;
                         outXYElement->element = tileElement;
                         return;
-                    } while (!(tileElement++)->IsLastForTile());
+                    }
                 }
                 break;
             case TRACK_ELEM_END_STATION:
@@ -5009,15 +5003,7 @@ static bool ride_create_vehicles(Ride* ride, CoordsXYE* element, int32_t isApply
         x = element->x - CoordsDirectionDelta[direction].x;
         y = element->y - CoordsDirectionDelta[direction].y;
 
-        tileElement = map_get_first_element_at(x >> 5, y >> 5);
-        do
-        {
-            if (tileElement->base_height != z)
-                continue;
-            if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
-                continue;
-            break;
-        } while (!(tileElement++)->IsLastForTile());
+        tileElement = reinterpret_cast<TileElement*>(map_get_track_element_at(x, y, z));
 
         z = tileElement->base_height;
         direction = tileElement->GetDirection();
@@ -5275,15 +5261,7 @@ static bool ride_create_cable_lift(ride_id_t rideIndex, bool isApplying)
     int32_t x = ride->cable_lift_x;
     int32_t y = ride->cable_lift_y;
     int32_t z = ride->cable_lift_z;
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
-    do
-    {
-        if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
-            continue;
-        if (tileElement->base_height != z)
-            continue;
-        break;
-    } while (!(tileElement++)->IsLastForTile());
+    auto tileElement = map_get_track_element_at(x, y, z);
     int32_t direction = tileElement->GetDirection();
 
     rct_vehicle* head = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4969,7 +4969,7 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
 
     outXYElement->x = firstX;
     outXYElement->y = firstY;
-    outXYElement->element = firstElement;
+    outXYElement->element = reinterpret_cast<TileElement*>(firstElement);
 }
 
 /**

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2836,7 +2836,7 @@ static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle)
     int32_t y = location.y * 32;
     int32_t z = ride->stations[station].Height;
 
-    TileElement* tileElement = map_get_track_element_at(x, y, z);
+    auto tileElement = map_get_track_element_at(x, y, z);
     if (tileElement == nullptr)
     {
         return false;
@@ -3989,14 +3989,14 @@ loc_6D8E36:
         return;
     }
 
-    TileElement* tileElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z / 8);
+    auto trackElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z / 8);
 
-    if (tileElement == nullptr)
+    if (trackElement == nullptr)
     {
         return;
     }
 
-    vehicle->current_station = tileElement->AsTrack()->GetStationIndex();
+    vehicle->current_station = trackElement->GetStationIndex();
     vehicle->num_laps++;
 
     if (vehicle->sub_state != 0)
@@ -4270,10 +4270,10 @@ static void loc_6DA9F9(rct_vehicle* vehicle, int32_t x, int32_t y, int32_t bx, i
         vehicle->track_x = bx;
         vehicle->track_y = dx;
 
-        TileElement* tileElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3);
+        auto trackElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3);
 
         Ride* ride = get_ride(vehicle->ride);
-        vehicle->track_type = (tileElement->AsTrack()->GetTrackType() << 2) | (ride->boat_hire_return_direction & 3);
+        vehicle->track_type = (trackElement->GetTrackType() << 2) | (ride->boat_hire_return_direction & 3);
 
         vehicle->track_progress = 0;
         vehicle->status = VEHICLE_STATUS_TRAVELLING;
@@ -6762,15 +6762,15 @@ static void vehicle_update_block_brakes_open_previous_section(rct_vehicle* vehic
     x = trackBeginEnd.begin_x;
     y = trackBeginEnd.begin_y;
     z = trackBeginEnd.begin_z;
-    tileElement = map_get_track_element_at(x, y, z >> 3);
-    if (tileElement == nullptr)
+    auto trackElement = map_get_track_element_at(x, y, z >> 3);
+    if (trackElement == nullptr)
     {
         return;
     }
-    tileElement->AsTrack()->SetBlockBrakeClosed(false);
-    map_invalidate_element(x, y, tileElement);
+    trackElement->SetBlockBrakeClosed(false);
+    map_invalidate_element(x, y, reinterpret_cast<TileElement*>(trackElement));
 
-    int32_t trackType = tileElement->AsTrack()->GetTrackType();
+    int32_t trackType = trackElement->GetTrackType();
     if (trackType == TRACK_ELEM_BLOCK_BRAKES || trackType == TRACK_ELEM_END_STATION)
     {
         Ride* ride = get_ride(vehicle->ride);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -3454,7 +3454,7 @@ void game_command_modify_tile(
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TileElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z)
+TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z)
 {
     TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
     do
@@ -3464,7 +3464,7 @@ TileElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z)
         if (tileElement->base_height != z)
             continue;
 
-        return tileElement;
+        return tileElement->AsTrack();
     } while (!(tileElement++)->IsLastForTile());
 
     return nullptr;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -268,7 +268,7 @@ bool map_large_scenery_get_origin(
 void map_offset_with_rotation(int16_t* x, int16_t* y, int16_t offsetX, int16_t offsetY, uint8_t rotation);
 CoordsXY translate_3d_to_2d_with_z(int32_t rotation, CoordsXYZ pos);
 
-TileElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);
+TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);
 TileElement* map_get_track_element_at_of_type(int32_t x, int32_t y, int32_t z, int32_t trackType);
 TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence);
 TileElement* map_get_track_element_at_of_type_from_ride(

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -82,7 +82,7 @@ TEST_F(TileElementWantsFootpathConnection, SlopedPath)
 TEST_F(TileElementWantsFootpathConnection, Stall)
 {
     // Stalls usually have one path direction flag, but can have multiple (info kiosk for example)
-    const TileElement* const stallElement = map_get_track_element_at(19 << 5, 15 << 5, 14);
+    const TrackElement* const stallElement = map_get_track_element_at(19 << 5, 15 << 5, 14);
     ASSERT_NE(stallElement, nullptr);
     EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 15, 14, 0 }, nullptr));
     EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 1 }, nullptr));


### PR DESCRIPTION
Fix #8858.

Had to use reinterpret cast in a few cases as can't implicitly convert between TileElements and TrackElements. We should probably make most tileelement pointers to TileBaseElement pointers to allow this.