### PR TITLE
Fix GameAction use during pause

### DIFF
--- a/src/openrct2/actions/BannerSetColourAction.hpp
+++ b/src/openrct2/actions/BannerSetColourAction.hpp
@@ -32,7 +32,7 @@ public:
 
     uint16_t GetActionFlags() const override
     {
-        return GameAction::GetActionFlags() | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED;
+        return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/actions/BannerSetStyleAction.hpp
+++ b/src/openrct2/actions/BannerSetStyleAction.hpp
@@ -44,7 +44,7 @@ public:
 
     uint16_t GetActionFlags() const override
     {
-        return GameAction::GetActionFlags() | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED;
+        return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/actions/LargeScenerySetColourAction.hpp
+++ b/src/openrct2/actions/LargeScenerySetColourAction.hpp
@@ -35,7 +35,7 @@ public:
 
     uint16_t GetActionFlags() const override
     {
-        return GameAction::GetActionFlags() | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED;
+        return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/actions/SmallScenerySetColourAction.hpp
+++ b/src/openrct2/actions/SmallScenerySetColourAction.hpp
@@ -51,7 +51,7 @@ public:
 
     uint16_t GetActionFlags() const override
     {
-        return GameAction::GetActionFlags() | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED;
+        return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "26"
+#define NETWORK_STREAM_VERSION "27"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Made a small mistake in a couple game actions that would prevent them from working when paused. This is a good example of flags not being strongly typed (I had used `GAME_COMMAND_FLAGS` instead of `GA_FLAGS`).