### PR TITLE
Fix marketing/money effect bugs

### DIFF
--- a/src/openrct2/management/Marketing.h
+++ b/src/openrct2/management/Marketing.h
@@ -36,6 +36,7 @@ enum
 
 enum
 {
+    CAMPAIGN_FIRST_WEEK_FLAG = (1 << 6),
     CAMPAIGN_ACTIVE_FLAG = (1 << 7)
 };
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "43"
+#define NETWORK_STREAM_VERSION "44"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -795,6 +795,8 @@ void S6Exporter::ExportMarketingCampaigns()
     for (const auto& campaign : gMarketingCampaigns)
     {
         _s6.campaign_weeks_left[campaign.Type] = campaign.WeeksLeft | CAMPAIGN_ACTIVE_FLAG;
+        if ((campaign.Flags & MarketingCampaignFlags::FIRST_WEEK))
+            _s6.campaign_weeks_left[campaign.Type] |= CAMPAIGN_FIRST_WEEK_FLAG;
         if (campaign.Type == ADVERTISING_CAMPAIGN_RIDE_FREE || campaign.Type == ADVERTISING_CAMPAIGN_RIDE)
         {
             _s6.campaign_ride_index[campaign.Type] = campaign.RideId;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1072,7 +1072,11 @@ public:
             {
                 MarketingCampaign campaign{};
                 campaign.Type = (uint8_t)i;
-                campaign.WeeksLeft = _s6.campaign_weeks_left[i] & ~CAMPAIGN_ACTIVE_FLAG;
+                campaign.WeeksLeft = _s6.campaign_weeks_left[i] & ~(CAMPAIGN_ACTIVE_FLAG | CAMPAIGN_FIRST_WEEK_FLAG);
+                if ((_s6.campaign_weeks_left[i] & CAMPAIGN_FIRST_WEEK_FLAG) != 0)
+                {
+                    campaign.Flags |= MarketingCampaignFlags::FIRST_WEEK;
+                }
                 if (campaign.Type == ADVERTISING_CAMPAIGN_RIDE_FREE || campaign.Type == ADVERTISING_CAMPAIGN_RIDE)
                 {
                     campaign.RideId = _s6.campaign_ride_index[i];

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -12,6 +12,7 @@
 #include "../interface/Viewport.h"
 #include "../interface/Window.h"
 #include "../localisation/Localisation.h"
+#include "../network/network.h"
 #include "Map.h"
 #include "Sprite.h"
 
@@ -80,6 +81,14 @@ void rct_money_effect::Create(money32 value)
 
     if (mapPosition.x == LOCATION_NULL)
     {
+        // If game actions return no valid location of the action we can not use the screen
+        // coordinates as every client will have different ones.
+        if (network_get_mode() != NETWORK_MODE_NONE)
+        {
+            log_warning("Attempted to create money effect without a valid location in multiplayer");
+            return;
+        }
+
         rct_window* mainWindow = window_get_main();
         if (mainWindow == nullptr)
             return;


### PR DESCRIPTION
This PR fixes two things.
1. MarketingCampaignFlags::FIRST_WEEK was never imported/exported. Given that the maximum value of weeks can be only 12 I decided to store the flag in the campaign_weeks_left field on the 7th bit. The only downside to this approach is that when you would export the save and try to load it on RCT2 it would show up 72 weeks. I was also considering to use some padding bytes but I wasn't sure what the default value can be of those.
2. If the game action does not return a valid position it would use the mouse position of the client and translates that into world space which of course produces a desync given that every client has the cursor somewhere else on the screen. I've disabled picking the screen position in multiplayer for when there is no valid position, it will simply not show any money effect for things like marketing actions.

This PR will resolve #9287