### PR TITLE
Fix non-networked game actions not showing errors.

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -363,7 +363,8 @@ namespace GameActions
         // In network mode the error should be only shown to the issuer of the action.
         if (network_get_mode() != NETWORK_MODE_NONE)
         {
-            if (action->GetPlayer() != network_get_current_player_id())
+            // Non-networked actions have the player id -1.
+            if (action->GetPlayer() != -1 && action->GetPlayer() != network_get_current_player_id())
             {
                 shouldShowError = false;
             }

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -309,8 +309,13 @@ namespace GameActions
                 if (network_get_mode() == NETWORK_MODE_SERVER)
                 {
                     NetworkPlayerId_t playerId = action->GetPlayer();
+                    int32_t playerIndex = -1;
 
-                    int32_t playerIndex = network_get_player_index(playerId.id);
+                    if (playerId == -1)
+                        playerIndex = 0; // Executed as host.
+                    else
+                        playerIndex = network_get_player_index(playerId.id);
+
                     Guard::Assert(playerIndex != -1);
 
                     network_set_player_last_action(playerIndex, action->GetType());

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -93,8 +93,8 @@ public:
 private:
     uint32_t const _type;
 
-    NetworkPlayerId_t _playerId = { 0 }; // Callee
-    uint32_t _flags = 0;                 // GAME_COMMAND_FLAGS
+    NetworkPlayerId_t _playerId = { -1 }; // Callee
+    uint32_t _flags = 0;                  // GAME_COMMAND_FLAGS
     uint32_t _networkId = 0;
     Callback_t _callback;
 


### PR DESCRIPTION
The player id should default to -1 on game actions which is currently considered an invalid player id, the server will assign the id when its networked back. So for errors to show up when the action won't make it to the server this condition has to be checked since currently it would test the default value 0 against player id 1.