### PR TITLE
Fix #9324: crash trying to remove invalid footpath scenery.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -56,6 +56,7 @@
 - Fix: [#9240] Crash when passing directory instead of save file.
 - Fix: [#9293] Issue with the native load/save dialog.
 - Fix: [#9322] Peep crashing the game trying to find a ride to look at.
+- Fix: [#9324] Crash trying to remove invalid footpath scenery.
 - Fix: [#9402] Ad campaigns disappear when you save and load the game.
 - Fix: [#9411] Ad campaigns end too soon.
 - Fix: Guests eating popcorn are drawn as if they're eating pizza.

--- a/src/openrct2/actions/FootpathSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathSceneryRemoveAction.hpp
@@ -69,17 +69,22 @@ public:
         }
 
         auto tileElement = map_get_footpath_element(_loc.x / 32, _loc.y / 32, _loc.z / 8);
-        auto pathElement = tileElement->AsPath();
+        if (tileElement == nullptr)
+        {
+            log_warning("Could not find path element.");
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_THIS);
+        }
 
+        auto pathElement = tileElement->AsPath();
         if (pathElement == nullptr)
         {
-            log_error("Could not find path element.");
+            log_warning("Could not find path element.");
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_REMOVE_THIS);
         }
 
         if (!pathElement->AdditionIsGhost() && (GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            log_error("Tried to remove non ghost during ghost removal.");
+            log_warning("Tried to remove non ghost during ghost removal.");
             return MakeResult(GA_ERROR::DISALLOWED, STR_CANT_REMOVE_THIS);
         }
         auto res = MakeResult();


### PR DESCRIPTION
Just a missing nullptr check