### PR TITLE
Allow different default colours per stall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ set(CMAKE_MACOSX_RPATH 1)
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip")
 set(TITLE_SEQUENCE_SHA1 "1136ef92bfb05cd1cba9831ba6dc4a653d87a246")
 
-set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.9/objects.zip")
-set(OBJECTS_SHA1 "be0bcb454505e4f7c56d21d6804f81faf8a0a652")
+set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip")
+set(OBJECTS_SHA1 "0e88a1a6d845eb3a56ad68ecf60a9d6a4194250f")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -3555,7 +3555,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "version=\"1.0.9\"\nzipname=\"objects.zip\"\nliburl=\"https://github.com/OpenRCT2/objects/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/object\" || ! -e \"${SRCROOT}/objectsversion\" || $(head -n 1 \"${SRCROOT}/objectsversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/object\" ]]; then rm -r \"${SRCROOT}/data/object\"; fi\nmkdir -p \"${SRCROOT}/data/object\"\n\ncurl -L -o \"${SRCROOT}/data/object/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/object\" \"${SRCROOT}/data/object/$zipname\"\nrm \"${SRCROOT}/data/object/$zipname\"\n\necho $version > \"${SRCROOT}/objectsversion\"\nfi";
+			shellScript = "version=\"1.0.10\"\nzipname=\"objects.zip\"\nliburl=\"https://github.com/OpenRCT2/objects/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/object\" || ! -e \"${SRCROOT}/objectsversion\" || $(head -n 1 \"${SRCROOT}/objectsversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/object\" ]]; then rm -r \"${SRCROOT}/data/object\"; fi\nmkdir -p \"${SRCROOT}/data/object\"\n\ncurl -L -o \"${SRCROOT}/data/object/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/object\" \"${SRCROOT}/data/object/$zipname\"\nrm \"${SRCROOT}/data/object/$zipname\"\n\necho $version > \"${SRCROOT}/objectsversion\"\nfi";
 		};
 		C68B2D471EC790710020651C /* Download Libraries */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -70,8 +70,8 @@
     <GtestSha1>058b9df80244c03f1633cb06e9f70471a29ebb8e</GtestSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip</TitleSequencesUrl>
     <TitleSequencesSha1>1136ef92bfb05cd1cba9831ba6dc4a653d87a246</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.9/objects.zip</ObjectsUrl>
-    <ObjectsSha1>be0bcb454505e4f7c56d21d6804f81faf8a0a652</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip</ObjectsUrl>
+    <ObjectsSha1>0e88a1a6d845eb3a56ad68ecf60a9d6a4194250f</ObjectsSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ let
   objects-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.0.9";
-    sha256 = "442b7da11b2b884559148ab9e7fdf781f50dd50feb69bfa569a78e52205a5709";
+    rev = "v1.0.10";
+    sha256 = "4f261964f1c01a04b7600d3d082fb4d3d9ec0d543c4eb66a819eb2ad01417aa0";
   };
 
   title-sequences-src = pkgs.fetchFromGitHub {

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -98,7 +98,7 @@ android.applicationVariants.all { variant ->
             into "$variant.mergeAssets.outputDir/data/title"
         }
         download {
-            src 'https://github.com/OpenRCT2/objects/releases/download/v1.0.9/objects.zip'
+            src 'https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip'
             dest new File(buildDir, 'objects.zip')
         }
         copy {

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -23,14 +23,6 @@ void EntranceObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
     GetImageTable().Read(context, stream);
-
-    // Fix issue #1705: The Medieval entrance from Time Twister has a straight banner,
-    // but scrolls its text as if it a curved one.
-    if (String::Equals(GetIdentifier(), "MEDIENTR"))
-    {
-        _legacyType.scrolling_mode = 32;
-        _legacyType.text_height += 1;
-    }
 }
 
 void EntranceObject::Load()

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -85,6 +85,13 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
         _presetColours.list[i] = stream->ReadValue<vehicle_colour>();
     }
 
+    if (IsRideTypeShopOrFacility(_legacyType.ride_type[0]))
+    {
+        // This used to be hard-coded. JSON objects set this themselves.
+        _presetColours.count = 1;
+        _presetColours.list[0] = { COLOUR_BRIGHT_RED, COLOUR_BRIGHT_RED, COLOUR_BRIGHT_RED };
+    }
+
     // Read peep loading positions
     for (int32_t i = 0; i < RCT2_MAX_VEHICLES_PER_RIDE_ENTRY; i++)
     {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -550,6 +550,8 @@ void RideObject::ReadJson(IReadObjectContext* context, const json_t* root)
     _legacyType.shop_item = SHOP_ITEM_NONE;
     _legacyType.shop_item_secondary = SHOP_ITEM_NONE;
 
+    _presetColours = ReadJsonCarColours(json_object_get(properties, "carColours"));
+
     if (IsRideTypeShopOrFacility(_legacyType.ride_type[0]))
     {
         // Standard car info for a shop
@@ -623,7 +625,6 @@ void RideObject::ReadJson(IReadObjectContext* context, const json_t* root)
         }
 
         auto availableTrackPieces = ObjectJsonHelpers::GetJsonStringArray(json_object_get(properties, "availableTrackPieces"));
-        _presetColours = ReadJsonCarColours(json_object_get(properties, "carColours"));
     }
 
     _legacyType.flags |= ObjectJsonHelpers::GetFlags<uint32_t>(

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -90,6 +90,12 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
         // This used to be hard-coded. JSON objects set this themselves.
         _presetColours.count = 1;
         _presetColours.list[0] = { COLOUR_BRIGHT_RED, COLOUR_BRIGHT_RED, COLOUR_BRIGHT_RED };
+
+        if (_legacyType.ride_type[0] == RIDE_TYPE_FOOD_STALL || _legacyType.ride_type[0] == RIDE_TYPE_DRINK_STALL)
+        {
+            // In RCT2, no food or drink stall could be recoloured.
+            _legacyType.flags |= RIDE_ENTRY_FLAG_DISABLE_COLOUR_TAB;
+        }
     }
 
     // Read peep loading positions

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -707,6 +707,7 @@ public:
             dst->track_colour[i].additional = src->track_colour_additional[i];
             dst->track_colour[i].supports = src->track_colour_supports[i];
         }
+        // This stall was not colourable in RCT2.
         if (dst->type == RIDE_TYPE_FOOD_STALL)
         {
             auto entry = object_entry_get_entry(OBJECT_TYPE_RIDE, dst->subtype);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -707,6 +707,19 @@ public:
             dst->track_colour[i].additional = src->track_colour_additional[i];
             dst->track_colour[i].supports = src->track_colour_supports[i];
         }
+        if (dst->type == RIDE_TYPE_FOOD_STALL)
+        {
+            auto entry = object_entry_get_entry(OBJECT_TYPE_RIDE, dst->subtype);
+            if (entry != nullptr)
+            {
+                char name[DAT_NAME_LENGTH + 1];
+                object_entry_get_name_fixed(name, sizeof(name), entry);
+                if (strncmp(name, "ICECR1  ", DAT_NAME_LENGTH) == 0)
+                {
+                    dst->track_colour[0].main = COLOUR_LIGHT_BLUE;
+                }
+            }
+        }
 
         dst->music = src->music;
         dst->entrance_style = src->entrance_style;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -216,6 +216,7 @@ static void ride_shop_connected(Ride* ride);
 static void ride_spiral_slide_update(Ride* ride);
 static void ride_update(Ride* ride);
 void loc_6DDF9C(Ride* ride, TileElement* tileElement);
+static bool ride_is_ride(Ride* ride);
 
 Ride* get_ride(int32_t index)
 {
@@ -5898,7 +5899,17 @@ void ride_set_colour_preset(Ride* ride, uint8_t index)
 {
     const track_colour_preset_list* colourPresets = &RideColourPresets[ride->type];
     TrackColour colours = { COLOUR_BLACK, COLOUR_BLACK, COLOUR_BLACK };
-    if (index < colourPresets->count)
+    // Stalls save their default colour in the vehicle settings (since they share a common ride type)
+    if (!ride_is_ride(ride))
+    {
+        auto rideEntry = get_ride_entry(ride->subtype);
+        if (rideEntry != nullptr && rideEntry->vehicle_preset_list->count > 0)
+        {
+            auto list = rideEntry->vehicle_preset_list->list[0];
+            colours = { list.main, list.additional_1, list.additional_2 };
+        }
+    }
+    else if (index < colourPresets->count)
     {
         colours = colourPresets->list[index];
     }


### PR DESCRIPTION
![Alton Towers 2019-03-20 13-05-12](https://user-images.githubusercontent.com/1478678/54683038-e7add580-4b10-11e9-89f8-cf5236b91b09.png)

This PR adds a few things that are intertwined. These are the following:

- Support for stalls determining their own default colours, rather than always defaulting to red.
- Recolouration support for food/drink stalls (not possible in RCT2. Hidden behind a flag which can be removed after switching to the new save format).
- Recolouration support for the Ice Cream Stall, along with import code in SV6 to make sure they're imported with a light blue colour (hidden behind a flag, see point 2).
- Unrelated object fixes that were the result of doing an objects release.