### PR TITLE
Fix #9270: Refactor Money Effect Cpp

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -130,6 +130,7 @@ The following people are not part of the development team, but have been contrib
 * Florian Will (w-flo)
 * Trevor Harkness (tharkne)
 * Steve Xu (stevexu-umich)
+* (aw20368)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -528,7 +528,7 @@ int32_t game_do_command_p(
                 {
                     // Create a +/- money text effect
                     if (cost != 0 && game_is_not_paused())
-                        money_effect_create(cost);
+                        rct_money_effect::Create(cost);
                 }
             }
 

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -301,7 +301,7 @@ namespace GameActions
             if (result->Error == GA_ERROR::OK && finance_check_money_required(flags) && result->Cost != 0)
             {
                 finance_payment(result->Cost, result->ExpenditureType);
-                money_effect_create(result->Cost);
+                rct_money_effect::Create(result->Cost);
             }
 
             if (!(actionFlags & GA_FLAGS::CLIENT_ONLY) && result->Error == GA_ERROR::OK)

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -49,8 +49,7 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
             }
 
             const rct_money_effect* moneyEffect = &misc->money_effect;
-            money32 value;
-            rct_string_id stringId = money_effect_get_string_id(moneyEffect, &value);
+            auto [stringId, value] = moneyEffect->GetStringId();
             paint_floating_money_effect(
                 session, value, stringId, moneyEffect->y, moneyEffect->z, (int8_t*)&money_wave[moneyEffect->wiggle % 22],
                 moneyEffect->offset_x, session->CurrentRotation);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2041,7 +2041,7 @@ void Guest::SpendMoney(money16& peep_expend_type, money32 amount)
         //      needing to be synchronised
         if (network_get_mode() == NETWORK_MODE_NONE && !gOpenRCT2Headless)
         {
-            money_effect_create_at(amount, x, y, z, true);
+            rct_money_effect::CreateAt(amount, x, y, z, true);
         }
     }
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -17,11 +17,27 @@
 
 static constexpr const LocationXY16 _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }, { -1, 1 }, { -1, -1 } };
 
+bool rct_sprite::IsMoneyEffect()
+{
+    return this->money_effect.sprite_identifier == SPRITE_IDENTIFIER_MISC
+        && this->money_effect.type == SPRITE_MISC_MONEY_EFFECT;
+}
+
+rct_money_effect* rct_sprite::AsMoneyEffect()
+{
+    rct_money_effect* result = nullptr;
+    if (IsMoneyEffect())
+    {
+        result = (rct_money_effect*)this;
+    }
+    return result;
+}
+
 /**
  *
  *  rct2: 0x0067351F
  */
-void money_effect_create_at(money32 value, int32_t x, int32_t y, int32_t z, bool vertical)
+void rct_money_effect::CreateAt(money32 value, int32_t x, int32_t y, int32_t z, bool vertical)
 {
     if (value == MONEY(0, 00))
         return;
@@ -44,10 +60,9 @@ void money_effect_create_at(money32 value, int32_t x, int32_t y, int32_t z, bool
     int16_t offsetX = 0;
     if (!gOpenRCT2NoGraphics)
     {
-        // Construct string to display
-        rct_string_id stringId = money_effect_get_string_id(moneyEffect, &value);
+        auto [stringId, newValue] = moneyEffect->GetStringId();
         char buffer[128];
-        format_string(buffer, 128, stringId, &value);
+        format_string(buffer, 128, stringId, &newValue);
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
         offsetX = -(gfx_get_string_width(buffer) / 2);
     }
@@ -59,7 +74,7 @@ void money_effect_create_at(money32 value, int32_t x, int32_t y, int32_t z, bool
  *
  *  rct2: 0x0069C5D0
  */
-void money_effect_create(money32 value)
+void rct_money_effect::Create(money32 value)
 {
     LocationXYZ16 mapPosition = { gCommandPosition.x, gCommandPosition.y, gCommandPosition.z };
 
@@ -79,66 +94,62 @@ void money_effect_create(money32 value)
         mapPosition.z = tile_element_height(mapPosition.x, mapPosition.y);
     }
     mapPosition.z += 10;
-    money_effect_create_at(-value, mapPosition.x, mapPosition.y, mapPosition.z, false);
+    CreateAt(-value, mapPosition.x, mapPosition.y, mapPosition.z, false);
 }
 
 /**
  *
  *  rct2: 0x00673232
  */
-void money_effect_update(rct_money_effect* moneyEffect)
+void rct_money_effect::Update()
 {
-    invalidate_sprite_2((rct_sprite*)moneyEffect);
-    moneyEffect->wiggle++;
-    if (moneyEffect->wiggle >= 22)
+    invalidate_sprite_2((rct_sprite*)this);
+    wiggle++;
+    if (wiggle >= 22)
     {
-        moneyEffect->wiggle = 0;
+        wiggle = 0;
     }
 
-    moneyEffect->move_delay++;
-    if (moneyEffect->move_delay < 2)
-    {
-        return;
-    }
-
-    int32_t x = moneyEffect->x;
-    int32_t y = moneyEffect->y;
-    int32_t z = moneyEffect->z;
-    moneyEffect->move_delay = 0;
-
-    if (moneyEffect->vertical)
-    {
-        z += 1;
-    }
-    y += _moneyEffectMoveOffset[get_current_rotation()].y;
-    x += _moneyEffectMoveOffset[get_current_rotation()].x;
-
-    sprite_move(x, y, z, (rct_sprite*)moneyEffect);
-
-    moneyEffect->num_movements++;
-    if (moneyEffect->num_movements < 55)
+    move_delay++;
+    if (move_delay < 2)
     {
         return;
     }
 
-    sprite_remove((rct_sprite*)moneyEffect);
+    int32_t newX = x;
+    int32_t newY = y;
+    int32_t newZ = z;
+    move_delay = 0;
+
+    if (vertical)
+    {
+        newZ += 1;
+    }
+    newY += _moneyEffectMoveOffset[get_current_rotation()].y;
+    newX += _moneyEffectMoveOffset[get_current_rotation()].x;
+
+    sprite_move(newX, newY, newZ, (rct_sprite*)this);
+
+    num_movements++;
+    if (num_movements < 55)
+    {
+        return;
+    }
+
+    sprite_remove((rct_sprite*)this);
 }
 
-rct_string_id money_effect_get_string_id(const rct_money_effect* sprite, money32* outValue)
+std::pair<rct_string_id, money32> rct_money_effect::GetStringId() const
 {
-    bool vertical = (sprite->vertical != 0);
     rct_string_id spentStringId = vertical ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
     rct_string_id receiveStringId = vertical ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
     rct_string_id stringId = receiveStringId;
-    money32 value = sprite->value;
+    money32 outValue = value;
     if (value < 0)
     {
-        value *= -1;
+        outValue *= -1;
         stringId = spentStringId;
     }
-    if (outValue != nullptr)
-    {
-        *outValue = value;
-    }
-    return stringId;
+
+    return std::make_pair(stringId, outValue);
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -541,7 +541,7 @@ static void sprite_misc_update(rct_sprite* sprite)
             sprite_steam_particle_update((rct_steam_particle*)sprite);
             break;
         case SPRITE_MISC_MONEY_EFFECT:
-            money_effect_update(&sprite->money_effect);
+            sprite->money_effect.Update();
             break;
         case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
             crashed_vehicle_particle_update((rct_crashed_vehicle_particle*)sprite);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -93,6 +93,11 @@ struct rct_money_effect : rct_sprite_common
     money32 value;
     int16_t offset_x;
     uint16_t wiggle;
+
+    static void CreateAt(money32 value, int32_t x, int32_t y, int32_t z, bool vertical);
+    static void Create(money32 value);
+    void Update();
+    std::pair<rct_string_id, money32> GetStringId() const;
 };
 
 struct rct_crashed_vehicle_particle : rct_sprite_generic
@@ -139,9 +144,11 @@ union rct_sprite
 
     bool IsBalloon();
     bool IsDuck();
+    bool IsMoneyEffect();
     bool IsPeep();
     rct_balloon* AsBalloon();
     rct_duck* AsDuck();
+    rct_money_effect* AsMoneyEffect();
     Peep* AsPeep();
 };
 assert_struct_size(rct_sprite, 0x100);
@@ -238,14 +245,6 @@ void duck_update(rct_duck* duck);
 void duck_press(rct_duck* duck);
 void duck_remove_all();
 uint32_t duck_get_frame_image(const rct_duck* duck, int32_t direction);
-
-///////////////////////////////////////////////////////////////
-// Money effect
-///////////////////////////////////////////////////////////////
-void money_effect_create(money32 value);
-void money_effect_create_at(money32 value, int32_t x, int32_t y, int32_t z, bool vertical);
-void money_effect_update(rct_money_effect* moneyEffect);
-rct_string_id money_effect_get_string_id(const rct_money_effect* sprite, money32* outValue);
 
 ///////////////////////////////////////////////////////////////
 // Crash particles


### PR DESCRIPTION
Changed static functions to rct_money_effect member functions. GetStringId now returns std::pair.