### PR TITLE
Refactor ride measurement storage

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5880,7 +5880,6 @@ static void window_ride_graphs_mousedown(rct_window* w, rct_widgetindex widgetIn
 static void window_ride_graphs_update(rct_window* w)
 {
     rct_widget* widget;
-    rct_ride_measurement* measurement;
     int32_t x;
 
     w->frame_no++;
@@ -5896,7 +5895,8 @@ static void window_ride_graphs_update(rct_window* w)
         auto ride = get_ride(w->number);
         if (ride != nullptr)
         {
-            measurement = ride_get_measurement(ride, nullptr);
+            RideMeasurement* measurement{};
+            std::tie(measurement, std::ignore) = ride_get_measurement(ride);
             x = measurement == nullptr ? 0 : measurement->current_item - (((widget->right - widget->left) / 4) * 3);
         }
     }
@@ -5911,8 +5911,6 @@ static void window_ride_graphs_update(rct_window* w)
  */
 static void window_ride_graphs_scrollgetheight(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    rct_ride_measurement* measurement;
-
     window_event_invalidate_call(w);
 
     // Set minimum size
@@ -5922,7 +5920,8 @@ static void window_ride_graphs_scrollgetheight(rct_window* w, int32_t scrollInde
     auto ride = get_ride(w->number);
     if (ride != nullptr)
     {
-        measurement = ride_get_measurement(ride, nullptr);
+        RideMeasurement* measurement{};
+        std::tie(measurement, std::ignore) = ride_get_measurement(ride);
         if (measurement != nullptr)
         {
             *width = std::max<int32_t>(*width, measurement->num_items);
@@ -5950,8 +5949,7 @@ static void window_ride_graphs_tooltip(rct_window* w, rct_widgetindex widgetInde
         auto ride = get_ride(w->number);
         if (ride != nullptr)
         {
-            rct_string_id message;
-            auto measurement = ride_get_measurement(ride, &message);
+            auto [measurement, message] = ride_get_measurement(ride);
             if (measurement != nullptr && (measurement->flags & RIDE_MEASUREMENT_FLAG_RUNNING))
             {
                 set_format_arg(4, uint16_t, measurement->vehicle_index + 1);
@@ -6053,11 +6051,11 @@ static void window_ride_graphs_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
 
     auto widget = &window_ride_graphs_widgets[WIDX_GRAPH];
     auto stringId = STR_NONE;
-    rct_ride_measurement* measurement{};
+    RideMeasurement* measurement{};
     auto ride = get_ride(w->number);
     if (ride != nullptr)
     {
-        measurement = ride_get_measurement(ride, &stringId);
+        std::tie(measurement, stringId) = ride_get_measurement(ride);
     }
     if (measurement == nullptr)
     {

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -186,7 +186,7 @@ public:
 
         ride->lift_hill_speed = RideLiftData[ride->type].minimum_speed;
 
-        ride->measurement_index = 255;
+        ride->measurement = {};
         ride->excitement = (ride_rating)-1;
         ride->cur_num_customers = 0;
         ride->num_customers_timeout = 0;

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -229,10 +229,6 @@ private:
             }
         }
 
-        user_string_free(ride->name);
-        ride->type = RIDE_TYPE_NULL;
-        gParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
-
         auto res = std::make_unique<GameActionResult>();
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
         res->Cost = refundPrice;
@@ -245,6 +241,9 @@ private:
 
             res->Position = { x, y, z };
         }
+
+        ride->Delete();
+        gParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
 
         // Close windows related to the demolished ride
         if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED))

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -212,7 +212,7 @@ public:
                 ride->status = _status;
                 ride->current_issues = 0;
                 ride->last_issue_time = 0;
-                ride_get_measurement(ride, nullptr);
+                ride_get_measurement(ride);
                 ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
                 window_invalidate_by_number(WC_RIDE, _rideIndex);
                 break;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "37"
+#define NETWORK_STREAM_VERSION "38"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -428,8 +428,8 @@ struct rct1_peep : RCT12SpriteBase
     uint8_t pad_C4;
     union
     {
-        uint8_t staff_id;                   // 0xC5
-        ride_id_t guest_heading_to_ride_id; // 0xC5
+        uint8_t staff_id;                 // 0xC5
+        uint8_t guest_heading_to_ride_id; // 0xC5
     };
     union
     {
@@ -681,7 +681,7 @@ struct rct1_s4
     uint32_t unk_1CADCA;
     uint16_t unk_1CADCE;
     uint8_t unk_1CADD0[116];
-    rct_ride_measurement ride_measurements[8];
+    RCT12RideMeasurement ride_measurements[8];
     uint32_t next_guest_index;
     uint16_t game_counter_5;
     uint8_t patrol_areas[(RCT1_MAX_STAFF + RCT12_STAFF_TYPE_COUNT) * RCT12_PATROL_AREA_SIZE];

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -952,7 +952,6 @@ private:
         dst->sheltered_eighths = src->num_inversions >> 5;
         dst->boat_hire_return_direction = src->boat_hire_return_direction;
         dst->boat_hire_return_position = src->boat_hire_return_position;
-        dst->measurement_index = src->data_logging_index;
         dst->chairlift_bullwheel_rotation = src->chairlift_bullwheel_rotation;
         for (int i = 0; i < 2; i++)
         {
@@ -1108,23 +1107,32 @@ private:
 
     void ImportRideMeasurements()
     {
-        for (int32_t i = 0; i < MAX_RIDE_MEASUREMENTS; i++)
+        for (const auto& src : _s4.ride_measurements)
         {
-            rct_ride_measurement* dst = get_ride_measurement(i);
-            rct_ride_measurement* src = &_s4.ride_measurements[i];
-            ImportRideMeasurement(dst, src);
+            if (src.ride_index != RCT12_RIDE_ID_NULL)
+            {
+                auto ride = get_ride(src.ride_index);
+                ride->measurement = std::make_unique<RideMeasurement>();
+                ride->measurement->ride = ride;
+                ImportRideMeasurement(*ride->measurement, src);
+            }
         }
     }
 
-    void ImportRideMeasurement(rct_ride_measurement* dst, rct_ride_measurement* src)
+    void ImportRideMeasurement(RideMeasurement& dst, const RCT12RideMeasurement& src)
     {
-        *dst = *src;
-        for (int32_t i = 0; i < RIDE_MEASUREMENT_MAX_ITEMS; i++)
+        dst.flags = src.flags;
+        dst.last_use_tick = src.last_use_tick;
+        dst.num_items = src.num_items;
+        dst.current_item = src.current_item;
+        dst.vehicle_index = src.vehicle_index;
+        dst.current_station = src.current_station;
+        for (size_t i = 0; i < std::size(src.velocity); i++)
         {
-            dst->velocity[i] /= 2;
-            dst->altitude[i] /= 2;
-            dst->vertical[i] /= 2;
-            dst->lateral[i] /= 2;
+            dst.velocity[i] = src.velocity[i] / 2;
+            dst.altitude[i] = src.altitude[i] / 2;
+            dst.vertical[i] = src.vertical[i] / 2;
+            dst.lateral[i] = src.lateral[i] / 2;
         }
     }
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -39,6 +39,9 @@
 
 #define RCT12_PEEP_MAX_THOUGHTS 5
 
+#define RCT12_RIDE_ID_NULL 255
+#define RCT12_RIDE_MEASUREMENT_MAX_ITEMS 4800
+
 constexpr uint16_t const RCT12_MAX_INVERSIONS = 31;
 constexpr uint16_t const RCT12_MAX_GOLF_HOLES = 31;
 constexpr uint16_t const RCT12_MAX_HELICES = 31;
@@ -501,5 +504,21 @@ struct RCT12PeepThought
     uint8_t fresh_timeout;
 };
 assert_struct_size(RCT12PeepThought, 4);
+
+struct RCT12RideMeasurement
+{
+    uint8_t ride_index;                                 // 0x0000
+    uint8_t flags;                                      // 0x0001
+    uint32_t last_use_tick;                             // 0x0002
+    uint16_t num_items;                                 // 0x0006
+    uint16_t current_item;                              // 0x0008
+    uint8_t vehicle_index;                              // 0x000A
+    uint8_t current_station;                            // 0x000B
+    int8_t vertical[RCT12_RIDE_MEASUREMENT_MAX_ITEMS];  // 0x000C
+    int8_t lateral[RCT12_RIDE_MEASUREMENT_MAX_ITEMS];   // 0x12CC
+    uint8_t velocity[RCT12_RIDE_MEASUREMENT_MAX_ITEMS]; // 0x258C
+    uint8_t altitude[RCT12_RIDE_MEASUREMENT_MAX_ITEMS]; // 0x384C
+};
+assert_struct_size(RCT12RideMeasurement, 0x4B0C);
 
 #pragma pack(pop)

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -310,7 +310,7 @@ struct RCT2SpriteVehicle : RCT12SpriteBase
     int32_t remaining_distance; // 0x24
     int32_t velocity;           // 0x28
     int32_t acceleration;       // 0x2C
-    ride_id_t ride;             // 0x30
+    uint8_t ride;               // 0x30
     uint8_t vehicle_type;       // 0x31
     rct_vehicle_colour colours; // 0x32
     union

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -57,4 +57,6 @@ private:
     void ExportResearchList();
     void ExportMarketingCampaigns();
     void ExportPeepSpawns();
+    void ExportRideMeasurements();
+    void ExportRideMeasurement(RCT12RideMeasurement& dst, const RideMeasurement& src);
 };

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -396,7 +396,7 @@ public:
         // pad_0138B582
 
         gRideRatingsCalcData = _s6.ride_ratings_calc_data;
-        std::memcpy(gRideMeasurements, _s6.ride_measurements, sizeof(_s6.ride_measurements));
+        ImportRideMeasurements();
         gNextGuestNumber = _s6.next_guest_index;
         gGrassSceneryTileLoopPosition = _s6.grass_and_scenery_tilepos;
         std::memcpy(gStaffPatrolAreas, _s6.patrol_areas, sizeof(_s6.patrol_areas));
@@ -586,8 +586,6 @@ public:
         dst->boat_hire_return_direction = src->boat_hire_return_direction;
         dst->boat_hire_return_position = src->boat_hire_return_position;
 
-        dst->measurement_index = src->measurement_index;
-
         dst->special_track_elements = src->special_track_elements;
         // pad_0D6[2];
 
@@ -748,6 +746,37 @@ public:
         dst->cable_lift = src->cable_lift;
 
         // pad_208[0x58];
+    }
+
+    void ImportRideMeasurements()
+    {
+        for (const auto& src : _s6.ride_measurements)
+        {
+            if (src.ride_index != RCT12_RIDE_ID_NULL)
+            {
+                auto ride = get_ride(src.ride_index);
+                ride->measurement = std::make_unique<RideMeasurement>();
+                ride->measurement->ride = ride;
+                ImportRideMeasurement(*ride->measurement, src);
+            }
+        }
+    }
+
+    void ImportRideMeasurement(RideMeasurement& dst, const RCT12RideMeasurement& src)
+    {
+        dst.flags = src.flags;
+        dst.last_use_tick = src.last_use_tick;
+        dst.num_items = src.num_items;
+        dst.current_item = src.current_item;
+        dst.vehicle_index = src.vehicle_index;
+        dst.current_station = src.current_station;
+        for (size_t i = 0; i < std::size(src.velocity); i++)
+        {
+            dst.velocity[i] = src.velocity[i];
+            dst.altitude[i] = src.altitude[i];
+            dst.vertical[i] = src.vertical[i];
+            dst.lateral[i] = src.lateral[i];
+        }
     }
 
     void ImportResearchedRideTypes()

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1798,6 +1798,7 @@ static bool track_design_place_preview(rct_track_td6* td6, money32* cost, Ride**
         _currentTrackPieceDirection = backup_rotation;
         user_string_free(ride->name);
         ride->type = RIDE_TYPE_NULL;
+        ride->measurement = {};
         byte_9D8150 = false;
         return false;
     }

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -457,10 +457,16 @@ enum
 #define VEHICLE_SEAT_PAIR_FLAG 0x80
 #define VEHICLE_SEAT_NUM_MASK 0x7F
 
+struct GForces
+{
+    int32_t VerticalG{};
+    int32_t LateralG{};
+};
+
 rct_vehicle* try_get_vehicle(uint16_t spriteIndex);
 void vehicle_update_all();
 void vehicle_sounds_update();
-void vehicle_get_g_forces(const rct_vehicle* vehicle, int32_t* verticalG, int32_t* lateralG);
+GForces vehicle_get_g_forces(const rct_vehicle* vehicle);
 void vehicle_set_map_toolbar(const rct_vehicle* vehicle);
 int32_t vehicle_is_used_in_pairs(const rct_vehicle* vehicle);
 int32_t vehicle_update_track_motion(rct_vehicle* vehicle, int32_t* outStation);

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -265,7 +265,7 @@ struct rct_s6_data
     uint8_t pad_0138B582[2];
     rct_ride_rating_calc_data ride_ratings_calc_data;
     uint8_t pad_0138B5D0[60];
-    rct_ride_measurement ride_measurements[8];
+    RCT12RideMeasurement ride_measurements[8];
     uint32_t next_guest_index;
     uint16_t grass_and_scenery_tilepos;
     uint32_t patrol_areas[(RCT2_MAX_STAFF + RCT12_STAFF_TYPE_COUNT) * RCT12_PATROL_AREA_SIZE];

--- a/test/testpaint/TestPaint.cpp
+++ b/test/testpaint/TestPaint.cpp
@@ -46,13 +46,11 @@ namespace TestPaint
         gPaintSession.DPI = dpi;
 
         {
-            Ride ride = {};
-            ride.entrance_style = 0;
             static rct_ride_entry rideEntry = {};
             rct_ride_entry_vehicle vehicleEntry{};
             vehicleEntry.base_image_id = 0x70000;
             rideEntry.vehicles[0] = vehicleEntry;
-            gRideList[0] = ride;
+            gRideList[0] = {};
             gRideEntries[0] = &rideEntry;
         }
         {


### PR DESCRIPTION
* Maximum number of simultaneous ride measurements can be increased at will.
* List of ride measurements removed, now just a pointer in `struct Ride`.
* Ride measurements now dynamically allocated on heap when required (~19 KiB per ride).