### PR TITLE
Fix #8507: Incorrect change in vehicle rolling direction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
 - Fix: [#8219] Faulty folder recreation in "save" folder.
+- Fix: [#8507] Incorrect change in vehicle rolling direction.
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
 - Fix: [#8649] Setting date does not work in multiplayer.
 - Fix: [#8873] Potential crash when placing footpaths.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "21"
+#define NETWORK_STREAM_VERSION "22"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9766,17 +9766,14 @@ int32_t vehicle_update_track_motion(rct_vehicle* vehicle, int32_t* outStation)
     {
         vehicle_update_track_motion_powered_ride_acceleration(vehicle, vehicleEntry, totalMass, &acceleration);
     }
-    else
+    else if (acceleration <= 0 && acceleration >= -500)
     {
-        if (acceleration <= 0)
+        // Probably moving slowly on a flat track piece, low rolling resistance and drag.
+
+        if (vehicle->velocity <= 0x8000 && vehicle->velocity >= 0)
         {
-            if (acceleration >= -500)
-            {
-                if (vehicle->velocity <= 0x8000)
-                {
-                    acceleration += 400;
-                }
-            }
+            // Vehicle is creeping forwards very slowly (less than ~2km/h), boost speed a bit.
+            acceleration += 400;
         }
     }
 


### PR DESCRIPTION
This needs to be merged (or rebased, but @IntelOrca disabled that button). Do not squash, as that will erase w-flo as the author.