### PR TITLE
Fix #9288: Replace repeated 3d to 2d functions

### DIFF
--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -253,30 +253,13 @@ void screenshot_giant()
     int32_t centreX = (mapSize / 2) * 32 + 16;
     int32_t centreY = (mapSize / 2) * 32 + 16;
 
-    int32_t x = 0, y = 0;
     int32_t z = tile_element_height(centreX, centreY);
-    switch (rotation)
-    {
-        case 0:
-            x = centreY - centreX;
-            y = ((centreX + centreY) / 2) - z;
-            break;
-        case 1:
-            x = -centreY - centreX;
-            y = ((-centreX + centreY) / 2) - z;
-            break;
-        case 2:
-            x = -centreY + centreX;
-            y = ((-centreX - centreY) / 2) - z;
-            break;
-        case 3:
-            x = centreY + centreX;
-            y = ((centreX - centreY) / 2) - z;
-            break;
-    }
 
-    viewport.view_x = x - ((viewport.view_width << zoom) / 2);
-    viewport.view_y = y - ((viewport.view_height << zoom) / 2);
+    CoordsXYZ centreCoords3d = { centreX, centreY, z };
+    CoordsXY centreCoords2d = translate_3d_to_2d_with_z(rotation, centreCoords3d);
+
+    viewport.view_x = centreCoords2d.x - ((viewport.view_width << zoom) / 2);
+    viewport.view_y = centreCoords2d.y - ((viewport.view_height << zoom) / 2);
     viewport.zoom = zoom;
     gCurrentRotation = rotation;
 
@@ -531,30 +514,13 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
             if (centreMapY)
                 customY = (mapSize / 2) * 32 + 16;
 
-            int32_t x = 0, y = 0;
             int32_t z = tile_element_height(customX, customY);
-            switch (customRotation)
-            {
-                case 0:
-                    x = customY - customX;
-                    y = ((customX + customY) / 2) - z;
-                    break;
-                case 1:
-                    x = -customY - customX;
-                    y = ((-customX + customY) / 2) - z;
-                    break;
-                case 2:
-                    x = -customY + customX;
-                    y = ((-customX - customY) / 2) - z;
-                    break;
-                case 3:
-                    x = customY + customX;
-                    y = ((customX - customY) / 2) - z;
-                    break;
-            }
+            CoordsXYZ coords3d = { customX, customY, z };
 
-            viewport.view_x = x - ((viewport.view_width << customZoom) / 2);
-            viewport.view_y = y - ((viewport.view_height << customZoom) / 2);
+            CoordsXY coords2d = translate_3d_to_2d_with_z(customRotation, coords3d);
+
+            viewport.view_x = coords2d.x - ((viewport.view_width << customZoom) / 2);
+            viewport.view_y = coords2d.y - ((viewport.view_height << customZoom) / 2);
             viewport.zoom = customZoom;
             gCurrentRotation = customRotation;
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7899,28 +7899,9 @@ StationObject* ride_get_station_object(const Ride* ride)
 
 LocationXY16 ride_get_rotated_coords(int16_t x, int16_t y, int16_t z)
 {
-    LocationXY16 rotatedCoords = { 0, 0 };
-
-    switch (get_current_rotation())
-    {
-        case 0:
-            rotatedCoords.x = y - x;
-            rotatedCoords.y = ((y + x) / 2) - z;
-            break;
-        case 1:
-            rotatedCoords.x = -x - y;
-            rotatedCoords.y = ((y - x) / 2) - z;
-            break;
-        case 2:
-            rotatedCoords.x = x - y;
-            rotatedCoords.y = ((-y - x) / 2) - z;
-            break;
-        case 3:
-            rotatedCoords.x = y + x;
-            rotatedCoords.y = ((x - y) / 2) - z;
-            break;
-    }
-
+    CoordsXYZ coords3d = { x, y, z };
+    CoordsXY coords2d = translate_3d_to_2d_with_z(get_current_rotation(), coords3d);
+    LocationXY16 rotatedCoords = { (int16_t)coords2d.x, (int16_t)coords2d.y };
     return rotatedCoords;
 }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -143,6 +143,8 @@ LocationXY16 coordinate_3d_to_2d(const LocationXYZ16* coordinate_3d, int32_t rot
 
     switch (rotation)
     {
+        // this function has to use right-shift (... >> 1) since dividing
+        // by 2 with (... / 2) can differ by -1 and cause issues (see PR #9301)
         default:
         case 0:
             coordinate_2d.x = coordinate_3d->y - coordinate_3d->x;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -642,31 +642,13 @@ void sprite_move(int16_t x, int16_t y, int16_t z, rct_sprite* sprite)
 
 void sprite_set_coordinates(int16_t x, int16_t y, int16_t z, rct_sprite* sprite)
 {
-    int16_t new_x = x, new_y = y, start_x = x;
-    switch (get_current_rotation())
-    {
-        case 0:
-            new_x = new_y - new_x;
-            new_y = (new_y + start_x) / 2 - z;
-            break;
-        case 1:
-            new_x = -new_y - new_x;
-            new_y = (new_y - start_x) / 2 - z;
-            break;
-        case 2:
-            new_x = -new_y + new_x;
-            new_y = (-new_y - start_x) / 2 - z;
-            break;
-        case 3:
-            new_x = new_y + new_x;
-            new_y = (-new_y + start_x) / 2 - z;
-            break;
-    }
+    CoordsXYZ coords3d = { x, y, z };
+    CoordsXY newCoords = translate_3d_to_2d_with_z(get_current_rotation(), coords3d);
 
-    sprite->generic.sprite_left = new_x - sprite->generic.sprite_width;
-    sprite->generic.sprite_right = new_x + sprite->generic.sprite_width;
-    sprite->generic.sprite_top = new_y - sprite->generic.sprite_height_negative;
-    sprite->generic.sprite_bottom = new_y + sprite->generic.sprite_height_positive;
+    sprite->generic.sprite_left = newCoords.x - sprite->generic.sprite_width;
+    sprite->generic.sprite_right = newCoords.x + sprite->generic.sprite_width;
+    sprite->generic.sprite_top = newCoords.y - sprite->generic.sprite_height_negative;
+    sprite->generic.sprite_bottom = newCoords.y + sprite->generic.sprite_height_positive;
     sprite->generic.x = x;
     sprite->generic.y = y;
     sprite->generic.z = z;


### PR DESCRIPTION
Replaced duplicate 3d coords to 2d code with translate_3d_to_2d_with_z(...) function