### PR TITLE
Remove unnecessary multiplication and division for sprite lists

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -182,7 +182,7 @@ struct GameStateSnapshots : public IGameStateSnapshots
         COMPARE_FIELD(rct_sprite_common, next_in_quadrant);
         COMPARE_FIELD(rct_sprite_common, next);
         COMPARE_FIELD(rct_sprite_common, previous);
-        COMPARE_FIELD(rct_sprite_common, linked_list_type_offset);
+        COMPARE_FIELD(rct_sprite_common, linked_list_index);
         COMPARE_FIELD(rct_sprite_common, sprite_index);
         COMPARE_FIELD(rct_sprite_common, flags);
         COMPARE_FIELD(rct_sprite_common, x);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5345,7 +5345,7 @@ void Guest::UpdateWalking()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -5942,7 +5942,7 @@ bool Guest::UpdateWalkingFindBench()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6132,7 +6132,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if ((sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2) || (sprite->peep.state != PEEP_STATE_SITTING)
+        if ((sprite->generic.linked_list_index != SPRITE_LIST_PEEP) || (sprite->peep.state != PEEP_STATE_SITTING)
             || (peep->z != sprite->peep.z))
         {
             continue;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -452,7 +452,7 @@ void peep_update_all()
         else
         {
             peep_128_tick_update(peep, i);
-            if (peep->linked_list_type_offset == SPRITE_LIST_PEEP * 2)
+            if (peep->linked_list_index == SPRITE_LIST_PEEP)
             {
                 peep->Update();
             }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1827,7 +1827,7 @@ static int32_t peep_update_patrolling_find_sweeping(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_type_offset != SPRITE_LIST_LITTER * 2)
+        if (sprite->generic.linked_list_index != SPRITE_LIST_LITTER)
             continue;
 
         uint16_t z_diff = abs(peep->z - sprite->litter.z);

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -377,25 +377,25 @@ assert_struct_size(RCT12EightCarsCorruptElement15, 8);
 
 struct RCT12SpriteBase
 {
-    uint8_t sprite_identifier;      // 0x00
-    uint8_t type;                   // 0x01
-    uint16_t next_in_quadrant;      // 0x02
-    uint16_t next;                  // 0x04
-    uint16_t previous;              // 0x06
-    uint8_t linked_list_index;      // 0x08
-    uint8_t sprite_height_negative; // 0x09
-    uint16_t sprite_index;          // 0x0A
-    uint16_t flags;                 // 0x0C
-    int16_t x;                      // 0x0E
-    int16_t y;                      // 0x10
-    int16_t z;                      // 0x12
-    uint8_t sprite_width;           // 0x14
-    uint8_t sprite_height_positive; // 0x15
-    int16_t sprite_left;            // 0x16
-    int16_t sprite_top;             // 0x18
-    int16_t sprite_right;           // 0x1A
-    int16_t sprite_bottom;          // 0x1C
-    uint8_t sprite_direction;       // 0x1E
+    uint8_t sprite_identifier;       // 0x00
+    uint8_t type;                    // 0x01
+    uint16_t next_in_quadrant;       // 0x02
+    uint16_t next;                   // 0x04
+    uint16_t previous;               // 0x06
+    uint8_t linked_list_type_offset; // 0x08
+    uint8_t sprite_height_negative;  // 0x09
+    uint16_t sprite_index;           // 0x0A
+    uint16_t flags;                  // 0x0C
+    int16_t x;                       // 0x0E
+    int16_t y;                       // 0x10
+    int16_t z;                       // 0x12
+    uint8_t sprite_width;            // 0x14
+    uint8_t sprite_height_positive;  // 0x15
+    int16_t sprite_left;             // 0x16
+    int16_t sprite_top;              // 0x18
+    int16_t sprite_right;            // 0x1A
+    int16_t sprite_bottom;           // 0x1C
+    uint8_t sprite_direction;        // 0x1E
 };
 assert_struct_size(RCT12SpriteBase, 0x1F);
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -377,25 +377,25 @@ assert_struct_size(RCT12EightCarsCorruptElement15, 8);
 
 struct RCT12SpriteBase
 {
-    uint8_t sprite_identifier;       // 0x00
-    uint8_t type;                    // 0x01
-    uint16_t next_in_quadrant;       // 0x02
-    uint16_t next;                   // 0x04
-    uint16_t previous;               // 0x06
-    uint8_t linked_list_type_offset; // 0x08
-    uint8_t sprite_height_negative;  // 0x09
-    uint16_t sprite_index;           // 0x0A
-    uint16_t flags;                  // 0x0C
-    int16_t x;                       // 0x0E
-    int16_t y;                       // 0x10
-    int16_t z;                       // 0x12
-    uint8_t sprite_width;            // 0x14
-    uint8_t sprite_height_positive;  // 0x15
-    int16_t sprite_left;             // 0x16
-    int16_t sprite_top;              // 0x18
-    int16_t sprite_right;            // 0x1A
-    int16_t sprite_bottom;           // 0x1C
-    uint8_t sprite_direction;        // 0x1E
+    uint8_t sprite_identifier;      // 0x00
+    uint8_t type;                   // 0x01
+    uint16_t next_in_quadrant;      // 0x02
+    uint16_t next;                  // 0x04
+    uint16_t previous;              // 0x06
+    uint8_t linked_list_index;      // 0x08
+    uint8_t sprite_height_negative; // 0x09
+    uint16_t sprite_index;          // 0x0A
+    uint16_t flags;                 // 0x0C
+    int16_t x;                      // 0x0E
+    int16_t y;                      // 0x10
+    int16_t z;                      // 0x12
+    uint8_t sprite_width;           // 0x14
+    uint8_t sprite_height_positive; // 0x15
+    int16_t sprite_left;            // 0x16
+    int16_t sprite_top;             // 0x18
+    int16_t sprite_right;           // 0x1A
+    int16_t sprite_bottom;          // 0x1C
+    uint8_t sprite_direction;       // 0x1E
 };
 assert_struct_size(RCT12SpriteBase, 0x1F);
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -861,7 +861,7 @@ void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const rct_sp
     dst->next_in_quadrant = src->next_in_quadrant;
     dst->next = src->next;
     dst->previous = src->previous;
-    dst->linked_list_type_offset = src->linked_list_type_offset;
+    dst->linked_list_index = src->linked_list_index * 2;
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;
     dst->flags = src->flags;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -861,7 +861,7 @@ void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const rct_sp
     dst->next_in_quadrant = src->next_in_quadrant;
     dst->next = src->next;
     dst->previous = src->previous;
-    dst->linked_list_index = src->linked_list_index * 2;
+    dst->linked_list_type_offset = src->linked_list_index * 2;
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;
     dst->flags = src->flags;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1428,7 +1428,7 @@ public:
         dst->next_in_quadrant = src->next_in_quadrant;
         dst->next = src->next;
         dst->previous = src->previous;
-        dst->linked_list_index = src->linked_list_index >> 1;
+        dst->linked_list_index = src->linked_list_type_offset >> 1;
         dst->sprite_height_negative = src->sprite_height_negative;
         dst->sprite_index = src->sprite_index;
         dst->flags = src->flags;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1428,7 +1428,7 @@ public:
         dst->next_in_quadrant = src->next_in_quadrant;
         dst->next = src->next;
         dst->previous = src->previous;
-        dst->linked_list_type_offset = src->linked_list_type_offset;
+        dst->linked_list_index = src->linked_list_index >> 1;
         dst->sprite_height_negative = src->sprite_height_negative;
         dst->sprite_index = src->sprite_index;
         dst->flags = src->flags;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -413,7 +413,7 @@ void ride_update_favourited_stat()
 
     FOR_ALL_PEEPS (spriteIndex, peep)
     {
-        if (peep->linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+        if (peep->linked_list_index != SPRITE_LIST_PEEP)
             return;
         if (peep->favourite_ride != RIDE_ID_NULL)
         {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -407,7 +407,7 @@ void footpath_remove_litter(int32_t x, int32_t y, int32_t z)
     {
         rct_litter* sprite = &get_sprite(spriteIndex)->litter;
         uint16_t nextSpriteIndex = sprite->next_in_quadrant;
-        if (sprite->linked_list_type_offset == SPRITE_LIST_LITTER * 2)
+        if (sprite->linked_list_index == SPRITE_LIST_LITTER)
         {
             int32_t distanceZ = abs(sprite->z - z);
             if (distanceZ <= 32)
@@ -431,7 +431,7 @@ void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z)
     {
         Peep* peep = &get_sprite(spriteIndex)->peep;
         uint16_t nextSpriteIndex = peep->next_in_quadrant;
-        if (peep->linked_list_type_offset == SPRITE_LIST_PEEP * 2)
+        if (peep->linked_list_index == SPRITE_LIST_PEEP)
         {
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)
             {

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -211,7 +211,7 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (sprite->generic.linked_list_type_offset != SPRITE_LIST_PEEP * 2)
+                    if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -10,7 +10,7 @@ struct rct_sprite_common
     uint16_t next;
     uint16_t previous;
     // Valid values are SPRITE_LINKEDLIST_OFFSET_...
-    uint8_t linked_list_type_offset;
+    uint8_t linked_list_index;
     // Height from centre of sprite to bottom
     uint8_t sprite_height_negative;
     uint16_t sprite_index;


### PR DESCRIPTION
We only need to do that during s6 import/export now. I think this made the whole thing look more complex than it is