### PR TITLE
Add suffix constant to avoid shifting too many bits

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -970,7 +970,7 @@ void window_scenery_invalidate(rct_window* w)
     if (gWindowSceneryEyedropperEnabled)
         w->pressed_widgets |= (1 << WIDX_SCENERY_EYEDROPPER_BUTTON);
     if (gWindowSceneryClusterEnabled == 1)
-        w->pressed_widgets |= (1 << WIDX_SCENERY_BUILD_CLUSTER_BUTTON);
+        w->pressed_widgets |= (1ULL << WIDX_SCENERY_BUILD_CLUSTER_BUTTON);
 
     window_scenery_widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WWT_EMPTY;
     window_scenery_widgets[WIDX_SCENERY_EYEDROPPER_BUTTON].type = WWT_EMPTY;


### PR DESCRIPTION
Since WIDX_SCENERY_BUILD_CLUSTER_BUTTON is 31, add suffix ULL to
avoid shifting 1 (which is an int and 4 bytes on most systems) 31 bits
which is technically undefined behaviour. This is already done in the
shift at line 463.

Detected by the help of cppcheck.