### PR TITLE
fix: Staff patrol areas getting clobbered when hiring new staff

### DIFF
--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -260,9 +260,9 @@ private:
 
             gStaffModes[staffIndex] = STAFF_MODE_WALK;
 
-            for (int32_t newStaffIndex = 0; newStaffIndex < STAFF_PATROL_AREA_SIZE; newStaffIndex++)
+            for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
             {
-                gStaffPatrolAreas[newStaffIndex * STAFF_PATROL_AREA_SIZE + newStaffId] = 0;
+                gStaffPatrolAreas[staffIndex * STAFF_PATROL_AREA_SIZE + i] = 0;
             }
 
             res->peepSriteIndex = newPeep->sprite_index;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "31"
+#define NETWORK_STREAM_VERSION "32"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Hi, I think I have found and fixed an issue with the resetting of staff patrol areas when hiring new staff members that end up reusing a fired staff member's old ID.  I noticed that some of my staff patrol areas would occasionally get messed up so decided to spend some time looking into it.

Steps to reproduce:

1. Hire a new staff member and assign them a patrol area
2. Fire the new staff member
3. Hire another new staff member
4. Now try to either:
  - set their patrol area to the same square - nothing is highlighted and the area is not assigned
  - or, click on a new square - the new square and the old square are highlighted, and some graphical issues may occur on the old square

It looks like the problem was introduced when the staff hire action was added in [`f96a1a1b`](https://github.com/OpenRCT2/OpenRCT2/commit/f96a1a1b5f0174e8736464a11e00ea0a3127b8d2#diff-3c354ecc83a4335deb4414c2a5fcb981L337); the loop indexing when resetting the patrol areas for the new staff member's ID is different in the new action code.  I think my commit changes the indexing logic back to what it was prior to the action being introduced.