### PR TITLE
Fix #8859: Network gCheatsEnableAllDrawableTrackPieces

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "38"
+#define NETWORK_STREAM_VERSION "39"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2918,6 +2918,7 @@ bool Network::LoadMap(IStream* stream)
         gGamePaused = stream->ReadValue<uint32_t>();
         _guestGenerationProbability = stream->ReadValue<uint32_t>();
         _suggestedGuestMaximum = stream->ReadValue<uint32_t>();
+        gCheatsEnableAllDrawableTrackPieces = stream->ReadValue<uint8_t>() != 0;
         gCheatsSandboxMode = stream->ReadValue<uint8_t>() != 0;
         gCheatsDisableClearanceChecks = stream->ReadValue<uint8_t>() != 0;
         gCheatsDisableSupportLimits = stream->ReadValue<uint8_t>() != 0;
@@ -2965,6 +2966,7 @@ bool Network::SaveMap(IStream* stream, const std::vector<const ObjectRepositoryI
         stream->WriteValue<uint32_t>(gGamePaused);
         stream->WriteValue<uint32_t>(_guestGenerationProbability);
         stream->WriteValue<uint32_t>(_suggestedGuestMaximum);
+        stream->WriteValue<uint8_t>(gCheatsEnableAllDrawableTrackPieces);
         stream->WriteValue<uint8_t>(gCheatsSandboxMode);
         stream->WriteValue<uint8_t>(gCheatsDisableClearanceChecks);
         stream->WriteValue<uint8_t>(gCheatsDisableSupportLimits);


### PR DESCRIPTION
When clients join and this cheat was enabled it would be still disabled on their end while on the server its not unless it was toggled after the client joined.