### PR TITLE
Fix #8723 Use rotate_map_coordinates to rotate coordinate

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -84,21 +84,8 @@ static paint_struct* sub_9819_c(
     paint_struct* ps = &session->NextFreePaintStruct->basic;
     ps->image_id = image_id;
 
-    switch (session->CurrentRotation)
-    {
-        case 0:
-            rotate_map_coordinates(&offset.x, &offset.y, 0);
-            break;
-        case 1:
-            rotate_map_coordinates(&offset.x, &offset.y, 3);
-            break;
-        case 2:
-            rotate_map_coordinates(&offset.x, &offset.y, 2);
-            break;
-        case 3:
-            rotate_map_coordinates(&offset.x, &offset.y, 1);
-            break;
-    }
+    uint8_t swappedRotation = (session->CurrentRotation * 3) % 4; // swaps 1 and 3
+    rotate_map_coordinates(&offset.x, &offset.y, swappedRotation);
     offset.x += session->SpritePosition.x;
     offset.y += session->SpritePosition.y;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -613,33 +613,12 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
     int32_t OriginZ = input->element->base_height * 8;
 
     uint8_t rotation = input->element->GetDirection();
-    switch (rotation)
-    {
-        case 0:
-            x += trackCoordinate->x;
-            x -= trackBlock->x;
-            y += trackCoordinate->y;
-            y -= trackBlock->y;
-            break;
-        case 1:
-            x += trackCoordinate->y;
-            x -= trackBlock->y;
-            y -= trackCoordinate->x;
-            y += trackBlock->x;
-            break;
-        case 2:
-            x -= trackCoordinate->x;
-            x += trackBlock->x;
-            y -= trackCoordinate->y;
-            y += trackBlock->y;
-            break;
-        case 3:
-            x -= trackCoordinate->y;
-            x += trackBlock->y;
-            y += trackCoordinate->x;
-            y -= trackBlock->x;
-            break;
-    }
+
+    CoordsXY coords = { x, y };
+    CoordsXY trackCoordOffset = { trackCoordinate->x, trackCoordinate->y };
+    CoordsXY trackBlockOffset = { trackBlock->x, trackBlock->y };
+    coords += trackCoordOffset.Rotate(rotation);
+    coords += trackBlockOffset.Rotate(direction_reverse(rotation));
 
     OriginZ -= trackBlock->z;
     OriginZ += trackCoordinate->z_end;
@@ -647,7 +626,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
     uint8_t directionStart = ((trackCoordinate->rotation_end + rotation) & TILE_ELEMENT_DIRECTION_MASK)
         | (trackCoordinate->rotation_end & (1 << 2));
 
-    return track_block_get_next_from_zero(x, y, OriginZ, ride, directionStart, output, z, direction, false);
+    return track_block_get_next_from_zero(coords.x, coords.y, OriginZ, ride, directionStart, output, z, direction, false);
 }
 
 /**
@@ -713,25 +692,12 @@ bool track_block_get_previous_from_zero(
         outTrackBeginEnd->begin_y = y;
         outTrackBeginEnd->end_x = x;
         outTrackBeginEnd->end_y = y;
-        switch (nextRotation & 3)
-        {
-            case 0:
-                outTrackBeginEnd->begin_x -= nextTrackCoordinate->x;
-                outTrackBeginEnd->begin_y -= nextTrackCoordinate->y;
-                break;
-            case 1:
-                outTrackBeginEnd->begin_x -= nextTrackCoordinate->y;
-                outTrackBeginEnd->begin_y += nextTrackCoordinate->x;
-                break;
-            case 2:
-                outTrackBeginEnd->begin_x += nextTrackCoordinate->x;
-                outTrackBeginEnd->begin_y += nextTrackCoordinate->y;
-                break;
-            case 3:
-                outTrackBeginEnd->begin_x += nextTrackCoordinate->y;
-                outTrackBeginEnd->begin_y -= nextTrackCoordinate->x;
-                break;
-        }
+
+        CoordsXY coords = { outTrackBeginEnd->begin_x, outTrackBeginEnd->begin_y };
+        CoordsXY offsets = { nextTrackCoordinate->x, nextTrackCoordinate->y };
+        coords += offsets.Rotate(direction_reverse(nextRotation));
+        outTrackBeginEnd->begin_x = coords.x;
+        outTrackBeginEnd->begin_y = coords.y;
 
         outTrackBeginEnd->begin_z = tileElement->base_height * 8;
         outTrackBeginEnd->begin_z += get_track_def_from_ride(ride, tileElement->AsTrack()->GetTrackType())->z
@@ -772,25 +738,9 @@ bool track_block_get_previous(int32_t x, int32_t y, TileElement* tileElement, tr
     int32_t z = tileElement->base_height * 8;
 
     uint8_t rotation = tileElement->GetDirection();
-    switch (rotation)
-    {
-        case 0:
-            x -= trackBlock->x;
-            y -= trackBlock->y;
-            break;
-        case 1:
-            x -= trackBlock->y;
-            y += trackBlock->x;
-            break;
-        case 2:
-            x += trackBlock->x;
-            y += trackBlock->y;
-            break;
-        case 3:
-            x += trackBlock->y;
-            y -= trackBlock->x;
-            break;
-    }
+    CoordsXY coords = { x, y };
+    CoordsXY offsets = { trackBlock->x, trackBlock->y };
+    coords += offsets.Rotate(direction_reverse(rotation));
 
     z -= trackBlock->z;
     z += trackCoordinate->z_begin;
@@ -798,7 +748,7 @@ bool track_block_get_previous(int32_t x, int32_t y, TileElement* tileElement, tr
     rotation = ((trackCoordinate->rotation_begin + rotation) & TILE_ELEMENT_DIRECTION_MASK)
         | (trackCoordinate->rotation_begin & (1 << 2));
 
-    return track_block_get_previous_from_zero(x, y, z, ride, rotation, outTrackBeginEnd);
+    return track_block_get_previous_from_zero(coords.x, coords.y, z, ride, rotation, outTrackBeginEnd);
 }
 
 /**
@@ -1299,56 +1249,29 @@ int32_t sub_6C683D(
     int32_t sequence = tileElement->AsTrack()->GetSequenceIndex();
     uint8_t mapDirection = tileElement->GetDirection();
 
-    switch (mapDirection)
-    {
-        case TILE_ELEMENT_DIRECTION_WEST:
-            *x -= trackBlock[sequence].x;
-            *y -= trackBlock[sequence].y;
-            break;
-        case TILE_ELEMENT_DIRECTION_NORTH:
-            *x -= trackBlock[sequence].y;
-            *y += trackBlock[sequence].x;
-            break;
-        case TILE_ELEMENT_DIRECTION_EAST:
-            *x += trackBlock[sequence].x;
-            *y += trackBlock[sequence].y;
-            break;
-        case TILE_ELEMENT_DIRECTION_SOUTH:
-            *x += trackBlock[sequence].y;
-            *y -= trackBlock[sequence].x;
-            break;
-    }
+    TileCoordsXY offsets = { trackBlock[sequence].x, trackBlock[sequence].y };
+    TileCoordsXY newCoords = { *x, *y };
+    newCoords += offsets.Rotate(direction_reverse(mapDirection));
+
+    *x = newCoords.x;
+    *y = newCoords.y;
+
     *z -= trackBlock[sequence].z;
 
     int32_t start_x = *x, start_y = *y, start_z = *z;
     *z += trackBlock[0].z;
     for (int32_t i = 0; trackBlock[i].index != 0xFF; ++i)
     {
-        int32_t cur_x = start_x, cur_y = start_y, cur_z = start_z;
-        switch (mapDirection)
-        {
-            case TILE_ELEMENT_DIRECTION_WEST:
-                cur_x += trackBlock[i].x;
-                cur_y += trackBlock[i].y;
-                break;
-            case TILE_ELEMENT_DIRECTION_NORTH:
-                cur_x += trackBlock[i].y;
-                cur_y -= trackBlock[i].x;
-                break;
-            case TILE_ELEMENT_DIRECTION_EAST:
-                cur_x -= trackBlock[i].x;
-                cur_y -= trackBlock[i].y;
-                break;
-            case TILE_ELEMENT_DIRECTION_SOUTH:
-                cur_x -= trackBlock[i].y;
-                cur_y += trackBlock[i].x;
-                break;
-        }
+        TileCoordsXY cur = { start_x, start_y };
+        int32_t cur_z = start_z;
+        offsets.x = trackBlock[i].x;
+        offsets.y = trackBlock[i].y;
+        cur += offsets.Rotate(mapDirection);
         cur_z += trackBlock[i].z;
 
-        map_invalidate_tile_full(cur_x, cur_y);
+        map_invalidate_tile_full(cur.x, cur.y);
 
-        tileElement = map_get_first_element_at(cur_x / 32, cur_y / 32);
+        tileElement = map_get_first_element_at(cur.x / 32, cur.y / 32);
         successTileElement = nullptr;
         do
         {

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -811,7 +811,7 @@ static bool TrackDesignPlaceSceneryElementGetPlaceZ(rct_td6_scenery_element* sce
 }
 
 static bool TrackDesignPlaceSceneryElement(
-    CoordsXY mapCoord, LocationXY8 tile, uint8_t mode, rct_td6_scenery_element* scenery, uint8_t rotation, int32_t originZ)
+    CoordsXY mapCoord, uint8_t mode, rct_td6_scenery_element* scenery, uint8_t rotation, int32_t originZ)
 {
     if (_trackDesignPlaceOperation == PTD_OPERATION_DRAW_OUTLINES && mode == 0)
     {
@@ -1101,31 +1101,14 @@ static int32_t track_design_place_all_scenery(
         for (rct_td6_scenery_element* scenery = scenery_start; scenery->scenery_object.end_flag != 0xFF; scenery++)
         {
             uint8_t rotation = _currentTrackPieceDirection;
-            LocationXY8 tile = { (uint8_t)(originX / 32), (uint8_t)(originY / 32) };
-            switch (rotation & 3)
-            {
-                case TILE_ELEMENT_DIRECTION_WEST:
-                    tile.x += scenery->x;
-                    tile.y += scenery->y;
-                    break;
-                case TILE_ELEMENT_DIRECTION_NORTH:
-                    tile.x += scenery->y;
-                    tile.y -= scenery->x;
-                    break;
-                case TILE_ELEMENT_DIRECTION_EAST:
-                    tile.x -= scenery->x;
-                    tile.y -= scenery->y;
-                    break;
-                case TILE_ELEMENT_DIRECTION_SOUTH:
-                    tile.x -= scenery->y;
-                    tile.y += scenery->x;
-                    break;
-            }
+            TileCoordsXY tileCoords = { originX / 32, originY / 32 };
+            TileCoordsXY offsets = { scenery->x, scenery->y };
+            tileCoords += offsets.Rotate(rotation);
 
-            CoordsXY mapCoord = { tile.x * 32, tile.y * 32 };
+            CoordsXY mapCoord = { tileCoords.x * 32, tileCoords.y * 32 };
             track_design_update_max_min_coordinates(mapCoord.x, mapCoord.y, originZ);
 
-            if (!TrackDesignPlaceSceneryElement(mapCoord, tile, mode, scenery, rotation, originZ))
+            if (!TrackDesignPlaceSceneryElement(mapCoord, mode, scenery, rotation, originZ))
             {
                 return 0;
             }

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -386,28 +386,11 @@ bool window_ride_construction_update_state(
             trackDirection |= 0x04;
         }
 
-        switch (trackDirection & 0x03)
-        {
-            case 0:
-                x -= trackCoordinates->x;
-                y -= trackCoordinates->y;
-                break;
-
-            case 1:
-                x -= trackCoordinates->y;
-                y += trackCoordinates->x;
-                break;
-
-            case 2:
-                x += trackCoordinates->x;
-                y += trackCoordinates->y;
-                break;
-
-            case 3:
-                x += trackCoordinates->y;
-                y -= trackCoordinates->x;
-                break;
-        }
+        CoordsXY offsets = { trackCoordinates->x, trackCoordinates->y };
+        CoordsXY coords = { x, y };
+        coords += offsets.Rotate(direction_reverse(trackDirection));
+        x = (uint16_t)coords.x;
+        y = (uint16_t)coords.y;
     }
     else
     {

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -70,6 +70,47 @@ struct CoordsXY
         , y(_y)
     {
     }
+
+    CoordsXY& operator+=(const CoordsXY rhs)
+    {
+        x += rhs.x;
+        y += rhs.y;
+        return *this;
+    }
+
+    CoordsXY& operator-=(const CoordsXY rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        return *this;
+    }
+
+    CoordsXY Rotate(int32_t direction)
+    {
+        CoordsXY rotatedCoords;
+        switch (direction & 3)
+        {
+            default:
+            case 0:
+                rotatedCoords.x = x;
+                rotatedCoords.y = y;
+                break;
+            case 1:
+                rotatedCoords.x = y;
+                rotatedCoords.y = -x;
+                break;
+            case 2:
+                rotatedCoords.x = -x;
+                rotatedCoords.y = -y;
+                break;
+            case 3:
+                rotatedCoords.x = -y;
+                rotatedCoords.y = x;
+                break;
+        }
+
+        return rotatedCoords;
+    }
 };
 
 struct TileCoordsXY
@@ -91,6 +132,40 @@ struct TileCoordsXY
         y += rhs.y;
         return *this;
     }
+    TileCoordsXY& operator-=(const TileCoordsXY rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        return *this;
+    }
+
+    TileCoordsXY Rotate(int32_t direction)
+    {
+        TileCoordsXY rotatedCoords;
+        switch (direction & 3)
+        {
+            default:
+            case 0:
+                rotatedCoords.x = x;
+                rotatedCoords.y = y;
+                break;
+            case 1:
+                rotatedCoords.x = y;
+                rotatedCoords.y = -x;
+                break;
+            case 2:
+                rotatedCoords.x = -x;
+                rotatedCoords.y = -y;
+                break;
+            case 3:
+                rotatedCoords.x = -y;
+                rotatedCoords.y = x;
+                break;
+        }
+
+        return rotatedCoords;
+    }
+
     int32_t x = 0, y = 0;
 };
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2577,25 +2577,12 @@ TileElement* map_get_track_element_at_with_direction_from_ride(
 
 void map_offset_with_rotation(int16_t* x, int16_t* y, int16_t offsetX, int16_t offsetY, uint8_t rotation)
 {
-    switch (rotation & 3)
-    {
-        case TILE_ELEMENT_DIRECTION_WEST:
-            *x += offsetX;
-            *y += offsetY;
-            break;
-        case TILE_ELEMENT_DIRECTION_NORTH:
-            *x += offsetY;
-            *y -= offsetX;
-            break;
-        case TILE_ELEMENT_DIRECTION_EAST:
-            *x -= offsetX;
-            *y -= offsetY;
-            break;
-        case TILE_ELEMENT_DIRECTION_SOUTH:
-            *x -= offsetY;
-            *y += offsetX;
-            break;
-    }
+    TileCoordsXY offsets = { offsetX, offsetY };
+    TileCoordsXY newCoords = { *x, *y };
+    newCoords += offsets.Rotate(rotation);
+
+    *x = (int16_t)newCoords.x;
+    *y = (int16_t)newCoords.y;
 }
 
 WallElement* map_get_wall_element_at(int32_t x, int32_t y, int32_t z, int32_t direction)

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -763,59 +763,28 @@ int32_t tile_inspector_track_base_height_offset(int32_t x, int32_t y, int32_t el
         trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
         uint8_t originDirection = trackElement->GetDirection();
-        switch (originDirection)
-        {
-            case 0:
-                originX -= trackBlock->x;
-                originY -= trackBlock->y;
-                break;
-            case 1:
-                originX -= trackBlock->y;
-                originY += trackBlock->x;
-                break;
-            case 2:
-                originX += trackBlock->x;
-                originY += trackBlock->y;
-                break;
-            case 3:
-                originX += trackBlock->y;
-                originY -= trackBlock->x;
-                break;
-        }
+        CoordsXY offsets = { trackBlock->x, trackBlock->y };
+        CoordsXY coords = { originX, originY };
+        coords += offsets.Rotate(direction_reverse(originDirection));
 
+        originX = (int16_t)coords.x;
+        originY = (int16_t)coords.y;
         originZ -= trackBlock->z;
 
         trackBlock = get_track_def_from_ride(ride, type);
         for (; trackBlock->index != 255; trackBlock++)
         {
-            int16_t elemX = originX, elemY = originY, elemZ = originZ;
-
-            switch (originDirection)
-            {
-                case 0:
-                    elemX += trackBlock->x;
-                    elemY += trackBlock->y;
-                    break;
-                case 1:
-                    elemX += trackBlock->y;
-                    elemY -= trackBlock->x;
-                    break;
-                case 2:
-                    elemX -= trackBlock->x;
-                    elemY -= trackBlock->y;
-                    break;
-                case 3:
-                    elemX -= trackBlock->y;
-                    elemY += trackBlock->x;
-                    break;
-            }
-
+            CoordsXY elem = { originX, originY };
+            int16_t elemZ = originZ;
+            offsets.x = trackBlock->x;
+            offsets.y = trackBlock->y;
+            elem += offsets.Rotate(originDirection);
             elemZ += trackBlock->z;
 
-            map_invalidate_tile_full(elemX, elemY);
+            map_invalidate_tile_full(elem.x, elem.y);
 
             bool found = false;
-            TileElement* tileElement = map_get_first_element_at(elemX >> 5, elemY >> 5);
+            TileElement* tileElement = map_get_first_element_at(elem.x >> 5, elem.y >> 5);
             do
             {
                 if (tileElement->base_height != elemZ / 8)
@@ -845,8 +814,7 @@ int32_t tile_inspector_track_base_height_offset(int32_t x, int32_t y, int32_t el
 
             // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
             // you decrease the map size.
-            openrct2_assert(
-                map_get_surface_element_at({ elemX, elemY }) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
+            openrct2_assert(map_get_surface_element_at(elem) != nullptr, "No surface at %d,%d", elem.x >> 5, elem.y >> 5);
 
             // Keep?
             // invalidate_test_results(ride);
@@ -896,59 +864,28 @@ int32_t tile_inspector_track_set_chain(
         trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
         uint8_t originDirection = trackElement->GetDirection();
-        switch (originDirection)
-        {
-            case 0:
-                originX -= trackBlock->x;
-                originY -= trackBlock->y;
-                break;
-            case 1:
-                originX -= trackBlock->y;
-                originY += trackBlock->x;
-                break;
-            case 2:
-                originX += trackBlock->x;
-                originY += trackBlock->y;
-                break;
-            case 3:
-                originX += trackBlock->y;
-                originY -= trackBlock->x;
-                break;
-        }
+        CoordsXY offsets = { trackBlock->x, trackBlock->y };
+        CoordsXY coords = { originX, originY };
+        coords += offsets.Rotate(direction_reverse(originDirection));
 
+        originX = (int16_t)coords.x;
+        originY = (int16_t)coords.y;
         originZ -= trackBlock->z;
 
         trackBlock = get_track_def_from_ride(ride, type);
         for (; trackBlock->index != 255; trackBlock++)
         {
-            int16_t elemX = originX, elemY = originY, elemZ = originZ;
-
-            switch (originDirection)
-            {
-                case 0:
-                    elemX += trackBlock->x;
-                    elemY += trackBlock->y;
-                    break;
-                case 1:
-                    elemX += trackBlock->y;
-                    elemY -= trackBlock->x;
-                    break;
-                case 2:
-                    elemX -= trackBlock->x;
-                    elemY -= trackBlock->y;
-                    break;
-                case 3:
-                    elemX -= trackBlock->y;
-                    elemY += trackBlock->x;
-                    break;
-            }
-
+            CoordsXY elem = { originX, originY };
+            int16_t elemZ = originZ;
+            offsets.x = trackBlock->x;
+            offsets.y = trackBlock->y;
+            elem += offsets.Rotate(originDirection);
             elemZ += trackBlock->z;
 
-            map_invalidate_tile_full(elemX, elemY);
+            map_invalidate_tile_full(elem.x, elem.y);
 
             bool found = false;
-            TileElement* tileElement = map_get_first_element_at(elemX >> 5, elemY >> 5);
+            TileElement* tileElement = map_get_first_element_at(elem.x >> 5, elem.y >> 5);
             do
             {
                 if (tileElement->base_height != elemZ / 8)
@@ -978,8 +915,7 @@ int32_t tile_inspector_track_set_chain(
 
             // track_remove returns here on failure, not sure when this would ever be hit. Only thing I can think of is for when
             // you decrease the map size.
-            openrct2_assert(
-                map_get_surface_element_at({ elemX, elemY }) != nullptr, "No surface at %d,%d", elemX >> 5, elemY >> 5);
+            openrct2_assert(map_get_surface_element_at(elem) != nullptr, "No surface at %d,%d", elem.x >> 5, elem.y >> 5);
 
             // Keep?
             // invalidate_test_results(ride);


### PR DESCRIPTION
Added Rotate to CoordsXY, TileCoordsXY and used them to replace redundant rotation code.

Mostly found the redundant code with `switch.*direction` and `switch.*rotation`. For completeness, also tried `x.*+=.*y`, `x.*=.*-.*y`, `case (0|1|2|3):.*\n.*break`, `case TILE_ELEMENT_DIRECTION_WEST`