### PR TITLE
Fix #9000: Incomplete error message when placing track with insuffient money

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#8909] Potential crash when invoking game actions as server.
 - Fix: [#8947] Detection of AVX2 support.
 - Fix: [#8988] Character sprite lookup noticeably slows down drawing.
+- Fix: [#9000] Show correct error message if not enough money available.
 - Improved: Allow the use of numpad enter key for console and chat.
 
 0.2.2 (2019-03-13)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1801,7 +1801,16 @@ static void window_ride_construction_construct(rct_window* w)
     }
     auto res = GameActions::Execute(&trackPlaceAction);
     // Used by some functions
-    _trackPlaceCost = res->Error == GA_ERROR::OK ? res->Cost : MONEY32_UNDEFINED;
+    if (res->Error != GA_ERROR::OK)
+    {
+        gGameCommandErrorText = res->ErrorMessage;
+        _trackPlaceCost = MONEY32_UNDEFINED;
+    }
+    else
+    {
+        gGameCommandErrorText = STR_NONE;
+        _trackPlaceCost = res->Cost;
+    }
 
     if (res->Error != GA_ERROR::OK)
     {


### PR DESCRIPTION
This is caused because game actions don't require to assign gGameCommandErrorText, there is a loop that would try to place the track/ride with multiple attempts and checks gGameCommandErrorText if its supposed to stop trying. I simply assign the error message to gGameCommandErrorText if the action fails now.