### PR TITLE
Don't store multithreading option permanently.

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3753,7 +3753,7 @@ STR_6302    :{SMALLFONT}{BLACK}Copy the entire list of missing objects to the cl
 STR_6303    :Downloading object ({COMMA16} / {COMMA16}): [{STRING}]
 STR_6304    :Open scenery picker
 STR_6305    :Multithreading
-STR_6306    :{SMALLFONT}{BLACK}Use multiple threads to render
+STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 
 #############
 # Scenarios #

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -195,7 +195,7 @@ namespace Config
             model->window_scale = reader->GetFloat("window_scale", platform_get_default_scale());
             model->scale_quality = reader->GetEnum<int32_t>("scale_quality", SCALE_QUALITY_SMOOTH_NN, Enum_ScaleQuality);
             model->show_fps = reader->GetBoolean("show_fps", false);
-            model->multithreading = reader->GetBoolean("multithreading", true);
+            model->multithreading = reader->GetBoolean("multi_threading", false);
             model->trap_cursor = reader->GetBoolean("trap_cursor", false);
             model->auto_open_shops = reader->GetBoolean("auto_open_shops", false);
             model->scenario_select_mode = reader->GetInt32("scenario_select_mode", SCENARIO_SELECT_MODE_ORIGIN);
@@ -269,7 +269,7 @@ namespace Config
         writer->WriteFloat("window_scale", model->window_scale);
         writer->WriteEnum<int32_t>("scale_quality", model->scale_quality, Enum_ScaleQuality);
         writer->WriteBoolean("show_fps", model->show_fps);
-        writer->WriteBoolean("multithreading", model->multithreading);
+        writer->WriteBoolean("multi_threading", model->multithreading);
         writer->WriteBoolean("trap_cursor", model->trap_cursor);
         writer->WriteBoolean("auto_open_shops", model->auto_open_shops);
         writer->WriteInt32("scenario_select_mode", model->scenario_select_mode);


### PR DESCRIPTION
I need to look at all the bugs that have been submitted and come up with better automated tests regarding languages like Korean that use TTF rendering.