### PR TITLE
 Fix #9124: Disconnected clients crashing the server

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#8947] Detection of AVX2 support.
 - Fix: [#8988] Character sprite lookup noticeably slows down drawing.
 - Fix: [#9000] Show correct error message if not enough money available.
+- Fix: [#9124] Disconnected clients can crash the server.
 - Fix: [#9132] System file browser cannot open SV4 files.
 - Fix: [#9152] Spectators can modify ride colours.
 - Fix: [#9202] Artefacts show when changing ride type as client or using in-game console.

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -35,6 +35,7 @@ public:
     NetworkKey Key;
     std::vector<uint8_t> Challenge;
     std::vector<const ObjectRepositoryItem*> RequestedObjects;
+    bool IsDisconnected = false;
 
     NetworkConnection();
     ~NetworkConnection();


### PR DESCRIPTION
I made sure the correct order is now in place, first the game actions/commands are executed, then the player information if any and then the player list if it needs to. Also it was possible that one of the player list updates was skipped if two packets arrived at the same tick, it would have processed only the last one. I also made sure that only one player list update is now sent to the clients per tick which saves some bandwidth and makes it deterministic at when its sent.