### PR TITLE
Allow to use the numpad enter key.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#8873] Potential crash when placing footpaths.
 - Fix: [#8900] Peep tracking is not synchronized.
+- Improved: Allow the use of numpad enter key for console and chat.
 
 0.2.2 (2019-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -36,6 +36,7 @@ static void input_handle_console(int32_t key)
             input = CONSOLE_INPUT_LINE_CLEAR;
             break;
         case SDL_SCANCODE_RETURN:
+        case SDL_SCANCODE_KP_ENTER:
             input = CONSOLE_INPUT_LINE_EXECUTE;
             break;
         case SDL_SCANCODE_UP:
@@ -67,6 +68,7 @@ static void input_handle_chat(int32_t key)
             input = CHAT_INPUT_CLOSE;
             break;
         case SDL_SCANCODE_RETURN:
+        case SDL_SCANCODE_KP_ENTER:
             input = CHAT_INPUT_SEND;
             break;
     }


### PR DESCRIPTION
The chat and console did nothing when using the numpad enter key, this PR changes that, been nagging me for a while.