### PR TITLE
Do not apply Discord Rich Presence in headless mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -54,6 +54,7 @@
 - Fix: [#9152] Spectators can modify ride colours.
 - Fix: [#9202] Artefacts show when changing ride type as client or using in-game console.
 - Fix: [#9240] Crash when passing directory instead of save file.
+- Fix: [#9245] Headless servers apply Discord Rich Presence.
 - Fix: [#9293] Issue with the native load/save dialog.
 - Fix: [#9322] Peep crashing the game trying to find a ride to look at.
 - Fix: [#9324] Crash trying to remove invalid footpath scenery.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -349,7 +349,10 @@ namespace OpenRCT2
             _replayManager = CreateReplayManager();
             _gameStateSnapshots = CreateGameStateSnapshots();
 #ifdef __ENABLE_DISCORD__
-            _discordService = std::make_unique<DiscordService>();
+            if (!gOpenRCT2Headless)
+            {
+                _discordService = std::make_unique<DiscordService>();
+            }
 #endif
 
             try


### PR DESCRIPTION
This pull request attempts to fix issue #9245.

Fix is that the DiscordService object is not created if the program is running in "headless" mode.  Otherwise, it is created and Rich Presence is applied like normal.