### PR TITLE
Fix #8079: Crash when unloading buggy custom rides

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
+- Fix: [#8079, #8969] Crash when unloading buggy custom rides.
 - Fix: [#8219] Faulty folder recreation in "save" folder.
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
 - Fix: [#8649] Setting date does not work in multiplayer.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,7 +13,7 @@
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
-- Fix: [#8079, #8969] Crash when unloading buggy custom rides.
+- Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
 - Fix: [#8219] Faulty folder recreation in "save" folder.
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
 - Fix: [#8649] Setting date does not work in multiplayer.

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -4049,6 +4049,12 @@ void Guest::UpdateRideLeaveVehicle()
                     break;
             }
         }
+        else
+        {
+            log_verbose(
+                "current_seat %d is too large! (Vehicle entry has room for %d.)", current_seat,
+                vehicle_entry->peep_loading_positions.size());
+        }
 
         platformLocation.z = ride->stations[current_ride_station].Height * 8;
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -4028,22 +4028,26 @@ void Guest::UpdateRideLeaveVehicle()
         platformLocation.x = vehicle->x + word_981D6C[platformLocation.direction].x * 12;
         platformLocation.y = vehicle->y + word_981D6C[platformLocation.direction].y * 12;
 
-        int8_t loadPosition = vehicle_entry->peep_loading_positions[current_seat];
-
-        switch (vehicle->sprite_direction / 8)
+        // This can evaluate to false with buggy custom rides.
+        if (current_seat < vehicle_entry->peep_loading_positions.size())
         {
-            case 0:
-                platformLocation.x -= loadPosition;
-                break;
-            case 1:
-                platformLocation.y += loadPosition;
-                break;
-            case 2:
-                platformLocation.x += loadPosition;
-                break;
-            case 3:
-                platformLocation.y -= loadPosition;
-                break;
+            int8_t loadPosition = vehicle_entry->peep_loading_positions[current_seat];
+
+            switch (vehicle->sprite_direction / 8)
+            {
+                case 0:
+                    platformLocation.x -= loadPosition;
+                    break;
+                case 1:
+                    platformLocation.y += loadPosition;
+                    break;
+                case 2:
+                    platformLocation.x += loadPosition;
+                    break;
+                case 3:
+                    platformLocation.y -= loadPosition;
+                    break;
+            }
         }
 
         platformLocation.z = ride->stations[current_ride_station].Height * 8;


### PR DESCRIPTION
Also fixes https://github.com/OpenRCT2/OpenRCT2/issues/8969, #7700 and https://openrct2.org/forums/topic/3642-crashing-when-playing-files/ .

Possibly also https://github.com/OpenRCT2/OpenRCT2/issues/8958 -- but that has missing objects that NE does not have.