### PR TITLE
Fix #8145: Mechanics fix vehicles that are not in the station

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#475] Water sides drawn incorrectly (original bug).
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).
 - Fix: [#7094] Back wall edge texture in water missing.
+- Fix: [#8145] Mechanics walk to vehicles in the middle of the track.
 - Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.
 - Fix: [#11005] Company value overflows.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2593,6 +2593,12 @@ static void ride_mechanic_status_update(Ride* ride, int32_t mechanicStatus)
                 ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE;
                 ride_mechanic_status_update(ride, RIDE_MECHANIC_STATUS_CALLING);
             }
+            else if (
+                mechanic->state == PEEP_STATE_HEADING_TO_INSPECTION && (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
+            {
+                // Ride has broken down while mechanic was HEADING_TO_INSPECTION, upgrade to ANSWERING.
+                ride_call_mechanic(ride, mechanic, false);
+            }
             break;
         }
         case RIDE_MECHANIC_STATUS_FIXING:

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2632,7 +2632,7 @@ static void ride_call_mechanic(Ride* ride, Peep* mechanic, int32_t forInspection
  */
 static void ride_call_closest_mechanic(Ride* ride)
 {
-    auto forInspection = (ride->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)) == 0;
+    auto forInspection = (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN) == 0;
     auto mechanic = ride_find_closest_mechanic(ride, forInspection);
     if (mechanic != nullptr)
         ride_call_mechanic(ride, mechanic, forInspection);


### PR DESCRIPTION
I put three independent commits in one pull request, because I believe they all need the network version bump that is only in the last commit. Obviously if that one turns out not to be acceptable, I can put the network version bump in a different commit. :-)

Two of the commits fix one bug each, and the third commit makes sure to "upgrade" a mechanic who is currently "heading for an inspection" to the "responding to breakdown call" status if that ride happens to break down. I believe this was not a reported bug, but is probably a change that makes sense in the context of fixing the "mechanic walks out of station to repair vehicle" bug. (Without that commit, the mechanic would keep the "heading for an inspection" status and then upgrade to "fixing" once they enter the station, but before that happens, players might wonder why no mechanic is called to fix the ride.)

Feel free to suggest any style changes, obviously. I hope clang-format likes my commits this time.