### PR TITLE
Fix #9293: Issue with the native load/save dialog

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,6 +47,7 @@
 - Fix: [#9152] Spectators can modify ride colours.
 - Fix: [#9202] Artefacts show when changing ride type as client or using in-game console.
 - Fix: [#9240] Crash when passing directory instead of save file.
+- Fix: [#9293] Issue with the native load/save dialog.
 - Fix: Guests eating popcorn are drawn as if they're eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -109,7 +109,6 @@ namespace OpenRCT2::Ui
             // Set open file name options
             OPENFILENAMEW openFileName = {};
             openFileName.lStructSize = sizeof(OPENFILENAMEW);
-            openFileName.hwndOwner = GetHWND(window);
             openFileName.lpstrTitle = wcTitle.c_str();
             openFileName.lpstrInitialDir = wcInitialDirectory.c_str();
             openFileName.lpstrFilter = wcFilters.c_str();


### PR DESCRIPTION
The only way I can think of fixing this is to not set the owner. This means that it then at least can be focused without the game window interfering.