### PR TITLE
Fix #7729: Money Input Prompt breaks on certain values

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,7 +7,7 @@
 - Fix: [#5579] Network desync immediately after connecting.
 - Fix: [#5905] Urban Park merry-go-round has entrance and exit swapped (original bug).
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
-- Fix: [#7729] Money Input Prompt break on certain values.
+- Fix: [#7729] Money Input Prompt breaks on certain values.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
 - Fix: [#8219] Faulty folder recreation in "save" folder.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#5579] Network desync immediately after connecting.
 - Fix: [#5905] Urban Park merry-go-round has entrance and exit swapped (original bug).
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
+- Fix: [#7729] Money Input Prompt break on certain values.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
 - Fix: [#8219] Faulty folder recreation in "save" folder.

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -34,6 +34,7 @@
 #include <ctype.h>
 #include <iterator>
 #include <limits.h>
+#include <cmath>
 
 char gCommonStringFormatBuffer[512];
 uint8_t gCommonFormatArgs[80];
@@ -1513,7 +1514,7 @@ money32 string_to_money(const char* string_to_monetise)
     auto number = std::stod(processedString, nullptr);
     number /= (currencyDesc->rate / 10.0);
     auto whole = static_cast<uint16_t>(number);
-    auto fraction = static_cast<uint8_t>((number - whole) * 100);
+    auto fraction = static_cast<uint8_t>(ceil((number - whole) * 100.0));
 
     money32 result = MONEY(whole, fraction);
     // Check if MONEY resulted in overflow

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -30,11 +30,11 @@
 #include "Localisation.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <ctype.h>
 #include <iterator>
 #include <limits.h>
-#include <cmath>
 
 char gCommonStringFormatBuffer[512];
 uint8_t gCommonFormatArgs[80];

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -1513,7 +1513,7 @@ money32 string_to_money(const char* string_to_monetise)
 
     auto number = std::stod(processedString, nullptr);
     number /= (currencyDesc->rate / 10.0);
-    auto whole = static_cast<uint16_t>(number);
+    auto whole = static_cast<int32_t>(number);
     auto fraction = static_cast<uint8_t>(ceil((number - whole) * 100.0));
 
     money32 result = MONEY(whole, fraction);


### PR DESCRIPTION
This fixes both issues; even very high amounts like 10,000,000 are now processed correctly.