### PR TITLE
Fix #8988: Improve lookups for codepoint offsets

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#8882] Submarine Ride does not count as indoors (original bug).
 - Fix: [#8900] Peep tracking is not synchronized.
 - Fix: [#8947] Detection of AVX2 support.
+- Fix: [#8988] Character sprite lookup noticeably slows down drawing.
 - Improved: Allow the use of numpad enter key for console and chat.
 
 0.2.2 (2019-03-13)

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -17,7 +17,7 @@
 #include "TTF.h"
 
 #include <iterator>
-#include <map>
+#include <unordered_map>
 
 static constexpr const int32_t SpriteFontLineHeight[FONT_SIZE_COUNT] = { 6, 10, 10 };
 
@@ -28,7 +28,7 @@ static uint8_t _additionalSpriteFontCharacterWidth[FONT_SIZE_COUNT][SPR_G2_GLYPH
 TTFFontSetDescriptor* gCurrentTTFFontSet;
 #endif // NO_TTF
 
-static const std::map<char32_t, int32_t> codepointOffsetMap = {
+static const std::unordered_map<char32_t, int32_t> codepointOffsetMap = {
     { UnicodeChar::ae_uc, SPR_G2_AE_UPPER - SPR_CHAR_START },
     { UnicodeChar::o_stroke_uc, SPR_G2_O_STROKE_UPPER - SPR_CHAR_START },
     { UnicodeChar::y_acute_uc, SPR_G2_Y_ACUTE_UPPER - SPR_CHAR_START },
@@ -197,12 +197,23 @@ static const std::map<char32_t, int32_t> codepointOffsetMap = {
     { UnicodeChar::superscript_minus_one, CSChar::superscript_minus_one - CS_SPRITE_FONT_OFFSET },
 };
 
+static char32_t _smallestCodepointValue = 0;
+static char32_t _biggestCodepointValue = 0;
+
 /**
  *
  *  rct2: 0x006C19AC
  */
 void font_sprite_initialise_characters()
 {
+    // Compute min and max that helps avoiding lookups for no reason.
+    _smallestCodepointValue = std::numeric_limits<char32_t>::max();
+    for (const auto entry : codepointOffsetMap)
+    {
+        _smallestCodepointValue = std::min(_smallestCodepointValue, entry.first);
+        _biggestCodepointValue = std::max(_biggestCodepointValue, entry.first);
+    }
+
     for (int32_t fontSize = 0; fontSize < FONT_SIZE_COUNT; fontSize++)
     {
         int32_t glyphOffset = fontSize * FONT_SPRITE_GLYPH_COUNT;
@@ -243,9 +254,14 @@ void font_sprite_initialise_characters()
 
 int32_t font_sprite_get_codepoint_offset(int32_t codepoint)
 {
-    auto result = codepointOffsetMap.find(codepoint);
-    if (result != codepointOffsetMap.end())
-        return result->second;
+    // Only search the table when its in range of the map.
+    if (static_cast<char32_t>(codepoint) >= _smallestCodepointValue
+        && static_cast<char32_t>(codepoint) <= _biggestCodepointValue)
+    {
+        auto result = codepointOffsetMap.find(codepoint);
+        if (result != codepointOffsetMap.end())
+            return result->second;
+    }
 
     if (codepoint < 32 || codepoint >= 256)
         codepoint = '?';


### PR DESCRIPTION
This change keeps the FPS constant at 40 on debug builds at 1920x1080. Park I used was Crazy Castle with nothing built and 10 Guests.