### PR TITLE
Update target Windows SDK to 10.0.17763.0

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- Allow any version of VS and Windows SDK -->
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
 
     <CharacterSet>MultiByte</CharacterSet>
 


### PR DESCRIPTION
10.0.14393.0 is no longer available through the Visual Studio installer.