### PR TITLE
Fix #8064 Ride construction errors shown as (undefined string)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
 - Fix: [#7829] Rotated information kiosk can cause 'unreachable' messages.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
+- Fix: [#8064] Ride construction errors shown as (undefined string)
 - Fix: [#8219] Faulty folder recreation in "save" folder.
 - Fix: [#8480, #8535] Crash when mirroring track design.
 - Fix: [#8507] Incorrect change in vehicle rolling direction.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3576,8 +3576,8 @@ void ride_construction_toolupdate_construct(int32_t screenX, int32_t screenY)
         return;
     }
 
-    // search for appropriate z value for ghost, up to max ride height (2^12 - 16)
-    int numAttempts = (z <= 2032 ? (2032 - z) / 8 + 1 : 2);
+    // search for appropriate z value for ghost, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
     for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
     {
         window_ride_construction_update_state(
@@ -3838,8 +3838,8 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
         return;
     }
 
-    // search for appropriate z value, up to max ride height (2^12 - 16)
-    int numAttempts = (z <= 2032 ? (2032 - z) / 8 + 1 : 2);
+    // search for z value to build at, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
 
     for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
     {

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -237,7 +237,7 @@ public:
 
             clearanceZ = (clearanceZ / 8) + baseZ;
 
-            if (clearanceZ >= 255)
+            if (clearanceZ > MAX_TRACK_HEIGHT)
             {
                 return std::make_unique<TrackPlaceActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_TOO_HIGH);
             }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "42"
+#define NETWORK_STREAM_VERSION "43"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -81,6 +81,7 @@ enum
 #define TRACK_ELEMENT_FLAG_STATION_NO_MASK 0x02
 
 #define MAX_STATION_PLATFORM_LENGTH 32
+constexpr uint16_t const MAX_TRACK_HEIGHT = 254;
 
 enum
 {


### PR DESCRIPTION
The search for height to build track sometimes ended at a half-height, leading to (undefined string) error. Changed to always end at whole height and search as high as possible.

The code previously does at most 41 searches (magic number afaik) for a z-value to build at, if the last search was at a half-height, the search aborts while displaying the last error, which would be null. Since the code did only 41 searches, the below occurs prior to this PR, rather than building on top of the paths. I based my numAttempts to search until the max allowable track height (based on the ride being too high `if (clearanceZ >= 255)` in TrackPlaceAction.hpp). Should I refactor 255 into a constant, similar to MAXIMUM_LAND_HEIGHT in Map.h?

![TrackUndefined](https://user-images.githubusercontent.com/29646196/59564635-1ad00a00-9017-11e9-8fa6-0823e31217de.png)

