### PR TITLE
Fix #7913: RCT1/RCT2 title sequence timing is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CMAKE_MACOSX_RPATH 1)
 
-set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip")
-set(TITLE_SEQUENCE_SHA1 "1136ef92bfb05cd1cba9831ba6dc4a653d87a246")
+set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2a/title-sequence-v0.1.2a.zip")
+set(TITLE_SEQUENCE_SHA1 "261a7185d8f60b90d1a390bf4e48a0c797b52e48")
 
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip")
 set(OBJECTS_SHA1 "0e88a1a6d845eb3a56ad68ecf60a9d6a4194250f")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#5579] Network desync immediately after connecting.
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
+- Fix: [#7913] RCT1/RCT2 title sequence timing is off.
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
 - Fix: [#8873] Potential crash when placing footpaths.
 - Fix: [#8882] Submarine Ride does not count as indoors (original bug).

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -68,8 +68,8 @@
     <GtestVersion>2fe3bd994b3189899d93f1d5a881e725e046fdc2</GtestVersion>
     <GtestUrl>https://github.com/google/googletest/archive/$(GtestVersion).zip</GtestUrl>
     <GtestSha1>058b9df80244c03f1633cb06e9f70471a29ebb8e</GtestSha1>
-    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip</TitleSequencesUrl>
-    <TitleSequencesSha1>1136ef92bfb05cd1cba9831ba6dc4a653d87a246</TitleSequencesSha1>
+    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2a/title-sequence-v0.1.2a.zip</TitleSequencesUrl>
+    <TitleSequencesSha1>261a7185d8f60b90d1a390bf4e48a0c797b52e48</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip</ObjectsUrl>
     <ObjectsSha1>0e88a1a6d845eb3a56ad68ecf60a9d6a4194250f</ObjectsSha1>
   </PropertyGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -22,8 +22,8 @@ let
   title-sequences-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "title-sequences";
-    rev = "v0.1.2";
-    sha256 = "1yb1ynkfmiankii3fngr9km5wbc07rp30nh0apkj6wryrhy7imgm";
+    rev = "v0.1.2a";
+    sha256 = "7536dbd7c8b91554306e5823128f6bb7e94862175ef09d366d25e4bce573d155";
 };
 in
 pkgs.stdenv.mkDerivation {

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -90,7 +90,7 @@ android.applicationVariants.all { variant ->
             dest "$variant.mergeAssets.outputDir/data"
         }
         download {
-            src 'https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip'
+            src 'https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2a/title-sequence-v0.1.2a.zip'
             dest new File(buildDir, 'title-sequence.zip')
         }
         copy {


### PR DESCRIPTION
The timing now matches perfectly (and having RCT1/RCT1AA/RCT1LL all ready was very handy).

Also made sure to sit through all of them to make sure that the updated scenario names are correct.


Removing the LOADMM and LOADRCT1 commands will be done in another PR.