### PR TITLE
Don't clear the screen to black for giant screenshots

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -845,12 +845,14 @@ static void viewport_fill_column(paint_session* session)
 static void viewport_paint_column(paint_session* session)
 {
     if (session->ViewFlags
-        & (VIEWPORT_FLAG_HIDE_VERTICAL | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_CLIP_VIEW))
+            & (VIEWPORT_FLAG_HIDE_VERTICAL | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE
+               | VIEWPORT_FLAG_CLIP_VIEW)
+        && (~session->ViewFlags & VIEWPORT_FLAG_TRANSPARENT_BACKGROUND))
     {
-        uint8_t colour = 10;
+        uint8_t colour = COLOUR_AQUAMARINE;
         if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SPRITES)
         {
-            colour = 0;
+            colour = COLOUR_BLACK;
         }
         gfx_clear(&session->DPI, colour);
     }

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -125,7 +125,7 @@ static void blank_tiles_paint(paint_session* session, int32_t x, int32_t y)
     session->SpritePosition.x = x;
     session->SpritePosition.y = y;
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
-    sub_98196C(session, 3123, 0, 0, 32, 32, -1, 16);
+    sub_98196C(session, SPR_BLANK_TILE, 0, 0, 32, 32, -1, 16);
 }
 
 bool gShowSupportSegmentHeights = false;

--- a/src/openrct2/sprites.h
+++ b/src/openrct2/sprites.h
@@ -39,6 +39,8 @@ enum
     PEEP_SPAWN_ARROW_2 = 3113,
     PEEP_SPAWN_ARROW_3 = 3114,
 
+    SPR_BLANK_TILE = 3123,
+
     // This is the start of every character there are
     // 224 characters per font (first 32 are control codes hence why it doesn't go to 255)
     // 4 fonts


### PR DESCRIPTION
Someone mentioned this issue on the OpenRCT2 forums: https://forums.openrct2.org/topic/3782-giant-screenshot-transparency/?tab=comments#comment-21826

When certain viewport flags were set (underground view, hide base land, hide vertical faces, clip view), the viewport would always be cleared, including for giant screenshots. With this fix, the background will also be transparent when these flags are set.

Current behaviour:
![trnds-before](https://user-images.githubusercontent.com/9705046/59550197-4e079000-8f68-11e9-8724-8091d8a9fbec.png)

With the fix:
![trnds-vertical](https://user-images.githubusercontent.com/9705046/59550200-5364da80-8f68-11e9-84a3-180373829a07.png) ![trnds-base](https://user-images.githubusercontent.com/9705046/59550201-5364da80-8f68-11e9-8bbf-a080c461f28d.png) ![trnds-see-through](https://user-images.githubusercontent.com/9705046/59550202-5364da80-8f68-11e9-955b-6f487d0cb7ad.png)