### PR TITLE
Add compile time selection for copying data with specialised paths

### DIFF
--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -52,15 +52,83 @@ interface IStream
     virtual const void* GetData() const abstract;
 
     ///////////////////////////////////////////////////////////////////////////
+    // Fast path methods, class can override them to use specialised copies.
+    ///////////////////////////////////////////////////////////////////////////
+    virtual void Read1(void* buffer)
+    {
+        Read(buffer, 1);
+    }
+    virtual void Read2(void* buffer)
+    {
+        Read(buffer, 2);
+    }
+    virtual void Read4(void* buffer)
+    {
+        Read(buffer, 4);
+    }
+    virtual void Read8(void* buffer)
+    {
+        Read(buffer, 8);
+    }
+    virtual void Read16(void* buffer)
+    {
+        Read(buffer, 16);
+    }
+
+    virtual void Write1(const void* buffer)
+    {
+        Write(buffer, 1);
+    }
+    virtual void Write2(const void* buffer)
+    {
+        Write(buffer, 2);
+    }
+    virtual void Write4(const void* buffer)
+    {
+        Write(buffer, 4);
+    }
+    virtual void Write8(const void* buffer)
+    {
+        Write(buffer, 8);
+    }
+    virtual void Write16(const void* buffer)
+    {
+        Write(buffer, 16);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // Helper methods
     ///////////////////////////////////////////////////////////////////////////
-
     /**
      * Reads the size of the given type from the stream directly into the given address.
      */
     template<typename T> void Read(T * value)
     {
-        Read(value, sizeof(T));
+        // Selects the best path at compile time
+        if constexpr (sizeof(T) == 1)
+        {
+            Read1(value);
+        }
+        else if constexpr (sizeof(T) == 2)
+        {
+            Read2(value);
+        }
+        else if constexpr (sizeof(T) == 4)
+        {
+            Read4(value);
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            Read8(value);
+        }
+        else if constexpr (sizeof(T) == 16)
+        {
+            Read16(value);
+        }
+        else
+        {
+            Read(value, sizeof(T));
+        }
     }
 
     /**
@@ -68,7 +136,31 @@ interface IStream
      */
     template<typename T> void Write(const T* value)
     {
-        Write(value, sizeof(T));
+        // Selects the best path at compile time
+        if constexpr (sizeof(T) == 1)
+        {
+            Write1(value);
+        }
+        else if constexpr (sizeof(T) == 2)
+        {
+            Write2(value);
+        }
+        else if constexpr (sizeof(T) == 4)
+        {
+            Write4(value);
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            Write8(value);
+        }
+        else if constexpr (sizeof(T) == 16)
+        {
+            Write16(value);
+        }
+        else
+        {
+            Write(value, sizeof(T));
+        }
     }
 
     /**

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -155,8 +155,33 @@ void MemoryStream::Read(void* buffer, uint64_t length)
         throw IOException("Attempted to read past end of stream.");
     }
 
-    std::copy_n((const uint8_t*)_position, length, (uint8_t*)buffer);
+    std::memcpy(buffer, _position, length);
     _position = (void*)((uintptr_t)_position + length);
+}
+
+void MemoryStream::Read1(void* buffer)
+{
+    Read<1>(buffer);
+}
+
+void MemoryStream::Read2(void* buffer)
+{
+    Read<2>(buffer);
+}
+
+void MemoryStream::Read4(void* buffer)
+{
+    Read<4>(buffer);
+}
+
+void MemoryStream::Read8(void* buffer)
+{
+    Read<8>(buffer);
+}
+
+void MemoryStream::Read16(void* buffer)
+{
+    Read<16>(buffer);
 }
 
 uint64_t MemoryStream::TryRead(void* buffer, uint64_t length)
@@ -183,9 +208,34 @@ void MemoryStream::Write(const void* buffer, uint64_t length)
         }
     }
 
-    std::copy_n((const uint8_t*)buffer, length, (uint8_t*)_position);
+    std::memcpy(_position, buffer, length);
     _position = (void*)((uintptr_t)_position + length);
     _dataSize = std::max<size_t>(_dataSize, (size_t)nextPosition);
+}
+
+void MemoryStream::Write1(const void* buffer)
+{
+    Write<1>(buffer);
+}
+
+void MemoryStream::Write2(const void* buffer)
+{
+    Write<2>(buffer);
+}
+
+void MemoryStream::Write4(const void* buffer)
+{
+    Write<4>(buffer);
+}
+
+void MemoryStream::Write8(const void* buffer)
+{
+    Write<8>(buffer);
+}
+
+void MemoryStream::Write16(const void* buffer)
+{
+    Write<16>(buffer);
 }
 
 void MemoryStream::EnsureCapacity(size_t capacity)


### PR DESCRIPTION
This improves the performance of IStream/MemoryStream most where the effect is most prominent with the recently introduced gamestate snapshots system.

openrct2 host parks/bpb.sv6:
```
In-Game FPS bpb.sv6 at 1080p Software (HW):
  Average Before: 39
  Average After: 56

GameStateSnapshots::Capture:
  Average Before: 0.003934 secs
  Average After: 0.002075 secs
```

This should also affect other areas where those functions are used, there are 280~ references to Read/ReadValue and 110~ references to Write/WriteValue