### PR TITLE
Fix #9467: Crash when windows create new window when being closed

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -105,15 +105,7 @@ static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, int
  */
 void game_handle_input()
 {
-    // NOTE: g_window_list may change during the event callbacks.
-    auto it = g_window_list.begin();
-    while (it != g_window_list.end())
-    {
-        auto itNext = std::next(it);
-        auto& w = *it;
-        window_event_periodic_update_call(w.get());
-        it = itNext;
-    }
+    window_visit_each([](rct_window* w) { window_event_periodic_update_call(w); });
 
     invalidate_all_windows_after_input();
 
@@ -139,14 +131,7 @@ void game_handle_input()
         process_mouse_tool(x, y);
     }
 
-    it = g_window_list.begin();
-    while (it != g_window_list.end())
-    {
-        auto itNext = std::next(it);
-        auto& w = *it;
-        window_event_unknown_08_call(w.get());
-        it = itNext;
-    }
+    window_visit_each([](rct_window* w) { window_event_unknown_08_call(w); });
 }
 
 /**

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -866,10 +866,7 @@ rct_string_id theme_desc_get_name(rct_windowclass wc)
 
 void colour_scheme_update_all()
 {
-    for (auto& w : g_window_list)
-    {
-        colour_scheme_update(w.get());
-    }
+    window_visit_each([](rct_window* w) { colour_scheme_update(w); });
 }
 
 void colour_scheme_update(rct_window* window)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -689,10 +689,9 @@ static void window_invalidate_pressed_image_buttons(rct_window* w)
  */
 void invalidate_all_windows_after_input()
 {
-    for (auto& w : g_window_list)
-    {
-        window_update_scroll_widgets(w.get());
-        window_invalidate_pressed_image_buttons(w.get());
-        window_event_resize_call(w.get());
-    }
+    window_visit_each([](rct_window* w) {
+        window_update_scroll_widgets(w);
+        window_invalidate_pressed_image_buttons(w);
+        window_event_resize_call(w);
+    });
 }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -13,6 +13,7 @@
 #include "../common.h"
 #include "../ride/RideTypes.h"
 
+#include <functional>
 #include <limits>
 #include <list>
 #include <memory>
@@ -582,7 +583,8 @@ extern colour_t gCurrentWindowColours[4];
 
 extern bool gDisableErrorWindowSound;
 
-std::list<std::unique_ptr<rct_window>>::iterator window_get_iterator(const rct_window* w);
+std::list<std::shared_ptr<rct_window>>::iterator window_get_iterator(const rct_window* w);
+void window_visit_each(std::function<void(rct_window*)> func);
 
 void window_dispatch_update_all();
 void window_update_all_viewports();

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -104,4 +104,4 @@ struct rct_window
 };
 
 // rct2: 0x01420078
-extern std::list<std::unique_ptr<rct_window>> g_window_list;
+extern std::list<std::shared_ptr<rct_window>> g_window_list;


### PR DESCRIPTION
There are a few situations where the list gets invalidated I've created a helper function windows_visit_each for safe iteration and changed unique_ptr to shared_ptr so it can copy the list before iterating so it can modify main list during iteration as much as it wants. Also I cleaned up some duplicate code and instead use a predicate.