### PR TITLE
Fix bug #8942 by adding missing if statement

### DIFF
--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -87,7 +87,7 @@ private:
                 SurfaceElement* surfaceElement = tileElement->AsSurface();
                 uint8_t height = surfaceElement->GetWaterHeight();
 
-                if(surfaceElement->base_height > maxHeight)
+                if (surfaceElement->base_height > maxHeight)
                     continue;
 
                 if (height != 0)

--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -86,6 +86,10 @@ private:
 
                 SurfaceElement* surfaceElement = tileElement->AsSurface();
                 uint8_t height = surfaceElement->GetWaterHeight();
+
+                if(surfaceElement->base_height > maxHeight)
+                    continue;
+
                 if (height != 0)
                 {
                     height *= 2;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
A missing if statement caused the water levels to all rise proportionally on the first "rise" action. Should be fine now