### PR TITLE
Fix bug OpenRCT2#8219

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -240,16 +240,11 @@ static const char* getFilterPatternByType(const int32_t type, const bool isSave)
 static int32_t window_loadsave_get_dir(const int32_t type, char* path, size_t pathSize)
 {
     const char* last_save = getLastDirectoryByType(type);
-    if (last_save && platform_ensure_directory_exists(last_save))
+    // checks for path existance
+    if (platform_directory_exists(last_save))
         safe_strcpy(path, last_save, pathSize);
     else
         getInitialDirectoryByType(type, path, pathSize);
-
-    if (!platform_ensure_directory_exists(path))
-    {
-        log_error("Unable to create save directory.");
-        return 0;
-    }
 
     return 1;
 }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -242,6 +242,7 @@ static int32_t window_loadsave_get_dir(const int32_t type, char* path, size_t pa
     const char* last_save = getLastDirectoryByType(type);
     // checks for path existance
     if (platform_directory_exists(last_save))
+    //If the last saved path is found
         safe_strcpy(path, last_save, pathSize);
     else
         getInitialDirectoryByType(type, path, pathSize);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -244,7 +244,6 @@ static int32_t window_loadsave_get_dir(const int32_t type, char* path, size_t pa
         safe_strcpy(path, last_save, pathSize);
     else
         getInitialDirectoryByType(type, path, pathSize);
-    
     return 1;
 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -240,12 +240,11 @@ static const char* getFilterPatternByType(const int32_t type, const bool isSave)
 static int32_t window_loadsave_get_dir(const int32_t type, char* path, size_t pathSize)
 {
     const char* last_save = getLastDirectoryByType(type);
-    // checks for path existance.
     if (platform_directory_exists(last_save))
         safe_strcpy(path, last_save, pathSize);
     else
         getInitialDirectoryByType(type, path, pathSize);
-
+    
     return 1;
 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -240,7 +240,7 @@ static const char* getFilterPatternByType(const int32_t type, const bool isSave)
 static int32_t window_loadsave_get_dir(const int32_t type, char* path, size_t pathSize)
 {
     const char* last_save = getLastDirectoryByType(type);
-    if (platform_directory_exists(last_save))
+    if (last_save != nullptr && platform_directory_exists(last_save))
         safe_strcpy(path, last_save, pathSize);
     else
         getInitialDirectoryByType(type, path, pathSize);


### PR DESCRIPTION
This is another pull request, the previous one was closed. This fix is to prevent the game from automatically creating a new sub folder even though it was deleted. If the sub folder exists, then it will take you there when you try to load  game. If it was moved or deleted, then it takes you to the default path.