### PR TITLE
Fix #9396. Pass the ghost flag to banner remove to prevent invalid removal

### DIFF
--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -157,7 +157,8 @@ private:
 
             auto bannerRemoveAction = BannerRemoveAction(
                 { x, y, tileElement->base_height * 8, tileElement->AsBanner()->GetPosition() });
-            bannerRemoveAction.SetFlags(GetFlags());
+            auto bannerFlags = GetFlags() | (tileElement->IsGhost() ? static_cast<uint32_t>(GAME_COMMAND_FLAG_GHOST) : 0);
+            bannerRemoveAction.SetFlags(bannerFlags);
             GameActions::ExecuteNested(&bannerRemoveAction);
             tileElement--;
         }

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -156,7 +156,7 @@ private:
         while (!(tileElement++)->IsLastForTile())
         {
             if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)
-                return;
+                return result;
             else if (tileElement->GetType() != TILE_ELEMENT_TYPE_BANNER)
                 continue;
 
@@ -173,5 +173,6 @@ private:
             }
             tileElement--;
         }
+        return result;
     }
 };

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "41"
+#define NETWORK_STREAM_VERSION "42"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Previously this would never have happened because the old code would do a scenery ghost removal before calling anything else. I think this is a better way of handling it though and don't want to revert to the old method.

One thing I noticed is that this is deleting banners for free. There is scope to further improve this.