### PR TITLE
Correctly determine size of wchar arrays

### DIFF
--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -10,6 +10,7 @@
 #include "Crash.h"
 
 #ifdef USE_BREAKPAD
+#    include <iterator>
 #    include <map>
 #    include <memory>
 #    include <stdio.h>
@@ -99,18 +100,18 @@ static bool OnCrash(
     wchar_t saveFilePath[MAX_PATH];
     wchar_t configFilePath[MAX_PATH];
     wchar_t saveFilePathGZIP[MAX_PATH];
-    swprintf_s(dumpFilePath, sizeof(dumpFilePath), L"%s\\%s.dmp", dumpPath, miniDumpId);
-    swprintf_s(saveFilePath, sizeof(saveFilePath), L"%s\\%s.sv6", dumpPath, miniDumpId);
-    swprintf_s(configFilePath, sizeof(configFilePath), L"%s\\%s.ini", dumpPath, miniDumpId);
-    swprintf_s(saveFilePathGZIP, sizeof(saveFilePathGZIP), L"%s\\%s.sv6.gz", dumpPath, miniDumpId);
+    swprintf_s(dumpFilePath, std::size(dumpFilePath), L"%s\\%s.dmp", dumpPath, miniDumpId);
+    swprintf_s(saveFilePath, std::size(saveFilePath), L"%s\\%s.sv6", dumpPath, miniDumpId);
+    swprintf_s(configFilePath, std::size(configFilePath), L"%s\\%s.ini", dumpPath, miniDumpId);
+    swprintf_s(saveFilePathGZIP, std::size(saveFilePathGZIP), L"%s\\%s.sv6.gz", dumpPath, miniDumpId);
 
     wchar_t dumpFilePathNew[MAX_PATH];
     swprintf_s(
-        dumpFilePathNew, sizeof(dumpFilePathNew), L"%s\\%s(%s_%s).dmp", dumpPath, miniDumpId, _wszCommitSha1Short,
+        dumpFilePathNew, std::size(dumpFilePathNew), L"%s\\%s(%s_%s).dmp", dumpPath, miniDumpId, _wszCommitSha1Short,
         _wszArchitecture);
 
     wchar_t dumpFilePathGZIP[MAX_PATH];
-    swprintf_s(dumpFilePathGZIP, sizeof(dumpFilePathGZIP), L"%s.gz", dumpFilePathNew);
+    swprintf_s(dumpFilePathGZIP, std::size(dumpFilePathGZIP), L"%s.gz", dumpFilePathNew);
 
     // Compress the dump
     {

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -179,7 +179,7 @@ namespace Platform
 
 #    ifdef __USE_GETDATEFORMATEX__
         wchar_t date[20];
-        GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, &st, nullptr, date, sizeof(date), nullptr);
+        GetDateFormatEx(LOCALE_NAME_USER_DEFAULT, DATE_SHORTDATE, &st, nullptr, date, (int)std::size(date), nullptr);
         std::string result = String::ToUtf8(std::wstring(date));
 #    else
         char date[20];
@@ -196,7 +196,7 @@ namespace Platform
 
 #    ifdef __USE_GETDATEFORMATEX__
         wchar_t time[20];
-        GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, nullptr, time, sizeof(time));
+        GetTimeFormatEx(LOCALE_NAME_USER_DEFAULT, 0, &st, nullptr, time, (int)std::size(time));
         std::string result = String::ToUtf8(std::wstring(time));
 #    else
         char time[20];

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -413,7 +413,7 @@ uint8_t platform_get_locale_date_format()
 {
     // Retrieve short date format, eg "MM/dd/yyyy"
     wchar_t dateFormat[20];
-    if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SSHORTDATE, dateFormat, sizeof(dateFormat)) == 0)
+    if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SSHORTDATE, dateFormat, (int)std::size(dateFormat)) == 0)
     {
         return DATE_FORMAT_DAY_MONTH_YEAR;
     }
@@ -584,8 +584,8 @@ static bool windows_setup_file_association(
 
     [[maybe_unused]] int32_t printResult;
 
-    GetModuleFileNameW(nullptr, exePathW, sizeof(exePathW));
-    GetModuleFileNameW(plaform_get_dll_module(), dllPathW, sizeof(dllPathW));
+    GetModuleFileNameW(nullptr, exePathW, (DWORD)std::size(exePathW));
+    GetModuleFileNameW(plaform_get_dll_module(), dllPathW, (DWORD)std::size(dllPathW));
 
     wchar_t* extensionW = utf8_to_widechar(extension);
     wchar_t* fileTypeTextW = utf8_to_widechar(fileTypeText);
@@ -737,7 +737,7 @@ bool platform_setup_uri_protocol()
                     GetModuleFileNameW(nullptr, exePath, MAX_PATH);
 
                     wchar_t buffer[512];
-                    swprintf_s(buffer, sizeof(buffer), L"\"%s\" handle-uri \"%%1\"", exePath);
+                    swprintf_s(buffer, std::size(buffer), L"\"%s\" handle-uri \"%%1\"", exePath);
                     if (RegSetValueW(hClassKey, L"shell\\open\\command", REG_SZ, buffer, 0) == ERROR_SUCCESS)
                     {
                         // Not compulsory, but gives the application a nicer name
@@ -745,11 +745,11 @@ bool platform_setup_uri_protocol()
                         HKEY hMuiCacheKey;
                         if (RegCreateKeyW(hRootKey, MUI_CACHE, &hMuiCacheKey) == ERROR_SUCCESS)
                         {
-                            swprintf_s(buffer, sizeof(buffer), L"%s.FriendlyAppName", exePath);
+                            swprintf_s(buffer, std::size(buffer), L"%s.FriendlyAppName", exePath);
                             // mingw-w64 used to define RegSetKeyValueW's signature incorrectly
                             // You need at least mingw-w64 5.0 including this commit:
                             //   https://sourceforge.net/p/mingw-w64/mingw-w64/ci/da9341980a4b70be3563ac09b5927539e7da21f7/
-                            RegSetKeyValueW(hMuiCacheKey, nullptr, buffer, REG_SZ, L"OpenRCT2", sizeof(L"OpenRCT2") + 1);
+                            RegSetKeyValueW(hMuiCacheKey, nullptr, buffer, REG_SZ, L"OpenRCT2", sizeof(L"OpenRCT2"));
                         }
 
                         log_verbose("URI protocol setup successful");


### PR DESCRIPTION
This PR fixes some mistakes when determining the size of wchar arrays I found while browsing the code:
- Most WinAPI functions want the number of characters, not the number of bytes. But sizeof returns the number of bytes.
- String literals already include the null-terminator, so there's no need to add 1 to the sizeof