### PR TITLE
Fix #7829 Rotated information kiosk can cause 'unreachable' messages

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
 - Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
+- Fix: [#7829] Rotated information kiosk can cause 'unreachable' messages.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
 - Fix: [#8219] Faulty folder recreation in "save" folder.
 - Fix: [#8480, #8535] Crash when mirroring track design.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3503,7 +3503,7 @@ static void ride_shop_connected(Ride* ride)
     if (trackElement == nullptr)
         return;
 
-    uint16_t entrance_directions = 0;
+    uint8_t entrance_directions = 0;
     uint8_t track_type = trackElement->GetTrackType();
     ride = get_ride(trackElement->GetRideIndex());
     if (ride == nullptr)
@@ -3512,16 +3512,15 @@ static void ride_shop_connected(Ride* ride)
     }
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
     {
-        entrance_directions = FlatRideTrackSequenceProperties[track_type][0];
+        entrance_directions = FlatRideTrackSequenceProperties[track_type][0] & 0xF;
     }
     else
     {
-        entrance_directions = TrackSequenceProperties[track_type][0];
+        entrance_directions = TrackSequenceProperties[track_type][0] & 0xF;
     }
 
     uint8_t tile_direction = trackElement->GetDirection();
-    entrance_directions <<= tile_direction;
-    entrance_directions = ((entrance_directions >> 12) | entrance_directions) & 0xF;
+    entrance_directions = rol4(entrance_directions, tile_direction);
 
     // Now each bit in entrance_directions stands for an entrance direction to check
     if (entrance_directions == 0)


### PR DESCRIPTION
The cause:

https://github.com/OpenRCT2/OpenRCT2/blob/3ee6be0dbf8bad7b80a3542c1b9b2c263758f6c2/src/openrct2/ride/Ride.cpp#L3504-L3515

entrance_directions for the kiosk is 111111 (where the last four 1s represent the north/e/s/w ), tile_direction is 2 (using the case from the screenshot as example), so then entrance_directions becomes 11111100 at line 3512. I have absolutely no idea what the bit shift by 12 is supposed to do...I believe it always return 0. Finally the entrance_directions is masked with 0x0F to result in 1100. Hence only checking for a path in the direction of the arrow and 90 degrees clockwise from the arrow.

Note that this bug does not occur if the kiosk faced the opposite direction, as a tile_direction of 0 leaves the entrance_directions at the correct 1111. I've verified this in-game.

I'm not totally confident about my commit, simply because I don't know what the code originally intended with the 12-shift (for reference below). I've tested my changes with the kiosk and a normal 1-entrance shop, are there any other type of ride that has a non-standard entrance I can play with? Eg.  FLAT_TRACK_ELEM_1_X_4_C has entrance directions 1010, which rides uses that?

https://github.com/OpenRCT2/OpenRCT2/blob/64bece02468cf766e689f6ae2a8dadbf311a7582/src/ride.c#L336-L343