### PR TITLE
Fix #9524: Cannot place staff in multiplayer without guest permission

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -699,7 +699,7 @@ void window_guest_overview_mouse_up(rct_window* w, rct_widgetindex widgetIndex)
                 return;
             }
             w->picked_peep_old_x = peep->x;
-            PeepPickupAction pickupAction{ PeepPickupType::Pickup, w->number, {}, network_get_current_player_id() };
+            GuestPickupAction pickupAction{ PeepPickupType::Pickup, w->number, {}, network_get_current_player_id() };
             pickupAction.SetCallback([peepnum = w->number](const GameAction* ga, const GameActionResult* result) {
                 if (result->Error != GA_ERROR::OK)
                     return;
@@ -1287,7 +1287,7 @@ void window_guest_overview_tool_down(rct_window* w, rct_widgetindex widgetIndex,
     if (dest_x == LOCATION_NULL)
         return;
 
-    PeepPickupAction pickupAction{
+    GuestPickupAction pickupAction{
         PeepPickupType::Place, w->number, { dest_x, dest_y, tileElement->base_height }, network_get_current_player_id()
     };
     pickupAction.SetCallback([](const GameAction* ga, const GameActionResult* result) {
@@ -1308,7 +1308,7 @@ void window_guest_overview_tool_abort(rct_window* w, rct_widgetindex widgetIndex
     if (widgetIndex != WIDX_PICKUP)
         return;
 
-    PeepPickupAction pickupAction{
+    GuestPickupAction pickupAction{
         PeepPickupType::Cancel, w->number, { w->picked_peep_old_x, 0, 0 }, network_get_current_player_id()
     };
     GameActions::Execute(&pickupAction);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -465,7 +465,7 @@ void window_staff_overview_mouseup(rct_window* w, rct_widgetindex widgetIndex)
         {
             w->picked_peep_old_x = peep->x;
 
-            PeepPickupAction pickupAction{ PeepPickupType::Pickup, w->number, {}, network_get_current_player_id() };
+            StaffPickupAction pickupAction{ PeepPickupType::Pickup, w->number, {}, network_get_current_player_id() };
             pickupAction.SetCallback([peepnum = w->number](const GameAction* ga, const GameActionResult* result) {
                 if (result->Error != GA_ERROR::OK)
                     return;
@@ -1205,7 +1205,7 @@ void window_staff_overview_tool_down(rct_window* w, rct_widgetindex widgetIndex,
         if (dest_x == LOCATION_NULL)
             return;
 
-        PeepPickupAction pickupAction{
+        StaffPickupAction pickupAction{
             PeepPickupType::Place, w->number, { dest_x, dest_y, tileElement->base_height }, network_get_current_player_id()
         };
         pickupAction.SetCallback([](const GameAction* ga, const GameActionResult* result) {
@@ -1299,7 +1299,7 @@ void window_staff_overview_tool_abort(rct_window* w, rct_widgetindex widgetIndex
 {
     if (widgetIndex == WIDX_PICKUP)
     {
-        PeepPickupAction pickupAction{
+        StaffPickupAction pickupAction{
             PeepPickupType::Cancel, w->number, { w->picked_peep_old_x, 0, 0 }, network_get_current_player_id()
         };
         GameActions::Execute(&pickupAction);

--- a/src/openrct2/actions/GameActionRegistration.cpp
+++ b/src/openrct2/actions/GameActionRegistration.cpp
@@ -111,7 +111,8 @@ namespace GameActions
         Register<ParkSetNameAction>();
         Register<ParkSetParameterAction>();
         Register<ParkSetResearchFundingAction>();
-        Register<PeepPickupAction>();
+        Register<GuestPickupAction>();
+        Register<StaffPickupAction>();
         Register<PlaceParkEntranceAction>();
         Register<PlacePeepSpawnAction>();
         Register<PlayerKickAction>();

--- a/src/openrct2/actions/PeepPickupAction.hpp
+++ b/src/openrct2/actions/PeepPickupAction.hpp
@@ -22,7 +22,7 @@ enum class PeepPickupType : uint8_t
     Count
 };
 
-DEFINE_GAME_ACTION(PeepPickupAction, GAME_COMMAND_PICKUP_GUEST, GameActionResult)
+DEFINE_GAME_ACTION(PeepPickupAction, GAME_COMMAND_COUNT, GameActionResult)
 {
 private:
     uint8_t _type = static_cast<uint8_t>(PeepPickupType::Count);
@@ -210,3 +210,6 @@ private:
         tool_cancel();
     }
 };
+
+DEFINE_GAME_ACTION_ALIAS(GuestPickupAction, GAME_COMMAND_PICKUP_GUEST, PeepPickupAction);
+DEFINE_GAME_ACTION_ALIAS(StaffPickupAction, GAME_COMMAND_PICKUP_STAFF, PeepPickupAction);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "46"
+#define NETWORK_STREAM_VERSION "47"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2247,10 +2247,10 @@ void Network::ServerClientDisconnected(std::unique_ptr<NetworkConnection>& conne
     Peep* pickup_peep = network_get_pickup_peep(connection_player->Id);
     if (pickup_peep)
     {
-        PeepPickupAction pickupAction{ PeepPickupType::Cancel,
-                                       pickup_peep->sprite_index,
-                                       { network_get_pickup_peep_old_x(connection_player->Id), 0, 0 },
-                                       network_get_current_player_id() };
+        GuestPickupAction pickupAction{ PeepPickupType::Cancel,
+                                        pickup_peep->sprite_index,
+                                        { network_get_pickup_peep_old_x(connection_player->Id), 0, 0 },
+                                        network_get_current_player_id() };
         auto res = GameActions::Execute(&pickupAction);
     }
     gNetwork.Server_Send_EVENT_PLAYER_DISCONNECTED(


### PR DESCRIPTION
Instead of merging the permissions I've created some macro that creates an alias for another game action so the implementation can be re-used with different game command ids.