### PR TITLE
Fix 9079

### DIFF
--- a/src/openrct2/actions/BannerSetStyleAction.hpp
+++ b/src/openrct2/actions/BannerSetStyleAction.hpp
@@ -96,6 +96,11 @@ public:
                 }
                 break;
             case BannerSetStyleType::NoEntry:
+                if (tileElement->AsBanner() == nullptr)
+                {
+                    log_error("Tile element was not a banner.");
+                    return MakeResult(GA_ERROR::UNKNOWN, STR_NONE);
+                }
                 break;
             default:
                 log_error("Invalid type: %u", _type);
@@ -161,6 +166,12 @@ public:
             case BannerSetStyleType::NoEntry:
             {
                 BannerElement* bannerElement = tileElement->AsBanner();
+                if (bannerElement == nullptr)
+                {
+                    log_error("Tile element was not a banner.");
+                    return MakeResult(GA_ERROR::UNKNOWN, STR_NONE);
+                }
+
                 banner->flags &= ~BANNER_FLAG_NO_ENTRY;
                 banner->flags |= (_parameter != 0) ? BANNER_FLAG_NO_ENTRY : 0;
                 uint8_t allowedEdges = 0xF;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Small mistake as `banner_get_tile_element` does not just return banner elements. It can also be small / large scenery with banners.