### PR TITLE
Updated KeyboardShortcuts.cpp

### DIFF
--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -169,27 +169,19 @@ void KeyboardShortcuts::GetKeyboardMapScroll(const uint8_t* keysState, int32_t* 
         if (!keysState[scancode])
             continue;
 
-        if (shortcutKey & SHIFT)
-        {
-            if (!keysState[SDL_SCANCODE_LSHIFT] && !keysState[SDL_SCANCODE_RSHIFT])
-                continue;
-        }
-        if (shortcutKey & CTRL)
-        {
-            if (!keysState[SDL_SCANCODE_LCTRL] && !keysState[SDL_SCANCODE_RCTRL])
-                continue;
-        }
-        if (shortcutKey & ALT)
-        {
-            if (!keysState[SDL_SCANCODE_LALT] && !keysState[SDL_SCANCODE_RALT])
-                continue;
-        }
+        if ((bool)(shortcutKey & SHIFT) !=
+            (keysState[SDL_SCANCODE_LSHIFT] || keysState[SDL_SCANCODE_RSHIFT]))
+            continue;
+        if ((bool)(shortcutKey & CTRL) !=
+            (keysState[SDL_SCANCODE_LCTRL] || keysState[SDL_SCANCODE_RCTRL]))
+            continue;
+        if ((bool)(shortcutKey & ALT) !=
+            (keysState[SDL_SCANCODE_LALT] || keysState[SDL_SCANCODE_RALT]))
+            continue;
 #ifdef __MACOSX__
-        if (shortcutKey & CMD)
-        {
-            if (!keysState[SDL_SCANCODE_LGUI] && !keysState[SDL_SCANCODE_RGUI])
-                continue;
-        }
+        if ((bool)(shortcutKey & CMD) !=
+            (keysState[SDL_SCANCODE_LGUI] || keysState[SDL_SCANCODE_RGUI]))
+            continue;
 #endif
         switch (shortcutId)
         {

--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -169,18 +169,14 @@ void KeyboardShortcuts::GetKeyboardMapScroll(const uint8_t* keysState, int32_t* 
         if (!keysState[scancode])
             continue;
 
-        if ((bool)(shortcutKey & SHIFT) !=
-            (keysState[SDL_SCANCODE_LSHIFT] || keysState[SDL_SCANCODE_RSHIFT]))
+        if ((bool)(shortcutKey & SHIFT) != (keysState[SDL_SCANCODE_LSHIFT] || keysState[SDL_SCANCODE_RSHIFT]))
             continue;
-        if ((bool)(shortcutKey & CTRL) !=
-            (keysState[SDL_SCANCODE_LCTRL] || keysState[SDL_SCANCODE_RCTRL]))
+        if ((bool)(shortcutKey & CTRL) != (keysState[SDL_SCANCODE_LCTRL] || keysState[SDL_SCANCODE_RCTRL]))
             continue;
-        if ((bool)(shortcutKey & ALT) !=
-            (keysState[SDL_SCANCODE_LALT] || keysState[SDL_SCANCODE_RALT]))
+        if ((bool)(shortcutKey & ALT) != (keysState[SDL_SCANCODE_LALT] || keysState[SDL_SCANCODE_RALT]))
             continue;
 #ifdef __MACOSX__
-        if ((bool)(shortcutKey & CMD) !=
-            (keysState[SDL_SCANCODE_LGUI] || keysState[SDL_SCANCODE_RGUI]))
+        if ((bool)(shortcutKey & CMD) != (keysState[SDL_SCANCODE_LGUI] || keysState[SDL_SCANCODE_RGUI]))
             continue;
 #endif
         switch (shortcutId)

--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -169,6 +169,8 @@ void KeyboardShortcuts::GetKeyboardMapScroll(const uint8_t* keysState, int32_t* 
         if (!keysState[scancode])
             continue;
 
+        // Check if SHIFT is either set in the shortcut key and currently, 
+        // or not set in the shortcut key and not currently pressed (in other words: check if they match).
         if ((bool)(shortcutKey & SHIFT) != (keysState[SDL_SCANCODE_LSHIFT] || keysState[SDL_SCANCODE_RSHIFT]))
             continue;
         if ((bool)(shortcutKey & CTRL) != (keysState[SDL_SCANCODE_LCTRL] || keysState[SDL_SCANCODE_RCTRL]))


### PR DESCRIPTION
Fix for scroll shortcut keys like Scroll right/left/up/down keys ignore SHIFT/CTRL/ALT modifiers. Applied fixed code given and shown in OpenRCT2#7878.