### PR TITLE
fix: Unable to use second skyscraper terrain edge style

### DIFF
--- a/src/openrct2/actions/SurfaceSetStyleAction.hpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.hpp
@@ -88,7 +88,7 @@ public:
             }
 
             const auto edgeObj = static_cast<TerrainEdgeObject*>(
-                objManager.GetLoadedObject(OBJECT_TYPE_TERRAIN_SURFACE, _edgeStyle));
+                objManager.GetLoadedObject(OBJECT_TYPE_TERRAIN_EDGE, _edgeStyle));
 
             if (edgeObj == nullptr)
             {

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "34"
+#define NETWORK_STREAM_VERSION "35"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Code to check if selected edge style is valid was passing the wrong object type
(surface instead of edge) to GetLoadedObject, causing that method to warn that
the selected edget style index was out-of-range.

Reproduction steps:

1. Open the Land tool
2. Select the last edge type (second skyscraper style edge)
3. Click a tile to try to change it to the selected edge, and the message "Can't change land type" is shown and the tile edge is not changed