### PR TITLE
Fix 9440 Tile Coordinate in tile inspector not updating

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1026,18 +1026,24 @@ static void window_tile_inspector_mousedown(rct_window* w, rct_widgetindex widge
     {
         case WIDX_SPINNER_X_INCREASE:
             windowTileInspectorTileX = std::min<uint32_t>(windowTileInspectorTileX + 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1);
+            windowTileInspectorToolMapX = std::min<int32_t>(
+                windowTileInspectorToolMapX + 32, (MAXIMUM_MAP_SIZE_TECHNICAL - 1) * 32);
             window_tile_inspector_load_tile(w, nullptr);
             break;
         case WIDX_SPINNER_X_DECREASE:
             windowTileInspectorTileX = std::max<uint32_t>(windowTileInspectorTileX - 1, 0);
+            windowTileInspectorToolMapX = std::max<int32_t>(windowTileInspectorToolMapX - 32, 0);
             window_tile_inspector_load_tile(w, nullptr);
             break;
         case WIDX_SPINNER_Y_INCREASE:
             windowTileInspectorTileY = std::min<uint32_t>(windowTileInspectorTileY + 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1);
+            windowTileInspectorToolMapY = std::min<int32_t>(
+                windowTileInspectorToolMapY + 32, (MAXIMUM_MAP_SIZE_TECHNICAL - 1) * 32);
             window_tile_inspector_load_tile(w, nullptr);
             break;
         case WIDX_SPINNER_Y_DECREASE:
             windowTileInspectorTileY = std::max<uint32_t>(windowTileInspectorTileY - 1, 0);
+            windowTileInspectorToolMapY = std::max<int32_t>(windowTileInspectorToolMapY - 32, 0);
             window_tile_inspector_load_tile(w, nullptr);
             break;
     } // switch widget index


### PR DESCRIPTION
For whatever reason there are two coordinates in the tile inspector for holding the current tile x y. I swaped to the other one in the tile action refactor but it seems it wasn't updated in every location.

Since I was touching this code thought I might as well refactor to use the CoordsXY struct.

There is still room for improvement in here removing the second x y variable but it is a bit more complex than you would guess.