### PR TITLE
Improve game action logging

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1348,7 +1348,7 @@ void Network::AppendLog(std::ostream& fs, const std::string& s)
     }
     try
     {
-        utf8 buffer[256];
+        utf8 buffer[1024];
         time_t timer;
         time(&timer);
         auto tmInfo = localtime(&timer);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1400,9 +1400,9 @@ void Network::BeginServerLog()
 
 #    if defined(_WIN32) && !defined(__MINGW32__)
     auto pathW = std::unique_ptr<wchar_t>(utf8_to_widechar(_serverLogPath.c_str()));
-    _server_log_fs.open(pathW.get(), std::ios::out | std::ios::app);
+    _server_log_fs.open(pathW.get(), std::ios::out | std::ios::app | std::ios::binary);
 #    else
-    _server_log_fs.open(_serverLogPath, std::ios::out | std::ios::app);
+    _server_log_fs.open(_serverLogPath, std::ios::out | std::ios::app | std::ios::binary);
 #    endif
 
     // Log server start event


### PR DESCRIPTION
This PR fixes two minor issues.
1. Given that ostream operated in text mode using "\r\n" would result in having actually "\r\r\n" where in editors like Notepad++ it would actually show an empty line looking like theres a duplicate new line.
2. Given how detailed the logging is now the buffer size of 256 was not enough truncating the line.
