### PR TITLE
Fix #8602: Wall piece collision detection deviates from vanilla

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -39,6 +39,7 @@
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
 - Fix: [#8553] Scenery removal tool removes fences and paths while paused.
 - Fix: [#8598] Taking screenshots fails with some park names.
+- Fix: [#8602] Wall piece collision detection deviates from vanilla
 - Fix: [#8649] Setting date does not work in multiplayer.
 - Fix: [#8873] Potential crash when placing footpaths.
 - Fix: [#8882] Submarine Ride does not count as indoors (original bug).

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -187,7 +187,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
         imageColourFlags &= 0x0DFFFFFFF;
     }
 
-    paint_util_set_general_support_height(session, height, 0x20);
+    paint_util_set_general_support_height(session, 8 * tile_element->clearance_height, 0x20);
 
     uint32_t dword_141F710 = 0;
     if (gTrackDesignSaveMode || (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))


### PR DESCRIPTION
Wall piece collision used the base height of the wall. Changed to use the clearance height.

Behaviour after change:

![PathSupport](https://user-images.githubusercontent.com/29646196/59396581-77050680-8d57-11e9-82da-2f8a66135b83.png)
