### PR TITLE
Fix #9068: Unable to place staff or peeps during multiplayer

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1934,7 +1934,13 @@ void Network::ProcessPlayerInfo()
         auto* player = GetPlayerByID(it->second.Id);
         if (player != nullptr)
         {
-            *player = it->second;
+            const NetworkPlayer& networkedInfo = it->second;
+            player->Flags = networkedInfo.Flags;
+            player->Group = networkedInfo.Group;
+            player->LastAction = networkedInfo.LastAction;
+            player->LastActionCoord = networkedInfo.LastActionCoord;
+            player->MoneySpent = networkedInfo.MoneySpent;
+            player->CommandsRan = networkedInfo.CommandsRan;
         }
     }
     _pendingPlayerInfo.erase(gCurrentTicks);


### PR DESCRIPTION
Small regression from #8905 as it didn't network the player pickup info. Also the reason is for try_get_sprite is that this info can be sen't before the map is fully loaded which would just trigger an assert otherwise.