### PR TITLE
Prevent unnecessary copies in certain loops

### DIFF
--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -208,7 +208,7 @@ void font_sprite_initialise_characters()
 {
     // Compute min and max that helps avoiding lookups for no reason.
     _smallestCodepointValue = std::numeric_limits<char32_t>::max();
-    for (const auto entry : codepointOffsetMap)
+    for (const auto& entry : codepointOffsetMap)
     {
         _smallestCodepointValue = std::min(_smallestCodepointValue, entry.first);
         _biggestCodepointValue = std::max(_biggestCodepointValue, entry.first);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -680,7 +680,7 @@ void track_design_mirror(rct_track_td6* td6)
 
 static void track_design_add_selection_tile(int16_t x, int16_t y)
 {
-    for (const auto tile : gMapSelectionTiles)
+    for (const auto& tile : gMapSelectionTiles)
     {
         if (tile.x == x && tile.y == y)
         {


### PR DESCRIPTION
These changes prevent a few unnecessary copies by using references in certain loops.