### PR TITLE
Hungarian Forint fix

### DIFF
--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -31,7 +31,7 @@ currency_descriptor CurrencyDescriptors[CURRENCY_END] = {
     {   "HKD",  100,    CURRENCY_PREFIX,    "$",            CURRENCY_PREFIX,    "HKD",  STR_HONG_KONG_DOLLAR},  // Hong Kong Dollar
     {   "TWD",  1000,   CURRENCY_PREFIX,    "NT$",          CURRENCY_PREFIX,    "NT$",  STR_NEW_TAIWAN_DOLLAR}, // New Taiwan Dollar
     {   "CNY",  100,    CURRENCY_PREFIX,    "CN\xC2\xA5",   CURRENCY_PREFIX,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
-    {   "HUF",  1000,   CURRENCY_PREFIX,    "Ft",           CURRENCY_PREFIX,    "Ft",   STR_HUNGARIAN_FORINT},  // Hungarian Forint
+    {   "HUF",  1000,   CURRENCY_SUFFIX,    " Ft",          CURRENCY_SUFFIX,    " Ft",  STR_HUNGARIAN_FORINT},  // Hungarian Forint
     {   "CTM",  10,     CURRENCY_PREFIX,    "Ctm",          CURRENCY_PREFIX,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
 };
 // clang-format on


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Hungarian_forint

> The Hungarian abbreviation for forint is Ft, which is written after the number with a space between.