### PR TITLE
Console command to set price of all rides of type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.2.2+ (in development)
 ------------------------------------------------------------------------
+- Feature: [#8919] Allow setting ride price from console.
 - Change: [#8688] Move common actions from debug menu into cheats menu.
 - Fix: [#5579] Network desync immediately after connecting.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -170,7 +170,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteFormatLine("rides set excitement <ride id> <excitement value>");
                     console.WriteFormatLine("rides set intensity <ride id> <intensity value>");
                     console.WriteFormatLine("rides set nausea <ride id> <nausea value>");
-                    console.WriteFormatLine("rides set price <ride id|all> [type] <price>");
+                    console.WriteFormatLine("rides set price <ride id / all> [type] <price>");
                 }
                 return 0;
             }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -16,6 +16,7 @@
 #include "../ReplayManager.h"
 #include "../Version.h"
 #include "../actions/ClimateSetAction.hpp"
+#include "../actions/RideSetPriceAction.hpp"
 #include "../actions/RideSetSetting.hpp"
 #include "../actions/StaffSetCostumeAction.hpp"
 #include "../config/Config.h"
@@ -169,6 +170,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteFormatLine("rides set excitement <ride id> <excitement value>");
                     console.WriteFormatLine("rides set intensity <ride id> <intensity value>");
                     console.WriteFormatLine("rides set nausea <ride id> <nausea value>");
+                    console.WriteFormatLine("rides set price <ride id|all> [type] <price>");
                 }
                 return 0;
             }
@@ -356,6 +358,67 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     {
                         ride->nausea = nausea;
                     }
+                }
+            }
+            else if (argv[1] == "price")
+            {
+                bool int_valid[2] = { false };
+                if (argv[2] == "all")
+                {
+                    auto arg1 = console_parse_int(argv[3], &int_valid[0]);
+                    if (argv.size() <= 4)
+                    {
+                        auto price = arg1;
+                        if (int_valid[0])
+                        {
+                            uint16_t rideId{};
+                            Ride* ride;
+                            FOR_ALL_RIDES (rideId, ride)
+                            {
+                                auto rideSetPrice = RideSetPriceAction(rideId, price, true);
+                                GameActions::Execute(&rideSetPrice);
+                            }
+                        }
+                        else
+                        {
+                            console.WriteFormatLine("This command expects one or two integer arguments");
+                        }
+                    }
+                    else
+                    {
+                        auto rideType = arg1;
+                        auto price = console_parse_int(argv[4], &int_valid[1]);
+
+                        if (int_valid[0] && int_valid[1])
+                        {
+                            uint16_t rideId{};
+                            Ride* ride;
+                            FOR_ALL_RIDES (rideId, ride)
+                            {
+                                if (ride->type == rideType)
+                                {
+                                    auto rideSetPrice = RideSetPriceAction(rideId, price, true);
+                                    GameActions::Execute(&rideSetPrice);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            console.WriteFormatLine("This command expects one or two integer arguments");
+                        }
+                    }
+                }
+                else
+                {
+                    int32_t rideId = console_parse_int(argv[2], &int_valid[0]);
+                    money16 price = console_parse_int(argv[3], &int_valid[1]);
+
+                    if (!int_valid[0] || !int_valid[1])
+                    {
+                        console.WriteFormatLine("This command expects the string all or two integer arguments");
+                    }
+                    auto rideSetPrice = RideSetPriceAction(rideId, price, true);
+                    GameActions::Execute(&rideSetPrice);
                 }
             }
         }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -170,7 +170,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteFormatLine("rides set excitement <ride id> <excitement value>");
                     console.WriteFormatLine("rides set intensity <ride id> <intensity value>");
                     console.WriteFormatLine("rides set nausea <ride id> <nausea value>");
-                    console.WriteFormatLine("rides set price <ride id / all> [type] <price>");
+                    console.WriteFormatLine("rides set price <ride id / all [type]> <price>");
                 }
                 return 0;
             }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -417,8 +417,11 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     {
                         console.WriteFormatLine("This command expects the string all or two integer arguments");
                     }
-                    auto rideSetPrice = RideSetPriceAction(rideId, price, true);
-                    GameActions::Execute(&rideSetPrice);
+                    else
+                    {
+                        auto rideSetPrice = RideSetPriceAction(rideId, price, true);
+                        GameActions::Execute(&rideSetPrice);
+                    }
                 }
             }
         }


### PR DESCRIPTION
RCT and friends suggested it would be useful to be able to set all rides of a certain type to a single price. 

This command can be used in 3 different ways:
single ride:
rides set price `<rideIndex> <price>`

All rides:
rides set price all `<price>`

All rides of type:
rides set price all `<type> <price>`