### PR TITLE
Fix #9322: Peep crashing the game trying to find a ride to look at

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -48,6 +48,7 @@
 - Fix: [#9202] Artefacts show when changing ride type as client or using in-game console.
 - Fix: [#9240] Crash when passing directory instead of save file.
 - Fix: [#9293] Issue with the native load/save dialog.
+- Fix: [#9322] Peep crashing the game trying to find a ride to look at.
 - Fix: Guests eating popcorn are drawn as if they're eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6278,6 +6278,11 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
     surfaceElement = map_get_surface_element_at({ peep->next_x, peep->next_y });
 
     tileElement = surfaceElement;
+    if (tileElement == nullptr)
+    {
+        return false;
+    }
+
     do
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
@@ -6312,6 +6317,11 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
     surfaceElement = map_get_surface_element_at({ x, y });
 
     tileElement = surfaceElement;
+    if (tileElement == nullptr)
+    {
+        return false;
+    }
+
     do
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
@@ -6541,6 +6551,11 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
 
     // TODO: extract loop A
     tileElement = surfaceElement;
+    if (tileElement == nullptr)
+    {
+        return false;
+    }
+
     do
     {
         // Ghosts are purely this-client-side and should not cause any interaction,


### PR DESCRIPTION
Another missing nullptr check. I believe this happens when peeps are walking near the edge of the map and then trying to find a ride to look at.