### PR TITLE
Fix #2294: Clients crashing the server with invalid object selection

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Feature: [#9154] Change map toolbar icon with current viewport rotation.
 - Change: [#7877] Files are now sorted in logical rather than dictionary order.
 - Change: [#8688] Move common actions from debug menu into cheats menu.
+- Fix: [#2294] Clients crashing the server with invalid object selection.
 - Fix: [#5103] OpenGL: ride track preview not rendered.
 - Fix: [#5889] Giant screenshot does not work while using OpenGL renderer.
 - Fix: [#5579] Network desync immediately after connecting.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "25"
+#define NETWORK_STREAM_VERSION "26"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
There is currently a way to make servers crash by typing "open select_objects" into the console as a client, pick some random objects the server has not loaded and then try to place them. Also I took the opportunity to cleanup the code a little.