### PR TITLE
Fix clients being behind one tick

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -230,10 +230,9 @@ void GameState::UpdateLogic()
     if (network_get_mode() == NETWORK_MODE_CLIENT && network_get_status() == NETWORK_STATUS_CONNECTED
         && network_get_authstatus() == NETWORK_AUTH_OK)
     {
-        // Can't be in sync with server, round trips won't work if we are at same level.
-        if (gCurrentTicks >= network_get_server_tick())
+        // Don't run ahead of the server but can be on same tick.
+        if (gCurrentTicks > network_get_server_tick())
         {
-            // Don't run past the server
             return;
         }
     }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "32"
+#define NETWORK_STREAM_VERSION "33"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
It may not seem like a problem but it can be if you pause the game as host, the client will never process  PauseToggleAction because it was never allowed to run at the server tick, while it did seem like the game was paused this is only because the server stops incrementing the tick and the client just queued the action never actually put gGamePaused to 1 because PauseToggleAction sits in the queue. In this state the client would never show errors if attempted to place something while the game is paused instead would send it directly to the server where it just gets rejected. This change will allow the client to be on the tick at where the game was paused and will run the PauseToggleAction action as expected.

It does not require a new network version but if server owners update so will clients hopefully