### PR TITLE
Fix #8909: Potential crash when invoking game actions as server

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#8873] Potential crash when placing footpaths.
 - Fix: [#8882] Submarine Ride does not count as indoors (original bug).
 - Fix: [#8900] Peep tracking is not synchronized.
+- Fix: [#8909] Potential crash when invoking game actions as server.
 - Fix: [#8947] Detection of AVX2 support.
 - Improved: Allow the use of numpad enter key for console and chat.
 

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -93,8 +93,8 @@ public:
 private:
     uint32_t const _type;
 
-    NetworkPlayerId_t _playerId = { 0 }; // Callee
-    uint32_t _flags = 0;                 // GAME_COMMAND_FLAGS
+    NetworkPlayerId_t _playerId = { -1 }; // Callee
+    uint32_t _flags = 0;                  // GAME_COMMAND_FLAGS
     uint32_t _networkId = 0;
     Callback_t _callback;
 


### PR DESCRIPTION
This also supersedes #8984. Also got the chance to clean it up a bit.