### PR TITLE
Disable warnings around incompatible function pointer cast

### DIFF
--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -222,10 +222,14 @@ namespace Platform
         if (hModule != nullptr)
         {
             using RtlGetVersionPtr = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wcast-function-type"
+#    if defined(__GNUC__) && __GNUC__ >= 8
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wcast-function-type"
+#    endif
             auto fn = (RtlGetVersionPtr)GetProcAddress(hModule, "RtlGetVersion");
-#    pragma GCC diagnostic pop
+#    if defined(__GNUC__) && __GNUC__ >= 8
+#        pragma GCC diagnostic pop
+#    endif
             if (fn != nullptr)
             {
                 RTL_OSVERSIONINFOW rovi{};

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -222,7 +222,10 @@ namespace Platform
         if (hModule != nullptr)
         {
             using RtlGetVersionPtr = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-function-type"
             auto fn = (RtlGetVersionPtr)GetProcAddress(hModule, "RtlGetVersion");
+#    pragma GCC diagnostic pop
             if (fn != nullptr)
             {
                 RTL_OSVERSIONINFOW rovi{};


### PR DESCRIPTION
This addresses a compilation issue with newer (8+) mingw.