### PR TITLE
Fix #8910. Staff patrol areas sharing id's.

### DIFF
--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -256,7 +256,7 @@ private:
 
             peep_update_name_sort(newPeep);
 
-            newPeep->staff_id = newStaffId;
+            newPeep->staff_id = staffIndex;
 
             gStaffModes[staffIndex] = STAFF_MODE_WALK;
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Mistake made during conversion to game action.