### PR TITLE
#9285 Add feature to remember scernario tab

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -960,6 +960,7 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                         {
                             SafeFree(gConfigGeneral.rct1_path);
                             gConfigGeneral.rct1_path = rct1path;
+                            gConfigInterface.scenarioselect_last_tab = 0;
                             config_save_default();
                             context_show_error(STR_RESTART_REQUIRED, STR_NONE);
                         }
@@ -1603,6 +1604,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     if (dropdownIndex != gConfigGeneral.scenario_select_mode)
                     {
                         gConfigGeneral.scenario_select_mode = dropdownIndex;
+                        gConfigInterface.scenarioselect_last_tab = 0;
                         config_save_default();
                         window_invalidate(w);
                         window_close_by_class(WC_SCENARIO_SELECT);

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -226,10 +226,17 @@ static void window_scenarioselect_init_tabs(rct_window* w)
         }
     }
 
-    int32_t firstPage = bitscanforward(showPages);
-    if (firstPage != -1)
+    if (showPages & 1 << gConfigInterface.scenarioselect_last_tab)
     {
-        w->selected_tab = firstPage;
+        w->selected_tab = gConfigInterface.scenarioselect_last_tab;
+    }
+    else
+    {
+        int32_t firstPage = bitscanforward(showPages);
+        if (firstPage != -1)
+        {
+            w->selected_tab = firstPage;
+        }
     }
 
     int32_t x = 3;
@@ -269,6 +276,8 @@ static void window_scenarioselect_mousedown(rct_window* w, rct_widgetindex widge
     {
         w->selected_tab = widgetIndex - 4;
         w->highlighted_scenario = nullptr;
+        gConfigInterface.scenarioselect_last_tab = w->selected_tab;
+        config_save_default();
         initialise_list_items(w);
         window_invalidate(w);
         window_event_resize_call(w);

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -226,7 +226,7 @@ static void window_scenarioselect_init_tabs(rct_window* w)
         }
     }
 
-    if (showPages & 1 << gConfigInterface.scenarioselect_last_tab)
+    if (showPages & (1 << gConfigInterface.scenarioselect_last_tab))
     {
         w->selected_tab = gConfigInterface.scenarioselect_last_tab;
     }

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -300,6 +300,7 @@ namespace Config
             model->current_theme_preset = reader->GetCString("current_theme", "*RCT2");
             model->current_title_sequence_preset = reader->GetCString("current_title_sequence", "*OPENRCT2");
             model->object_selection_filter_flags = reader->GetInt32("object_selection_filter_flags", 0x3FFF);
+            model->scenarioselect_last_tab = reader->GetInt32("scenarioselect_last_tab", 0);
         }
     }
 
@@ -317,6 +318,7 @@ namespace Config
         writer->WriteString("current_theme", model->current_theme_preset);
         writer->WriteString("current_title_sequence", model->current_title_sequence_preset);
         writer->WriteInt32("object_selection_filter_flags", model->object_selection_filter_flags);
+        writer->WriteInt32("scenarioselect_last_tab", model->scenarioselect_last_tab);
     }
 
     static void ReadSound(IIniReader* reader)

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -109,6 +109,7 @@ struct InterfaceConfiguration
     utf8* current_theme_preset;
     utf8* current_title_sequence_preset;
     int32_t object_selection_filter_flags;
+    int32_t scenarioselect_last_tab;
 };
 
 struct SoundConfiguration


### PR DESCRIPTION
[#9285 Save current group in scenario list window](https://github.com/OpenRCT2/OpenRCT2/issues/9285)

It seems to work well enough. It remembers your tab between sessions, but sets the saved value back to 0 if the sorting type is changed, or if the path to RCT1 is changed.

In any case, if the tab is invalid, it defaults to the first populated tab. Also, I tried removing all of the scenarios, and it didn't crash or complain.