### PR TITLE
Fix #5896 Fences not always removed when building a tracked ride through

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Change: [#8427] Ghost elements now show up as white on the mini-map.
 - Change: [#8688] Move common actions from debug menu into cheats menu.
 - Fix: [#2294] Clients crashing the server with invalid object selection.
+- Fix: [#4568, #5896] Incorrect fences removed when building a tracked ride through
 - Fix: [#5103] OpenGL: ride track preview not rendered.
 - Fix: [#5889] Giant screenshot does not work while using OpenGL renderer.
 - Fix: [#5579] Network desync immediately after connecting.

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -491,6 +491,7 @@ public:
                     // Remove walls in the directions this track intersects
                     uint8_t intersectingDirections = (*wallEdges)[blockIndex];
                     intersectingDirections ^= 0x0F;
+                    intersectingDirections = rol4(intersectingDirections, _origin.direction);
                     for (int32_t i = 0; i < 4; i++)
                     {
                         if (intersectingDirections & (1 << i))

--- a/src/openrct2/core/Numerics.hpp
+++ b/src/openrct2/core/Numerics.hpp
@@ -31,6 +31,18 @@ namespace Numerics
     }
 
     /**
+     * Bitwise left rotate of lowest 4 bits
+     * @param x unsigned 8-bit integer value
+     * @param shift positions to shift
+     * @return rotated value
+     */
+    [[maybe_unused]] static constexpr uint8_t rol4(uint8_t x, size_t shift)
+    {
+        x &= 0x0F;
+        return (x << shift | x >> (4 - shift)) & 0x0F;
+    }
+
+    /**
      * Bitwise right rotate
      * @tparam _UIntType unsigned integral type
      * @param x value
@@ -42,6 +54,18 @@ namespace Numerics
         static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
         using limits = std::numeric_limits<_UIntType>;
         return (((_UIntType)(x) >> shift) | ((_UIntType)(x) << (limits::digits - shift)));
+    }
+
+    /**
+     * Bitwise right rotate of lowest 4 bits
+     * @param x unsigned 8-bit integer value
+     * @param shift positions to shift
+     * @return rotated value
+     */
+    [[maybe_unused]] static constexpr uint8_t ror4(uint8_t x, size_t shift)
+    {
+        x &= 0x0F;
+        return (x >> shift | x << (4 - shift)) & 0x0F;
     }
 
 } // namespace Numerics

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "36"
+#define NETWORK_STREAM_VERSION "37"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fence removal did not account for track direction. Added the rotation for the track/fence intersection test.

Note that this bug also caused extraneous fences to be removed when building curved track (the picture on the left is the behavior in v0.2.2, my branch on the right).

![Fence](https://user-images.githubusercontent.com/29646196/58736523-26db8b00-83cc-11e9-8106-55a2486d2eac.png)