### PR TITLE
Improve util_rand

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -426,7 +426,6 @@ namespace OpenRCT2
             }
 
             gScenarioTicks = 0;
-            util_srand((uint32_t)time(nullptr));
             input_reset_place_obj_modifier();
             viewport_init_all();
 

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -244,7 +244,7 @@ private:
         };
 
         std::random_device rd;
-        std::uniform_int_distribution<> dist(0, std::size(hexChars) - 1);
+        std::uniform_int_distribution<int32_t> dist(0, static_cast<int32_t>(std::size(hexChars) - 1));
 
         char key[17];
         for (int32_t i = 0; i < 16; i++)

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -27,6 +27,7 @@
 
 #    include <iterator>
 #    include <memory>
+#    include <random>
 #    include <string>
 
 #    ifndef DISABLE_HTTP
@@ -241,10 +242,14 @@ private:
         static constexpr char hexChars[] = {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
         };
+
+        std::random_device rd;
+        std::uniform_int_distribution<> dist(0, std::size(hexChars) - 1);
+
         char key[17];
         for (int32_t i = 0; i < 16; i++)
         {
-            int32_t hexCharIndex = util_rand() % std::size(hexChars);
+            int32_t hexCharIndex = dist(rd);
             key[i] = hexChars[hexCharIndex];
         }
         key[std::size(key) - 1] = 0;

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -21,6 +21,9 @@
 #include <cctype>
 #include <cmath>
 #include <ctime>
+#include <random>
+
+static std::mt19937 _prng;
 
 int32_t squaredmetres_to_squaredfeet(int32_t squaredMetres)
 {
@@ -528,13 +531,12 @@ bool str_is_null_or_empty(const char* str)
 
 void util_srand(int32_t source)
 {
-    srand(source);
+    _prng.seed(source);
 }
 
-// Caveat: rand() might only return values up to 0x7FFF, which is the minimum specified in the C standard.
 uint32_t util_rand()
 {
-    return rand();
+    return _prng();
 }
 
 #define CHUNK (128 * 1024)

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -23,8 +23,6 @@
 #include <ctime>
 #include <random>
 
-static std::mt19937 _prng;
-
 int32_t squaredmetres_to_squaredfeet(int32_t squaredMetres)
 {
     // 1 metre squared = 10.7639104 feet squared
@@ -529,13 +527,9 @@ bool str_is_null_or_empty(const char* str)
     return str == nullptr || str[0] == 0;
 }
 
-void util_srand(int32_t source)
-{
-    _prng.seed(source);
-}
-
 uint32_t util_rand()
 {
+    thread_local std::mt19937 _prng(std::random_device{}());
     return _prng();
 }
 

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -50,7 +50,6 @@ char* strcasestr(const char* haystack, const char* needle);
 bool utf8_is_bom(const char* str);
 bool str_is_null_or_empty(const char* str);
 
-void util_srand(int32_t source);
 uint32_t util_rand();
 
 uint8_t* util_zlib_deflate(const uint8_t* data, size_t data_in_size, size_t* data_out_size);

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -136,8 +136,6 @@ void mapgen_generate(mapgen_settings* settings)
     int32_t x, y, mapSize, floorTexture, wallTexture, waterLevel;
     TileElement* tileElement;
 
-    util_srand((int32_t)platform_get_ticks());
-
     mapSize = settings->mapSize;
     floorTexture = settings->floor;
     wallTexture = settings->wall;


### PR DESCRIPTION
util_rand was changed at some point to use rand() which only ever returns a maximum value with 15 bits. 
https://github.com/OpenRCT2/OpenRCT2/blob/c8f822ea70ba41deefdef2767235d7ecdd744281/src/openrct2/world/Climate.cpp#L178
Would always be zero and causes thunder sounds every 43 ticks with the same sound and lightining would never work because
https://github.com/OpenRCT2/OpenRCT2/blob/c8f822ea70ba41deefdef2767235d7ecdd744281/src/openrct2/world/Climate.cpp#L180
Would always be zero.
I also made sure that when generating a key for the advertisment it would seed it which didn't happen before.