### PR TITLE
Refactor windows code

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		01C6F0C422FD51B70057E2F7 /* T4Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01C6F0C322FD51B70057E2F7 /* T4Importer.cpp */; };
 		01C6F0C822FD51FC0057E2F7 /* T6Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01C6F0C522FD51FC0057E2F7 /* T6Exporter.cpp */; };
 		01C6F0C922FD51FC0057E2F7 /* T6Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01C6F0C622FD51FC0057E2F7 /* T6Importer.cpp */; };
+		01DDFE6522FD608500221318 /* Window_internal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01DDFE6422FD608500221318 /* Window_internal.cpp */; };
 		2A1F4FE0221FF4B0003CA045 /* Twitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C840F1EC4E7CC00FA49E2 /* Twitch.cpp */; };
 		2A1F4FE1221FF4B0003CA045 /* Audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83571EC4E7CC00FA49E2 /* Audio.cpp */; };
 		2A1F4FE2221FF4B0003CA045 /* macos.mm in Sources */ = {isa = PBXBuildFile; fileRef = F76C845D1EC4E7CC00FA49E2 /* macos.mm */; };
@@ -77,6 +78,8 @@
 		9346F9DB208A191900C77D91 /* GuestPathfinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9346F9D7208A191900C77D91 /* GuestPathfinding.cpp */; };
 		9346F9DC208A191900C77D91 /* GuestPathfinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9346F9D7208A191900C77D91 /* GuestPathfinding.cpp */; };
 		9346F9DD208A191900C77D91 /* GuestPathfinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9346F9D7208A191900C77D91 /* GuestPathfinding.cpp */; };
+		937A92132242CCB300B09278 /* LandBuyRightsAction.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 937A92122242CCB300B09278 /* LandBuyRightsAction.hpp */; };
+		937A92152242CDAA00B09278 /* LandSmoothAction.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 937A92142242CDAA00B09278 /* LandSmoothAction.hpp */; };
 		939A359A20C12FC800630B3F /* Paint.Litter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 939A359720C12FC700630B3F /* Paint.Litter.cpp */; };
 		939A359B20C12FC800630B3F /* Paint.Misc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 939A359820C12FC700630B3F /* Paint.Misc.cpp */; };
 		939A359C20C12FC800630B3F /* Paint.Sprite.h in Headers */ = {isa = PBXBuildFile; fileRef = 939A359920C12FC700630B3F /* Paint.Sprite.h */; };
@@ -630,6 +633,13 @@
 		01C6F0C522FD51FC0057E2F7 /* T6Exporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = T6Exporter.cpp; sourceTree = "<group>"; };
 		01C6F0C622FD51FC0057E2F7 /* T6Importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = T6Importer.cpp; sourceTree = "<group>"; };
 		01C6F0C722FD51FC0057E2F7 /* T6Exporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = T6Exporter.h; sourceTree = "<group>"; };
+		01DDFE6422FD608500221318 /* Window_internal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Window_internal.cpp; sourceTree = "<group>"; };
+		2A43D2B72225B8D900E8F73B /* RideSetVehiclesAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideSetVehiclesAction.hpp; sourceTree = "<group>"; };
+		2A43D2B82225B8D900E8F73B /* SmallSceneryPlaceAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SmallSceneryPlaceAction.hpp; sourceTree = "<group>"; };
+		2A43D2B92225B8D900E8F73B /* LoadOrQuitAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LoadOrQuitAction.hpp; sourceTree = "<group>"; };
+		2A43D2BD2225B91A00E8F73B /* RideSetVehiclesAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideSetVehiclesAction.hpp; sourceTree = "<group>"; };
+		2A43D2BE2225B91A00E8F73B /* RideEntranceExitRemoveAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideEntranceExitRemoveAction.hpp; sourceTree = "<group>"; };
+		2A43D2BF2225B91A00E8F73B /* LoadOrQuitAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LoadOrQuitAction.hpp; sourceTree = "<group>"; };
 		2A5354E822099C4F00A5440F /* Network.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Network.cpp; sourceTree = "<group>"; };
 		2A5354EA22099C7200A5440F /* CircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircularBuffer.h; sourceTree = "<group>"; };
 		2ADE2F21224418B1002598AF /* Random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Random.hpp; sourceTree = "<group>"; };
@@ -1228,6 +1238,8 @@
 		9350B52820B46E0900897BC5 /* ftrender.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ftrender.h; sourceTree = "<group>"; };
 		9350B52920B46E0900897BC5 /* ft2build.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ft2build.h; sourceTree = "<group>"; };
 		9391535A22D74359008E0780 /* OpenRCT2.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenRCT2.entitlements; sourceTree = "<group>"; };
+		937A92122242CCB300B09278 /* LandBuyRightsAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LandBuyRightsAction.hpp; sourceTree = "<group>"; };
+		937A92142242CDAA00B09278 /* LandSmoothAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LandSmoothAction.hpp; sourceTree = "<group>"; };
 		939A359720C12FC700630B3F /* Paint.Litter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Paint.Litter.cpp; sourceTree = "<group>"; };
 		939A359820C12FC700630B3F /* Paint.Misc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Paint.Misc.cpp; sourceTree = "<group>"; };
 		939A359920C12FC700630B3F /* Paint.Sprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Paint.Sprite.h; sourceTree = "<group>"; };
@@ -1365,6 +1377,11 @@
 		C6E96E351E0408B40076A04F /* libzip.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libzip.dylib; sourceTree = "<group>"; };
 		C9C630B42235A22C009AD16E /* GameStateSnapshots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameStateSnapshots.h; sourceTree = "<group>"; };
 		C9C630B52235A22C009AD16E /* GameStateSnapshots.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameStateSnapshots.cpp; sourceTree = "<group>"; };
+		C9C630B92235A7E7009AD16E /* LandRaiseAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LandRaiseAction.hpp; sourceTree = "<group>"; };
+		C9C630BA2235A7E7009AD16E /* LandLowerAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LandLowerAction.hpp; sourceTree = "<group>"; };
+		C9C630BB2235A7F9009AD16E /* WaterLowerAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WaterLowerAction.hpp; sourceTree = "<group>"; };
+		C9C630BC2235A7F9009AD16E /* WaterRaiseAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WaterRaiseAction.hpp; sourceTree = "<group>"; };
+		C9C630BD2235A9C6009AD16E /* FootpathPlaceFromTrackAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = FootpathPlaceFromTrackAction.hpp; sourceTree = "<group>"; };
 		D41B73EE1C2101890080A7B9 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
 		D41B741C1C210A7A0080A7B9 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 		D41B74721C2125E50080A7B9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = distribution/macos/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -2715,6 +2732,7 @@
 		F76C83BB1EC4E7CC00FA49E2 /* interface */ = {
 			isa = PBXGroup;
 			children = (
+				01DDFE6422FD608500221318 /* Window_internal.cpp */,
 				4C7B53DD200143C200A52E21 /* Chat.cpp */,
 				4C7B53DE200143C200A52E21 /* Chat.h */,
 				4C7B53DF200143C200A52E21 /* Colour.cpp */,
@@ -3616,6 +3634,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -3852,6 +3871,7 @@
 				93CBA4C920A7504500867D56 /* ImageImporter.cpp in Sources */,
 				933CBDB620CB1ACD00134678 /* Theme.cpp in Sources */,
 				93CBA4C020A74FF200867D56 /* BitmapReader.cpp in Sources */,
+				01DDFE6522FD608500221318 /* Window_internal.cpp in Sources */,
 				C68878CC20289B710084B384 /* SoftwareDrawingEngine.cpp in Sources */,
 				C67CCD681FBBD138004FAE4C /* EditorMain.cpp in Sources */,
 				C6E415511FAFD6DC00D4A52A /* RideConstruction.cpp in Sources */,

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -387,7 +387,7 @@ public:
                 if (vehicle->sprite_index != ride->vehicles[viewVehicleIndex])
                     return;
 
-                window_invalidate(w);
+                w->Invalidate();
                 break;
             }
 
@@ -401,7 +401,7 @@ public:
                     {
                         w->vehicleIndex = 0;
                     }
-                    window_invalidate(w);
+                    w->Invalidate();
                 }
                 break;
             }
@@ -432,7 +432,7 @@ public:
                 rct_window* w = window_find_by_number(WC_BANNER, bannerIndex);
                 if (w != nullptr)
                 {
-                    window_invalidate(w);
+                    w->Invalidate();
                 }
                 break;
             }
@@ -503,7 +503,7 @@ public:
             // Make sure the viewport has correct coordinates set.
             viewport_update_position(mainWindow);
 
-            window_invalidate(mainWindow);
+            mainWindow->Invalidate();
         }
     }
 

--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -79,7 +79,7 @@ static void toggle_view_flag(int32_t viewportFlag)
     if (window != nullptr)
     {
         window->viewport->flags ^= viewportFlag;
-        window_invalidate(window);
+        window->Invalidate();
     }
 }
 
@@ -115,7 +115,7 @@ static void shortcut_pause_game()
         rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
         if (window != nullptr)
         {
-            window_invalidate(window);
+            window->Invalidate();
             window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_PAUSE);
         }
     }
@@ -353,7 +353,7 @@ static void shortcut_adjust_land()
             rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
             if (window != nullptr)
             {
-                window_invalidate(window);
+                window->Invalidate();
                 window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_LAND);
             }
         }
@@ -372,7 +372,7 @@ static void shortcut_adjust_water()
             rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
             if (window != nullptr)
             {
-                window_invalidate(window);
+                window->Invalidate();
                 window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_WATER);
             }
         }
@@ -391,7 +391,7 @@ static void shortcut_build_scenery()
             rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
             if (window != nullptr)
             {
-                window_invalidate(window);
+                window->Invalidate();
                 window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_SCENERY);
             }
         }
@@ -410,7 +410,7 @@ static void shortcut_build_paths()
             rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
             if (window != nullptr)
             {
-                window_invalidate(window);
+                window->Invalidate();
                 window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_PATH);
             }
         }
@@ -565,7 +565,7 @@ static void shortcut_clear_scenery()
             rct_window* window = window_find_by_class(WC_TOP_TOOLBAR);
             if (window != nullptr)
             {
-                window_invalidate(window);
+                window->Invalidate();
                 window_event_mouse_up_call(window, WC_TOP_TOOLBAR__WIDX_CLEAR_SCENERY);
             }
         }
@@ -780,7 +780,7 @@ static void shortcut_open_scenery_picker()
         rct_window* window_toolbar = window_find_by_class(WC_TOP_TOOLBAR);
         if (window_toolbar != nullptr)
         {
-            window_invalidate(window_toolbar);
+            window_toolbar->Invalidate();
             window_event_mouse_up_call(window_toolbar, WC_TOP_TOOLBAR__WIDX_SCENERY);
         }
     }

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -170,7 +170,7 @@ rct_window* window_create(
     w->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
 
     colour_scheme_update(w);
-    window_invalidate(w);
+    w->Invalidate();
     return w;
 }
 

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -529,7 +529,7 @@ private:
             // Prevent scroll adjustment due to window placement when in-game
             auto oldScreenFlags = gScreenFlags;
             gScreenFlags = SCREEN_FLAGS_TITLE_DEMO;
-            window_set_location(w, x, y, z);
+            w->SetLocation(x, y, z);
             gScreenFlags = oldScreenFlags;
 
             viewport_update_position(w);

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -333,5 +333,5 @@ static void window_about_set_page(rct_window* w, int32_t page)
     w->pressed_widgets |= (page == WINDOW_ABOUT_PAGE_RCT2) ? (1ULL << WIDX_TAB_ABOUT_RCT2) : (1ULL << WIDX_TAB_ABOUT_OPENRCT2);
 
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -160,7 +160,7 @@ rct_window* window_banner_open(rct_windownumber number)
         (viewportWidget->bottom - viewportWidget->top) - 2, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
-    window_invalidate(w);
+    w->Invalidate();
 
     return w;
 }
@@ -356,5 +356,5 @@ static void window_banner_viewport_rotate(rct_window* w)
 
     if (w->viewport != nullptr)
         w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
-    window_invalidate(w);
+    w->Invalidate();
 }

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -147,12 +147,12 @@ static void window_changelog_resize(rct_window* w)
     w->min_height = MIN_WH;
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -1075,7 +1075,7 @@ static void window_cheats_text_input(rct_window* w, rct_widgetindex widgetIndex,
         {
             _moneySpinnerValue = val;
         }
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1271,9 +1271,9 @@ static void window_cheats_set_page(rct_window* w, int32_t page)
     }
     maxY += 6;
 
-    window_invalidate(w);
+    w->Invalidate();
     w->height = maxY;
     w->widgets[WIDX_BACKGROUND].bottom = maxY - 1;
     w->widgets[WIDX_PAGE_BACKGROUND].bottom = maxY - 1;
-    window_invalidate(w);
+    w->Invalidate();
 }

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -141,15 +141,15 @@ static void window_clear_scenery_mouseup(rct_window* w, rct_widgetindex widgetIn
             break;
         case WIDX_SMALL_SCENERY:
             gClearSmallScenery ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_LARGE_SCENERY:
             gClearLargeScenery ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_FOOTPATH:
             gClearFootpath ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -163,14 +163,14 @@ static void window_clear_scenery_mousedown(rct_window* w, rct_widgetindex widget
             gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INCREMENT:
             // Increment land tool size, if it stays within the limit
             gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -189,7 +189,7 @@ static void window_clear_scenery_textinput(rct_window* w, rct_widgetindex widget
         size = std::max(MINIMUM_TOOL_SIZE, size);
         size = std::min(MAXIMUM_TOOL_SIZE, size);
         gLandToolSize = size;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -145,7 +145,7 @@ static void window_debug_paint_invalidate(rct_window* w)
     if (ResizeLanguage != currentLanguage)
     {
         ResizeLanguage = currentLanguage;
-        window_invalidate(w);
+        w->Invalidate();
 
         // Find the width of the longest string
         int16_t newWidth = 0;
@@ -171,7 +171,7 @@ static void window_debug_paint_invalidate(rct_window* w)
         w->widgets[WIDX_TOGGLE_SHOW_BOUND_BOXES].right = newWidth - 8;
         w->widgets[WIDX_TOGGLE_SHOW_DIRTY_VISUALS].right = newWidth - 8;
 
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     widget_set_checkbox_value(w, WIDX_TOGGLE_SHOW_WIDE_PATHS, gPaintWidePathsAsGhost);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -232,7 +232,7 @@ static void move_research_item(rct_research_item* beforeItem)
     if (w != nullptr)
     {
         w->research_item = nullptr;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -388,17 +388,17 @@ static void window_editor_inventions_list_mouseup(rct_window* w, rct_widgetindex
             break;
         case WIDX_RANDOM_SHUFFLE:
             research_items_shuffle();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MOVE_ITEMS_TO_TOP:
             research_items_make_all_researched();
             window_init_scroll_widgets(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MOVE_ITEMS_TO_BOTTOM:
             research_items_make_all_unresearched();
             window_init_scroll_widgets(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -407,12 +407,12 @@ static void window_editor_inventions_list_resize(rct_window* w)
 {
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 }
@@ -434,7 +434,7 @@ static void window_editor_inventions_list_update(rct_window* w)
         return;
 
     _editorInventionsListDraggedItem = nullptr;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -478,7 +478,7 @@ static void window_editor_inventions_list_scrollmousedown(rct_window* w, int32_t
     if (researchItem->rawValue < RESEARCHED_ITEMS_END_2 || research_item_is_always_researched(researchItem))
         return;
 
-    window_invalidate(w);
+    w->Invalidate();
     window_editor_inventions_list_drag_open(researchItem);
 }
 
@@ -494,7 +494,7 @@ static void window_editor_inventions_list_scrollmouseover(rct_window* w, int32_t
     if (researchItem != w->research_item)
     {
         w->research_item = researchItem;
-        window_invalidate(w);
+        w->Invalidate();
 
         // Prevent always-researched items from being highlighted when hovered over
         if (researchItem != nullptr && research_item_is_always_researched(researchItem))
@@ -836,7 +836,7 @@ static void window_editor_inventions_list_drag_cursor(
         rct_research_item* researchItem = get_research_item_at(x, y);
         if (researchItem != inventionListWindow->research_item)
         {
-            window_invalidate(inventionListWindow);
+            inventionListWindow->Invalidate();
         }
     }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -352,7 +352,7 @@ static void visible_list_refresh(rct_window* w)
             }
         }
     }
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_editor_object_selection_init_widgets()
@@ -485,7 +485,7 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             w->selected_list_item = -1;
             w->object_entry = nullptr;
             w->scrolls[0].v_top = 0;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_FILTER_RIDE_TAB_TRANSPORT:
         case WIDX_FILTER_RIDE_TAB_GENTLE:
@@ -505,12 +505,12 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             w->object_entry = nullptr;
             w->scrolls[0].v_top = 0;
             w->frame_no = 0;
-            window_invalidate(w);
+            w->Invalidate();
             break;
 
         case WIDX_ADVANCED:
             w->list_information_type ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
 
         case WIDX_INSTALL_TRACK:
@@ -519,7 +519,7 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             {
                 w->selected_list_item = -1;
             }
-            window_invalidate(w);
+            w->Invalidate();
 
             auto intent = Intent(WC_LOADSAVE);
             intent.putExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK);
@@ -534,7 +534,7 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             filter_update_counts();
             w->scrolls->v_top = 0;
             visible_list_refresh(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_LIST_SORT_TYPE:
             if (_listSortType == RIDE_SORT_TYPE)
@@ -662,7 +662,7 @@ static void window_editor_object_selection_dropdown(rct_window* w, rct_widgetind
             w->scrolls->v_top = 0;
 
             visible_list_refresh(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -695,7 +695,7 @@ static void window_editor_object_selection_scroll_mousedown(rct_window* w, int32
     if (object_selection_flags & OBJECT_SELECTION_FLAG_6)
         return;
 
-    window_invalidate(w);
+    w->Invalidate();
 
     const CursorState* state = context_get_cursor_state();
     audio_play_sound(SoundId::Click1, 0, state->x);
@@ -732,7 +732,7 @@ static void window_editor_object_selection_scroll_mousedown(rct_window* w, int32
     {
         filter_update_counts();
         visible_list_refresh(w);
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (_maxObjectsWasHit)
@@ -775,7 +775,7 @@ static void window_editor_object_selection_scroll_mouseover(rct_window* w, int32
             _loadedObject = object_repository_load_object(listItem->entry);
         }
 
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1213,7 +1213,7 @@ static void window_editor_object_set_page(rct_window* w, int32_t page)
     }
 
     visible_list_refresh(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_editor_object_selection_set_pressed_tab(rct_window* w)
@@ -1346,7 +1346,7 @@ static void window_editor_object_selection_textinput(rct_window* w, rct_widgetin
     w->scrolls->v_top = 0;
 
     visible_list_refresh(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static bool filter_selected(uint8_t objectFlag)

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -335,12 +335,12 @@ static void window_editor_objective_options_set_page(rct_window* w, int32_t page
     w->hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[page];
     w->event_handlers = window_editor_objective_options_page_events[page];
     w->widgets = window_editor_objective_options_widgets[page];
-    window_invalidate(w);
+    w->Invalidate();
     window_editor_objective_options_update_disabled_widgets(w);
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -350,7 +350,7 @@ static void window_editor_objective_options_set_page(rct_window* w, int32_t page
 static void window_editor_objective_options_set_objective(rct_window* w, int32_t objective)
 {
     gScenarioObjectiveType = objective;
-    window_invalidate(w);
+    w->Invalidate();
 
     // Set default objective arguments
     switch (objective)
@@ -531,7 +531,7 @@ static void window_editor_objective_options_arg_1_increase(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency += MONEY(1000, 0);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_MONTHLY_FOOD_INCOME:
@@ -542,7 +542,7 @@ static void window_editor_objective_options_arg_1_increase(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency += MONEY(100, 0);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
@@ -553,7 +553,7 @@ static void window_editor_objective_options_arg_1_increase(rct_window* w)
             else
             {
                 gScenarioObjectiveNumGuests += 100;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
@@ -564,7 +564,7 @@ static void window_editor_objective_options_arg_1_increase(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency += FIXED_2DP(0, 10);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         default:
@@ -575,7 +575,7 @@ static void window_editor_objective_options_arg_1_increase(rct_window* w)
             else
             {
                 gScenarioObjectiveNumGuests += 50;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
     }
@@ -595,7 +595,7 @@ static void window_editor_objective_options_arg_1_decrease(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency -= MONEY(1000, 0);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_MONTHLY_FOOD_INCOME:
@@ -606,7 +606,7 @@ static void window_editor_objective_options_arg_1_decrease(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency -= MONEY(100, 0);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
@@ -617,7 +617,7 @@ static void window_editor_objective_options_arg_1_decrease(rct_window* w)
             else
             {
                 gScenarioObjectiveNumGuests -= 100;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
@@ -628,7 +628,7 @@ static void window_editor_objective_options_arg_1_decrease(rct_window* w)
             else
             {
                 gScenarioObjectiveCurrency -= FIXED_2DP(0, 10);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         default:
@@ -639,7 +639,7 @@ static void window_editor_objective_options_arg_1_decrease(rct_window* w)
             else
             {
                 gScenarioObjectiveNumGuests -= 50;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
     }
@@ -654,7 +654,7 @@ static void window_editor_objective_options_arg_2_increase(rct_window* w)
     else
     {
         gScenarioObjectiveYear++;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -667,7 +667,7 @@ static void window_editor_objective_options_arg_2_decrease(rct_window* w)
     else
     {
         gScenarioObjectiveYear--;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -723,7 +723,7 @@ static void window_editor_objective_options_main_dropdown(rct_window* w, rct_wid
             if (gS6Info.category != (uint8_t)dropdownIndex)
             {
                 gS6Info.category = (uint8_t)dropdownIndex;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
     }
@@ -784,11 +784,11 @@ static void window_editor_objective_options_main_textinput(rct_window* w, rct_wi
         }
         case WIDX_SCENARIO_NAME:
             safe_strcpy(gS6Info.name, text, std::size(gS6Info.name));
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_DETAILS:
             safe_strcpy(gS6Info.details, text, std::size(gS6Info.details));
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -1048,7 +1048,7 @@ static void window_editor_objective_options_rides_update(rct_window* w)
     if (w->no_list_items != numItems)
     {
         w->no_list_items = numItems;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1077,7 +1077,7 @@ static void window_editor_objective_options_rides_scrollmousedown(rct_window* w,
     {
         ride->lifecycle_flags ^= RIDE_LIFECYCLE_INDESTRUCTIBLE;
     }
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -1095,7 +1095,7 @@ static void window_editor_objective_options_rides_scrollmouseover(rct_window* w,
     if (w->selected_list_item != i)
     {
         w->selected_list_item = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -471,11 +471,11 @@ static void window_editor_scenario_options_set_page(rct_window* w, int32_t page)
     w->hold_down_widgets = window_editor_scenario_options_page_hold_down_widgets[page];
     w->event_handlers = window_editor_scenario_options_page_events[page];
     w->widgets = window_editor_scenario_options_widgets[page];
-    window_invalidate(w);
+    w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 #pragma region Financial
@@ -511,7 +511,7 @@ static void window_editor_scenario_options_financial_mouseup(rct_window* w, rct_
 
             auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::NoMoney, newMoneySetting);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_FORBID_MARKETING:
@@ -519,7 +519,7 @@ static void window_editor_scenario_options_financial_mouseup(rct_window* w, rct_
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::ForbidMarketingCampaigns, gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
     }
@@ -571,7 +571,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_INCREASE_CASH, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INITIAL_CASH_DECREASE:
             if (gInitialCash > MONEY(0, 00))
@@ -584,7 +584,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_REDUCE_CASH, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INITIAL_LOAN_INCREASE:
             if (gBankLoan < MONEY(5000000, 00))
@@ -597,7 +597,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_INCREASE_INIT_LOAN, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INITIAL_LOAN_DECREASE:
             if (gBankLoan > MONEY(0, 00))
@@ -610,7 +610,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_REDUCE_INIT_LOAN, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MAXIMUM_LOAN_INCREASE:
             if (gMaxBankLoan < MONEY(5000000, 00))
@@ -623,7 +623,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_INCREASE_MAX_LOAN, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MAXIMUM_LOAN_DECREASE:
             if (gMaxBankLoan > MONEY(0, 00))
@@ -636,7 +636,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_REDUCE_MAX_LOAN, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INTEREST_RATE_INCREASE:
             if (gBankLoanInterestRate < 80)
@@ -649,7 +649,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_INCREASE_INTEREST_RATE, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INTEREST_RATE_DECREASE:
             if (gBankLoanInterestRate > 0)
@@ -662,7 +662,7 @@ static void window_editor_scenario_options_financial_mousedown(rct_window* w, rc
             {
                 context_show_error(STR_CANT_REDUCE_INTEREST_RATE, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 
@@ -817,7 +817,7 @@ static void window_editor_scenario_options_guests_mouseup(rct_window* w, rct_wid
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::GuestsPreferLessIntenseRides, gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_GUEST_PREFER_MORE_INTENSE_RIDES:
@@ -825,7 +825,7 @@ static void window_editor_scenario_options_guests_mouseup(rct_window* w, rct_wid
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::GuestsPreferMoreIntenseRides, gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
     }
@@ -859,7 +859,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CASH_PER_GUEST_DECREASE:
             if (gGuestInitialCash > MONEY(0, 00))
@@ -872,7 +872,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_HAPPINESS_INCREASE:
             if (gGuestInitialHappiness < 250)
@@ -885,7 +885,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_HAPPINESS_DECREASE:
             if (gGuestInitialHappiness > 40)
@@ -898,7 +898,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_HUNGER_INCREASE:
             if (gGuestInitialHunger > 40)
@@ -911,7 +911,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_HUNGER_DECREASE:
             if (gGuestInitialHunger < 250)
@@ -924,7 +924,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_THIRST_INCREASE:
             if (gGuestInitialThirst > 40)
@@ -937,7 +937,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_GUEST_INITIAL_THIRST_DECREASE:
             if (gGuestInitialThirst < 250)
@@ -950,7 +950,7 @@ static void window_editor_scenario_options_guests_mousedown(rct_window* w, rct_w
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -1098,7 +1098,7 @@ static void window_editor_scenario_options_park_mouseup(rct_window* w, rct_widge
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::ForbidTreeRemoval, gParkFlags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_FORBID_LANDSCAPE_CHANGES:
@@ -1106,7 +1106,7 @@ static void window_editor_scenario_options_park_mouseup(rct_window* w, rct_widge
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::ForbidLandscapeChanges, gParkFlags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_FORBID_HIGH_CONSTRUCTION:
@@ -1114,7 +1114,7 @@ static void window_editor_scenario_options_park_mouseup(rct_window* w, rct_widge
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::ForbidHighConstruction, gParkFlags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_HARD_PARK_RATING:
@@ -1122,7 +1122,7 @@ static void window_editor_scenario_options_park_mouseup(rct_window* w, rct_widge
             auto scenarioSetSetting = ScenarioSetSettingAction(
                 ScenarioSetSetting::ParkRatingHigherDifficultyLevel, gParkFlags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_HARD_GUEST_GENERATION:
@@ -1131,7 +1131,7 @@ static void window_editor_scenario_options_park_mouseup(rct_window* w, rct_widge
                 ScenarioSetSetting::GuestGenerationHigherDifficultyLevel,
                 gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
     }
@@ -1167,7 +1167,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_LAND_COST_DECREASE:
             if (gLandPrice > MONEY(5, 00))
@@ -1180,7 +1180,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE:
             if (gConstructionRightsPrice < MONEY(200, 00))
@@ -1193,7 +1193,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE:
             if (gConstructionRightsPrice > MONEY(5, 00))
@@ -1206,7 +1206,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_ENTRY_PRICE_INCREASE:
             if (gParkEntranceFee < MAX_ENTRANCE_FEE)
@@ -1219,7 +1219,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_INCREASE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_ENTRY_PRICE_DECREASE:
             if (gParkEntranceFee > MONEY(0, 00))
@@ -1232,7 +1232,7 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             {
                 context_show_error(STR_CANT_REDUCE_FURTHER, STR_NONE);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN:
             dropdownWidget = widget - 1;
@@ -1279,7 +1279,7 @@ static void window_editor_scenario_options_park_dropdown(rct_window* w, rct_widg
         {
             auto scenarioSetSetting = ScenarioSetSettingAction(ScenarioSetSetting::ParkChargeMethod, dropdownIndex);
             GameActions::Execute(&scenarioSetSetting);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
         case WIDX_CLIMATE_DROPDOWN:

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -536,10 +536,10 @@ rct_window* window_finances_open()
     }
 
     w->page = WINDOW_FINANCES_PAGE_SUMMARY;
-    window_invalidate(w);
+    w->Invalidate();
     w->width = 530;
     w->height = 310;
-    window_invalidate(w);
+    w->Invalidate();
 
     w->widgets = _windowFinancesPageWidgets[WINDOW_FINANCES_PAGE_SUMMARY];
     w->enabled_widgets = WindowFinancesPageEnabledWidgets[WINDOW_FINANCES_PAGE_SUMMARY];
@@ -1427,7 +1427,7 @@ static void window_finances_set_page(rct_window* w, int32_t page)
     w->disabled_widgets = 0;
     w->pressed_widgets = 0;
 
-    window_invalidate(w);
+    w->Invalidate();
     if (w->page == WINDOW_FINANCES_PAGE_RESEARCH)
     {
         w->width = 320;
@@ -1447,7 +1447,7 @@ static void window_finances_set_page(rct_window* w, int32_t page)
     window_event_invalidate_call(w);
 
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     // Scroll summary all the way to the right, initially.
     if (w->page == WINDOW_FINANCES_PAGE_SUMMARY)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -398,7 +398,7 @@ static void window_footpath_dropdown(rct_window* w, rct_widgetindex widgetIndex,
     gFootpathSelectedId = pathId;
     footpath_provisional_update();
     _window_footpath_cost = MONEY32_UNDEFINED;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -1218,7 +1218,7 @@ static void window_footpath_set_enabled_and_pressed_widgets()
 
     w->pressed_widgets = pressedWidgets;
     w->disabled_widgets = disabledWidgets;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -719,7 +719,7 @@ void window_guest_overview_mouse_up(rct_window* w, rct_widgetindex widgetIndex)
             break;
         }
         case WIDX_LOCATE:
-            window_scroll_to_viewport(w);
+            w->ScrollToViewport();
             break;
         case WIDX_TRACK:
         {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -535,7 +535,7 @@ rct_window* window_guest_open(Peep* peep)
     }
 
     window->page = 0;
-    window_invalidate(window);
+    window->Invalidate();
 
     window->widgets = window_guest_page_widgets[WINDOW_GUEST_OVERVIEW];
     window->enabled_widgets = window_guest_page_enabled_widgets[WINDOW_GUEST_OVERVIEW];
@@ -608,13 +608,13 @@ void window_guest_disable_widgets(rct_window* w)
     if (peep_can_be_picked_up(peep))
     {
         if (w->disabled_widgets & (1 << WIDX_PICKUP))
-            window_invalidate(w);
+            w->Invalidate();
     }
     else
     {
         disabled_widgets = (1 << WIDX_PICKUP);
         if (!(w->disabled_widgets & (1 << WIDX_PICKUP)))
-            window_invalidate(w);
+            w->Invalidate();
     }
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
     {
@@ -768,11 +768,11 @@ void window_guest_set_page(rct_window* w, int32_t page)
     w->pressed_widgets = 0;
     w->widgets = window_guest_page_widgets[page];
     window_guest_disable_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     if (listen && w->viewport)
         w->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
@@ -837,9 +837,9 @@ void window_guest_viewport_init(rct_window* w)
                 w->viewport->flags = origViewportFlags;
             }
             w->flags |= WF_NO_SCROLLING;
-            window_invalidate(w);
+            w->Invalidate();
         }
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1346,7 +1346,7 @@ void window_guest_stats_update(rct_window* w)
     Peep* peep = GET_PEEP(w->number);
     peep->window_invalidate_flags &= ~PEEP_INVALIDATE_PEEP_STATS;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -1578,7 +1578,7 @@ void window_guest_rides_update(rct_window* w)
         // Every 2048 ticks do a full window_invalidate
         int32_t number_of_ticks = gScenarioTicks - peep->time_in_park;
         if (!(number_of_ticks & 0x7FF))
-            window_invalidate(w);
+            w->Invalidate();
 
         uint8_t curr_list_position = 0;
         for (const auto& ride : GetRideManager())
@@ -1594,7 +1594,7 @@ void window_guest_rides_update(rct_window* w)
         if (w->no_list_items != curr_list_position)
         {
             w->no_list_items = curr_list_position;
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }
@@ -1610,7 +1610,7 @@ void window_guest_rides_scroll_get_size(rct_window* w, int32_t scrollIndex, int3
     if (w->selected_list_item != -1)
     {
         w->selected_list_item = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     int32_t visable_height = *height - window_guest_rides_widgets[WIDX_RIDE_SCROLL].bottom
@@ -1622,7 +1622,7 @@ void window_guest_rides_scroll_get_size(rct_window* w, int32_t scrollIndex, int3
     if (visable_height < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = visable_height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1659,7 +1659,7 @@ void window_guest_rides_scroll_mouse_over(rct_window* w, int32_t scrollIndex, in
         return;
     w->selected_list_item = index;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -1863,7 +1863,7 @@ void window_guest_thoughts_update(rct_window* w)
     if (peep->window_invalidate_flags & PEEP_INVALIDATE_PEEP_THOUGHTS)
     {
         peep->window_invalidate_flags &= ~PEEP_INVALIDATE_PEEP_THOUGHTS;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1926,7 +1926,7 @@ void window_guest_inventory_update(rct_window* w)
     if (peep->window_invalidate_flags & PEEP_INVALIDATE_PEEP_INVENTORY)
     {
         peep->window_invalidate_flags &= ~PEEP_INVALIDATE_PEEP_INVENTORY;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -2064,7 +2064,7 @@ void window_guest_inventory_paint(rct_window* w, rct_drawpixelinfo* dpi)
 void window_guest_debug_update(rct_window* w)
 {
     w->frame_no++;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -340,7 +340,7 @@ static void window_guest_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
                 w->pressed_widgets |= (1 << WIDX_TRACKING);
             else
                 w->pressed_widgets &= ~(1 << WIDX_TRACKING);
-            window_invalidate(w);
+            w->Invalidate();
             w->scrolls[0].v_top = 0;
             break;
         case WIDX_FILTER_BY_NAME:
@@ -370,12 +370,12 @@ static void window_guest_list_resize(rct_window* w)
     w->min_height = 330;
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 }
@@ -408,7 +408,7 @@ static void window_guest_list_mousedown(rct_window* w, rct_widgetindex widgetInd
             window_guest_list_widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WWT_EMPTY;
             w->list_information_type = 0;
             _window_guest_list_selected_filter = -1;
-            window_invalidate(w);
+            w->Invalidate();
             w->scrolls[0].v_top = 0;
             break;
         case WIDX_PAGE_DROPDOWN_BUTTON:
@@ -455,13 +455,13 @@ static void window_guest_list_dropdown(rct_window* w, rct_widgetindex widgetInde
             if (dropdownIndex == -1)
                 break;
             _window_guest_list_selected_page = dropdownIndex;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INFO_TYPE_DROPDOWN_BUTTON:
             if (dropdownIndex == -1)
                 break;
             _window_guest_list_selected_view = dropdownIndex;
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -533,7 +533,7 @@ static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, 
     if (_window_guest_list_highlighted_index != -1)
     {
         _window_guest_list_highlighted_index = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     i = y - window_guest_list_widgets[WIDX_GUEST_LIST].bottom + window_guest_list_widgets[WIDX_GUEST_LIST].top + 21;
@@ -542,7 +542,7 @@ static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, 
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *width = 447;
@@ -594,7 +594,7 @@ static void window_guest_list_scrollmousedown(rct_window* w, int32_t scrollIndex
                 _window_guest_list_selected_filter = _window_guest_list_selected_view;
                 _window_guest_list_selected_tab = PAGE_INDIVIDUAL;
                 window_guest_list_widgets[WIDX_TRACKING].type = WWT_FLATBTN;
-                window_invalidate(w);
+                w->Invalidate();
                 w->scrolls[0].v_top = 0;
             }
             break;
@@ -614,7 +614,7 @@ static void window_guest_list_scrollmouseover(rct_window* w, int32_t scrollIndex
     if (i != _window_guest_list_highlighted_index)
     {
         _window_guest_list_highlighted_index = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -147,7 +147,7 @@ rct_window* window_install_track_open(const utf8* path)
     _trackDesignPreviewPixels.resize(4 * TRACK_PREVIEW_IMAGE_SIZE);
 
     window_install_track_update_preview();
-    window_invalidate(w);
+    w->Invalidate();
 
     return w;
 }
@@ -180,12 +180,12 @@ static void window_install_track_mouseup(rct_window* w, rct_widgetindex widgetIn
         case WIDX_ROTATE:
             _currentTrackPieceDirection++;
             _currentTrackPieceDirection %= 4;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_TOGGLE_SCENERY:
             gTrackDesignSceneryToggle = !gTrackDesignSceneryToggle;
             window_install_track_update_preview();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INSTALL:
             window_install_track_design(w);

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -158,12 +158,12 @@ static void window_land_mouseup(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_MOUNTAINMODE:
             gLandMountainMode ^= 1;
             gLandPaintMode = 0;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_PAINTMODE:
             gLandMountainMode = 0;
             gLandPaintMode ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_PREVIEW:
             window_land_inputsize(w);
@@ -193,14 +193,14 @@ static void window_land_mousedown(rct_window* w, rct_widgetindex widgetIndex, rc
             gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INCREMENT:
             // Increment land tool size
             gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -230,7 +230,7 @@ static void window_land_dropdown(rct_window* w, rct_widgetindex widgetIndex, int
                 gLandToolTerrainSurface = type;
                 _selectedFloorTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_WALL:
             if (dropdownIndex == -1)
@@ -247,7 +247,7 @@ static void window_land_dropdown(rct_window* w, rct_widgetindex widgetIndex, int
                 gLandToolTerrainEdge = type;
                 _selectedWallTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -267,7 +267,7 @@ static void window_land_textinput(rct_window* w, rct_widgetindex widgetIndex, ch
         size = std::min(MAXIMUM_TOOL_SIZE, size);
         gLandToolSize = size;
 
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -161,7 +161,7 @@ static void window_land_rights_mouseup(rct_window* w, rct_widgetindex widgetInde
                 tool_set(w, WIDX_BUY_LAND_RIGHTS, TOOL_UP_ARROW);
                 _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
                 show_land_rights();
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case WIDX_BUY_CONSTRUCTION_RIGHTS:
@@ -170,7 +170,7 @@ static void window_land_rights_mouseup(rct_window* w, rct_widgetindex widgetInde
                 tool_set(w, WIDX_BUY_CONSTRUCTION_RIGHTS, TOOL_UP_ARROW);
                 _landRightsMode = LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS;
                 show_construction_rights();
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
     }
@@ -185,14 +185,14 @@ static void window_land_rights_mousedown(rct_window* w, rct_widgetindex widgetIn
             gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INCREMENT:
             // Decrement land rights tool size
             gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -211,7 +211,7 @@ static void window_land_rights_textinput(rct_window* w, rct_widgetindex widgetIn
         size = std::max(MINIMUM_TOOL_SIZE, size);
         size = std::min(MAXIMUM_TOOL_SIZE, size);
         gLandToolSize = size;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -343,12 +343,12 @@ static void window_loadsave_resize(rct_window* w)
 {
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 }
@@ -496,7 +496,7 @@ static void window_loadsave_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             }
             config_save_default();
             window_loadsave_sort_list();
-            window_invalidate(w);
+            w->Invalidate();
             break;
 
         case WIDX_SORT_DATE:
@@ -510,7 +510,7 @@ static void window_loadsave_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             }
             config_save_default();
             window_loadsave_sort_list();
-            window_invalidate(w);
+            w->Invalidate();
             break;
 
         case WIDX_DEFAULT:
@@ -573,7 +573,7 @@ static void window_loadsave_scrollmouseover(rct_window* w, int32_t scrollIndex, 
 
     w->selected_list_item = selectedItem;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_loadsave_textinput(rct_window* w, rct_widgetindex widgetIndex, char* text)
@@ -609,7 +609,7 @@ static void window_loadsave_textinput(rct_window* w, rct_widgetindex widgetIndex
             window_init_scroll_widgets(w);
 
             w->no_list_items = static_cast<uint16_t>(_listItems.size());
-            window_invalidate(w);
+            w->Invalidate();
             break;
 
         case WIDX_NEW_FILE:
@@ -942,7 +942,7 @@ static void window_loadsave_populate_list(rct_window* w, int32_t includeNewItem,
         window_loadsave_sort_list();
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_loadsave_invoke_callback(int32_t result, const utf8* path)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -292,7 +292,7 @@ static void window_map_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             window_close(w);
             break;
         case WIDX_SET_LAND_RIGHTS:
-            window_invalidate(w);
+            w->Invalidate();
             if (tool_set(w, widgetIndex, TOOL_UP_ARROW))
                 break;
             _activeTool = 2;
@@ -308,7 +308,7 @@ static void window_map_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (_activeTool & 2)
                 _activeTool &= 0xF2;
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_LAND_SALE_CHECKBOX:
             _activeTool ^= 8;
@@ -316,7 +316,7 @@ static void window_map_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (_activeTool & 8)
                 _activeTool &= 0xF8;
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX:
             _activeTool ^= 1;
@@ -324,7 +324,7 @@ static void window_map_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (_activeTool & 1)
                 _activeTool &= 0xF1;
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX:
             _activeTool ^= 4;
@@ -332,10 +332,10 @@ static void window_map_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (_activeTool & 4)
                 _activeTool &= 0xF4;
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_BUILD_PARK_ENTRANCE:
-            window_invalidate(w);
+            w->Invalidate();
             if (tool_set(w, widgetIndex, TOOL_UP_ARROW))
                 break;
 
@@ -410,13 +410,13 @@ static void window_map_mousedown(rct_window* w, rct_widgetindex widgetIndex, rct
             // Decrement land rights tool size
             _landRightsToolSize = std::max(MINIMUM_TOOL_SIZE, _landRightsToolSize - 1);
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_LAND_TOOL_LARGER:
             // Increment land rights tool size
             _landRightsToolSize = std::min(MAXIMUM_TOOL_SIZE, _landRightsToolSize + 1);
 
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -437,7 +437,7 @@ static void window_map_update(rct_window* w)
     for (int32_t i = 0; i < 16; i++)
         map_window_set_pixels(w);
 
-    window_invalidate(w);
+    w->Invalidate();
 
     // Update tab animations
     w->list_information_type++;
@@ -524,20 +524,20 @@ static void window_map_toolabort(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_SET_LAND_RIGHTS:
-            window_invalidate(w);
+            w->Invalidate();
             hide_gridlines();
             hide_land_rights();
             hide_construction_rights();
             break;
         case WIDX_BUILD_PARK_ENTRANCE:
             park_entrance_remove_ghost();
-            window_invalidate(w);
+            w->Invalidate();
             hide_gridlines();
             hide_land_rights();
             hide_construction_rights();
             break;
         case WIDX_PEOPLE_STARTING_POSITION:
-            window_invalidate(w);
+            w->Invalidate();
             hide_gridlines();
             hide_land_rights();
             hide_construction_rights();
@@ -638,7 +638,7 @@ static void window_map_textinput(rct_window* w, rct_widgetindex widgetIndex, cha
             {
                 size = std::clamp(size, MINIMUM_TOOL_SIZE, MAXIMUM_TOOL_SIZE);
                 _landRightsToolSize = size;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case WIDX_MAP_SIZE_SPINNER:
@@ -660,7 +660,7 @@ static void window_map_textinput(rct_window* w, rct_widgetindex widgetIndex, cha
                     map_window_increase_map_size();
                     currentSize++;
                 }
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
     }

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -534,7 +534,7 @@ rct_window* window_mapgen_open()
     w->frame_no = 0;
 
     w->page = WINDOW_MAPGEN_PAGE_BASE;
-    window_invalidate(w);
+    w->Invalidate();
     w->widgets = PageWidgets[WINDOW_MAPGEN_PAGE_BASE];
     w->enabled_widgets = PageEnabledWidgets[WINDOW_MAPGEN_PAGE_BASE];
     w->hold_down_widgets = HoldDownWidgets[WINDOW_MAPGEN_PAGE_BASE];
@@ -616,27 +616,27 @@ static void window_mapgen_base_mousedown(rct_window* w, rct_widgetindex widgetIn
     {
         case WIDX_MAP_SIZE_UP:
             _mapSize = std::min(_mapSize + 1, MAXIMUM_MAP_SIZE_TECHNICAL);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MAP_SIZE_DOWN:
             _mapSize = std::max(_mapSize - 1, MINIMUM_MAP_SIZE_TECHNICAL);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_BASE_HEIGHT_UP:
             _baseHeight = std::min(_baseHeight + 2, BASESIZE_MAX);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_BASE_HEIGHT_DOWN:
             _baseHeight = std::max(_baseHeight - 2, BASESIZE_MIN);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_WATER_LEVEL_UP:
             _waterLevel = std::min(_waterLevel + 2, WATERLEVEL_MAX);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_WATER_LEVEL_DOWN:
             _waterLevel = std::max(_waterLevel - 2, WATERLEVEL_MIN);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_FLOOR_TEXTURE:
             land_tool_show_surface_style_dropdown(w, widget, _floorTexture);
@@ -668,7 +668,7 @@ static void window_mapgen_base_dropdown(rct_window* w, rct_widgetindex widgetInd
                 gLandToolTerrainSurface = type;
                 _floorTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_WALL_TEXTURE:
             if (dropdownIndex == -1)
@@ -685,7 +685,7 @@ static void window_mapgen_base_dropdown(rct_window* w, rct_widgetindex widgetInd
                 gLandToolTerrainEdge = type;
                 _wallTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -729,7 +729,7 @@ static void window_mapgen_textinput(rct_window* w, rct_widgetindex widgetIndex, 
             break;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_mapgen_base_invalidate(rct_window* w)
@@ -916,55 +916,55 @@ static void window_mapgen_simplex_mousedown(rct_window* w, rct_widgetindex widge
     {
         case WIDX_SIMPLEX_LOW_UP:
             _simplex_low = std::min(_simplex_low + 1, 24);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_LOW_DOWN:
             _simplex_low = std::max(_simplex_low - 1, 0);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_HIGH_UP:
             _simplex_high = std::min(_simplex_high + 1, 36);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_HIGH_DOWN:
             _simplex_high = std::max(_simplex_high - 1, 0);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_BASE_FREQ_UP:
             _simplex_base_freq = std::min(_simplex_base_freq + 5, 1000);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_BASE_FREQ_DOWN:
             _simplex_base_freq = std::max(_simplex_base_freq - 5, 0);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_OCTAVES_UP:
             _simplex_octaves = std::min(_simplex_octaves + 1, 10);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_OCTAVES_DOWN:
             _simplex_octaves = std::max(_simplex_octaves - 1, 1);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_MAP_SIZE_UP:
             _mapSize = std::min(_mapSize + 1, MAXIMUM_MAP_SIZE_TECHNICAL);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_MAP_SIZE_DOWN:
             _mapSize = std::max(_mapSize - 1, MINIMUM_MAP_SIZE_TECHNICAL);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_WATER_LEVEL_UP:
             _waterLevel = std::min(_waterLevel + 2, 54);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_WATER_LEVEL_DOWN:
             _waterLevel = std::max(_waterLevel - 2, 0);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX:
             _randomTerrain = !_randomTerrain;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_FLOOR_TEXTURE:
             land_tool_show_surface_style_dropdown(w, widget, _floorTexture);
@@ -974,7 +974,7 @@ static void window_mapgen_simplex_mousedown(rct_window* w, rct_widgetindex widge
             break;
         case WIDX_SIMPLEX_PLACE_TREES_CHECKBOX:
             _placeTrees ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -1000,7 +1000,7 @@ static void window_mapgen_simplex_dropdown(rct_window* w, rct_widgetindex widget
                 gLandToolTerrainSurface = type;
                 _floorTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SIMPLEX_WALL_TEXTURE:
             if (dropdownIndex == -1)
@@ -1017,7 +1017,7 @@ static void window_mapgen_simplex_dropdown(rct_window* w, rct_widgetindex widget
                 gLandToolTerrainEdge = type;
                 _wallTexture = type;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -1356,7 +1356,7 @@ static void window_mapgen_set_page(rct_window* w, int32_t page)
     }
 
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_mapgen_set_pressed_tab(rct_window* w)

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -134,7 +134,7 @@ static void window_map_tooltip_open()
     }
     else
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->x = x;
         w->y = y;
         w->width = width;
@@ -148,7 +148,7 @@ static void window_map_tooltip_open()
  */
 static void window_map_tooltip_update(rct_window* w)
 {
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -471,7 +471,7 @@ void window_maze_construction_update_pressed_widgets()
     }
 
     w->pressed_widgets = pressedWidgets;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -334,7 +334,7 @@ static void window_multiplayer_set_page(rct_window* w, int32_t page)
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_anchor_border_widgets(rct_window* w)
@@ -561,7 +561,7 @@ static void window_multiplayer_players_resize(rct_window* w)
     w->widgets[WIDX_HEADER_PING].right = w->width - 5;
 
     w->selected_list_item = -1;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_players_update(rct_window* w)
@@ -577,7 +577,7 @@ static void window_multiplayer_players_scrollgetsize(rct_window* w, int32_t scro
     if (w->selected_list_item != -1)
     {
         w->selected_list_item = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *height = network_get_num_players() * SCROLLABLE_ROW_HEIGHT;
@@ -587,7 +587,7 @@ static void window_multiplayer_players_scrollgetsize(rct_window* w, int32_t scro
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -600,7 +600,7 @@ static void window_multiplayer_players_scrollmousedown(rct_window* w, int32_t sc
         return;
 
     w->selected_list_item = index;
-    window_invalidate(w);
+    w->Invalidate();
 
     window_player_open(network_get_player_id(index));
 }
@@ -614,7 +614,7 @@ static void window_multiplayer_players_scrollmouseover(rct_window* w, int32_t sc
         return;
 
     w->selected_list_item = index;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_players_invalidate(rct_window* w)
@@ -769,7 +769,7 @@ static void window_multiplayer_groups_resize(rct_window* w)
     w->list_item_positions[0] = 0;
 
     w->selected_list_item = -1;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_groups_mousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
@@ -806,7 +806,7 @@ static void window_multiplayer_groups_dropdown(rct_window* w, rct_widgetindex wi
             break;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_groups_update(rct_window* w)
@@ -822,7 +822,7 @@ static void window_multiplayer_groups_scrollgetsize(rct_window* w, int32_t scrol
     if (w->selected_list_item != -1)
     {
         w->selected_list_item = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *height = network_get_num_actions() * SCROLLABLE_ROW_HEIGHT;
@@ -832,7 +832,7 @@ static void window_multiplayer_groups_scrollgetsize(rct_window* w, int32_t scrol
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -845,7 +845,7 @@ static void window_multiplayer_groups_scrollmousedown(rct_window* w, int32_t scr
         return;
 
     w->selected_list_item = index;
-    window_invalidate(w);
+    w->Invalidate();
 
     auto networkModifyGroup = NetworkModifyGroupAction(
         ModifyGroupType::SetPermissions, _selectedGroup, "", index, PermissionState::Toggle);
@@ -861,7 +861,7 @@ static void window_multiplayer_groups_scrollmouseover(rct_window* w, int32_t scr
         return;
 
     w->selected_list_item = index;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_multiplayer_groups_text_input(rct_window* w, rct_widgetindex widgetIndex, char* text)

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -186,7 +186,7 @@ static void window_network_set_page(rct_window* w, int32_t page)
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_network_anchor_border_widgets(rct_window* w)
@@ -237,7 +237,7 @@ static void window_network_information_update(rct_window* w)
 {
     w->frame_no++;
     widget_invalidate(w, WIDX_TAB1 + w->page);
-    window_invalidate(w);
+    w->Invalidate();
 
     NetworkStats_t curStats = network_get_stats();
 

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -308,11 +308,11 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
         // In RCT2, the maximum was 6 weeks
         case WIDX_WEEKS_INCREASE_BUTTON:
             w->campaign.no_weeks = std::min(w->campaign.no_weeks + 1, 12);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_WEEKS_DECREASE_BUTTON:
             w->campaign.no_weeks = std::max(w->campaign.no_weeks - 1, 2);
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -338,7 +338,7 @@ static void window_new_campaign_dropdown(rct_window* w, rct_widgetindex widgetIn
         w->campaign.ride_id = window_new_campaign_rides[dropdownIndex];
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -589,7 +589,7 @@ static void window_new_ride_set_page(rct_window* w, int32_t page)
     }
 
     window_new_ride_refresh_widget_sizing(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     if (page < WINDOW_NEW_RIDE_PAGE_RESEARCH)
     {
@@ -633,7 +633,7 @@ static void window_new_ride_refresh_widget_sizing(rct_window* w)
     // Handle new window size
     if (w->width != width || w->height != height)
     {
-        window_invalidate(w);
+        w->Invalidate();
 
         // Resize widgets to new window size
         window_new_ride_widgets[WIDX_BACKGROUND].right = width - 1;
@@ -646,7 +646,7 @@ static void window_new_ride_refresh_widget_sizing(rct_window* w)
 
         w->width = width;
         w->height = height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     window_init_scroll_widgets(w);
@@ -776,7 +776,7 @@ static void window_new_ride_scrollmousedown(rct_window* w, int32_t scrollIndex, 
 
     audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     w->new_ride.selected_ride_countdown = 8;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -797,7 +797,7 @@ static void window_new_ride_scrollmouseover(rct_window* w, int32_t scrollIndex, 
 
     w->new_ride.highlighted_ride_id = item.ride_type_and_entry;
     _windowNewRideHighlightedItem[_windowNewRideCurrentTab] = item;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -143,7 +143,7 @@ static void window_news_update(rct_window* w)
         return;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
     audio_play_sound(SoundId::Click2, 0, w->x + (w->width / 2));
 
     j = w->news.var_480;
@@ -237,7 +237,7 @@ static void window_news_scrollmousedown(rct_window* w, int32_t scrollIndex, int3
         w->news.var_480 = i - 11;
         w->news.var_482 = buttonIndex;
         w->news.var_484 = 4;
-        window_invalidate(w);
+        w->Invalidate();
         audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     }
 }

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -244,11 +244,11 @@ static void window_news_options_invalidate(rct_window* w)
 
     if (w->height != y)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = y;
         w->widgets[WIDX_BACKGROUND].bottom = y - 1;
         w->widgets[WIDX_TAB_CONTENT_PANEL].bottom = y - 1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -264,7 +264,7 @@ static void window_news_options_set_page(rct_window* w, int32_t page)
     {
         w->page = page;
         w->frame_no = 0;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -389,7 +389,7 @@ rct_window* window_object_load_error_open(utf8* path, size_t numMissingObjects, 
     window->no_list_items = (uint16_t)numMissingObjects;
     file_path = path;
 
-    window_invalidate(window);
+    window->Invalidate();
     return window;
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -683,34 +683,34 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     gConfigGeneral.uncap_fps ^= 1;
                     drawing_engine_set_vsync(gConfigGeneral.use_vsync);
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_USE_VSYNC_CHECKBOX:
                     gConfigGeneral.use_vsync ^= 1;
                     drawing_engine_set_vsync(gConfigGeneral.use_vsync);
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_SHOW_FPS_CHECKBOX:
                     gConfigGeneral.show_fps ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_MULTITHREADING_CHECKBOX:
                     gConfigGeneral.multithreading ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_MINIMIZE_FOCUS_LOSS:
                     gConfigGeneral.minimize_fullscreen_focus_loss ^= 1;
                     platform_refresh_video(false);
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_STEAM_OVERLAY_PAUSE:
                     gConfigGeneral.steam_overlay_pause ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -738,39 +738,39 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_DAY_NIGHT_CHECKBOX:
                     gConfigGeneral.day_night_cycle ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_ENABLE_LIGHT_FX_CHECKBOX:
                     gConfigGeneral.enable_light_fx ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_UPPER_CASE_BANNERS_CHECKBOX:
                     gConfigGeneral.upper_case_banners ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX:
                     gConfigGeneral.disable_lightning_effect ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX:
                     gConfigGeneral.render_weather_effects ^= 1;
                     gConfigGeneral.render_weather_gloom = gConfigGeneral.render_weather_effects;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     gfx_invalidate_screen();
                     break;
                 case WIDX_SHOW_GUEST_PURCHASES_CHECKBOX:
                     gConfigGeneral.show_guest_purchases ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX:
                     gConfigGeneral.transparent_screenshot ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -784,7 +784,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_SOUND_CHECKBOX:
                     gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
 
                 case WIDX_MASTER_SOUND_CHECKBOX:
@@ -795,7 +795,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                         audio_unpause_sounds();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
 
                 case WIDX_MUSIC_CHECKBOX:
@@ -805,13 +805,13 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                         audio_stop_ride_music();
                     }
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
 
                 case WIDX_AUDIO_FOCUS_CHECKBOX:
                     gConfigSound.audio_focus = !gConfigSound.audio_focus;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -825,63 +825,63 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_SCREEN_EDGE_SCROLLING:
                     gConfigGeneral.edge_scrolling ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_TRAP_CURSOR:
                     gConfigGeneral.trap_cursor ^= 1;
                     config_save_default();
                     context_set_cursor_trap(gConfigGeneral.trap_cursor);
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_ZOOM_TO_CURSOR:
                     gConfigGeneral.zoom_to_cursor ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_TOOLBAR_SHOW_FINANCES:
                     gConfigInterface.toolbar_show_finances ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_TOOLBAR_SHOW_RESEARCH:
                     gConfigInterface.toolbar_show_research ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_TOOLBAR_SHOW_CHEATS:
                     gConfigInterface.toolbar_show_cheats ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_TOOLBAR_SHOW_NEWS:
                     gConfigInterface.toolbar_show_news ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_TOOLBAR_SHOW_MUTE:
                     gConfigInterface.toolbar_show_mute ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_TOOLBAR_SHOW_CHAT:
                     gConfigInterface.toolbar_show_chat ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     window_invalidate_by_class(WC_TOP_TOOLBAR);
                     break;
                 case WIDX_INVERT_DRAG:
                     gConfigGeneral.invert_viewport_drag ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_THEMES_BUTTON:
                     context_open_window(WC_THEMES);
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -892,13 +892,13 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_REAL_NAME_CHECKBOX:
                     gConfigGeneral.show_real_names_of_guests ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     peep_update_names(gConfigGeneral.show_real_names_of_guests);
                     break;
                 case WIDX_AUTO_STAFF_PLACEMENT:
                     gConfigGeneral.auto_staff_placement ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_TITLE_SEQUENCE_BUTTON:
                     window_title_editor_open(0);
@@ -911,12 +911,12 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_AUTO_OPEN_SHOPS:
                     gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_ALLOW_EARLY_COMPLETION:
                     gConfigGeneral.allow_early_completion ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -933,22 +933,22 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     gConfigGeneral.allow_loading_with_incorrect_checksum = !gConfigGeneral
                                                                                 .allow_loading_with_incorrect_checksum;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
                     gConfigGeneral.save_plugin_data ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_STAY_CONNECTED_AFTER_DESYNC:
                     gConfigNetwork.stay_connected = !gConfigNetwork.stay_connected;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_ALWAYS_NATIVE_LOADSAVE:
                     gConfigGeneral.use_native_browse_dialog = !gConfigGeneral.use_native_browse_dialog;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_PATH_TO_RCT1_BUTTON:
                 {
@@ -970,7 +970,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                             context_show_error(STR_PATH_TO_RCT1_WRONG_ERROR, STR_NONE);
                         }
                     }
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 }
                 case WIDX_PATH_TO_RCT1_CLEAR:
@@ -979,7 +979,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                         SafeFree(gConfigGeneral.rct1_path);
                         config_save_default();
                     }
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
             }
             break;
@@ -994,27 +994,27 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 case WIDX_FOLLOWER_PEEP_NAMES_CHECKBOX:
                     gConfigTwitch.enable_follower_peep_names ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_FOLLOWER_PEEP_TRACKING_CHECKBOX:
                     gConfigTwitch.enable_follower_peep_tracking ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_CHAT_PEEP_NAMES_CHECKBOX:
                     gConfigTwitch.enable_chat_peep_names ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_CHAT_PEEP_TRACKING_CHECKBOX:
                     gConfigTwitch.enable_chat_peep_tracking ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_NEWS_CHECKBOX:
                     gConfigTwitch.enable_news ^= 1;
                     config_save_default();
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_API_URL_BUTTON:
                     window_text_input_raw_open(
@@ -1420,7 +1420,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                         bool recreate_window = drawing_engine_requires_new_window(srcEngine, dstEngine);
                         platform_refresh_video(recreate_window);
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
                 case WIDX_SCALE_QUALITY_DROPDOWN:
@@ -1546,7 +1546,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                         config_save_default();
                         audio_start_title_music();
                     }
-                    window_invalidate(w);
+                    w->Invalidate();
                     break;
                 case WIDX_TITLE_MUSIC_DROPDOWN:
                     if ((dropdownIndex == 1 || dropdownIndex == 3)
@@ -1558,7 +1558,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     {
                         gConfigSound.title_music = (int8_t)dropdownIndex;
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
 
                     audio_stop_title_music();
@@ -1589,7 +1589,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     {
                         title_sequence_change_preset((size_t)dropdownIndex);
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
                 case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
@@ -1597,7 +1597,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     {
                         gConfigGeneral.default_inspection_interval = (uint8_t)dropdownIndex;
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
                 case WIDX_SCENARIO_GROUPING_DROPDOWN:
@@ -1606,7 +1606,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                         gConfigGeneral.scenario_select_mode = dropdownIndex;
                         gConfigInterface.scenarioselect_last_tab = 0;
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                         window_close_by_class(WC_SCENARIO_SELECT);
                     }
                     break;
@@ -1621,7 +1621,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     {
                         gConfigGeneral.autosave_frequency = (uint8_t)dropdownIndex;
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
             }
@@ -2210,11 +2210,11 @@ static void window_options_set_page(rct_window* w, int32_t page)
     w->pressed_widgets = 0;
     w->widgets = window_options_page_widgets[page];
 
-    window_invalidate(w);
+    w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_options_set_pressed_tab(rct_window* w)

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -609,7 +609,7 @@ rct_window* window_park_entrance_open()
     }
 
     window->page = WINDOW_PARK_PAGE_ENTRANCE;
-    window_invalidate(window);
+    window->Invalidate();
     window->widgets = window_park_entrance_widgets;
     window->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_ENTRANCE];
     window->event_handlers = &window_park_entrance_events;
@@ -935,13 +935,13 @@ static void window_park_init_viewport(rct_window* w)
                 (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0, x, y,
                 z, w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_MASK, SPRITE_INDEX_NULL);
             w->flags |= (1 << 2);
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 
     if (w->viewport != nullptr)
         w->viewport->flags = viewportFlags;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 #pragma endregion
@@ -971,7 +971,7 @@ rct_window* window_park_rating_open()
 
     window->viewport = nullptr;
     window->page = WINDOW_PARK_PAGE_RATING;
-    window_invalidate(window);
+    window->Invalidate();
     window->widgets = window_park_rating_widgets;
     window->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_RATING];
     window->hold_down_widgets = window_park_page_hold_down_widgets[WINDOW_PARK_PAGE_RATING];
@@ -1092,7 +1092,7 @@ rct_window* window_park_guests_open()
 
     window->viewport = nullptr;
     window->page = WINDOW_PARK_PAGE_GUESTS;
-    window_invalidate(window);
+    window->Invalidate();
     window->widgets = window_park_guests_widgets;
     window->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_GUESTS];
     window->hold_down_widgets = window_park_page_hold_down_widgets[WINDOW_PARK_PAGE_GUESTS];
@@ -1463,7 +1463,7 @@ rct_window* window_park_objective_open()
 
     window->viewport = nullptr;
     window->page = WINDOW_PARK_PAGE_OBJECTIVE;
-    window_invalidate(window);
+    window->Invalidate();
     window->widgets = window_park_objective_widgets;
     window->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_OBJECTIVE];
     window->hold_down_widgets = window_park_page_hold_down_widgets[WINDOW_PARK_PAGE_OBJECTIVE];
@@ -1471,7 +1471,7 @@ rct_window* window_park_objective_open()
     window_init_scroll_widgets(window);
     window->x = context_get_width() / 2 - 115;
     window->y = context_get_height() / 2 - 87;
-    window_invalidate(window);
+    window->Invalidate();
 
     return window;
 }
@@ -1536,7 +1536,7 @@ static void window_park_objective_textinput(rct_window* w, rct_widgetindex widge
     if (widgetIndex == WIDX_ENTER_NAME && text != nullptr && text[0] != 0)
     {
         scenario_success_submit_name(text);
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1638,7 +1638,7 @@ rct_window* window_park_awards_open()
 
     window->viewport = nullptr;
     window->page = WINDOW_PARK_PAGE_AWARDS;
-    window_invalidate(window);
+    window->Invalidate();
     window->widgets = window_park_awards_widgets;
     window->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_AWARDS];
     window->hold_down_widgets = window_park_page_hold_down_widgets[WINDOW_PARK_PAGE_AWARDS];
@@ -1766,7 +1766,7 @@ static void window_park_set_page(rct_window* w, int32_t page)
     w->event_handlers = window_park_page_events[page];
     w->widgets = window_park_page_widgets[page];
     window_park_set_disabled_tabs(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     window_event_resize_call(w);
     window_event_invalidate_call(w);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -655,7 +655,7 @@ static void window_park_entrance_mouseup(rct_window* w, rct_widgetindex widgetIn
             context_open_window(WC_LAND_RIGHTS);
             break;
         case WIDX_LOCATE:
-            window_scroll_to_viewport(w);
+            w->ScrollToViewport();
             break;
         case WIDX_RENAME:
         {

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -210,7 +210,7 @@ rct_window* window_player_open(uint8_t id)
     }
 
     window->page = 0;
-    window_invalidate(window);
+    window->Invalidate();
 
     window->widgets = window_player_page_widgets[WINDOW_PLAYER_PAGE_OVERVIEW];
     window->enabled_widgets = window_player_page_enabled_widgets[WINDOW_PLAYER_PAGE_OVERVIEW];
@@ -319,7 +319,7 @@ void window_player_overview_dropdown(rct_window* w, rct_widgetindex widgetIndex,
     playerSetGroupAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
         if (result->Error == GA_ERROR::OK)
         {
-            window_invalidate(w);
+            w->Invalidate();
         }
     });
     GameActions::Execute(&playerSetGroupAction);
@@ -571,11 +571,11 @@ static void window_player_set_page(rct_window* w, int32_t page)
     w->event_handlers = window_player_page_events[page];
     w->pressed_widgets = 0;
     w->widgets = window_player_page_widgets[page];
-    window_invalidate(w);
+    w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     if (page == WINDOW_PLAYER_PAGE_OVERVIEW)
     {

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -246,10 +246,10 @@ rct_window* window_research_open()
     }
 
     w->page = 0;
-    window_invalidate(w);
+    w->Invalidate();
     w->width = 300;
     w->height = 196;
-    window_invalidate(w);
+    w->Invalidate();
 
     w->widgets = window_research_page_widgets[0];
     w->enabled_widgets = window_research_page_enabled_widgets[0];
@@ -598,7 +598,7 @@ static void window_research_set_page(rct_window* w, int32_t page)
     w->disabled_widgets = 0;
     w->pressed_widgets = 0;
 
-    window_invalidate(w);
+    w->Invalidate();
     if (w->page == WINDOW_RESEARCH_PAGE_DEVELOPMENT)
     {
         w->width = 300;
@@ -613,7 +613,7 @@ static void window_research_set_page(rct_window* w, int32_t page)
     window_event_invalidate_call(w);
 
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_research_set_pressed_tab(rct_window* w)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2047,7 +2047,7 @@ static void window_ride_main_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             window_ride_rename(w);
             break;
         case WIDX_LOCATE:
-            window_scroll_to_viewport(w);
+            w->ScrollToViewport();
             break;
         case WIDX_DEMOLISH:
             context_open_detail_window(WD_DEMOLISH_RIDE, w->number);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1626,7 +1626,7 @@ static rct_window* window_ride_open_station(Ride* ride, int32_t stationIndex)
     w->page = WINDOW_RIDE_PAGE_MAIN;
     w->width = 316;
     w->height = 180;
-    window_invalidate(w);
+    w->Invalidate();
 
     w->widgets = window_ride_page_widgets[w->page];
     w->enabled_widgets = window_ride_page_enabled_widgets[w->page];
@@ -1714,7 +1714,7 @@ rct_window* window_ride_open_vehicle(rct_vehicle* vehicle)
     rct_window* w = window_find_by_number(WC_RIDE, ride->id);
     if (w != nullptr)
     {
-        window_invalidate(w);
+        w->Invalidate();
 
         if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE) && gCurrentToolWidget.window_classification == w->classification
             && gCurrentToolWidget.window_number == w->number)
@@ -1759,7 +1759,7 @@ rct_window* window_ride_open_vehicle(rct_vehicle* vehicle)
     w->page = WINDOW_RIDE_PAGE_MAIN;
     w->width = 316;
     w->height = 180;
-    window_invalidate(w);
+    w->Invalidate();
 
     w->widgets = window_ride_page_widgets[w->page];
     w->enabled_widgets = window_ride_page_enabled_widgets[w->page];
@@ -1771,7 +1771,7 @@ rct_window* window_ride_open_vehicle(rct_vehicle* vehicle)
 
     w->ride.view = view;
     window_ride_init_viewport(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     return w;
 }
@@ -1814,12 +1814,12 @@ static void window_ride_set_page(rct_window* w, int32_t page)
     w->pressed_widgets = 0;
     w->widgets = window_ride_page_widgets[page];
     window_ride_disable_tabs(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     window_event_resize_call(w);
     window_event_invalidate_call(w);
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     if (listen != 0 && w->viewport != nullptr)
         w->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
@@ -1983,12 +1983,12 @@ static void window_ride_init_viewport(rct_window* w)
             focus.coordinate.z, focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
 
         w->flags |= WF_NO_SCROLLING;
-        window_invalidate(w);
+        w->Invalidate();
     }
     if (w->viewport)
     {
         w->viewport->flags = viewport_flags;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -2474,7 +2474,7 @@ static void window_ride_main_dropdown(rct_window* w, rct_widgetindex widgetIndex
 
             w->ride.view = dropdownIndex;
             window_ride_init_viewport(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_OPEN:
         {
@@ -3602,7 +3602,7 @@ static void window_ride_operating_update(rct_window* w)
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_OPERATING)
     {
         ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_OPERATING;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -4183,7 +4183,7 @@ static void window_ride_maintenance_update(rct_window* w)
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_MAINTENANCE)
     {
         ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_MAINTENANCE;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -4618,7 +4618,7 @@ static void window_ride_colour_dropdown(rct_window* w, rct_widgetindex widgetInd
     {
         case WIDX_TRACK_COLOUR_SCHEME_DROPDOWN:
             w->ride_colour = (uint16_t)dropdownIndex;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_TRACK_MAIN_COLOUR:
         {
@@ -4679,7 +4679,7 @@ static void window_ride_colour_dropdown(rct_window* w, rct_widgetindex widgetInd
         break;
         case WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN:
             w->vehicleIndex = dropdownIndex;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_VEHICLE_MAIN_COLOUR:
         {
@@ -5918,7 +5918,7 @@ static void window_ride_set_graph(rct_window* w, int32_t type)
         w->list_information_type &= 0xFF00;
         w->list_information_type |= type;
     }
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -6596,7 +6596,7 @@ static void window_ride_income_update(rct_window* w)
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_INCOME)
     {
         ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_INCOME;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -6899,7 +6899,7 @@ static void window_ride_customer_update(rct_window* w)
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_CUSTOMER)
     {
         ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_CUSTOMER;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3243,7 +3243,7 @@ static void window_ride_construction_update_widgets(rct_window* w)
             break;
         default:
             w->pressed_widgets = pressedWidgets;
-            window_invalidate(w);
+            w->Invalidate();
             return;
     }
 
@@ -3337,7 +3337,7 @@ static void window_ride_construction_update_widgets(rct_window* w)
         pressedWidgets |= (1 << WIDX_CHAIN_LIFT);
 
     w->pressed_widgets = pressedWidgets;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_ride_construction_select_map_tiles(

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -275,7 +275,7 @@ static void window_ride_list_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 _quickDemolishMode = false;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -290,12 +290,12 @@ static void window_ride_list_resize(rct_window* w)
     w->min_height = 124;
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 
@@ -379,7 +379,7 @@ static void window_ride_list_dropdown(rct_window* w, rct_widgetindex widgetIndex
             window_ride_list_open_all(w);
         }
 
-        window_invalidate(w);
+        w->Invalidate();
     }
     else if (widgetIndex == WIDX_INFORMATION_TYPE_DROPDOWN)
     {
@@ -397,7 +397,7 @@ static void window_ride_list_dropdown(rct_window* w, rct_widgetindex widgetIndex
         }
 
         _window_ride_list_information_type = informationType;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -410,7 +410,7 @@ static void window_ride_list_update(rct_window* w)
     w->frame_no = (w->frame_no + 1) % 64;
     widget_invalidate(w, WIDX_TAB_1 + w->page);
     if (_window_ride_list_information_type != INFORMATION_TYPE_STATUS)
-        window_invalidate(w);
+        w->Invalidate();
 }
 
 /**
@@ -425,7 +425,7 @@ static void window_ride_list_scrollgetsize(rct_window* w, int32_t scrollIndex, i
     if (w->selected_list_item != -1)
     {
         w->selected_list_item = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     top = *height - window_ride_list_widgets[WIDX_LIST].bottom + window_ride_list_widgets[WIDX_LIST].top + 21;
@@ -434,7 +434,7 @@ static void window_ride_list_scrollgetsize(rct_window* w, int32_t scrollIndex, i
     if (top < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = top;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -479,7 +479,7 @@ static void window_ride_list_scrollmouseover(rct_window* w, int32_t scrollIndex,
         return;
 
     w->selected_list_item = index;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -998,7 +998,7 @@ void window_ride_list_refresh_list(rct_window* w)
 
     w->no_list_items = list_index;
     w->selected_list_item = -1;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_ride_list_close_all(rct_window* w)

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -568,20 +568,20 @@ static void window_scenery_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             gWindowSceneryRotation++;
             gWindowSceneryRotation = gWindowSceneryRotation % 4;
             scenery_remove_ghost_tool_placement();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SCENERY_REPAINT_SCENERY_BUTTON:
             gWindowSceneryPaintEnabled ^= 1;
             gWindowSceneryClusterEnabled = 0;
             gWindowSceneryEyedropperEnabled = false;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SCENERY_EYEDROPPER_BUTTON:
             gWindowSceneryPaintEnabled = 0;
             gWindowSceneryClusterEnabled = 0;
             gWindowSceneryEyedropperEnabled = !gWindowSceneryEyedropperEnabled;
             scenery_remove_ghost_tool_placement();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SCENERY_BUILD_CLUSTER_BUTTON:
             gWindowSceneryPaintEnabled = 0;
@@ -600,7 +600,7 @@ static void window_scenery_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 context_show_error(STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -641,23 +641,23 @@ static void window_scenery_resize(rct_window* w)
 {
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->width > w->max_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->max_width;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
-        window_invalidate(w);
+        w->Invalidate();
         // HACK: For some reason invalidate has not been called
         window_event_invalidate_call(w);
         window_scenery_update_scroll(w);
@@ -665,9 +665,9 @@ static void window_scenery_resize(rct_window* w)
 
     if (w->height > w->max_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->max_height;
-        window_invalidate(w);
+        w->Invalidate();
         // HACK: For some reason invalidate has not been called
         window_event_invalidate_call(w);
         window_scenery_update_scroll(w);
@@ -696,7 +696,7 @@ static void window_scenery_mousedown(rct_window* w, rct_widgetindex widgetIndex,
     if (widgetIndex >= WIDX_SCENERY_TAB_1 && widgetIndex <= WIDX_SCENERY_TAB_20)
     {
         gWindowSceneryActiveTabIndex = widgetIndex - WIDX_SCENERY_TAB_1;
-        window_invalidate(w);
+        w->Invalidate();
         gSceneryPlaceCost = MONEY32_UNDEFINED;
 
         // HACK: for 3210 Ensures that window_scenery_update_scroll gets called one time
@@ -726,7 +726,7 @@ static void window_scenery_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
         gWindowSceneryTertiaryColour = (uint8_t)dropdownIndex;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -797,7 +797,7 @@ static void window_scenery_update(rct_window* w)
         }
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 
     if (!scenery_tool_is_active())
     {
@@ -892,7 +892,7 @@ void window_scenery_scrollmousedown(rct_window* w, int32_t scrollIndex, int32_t 
     audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     w->scenery.hover_counter = -16;
     gSceneryPlaceCost = MONEY32_UNDEFINED;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -905,7 +905,7 @@ void window_scenery_scrollmouseover(rct_window* w, int32_t scrollIndex, int32_t 
     if (sceneryId != WINDOW_SCENERY_TAB_SELECTION_UNDEFINED)
     {
         w->scenery.selected_scenery_id = sceneryId;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1378,7 +1378,7 @@ bool window_scenery_set_selected_item(int32_t sceneryId)
             audio_play_sound(SoundId::Click1, 0, context_get_width() / 2);
             w->scenery.hover_counter = -16;
             gSceneryPlaceCost = MONEY32_UNDEFINED;
-            window_invalidate(w);
+            w->Invalidate();
             result = true;
         }
     }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -329,7 +329,7 @@ static void window_server_list_scroll_mouseover(rct_window* w, int32_t scrollInd
         w->selected_list_item = index;
         _hoverButtonIndex = hoverButtonIndex;
         window_tooltip_close();
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -367,7 +367,7 @@ static void window_server_list_textinput(rct_window* w, rct_widgetindex widgetIn
             entry.favourite = true;
             _serverList.Add(entry);
             _serverList.WriteFavourites();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         }
     }
@@ -611,7 +611,7 @@ static void server_list_fetch_servers_check(rct_window* w)
                 log_warning("Unable to connect to master server: %s", e.what());
             }
             _fetchFuture = {};
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -195,7 +195,7 @@ static void window_server_start_mouseup(rct_window* w, rct_widgetindex widgetInd
                 gConfigNetwork.maxplayers++;
             }
             config_save_default();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_MAXPLAYERS_DECREASE:
             if (gConfigNetwork.maxplayers > 1)
@@ -203,12 +203,12 @@ static void window_server_start_mouseup(rct_window* w, rct_widgetindex widgetInd
                 gConfigNetwork.maxplayers--;
             }
             config_save_default();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_ADVERTISE_CHECKBOX:
             gConfigNetwork.advertise = !gConfigNetwork.advertise;
             config_save_default();
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_START_SERVER:
             window_scenarioselect_open(window_server_start_scenarioselect_callback, false);

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -193,7 +193,7 @@ static void window_shortcut_mouseup(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_RESET:
             keyboard_shortcuts_reset();
             keyboard_shortcuts_save();
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -259,7 +259,7 @@ static void window_shortcut_scrollmouseover(rct_window* w, int32_t scrollIndex, 
 
     w->selected_list_item = selected_item;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -194,7 +194,7 @@ rct_window* window_sign_open(rct_windownumber number)
         (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
-    window_invalidate(w);
+    w->Invalidate();
 
     return w;
 }
@@ -290,7 +290,7 @@ static void window_sign_dropdown(rct_window* w, rct_widgetindex widgetIndex, int
             return;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -372,7 +372,7 @@ static void window_sign_viewport_rotate(rct_window* w)
         (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
     if (w->viewport != nullptr)
         w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -438,7 +438,7 @@ rct_window* window_sign_small_open(rct_windownumber number)
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
     w->flags |= WF_NO_SCROLLING;
-    window_invalidate(w);
+    w->Invalidate();
 
     return w;
 }
@@ -514,7 +514,7 @@ static void window_sign_small_dropdown(rct_window* w, rct_widgetindex widgetInde
             return;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -459,7 +459,7 @@ void window_staff_overview_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             window_staff_set_page(w, widgetIndex - WIDX_TAB_1);
             break;
         case WIDX_LOCATE:
-            window_scroll_to_viewport(w);
+            w->ScrollToViewport();
             break;
         case WIDX_PICKUP:
         {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -331,7 +331,7 @@ rct_window* window_staff_open(Peep* peep)
         w->max_height = 450;
     }
     w->page = 0;
-    window_invalidate(w);
+    w->Invalidate();
 
     w->widgets = window_staff_overview_widgets;
     w->enabled_widgets = window_staff_page_enabled_widgets[0];
@@ -366,13 +366,13 @@ void window_staff_disable_widgets(rct_window* w)
         if (peep_can_be_picked_up(peep))
         {
             if (w->disabled_widgets & (1 << WIDX_PICKUP))
-                window_invalidate(w);
+                w->Invalidate();
         }
         else
         {
             disabled_widgets |= (1 << WIDX_PICKUP);
             if (!(w->disabled_widgets & (1 << WIDX_PICKUP)))
-                window_invalidate(w);
+                w->Invalidate();
         }
     }
 
@@ -428,13 +428,13 @@ void window_staff_set_page(rct_window* w, int32_t page)
     w->widgets = window_staff_page_widgets[page];
 
     window_staff_disable_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     window_event_resize_call(w);
     window_event_invalidate_call(w);
 
     window_init_scroll_widgets(w);
-    window_invalidate(w);
+    w->Invalidate();
 
     if (listen && w->viewport)
         w->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
@@ -511,24 +511,24 @@ void window_staff_overview_resize(rct_window* w)
     if (w->width < w->min_width)
     {
         w->width = w->min_width;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->width > w->max_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->max_width;
     }
 
     if (w->height < w->min_height)
     {
         w->height = w->min_height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->height > w->max_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->max_height;
     }
 
@@ -714,24 +714,24 @@ void window_staff_stats_resize(rct_window* w)
     if (w->width < w->min_width)
     {
         w->width = w->min_width;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->width > w->max_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->max_width;
     }
 
     if (w->height < w->min_height)
     {
         w->height = w->min_height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     if (w->height > w->max_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->max_height;
     }
 }
@@ -749,7 +749,7 @@ void window_staff_stats_update(rct_window* w)
     if (peep->window_invalidate_flags & PEEP_INVALIDATE_STAFF_STATS)
     {
         peep->window_invalidate_flags &= ~PEEP_INVALIDATE_STAFF_STATS;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -1392,13 +1392,13 @@ void window_staff_viewport_init(rct_window* w)
 
             viewport_create(w, x, y, width, height, 0, 0, 0, 0, focus.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite_id);
             w->flags |= WF_NO_SCROLLING;
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 
     if (w->viewport)
         w->viewport->flags = viewport_flags;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -229,7 +229,7 @@ static void window_staff_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
             break;
         case WIDX_STAFF_LIST_QUICK_FIRE:
             _quick_fire_mode ^= 1;
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -245,12 +245,12 @@ static void window_staff_list_resize(rct_window* w)
     if (w->width < w->min_width)
     {
         w->width = w->min_width;
-        window_invalidate(w);
+        w->Invalidate();
     }
     if (w->height < w->min_height)
     {
         w->height = w->min_height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -273,7 +273,7 @@ static void window_staff_list_mousedown(rct_window* w, rct_widgetindex widgetInd
                 break;
 
             _windowStaffListSelectedTab = (uint8_t)newSelectedTab;
-            window_invalidate(w);
+            w->Invalidate();
             w->scrolls[0].v_top = 0;
             window_staff_list_cancel_tools(w);
             break;
@@ -431,7 +431,7 @@ void window_staff_list_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t
     if (_windowStaffListHighlightedIndex != -1)
     {
         _windowStaffListHighlightedIndex = -1;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *height = staffCount * SCROLLABLE_ROW_HEIGHT;
@@ -442,7 +442,7 @@ void window_staff_list_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *width = w->widgets[WIDX_STAFF_LIST_LIST].right - w->widgets[WIDX_STAFF_LIST_LIST].left - 15;
@@ -495,7 +495,7 @@ void window_staff_list_scrollmouseover(rct_window* w, int32_t scrollIndex, int32
     if (i != _windowStaffListHighlightedIndex)
     {
         _windowStaffListHighlightedIndex = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -298,7 +298,7 @@ void window_text_input_key(rct_window* w, char keychar)
     }
 
     if (w)
-        window_invalidate(w);
+        w->Invalidate();
 }
 
 void window_text_input_periodic_update(rct_window* w)
@@ -317,7 +317,7 @@ void window_text_input_periodic_update(rct_window* w)
     if (w->frame_no > 30)
         w->frame_no = 0;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_text_input_close(rct_window* w)
@@ -344,7 +344,7 @@ static void window_text_input_invalidate(rct_window* w)
     // Change window size if required.
     if (height != w->height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         window_set_resize(w, WW, height, WW, height);
     }
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -465,22 +465,22 @@ static void window_themes_resize(rct_window* w)
         if (w->width < w->min_width)
         {
             w->width = w->min_width;
-            window_invalidate(w);
+            w->Invalidate();
         }
         if (w->height < w->min_height)
         {
             w->height = w->min_height;
-            window_invalidate(w);
+            w->Invalidate();
         }
         if (w->width > w->max_width)
         {
             w->width = w->max_width;
-            window_invalidate(w);
+            w->Invalidate();
         }
         if (w->height > w->max_height)
         {
             w->height = w->max_height;
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }
@@ -508,7 +508,7 @@ static void window_themes_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
             w->scrolls[0].v_top = 0;
             w->frame_no = 0;
             window_event_resize_call(w);
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_THEMES_PRESETS_DROPDOWN:
             theme_manager_load_available_themes();
@@ -628,7 +628,7 @@ void window_themes_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* wi
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *width = 420;
@@ -727,7 +727,7 @@ static void window_themes_textinput(rct_window* w, rct_widgetindex widgetIndex, 
                     {
                         theme_rename(text);
                     }
-                    window_invalidate(w);
+                    w->Invalidate();
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -591,7 +591,7 @@ static void window_tile_inspector_select_element_from_list(rct_window* w, int32_
         windowTileInspectorSelectedIndex = index;
     }
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_tile_inspector_load_tile(rct_window* w, TileElement* elementToSelect)
@@ -613,7 +613,7 @@ static void window_tile_inspector_load_tile(rct_window* w, TileElement* elementT
 
     windowTileInspectorElementCount = numItems;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_tile_inspector_insert_corrupt_element(int32_t elementIndex)
@@ -658,7 +658,7 @@ static void window_tile_inspector_copy_element(rct_window* w)
     // Copy value, in case the element gets moved
     tileInspectorCopiedElement = *window_tile_inspector_get_selected_element(w);
     windowTileInspectorElementCopied = true;
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_tile_inspector_paste_element(rct_window* w)
@@ -989,12 +989,12 @@ static void window_tile_inspector_resize(rct_window* w)
     w->min_height = MIN_WH;
     if (w->width < w->min_width)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = w->min_width;
     }
     if (w->height < w->min_height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->height = w->min_height;
     }
 }
@@ -1325,7 +1325,7 @@ static void window_tile_inspector_scrollgetsize(rct_window* w, int32_t scrollInd
 static void window_tile_inspector_set_page(rct_window* w, const TILE_INSPECTOR_PAGE page)
 {
     // Invalidate the window already, because the size may change
-    window_invalidate(w);
+    w->Invalidate();
 
     // subtract current page height, then add new page height
     if (w->page != TILE_INSPECTOR_PAGE_DEFAULT)
@@ -1408,7 +1408,7 @@ static void window_tile_inspector_invalidate(rct_window* w)
     if (w->page != page)
     {
         window_tile_inspector_set_page(w, page);
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     // X and Y spinners

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -336,7 +336,7 @@ static void window_title_command_editor_mouseup(rct_window* w, rct_widgetindex w
                 command.Zoom = zoom;
                 snprintf(textbox1Buffer, BUF_SIZE, "%d", command.Zoom);
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_SELECT_SCENARIO:
             window_scenarioselect_open(scenario_select_callback, true);
@@ -501,7 +501,7 @@ static void window_title_command_editor_dropdown(rct_window* w, rct_widgetindex 
                 case TITLE_SCRIPT_LOADSC:
                     command.Scenario[0] = '\0';
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INPUT_DROPDOWN:
             switch (command.Type)
@@ -510,14 +510,14 @@ static void window_title_command_editor_dropdown(rct_window* w, rct_widgetindex 
                     if (dropdownIndex != command.Speed - 1)
                     {
                         command.Speed = (uint8_t)(dropdownIndex + 1);
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
                 case TITLE_SCRIPT_LOAD:
                     if (dropdownIndex != command.SaveIndex)
                     {
                         command.SaveIndex = (uint8_t)dropdownIndex;
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     break;
             }
@@ -561,7 +561,7 @@ static void window_title_command_editor_textinput(rct_window* w, rct_widgetindex
                         snprintf(textbox1Buffer, BUF_SIZE, "%d", command.Rotations);
                     }
                 }
-                window_invalidate(w);
+                w->Invalidate();
             }
             else
             {
@@ -576,7 +576,7 @@ static void window_title_command_editor_textinput(rct_window* w, rct_widgetindex
                     command.X = (uint8_t)value;
                 }
                 snprintf(textbox1Buffer, BUF_SIZE, "%d", command.X);
-                window_invalidate(w);
+                w->Invalidate();
             }
             else
             {
@@ -591,7 +591,7 @@ static void window_title_command_editor_textinput(rct_window* w, rct_widgetindex
                     command.Y = (uint8_t)value;
                 }
                 snprintf(textbox2Buffer, BUF_SIZE, "%d", command.Y);
-                window_invalidate(w);
+                w->Invalidate();
             }
             else
             {
@@ -673,7 +673,7 @@ static void window_title_command_editor_tool_down(rct_window* w, rct_widgetindex
             command.SpriteIndex = spriteIndex;
             window_follow_sprite(w, (size_t)command.SpriteIndex);
             tool_cancel();
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -535,7 +535,7 @@ static void window_title_editor_mousedown(rct_window* w, rct_widgetindex widgetI
                 w->scrolls[0].v_top = 0;
                 w->frame_no = 0;
                 window_event_resize_call(w);
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         }
@@ -571,7 +571,7 @@ static void window_title_editor_dropdown(rct_window* w, rct_widgetindex widgetIn
     if (widgetIndex == WIDX_TITLE_EDITOR_PRESETS_DROPDOWN)
     {
         window_title_editor_load_sequence(dropdownIndex);
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -610,7 +610,7 @@ static void window_title_editor_scrollgetsize(rct_window* w, int32_t scrollIndex
     if (i < w->scrolls[0].v_top)
     {
         w->scrolls[0].v_top = i;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     *width = SCROLL_WIDTH;
@@ -688,7 +688,7 @@ static void window_title_editor_textinput(rct_window* w, rct_widgetindex widgetI
                             window_title_editor_load_sequence(newIndex);
                         }
                         config_save_default();
-                        window_invalidate(w);
+                        w->Invalidate();
                     }
                     else
                     {

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -279,11 +279,11 @@ static void window_scenarioselect_mousedown(rct_window* w, rct_widgetindex widge
         gConfigInterface.scenarioselect_last_tab = w->selected_tab;
         config_save_default();
         initialise_list_items(w);
-        window_invalidate(w);
+        w->Invalidate();
         window_event_resize_call(w);
         window_event_invalidate_call(w);
         window_init_scroll_widgets(w);
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 
@@ -399,11 +399,11 @@ static void window_scenarioselect_scrollmouseover(rct_window* w, int32_t scrollI
     if (w->highlighted_scenario != selected)
     {
         w->highlighted_scenario = selected;
-        window_invalidate(w);
+        w->Invalidate();
     }
     else if (_showLockedInformation != originalShowLockedInformation)
     {
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3308,7 +3308,7 @@ static void top_toolbar_fastforward_menu_dropdown(int16_t dropdownIndex)
             gGameSpeed = dropdownIndex + 1;
             if (gGameSpeed >= 5)
                 gGameSpeed = 8;
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }
@@ -3332,12 +3332,12 @@ static void top_toolbar_rotate_menu_dropdown(int16_t dropdownIndex)
         if (dropdownIndex == 0)
         {
             window_rotate_camera(w, 1);
-            window_invalidate(w);
+            w->Invalidate();
         }
         else if (dropdownIndex == 1)
         {
             window_rotate_camera(w, -1);
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }
@@ -3651,7 +3651,7 @@ static void top_toolbar_view_menu_dropdown(int16_t dropdownIndex)
             default:
                 return;
         }
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -207,14 +207,14 @@ static void window_track_place_mouseup(rct_window* w, rct_widgetindex widgetInde
         case WIDX_ROTATE:
             window_track_place_clear_provisional();
             _currentTrackPieceDirection = (_currentTrackPieceDirection + 1) & 3;
-            window_invalidate(w);
+            w->Invalidate();
             _window_track_place_last_x = -1;
             window_track_place_draw_mini_preview(_trackDesign.get());
             break;
         case WIDX_MIRROR:
             track_design_mirror(_trackDesign.get());
             _currentTrackPieceDirection = (0 - _currentTrackPieceDirection) & 3;
-            window_invalidate(w);
+            w->Invalidate();
             _window_track_place_last_x = -1;
             window_track_place_draw_mini_preview(_trackDesign.get());
             break;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -316,12 +316,12 @@ static void window_track_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_ROTATE:
             _currentTrackPieceDirection++;
             _currentTrackPieceDirection %= 4;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_TOGGLE_SCENERY:
             gTrackDesignSceneryToggle = !gTrackDesignSceneryToggle;
             _loadedTrackDesignIndex = TRACK_DESIGN_INDEX_UNLOADED;
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_BACK:
             window_close(w);
@@ -347,7 +347,7 @@ static void window_track_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
 
             String::Set(_filterString, sizeof(_filterString), "");
             window_track_list_filter_list();
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -396,7 +396,7 @@ static void window_track_list_scrollmouseover(rct_window* w, int32_t scrollIndex
         if (i != -1 && w->selected_list_item != i)
         {
             w->selected_list_item = i;
-            window_invalidate(w);
+            w->Invalidate();
         }
     }
 }
@@ -415,7 +415,7 @@ static void window_track_list_textinput(rct_window* w, rct_widgetindex widgetInd
 
     w->scrolls->v_top = 0;
 
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 static void window_track_list_update(rct_window* w)
@@ -430,7 +430,7 @@ static void window_track_list_update(rct_window* w)
     {
         track_list_load_designs(_window_track_list_item);
         w->selected_list_item = 0;
-        window_invalidate(w);
+        w->Invalidate();
         w->track_list.reload_track_designs = false;
     }
 }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -165,7 +165,7 @@ rct_window* window_view_clipping_open()
     if (mainWindow != nullptr)
     {
         mainWindow->viewport->flags |= VIEWPORT_FLAG_CLIP_VIEW;
-        window_invalidate(mainWindow);
+        mainWindow->Invalidate();
     }
 
     _toolActive = false;
@@ -181,7 +181,7 @@ static void window_view_clipping_close()
     if (mainWindow != nullptr)
     {
         mainWindow->viewport->flags &= ~VIEWPORT_FLAG_CLIP_VIEW;
-        window_invalidate(mainWindow);
+        mainWindow->Invalidate();
     }
 }
 
@@ -216,9 +216,9 @@ static void window_view_clipping_mouseup(rct_window* w, rct_widgetindex widgetIn
             if (mainWindow != nullptr)
             {
                 mainWindow->viewport->flags ^= VIEWPORT_FLAG_CLIP_VIEW;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CLIP_HEIGHT_VALUE:
             // Toggle display of the cut height value in RAW vs UNITS
@@ -230,7 +230,7 @@ static void window_view_clipping_mouseup(rct_window* w, rct_widgetindex widgetIn
             {
                 gClipHeightDisplayType = DISPLAY_TYPE::DISPLAY_RAW;
             }
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_CLIP_SELECTOR:
             // Activate the selection tool
@@ -269,14 +269,14 @@ static void window_view_clipping_mousedown(rct_window* w, rct_widgetindex widget
                 window_view_clipping_set_clipheight(w, gClipHeight + 1);
             mainWindow = window_get_main();
             if (mainWindow != nullptr)
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             break;
         case WIDX_CLIP_HEIGHT_DECREASE:
             if (gClipHeight > 0)
                 window_view_clipping_set_clipheight(w, gClipHeight - 1);
             mainWindow = window_get_main();
             if (mainWindow != nullptr)
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             break;
     }
 }
@@ -295,7 +295,7 @@ static void window_view_clipping_update(rct_window* w)
         rct_window* mainWindow = window_get_main();
         if (mainWindow != nullptr)
         {
-            window_invalidate(mainWindow);
+            mainWindow->Invalidate();
         }
     }
 

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -135,14 +135,14 @@ static void window_viewport_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (w->viewport != nullptr && w->viewport->zoom > 0)
             {
                 w->viewport->zoom--;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case WIDX_ZOOM_OUT:
             if (w->viewport != nullptr && w->viewport->zoom < 3)
             {
                 w->viewport->zoom++;
-                window_invalidate(w);
+                w->Invalidate();
             }
             break;
         case WIDX_LOCATE:
@@ -175,7 +175,7 @@ static void window_viewport_update(rct_window* w)
     if (w->viewport->flags != mainWindow->viewport->flags)
     {
         w->viewport->flags = mainWindow->viewport->flags;
-        window_invalidate(w);
+        w->Invalidate();
     }
 
     // Not sure how to invalidate part of the viewport that has changed, this will have to do for now

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -141,14 +141,14 @@ static void window_water_mousedown(rct_window* w, rct_widgetindex widgetIndex, r
             gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
         case WIDX_INCREMENT:
             // Increment land tool size
             gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
 
             // Invalidate the window
-            window_invalidate(w);
+            w->Invalidate();
             break;
     }
 }
@@ -168,7 +168,7 @@ static void window_water_textinput(rct_window* w, rct_widgetindex widgetIndex, c
         size = std::min(MAXIMUM_TOOL_SIZE, size);
         gLandToolSize = size;
 
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -20,6 +20,7 @@
 #include "actions/LandSetRightsAction.hpp"
 #include "audio/audio.h"
 #include "interface/Viewport.h"
+#include "interface/Window_internal.h"
 #include "localisation/Localisation.h"
 #include "localisation/LocalisationService.h"
 #include "management/NewsItem.h"
@@ -86,7 +87,7 @@ namespace Editor
         gS6Info.category = SCENARIO_CATEGORY_OTHER;
         viewport_init_all();
         rct_window* mainWindow = context_open_window_view(WV_EDITOR_MAIN);
-        window_set_location(mainWindow, 2400, 2400, 112);
+        mainWindow->SetLocation(2400, 2400, 112);
         load_palette();
         gScreenAge = 0;
         gScenarioName = language_get_string(STR_MY_NEW_SCENARIO);
@@ -162,7 +163,7 @@ namespace Editor
         gS6Info.editor_step = EDITOR_STEP_OBJECT_SELECTION;
         viewport_init_all();
         rct_window* mainWindow = context_open_window_view(WV_EDITOR_MAIN);
-        window_set_location(mainWindow, 2400, 2400, 112);
+        mainWindow->SetLocation(2400, 2400, 112);
         load_palette();
     }
 
@@ -183,7 +184,7 @@ namespace Editor
         gS6Info.editor_step = EDITOR_STEP_OBJECT_SELECTION;
         viewport_init_all();
         rct_window* mainWindow = context_open_window_view(WV_EDITOR_MAIN);
-        window_set_location(mainWindow, 2400, 2400, 112);
+        mainWindow->SetLocation(2400, 2400, 112);
         load_palette();
     }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -27,6 +27,7 @@
 #include "../drawing/Font.h"
 #include "../interface/Chat.h"
 #include "../interface/Colour.h"
+#include "../interface/Window_internal.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/Research.h"
@@ -907,7 +908,7 @@ static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
                 int32_t x = (int16_t)(int_val[0] * 32 + 16);
                 int32_t y = (int16_t)(int_val[1] * 32 + 16);
                 int32_t z = tile_element_height(x, y);
-                window_set_location(w, x, y, z);
+                w->SetLocation(x, y, z);
                 viewport_update_position(w);
                 console.Execute("get location");
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -524,7 +524,7 @@ static void viewport_set_underground_flag(int32_t underground, rct_window* windo
             if (bit)
                 return;
         }
-        window_invalidate(window);
+        window->Invalidate();
     }
 }
 
@@ -1089,7 +1089,7 @@ void show_gridlines()
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_GRIDLINES))
             {
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_GRIDLINES;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1111,7 +1111,7 @@ void hide_gridlines()
             if (!gConfigGeneral.always_show_gridlines)
             {
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1131,7 +1131,7 @@ void show_land_rights()
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP))
             {
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_LAND_OWNERSHIP;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1153,7 +1153,7 @@ void hide_land_rights()
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP)
             {
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_LAND_OWNERSHIP;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1173,7 +1173,7 @@ void show_construction_rights()
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS))
             {
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1195,7 +1195,7 @@ void hide_construction_rights()
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS)
             {
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
-                window_invalidate(mainWindow);
+                mainWindow->Invalidate();
             }
         }
     }
@@ -1246,7 +1246,7 @@ void viewport_set_visibility(uint8_t mode)
                 break;
         }
         if (invalidate != 0)
-            window_invalidate(window);
+            window->Invalidate();
     }
 }
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -836,12 +836,6 @@ void window_scroll_to_viewport(rct_window* w)
         window_scroll_to_location(mainWindow, x, y, z);
 }
 
-void window_set_location(rct_window* w, int32_t x, int32_t y, int32_t z)
-{
-    window_scroll_to_location(w, x, y, z);
-    w->flags &= ~WF_SCROLLING_TO_LOCATION;
-}
-
 /**
  *
  *  rct2: 0x006E7C9C

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -150,7 +150,7 @@ void window_update_all()
             w->flags -= WF_WHITE_BORDER_ONE;
             if (!(w->flags & WF_WHITE_BORDER_MASK))
             {
-                window_invalidate(w);
+                w->Invalidate();
             }
         }
     });
@@ -228,7 +228,7 @@ void window_close(rct_window* w)
     }
 
     // Invalidate the window (area)
-    window_invalidate(window.get());
+    window->Invalidate();
 
     // The window list may have been modified in the close event
     itWindow = window_get_iterator(w);
@@ -463,18 +463,12 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, int32_t x, int32_t 
  *
  * @param window The window to invalidate (esi).
  */
-void window_invalidate(rct_window* window)
-{
-    if (window != nullptr)
-        gfx_set_dirty_blocks(window->x, window->y, window->x + window->width, window->y + window->height);
-}
-
 template<typename _TPred> static void window_invalidate_by_condition(_TPred pred)
 {
     window_visit_each([pred](rct_window* w) {
         if (pred(w))
         {
-            window_invalidate(w);
+            w->Invalidate();
         }
     });
 }
@@ -504,7 +498,7 @@ void window_invalidate_by_number(rct_windowclass cls, rct_windownumber number)
  */
 void window_invalidate_all()
 {
-    window_visit_each([](rct_window* w) { window_invalidate(w); });
+    window_visit_each([](rct_window* w) { w->Invalidate(); });
 }
 
 /**
@@ -535,7 +529,7 @@ template<typename _TPred> static void widget_invalidate_by_condition(_TPred pred
     window_visit_each([pred](rct_window* w) {
         if (pred(w))
         {
-            window_invalidate(w);
+            w->Invalidate();
         }
     });
 }
@@ -619,7 +613,7 @@ void window_update_scroll_widgets(rct_window* w)
         if (scrollPositionChanged)
         {
             widget_scroll_update_thumbs(w, widgetIndex);
-            window_invalidate(w);
+            w->Invalidate();
         }
         scrollIndex++;
     }
@@ -663,7 +657,7 @@ rct_window* window_bring_to_front(rct_window* w)
             }
 
             g_window_list.splice(itDestPos, g_window_list, itSourcePos);
-            window_invalidate(w);
+            w->Invalidate();
 
             if (w->x + w->width < 20)
             {
@@ -671,7 +665,7 @@ rct_window* window_bring_to_front(rct_window* w)
                 w->x += i;
                 if (w->viewport != nullptr)
                     w->viewport->x += i;
-                window_invalidate(w);
+                w->Invalidate();
             }
         }
     }
@@ -686,7 +680,7 @@ rct_window* window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint1
     if (w != nullptr)
     {
         w->flags |= flags;
-        window_invalidate(w);
+        w->Invalidate();
         w = window_bring_to_front(w);
     }
 
@@ -712,7 +706,7 @@ rct_window* window_bring_to_front_by_number(rct_windowclass cls, rct_windownumbe
     if (w != nullptr)
     {
         w->flags |= WF_WHITE_BORDER_MASK;
-        window_invalidate(w);
+        w->Invalidate();
         w = window_bring_to_front(w);
     }
 
@@ -739,12 +733,12 @@ void window_push_others_right(rct_window* window)
         if (w->y + w->height <= window->y)
             return;
 
-        window_invalidate(w);
+        w->Invalidate();
         if (window->x + window->width + 13 >= context_get_width())
             return;
         uint16_t push_amount = window->x + window->width - w->x + 3;
         w->x += push_amount;
-        window_invalidate(w);
+        w->Invalidate();
         if (w->viewport != nullptr)
             w->viewport->x += push_amount;
     });
@@ -774,13 +768,13 @@ void window_push_others_below(rct_window* w1)
             return;
 
         // Invalidate the window's current area
-        window_invalidate(w2);
+        w2->Invalidate();
 
         int32_t push_amount = w1->y + w1->height - w2->y + 3;
         w2->y += push_amount;
 
         // Invalidate the window's new area
-        window_invalidate(w2);
+        w2->Invalidate();
 
         // Update viewport position if necessary
         if (w2->viewport != nullptr)
@@ -828,7 +822,7 @@ void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z)
             if (!(w->viewport->flags & 1 << 0))
             {
                 w->viewport->flags |= 1 << 0;
-                window_invalidate(w);
+                w->Invalidate();
             }
         }
         else
@@ -836,7 +830,7 @@ void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z)
             if (w->viewport->flags & 1 << 0)
             {
                 w->viewport->flags &= ~(1 << 0);
-                window_invalidate(w);
+                w->Invalidate();
             }
         }
 
@@ -946,7 +940,7 @@ void window_rotate_camera(rct_window* w, int32_t direction)
     viewport->view_x = new_x;
     viewport->view_y = new_y;
 
-    window_invalidate(w);
+    w->Invalidate();
 
     call_event_viewport_rotate_on_all_windows();
     reset_all_sprite_quadrant_placements();
@@ -1043,7 +1037,7 @@ void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
     // HACK: Prevents the redraw from failing when there is
     // a window on top of the viewport.
     window_bring_to_front(w);
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 /**
@@ -1256,7 +1250,7 @@ void window_move_position(rct_window* w, int32_t dx, int32_t dy)
         return;
 
     // Invalidate old region
-    window_invalidate(w);
+    w->Invalidate();
 
     // Translate window and viewport
     w->x += dx;
@@ -1268,7 +1262,7 @@ void window_move_position(rct_window* w, int32_t dx, int32_t dy)
     }
 
     // Invalidate new region
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 void window_resize(rct_window* w, int32_t dw, int32_t dh)
@@ -1278,7 +1272,7 @@ void window_resize(rct_window* w, int32_t dw, int32_t dh)
         return;
 
     // Invalidate old region
-    window_invalidate(w);
+    w->Invalidate();
 
     // Clamp new size to minimum and maximum
     w->width = std::clamp<int16_t>(w->width + dw, w->min_width, w->max_width);
@@ -1296,7 +1290,7 @@ void window_resize(rct_window* w, int32_t dw, int32_t dh)
     window_update_scroll_widgets(w);
 
     // Invalidate new region
-    window_invalidate(w);
+    w->Invalidate();
 }
 
 void window_set_resize(rct_window* w, int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight)
@@ -1313,10 +1307,10 @@ void window_set_resize(rct_window* w, int32_t minWidth, int32_t minHeight, int32
     // Resize window if size has changed
     if (w->width != width || w->height != height)
     {
-        window_invalidate(w);
+        w->Invalidate();
         w->width = width;
         w->height = height;
-        window_invalidate(w);
+        w->Invalidate();
     }
 }
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -805,38 +805,6 @@ rct_window* window_get_main()
 }
 
 /**
- * Based on
- *  rct2: 0x696ee9, 0x66842F, 0x006AF3B3
- */
-void window_scroll_to_viewport(rct_window* w)
-{
-    int32_t x, y, z;
-    rct_window* mainWindow;
-    assert(w != nullptr);
-    // In original checked to make sure x and y were not -1 as well.
-    if (w->viewport == nullptr || w->viewport_focus_coordinates.y == -1)
-        return;
-
-    if (w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_SPRITE)
-    {
-        rct_sprite* sprite = get_sprite(w->viewport_focus_sprite.sprite_id);
-        x = sprite->generic.x;
-        y = sprite->generic.y;
-        z = sprite->generic.z;
-    }
-    else
-    {
-        x = w->viewport_focus_coordinates.x;
-        y = w->viewport_focus_coordinates.y & VIEWPORT_FOCUS_Y_MASK;
-        z = w->viewport_focus_coordinates.z;
-    }
-
-    mainWindow = window_get_main();
-    if (mainWindow != nullptr)
-        window_scroll_to_location(mainWindow, x, y, z);
-}
-
-/**
  *
  *  rct2: 0x006E7C9C
  * @param w (esi)

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -631,7 +631,6 @@ void window_push_others_below(rct_window* w1);
 
 rct_window* window_get_main();
 
-void window_scroll_to_viewport(rct_window* w);
 void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z);
 void window_rotate_camera(rct_window* w, int32_t direction);
 void window_viewport_get_map_coords_by_cursor(

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -631,7 +631,6 @@ void window_push_others_below(rct_window* w1);
 
 rct_window* window_get_main();
 
-void window_set_location(rct_window* w, int32_t x, int32_t y, int32_t z);
 void window_scroll_to_viewport(rct_window* w);
 void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z);
 void window_rotate_camera(rct_window* w, int32_t direction);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -610,7 +610,6 @@ rct_window* window_find_by_class(rct_windowclass cls);
 rct_window* window_find_by_number(rct_windowclass cls, rct_windownumber number);
 rct_window* window_find_from_point(int32_t x, int32_t y);
 rct_widgetindex window_find_widget_from_point(rct_window* w, int32_t x, int32_t y);
-void window_invalidate(rct_window* window);
 void window_invalidate_by_class(rct_windowclass cls);
 void window_invalidate_by_number(rct_windowclass cls, rct_windownumber number);
 void window_invalidate_all();

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -1,0 +1,7 @@
+#include "Window_internal.h"
+
+void rct_window::SetLocation(int32_t newX, int32_t newY, int32_t newZ)
+{
+    window_scroll_to_location(this, newX, newY, newZ);
+    flags &= ~WF_SCROLLING_TO_LOCATION;
+}

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -1,7 +1,37 @@
 #include "Window_internal.h"
 
+#include "../world/Sprite.h"
+
 void rct_window::SetLocation(int32_t newX, int32_t newY, int32_t newZ)
 {
     window_scroll_to_location(this, newX, newY, newZ);
     flags &= ~WF_SCROLLING_TO_LOCATION;
+}
+
+void rct_window::ScrollToViewport()
+{
+    int32_t newX, newY, newZ;
+    rct_window* mainWindow;
+
+    // In original checked to make sure x and y were not -1 as well.
+    if (viewport == nullptr || viewport_focus_coordinates.y == -1)
+        return;
+
+    if (viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_SPRITE)
+    {
+        rct_sprite* sprite = get_sprite(viewport_focus_sprite.sprite_id);
+        newX = sprite->generic.x;
+        newY = sprite->generic.y;
+        newZ = sprite->generic.z;
+    }
+    else
+    {
+        newX = viewport_focus_coordinates.x;
+        newY = viewport_focus_coordinates.y & VIEWPORT_FOCUS_Y_MASK;
+        newZ = viewport_focus_coordinates.z;
+    }
+
+    mainWindow = window_get_main();
+    if (mainWindow != nullptr)
+        window_scroll_to_location(mainWindow, newX, newY, newZ);
 }

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -35,3 +35,8 @@ void rct_window::ScrollToViewport()
     if (mainWindow != nullptr)
         window_scroll_to_location(mainWindow, newX, newY, newZ);
 }
+
+void rct_window::Invalidate()
+{
+    gfx_set_dirty_blocks(x, y, x + width, y + height);
+}

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -103,6 +103,7 @@ struct rct_window
     uint16_t viewport_smart_follow_sprite; // Smart following of sprites. Handles setting viewport target sprite etc
 
     void SetLocation(int32_t x, int32_t y, int32_t z);
+    void ScrollToViewport();
 };
 
 // rct2: 0x01420078

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -104,6 +104,7 @@ struct rct_window
 
     void SetLocation(int32_t x, int32_t y, int32_t z);
     void ScrollToViewport();
+    void Invalidate();
 };
 
 // rct2: 0x01420078

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -101,6 +101,8 @@ struct rct_window
     uint8_t colours[6];                    // 0x4BA
     uint8_t visibility;                    // VISIBILITY_CACHE
     uint16_t viewport_smart_follow_sprite; // Smart following of sprites. Handles setting viewport target sprite etc
+
+    void SetLocation(int32_t x, int32_t y, int32_t z);
 };
 
 // rct2: 0x01420078

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -14,6 +14,7 @@
 #include "../OpenRCT2.h"
 #include "../audio/audio.h"
 #include "../interface/Window.h"
+#include "../interface/Window_internal.h"
 #include "../localisation/Date.h"
 #include "../localisation/Localisation.h"
 #include "../management/Research.h"
@@ -371,7 +372,7 @@ void news_item_open_subject(int32_t type, int32_t subject)
                 window = window_find_by_class(WC_TOP_TOOLBAR);
                 if (window != nullptr)
                 {
-                    window_invalidate(window);
+                    window->Invalidate();
                     if (!tool_set(window, WC_TOP_TOOLBAR__WIDX_SCENERY, TOOL_ARROW))
                     {
                         input_set_flag(INPUT_FLAG_6, true);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -13,6 +13,7 @@
 #include "../audio/audio.h"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
+#include "../interface/Window_internal.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/Marketing.h"

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -15,6 +15,7 @@
 #include "../common.h"
 #include "../core/Guard.hpp"
 #include "../interface/Window.h"
+#include "../interface/Window_internal.h"
 #include "../localisation/Localisation.h"
 #include "../ride/Station.h"
 #include "../ride/Track.h"
@@ -132,7 +133,7 @@ GameActionResult::Ptr tile_inspector_insert_corrupt_at(CoordsXY loc, int16_t ele
                 windowTileInspectorSelectedIndex++;
             }
 
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -175,7 +176,7 @@ GameActionResult::Ptr tile_inspector_remove_element_at(CoordsXY loc, int16_t ele
                 windowTileInspectorSelectedIndex = -1;
             }
 
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -203,7 +204,7 @@ GameActionResult::Ptr tile_inspector_swap_elements_at(CoordsXY loc, int16_t firs
             else if (windowTileInspectorSelectedIndex == second)
                 windowTileInspectorSelectedIndex = first;
 
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -344,7 +345,7 @@ GameActionResult::Ptr tile_inspector_paste_element_at(CoordsXY loc, TileElement 
             else if (windowTileInspectorSelectedIndex >= newIndex)
                 windowTileInspectorSelectedIndex++;
 
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -401,7 +402,7 @@ GameActionResult::Ptr tile_inspector_sort_elements_at(CoordsXY loc, bool isExecu
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
             windowTileInspectorSelectedIndex = -1;
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -459,7 +460,7 @@ GameActionResult::Ptr tile_inspector_any_base_height_offset(
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -487,7 +488,7 @@ GameActionResult::Ptr tile_inspector_surface_show_park_fences(CoordsXY loc, bool
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -554,7 +555,7 @@ GameActionResult::Ptr tile_inspector_surface_toggle_corner(CoordsXY loc, int32_t
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -592,7 +593,7 @@ GameActionResult::Ptr tile_inspector_surface_toggle_diagonal(CoordsXY loc, bool 
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -616,7 +617,7 @@ GameActionResult::Ptr tile_inspector_path_set_sloped(CoordsXY loc, int32_t eleme
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -640,7 +641,7 @@ GameActionResult::Ptr tile_inspector_path_set_broken(CoordsXY loc, int32_t eleme
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -665,7 +666,7 @@ GameActionResult::Ptr tile_inspector_path_toggle_edge(CoordsXY loc, int32_t elem
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -705,7 +706,7 @@ GameActionResult::Ptr tile_inspector_entrance_make_usable(CoordsXY loc, int32_t 
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -730,7 +731,7 @@ GameActionResult::Ptr tile_inspector_wall_set_slope(CoordsXY loc, int32_t elemen
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -957,7 +958,7 @@ GameActionResult::Ptr tile_inspector_track_set_block_brake(
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 
@@ -982,7 +983,7 @@ GameActionResult::Ptr tile_inspector_track_set_indestructible(
         if (tileInspectorWindow != nullptr && (uint32_t)(loc.x / 32) == windowTileInspectorTileX
             && (uint32_t)(loc.y / 32) == windowTileInspectorTileY)
         {
-            window_invalidate(tileInspectorWindow);
+            tileInspectorWindow->Invalidate();
         }
     }
 


### PR DESCRIPTION
This is basically a start for a long run of refactoring the windows code. This first PR moves a few functions out of the global scope into rct_struct for skeleton work. The idea is to first move out most of the functions into rct_struct and once all direct data access is eliminated and it has all the members functions we can create a new interface and move the entire code into the UI part of the project. Once that is completed the window manager should take care of all the window management also. The end goal is to have the window manager do all the heavy lifting while providing safe access to the window list at any time even during events.

Because this involves a lot of changes I decided to do this gradually.