### PR TITLE
Fix #7323 Tunnel entrances not rendering in 'highlight path issues'

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7039] Map window not rendering properly when using OpenGL.
 - Fix: [#7045] Theme window's colour pickers not drawn properly on OpenGL.
+- Fix: [#7323] Tunnel entrances not rendering in 'highlight path issues' mode if they have benches inside.
 - Fix: [#7729] Money Input Prompt breaks on certain values.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -690,6 +690,8 @@ static void sub_6A3F61(
 
     if (dpi->zoom_level <= 1)
     {
+        bool paintScenery = true;
+
         if (!gTrackDesignSaveMode)
         {
             if (tile_element->AsPath()->HasAddition())
@@ -705,45 +707,50 @@ static void sub_6A3F61(
 
                 // Can be null if the object is not loaded.
                 if (sceneryEntry == nullptr)
-                    return;
-
-                if ((session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) && !(tile_element->AsPath()->IsBroken())
+                {
+                    paintScenery = false;
+                }
+                else if (
+                    (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) && !(tile_element->AsPath()->IsBroken())
                     && !(sceneryEntry->path_bit.draw_type == PATH_BIT_DRAW_TYPE_BINS))
                 {
-                    return;
+                    paintScenery = false;
                 }
-
-                switch (sceneryEntry->path_bit.draw_type)
+                else
                 {
-                    case PATH_BIT_DRAW_TYPE_LIGHTS:
-                        path_bit_lights_paint(
-                            session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
-                        break;
-                    case PATH_BIT_DRAW_TYPE_BINS:
-                        path_bit_bins_paint(
-                            session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
-                        break;
-                    case PATH_BIT_DRAW_TYPE_BENCHES:
-                        path_bit_benches_paint(
-                            session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
-                        break;
-                    case PATH_BIT_DRAW_TYPE_JUMPING_FOUNTAINS:
-                        path_bit_jumping_fountains_paint(session, sceneryEntry, height, sceneryImageFlags, dpi);
-                        break;
-                }
+                    switch (sceneryEntry->path_bit.draw_type)
+                    {
+                        case PATH_BIT_DRAW_TYPE_LIGHTS:
+                            path_bit_lights_paint(
+                                session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
+                            break;
+                        case PATH_BIT_DRAW_TYPE_BINS:
+                            path_bit_bins_paint(
+                                session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
+                            break;
+                        case PATH_BIT_DRAW_TYPE_BENCHES:
+                            path_bit_benches_paint(
+                                session, sceneryEntry, tile_element, height, (uint8_t)connectedEdges, sceneryImageFlags);
+                            break;
+                        case PATH_BIT_DRAW_TYPE_JUMPING_FOUNTAINS:
+                            path_bit_jumping_fountains_paint(session, sceneryEntry, height, sceneryImageFlags, dpi);
+                            break;
+                    }
 
-                session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
+                    session->InteractionType = VIEWPORT_INTERACTION_ITEM_FOOTPATH;
 
-                if (sceneryImageFlags != 0)
-                {
-                    session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    if (sceneryImageFlags != 0)
+                    {
+                        session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
+                    }
                 }
             }
         }
 
         // Redundant zoom-level check removed
 
-        sub_6A4101(session, tile_element, height, connectedEdges, word_F3F038, railingEntry, imageFlags);
+        if (paintScenery)
+            sub_6A4101(session, tile_element, height, connectedEdges, word_F3F038, railingEntry, imageFlags);
     }
 
     // This is about tunnel drawing


### PR DESCRIPTION
Hiding path scenery caused function that draws tunnel to prematurely return. Changed to only skip drawing scenery.