### PR TITLE
Fix #9152

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,7 +25,7 @@
 - Fix: [#8947] Detection of AVX2 support.
 - Fix: [#8988] Character sprite lookup noticeably slows down drawing.
 - Fix: [#9000] Show correct error message if not enough money available.
-- Fix: [#9152] Spectators being able to modify ride colours.
+- Fix: [#9152] Spectators can modify ride colours.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.
 - Improved: Allow the use of numpad enter key for console and chat.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#8947] Detection of AVX2 support.
 - Fix: [#8988] Character sprite lookup noticeably slows down drawing.
 - Fix: [#9000] Show correct error message if not enough money available.
+- Fix: [#9152] Spectators being able to modify ride colours.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.
 - Improved: Allow the use of numpad enter key for console and chat.
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/NetworkAction.h
+++ b/src/openrct2/network/NetworkAction.h
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <string>
+#include <vector>
 
 enum MISC_COMMAND
 {
@@ -55,7 +56,7 @@ class NetworkAction final
 public:
     rct_string_id Name;
     std::string PermissionName;
-    std::array<int32_t, NETWORK_PERMISSION_COUNT> Commands;
+    std::vector<int32_t> Commands;
 };
 
 class NetworkActions final


### PR DESCRIPTION
The reason is pretty simple, NetworkAction uses std::array which initializes everything by default to 0, the Spectator group has only one command in it so the remaining entries would be all 0. Since GAME_COMMAND_SET_RIDE_APPEARANCE is also 0 it would of course think that the group has such command in it.