### PR TITLE
Fix Werror=maybe-uninitialized issue of struct, found by gcc 9.1.1

### DIFF
--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -263,7 +263,7 @@ std::vector<rct_large_scenery_text_glyph> LargeSceneryObject::ReadJsonGlyphs(con
     const json_t* jGlyph;
     json_array_foreach(jGlpyhs, index, jGlyph)
     {
-        rct_large_scenery_text_glyph glyph;
+        rct_large_scenery_text_glyph glyph = {};
         glyph.image_offset = json_integer_value(json_object_get(jGlyph, "image"));
         glyph.width = json_integer_value(json_object_get(jGlyph, "width"));
         glyph.height = json_integer_value(json_object_get(jGlyph, "height"));


### PR DESCRIPTION
When building with gcc 9.1.1 there is an error (warning, but as of #4401 they are treatened as errors):

    OpenRCT2-0.2.3/src/openrct2/object/LargeSceneryObject.cpp: In function 'ReadJsonGlyphs':
    OpenRCT2-0.2.3/src/openrct2/object/LargeSceneryObject.cpp:266:38: error: 'MEM[(const struct rct_large_scenery_text_glyph *)&glyph + 3B]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       266 |         rct_large_scenery_text_glyph glyph;
           |                                      ^

Looks like the pad3 of the struct is the problem, so simply initializing the struct is fixing it.