### PR TITLE
Fix #9083: Wrong sign index is set for clients

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "18"
+#define NETWORK_STREAM_VERSION "19"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1976,6 +1976,17 @@ void Network::ProcessGameCommands()
 
         if (gc.action != nullptr)
         {
+            // Remove ghost scenery so it doesn't interfere with incoming network command
+            switch (gc.action->GetType())
+            {
+                case GAME_COMMAND_PLACE_WALL:
+                case GAME_COMMAND_PLACE_LARGE_SCENERY:
+                case GAME_COMMAND_PLACE_BANNER:
+                case GAME_COMMAND_PLACE_SCENERY:
+                    scenery_remove_ghost_tool_placement();
+                    break;
+            }
+
             GameAction* action = gc.action.get();
             action->SetFlags(action->GetFlags() | GAME_COMMAND_FLAG_NETWORKED);
 


### PR DESCRIPTION
This issue was caused by the ghost for banners, which already create an entry on the banner. The game command is then received while the ghost still exists, giving the placed banner another ID.

This fix is basically a copy a workaround from `game_do_command_p` that tackles this same issue. Having moved over the `GAME_COMMAND_PLACE_LARGE_SCENERY` command to game actions, this fix was no longer working.

https://github.com/OpenRCT2/OpenRCT2/blob/8632eb7297de719f6f192fe34eeac6173bd6aa00/src/openrct2/Game.cpp#L411-L414