### PR TITLE
Remove sloped curves from Spinning Wild Mouse

### DIFF
--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -133,7 +133,7 @@ static constexpr const RideGroup ride_group_spinning_wild_mouse = {
     /*.MaximumHeight =*/16,
     /*.AvailableTrackPieces =*/(1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL)
         | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL)
-        | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES), | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),
+        | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),
     /*.Naming =*/{ STR_SPINNING_WILD_MOUSE_GROUP, STR_SPINNING_WILD_MOUSE_GROUP_DESC },
     /*.Flags =*/0,
 };

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -132,9 +132,8 @@ static constexpr const RideGroup ride_group_spinning_wild_mouse = {
     /*.RideType =*/RIDE_TYPE_STEEL_WILD_MOUSE,
     /*.MaximumHeight =*/16,
     /*.AvailableTrackPieces =*/(1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL)
-        | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_CURVE_VERY_SMALL)
-        | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES)
-        | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),
+        | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL)
+        | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES), | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),
     /*.Naming =*/{ STR_SPINNING_WILD_MOUSE_GROUP, STR_SPINNING_WILD_MOUSE_GROUP_DESC },
     /*.Flags =*/0,
 };

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -132,7 +132,7 @@ static constexpr const RideGroup ride_group_spinning_wild_mouse = {
     /*.RideType =*/RIDE_TYPE_STEEL_WILD_MOUSE,
     /*.MaximumHeight =*/16,
     /*.AvailableTrackPieces =*/(1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_LIFT_HILL)
-        | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_CURVE_VERY_SMALL)
+        | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_CURVE_VERY_SMALL)
         | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES)
         | (1ULL << TRACK_ROTATION_CONTROL_TOGGLE),
     /*.Naming =*/{ STR_SPINNING_WILD_MOUSE_GROUP, STR_SPINNING_WILD_MOUSE_GROUP_DESC },


### PR DESCRIPTION
The Spinning Wild Mouse did not have sloped curves in either vanilla RCT2 or RCT Classic. Unfortunately the cars lack the proper sprites to make this work, so this pull request reverts this to vanilla behavior. Sloped curves can still be used with the enable all track pieces cheat, but this restricts them in scenario play.