### PR TITLE
Fix: artifacts when changing ride type as client or using the in-game console

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2435,7 +2435,6 @@ static void window_ride_main_dropdown(rct_window* w, rct_widgetindex widgetIndex
                 {
                     set_operating_setting(w->number, RideSetSetting::RideType, rideType);
                 }
-                window_invalidate_all();
             }
     }
 }

--- a/src/openrct2/actions/RideSetSetting.hpp
+++ b/src/openrct2/actions/RideSetSetting.hpp
@@ -243,6 +243,7 @@ public:
                 break;
             case RideSetSetting::RideType:
                 ride->type = _value;
+                gfx_invalidate_screen();
                 break;
         }
 


### PR DESCRIPTION
Something I recently noticed while playing in multiplayer. When changing a ride's type while the arbitrary ride type changes is enabled, the screen only gets invalidated properly when done from the dropdown menu as the server. When running the command `rides set type` or changing a ride's type as a client, the screen does not invalidate, and you're left with something like this:

![Dynamite Dunes 2019-05-03 23-12-03](https://user-images.githubusercontent.com/9705046/57166732-58782b00-6dfb-11e9-9e62-d610a23ac1fa.png)

This part in the code makes it work properly for single-player and clients (`Ride.cpp` from the UI project):
https://github.com/OpenRCT2/OpenRCT2/blob/0da35a599d494d120660bc3bc25d5c9297ac4bba/src/openrct2-ui/windows/Ride.cpp#L2434-L2438

This PR basically moves the invalidation to the game action itself. This is outside the UI project though, but I'm not sure if there's a better way to handle screen invalidation reliably at the moment. Ideally the drawing engine should go over the game actions to see what needs to be invalidated instead.