### PR TITLE
Use 0.1.2b release of title sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CMAKE_MACOSX_RPATH 1)
 
-set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2a/title-sequence-v0.1.2a.zip")
-set(TITLE_SEQUENCE_SHA1 "261a7185d8f60b90d1a390bf4e48a0c797b52e48")
+set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2b/title-sequence-v0.1.2b.zip")
+set(TITLE_SEQUENCE_SHA1 "19263f8ca383345959473e64da4785a60f00f420")
 
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip")
 set(OBJECTS_SHA1 "0e88a1a6d845eb3a56ad68ecf60a9d6a4194250f")


### PR DESCRIPTION
0.1.2b contains the same title sequence as previous release, but the
parks no longer use RLE chunks, which improves overall compression when
distributing as zip file.

This aims to alleviate the problems with Linux builds on Travis going
over quota and failing to upload to https://openrct2.org/