### PR TITLE
Fix false positive desync when changing map during network play

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2643,6 +2643,7 @@ void Network::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connection, 
         {
             game_load_init();
             game_command_queue.clear();
+            _serverTickData.clear();
             server_tick = gCurrentTicks;
             // window_network_status_open("Loaded new map from network");
             _desynchronised = false;


### PR DESCRIPTION
This is because the client wont reconnect and keeps the tick data from the previous map, this PR simply clears the data whenever the map is loaded to ensure there are no colliding entries.