### PR TITLE
Add sprite_index to Guest Debug Tab

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3119,7 +3119,7 @@ STR_5630    :Enable progressive unlocking
 STR_5631    :Original DLC Parks
 STR_5632    :Build your own...
 STR_5633    :CMD + 
-STR_5634    :OPTION +
+STR_5634    :OPTION + 
 STR_5635    :{WINDOW_COLOUR_2}Money spent: {BLACK}{CURRENCY2DP}
 STR_5636    :{WINDOW_COLOUR_2}Commands ran: {BLACK}{COMMA16}
 STR_5637    :Can't do this...

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -723,10 +723,10 @@ STR_1339    :{BLACK}No test results yet...
 STR_1340    :{WINDOW_COLOUR_2}Max. speed: {BLACK}{VELOCITY}
 STR_1341    :{WINDOW_COLOUR_2}Ride time: {BLACK}{STRINGID}{STRINGID}{STRINGID}{STRINGID}
 STR_1342    :{DURATION}
-STR_1343    :{DURATION} /
+STR_1343    :{DURATION} / 
 STR_1344    :{WINDOW_COLOUR_2}Ride length: {BLACK}{STRINGID}{STRINGID}{STRINGID}{STRINGID}
 STR_1345    :{LENGTH}
-STR_1346    :{LENGTH} /
+STR_1346    :{LENGTH} / 
 STR_1347    :{WINDOW_COLOUR_2}Average speed: {BLACK}{VELOCITY}
 STR_1348    :{WINDOW_COLOUR_2}Max. positive vertical G's: {BLACK}{COMMA2DP32}g
 STR_1349    :{WINDOW_COLOUR_2}Max. positive vertical G's: {OUTLINE}{RED}{COMMA2DP32}g
@@ -1109,7 +1109,7 @@ STR_1727    :Construction rights not for sale!
 STR_1728    :Can't buy construction rights here...
 STR_1729    :Land not owned by park!
 STR_1730    :{RED}Closed
-STR_1731    :{WHITE}{STRINGID} - -
+STR_1731    :{WHITE}{STRINGID} - - 
 STR_1732    :Build
 STR_1733    :Mode
 STR_1734    :{WINDOW_COLOUR_2}Number of laps:
@@ -1150,7 +1150,7 @@ STR_1771    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{COM
 STR_1773    :Only one on-ride photo section allowed per ride
 STR_1774    :Only one cable lift hill allowed per ride
 STR_1777    :Ride music
-STR_1778    :{STRINGID} - -
+STR_1778    :{STRINGID} - - 
 STR_1779    :{INLINE_SPRITE}{254}{19}{00}{00} Panda costume
 STR_1780    :{INLINE_SPRITE}{255}{19}{00}{00} Tiger costume
 STR_1781    :{INLINE_SPRITE}{00}{20}{00}{00} Elephant costume
@@ -2106,8 +2106,8 @@ STR_2779    :Viewport #{COMMA16}
 STR_2780    :Extra viewport
 # End of new strings
 STR_2781    :{STRINGID}:{MOVE_X}{255}{STRINGID}
-STR_2782    :SHIFT +
-STR_2783    :CTRL +
+STR_2782    :SHIFT + 
+STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
 STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}“{STRINGID}”
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
@@ -2386,10 +2386,10 @@ STR_3143    :{SMALLFONT}{BLACK}Show people on map
 STR_3144    :{SMALLFONT}{BLACK}Show rides and stalls on map
 STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3162    :Unable to allocate enough memory
-STR_3163    :Installing new data:
+STR_3163    :Installing new data: 
 STR_3164    :{BLACK}{COMMA16} selected (maximum {COMMA16})
 STR_3167    :{WINDOW_COLOUR_2}Includes: {BLACK}{COMMA16} objects
-STR_3169    :Data for the following object not found:
+STR_3169    :Data for the following object not found: 
 STR_3170    :Not enough space for graphics
 STR_3171    :Too many objects of this type selected
 STR_3172    :The following object must be selected first: {STRING}
@@ -2676,7 +2676,7 @@ STR_5182    :{INT32}
 STR_5183    :Base height
 STR_5184    :Enter base height between {COMMA16} and {COMMA16}
 STR_5185    :Water level
-STR_5186    :Enter water level between {COMMA16} and {COMMA16}
+STR_5186    :Enter water level between {COMMA16} and {COMMA16} 
 STR_5187    :Finances
 STR_5188    :New Campaign
 STR_5189    :Research
@@ -2955,7 +2955,7 @@ STR_5463    :Goal: Have fun!
 STR_5464    :General
 STR_5465    :Weather
 STR_5466    :Staff
-STR_5467    :ALT +
+STR_5467    :ALT + 
 STR_5468    :Recent messages
 STR_5469    :Scroll map up
 STR_5470    :Scroll map left
@@ -3118,7 +3118,7 @@ STR_5629    :Difficulty level
 STR_5630    :Enable progressive unlocking
 STR_5631    :Original DLC Parks
 STR_5632    :Build your own...
-STR_5633    :CMD +
+STR_5633    :CMD + 
 STR_5634    :OPTION +
 STR_5635    :{WINDOW_COLOUR_2}Money spent: {BLACK}{CURRENCY2DP}
 STR_5636    :{WINDOW_COLOUR_2}Commands ran: {BLACK}{COMMA16}
@@ -3332,7 +3332,7 @@ STR_5880    :Selected only
 STR_5881    :Non-selected only
 STR_5882    :Custom currency
 STR_5883    :Custom currency configuration
-STR_5884    :{WINDOW_COLOUR_2}Exchange rate:
+STR_5884    :{WINDOW_COLOUR_2}Exchange rate: 
 STR_5885    :{WINDOW_COLOUR_2}is equivalent to {COMMA32} GBP (£)
 STR_5886    :{WINDOW_COLOUR_2}Currency symbol:
 STR_5887    :Prefix

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -723,10 +723,10 @@ STR_1339    :{BLACK}No test results yet...
 STR_1340    :{WINDOW_COLOUR_2}Max. speed: {BLACK}{VELOCITY}
 STR_1341    :{WINDOW_COLOUR_2}Ride time: {BLACK}{STRINGID}{STRINGID}{STRINGID}{STRINGID}
 STR_1342    :{DURATION}
-STR_1343    :{DURATION} / 
+STR_1343    :{DURATION} /
 STR_1344    :{WINDOW_COLOUR_2}Ride length: {BLACK}{STRINGID}{STRINGID}{STRINGID}{STRINGID}
 STR_1345    :{LENGTH}
-STR_1346    :{LENGTH} / 
+STR_1346    :{LENGTH} /
 STR_1347    :{WINDOW_COLOUR_2}Average speed: {BLACK}{VELOCITY}
 STR_1348    :{WINDOW_COLOUR_2}Max. positive vertical G's: {BLACK}{COMMA2DP32}g
 STR_1349    :{WINDOW_COLOUR_2}Max. positive vertical G's: {OUTLINE}{RED}{COMMA2DP32}g
@@ -1109,7 +1109,7 @@ STR_1727    :Construction rights not for sale!
 STR_1728    :Can't buy construction rights here...
 STR_1729    :Land not owned by park!
 STR_1730    :{RED}Closed
-STR_1731    :{WHITE}{STRINGID} - - 
+STR_1731    :{WHITE}{STRINGID} - -
 STR_1732    :Build
 STR_1733    :Mode
 STR_1734    :{WINDOW_COLOUR_2}Number of laps:
@@ -1150,7 +1150,7 @@ STR_1771    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{COM
 STR_1773    :Only one on-ride photo section allowed per ride
 STR_1774    :Only one cable lift hill allowed per ride
 STR_1777    :Ride music
-STR_1778    :{STRINGID} - - 
+STR_1778    :{STRINGID} - -
 STR_1779    :{INLINE_SPRITE}{254}{19}{00}{00} Panda costume
 STR_1780    :{INLINE_SPRITE}{255}{19}{00}{00} Tiger costume
 STR_1781    :{INLINE_SPRITE}{00}{20}{00}{00} Elephant costume
@@ -2106,8 +2106,8 @@ STR_2779    :Viewport #{COMMA16}
 STR_2780    :Extra viewport
 # End of new strings
 STR_2781    :{STRINGID}:{MOVE_X}{255}{STRINGID}
-STR_2782    :SHIFT + 
-STR_2783    :CTRL + 
+STR_2782    :SHIFT +
+STR_2783    :CTRL +
 STR_2784    :Change keyboard shortcut
 STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}“{STRINGID}”
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
@@ -2386,10 +2386,10 @@ STR_3143    :{SMALLFONT}{BLACK}Show people on map
 STR_3144    :{SMALLFONT}{BLACK}Show rides and stalls on map
 STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3162    :Unable to allocate enough memory
-STR_3163    :Installing new data: 
+STR_3163    :Installing new data:
 STR_3164    :{BLACK}{COMMA16} selected (maximum {COMMA16})
 STR_3167    :{WINDOW_COLOUR_2}Includes: {BLACK}{COMMA16} objects
-STR_3169    :Data for the following object not found: 
+STR_3169    :Data for the following object not found:
 STR_3170    :Not enough space for graphics
 STR_3171    :Too many objects of this type selected
 STR_3172    :The following object must be selected first: {STRING}
@@ -2676,7 +2676,7 @@ STR_5182    :{INT32}
 STR_5183    :Base height
 STR_5184    :Enter base height between {COMMA16} and {COMMA16}
 STR_5185    :Water level
-STR_5186    :Enter water level between {COMMA16} and {COMMA16} 
+STR_5186    :Enter water level between {COMMA16} and {COMMA16}
 STR_5187    :Finances
 STR_5188    :New Campaign
 STR_5189    :Research
@@ -2955,7 +2955,7 @@ STR_5463    :Goal: Have fun!
 STR_5464    :General
 STR_5465    :Weather
 STR_5466    :Staff
-STR_5467    :ALT + 
+STR_5467    :ALT +
 STR_5468    :Recent messages
 STR_5469    :Scroll map up
 STR_5470    :Scroll map left
@@ -3118,8 +3118,8 @@ STR_5629    :Difficulty level
 STR_5630    :Enable progressive unlocking
 STR_5631    :Original DLC Parks
 STR_5632    :Build your own...
-STR_5633    :CMD + 
-STR_5634    :OPTION + 
+STR_5633    :CMD +
+STR_5634    :OPTION +
 STR_5635    :{WINDOW_COLOUR_2}Money spent: {BLACK}{CURRENCY2DP}
 STR_5636    :{WINDOW_COLOUR_2}Commands ran: {BLACK}{COMMA16}
 STR_5637    :Can't do this...
@@ -3332,7 +3332,7 @@ STR_5880    :Selected only
 STR_5881    :Non-selected only
 STR_5882    :Custom currency
 STR_5883    :Custom currency configuration
-STR_5884    :{WINDOW_COLOUR_2}Exchange rate: 
+STR_5884    :{WINDOW_COLOUR_2}Exchange rate:
 STR_5885    :{WINDOW_COLOUR_2}is equivalent to {COMMA32} GBP (£)
 STR_5886    :{WINDOW_COLOUR_2}Currency symbol:
 STR_5887    :Prefix
@@ -3769,6 +3769,7 @@ STR_6318    :Network desync detected.{NEWLINE}Log file: {STRING}
 STR_6319    :{WINDOW_COLOUR_2}Block Brake Closed
 STR_6320    :{WINDOW_COLOUR_2}Indestructible
 STR_6321    :{WINDOW_COLOUR_2}Addition is broken
+STR_6322    :{WINDOW_COLOUR_2}Sprite Id: {BLACK}{INT32}
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -486,7 +486,7 @@ static constexpr const rct_size16 window_guest_page_sizes[][2] = {
     { 210, 148, 210, 148 },     // WINDOW_GUEST_FINANCE
     { 192, 159, 500, 450 },     // WINDOW_GUEST_THOUGHTS
     { 192, 159, 500, 450 },     // WINDOW_GUEST_INVENTORY
-    { 192, 159, 192, 159 }      // WINDOW_GUEST_DEBUG
+    { 192, 159, 192, 171 }      // WINDOW_GUEST_DEBUG
 };
 // clang-format on
 
@@ -2067,6 +2067,12 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto peep = GET_PEEP(w->number);
     auto x = w->x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     auto y = w->y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    {
+        //args only holds one thing, so no array
+        int32_t args = {peep->sprite_index};
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, args, 0 x, y);
+    }
+    y += LIST_ROW_HEIGHT;
     {
         int32_t args[] = { peep->x, peep->y, peep->x };
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_POSITION, args, 0, x, y);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2068,9 +2068,8 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto x = w->x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     auto y = w->y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     {
-        //args only holds one thing, so no array
-        int32_t args = {peep->sprite_index};
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, args, 0 x, y);
+        set_format_arg(0, uint32_t, peep->sprite_index);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFromatArgs, 0 x, y);
     }
     y += LIST_ROW_HEIGHT;
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2069,7 +2069,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto y = w->y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFromatArgs, 0 x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0 x, y);
     }
     y += LIST_ROW_HEIGHT;
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2069,7 +2069,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto y = w->y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0 x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, x, y);
     }
     y += LIST_ROW_HEIGHT;
     {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3959,7 +3959,6 @@ enum
 
     STR_DESYNC_REPORT = 6318,
 
-
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3955,10 +3955,10 @@ enum
     STR_PEEP_DEBUG_PATHFIND_GOAL = 6315,
     STR_PEEP_DEBUG_PATHFIND_HISTORY = 6316,
     STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM = 6317,
+    STR_PEEP_DEBUG_SPRITE_INDEX = 6322,
 
     STR_DESYNC_REPORT = 6318,
 
-    STR_PEEP_DEBUG_SPRITE_INDEX = 6322,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3958,6 +3958,8 @@ enum
 
     STR_DESYNC_REPORT = 6318,
 
+    STR_PEEP_DEBUG_SPRITE_INDEX = 6322,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
Fix issue #9231, (Add Peep sprite index to the Guest Debug Tab).

I have no idea why the file change tracker is listing a bunch of lines as having a single space added to the end of them in data/language/en-GB.txt. I tried re-committing after spamming the undo button and changing nothing but line 3769, but it would not let me add the file to the branch, claiming that nothing had been changed. Please let me know if these extra spaces cause issues.