### PR TITLE
Fix #9365: Crash when bringing window to front

### DIFF
--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -681,9 +681,6 @@ rct_window* window_bring_to_front(rct_window* w)
         auto itSourcePos = window_get_iterator(w);
         if (itSourcePos != g_window_list.end())
         {
-            auto wptr = std::move(*itSourcePos);
-            g_window_list.erase(itSourcePos);
-
             // Insert in front of the first non-stick-to-front window
             auto itDestPos = g_window_list.begin();
             for (auto it = g_window_list.rbegin(); it != g_window_list.rend(); it++)
@@ -696,7 +693,7 @@ rct_window* window_bring_to_front(rct_window* w)
                 }
             }
 
-            g_window_list.insert(itDestPos, std::move(wptr));
+            g_window_list.splice(itDestPos, g_window_list, itSourcePos);
             window_invalidate(w);
 
             if (w->x + w->width < 20)


### PR DESCRIPTION
This PR prevents the object from being destructed and constructed back thus keeping the iterators valid. To reproduce this issue simply create a ride that is not complete and try to set the ride status to Testing.

Took me a while to figure this one out as window_close is supposed to destroy only the window its supposed to close but given the way the list was re-arranged it always destructed/constructed new nodes for the list invaliding the iterators, std::list::splice ensures that it only re-links nodes without having to copy the elements.