### PR TITLE
Fix desync when host changes map

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -545,6 +545,8 @@ namespace OpenRCT2
                         sprite_position_tween_reset();
                         gScreenAge = 0;
                         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
+
+                        bool sendMap = false;
                         if (info.Type == FILE_TYPE::SAVED_GAME)
                         {
                             if (network_get_mode() == NETWORK_MODE_CLIENT)
@@ -554,7 +556,7 @@ namespace OpenRCT2
                             game_load_init();
                             if (network_get_mode() == NETWORK_MODE_SERVER)
                             {
-                                network_send_map();
+                                sendMap = true;
                             }
                         }
                         else
@@ -562,7 +564,7 @@ namespace OpenRCT2
                             scenario_begin();
                             if (network_get_mode() == NETWORK_MODE_SERVER)
                             {
-                                network_send_map();
+                                sendMap = true;
                             }
                             if (network_get_mode() == NETWORK_MODE_CLIENT)
                             {
@@ -572,6 +574,10 @@ namespace OpenRCT2
                         // This ensures that the newly loaded save reflects the user's
                         // 'show real names of guests' option, now that it's a global setting
                         peep_update_names(gConfigGeneral.show_real_names_of_guests);
+                        if (sendMap)
+                        {
+                            network_send_map();
+                        }
                         return true;
                     }
                     catch (const ObjectLoadException& e)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "33"
+#define NETWORK_STREAM_VERSION "34"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
The server sent the map before sorting the peeps by name. The function peep_update_names calls peep_sort which changes their order in the sprite list.