### PR TITLE
Fix #9314 Trying to delete ride piece while paused moves the selection

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1932,11 +1932,14 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
         { _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z, _currentTrackPieceDirection });
 
     trackRemoveAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
-        _stationConstructed = get_ride(w->number)->num_stations != 0;
-        window_ride_construction_mouseup_demolish_next_piece(x, y, z, direction, type);
         if (result->Error != GA_ERROR::OK)
         {
             window_ride_construction_update_active_elements();
+        }
+        else
+        {
+            _stationConstructed = get_ride(w->number)->num_stations != 0;
+            window_ride_construction_mouseup_demolish_next_piece(x, y, z, direction, type);
         }
     });
 


### PR DESCRIPTION
Failed track removal was triggering a move to the next piece. Changed to move only upon successful removal.

Fixed was based on the behaviour of the code before the GameActions refractor: https://github.com/OpenRCT2/OpenRCT2/blob/ba445cb6ef7cab31e8325878ae0de8a0aaf499d8/src/openrct2-ui/windows/RideConstruction.cpp#L1872-L1894

where 
```
_stationConstructed = get_ride(w->number)->num_stations != 0;
window_ride_construction_mouseup_demolish_next_piece(x, y, z, direction, type);
```
were not run if the track removal was unsucessful (I assume, when the function returned a cost of MONEY32_UNDEFINED).