### PR TITLE
Move research to vectors

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -223,7 +223,6 @@ static void move_research_item(ResearchItem* beforeItem, int32_t scrollIndex)
                 gResearchItemsInvented.push_back(_editorInventionsListDraggedItem);
             }
         }
-
     }
     else if (scrollIndex == 1)
     {

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -84,7 +84,7 @@ static void window_editor_inventions_list_drag_cursor(rct_window *w, rct_widgeti
 static void window_editor_inventions_list_drag_moved(rct_window* w, int32_t x, int32_t y);
 static void window_editor_inventions_list_drag_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_string_id window_editor_inventions_list_prepare_name(const rct_research_item * researchItem, bool withGap);
+static rct_string_id window_editor_inventions_list_prepare_name(const ResearchItem * researchItem, bool withGap);
 
 // 0x0098177C
 static rct_window_event_list window_editor_inventions_list_events = {
@@ -152,7 +152,7 @@ static rct_window_event_list window_editor_inventions_list_drag_events = {
 
 #pragma endregion
 
-static rct_research_item *_editorInventionsListDraggedItem;
+static ResearchItem *_editorInventionsListDraggedItem;
 
 static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
     STR_RESEARCH_NEW_TRANSPORT_RIDES,
@@ -165,8 +165,8 @@ static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
 };
 // clang-format on
 
-static void window_editor_inventions_list_drag_open(rct_research_item* researchItem);
-static void move_research_item(rct_research_item* beforeItem);
+static void window_editor_inventions_list_drag_open(ResearchItem* researchItem);
+static void move_research_item(ResearchItem* beforeItem);
 
 /**
  *
@@ -196,10 +196,10 @@ static void research_rides_setup()
  *
  *  rct2: 0x006855E7
  */
-static void move_research_item(rct_research_item* beforeItem)
+static void move_research_item(ResearchItem* beforeItem)
 {
     rct_window* w;
-    rct_research_item *researchItem, draggedItem;
+    ResearchItem *researchItem, draggedItem;
 
     if (_editorInventionsListDraggedItem + 1 == beforeItem)
         return;
@@ -240,9 +240,9 @@ static void move_research_item(rct_research_item* beforeItem)
  *
  *  rct2: 0x0068558E
  */
-static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y(int32_t scrollIndex, int32_t y)
+static ResearchItem* window_editor_inventions_list_get_item_from_scroll_y(int32_t scrollIndex, int32_t y)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     researchItem = gResearchItems;
 
@@ -272,9 +272,9 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y(i
  *
  *  rct2: 0x006855BB
  */
-static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_include_seps(int32_t scrollIndex, int32_t y)
+static ResearchItem* window_editor_inventions_list_get_item_from_scroll_y_include_seps(int32_t scrollIndex, int32_t y)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     researchItem = gResearchItems;
 
@@ -300,7 +300,7 @@ static rct_research_item* window_editor_inventions_list_get_item_from_scroll_y_i
     return researchItem;
 }
 
-static rct_research_item* get_research_item_at(int32_t x, int32_t y)
+static ResearchItem* get_research_item_at(int32_t x, int32_t y)
 {
     rct_window* w = window_find_by_class(WC_EDITOR_INVENTION_LIST);
     if (w != nullptr && w->x <= x && w->y < y && w->x + w->width > x && w->y + w->height > y)
@@ -443,7 +443,7 @@ static void window_editor_inventions_list_update(rct_window* w)
  */
 static void window_editor_inventions_list_scrollgetheight(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     *height = 0;
 
@@ -468,7 +468,7 @@ static void window_editor_inventions_list_scrollgetheight(rct_window* w, int32_t
  */
 static void window_editor_inventions_list_scrollmousedown(rct_window* w, int32_t scrollIndex, int32_t x, int32_t y)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     researchItem = window_editor_inventions_list_get_item_from_scroll_y(scrollIndex, y);
     if (researchItem == nullptr)
@@ -488,7 +488,7 @@ static void window_editor_inventions_list_scrollmousedown(rct_window* w, int32_t
  */
 static void window_editor_inventions_list_scrollmouseover(rct_window* w, int32_t scrollIndex, int32_t x, int32_t y)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     researchItem = window_editor_inventions_list_get_item_from_scroll_y(scrollIndex, y);
     if (researchItem != w->research_item)
@@ -511,7 +511,7 @@ static void window_editor_inventions_list_scrollmouseover(rct_window* w, int32_t
 static void window_editor_inventions_list_cursor(
     rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t y, int32_t* cursorId)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
     int32_t scrollIndex;
 
     switch (widgetIndex)
@@ -589,7 +589,7 @@ static void window_editor_inventions_list_invalidate(rct_window* w)
 static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     rct_widget* widget;
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
     rct_string_id stringId;
     int32_t x, y, width;
 
@@ -676,7 +676,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     gfx_clear(dpi, paletteIndex);
 
-    rct_research_item* researchItem = gResearchItems;
+    ResearchItem* researchItem = gResearchItems;
     int32_t researchItemEndMarker;
 
     if (scrollIndex == 1)
@@ -786,7 +786,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
  *
  *  rct2: 0x006852F4
  */
-static void window_editor_inventions_list_drag_open(rct_research_item* researchItem)
+static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
 {
     char buffer[256], *ptr;
     int32_t stringWidth;
@@ -833,7 +833,7 @@ static void window_editor_inventions_list_drag_cursor(
     rct_window* inventionListWindow = window_find_by_class(WC_EDITOR_INVENTION_LIST);
     if (inventionListWindow != nullptr)
     {
-        rct_research_item* researchItem = get_research_item_at(x, y);
+        ResearchItem* researchItem = get_research_item_at(x, y);
         if (researchItem != inventionListWindow->research_item)
         {
             inventionListWindow->Invalidate();
@@ -849,7 +849,7 @@ static void window_editor_inventions_list_drag_cursor(
  */
 static void window_editor_inventions_list_drag_moved(rct_window* w, int32_t x, int32_t y)
 {
-    rct_research_item* researchItem;
+    ResearchItem* researchItem;
 
     // Skip always researched items, so that the dragged item gets placed underneath them
     do
@@ -881,7 +881,7 @@ static void window_editor_inventions_list_drag_paint(rct_window* w, rct_drawpixe
     gfx_draw_string_left(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK | COLOUR_FLAG_OUTLINE, x, y);
 }
 
-static rct_string_id window_editor_inventions_list_prepare_name(const rct_research_item* researchItem, bool withGap)
+static rct_string_id window_editor_inventions_list_prepare_name(const ResearchItem* researchItem, bool withGap)
 {
     rct_string_id drawString;
     rct_string_id stringId = research_item_get_name(researchItem);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -432,7 +432,7 @@ static void window_editor_inventions_list_scrollmousedown(rct_window* w, int32_t
         return;
 
     // Disallow picking up always-researched items
-    if (researchItem->rawValue < RESEARCHED_ITEMS_END_2 || research_item_is_always_researched(researchItem))
+    if (research_item_is_always_researched(researchItem))
         return;
 
     w->Invalidate();
@@ -485,8 +485,7 @@ static void window_editor_inventions_list_cursor(
 
     // Use the open hand as cursor for items that can be picked up
     researchItem = window_editor_inventions_list_get_item_from_scroll_y(scrollIndex, y);
-    if (researchItem != nullptr && researchItem->rawValue >= RESEARCHED_ITEMS_END_2
-        && !research_item_is_always_researched(researchItem))
+    if (researchItem != nullptr && !research_item_is_always_researched(researchItem))
     {
         *cursorId = CURSOR_HAND_OPEN;
     }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -292,7 +292,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
 
         for (auto rideType : rideEntry->ride_type)
         {
-            rct_research_item tmp = {};
+            ResearchItem tmp = {};
             tmp.type = RESEARCH_ENTRY_TYPE_RIDE;
             tmp.entryIndex = entry_index;
             tmp.baseRideType = rideType;
@@ -301,7 +301,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
     }
     else if (entry_type == OBJECT_TYPE_SCENERY_GROUP)
     {
-        rct_research_item tmp = {};
+        ResearchItem tmp = {};
         tmp.type = RESEARCH_ENTRY_TYPE_SCENERY;
         tmp.entryIndex = entry_index;
         research_remove(&tmp);

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -14,7 +14,7 @@
 #include <list>
 #include <memory>
 
-struct rct_research_item;
+struct ResearchItem;
 struct rct_object_entry;
 
 /**
@@ -79,7 +79,7 @@ struct rct_window
     { // 0x494
         uint32_t highlighted_item;
         uint16_t ride_colour;
-        rct_research_item* research_item;
+        ResearchItem* research_item;
         rct_object_entry* object_entry;
         const scenario_index_entry* highlighted_scenario;
         struct

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -53,6 +53,8 @@ ResearchItem gResearchNextItem;
 
 // 0x01358844[500]
 ResearchItem gResearchItems[MAX_RESEARCH_ITEMS];
+std::vector<ResearchItem> gResearchItemsUninvented;
+std::vector<ResearchItem> gResearchItemsInvented;
 
 // 0x00EE787C
 uint8_t gResearchUncompletedCategories;
@@ -69,9 +71,8 @@ bool gSilentResearch = false;
  */
 void research_reset_items()
 {
-    gResearchItems[0].rawValue = RESEARCHED_ITEMS_SEPARATOR;
-    gResearchItems[1].rawValue = RESEARCHED_ITEMS_END;
-    gResearchItems[2].rawValue = RESEARCHED_ITEMS_END_2;
+    gResearchItemsUninvented.clear();
+    gResearchItemsInvented.clear();
 }
 
 /**
@@ -81,13 +82,10 @@ void research_reset_items()
 void research_update_uncompleted_types()
 {
     int32_t uncompletedResearchTypes = 0;
-    ResearchItem* researchItem = gResearchItems;
-    while (researchItem++->rawValue != RESEARCHED_ITEMS_SEPARATOR)
-        ;
 
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    for (auto const& researchItem : gResearchItemsUninvented)
     {
-        uncompletedResearchTypes |= (1 << researchItem->category);
+        uncompletedResearchTypes |= (1 << researchItem.category);
     }
 
     gResearchUncompletedCategories = uncompletedResearchTypes;
@@ -133,27 +131,24 @@ static void research_invalidate_related_windows()
  */
 static void research_next_design()
 {
-    ResearchItem *firstUnresearchedItem, *researchItem, tmp;
-    int32_t ignoreActiveResearchTypes;
-
-    // Skip already researched items
-    firstUnresearchedItem = gResearchItems;
-    while (firstUnresearchedItem->rawValue != RESEARCHED_ITEMS_SEPARATOR)
+    if (gResearchItemsUninvented.empty())
     {
-        firstUnresearchedItem++;
+        return;
     }
 
-    ignoreActiveResearchTypes = 0;
-    researchItem = firstUnresearchedItem;
+    ResearchItem researchItem;
+
+    bool ignoreActiveResearchTypes = false;
+    auto it = gResearchItemsUninvented.begin();
     for (;;)
     {
-        researchItem++;
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
+        researchItem = *it;
+        if (it == gResearchItemsUninvented.end())
         {
             if (!ignoreActiveResearchTypes)
             {
-                ignoreActiveResearchTypes = 1;
-                researchItem = firstUnresearchedItem;
+                ignoreActiveResearchTypes = true;
+                it = gResearchItemsUninvented.begin();
                 continue;
             }
             else
@@ -167,24 +162,19 @@ static void research_next_design()
                 return;
             }
         }
-        else if (ignoreActiveResearchTypes || (gResearchPriorities & (1 << researchItem->category)))
+        else if (ignoreActiveResearchTypes || (gResearchPriorities & (1 << researchItem.category)))
         {
             break;
         }
+        it++;
     }
 
-    gResearchNextItem = *researchItem;
+    gResearchNextItem = researchItem;
     gResearchProgress = 0;
     gResearchProgressStage = RESEARCH_STAGE_DESIGNING;
 
-    // Bubble research item up until it is above the researched items separator
-    do
-    {
-        tmp = *researchItem;
-        *researchItem = *(researchItem - 1);
-        *(researchItem - 1) = tmp;
-        researchItem--;
-    } while ((researchItem + 1)->rawValue != RESEARCHED_ITEMS_SEPARATOR);
+    gResearchItemsUninvented.erase(it);
+    gResearchItemsInvented.push_back(researchItem);
 
     research_invalidate_related_windows();
 }
@@ -229,15 +219,15 @@ void research_finish_item(ResearchItem* researchItem)
             ride_entry_set_invented(rideEntryIndex);
 
             bool seenRideEntry[MAX_RIDE_OBJECTS]{};
-
-            ResearchItem* researchItem2 = gResearchItems;
-            for (; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
+            for (auto const& researchItem3 : gResearchItemsUninvented)
             {
-                if (researchItem2->rawValue != RESEARCHED_ITEMS_SEPARATOR && researchItem2->type == RESEARCH_ENTRY_TYPE_RIDE)
-                {
-                    uint8_t index = researchItem2->entryIndex;
-                    seenRideEntry[index] = true;
-                }
+                uint8_t index = researchItem3.entryIndex;
+                seenRideEntry[index] = true;
+            }
+            for (auto const& researchItem3 : gResearchItemsInvented)
+            {
+                uint8_t index = researchItem3.entryIndex;
+                seenRideEntry[index] = true;
             }
 
             // RCT2 made non-separated vehicles available at once, by removing all but one from research.
@@ -386,54 +376,12 @@ void research_update()
     }
 }
 
-void research_process_random_items()
-{
-    ResearchItem* research = gResearchItems;
-    for (; research->rawValue != RESEARCHED_ITEMS_END; research++)
-    {
-    }
-
-    research++;
-    for (; research->rawValue != RESEARCHED_ITEMS_END_2; research += 2)
-    {
-        if (scenario_rand() & 1)
-        {
-            continue;
-        }
-
-        ResearchItem* edx = nullptr;
-        ResearchItem* ebp = nullptr;
-        ResearchItem* inner_research = gResearchItems;
-        do
-        {
-            if (research->rawValue == inner_research->rawValue)
-            {
-                edx = inner_research;
-            }
-            if ((research + 1)->rawValue == inner_research->rawValue)
-            {
-                ebp = inner_research;
-            }
-        } while ((inner_research++)->rawValue != RESEARCHED_ITEMS_END);
-        assert(edx != nullptr);
-        edx->rawValue = research->rawValue;
-        assert(ebp != nullptr);
-        ebp->rawValue = (research + 1)->rawValue;
-
-        uint8_t cat = edx->category;
-        edx->category = ebp->category;
-        ebp->category = cat;
-    }
-}
-
 /**
  *
  *  rct2: 0x00684AC3
  */
 void research_reset_current_item()
 {
-    research_process_random_items();
-
     set_every_ride_type_not_invented();
     set_every_ride_entry_not_invented();
 
@@ -441,9 +389,9 @@ void research_reset_current_item()
     set_all_scenery_items_invented();
     set_all_scenery_groups_not_invented();
 
-    for (ResearchItem* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_SEPARATOR; research++)
+    for (auto& researchItem : gResearchItemsInvented)
     {
-        research_finish_item(research);
+        research_finish_item(&researchItem);
     }
 
     gResearchLastItem.rawValue = RESEARCHED_ITEMS_SEPARATOR;
@@ -455,29 +403,9 @@ void research_reset_current_item()
  *
  *  rct2: 0x006857FA
  */
-static void research_insert_unresearched(int32_t rawValue, int32_t category)
+static void research_insert_unresearched(int32_t rawValue, uint8_t category)
 {
-    ResearchItem *researchItem, *researchItem2;
-
-    researchItem = gResearchItems;
-    do
-    {
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
-        {
-            // Insert slot
-            researchItem2 = researchItem;
-            while (researchItem2->rawValue != RESEARCHED_ITEMS_END_2)
-            {
-                researchItem2++;
-            }
-            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(ResearchItem));
-
-            // Place new item
-            researchItem->rawValue = rawValue;
-            researchItem->category = category;
-            break;
-        }
-    } while (rawValue != (researchItem++)->rawValue);
+    gResearchItemsUninvented.push_back({ rawValue, category });
 }
 
 /**
@@ -486,36 +414,14 @@ static void research_insert_unresearched(int32_t rawValue, int32_t category)
  */
 static void research_insert_researched(int32_t rawValue, uint8_t category)
 {
-    ResearchItem *researchItem, *researchItem2;
-
-    researchItem = gResearchItems;
     // First check to make sure that entry is not already accounted for
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
+    ResearchItem item = { rawValue, category };
+    if (item.Exists())
     {
-        if ((researchItem->rawValue & 0xFFFFFF) == (rawValue & 0xFFFFFF))
-        {
-            return;
-        }
+        return;
     }
-    researchItem = gResearchItems;
-    do
-    {
-        if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
-        {
-            // Insert slot
-            researchItem2 = researchItem;
-            while (researchItem2->rawValue != RESEARCHED_ITEMS_END_2)
-            {
-                researchItem2++;
-            }
-            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(ResearchItem));
 
-            // Place new item
-            researchItem->rawValue = rawValue;
-            researchItem->category = category;
-            break;
-        }
-    } while (rawValue != (researchItem++)->rawValue);
+    gResearchItemsInvented.push_back(item);
 }
 
 /**
@@ -524,16 +430,23 @@ static void research_insert_researched(int32_t rawValue, uint8_t category)
  */
 void research_remove(ResearchItem* researchItem)
 {
-    for (ResearchItem* researchItem2 = gResearchItems; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
+    for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end(); it++)
     {
-        if (researchItem2->rawValue == researchItem->rawValue)
+        auto& researchItem2 = *it;
+        if (researchItem2.Equals(researchItem))
         {
-            do
-            {
-                *researchItem2 = *(researchItem2 + 1);
-            } while (researchItem2++->rawValue != RESEARCHED_ITEMS_END_2);
+            gResearchItemsUninvented.erase(it);
             return;
         }
+    }
+    for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end(); it++)
+    {
+        auto& researchItem2 = *it;
+        if (researchItem2.Equals(researchItem))
+        {
+            return;
+        }
+        gResearchItemsInvented.erase(it);
     }
 }
 
@@ -821,54 +734,76 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8_t trackType, rct_r
  *
  *  rct2: 0x00685A79
  *  Do not use the research list outside of the inventions list window with the flags
+ *  Clears flags like "always researched".
  */
 void research_remove_flags()
 {
-    for (ResearchItem* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_END_2; research++)
+    for (auto& researchItem : gResearchItemsUninvented)
     {
-        // Clear the always researched flags.
-        if (research->rawValue > RESEARCHED_ITEMS_SEPARATOR)
-        {
-            research->flags = 0;
-        }
+        researchItem.flags = 0;
+    }
+    for (auto& researchItem : gResearchItemsInvented)
+    {
+        researchItem.flags = 0;
     }
 }
 
 void research_fix()
 {
     // Fix invalid research items
-    for (int32_t i = 0; i < MAX_RESEARCH_ITEMS; i++)
+    for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end();)
     {
-        ResearchItem* researchItem = &gResearchItems[i];
-        if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
-            continue;
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END)
+        auto& researchItem = *it;
+        if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE)
         {
-            if (i == MAX_RESEARCH_ITEMS - 1)
-            {
-                (--researchItem)->rawValue = RESEARCHED_ITEMS_END;
-            }
-            (++researchItem)->rawValue = RESEARCHED_ITEMS_END_2;
-            break;
-        }
-        if (researchItem->rawValue == RESEARCHED_ITEMS_END_2)
-            break;
-        if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE)
-        {
-            rct_ride_entry* rideEntry = get_ride_entry(researchItem->entryIndex);
+            rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
             {
-                research_remove(researchItem);
-                i--;
+                gResearchItemsInvented.erase(it);
+            }
+            else
+            {
+                it++;
             }
         }
         else
         {
-            rct_scenery_group_entry* sceneryGroupEntry = get_scenery_group_entry(researchItem->rawValue);
+            rct_scenery_group_entry* sceneryGroupEntry = get_scenery_group_entry(researchItem.rawValue);
             if (sceneryGroupEntry == nullptr)
             {
-                research_remove(researchItem);
-                i--;
+                gResearchItemsInvented.erase(it);
+            }
+            else
+            {
+                it++;
+            }
+        }
+    }
+    for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end();)
+    {
+        auto& researchItem = *it;
+        if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE)
+        {
+            rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
+            if (rideEntry == nullptr)
+            {
+                gResearchItemsUninvented.erase(it);
+            }
+            else
+            {
+                it++;
+            }
+        }
+        else
+        {
+            rct_scenery_group_entry* sceneryGroupEntry = get_scenery_group_entry(researchItem.rawValue);
+            if (sceneryGroupEntry == nullptr)
+            {
+                gResearchItemsUninvented.erase(it);
+            }
+            else
+            {
+                it++;
             }
         }
     }
@@ -914,50 +849,19 @@ void research_fix()
 
 void research_items_make_all_unresearched()
 {
-    ResearchItem *researchItem, *nextResearchItem, researchItemTemp;
-
-    int32_t sorted;
-    do
+    for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end();)
     {
-        sorted = 1;
-        for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
-        {
-            if (research_item_is_always_researched(researchItem))
-                continue;
-
-            nextResearchItem = researchItem + 1;
-            if (nextResearchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR
-                || research_item_is_always_researched(nextResearchItem))
-            {
-                // Bubble up always researched item or separator
-                researchItemTemp = *researchItem;
-                *researchItem = *nextResearchItem;
-                *nextResearchItem = researchItemTemp;
-                sorted = 0;
-
-                if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
-                    break;
-            }
-        }
-    } while (!sorted);
+        auto& researchItem = *it;
+        gResearchItemsUninvented.push_back(researchItem);
+    }
 }
 
 void research_items_make_all_researched()
 {
-    ResearchItem *researchItem, researchItemTemp;
-
-    // Find separator
-    for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
+    for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end();)
     {
-    }
-
-    // Move separator below all items
-    for (; (researchItem + 1)->rawValue != RESEARCHED_ITEMS_END; researchItem++)
-    {
-        // Swap separator with research item
-        researchItemTemp = *researchItem;
-        *researchItem = *(researchItem + 1);
-        *(researchItem + 1) = researchItemTemp;
+        auto& researchItem = *it;
+        gResearchItemsInvented.push_back(researchItem);
     }
 }
 
@@ -967,31 +871,19 @@ void research_items_make_all_researched()
  */
 void research_items_shuffle()
 {
-    ResearchItem *researchItem, *researchOrderBase, researchItemTemp;
-    int32_t i, numNonResearchedItems;
-
-    // Skip pre-researched items
-    for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
-    {
-    }
-    researchItem++;
-    researchOrderBase = researchItem;
-
     // Count non pre-researched items
-    numNonResearchedItems = 0;
-    for (; researchItem->rawValue != RESEARCHED_ITEMS_END; researchItem++)
-        numNonResearchedItems++;
+    size_t numNonResearchedItems = gResearchItemsUninvented.size();
 
     // Shuffle list
-    for (i = 0; i < numNonResearchedItems; i++)
+    for (size_t i = 0; i < numNonResearchedItems; i++)
     {
-        int32_t ri = util_rand() % numNonResearchedItems;
+        size_t ri = util_rand() % numNonResearchedItems;
         if (ri == i)
             continue;
 
-        researchItemTemp = researchOrderBase[i];
-        researchOrderBase[i] = researchOrderBase[ri];
-        researchOrderBase[ri] = researchItemTemp;
+        ResearchItem researchItemTemp = gResearchItemsUninvented[i];
+        gResearchItemsUninvented[i] = gResearchItemsUninvented[ri];
+        gResearchItemsUninvented[ri] = researchItemTemp;
     }
 }
 
@@ -1005,4 +897,28 @@ bool research_item_is_always_researched(ResearchItem* researchItem)
 bool ResearchItem::IsInventedEndMarker() const
 {
     return rawValue == RESEARCHED_ITEMS_SEPARATOR;
+}
+
+bool ResearchItem::Equals(const ResearchItem* otherItem) const
+{
+    return (entryIndex == otherItem->entryIndex && baseRideType == otherItem->baseRideType && type == otherItem->type);
+}
+
+bool ResearchItem::Exists() const
+{
+    for (auto const& researchItem : gResearchItemsUninvented)
+    {
+        if (researchItem.Equals(this))
+        {
+            return true;
+        }
+    }
+    for (auto const& researchItem : gResearchItemsInvented)
+    {
+        if (researchItem.Equals(this))
+        {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -444,9 +444,9 @@ void research_remove(ResearchItem* researchItem)
         auto& researchItem2 = *it;
         if (researchItem2.Equals(researchItem))
         {
+            gResearchItemsInvented.erase(it);
             return;
         }
-        gResearchItemsInvented.erase(it);
     }
 }
 
@@ -853,6 +853,7 @@ void research_items_make_all_unresearched()
     {
         auto& researchItem = *it;
         gResearchItemsUninvented.push_back(researchItem);
+        gResearchItemsInvented.erase(it);
     }
 }
 
@@ -862,6 +863,7 @@ void research_items_make_all_researched()
     {
         auto& researchItem = *it;
         gResearchItemsInvented.push_back(researchItem);
+        gResearchItemsUninvented.erase(it);
     }
 }
 

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -125,6 +125,16 @@ static void research_invalidate_related_windows()
     window_invalidate_by_class(WC_RESEARCH);
 }
 
+static void research_mark_as_fully_completed()
+{
+    gResearchProgress = 0;
+    gResearchProgressStage = RESEARCH_STAGE_FINISHED_ALL;
+    research_invalidate_related_windows();
+    // Reset funding to 0 if no more rides.
+    auto gameAction = ParkSetResearchFundingAction(gResearchPriorities, 0);
+    GameActions::Execute(&gameAction);
+}
+
 /**
  *
  *  rct2: 0x00684BE5
@@ -133,6 +143,7 @@ static void research_next_design()
 {
     if (gResearchItemsUninvented.empty())
     {
+        research_mark_as_fully_completed();
         return;
     }
 
@@ -153,12 +164,7 @@ static void research_next_design()
             }
             else
             {
-                gResearchProgress = 0;
-                gResearchProgressStage = RESEARCH_STAGE_FINISHED_ALL;
-                research_invalidate_related_windows();
-                // Reset funding to 0 if no more rides.
-                auto gameAction = ParkSetResearchFundingAction(gResearchPriorities, 0);
-                GameActions::Execute(&gameAction);
+                research_mark_as_fully_completed();
                 return;
             }
         }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -759,7 +759,7 @@ void research_fix()
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
             {
-                gResearchItemsInvented.erase(it);
+                it = gResearchItemsInvented.erase(it);
             }
             else
             {
@@ -771,7 +771,7 @@ void research_fix()
             rct_scenery_group_entry* sceneryGroupEntry = get_scenery_group_entry(researchItem.rawValue);
             if (sceneryGroupEntry == nullptr)
             {
-                gResearchItemsInvented.erase(it);
+                it = gResearchItemsInvented.erase(it);
             }
             else
             {
@@ -787,7 +787,7 @@ void research_fix()
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
             {
-                gResearchItemsUninvented.erase(it);
+                it = gResearchItemsUninvented.erase(it);
             }
             else
             {
@@ -799,7 +799,7 @@ void research_fix()
             rct_scenery_group_entry* sceneryGroupEntry = get_scenery_group_entry(researchItem.rawValue);
             if (sceneryGroupEntry == nullptr)
             {
-                gResearchItemsUninvented.erase(it);
+                it = gResearchItemsUninvented.erase(it);
             }
             else
             {
@@ -849,22 +849,16 @@ void research_fix()
 
 void research_items_make_all_unresearched()
 {
-    for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end();)
-    {
-        auto& researchItem = *it;
-        gResearchItemsUninvented.push_back(researchItem);
-        gResearchItemsInvented.erase(it);
-    }
+    gResearchItemsUninvented.insert(
+        gResearchItemsUninvented.end(), std::make_move_iterator(gResearchItemsInvented.begin()),
+        std::make_move_iterator(gResearchItemsInvented.end()));
 }
 
 void research_items_make_all_researched()
 {
-    for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end();)
-    {
-        auto& researchItem = *it;
-        gResearchItemsInvented.push_back(researchItem);
-        gResearchItemsUninvented.erase(it);
-    }
+    gResearchItemsInvented.insert(
+        gResearchItemsInvented.end(), std::make_move_iterator(gResearchItemsUninvented.begin()),
+        std::make_move_iterator(gResearchItemsUninvented.end()));
 }
 
 /**
@@ -873,20 +867,7 @@ void research_items_make_all_researched()
  */
 void research_items_shuffle()
 {
-    // Count non pre-researched items
-    size_t numNonResearchedItems = gResearchItemsUninvented.size();
-
-    // Shuffle list
-    for (size_t i = 0; i < numNonResearchedItems; i++)
-    {
-        size_t ri = util_rand() % numNonResearchedItems;
-        if (ri == i)
-            continue;
-
-        ResearchItem researchItemTemp = gResearchItemsUninvented[i];
-        gResearchItemsUninvented[i] = gResearchItemsUninvented[ri];
-        gResearchItemsUninvented[ri] = researchItemTemp;
-    }
+    std::shuffle(std::begin(gResearchItemsUninvented), std::end(gResearchItemsUninvented), std::default_random_engine{});
 }
 
 bool research_item_is_always_researched(const ResearchItem* researchItem)

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -887,7 +887,7 @@ void research_items_shuffle()
     }
 }
 
-bool research_item_is_always_researched(ResearchItem* researchItem)
+bool research_item_is_always_researched(const ResearchItem* researchItem)
 {
     return (researchItem->flags
             & (RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED | RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED))

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -46,13 +46,13 @@ uint8_t gResearchFundingLevel;
 uint8_t gResearchPriorities;
 uint16_t gResearchProgress;
 uint8_t gResearchProgressStage;
-rct_research_item gResearchLastItem;
+ResearchItem gResearchLastItem;
 uint8_t gResearchExpectedMonth;
 uint8_t gResearchExpectedDay;
-rct_research_item gResearchNextItem;
+ResearchItem gResearchNextItem;
 
 // 0x01358844[500]
-rct_research_item gResearchItems[MAX_RESEARCH_ITEMS];
+ResearchItem gResearchItems[MAX_RESEARCH_ITEMS];
 
 // 0x00EE787C
 uint8_t gResearchUncompletedCategories;
@@ -81,7 +81,7 @@ void research_reset_items()
 void research_update_uncompleted_types()
 {
     int32_t uncompletedResearchTypes = 0;
-    rct_research_item* researchItem = gResearchItems;
+    ResearchItem* researchItem = gResearchItems;
     while (researchItem++->rawValue != RESEARCHED_ITEMS_SEPARATOR)
         ;
 
@@ -133,7 +133,7 @@ static void research_invalidate_related_windows()
  */
 static void research_next_design()
 {
-    rct_research_item *firstUnresearchedItem, *researchItem, tmp;
+    ResearchItem *firstUnresearchedItem, *researchItem, tmp;
     int32_t ignoreActiveResearchTypes;
 
     // Skip already researched items
@@ -193,7 +193,7 @@ static void research_next_design()
  *
  *  rct2: 0x006848D4
  */
-void research_finish_item(rct_research_item* researchItem)
+void research_finish_item(ResearchItem* researchItem)
 {
     gResearchLastItem = *researchItem;
     research_invalidate_related_windows();
@@ -230,7 +230,7 @@ void research_finish_item(rct_research_item* researchItem)
 
             bool seenRideEntry[MAX_RIDE_OBJECTS]{};
 
-            rct_research_item* researchItem2 = gResearchItems;
+            ResearchItem* researchItem2 = gResearchItems;
             for (; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
             {
                 if (researchItem2->rawValue != RESEARCHED_ITEMS_SEPARATOR && researchItem2->type == RESEARCH_ENTRY_TYPE_RIDE)
@@ -388,7 +388,7 @@ void research_update()
 
 void research_process_random_items()
 {
-    rct_research_item* research = gResearchItems;
+    ResearchItem* research = gResearchItems;
     for (; research->rawValue != RESEARCHED_ITEMS_END; research++)
     {
     }
@@ -401,9 +401,9 @@ void research_process_random_items()
             continue;
         }
 
-        rct_research_item* edx = nullptr;
-        rct_research_item* ebp = nullptr;
-        rct_research_item* inner_research = gResearchItems;
+        ResearchItem* edx = nullptr;
+        ResearchItem* ebp = nullptr;
+        ResearchItem* inner_research = gResearchItems;
         do
         {
             if (research->rawValue == inner_research->rawValue)
@@ -441,7 +441,7 @@ void research_reset_current_item()
     set_all_scenery_items_invented();
     set_all_scenery_groups_not_invented();
 
-    for (rct_research_item* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_SEPARATOR; research++)
+    for (ResearchItem* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_SEPARATOR; research++)
     {
         research_finish_item(research);
     }
@@ -457,7 +457,7 @@ void research_reset_current_item()
  */
 static void research_insert_unresearched(int32_t rawValue, int32_t category)
 {
-    rct_research_item *researchItem, *researchItem2;
+    ResearchItem *researchItem, *researchItem2;
 
     researchItem = gResearchItems;
     do
@@ -470,7 +470,7 @@ static void research_insert_unresearched(int32_t rawValue, int32_t category)
             {
                 researchItem2++;
             }
-            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(rct_research_item));
+            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(ResearchItem));
 
             // Place new item
             researchItem->rawValue = rawValue;
@@ -486,7 +486,7 @@ static void research_insert_unresearched(int32_t rawValue, int32_t category)
  */
 static void research_insert_researched(int32_t rawValue, uint8_t category)
 {
-    rct_research_item *researchItem, *researchItem2;
+    ResearchItem *researchItem, *researchItem2;
 
     researchItem = gResearchItems;
     // First check to make sure that entry is not already accounted for
@@ -508,7 +508,7 @@ static void research_insert_researched(int32_t rawValue, uint8_t category)
             {
                 researchItem2++;
             }
-            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(rct_research_item));
+            memmove(researchItem + 1, researchItem, (researchItem2 - researchItem + 1) * sizeof(ResearchItem));
 
             // Place new item
             researchItem->rawValue = rawValue;
@@ -522,9 +522,9 @@ static void research_insert_researched(int32_t rawValue, uint8_t category)
  *
  *  rct2: 0x006857CF
  */
-void research_remove(rct_research_item* researchItem)
+void research_remove(ResearchItem* researchItem)
 {
-    for (rct_research_item* researchItem2 = gResearchItems; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
+    for (ResearchItem* researchItem2 = gResearchItems; researchItem2->rawValue != RESEARCHED_ITEMS_END; researchItem2++)
     {
         if (researchItem2->rawValue == researchItem->rawValue)
         {
@@ -773,7 +773,7 @@ void set_every_ride_entry_not_invented()
  *
  *  rct2: 0x0068563D
  */
-rct_string_id research_item_get_name(const rct_research_item* researchItem)
+rct_string_id research_item_get_name(const ResearchItem* researchItem)
 {
     if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE)
     {
@@ -824,7 +824,7 @@ rct_string_id research_get_friendly_base_ride_type_name(uint8_t trackType, rct_r
  */
 void research_remove_flags()
 {
-    for (rct_research_item* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_END_2; research++)
+    for (ResearchItem* research = gResearchItems; research->rawValue != RESEARCHED_ITEMS_END_2; research++)
     {
         // Clear the always researched flags.
         if (research->rawValue > RESEARCHED_ITEMS_SEPARATOR)
@@ -839,7 +839,7 @@ void research_fix()
     // Fix invalid research items
     for (int32_t i = 0; i < MAX_RESEARCH_ITEMS; i++)
     {
-        rct_research_item* researchItem = &gResearchItems[i];
+        ResearchItem* researchItem = &gResearchItems[i];
         if (researchItem->rawValue == RESEARCHED_ITEMS_SEPARATOR)
             continue;
         if (researchItem->rawValue == RESEARCHED_ITEMS_END)
@@ -914,7 +914,7 @@ void research_fix()
 
 void research_items_make_all_unresearched()
 {
-    rct_research_item *researchItem, *nextResearchItem, researchItemTemp;
+    ResearchItem *researchItem, *nextResearchItem, researchItemTemp;
 
     int32_t sorted;
     do
@@ -944,7 +944,7 @@ void research_items_make_all_unresearched()
 
 void research_items_make_all_researched()
 {
-    rct_research_item *researchItem, researchItemTemp;
+    ResearchItem *researchItem, researchItemTemp;
 
     // Find separator
     for (researchItem = gResearchItems; researchItem->rawValue != RESEARCHED_ITEMS_SEPARATOR; researchItem++)
@@ -967,7 +967,7 @@ void research_items_make_all_researched()
  */
 void research_items_shuffle()
 {
-    rct_research_item *researchItem, *researchOrderBase, researchItemTemp;
+    ResearchItem *researchItem, *researchOrderBase, researchItemTemp;
     int32_t i, numNonResearchedItems;
 
     // Skip pre-researched items
@@ -995,14 +995,14 @@ void research_items_shuffle()
     }
 }
 
-bool research_item_is_always_researched(rct_research_item* researchItem)
+bool research_item_is_always_researched(ResearchItem* researchItem)
 {
     return (researchItem->flags
             & (RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED | RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED))
         != 0;
 }
 
-bool rct_research_item::IsInventedEndMarker() const
+bool ResearchItem::IsInventedEndMarker() const
 {
     return rawValue == RESEARCHED_ITEMS_SEPARATOR;
 }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -852,6 +852,7 @@ void research_items_make_all_unresearched()
     gResearchItemsUninvented.insert(
         gResearchItemsUninvented.end(), std::make_move_iterator(gResearchItemsInvented.begin()),
         std::make_move_iterator(gResearchItemsInvented.end()));
+    gResearchItemsInvented.clear();
 }
 
 void research_items_make_all_researched()
@@ -859,6 +860,7 @@ void research_items_make_all_researched()
     gResearchItemsInvented.insert(
         gResearchItemsInvented.end(), std::make_move_iterator(gResearchItemsUninvented.begin()),
         std::make_move_iterator(gResearchItemsUninvented.end()));
+    gResearchItemsUninvented.clear();
 }
 
 /**

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -1006,13 +1006,3 @@ bool rct_research_item::IsInventedEndMarker() const
 {
     return rawValue == RESEARCHED_ITEMS_SEPARATOR;
 }
-
-bool rct_research_item::IsUninventedEndMarker() const
-{
-    return rawValue == RESEARCHED_ITEMS_END;
-}
-
-bool rct_research_item::IsRandomEndMarker() const
-{
-    return rawValue == RESEARCHED_ITEMS_END_2;
-}

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -15,7 +15,6 @@
 
 struct rct_ride_entry;
 
-#pragma pack(push, 1)
 struct ResearchItem
 {
     // Bit 16 (0: scenery entry, 1: ride entry)
@@ -36,8 +35,6 @@ struct ResearchItem
     bool Equals(const ResearchItem* otherItem) const;
     bool Exists() const;
 };
-assert_struct_size(ResearchItem, 5);
-#pragma pack(pop)
 
 enum
 {

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -33,8 +33,6 @@ struct ResearchItem
     uint8_t category;
 
     bool IsInventedEndMarker() const;
-    bool IsRandomEndMarker() const;
-    bool IsUninventedEndMarker() const;
     bool Equals(const ResearchItem* otherItem) const;
     bool Exists() const;
 };

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -149,4 +149,4 @@ void research_fix();
 void research_items_make_all_unresearched();
 void research_items_make_all_researched();
 void research_items_shuffle();
-bool research_item_is_always_researched(ResearchItem* researchItem);
+bool research_item_is_always_researched(const ResearchItem* researchItem);

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -16,7 +16,7 @@
 struct rct_ride_entry;
 
 #pragma pack(push, 1)
-struct rct_research_item
+struct ResearchItem
 {
     // Bit 16 (0: scenery entry, 1: ride entry)
     union
@@ -36,7 +36,7 @@ struct rct_research_item
     bool IsRandomEndMarker() const;
     bool IsUninventedEndMarker() const;
 };
-assert_struct_size(rct_research_item, 5);
+assert_struct_size(ResearchItem, 5);
 #pragma pack(pop)
 
 enum
@@ -100,10 +100,10 @@ extern uint16_t gResearchProgress;
 extern uint8_t gResearchProgressStage;
 extern uint8_t gResearchExpectedMonth;
 extern uint8_t gResearchExpectedDay;
-extern rct_research_item gResearchLastItem;
-extern rct_research_item gResearchNextItem;
+extern ResearchItem gResearchLastItem;
+extern ResearchItem gResearchNextItem;
 
-extern rct_research_item gResearchItems[MAX_RESEARCH_ITEMS];
+extern ResearchItem gResearchItems[MAX_RESEARCH_ITEMS];
 extern uint8_t gResearchUncompletedCategories;
 extern bool gSilentResearch;
 
@@ -115,9 +115,9 @@ void research_populate_list_random();
 void research_populate_list_researched();
 void research_process_random_items();
 
-void research_finish_item(rct_research_item* researchItem);
+void research_finish_item(ResearchItem* researchItem);
 void research_insert(int32_t researched, int32_t rawValue, uint8_t category);
-void research_remove(rct_research_item* researchItem);
+void research_remove(ResearchItem* researchItem);
 
 void research_insert_ride_entry(uint8_t entryIndex, bool researched);
 void research_insert_scenery_group_entry(uint8_t entryIndex, bool researched);
@@ -139,7 +139,7 @@ void set_every_ride_type_invented();
 void set_every_ride_type_not_invented();
 void set_every_ride_entry_invented();
 void set_every_ride_entry_not_invented();
-rct_string_id research_item_get_name(const rct_research_item* researchItem);
+rct_string_id research_item_get_name(const ResearchItem* researchItem);
 rct_string_id research_get_friendly_base_ride_type_name(uint8_t trackType, rct_ride_entry* rideEntry);
 void research_remove_flags();
 void research_fix();
@@ -147,4 +147,4 @@ void research_fix();
 void research_items_make_all_unresearched();
 void research_items_make_all_researched();
 void research_items_shuffle();
-bool research_item_is_always_researched(rct_research_item* researchItem);
+bool research_item_is_always_researched(ResearchItem* researchItem);

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -35,6 +35,8 @@ struct ResearchItem
     bool IsInventedEndMarker() const;
     bool IsRandomEndMarker() const;
     bool IsUninventedEndMarker() const;
+    bool Equals(const ResearchItem* otherItem) const;
+    bool Exists() const;
 };
 assert_struct_size(ResearchItem, 5);
 #pragma pack(pop)
@@ -103,7 +105,8 @@ extern uint8_t gResearchExpectedDay;
 extern ResearchItem gResearchLastItem;
 extern ResearchItem gResearchNextItem;
 
-extern ResearchItem gResearchItems[MAX_RESEARCH_ITEMS];
+extern std::vector<ResearchItem> gResearchItemsUninvented;
+extern std::vector<ResearchItem> gResearchItemsInvented;
 extern uint8_t gResearchUncompletedCategories;
 extern bool gSilentResearch;
 
@@ -113,7 +116,6 @@ void research_update();
 void research_reset_current_item();
 void research_populate_list_random();
 void research_populate_list_researched();
-void research_process_random_items();
 
 void research_finish_item(ResearchItem* researchItem);
 void research_insert(int32_t researched, int32_t rawValue, uint8_t category);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2496,7 +2496,7 @@ private:
                 uint8_t researchItem = src->Assoc & 0x000000FF;
                 uint8_t researchType = (src->Assoc & 0x00FF0000) >> 16;
 
-                rct_research_item tmpResearchItem = {};
+                ResearchItem tmpResearchItem = {};
                 ConvertResearchEntry(&tmpResearchItem, researchItem, researchType);
                 dst->Assoc = (uint32_t)tmpResearchItem.rawValue;
             }
@@ -2540,7 +2540,7 @@ private:
         gTotalRideValueForMoney = _s4.total_ride_value_for_money;
     }
 
-    void ConvertResearchEntry(rct_research_item* dst, uint8_t srcItem, uint8_t srcType)
+    void ConvertResearchEntry(ResearchItem* dst, uint8_t srcItem, uint8_t srcType)
     {
         dst->rawValue = RESEARCHED_ITEMS_SEPARATOR;
         if (srcType == RCT1_RESEARCH_TYPE_RIDE)

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -915,3 +915,18 @@ void RCT12BannerElement::SetAllowedEdges(uint8_t newEdges)
     flags &= ~0b00001111;
     flags |= (newEdges & 0b00001111);
 }
+
+bool RCT12ResearchItem::IsInventedEndMarker() const
+{
+    return rawValue == RCT12_RESEARCHED_ITEMS_SEPARATOR;
+}
+
+bool RCT12ResearchItem::IsUninventedEndMarker() const
+{
+    return rawValue == RCT12_RESEARCHED_ITEMS_END;
+}
+
+bool RCT12ResearchItem::IsRandomEndMarker() const
+{
+    return rawValue == RCT12_RESEARCHED_ITEMS_END_2;
+}

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -49,6 +49,7 @@ constexpr uint16_t const RCT12_MAX_INVERSIONS = 31;
 constexpr uint16_t const RCT12_MAX_GOLF_HOLES = 31;
 constexpr uint16_t const RCT12_MAX_HELICES = 31;
 
+<<<<<<< HEAD
 enum class RCT12TrackDesignVersion : uint8_t
 {
     TD4,
@@ -56,6 +57,14 @@ enum class RCT12TrackDesignVersion : uint8_t
     TD6,
     unknown
 };
+=======
+// Everything before this point has been researched
+#define RCT12_RESEARCHED_ITEMS_SEPARATOR (-1)
+// Everything before this point and after separator still requires research
+#define RCT12_RESEARCHED_ITEMS_END (-2)
+// Extra end of list entry. Leftover from RCT1.
+#define RCT12_RESEARCHED_ITEMS_END_2 (-3)
+>>>>>>> 04e9e626d... Split off RCT12ResearchItem
 
 #pragma pack(push, 1)
 
@@ -657,6 +666,28 @@ struct RCT12MapAnimation
     uint16_t y;
 };
 assert_struct_size(RCT12MapAnimation, 6);
+
+struct RCT12ResearchItem
+{
+    // Bit 16 (0: scenery entry, 1: ride entry)
+    union
+    {
+        int32_t rawValue;
+        struct
+        {
+            uint8_t entryIndex;
+            uint8_t baseRideType;
+            uint8_t type; // 0: scenery entry, 1: ride entry
+            uint8_t flags;
+        };
+    };
+    uint8_t category;
+
+    bool IsInventedEndMarker() const;
+    bool IsRandomEndMarker() const;
+    bool IsUninventedEndMarker() const;
+};
+assert_struct_size(RCT12ResearchItem, 5);
 
 #pragma pack(pop)
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -49,7 +49,6 @@ constexpr uint16_t const RCT12_MAX_INVERSIONS = 31;
 constexpr uint16_t const RCT12_MAX_GOLF_HOLES = 31;
 constexpr uint16_t const RCT12_MAX_HELICES = 31;
 
-<<<<<<< HEAD
 enum class RCT12TrackDesignVersion : uint8_t
 {
     TD4,
@@ -57,14 +56,13 @@ enum class RCT12TrackDesignVersion : uint8_t
     TD6,
     unknown
 };
-=======
+
 // Everything before this point has been researched
 #define RCT12_RESEARCHED_ITEMS_SEPARATOR (-1)
 // Everything before this point and after separator still requires research
 #define RCT12_RESEARCHED_ITEMS_END (-2)
 // Extra end of list entry. Leftover from RCT1.
 #define RCT12_RESEARCHED_ITEMS_END_2 (-3)
->>>>>>> 04e9e626d... Split off RCT12ResearchItem
 
 #pragma pack(push, 1)
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -848,7 +848,18 @@ void S6Exporter::ExportResearchedSceneryItems()
 
 void S6Exporter::ExportResearchList()
 {
-    std::memcpy(_s6.research_items, gResearchItems, sizeof(_s6.research_items));
+    size_t i = 0;
+    for (const auto& researchItem : gResearchItemsInvented)
+    {
+        _s6.research_items[i++] = RCT12ResearchItem{ researchItem.rawValue, researchItem.category };
+    }
+    _s6.research_items[i++] = { RCT12_RESEARCHED_ITEMS_SEPARATOR, 0 };
+    for (const auto& researchItem : gResearchItemsUninvented)
+    {
+        _s6.research_items[i++] = RCT12ResearchItem{ researchItem.rawValue, researchItem.category };
+    }
+    _s6.research_items[i++] = { RCT12_RESEARCHED_ITEMS_END, 0 };
+    _s6.research_items[i] = { RCT12_RESEARCHED_ITEMS_END_2, 0 };
 }
 
 void S6Exporter::ExportMarketingCampaigns()

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -850,7 +850,25 @@ public:
 
     void ImportResearchList()
     {
-        std::memcpy(gResearchItems, _s6.research_items, sizeof(_s6.research_items));
+        bool invented = true;
+        for (size_t i = 0; i < sizeof(_s6.research_items); i++)
+        {
+            if (_s6.research_items[i].IsInventedEndMarker())
+            {
+                invented = false;
+                continue;
+            }
+            else if (_s6.research_items[i].IsUninventedEndMarker() || _s6.research_items[i].IsRandomEndMarker())
+            {
+                break;
+            }
+
+            RCT12ResearchItem* ri = &_s6.research_items[i];
+            if (invented)
+                gResearchItemsInvented.push_back(ResearchItem{ ri->rawValue, ri->category });
+            else
+                gResearchItemsUninvented.push_back(ResearchItem{ ri->rawValue, ri->category });
+        }
     }
 
     void ImportBanner(Banner* dst, const RCT12Banner* src)

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -238,7 +238,7 @@ struct rct_s6_data
     uint8_t last_entrance_style;
     uint8_t rct1_water_colour;
     uint8_t pad_01358842[2];
-    rct_research_item research_items[MAX_RESEARCH_ITEMS];
+    RCT12ResearchItem research_items[MAX_RESEARCH_ITEMS];
     uint16_t map_base_z;
     char scenario_name[64];
     char scenario_description[256];


### PR DESCRIPTION
This is mostly done, but the Research List window in the Editor is still a little bit buggy. However, it seems to import and process the research lists of both Forest Frontiers and Crazy Castle correctly.

This deliberately skips changing the ResearchItem struct itself - that is left for a later PR.