### PR TITLE
Allow disabling of scroll-wheel zooming

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3756,7 +3756,7 @@ STR_6305    :Multithreading
 STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
 STR_6308    :Scroll wheel behaviour:
-STR_6309    :Zoom From Centere of Screen
+STR_6309    :Zoom from centre of screen
 STR_6310    :Disabled
 STR_6311    :{SMALLFONT}{BLACK}When zooming in/out with the scroll wheel, whether to zoom at the cursor or screen centre. If set to "Disabled", scrolling will not zoom in/out (reccommended for trackpad users).
 

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3755,6 +3755,8 @@ STR_6304    :Open scenery picker
 STR_6305    :Multithreading
 STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
+STR_6308    :Trackpad Mode
+STR_6309    :When enabled, scrollling up/down will not zoom in/out
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3353,7 +3353,7 @@ STR_5902    :Show bounding boxes
 STR_5903    :Show paint debug window
 STR_5904    :Reset date
 STR_5905    :{SMALLFONT}{BLACK}A map generation tool that automatically creates a custom landscape
-STR_5906    :Zoom to cursor position
+STR_5906    :Zoom from cursor position
 STR_5907    :{SMALLFONT}{BLACK}When enabled, zooming in will centre around the cursor, as opposed to the screen centre.
 STR_5908    :Allow arbitrary ride type changes
 STR_5909    :{SMALLFONT}{BLACK}Allows changing ride type freely. May cause crashes.
@@ -3755,8 +3755,11 @@ STR_6304    :Open scenery picker
 STR_6305    :Multithreading
 STR_6306    :{SMALLFONT}{BLACK}Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
-STR_6308    :Trackpad Mode
-STR_6309    :When enabled, scrollling up/down will not zoom in/out
+STR_6308    :Scroll wheel behaviour:
+STR_6309    :Zoom From Centere of Screen
+STR_6310    :Disabled
+STR_6311    :{SMALLFONT}{BLACK}When zooming in/out with the scroll wheel, whether to zoom at the cursor or screen centre. If set to "Disabled", scrolling will not zoom in/out (reccommended for trackpad users).
+
 
 #############
 # Scenarios #

--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -924,11 +924,6 @@ STR_6206    :Gray stucco
 STR_6212    :Gray sandstone
 STR_6274    :Can't set color scheme...
 
-STR_6308    :Scroll wheel behavior:
-STR_6309    :Zoom from center of screen
-STR_6310    :Disabled
-STR_6311    :{SMALLFONT}{BLACK}When zooming in/out with the scroll wheel, whether to zoom at the cursor or screen center. If set to "Disabled", scrolling will not zoom in/out (reccommended for trackpad users).
-
 #############
 # Scenarios #
 #############

--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -924,6 +924,11 @@ STR_6206    :Gray stucco
 STR_6212    :Gray sandstone
 STR_6274    :Can't set color scheme...
 
+STR_6308    :Scroll wheel behavior:
+STR_6309    :Zoom from center of screen
+STR_6310    :Disabled
+STR_6311    :{SMALLFONT}{BLACK}When zooming in/out with the scroll wheel, whether to zoom at the cursor or screen center. If set to "Disabled", scrolling will not zoom in/out (reccommended for trackpad users).
+
 #############
 # Scenarios #
 #############

--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -108,7 +108,9 @@ static void game_handle_key_scroll()
     {
         window_unfollow_sprite(mainWindow);
     }
+    //scrollZOOM
     input_scroll_viewport(scrollX, scrollY);
+    //printf("scroll");
 }
 
 static int32_t input_scancode_to_rct_keycode(int32_t sdl_key)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -435,10 +435,13 @@ static void window_viewport_wheel_input(rct_window* w, int32_t wheel)
 {
     if (gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO))
         return;
-    if (wheel < 0 && !gConfigGeneral.scroll_wheel_behaviour == 0)
+    if (gConfigGeneral.scroll_wheel_behaviour != 0 )
+    {
+    if (wheel < 0)
         window_zoom_in(w, true);
-    else if (wheel > 0 && !gConfigGeneral.scroll_wheel_behaviour == 0)
+    else if (wheel > 0)
         window_zoom_out(w, true);
+    }
 }
 
 static bool window_other_wheel_input(rct_window* w, rct_widgetindex widgetIndex, int32_t wheel)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -435,9 +435,9 @@ static void window_viewport_wheel_input(rct_window* w, int32_t wheel)
 {
     if (gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO))
         return;
-    if (wheel < 0 && !gConfigGeneral.disable_scroll_zoom)
+    if (wheel < 0 && !gConfigGeneral.scroll_wheel_behaviour == 0)
         window_zoom_in(w, true);
-    else if (wheel > 0 && !gConfigGeneral.disable_scroll_zoom)
+    else if (wheel > 0 && !gConfigGeneral.scroll_wheel_behaviour == 0)
         window_zoom_out(w, true);
 }
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -435,10 +435,9 @@ static void window_viewport_wheel_input(rct_window* w, int32_t wheel)
 {
     if (gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO))
         return;
-
-    if (wheel < 0)
+    if (wheel < 0 && !gConfigGeneral.disable_scroll_zoom)
         window_zoom_in(w, true);
-    else if (wheel > 0)
+    else if (wheel > 0 && !gConfigGeneral.disable_scroll_zoom)
         window_zoom_out(w, true);
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -427,9 +427,9 @@ static constexpr const rct_string_id window_options_fullscreen_mode_names[] = {
     STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
 };
 static constexpr const rct_string_id window_options_scroll_mode_names[] = {
+    STR_SCROLL_MODE_DISABLED,
     STR_SCROLL_MODE_STANDARD,
     STR_ZOOM_TO_CURSOR,
-    STR_SCROLL_MODE_DISABLED,
 };
 
 const int32_t window_options_tab_animation_divisor[] =
@@ -1588,21 +1588,16 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
             switch (widgetIndex)
             {
                 case WIDX_SCROLL_MODE_DROPDOWN :
-                    if (dropdownIndex == 0)
-                    {
-                        gConfigGeneral.zoom_to_cursor = false;
-                        gConfigGeneral.disable_scroll_zoom = false;
-                        
-                    }
-                    if (dropdownIndex == 1)
-                    {
-                        gConfigGeneral.zoom_to_cursor = true;
-                        gConfigGeneral.disable_scroll_zoom = false;
-                    }
-                    if (dropdownIndex == 2)
-                    {
-                        gConfigGeneral.zoom_to_cursor = false;
-                        gConfigGeneral.disable_scroll_zoom = true;
+                    switch (dropdownIndex) {
+                        case 0:
+                            gConfigGeneral.scroll_wheel_behaviour = 0;
+                            break;
+                        case 1:
+                            gConfigGeneral.scroll_wheel_behaviour = 1;
+                            break;
+                        case 2:
+                            gConfigGeneral.scroll_wheel_behaviour = 2;
+                            break;
                     }
                     config_save_default();
                     window_invalidate(w);
@@ -1913,18 +1908,7 @@ static void window_options_invalidate(rct_window* w)
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_MUTE, gConfigInterface.toolbar_show_mute);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_CHAT, gConfigInterface.toolbar_show_chat);
             
-            if (gConfigGeneral.zoom_to_cursor == false && gConfigGeneral.disable_scroll_zoom == false)
-            {
-                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE_STANDARD;
-            }
-            if (gConfigGeneral.zoom_to_cursor == true && gConfigGeneral.disable_scroll_zoom == false)
-            {
-                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_ZOOM_TO_CURSOR;
-            }
-            if (gConfigGeneral.disable_scroll_zoom == true)
-            {
-                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE_DISABLED;
-            }
+            window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = window_options_scroll_mode_names[gConfigGeneral.scroll_wheel_behaviour];
             
             //window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE;
             

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -137,10 +137,10 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     // Controls and interface
     WIDX_CONTROLS_GROUP = WIDX_PAGE_START,
     WIDX_SCREEN_EDGE_SCROLLING,
-    WIDX_DISABLE_SCROLL_ZOOM,
     WIDX_TRAP_CURSOR,
     WIDX_INVERT_DRAG,
-    WIDX_ZOOM_TO_CURSOR,
+    WIDX_SCROLL_MODE,
+    WIDX_SCROLL_MODE_DROPDOWN,
     WIDX_HOTKEY_DROPDOWN,
     WIDX_THEMES_GROUP,
     WIDX_THEMES,
@@ -303,21 +303,21 @@ static rct_widget window_options_audio_widgets[] = {
 static rct_widget window_options_controls_and_interface_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
 #define CONTROLS_GROUP_START 53
-    { WWT_GROUPBOX,         1,  5,      304,    CONTROLS_GROUP_START + 0,    CONTROLS_GROUP_START + 104,   STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
+    { WWT_GROUPBOX,         1,  5,      304,    CONTROLS_GROUP_START + 0,    CONTROLS_GROUP_START + 90,   STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
     { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 13,   CONTROLS_GROUP_START + 26,   STR_SCREEN_EDGE_SCROLLING,              STR_SCREEN_EDGE_SCROLLING_TIP },            // Edge scrolling
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 30, CONTROLS_GROUP_START + 41, STR_DISABLE_SCROLL_ZOOM, STR_DISABLE_SCROLL_ZOOM_TIP },                             //Trackpad Mode
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 45,   CONTROLS_GROUP_START + 56,   STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 60,   CONTROLS_GROUP_START + 71,   STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 75,   CONTROLS_GROUP_START + 87,   STR_ZOOM_TO_CURSOR,                     STR_ZOOM_TO_CURSOR_TIP },                   // Zoom to cursor
-    { WWT_BUTTON,           1,  155,    299,    CONTROLS_GROUP_START + 90,   CONTROLS_GROUP_START + 100,   STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 30,   CONTROLS_GROUP_START + 41,   STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 45,   CONTROLS_GROUP_START + 56,   STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
+    { WWT_DROPDOWN,         1,  135,    299,    CONTROLS_GROUP_START + 60,  CONTROLS_GROUP_START + 71, STR_SCROLL_MODE,                             STR_NONE},
+    { WWT_BUTTON,           1,  288,    298,    CONTROLS_GROUP_START + 61,  CONTROLS_GROUP_START + 70, STR_DROPDOWN_GLYPH,                     STR_SCROLL_MODE_TIP },
+    { WWT_BUTTON,           1,  155,    299,    CONTROLS_GROUP_START + 74,   CONTROLS_GROUP_START + 86,   STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
 #undef CONTROLS_GROUP_START
-#define THEMES_GROUP_START 159
-    { WWT_GROUPBOX,         1,  5,      304,    THEMES_GROUP_START + 0,      THEMES_GROUP_START + 47,     STR_THEMES_GROUP,                       STR_NONE },                                 // Toolbar buttons group
+#define THEMES_GROUP_START 147
+    { WWT_GROUPBOX,         1,  5,      304,    THEMES_GROUP_START + 0,      THEMES_GROUP_START + 46,     STR_THEMES_GROUP,                       STR_NONE },                                 // Toolbar buttons group
     { WWT_DROPDOWN,         1,  155,    299,    THEMES_GROUP_START + 14,     THEMES_GROUP_START + 25,     STR_STRING,                             STR_NONE },                                 // Themes
     { WWT_BUTTON,           1,  288,    298,    THEMES_GROUP_START + 15,     THEMES_GROUP_START + 24,     STR_DROPDOWN_GLYPH,                     STR_CURRENT_THEME_TIP },
     { WWT_BUTTON,           1,  155,    299,    THEMES_GROUP_START + 30,     THEMES_GROUP_START + 42,     STR_EDIT_THEMES_BUTTON,                 STR_EDIT_THEMES_BUTTON_TIP },               // Themes button
 #undef THEMES_GROUP_START
-#define TOOLBAR_GROUP_START 209
+#define TOOLBAR_GROUP_START 197
     { WWT_GROUPBOX,         1,  5,      304,    TOOLBAR_GROUP_START + 0,     TOOLBAR_GROUP_START + 75,    STR_TOOLBAR_BUTTONS_GROUP,              STR_NONE },                                 // Toolbar buttons group
     { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 31,    TOOLBAR_GROUP_START + 42,    STR_FINANCES_BUTTON_ON_TOOLBAR,         STR_FINANCES_BUTTON_ON_TOOLBAR_TIP },       // Finances
     { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 46,    TOOLBAR_GROUP_START + 57,    STR_RESEARCH_BUTTON_ON_TOOLBAR,         STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP },       // Research
@@ -425,6 +425,11 @@ static constexpr const rct_string_id window_options_fullscreen_mode_names[] = {
     STR_OPTIONS_DISPLAY_WINDOWED,
     STR_OPTIONS_DISPLAY_FULLSCREEN,
     STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
+};
+static constexpr const rct_string_id window_options_scroll_mode_names[] = {
+    STR_SCROLL_MODE_STANDARD,
+    STR_ZOOM_TO_CURSOR,
+    STR_SCROLL_MODE_DISABLED,
 };
 
 const int32_t window_options_tab_animation_divisor[] =
@@ -573,10 +578,10 @@ static uint64_t window_options_page_enabled_widgets[] = {
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_SCREEN_EDGE_SCROLLING) |
-    (1 << WIDX_DISABLE_SCROLL_ZOOM) |
     (1 << WIDX_TRAP_CURSOR) |
     (1 << WIDX_INVERT_DRAG) |
-    (1 << WIDX_ZOOM_TO_CURSOR) |
+    (1 << WIDX_SCROLL_MODE) |
+    (1 << WIDX_SCROLL_MODE_DROPDOWN) |
     (1 << WIDX_HOTKEY_DROPDOWN) |
     (1 << WIDX_TOOLBAR_SHOW_FINANCES) |
     (1 << WIDX_TOOLBAR_SHOW_RESEARCH) |
@@ -825,20 +830,10 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     config_save_default();
                     window_invalidate(w);
                     break;
-                case WIDX_DISABLE_SCROLL_ZOOM:
-                    gConfigGeneral.disable_scroll_zoom ^=1;
-                    config_save_default();
-                    window_invalidate(w);
-                    break;
                 case WIDX_TRAP_CURSOR:
                     gConfigGeneral.trap_cursor ^= 1;
                     config_save_default();
                     context_set_cursor_trap(gConfigGeneral.trap_cursor);
-                    window_invalidate(w);
-                    break;
-                case WIDX_ZOOM_TO_CURSOR:
-                    gConfigGeneral.zoom_to_cursor ^= 1;
-                    config_save_default();
                     window_invalidate(w);
                     break;
                 case WIDX_TOOLBAR_SHOW_FINANCES:
@@ -1274,6 +1269,20 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
             switch (widgetIndex)
             {
+                case WIDX_SCROLL_MODE_DROPDOWN:
+                    num_items = 3;
+                    for (size_t i = 0; i < num_items; i++)
+                    {
+                        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
+                        gDropdownItemsArgs[i] = window_options_scroll_mode_names[i];
+                    }
+                    
+                    window_options_show_dropdown(w, widget, num_items);
+                    
+                   // dropdown_set_checked(gConfigSound.title_music, true);
+                    
+                   // dropdown_set_checked((int32_t)theme_manager_get_active_available_theme_index(), true);
+                    break;
                 case WIDX_THEMES_DROPDOWN:
                     num_items = (uint32_t)theme_manager_get_num_available_themes();
 
@@ -1578,6 +1587,26 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
             switch (widgetIndex)
             {
+                case WIDX_SCROLL_MODE_DROPDOWN :
+                    if (dropdownIndex == 0)
+                    {
+                        gConfigGeneral.zoom_to_cursor = false;
+                        gConfigGeneral.disable_scroll_zoom = false;
+                        
+                    }
+                    if (dropdownIndex == 1)
+                    {
+                        gConfigGeneral.zoom_to_cursor = true;
+                        gConfigGeneral.disable_scroll_zoom = false;
+                    }
+                    if (dropdownIndex == 2)
+                    {
+                        gConfigGeneral.zoom_to_cursor = false;
+                        gConfigGeneral.disable_scroll_zoom = true;
+                    }
+                    config_save_default();
+                    window_invalidate(w);
+                    break;
                 case WIDX_THEMES_DROPDOWN:
                     if (dropdownIndex != -1)
                     {
@@ -1875,17 +1904,30 @@ static void window_options_invalidate(rct_window* w)
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
         {
             widget_set_checkbox_value(w, WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
-            widget_set_checkbox_value(w, WIDX_DISABLE_SCROLL_ZOOM, gConfigGeneral.disable_scroll_zoom);
             widget_set_checkbox_value(w, WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
             widget_set_checkbox_value(w, WIDX_INVERT_DRAG, gConfigGeneral.invert_viewport_drag);
-            widget_set_checkbox_value(w, WIDX_ZOOM_TO_CURSOR, gConfigGeneral.zoom_to_cursor);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_FINANCES, gConfigInterface.toolbar_show_finances);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_RESEARCH, gConfigInterface.toolbar_show_research);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_CHEATS, gConfigInterface.toolbar_show_cheats);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_NEWS, gConfigInterface.toolbar_show_news);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_MUTE, gConfigInterface.toolbar_show_mute);
             widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_CHAT, gConfigInterface.toolbar_show_chat);
-
+            
+            if (gConfigGeneral.zoom_to_cursor == false && gConfigGeneral.disable_scroll_zoom == false)
+            {
+                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE_STANDARD;
+            }
+            if (gConfigGeneral.zoom_to_cursor == true && gConfigGeneral.disable_scroll_zoom == false)
+            {
+                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_ZOOM_TO_CURSOR;
+            }
+            if (gConfigGeneral.disable_scroll_zoom == true)
+            {
+                window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE_DISABLED;
+            }
+            
+            //window_options_controls_and_interface_widgets[WIDX_SCROLL_MODE].text = STR_SCROLL_MODE;
+            
             size_t activeAvailableThemeIndex = theme_manager_get_active_available_theme_index();
             const utf8* activeThemeName = theme_manager_get_available_theme_name(activeAvailableThemeIndex);
             set_format_arg(0, uintptr_t, (uintptr_t)activeThemeName);
@@ -2087,6 +2129,9 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
             gfx_draw_string_left(
                 dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1], w->x + 10,
                 w->y + window_options_controls_and_interface_widgets[WIDX_THEMES].top + 1);
+            gfx_draw_string_left(
+             dpi, STR_SCROLL_MODE, w, w->colours[1], w->x+10,
+             w->y + window_options_controls_and_interface_widgets[WIDX_CONTROLS_GROUP].top + 61);
             break;
         }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -137,6 +137,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     // Controls and interface
     WIDX_CONTROLS_GROUP = WIDX_PAGE_START,
     WIDX_SCREEN_EDGE_SCROLLING,
+    WIDX_DISABLE_SCROLL_ZOOM,
     WIDX_TRAP_CURSOR,
     WIDX_INVERT_DRAG,
     WIDX_ZOOM_TO_CURSOR,
@@ -302,20 +303,21 @@ static rct_widget window_options_audio_widgets[] = {
 static rct_widget window_options_controls_and_interface_widgets[] = {
     MAIN_OPTIONS_WIDGETS,
 #define CONTROLS_GROUP_START 53
-    { WWT_GROUPBOX,         1,  5,      304,    CONTROLS_GROUP_START + 0,    CONTROLS_GROUP_START + 91,   STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
+    { WWT_GROUPBOX,         1,  5,      304,    CONTROLS_GROUP_START + 0,    CONTROLS_GROUP_START + 104,   STR_CONTROLS_GROUP,                     STR_NONE },                                 // Controls group
     { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 13,   CONTROLS_GROUP_START + 26,   STR_SCREEN_EDGE_SCROLLING,              STR_SCREEN_EDGE_SCROLLING_TIP },            // Edge scrolling
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 30,   CONTROLS_GROUP_START + 41,   STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 45,   CONTROLS_GROUP_START + 56,   STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
-    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 60,   CONTROLS_GROUP_START + 71,   STR_ZOOM_TO_CURSOR,                     STR_ZOOM_TO_CURSOR_TIP },                   // Zoom to cursor
-    { WWT_BUTTON,           1,  155,    299,    CONTROLS_GROUP_START + 75,   CONTROLS_GROUP_START + 87,   STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 30, CONTROLS_GROUP_START + 41, STR_DISABLE_SCROLL_ZOOM, STR_DISABLE_SCROLL_ZOOM_TIP },                             //Trackpad Mode
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 45,   CONTROLS_GROUP_START + 56,   STR_TRAP_MOUSE,                         STR_TRAP_MOUSE_TIP },                       // Trap mouse
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 60,   CONTROLS_GROUP_START + 71,   STR_INVERT_RIGHT_MOUSE_DRAG,            STR_INVERT_RIGHT_MOUSE_DRAG_TIP },          // Invert right mouse dragging
+    { WWT_CHECKBOX,         2,  10,     299,    CONTROLS_GROUP_START + 75,   CONTROLS_GROUP_START + 87,   STR_ZOOM_TO_CURSOR,                     STR_ZOOM_TO_CURSOR_TIP },                   // Zoom to cursor
+    { WWT_BUTTON,           1,  155,    299,    CONTROLS_GROUP_START + 90,   CONTROLS_GROUP_START + 100,   STR_HOTKEY,                             STR_HOTKEY_TIP },                           // Set hotkeys buttons
 #undef CONTROLS_GROUP_START
-#define THEMES_GROUP_START 148
+#define THEMES_GROUP_START 159
     { WWT_GROUPBOX,         1,  5,      304,    THEMES_GROUP_START + 0,      THEMES_GROUP_START + 47,     STR_THEMES_GROUP,                       STR_NONE },                                 // Toolbar buttons group
     { WWT_DROPDOWN,         1,  155,    299,    THEMES_GROUP_START + 14,     THEMES_GROUP_START + 25,     STR_STRING,                             STR_NONE },                                 // Themes
     { WWT_BUTTON,           1,  288,    298,    THEMES_GROUP_START + 15,     THEMES_GROUP_START + 24,     STR_DROPDOWN_GLYPH,                     STR_CURRENT_THEME_TIP },
     { WWT_BUTTON,           1,  155,    299,    THEMES_GROUP_START + 30,     THEMES_GROUP_START + 42,     STR_EDIT_THEMES_BUTTON,                 STR_EDIT_THEMES_BUTTON_TIP },               // Themes button
 #undef THEMES_GROUP_START
-#define TOOLBAR_GROUP_START 200
+#define TOOLBAR_GROUP_START 209
     { WWT_GROUPBOX,         1,  5,      304,    TOOLBAR_GROUP_START + 0,     TOOLBAR_GROUP_START + 75,    STR_TOOLBAR_BUTTONS_GROUP,              STR_NONE },                                 // Toolbar buttons group
     { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 31,    TOOLBAR_GROUP_START + 42,    STR_FINANCES_BUTTON_ON_TOOLBAR,         STR_FINANCES_BUTTON_ON_TOOLBAR_TIP },       // Finances
     { WWT_CHECKBOX,         2,  24,     145,    TOOLBAR_GROUP_START + 46,    TOOLBAR_GROUP_START + 57,    STR_RESEARCH_BUTTON_ON_TOOLBAR,         STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP },       // Research
@@ -571,6 +573,7 @@ static uint64_t window_options_page_enabled_widgets[] = {
 
     MAIN_OPTIONS_ENABLED_WIDGETS |
     (1 << WIDX_SCREEN_EDGE_SCROLLING) |
+    (1 << WIDX_DISABLE_SCROLL_ZOOM) |
     (1 << WIDX_TRAP_CURSOR) |
     (1 << WIDX_INVERT_DRAG) |
     (1 << WIDX_ZOOM_TO_CURSOR) |
@@ -819,6 +822,11 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     break;
                 case WIDX_SCREEN_EDGE_SCROLLING:
                     gConfigGeneral.edge_scrolling ^= 1;
+                    config_save_default();
+                    window_invalidate(w);
+                    break;
+                case WIDX_DISABLE_SCROLL_ZOOM:
+                    gConfigGeneral.disable_scroll_zoom ^=1;
                     config_save_default();
                     window_invalidate(w);
                     break;
@@ -1867,6 +1875,7 @@ static void window_options_invalidate(rct_window* w)
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
         {
             widget_set_checkbox_value(w, WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
+            widget_set_checkbox_value(w, WIDX_DISABLE_SCROLL_ZOOM, gConfigGeneral.disable_scroll_zoom);
             widget_set_checkbox_value(w, WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
             widget_set_checkbox_value(w, WIDX_INVERT_DRAG, gConfigGeneral.invert_viewport_drag);
             widget_set_checkbox_value(w, WIDX_ZOOM_TO_CURSOR, gConfigGeneral.zoom_to_cursor);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -146,6 +146,7 @@ namespace Config
             model->custom_currency_symbol = reader->GetCString("custom_currency_symbol", "Ctm");
             model->edge_scrolling = reader->GetBoolean("edge_scrolling", true);
             model->edge_scrolling_speed = reader->GetInt32("edge_scrolling_speed", 12);
+            model->disable_scroll_zoom = reader->GetBoolean("scroll_zoom", true);
             model->fullscreen_mode = reader->GetInt32("fullscreen_mode", 0);
             model->fullscreen_height = reader->GetInt32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetInt32("fullscreen_width", -1);
@@ -229,6 +230,7 @@ namespace Config
         writer->WriteEnum<int32_t>("custom_currency_affix", model->custom_currency_affix, Enum_CurrencySymbolAffix);
         writer->WriteString("custom_currency_symbol", model->custom_currency_symbol);
         writer->WriteBoolean("edge_scrolling", model->edge_scrolling);
+        writer->WriteBoolean("disable_scroll_zoom", model->disable_scroll_zoom);
         writer->WriteInt32("edge_scrolling_speed", model->edge_scrolling_speed);
         writer->WriteInt32("fullscreen_mode", model->fullscreen_mode);
         writer->WriteInt32("fullscreen_height", model->fullscreen_height);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -146,7 +146,7 @@ namespace Config
             model->custom_currency_symbol = reader->GetCString("custom_currency_symbol", "Ctm");
             model->edge_scrolling = reader->GetBoolean("edge_scrolling", true);
             model->edge_scrolling_speed = reader->GetInt32("edge_scrolling_speed", 12);
-            model->disable_scroll_zoom = reader->GetBoolean("scroll_zoom", true);
+            model->disable_scroll_zoom = reader->GetBoolean("scroll_zoom", false);
             model->fullscreen_mode = reader->GetInt32("fullscreen_mode", 0);
             model->fullscreen_height = reader->GetInt32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetInt32("fullscreen_width", -1);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -146,7 +146,6 @@ namespace Config
             model->custom_currency_symbol = reader->GetCString("custom_currency_symbol", "Ctm");
             model->edge_scrolling = reader->GetBoolean("edge_scrolling", true);
             model->edge_scrolling_speed = reader->GetInt32("edge_scrolling_speed", 12);
-            model->disable_scroll_zoom = reader->GetBoolean("scroll_zoom", false);
             model->fullscreen_mode = reader->GetInt32("fullscreen_mode", 0);
             model->fullscreen_height = reader->GetInt32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetInt32("fullscreen_width", -1);
@@ -206,9 +205,9 @@ namespace Config
             model->last_save_landscape_directory = reader->GetCString("last_landscape_directory", nullptr);
             model->last_save_scenario_directory = reader->GetCString("last_scenario_directory", nullptr);
             model->last_save_track_directory = reader->GetCString("last_track_directory", nullptr);
+            model->scroll_wheel_behaviour = reader->GetInt32("scroll_wheel_behaviour", 1);
             model->use_native_browse_dialog = reader->GetBoolean("use_native_browse_dialog", false);
             model->window_limit = reader->GetInt32("window_limit", WINDOW_LIMIT_MAX);
-            model->zoom_to_cursor = reader->GetBoolean("zoom_to_cursor", true);
             model->render_weather_effects = reader->GetBoolean("render_weather_effects", true);
             model->render_weather_gloom = reader->GetBoolean("render_weather_gloom", true);
             model->show_guest_purchases = reader->GetBoolean("show_guest_purchases", false);
@@ -230,7 +229,6 @@ namespace Config
         writer->WriteEnum<int32_t>("custom_currency_affix", model->custom_currency_affix, Enum_CurrencySymbolAffix);
         writer->WriteString("custom_currency_symbol", model->custom_currency_symbol);
         writer->WriteBoolean("edge_scrolling", model->edge_scrolling);
-        writer->WriteBoolean("disable_scroll_zoom", model->disable_scroll_zoom);
         writer->WriteInt32("edge_scrolling_speed", model->edge_scrolling_speed);
         writer->WriteInt32("fullscreen_mode", model->fullscreen_mode);
         writer->WriteInt32("fullscreen_height", model->fullscreen_height);
@@ -281,9 +279,9 @@ namespace Config
         writer->WriteString("last_landscape_directory", model->last_save_landscape_directory);
         writer->WriteString("last_scenario_directory", model->last_save_scenario_directory);
         writer->WriteString("last_track_directory", model->last_save_track_directory);
+        writer->WriteInt32("scroll_wheel_behaviour", model->scroll_wheel_behaviour);
         writer->WriteBoolean("use_native_browse_dialog", model->use_native_browse_dialog);
         writer->WriteInt32("window_limit", model->window_limit);
-        writer->WriteBoolean("zoom_to_cursor", model->zoom_to_cursor);
         writer->WriteBoolean("render_weather_effects", model->render_weather_effects);
         writer->WriteBoolean("render_weather_gloom", model->render_weather_gloom);
         writer->WriteBoolean("show_guest_purchases", model->show_guest_purchases);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -205,7 +205,7 @@ namespace Config
             model->last_save_landscape_directory = reader->GetCString("last_landscape_directory", nullptr);
             model->last_save_scenario_directory = reader->GetCString("last_scenario_directory", nullptr);
             model->last_save_track_directory = reader->GetCString("last_track_directory", nullptr);
-            model->scroll_wheel_behaviour = reader->GetInt32("scroll_wheel_behaviour", 1);
+            model->scroll_wheel_behaviour = reader->GetInt32("scroll_wheel_behaviour", 2);
             model->use_native_browse_dialog = reader->GetBoolean("use_native_browse_dialog", false);
             model->window_limit = reader->GetInt32("window_limit", WINDOW_LIMIT_MAX);
             model->render_weather_effects = reader->GetBoolean("render_weather_effects", true);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -61,10 +61,9 @@ struct GeneralConfiguration
     // Controls
     bool edge_scrolling;
     int32_t edge_scrolling_speed;
-    bool disable_scroll_zoom;
+    int32_t scroll_wheel_behaviour;
     bool trap_cursor;
     bool invert_viewport_drag;
-    bool zoom_to_cursor;
 
     // Miscellaneous
     bool play_intro;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -61,6 +61,7 @@ struct GeneralConfiguration
     // Controls
     bool edge_scrolling;
     int32_t edge_scrolling_speed;
+    bool disable_scroll_zoom;
     bool trap_cursor;
     bool invert_viewport_drag;
     bool zoom_to_cursor;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1053,7 +1053,7 @@ void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
     int16_t saved_map_y = 0;
     int16_t offset_x = 0;
     int16_t offset_y = 0;
-    if (gConfigGeneral.zoom_to_cursor && atCursor)
+    if (gConfigGeneral.scroll_wheel_behaviour == 2 && atCursor)
     {
         window_viewport_get_map_coords_by_cursor(w, &saved_map_x, &saved_map_y, &offset_x, &offset_y);
     }
@@ -1079,7 +1079,7 @@ void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
     }
 
     // Zooming to cursor? Centre around the tile we were hovering over just now.
-    if (gConfigGeneral.zoom_to_cursor && atCursor)
+    if (gConfigGeneral.scroll_wheel_behaviour == 2 && atCursor)
     {
         window_viewport_centre_tile_around_cursor(w, saved_map_x, saved_map_y, offset_x, offset_y);
     }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3938,9 +3938,12 @@ enum
     STR_MULTITHREADING_TIP = 6306,
 
     STR_TILE_INSPECTOR_COLOUR_SCHEME = 6307,
+    
+    STR_DISABLE_SCROLL_ZOOM = 6308,
+    STR_DISABLE_SCROLL_ZOOM_TIP = 6309,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
-    STR_COUNT = 32768
+    STR_COUNT = 32770
 };
 
 #endif

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3939,11 +3939,13 @@ enum
 
     STR_TILE_INSPECTOR_COLOUR_SCHEME = 6307,
     
-    STR_DISABLE_SCROLL_ZOOM = 6308,
-    STR_DISABLE_SCROLL_ZOOM_TIP = 6309,
+    STR_SCROLL_MODE = 6308,
+    STR_SCROLL_MODE_STANDARD = 6309,
+    STR_SCROLL_MODE_DISABLED = 6310,
+    STR_SCROLL_MODE_TIP = 6311,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
-    STR_COUNT = 32770
+    STR_COUNT = 32771
 };
 
 #endif

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3945,7 +3945,7 @@ enum
     STR_SCROLL_MODE_TIP = 6311,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
-    STR_COUNT = 32771
+    STR_COUNT = 32769
 };
 
 #endif


### PR DESCRIPTION
When this feature is enabled, scrolling up/down on the trackpad will not zoom in/out of the map