### PR TITLE
Protect FileStream opening directories on unix/linux systems

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#9000] Show correct error message if not enough money available.
 - Fix: [#9152] Spectators can modify ride colours.
 - Fix: [#9202] Artefacts show when changing ride type as client or using in-game console.
+- Fix: [#9240] Crash when passing directory instead of save file.
 - Fix: Guests eating popcorn are drawn as if they're eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.

--- a/src/openrct2/core/FileStream.hpp
+++ b/src/openrct2/core/FileStream.hpp
@@ -15,6 +15,9 @@
 #include "String.hpp"
 
 #include <algorithm>
+#ifndef _WIN32
+#    include <sys/stat.h>
+#endif
 
 enum
 {
@@ -73,7 +76,12 @@ public:
         free(pathW);
         free(modeW);
 #else
-        _file = fopen(path, mode);
+        struct stat fileStat;
+        // Only allow regular files to be opened as its possible to open directories.
+        if (stat(path, &fileStat) == 0 && S_ISREG(fileStat.st_mode))
+        {
+            _file = fopen(path, mode);
+        }
 #endif
         if (_file == nullptr)
         {


### PR DESCRIPTION
Apparently thats a thing and yields potential issues if the user accidentally supplies directories as input.