### PR TITLE
Switch back to Windows 8.1 SDK

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- Allow any version of VS and Windows SDK -->
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
 
     <CharacterSet>MultiByte</CharacterSet>
 

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -32,7 +32,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>4068;4091;4100;4132;4200;4201;4204;4206;4221;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4068;4091;4100;4132;4200;4201;4204;4206;4221;4244;4548;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Warnings:
              C4068: unknown pragma
              C4091: 'keyword': ignored on left of 'type' when no variable is declared
@@ -44,12 +44,12 @@
              C4206: nonstandard extension used: translation unit is empty
              C4221: nonstandard extension used: 'identifier': cannot be initialized using address of automatic variable 'identifier'
              C4244: 'conversion_type': conversion from 'type1' to 'type2', possible loss of data
+             C4548: expression before comma has no effect; expected expression with side-effect
       -->
-      <TreatSpecificWarningsAsErrors>4263;4265;4548;4549;4555</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>4263;4265;4549;4555</TreatSpecificWarningsAsErrors>
       <!-- Warnings, that have to be enabled manually:
              C4263: 'function': member function does not override any base class virtual member function
              C4265: 'class': class has virtual functions, but destructor is not virtual
-             C4548: expression before comma has no effect; expected expression with side-effect
              C4549: 'operator': operator before comma has no effect; did you intend 'operator'?
              C4555: expression has no effect; expected expression with side-effect
       -->
@@ -58,7 +58,7 @@
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/utf-8 /std:c++17 /permissive- /Zc:externConstexpr</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /std:c++17 /Zc:externConstexpr</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/readme.md
+++ b/readme.md
@@ -85,9 +85,8 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 
 ### Windows:
 - 7 / 8 / 10
-- Visual Studio 2017 update 7 (Enterprise / Professional / [Community (Free)](https://www.visualstudio.com/vs/community/))
+- [Visual Studio](https://www.visualstudio.com/vs/community/) 2017 update 7 or 2019
   - Desktop development with C++
-  - [Windows 10 SDK (10.0.14393.0)](https://go.microsoft.com/fwlink/p/?LinkId=838916)
 - [7-Zip](http://www.7-zip.org/) (for deployment only)
 - [NSIS](http://nsis.sourceforge.net/) (for deployment only)
 

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -21,7 +21,9 @@
 #    if !defined(__MINGW32__) && ((NTDDI_VERSION >= NTDDI_VISTA) && !defined(_USING_V110_SDK71_) && !defined(_ATL_XP_TARGETING))
 #        define __USE_SHGETKNOWNFOLDERPATH__
 #        define __USE_GETDATEFORMATEX__
-#    else
+#    endif
+
+#    ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #        define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #    endif
 


### PR DESCRIPTION
This should increase compatibility across different versions of Visual Studio. 10.0.14393.0 is also no longer available through the Visual Studio installer