### PR TITLE
Issue #7729: Money Input Prompt break on certain values fix

### DIFF
--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -35,9 +35,9 @@
 #include <iterator>
 #include <limits.h>
 
-char gCommonStringFormatBuffer[512];
-uint8_t gCommonFormatArgs[80];
-uint8_t gMapTooltipFormatArgs[40];
+thread_local char gCommonStringFormatBuffer[512];
+thread_local uint8_t gCommonFormatArgs[80];
+thread_local uint8_t gMapTooltipFormatArgs[40];
 
 #ifdef DEBUG
 // Set to true before a string format call to see details of the formatting.

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -35,9 +35,9 @@
 #include <iterator>
 #include <limits.h>
 
-thread_local char gCommonStringFormatBuffer[512];
-thread_local uint8_t gCommonFormatArgs[80];
-thread_local uint8_t gMapTooltipFormatArgs[40];
+char gCommonStringFormatBuffer[512];
+uint8_t gCommonFormatArgs[80];
+uint8_t gMapTooltipFormatArgs[40];
 
 #ifdef DEBUG
 // Set to true before a string format call to see details of the formatting.
@@ -1512,8 +1512,9 @@ money32 string_to_money(const char* string_to_monetise)
 
     auto number = std::stod(processedString, nullptr);
     number /= (currencyDesc->rate / 10.0);
-    auto whole = static_cast<uint16_t>(number);
-    auto fraction = static_cast<uint8_t>((number - whole) * 100);
+    auto whole = static_cast<int32_t>(number);
+    auto rounded = (static_cast<uint32_t>(number * 100 + .5) - (whole * 100)) / 100.0;
+    auto fraction = static_cast<uint8_t>(rounded * 100);
 
     money32 result = MONEY(whole, fraction);
     // Check if MONEY resulted in overflow


### PR DESCRIPTION
Fixed errors in the string_to_money function that caused larger input values to not be properly converted and caused decimal values of 10 to not get carried through the conversion (ex. 4.10 -> 4.00).

Additional commit was done to add "thread_local" back to variables that lost it for an unknown reason.