### PR TITLE
Fix game action errors not showing if no round trip was done

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -363,7 +363,10 @@ namespace GameActions
         // In network mode the error should be only shown to the issuer of the action.
         if (network_get_mode() != NETWORK_MODE_NONE)
         {
-            if (action->GetPlayer() != network_get_current_player_id())
+            // If the action was never networked and query fails locally the player id is not assigned.
+            // So compare only if the action went into the queue otherwise show errors by default.
+            const bool isActionFromNetwork = (action->GetFlags() & GAME_COMMAND_FLAG_NETWORKED) != 0;
+            if (isActionFromNetwork && action->GetPlayer() != network_get_current_player_id())
             {
                 shouldShowError = false;
             }


### PR DESCRIPTION
Minor oversight from me, as long it doesn't enter the network or the queue and query fails no player id will be ever assigned leaving the condition always false.