### PR TITLE
Make cheats menu partially accessible in scenario editor

### DIFF
--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -445,7 +445,7 @@ static void shortcut_show_research_information()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         context_open_window_view(WV_RIDE_RESEARCH);
     }
@@ -456,7 +456,7 @@ static void shortcut_show_rides_list()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         context_open_window(WC_RIDE_LIST);
     }
@@ -467,7 +467,7 @@ static void shortcut_show_park_information()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         context_open_window(WC_PARK_INFORMATION);
     }
@@ -478,7 +478,7 @@ static void shortcut_show_guest_list()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         context_open_window(WC_GUEST_LIST);
     }
@@ -489,7 +489,7 @@ static void shortcut_show_staff_list()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         context_open_window(WC_STAFF_LIST);
     }
@@ -500,7 +500,7 @@ static void shortcut_show_recent_messages()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
         context_open_window(WC_RECENT_NEWS);
 }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -712,7 +712,7 @@ static void window_top_toolbar_invalidate(rct_window* w)
         window_top_toolbar_widgets[WIDX_CHAT].type = WWT_EMPTY;
     }
 
-    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
         window_top_toolbar_widgets[WIDX_PAUSE].type = WWT_EMPTY;
         window_top_toolbar_widgets[WIDX_RIDES].type = WWT_EMPTY;
@@ -3267,7 +3267,7 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
         dropdown_set_disabled(DDIDX_INVENTIONS_LIST, true);
     }
 
-    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
         dropdown_set_disabled(DDIDX_CHEATS, true);
         dropdown_set_disabled(DDIDX_OBJECT_SELECTION, true);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -721,7 +721,6 @@ static void window_top_toolbar_invalidate(rct_window* w)
         window_top_toolbar_widgets[WIDX_GUESTS].type = WWT_EMPTY;
         window_top_toolbar_widgets[WIDX_FINANCES].type = WWT_EMPTY;
         window_top_toolbar_widgets[WIDX_RESEARCH].type = WWT_EMPTY;
-        window_top_toolbar_widgets[WIDX_CHEATS].type = WWT_EMPTY;
         window_top_toolbar_widgets[WIDX_NEWS].type = WWT_EMPTY;
         window_top_toolbar_widgets[WIDX_NETWORK].type = WWT_EMPTY;
 
@@ -3268,6 +3267,15 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
         dropdown_set_disabled(DDIDX_INVENTIONS_LIST, true);
     }
 
+    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+    {
+        dropdown_set_disabled(DDIDX_CHEATS, true);
+        dropdown_set_disabled(DDIDX_OBJECT_SELECTION, true);
+        dropdown_set_disabled(DDIDX_INVENTIONS_LIST, true);
+        dropdown_set_disabled(DDIDX_SCENARIO_OPTIONS, true);
+        dropdown_set_disabled(DDIDX_ENABLE_SANDBOX_MODE, true);
+    }
+
     if (gCheatsSandboxMode)
     {
         dropdown_set_checked(DDIDX_ENABLE_SANDBOX_MODE, true);
@@ -3281,7 +3289,10 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
         dropdown_set_checked(DDIDX_DISABLE_SUPPORT_LIMITS, true);
     }
 
-    gDropdownDefaultIndex = DDIDX_CHEATS;
+    if (!dropdown_is_disabled(DDIDX_CHEATS))
+        gDropdownDefaultIndex = DDIDX_CHEATS;
+    else
+        gDropdownDefaultIndex = DDIDX_TILE_INSPECTOR;
 }
 
 static void top_toolbar_cheats_menu_dropdown(int16_t dropdownIndex)

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -262,7 +262,7 @@ void GameState::UpdateLogic()
     sprite_misc_update_all();
     ride_update_all();
 
-    if (!(gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
+    if (!(gScreenFlags & SCREEN_FLAGS_EDITOR))
     {
         _park->Update(_date);
     }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1662,7 +1662,7 @@ void window_relocate_windows(int32_t width, int32_t height)
  */
 void window_resize_gui(int32_t width, int32_t height)
 {
-    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
         window_resize_gui_scenario_editor(width, height);
         return;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -435,7 +435,7 @@ void peep_update_all()
     uint16_t spriteIndex;
     Peep* peep;
 
-    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
         return;
 
     spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP];


### PR DESCRIPTION
This makes the cheats menu partially accessible in the scenario editor. Irrelevant items have been disabled.

![Screenshot_20190320_200259](https://user-images.githubusercontent.com/604665/54711952-61fb4b80-4b4b-11e9-90af-1705abdf2d86.png)

As the majority of the items are greyed out, it might be better to outright hide them instead. However, that would mean their dropdown indices change as well. I'm afraid that would make things a bit messier behind the scenes, so I've kept it like this, for now.

Fixes #8927.