### PR TITLE
Move common actions from debug menu into cheats menu

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#5579] Network desync immediately after connecting.
 - Fix: [#8873] Potential crash when placing footpaths.
+- Change: [#8688] Move common actions from debug menu into cheats menu.
 
 0.2.2 (2019-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -136,11 +136,7 @@ enum TOP_TOOLBAR_VIEW_MENU_DDIDX {
 
 enum TOP_TOOLBAR_DEBUG_DDIDX {
     DDIDX_CONSOLE = 0,
-    DDIDX_TILE_INSPECTOR = 1,
-    DDIDX_OBJECT_SELECTION = 2,
-    DDIDX_INVENTIONS_LIST = 3,
-    DDIDX_SCENARIO_OPTIONS = 4,
-    DDIDX_DEBUG_PAINT = 5,
+    DDIDX_DEBUG_PAINT = 1,
 
     TOP_TOOLBAR_DEBUG_COUNT
 };
@@ -152,9 +148,16 @@ enum TOP_TOOLBAR_NETWORK_DDIDX {
 
 enum {
     DDIDX_CHEATS,
-    DDIDX_ENABLE_SANDBOX_MODE = 2,
-    DDIDX_DISABLE_CLEARANCE_CHECKS,
-    DDIDX_DISABLE_SUPPORT_LIMITS
+    DDIDX_TILE_INSPECTOR = 1,
+    DDIDX_OBJECT_SELECTION = 2,
+    DDIDX_INVENTIONS_LIST = 3,
+    DDIDX_SCENARIO_OPTIONS = 4,
+    // 5 is a separator
+    DDIDX_ENABLE_SANDBOX_MODE = 6,
+    DDIDX_DISABLE_CLEARANCE_CHECKS = 7,
+    DDIDX_DISABLE_SUPPORT_LIMITS = 8,
+
+    TOP_TOOLBAR_CHEATS_COUNT
 };
 
 enum {
@@ -293,6 +296,8 @@ static void top_toolbar_init_fastforward_menu(rct_window* window, rct_widget* wi
 static void top_toolbar_fastforward_menu_dropdown(int16_t dropdownIndex);
 static void top_toolbar_init_rotate_menu(rct_window* window, rct_widget* widget);
 static void top_toolbar_rotate_menu_dropdown(int16_t dropdownIndex);
+static void top_toolbar_init_cheats_menu(rct_window* window, rct_widget* widget);
+static void top_toolbar_cheats_menu_dropdown(int16_t dropdownIndex);
 static void top_toolbar_init_debug_menu(rct_window* window, rct_widget* widget);
 static void top_toolbar_debug_menu_dropdown(int16_t dropdownIndex);
 static void top_toolbar_init_network_menu(rct_window* window, rct_widget* widget);
@@ -496,30 +501,7 @@ static void window_top_toolbar_mousedown(rct_window* w, rct_widgetindex widgetIn
 #endif
             break;
         case WIDX_CHEATS:
-            gDropdownItemsFormat[0] = STR_TOGGLE_OPTION;
-            gDropdownItemsFormat[1] = STR_EMPTY;
-            gDropdownItemsFormat[2] = STR_TOGGLE_OPTION;
-            gDropdownItemsFormat[3] = STR_TOGGLE_OPTION;
-            gDropdownItemsFormat[4] = STR_TOGGLE_OPTION;
-            gDropdownItemsArgs[0] = STR_CHEAT_TITLE;
-            gDropdownItemsArgs[2] = STR_ENABLE_SANDBOX_MODE;
-            gDropdownItemsArgs[3] = STR_DISABLE_CLEARANCE_CHECKS;
-            gDropdownItemsArgs[4] = STR_DISABLE_SUPPORT_LIMITS;
-            window_dropdown_show_text(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, 5);
-            if (gCheatsSandboxMode)
-            {
-                dropdown_set_checked(DDIDX_ENABLE_SANDBOX_MODE, true);
-            }
-            if (gCheatsDisableClearanceChecks)
-            {
-                dropdown_set_checked(DDIDX_DISABLE_CLEARANCE_CHECKS, true);
-            }
-            if (gCheatsDisableSupportLimits)
-            {
-                dropdown_set_checked(DDIDX_DISABLE_SUPPORT_LIMITS, true);
-            }
-            gDropdownDefaultIndex = DDIDX_CHEATS;
+            top_toolbar_init_cheats_menu(w, widget);
             break;
         case WIDX_VIEW_MENU:
             top_toolbar_init_view_menu(w, widget);
@@ -648,26 +630,7 @@ static void window_top_toolbar_dropdown(rct_window* w, rct_widgetindex widgetInd
             }
             break;
         case WIDX_CHEATS:
-            switch (dropdownIndex)
-            {
-                case DDIDX_CHEATS:
-                    context_open_window(WC_CHEATS);
-                    break;
-                case DDIDX_ENABLE_SANDBOX_MODE:
-                    game_do_command(
-                        0, GAME_COMMAND_FLAG_APPLY, CHEAT_SANDBOXMODE, !gCheatsSandboxMode, GAME_COMMAND_CHEAT, 0, 0);
-                    break;
-                case DDIDX_DISABLE_CLEARANCE_CHECKS:
-                    game_do_command(
-                        0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLECLEARANCECHECKS, !gCheatsDisableClearanceChecks,
-                        GAME_COMMAND_CHEAT, 0, 0);
-                    break;
-                case DDIDX_DISABLE_SUPPORT_LIMITS:
-                    game_do_command(
-                        0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLESUPPORTLIMITS, !gCheatsDisableSupportLimits,
-                        GAME_COMMAND_CHEAT, 0, 0);
-                    break;
-            }
+            top_toolbar_cheats_menu_dropdown(dropdownIndex);
             break;
         case WIDX_VIEW_MENU:
             top_toolbar_view_menu_dropdown(dropdownIndex);
@@ -3261,24 +3224,36 @@ static void top_toolbar_rotate_menu_dropdown(int16_t dropdownIndex)
     }
 }
 
-static void top_toolbar_init_debug_menu(rct_window* w, rct_widget* widget)
+static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[DDIDX_CONSOLE] = STR_TOGGLE_OPTION;
-    gDropdownItemsArgs[DDIDX_CONSOLE] = STR_DEBUG_DROPDOWN_CONSOLE;
+    gDropdownItemsFormat[DDIDX_CHEATS] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_CHEATS] = STR_CHEAT_TITLE;
+
     gDropdownItemsFormat[DDIDX_TILE_INSPECTOR] = STR_TOGGLE_OPTION;
     gDropdownItemsArgs[DDIDX_TILE_INSPECTOR] = STR_DEBUG_DROPDOWN_TILE_INSPECTOR;
+
     gDropdownItemsFormat[DDIDX_OBJECT_SELECTION] = STR_TOGGLE_OPTION;
     gDropdownItemsArgs[DDIDX_OBJECT_SELECTION] = STR_DEBUG_DROPDOWN_OBJECT_SELECTION;
+
     gDropdownItemsFormat[DDIDX_INVENTIONS_LIST] = STR_TOGGLE_OPTION;
     gDropdownItemsArgs[DDIDX_INVENTIONS_LIST] = STR_DEBUG_DROPDOWN_INVENTIONS_LIST;
+
     gDropdownItemsFormat[DDIDX_SCENARIO_OPTIONS] = STR_TOGGLE_OPTION;
     gDropdownItemsArgs[DDIDX_SCENARIO_OPTIONS] = STR_DEBUG_DROPDOWN_SCENARIO_OPTIONS;
-    gDropdownItemsFormat[DDIDX_DEBUG_PAINT] = STR_TOGGLE_OPTION;
-    gDropdownItemsArgs[DDIDX_DEBUG_PAINT] = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
+
+    gDropdownItemsFormat[5] = STR_EMPTY;
+
+    gDropdownItemsFormat[DDIDX_ENABLE_SANDBOX_MODE] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_ENABLE_SANDBOX_MODE] = STR_ENABLE_SANDBOX_MODE;
+
+    gDropdownItemsFormat[DDIDX_DISABLE_CLEARANCE_CHECKS] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_DISABLE_CLEARANCE_CHECKS] = STR_DISABLE_CLEARANCE_CHECKS;
+
+    gDropdownItemsFormat[DDIDX_DISABLE_SUPPORT_LIMITS] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_DISABLE_SUPPORT_LIMITS] = STR_DISABLE_SUPPORT_LIMITS;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80,
-        DROPDOWN_FLAG_STAY_OPEN, TOP_TOOLBAR_DEBUG_COUNT);
+        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, TOP_TOOLBAR_CHEATS_COUNT);
 
     // Disable items that are not yet available in multiplayer
     if (network_get_mode() != NETWORK_MODE_NONE)
@@ -3286,6 +3261,70 @@ static void top_toolbar_init_debug_menu(rct_window* w, rct_widget* widget)
         dropdown_set_disabled(DDIDX_OBJECT_SELECTION, true);
         dropdown_set_disabled(DDIDX_INVENTIONS_LIST, true);
     }
+
+    if (gCheatsSandboxMode)
+    {
+        dropdown_set_checked(DDIDX_ENABLE_SANDBOX_MODE, true);
+    }
+    if (gCheatsDisableClearanceChecks)
+    {
+        dropdown_set_checked(DDIDX_DISABLE_CLEARANCE_CHECKS, true);
+    }
+    if (gCheatsDisableSupportLimits)
+    {
+        dropdown_set_checked(DDIDX_DISABLE_SUPPORT_LIMITS, true);
+    }
+
+    gDropdownDefaultIndex = DDIDX_CHEATS;
+}
+
+static void top_toolbar_cheats_menu_dropdown(int16_t dropdownIndex)
+{
+    switch (dropdownIndex)
+    {
+        case DDIDX_CHEATS:
+            context_open_window(WC_CHEATS);
+            break;
+        case DDIDX_TILE_INSPECTOR:
+            context_open_window(WC_TILE_INSPECTOR);
+            break;
+        case DDIDX_OBJECT_SELECTION:
+            window_close_all();
+            context_open_window(WC_EDITOR_OBJECT_SELECTION);
+            break;
+        case DDIDX_INVENTIONS_LIST:
+            context_open_window(WC_EDITOR_INVENTION_LIST);
+            break;
+        case DDIDX_SCENARIO_OPTIONS:
+            context_open_window(WC_EDITOR_SCENARIO_OPTIONS);
+            break;
+        case DDIDX_ENABLE_SANDBOX_MODE:
+            game_do_command(
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_SANDBOXMODE, !gCheatsSandboxMode, GAME_COMMAND_CHEAT, 0, 0);
+            break;
+        case DDIDX_DISABLE_CLEARANCE_CHECKS:
+            game_do_command(
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLECLEARANCECHECKS, !gCheatsDisableClearanceChecks,
+                GAME_COMMAND_CHEAT, 0, 0);
+            break;
+        case DDIDX_DISABLE_SUPPORT_LIMITS:
+            game_do_command(
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLESUPPORTLIMITS, !gCheatsDisableSupportLimits,
+                GAME_COMMAND_CHEAT, 0, 0);
+            break;
+    }
+}
+
+static void top_toolbar_init_debug_menu(rct_window* w, rct_widget* widget)
+{
+    gDropdownItemsFormat[DDIDX_CONSOLE] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_CONSOLE] = STR_DEBUG_DROPDOWN_CONSOLE;
+    gDropdownItemsFormat[DDIDX_DEBUG_PAINT] = STR_TOGGLE_OPTION;
+    gDropdownItemsArgs[DDIDX_DEBUG_PAINT] = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
+
+    window_dropdown_show_text(
+        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80,
+        DROPDOWN_FLAG_STAY_OPEN, TOP_TOOLBAR_DEBUG_COUNT);
 
     dropdown_set_checked(DDIDX_DEBUG_PAINT, window_find_by_class(WC_DEBUG_PAINT) != nullptr);
 }
@@ -3316,19 +3355,6 @@ static void top_toolbar_debug_menu_dropdown(int16_t dropdownIndex)
                 console.Open();
                 break;
             }
-            case DDIDX_TILE_INSPECTOR:
-                context_open_window(WC_TILE_INSPECTOR);
-                break;
-            case DDIDX_OBJECT_SELECTION:
-                window_close_all();
-                context_open_window(WC_EDITOR_OBJECT_SELECTION);
-                break;
-            case DDIDX_INVENTIONS_LIST:
-                context_open_window(WC_EDITOR_INVENTION_LIST);
-                break;
-            case DDIDX_SCENARIO_OPTIONS:
-                context_open_window(WC_EDITOR_SCENARIO_OPTIONS);
-                break;
             case DDIDX_DEBUG_PAINT:
                 if (window_find_by_class(WC_DEBUG_PAINT) == nullptr)
                 {

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3253,7 +3253,8 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsArgs[DDIDX_DISABLE_SUPPORT_LIMITS] = STR_DISABLE_SUPPORT_LIMITS;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, TOP_TOOLBAR_CHEATS_COUNT);
+        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
+        TOP_TOOLBAR_CHEATS_COUNT);
 
     // Disable items that are not yet available in multiplayer
     if (network_get_mode() != NETWORK_MODE_NONE)
@@ -3299,18 +3300,16 @@ static void top_toolbar_cheats_menu_dropdown(int16_t dropdownIndex)
             context_open_window(WC_EDITOR_SCENARIO_OPTIONS);
             break;
         case DDIDX_ENABLE_SANDBOX_MODE:
-            game_do_command(
-                0, GAME_COMMAND_FLAG_APPLY, CHEAT_SANDBOXMODE, !gCheatsSandboxMode, GAME_COMMAND_CHEAT, 0, 0);
+            game_do_command(0, GAME_COMMAND_FLAG_APPLY, CHEAT_SANDBOXMODE, !gCheatsSandboxMode, GAME_COMMAND_CHEAT, 0, 0);
             break;
         case DDIDX_DISABLE_CLEARANCE_CHECKS:
             game_do_command(
-                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLECLEARANCECHECKS, !gCheatsDisableClearanceChecks,
-                GAME_COMMAND_CHEAT, 0, 0);
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLECLEARANCECHECKS, !gCheatsDisableClearanceChecks, GAME_COMMAND_CHEAT, 0,
+                0);
             break;
         case DDIDX_DISABLE_SUPPORT_LIMITS:
             game_do_command(
-                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLESUPPORTLIMITS, !gCheatsDisableSupportLimits,
-                GAME_COMMAND_CHEAT, 0, 0);
+                0, GAME_COMMAND_FLAG_APPLY, CHEAT_DISABLESUPPORTLIMITS, !gCheatsDisableSupportLimits, GAME_COMMAND_CHEAT, 0, 0);
             break;
     }
 }


### PR DESCRIPTION
This aims to make it less necessary for users to enable debugging tools.

![Screenshot_20190316_163937](https://user-images.githubusercontent.com/604665/54477695-5c7bc980-480a-11e9-98f7-a7d90326bb71.png)

Implements #8688. Feedback is welcome.