### PR TITLE
Do not store park name as user string

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/BalloonPressAction.hpp>
@@ -94,9 +95,14 @@ int32_t viewport_interaction_get_item_left(int32_t x, int32_t y, viewport_intera
             ride_set_map_tooltip(tileElement);
             break;
         case VIEWPORT_INTERACTION_ITEM_PARK:
-            set_map_tooltip_format_arg(0, rct_string_id, gParkName);
-            set_map_tooltip_format_arg(2, uint32_t, gParkNameArgs);
+        {
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto parkName = park.Name.c_str();
+
+            set_map_tooltip_format_arg(0, rct_string_id, STR_STRING);
+            set_map_tooltip_format_arg(2, const char*, parkName);
             break;
+        }
         default:
             info->type = VIEWPORT_INTERACTION_ITEM_NONE;
             break;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -14,8 +14,10 @@
 
 #include <iterator>
 #include <openrct2/Context.h>
+#include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/ParkSetNameAction.hpp>
+#include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Font.h>
 #include <openrct2/interface/Colour.h>
@@ -402,9 +404,11 @@ static void window_editor_objective_options_main_mouseup(rct_window* w, rct_widg
             window_editor_objective_options_set_page(w, widgetIndex - WIDX_TAB_1);
             break;
         case WIDX_PARK_NAME:
-            set_format_arg(16, uint32_t, gParkNameArgs);
-            window_text_input_open(w, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, gParkName, 0, 32);
+        {
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            window_text_input_raw_open(w, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, park.Name.c_str(), 32);
             break;
+        }
         case WIDX_SCENARIO_NAME:
             window_text_input_raw_open(w, WIDX_SCENARIO_NAME, STR_SCENARIO_NAME, STR_ENTER_SCENARIO_NAME, gS6Info.name, 64);
             break;
@@ -771,7 +775,10 @@ static void window_editor_objective_options_main_textinput(rct_window* w, rct_wi
             GameActions::Execute(&action);
 
             if (gS6Info.name[0] == '\0')
-                format_string(gS6Info.name, 64, gParkName, &gParkNameArgs);
+            {
+                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                String::Set(gS6Info.name, sizeof(gS6Info.name), park.Name.c_str());
+            }
             break;
         }
         case WIDX_SCENARIO_NAME:
@@ -943,9 +950,14 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     y = w->y + w->widgets[WIDX_PARK_NAME].top;
     width = w->widgets[WIDX_PARK_NAME].left - 16;
 
-    set_format_arg(0, rct_string_id, gParkName);
-    set_format_arg(2, uint32_t, gParkNameArgs);
-    gfx_draw_string_left_clipped(dpi, STR_WINDOW_PARK_NAME, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    {
+        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+        auto parkName = park.Name.c_str();
+
+        set_format_arg(0, rct_string_id, STR_STRING);
+        set_format_arg(2, const char*, parkName);
+        gfx_draw_string_left_clipped(dpi, STR_WINDOW_PARK_NAME, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    }
 
     // Scenario name
     x = w->x + 8;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/actions/ParkSetLoanAction.hpp>
 #include <openrct2/actions/ParkSetResearchFundingAction.hpp>
 #include <openrct2/config/Config.h>
@@ -1182,8 +1183,6 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
             continue;
 
         noCampaignsActive = 0;
-        set_format_arg(0, rct_string_id, gParkName);
-        set_format_arg(2, uint32_t, gParkNameArgs);
 
         // Set special parameters
         switch (i)
@@ -1199,6 +1198,13 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
             case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
                 set_format_arg(0, rct_string_id, ShopItems[campaign->ShopItemType].Naming.Plural);
                 break;
+            default:
+            {
+                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                auto parkName = park.Name.c_str();
+                set_format_arg(0, rct_string_id, STR_STRING);
+                set_format_arg(2, const char*, parkName);
+            }
         }
 
         // Advertisement

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/GuestSetFlagsAction.hpp>
 #include <openrct2/actions/PeepPickupAction.hpp>
@@ -1942,15 +1943,17 @@ void window_guest_inventory_update(rct_window* w)
 
 static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item)
 {
-    Ride* ride;
+    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+    auto parkName = park.Name.c_str();
 
     // Default arguments
     set_format_arg(0, uint32_t, ShopItems[item].Image);
     set_format_arg(4, rct_string_id, ShopItems[item].Naming.Display);
-    set_format_arg(6, rct_string_id, gParkName);
-    set_format_arg(8, uint32_t, gParkNameArgs);
+    set_format_arg(6, rct_string_id, STR_STRING);
+    set_format_arg(8, const char*, parkName);
 
     // Special overrides
+    Ride* ride{};
     switch (item)
     {
         case SHOP_ITEM_BALLOON:
@@ -1969,8 +1972,8 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
             {
                 case VOUCHER_TYPE_PARK_ENTRY_FREE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_FREE);
-                    set_format_arg(8, rct_string_id, gParkName);
-                    set_format_arg(10, uint32_t, gParkNameArgs);
+                    set_format_arg(8, rct_string_id, STR_STRING);
+                    set_format_arg(10, const char*, parkName);
                     break;
                 case VOUCHER_TYPE_RIDE_FREE:
                     ride = get_ride(peep->voucher_arguments);
@@ -1980,8 +1983,8 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                     break;
                 case VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_HALF_PRICE);
-                    set_format_arg(8, rct_string_id, gParkName);
-                    set_format_arg(10, uint32_t, gParkNameArgs);
+                    set_format_arg(8, rct_string_id, STR_STRING);
+                    set_format_arg(10, const char*, parkName);
                     break;
                 case VOUCHER_TYPE_FOOD_OR_DRINK_FREE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_FOOD_OR_DRINK_FREE);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -411,7 +411,7 @@ static bool browse(bool isSave, char* path, size_t pathSize)
             auto buffer = park.Name;
             if (buffer.empty())
             {
-                // Use localized "Unnamed Park" if park name was empty
+                // Use localised "Unnamed Park" if park name was empty.
                 buffer = format_string(STR_UNNAMED_PARK, nullptr);
             }
             safe_strcat_path(path, buffer.c_str(), pathSize);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/Editor.h>
 #include <openrct2/FileClassifier.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/FileScanner.h>
 #include <openrct2/core/Guard.hpp>
@@ -406,15 +407,14 @@ static bool browse(bool isSave, char* path, size_t pathSize)
         }
         else
         {
-            utf8 buffer[USER_STRING_MAX_LENGTH]{};
-            if (gParkName != STR_NONE)
-                format_string(buffer, pathSize, gParkName, nullptr);
-
-            // Use localized "Unnamed Park" if park name was empty
-            if (String::SizeOf(buffer) == 0)
-                format_string(buffer, pathSize, STR_UNNAMED_PARK, nullptr);
-
-            safe_strcat_path(path, buffer, pathSize);
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto buffer = park.Name;
+            if (buffer.empty())
+            {
+                // Use localized "Unnamed Park" if park name was empty
+                buffer = format_string(STR_UNNAMED_PARK, nullptr);
+            }
+            safe_strcat_path(path, buffer.c_str(), pathSize);
         }
     }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -19,6 +19,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/ParkSetNameAction.hpp>
 #include <openrct2/config/Config.h>
@@ -582,8 +583,11 @@ static void window_park_set_disabled_tabs(rct_window* w)
 
 static void window_park_prepare_window_title_text()
 {
-    set_format_arg(0, rct_string_id, gParkName);
-    set_format_arg(2, uint32_t, gParkNameArgs);
+    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+    auto parkName = park.Name.c_str();
+
+    set_format_arg(0, rct_string_id, STR_STRING);
+    set_format_arg(2, const char*, parkName);
 }
 
 #pragma region Entrance page
@@ -654,9 +658,12 @@ static void window_park_entrance_mouseup(rct_window* w, rct_widgetindex widgetIn
             window_scroll_to_viewport(w);
             break;
         case WIDX_RENAME:
-            set_format_arg(16, uint32_t, gParkNameArgs);
-            window_text_input_open(w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, gParkName, 0, USER_STRING_MAX_LENGTH);
+        {
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            window_text_input_raw_open(
+                w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, park.Name.c_str(), USER_STRING_MAX_LENGTH);
             break;
+        }
         case WIDX_CLOSE_LIGHT:
             park_set_open(false);
             break;
@@ -764,8 +771,13 @@ static void window_park_entrance_invalidate(rct_window* w)
     window_park_set_pressed_tab(w);
 
     // Set open / close park button state
-    set_format_arg(0, rct_string_id, gParkName);
-    set_format_arg(2, uint32_t, gParkNameArgs);
+    {
+        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+        auto parkName = park.Name.c_str();
+
+        set_format_arg(0, rct_string_id, STR_STRING);
+        set_format_arg(2, const char*, parkName);
+    }
     window_park_entrance_widgets[WIDX_OPEN_OR_CLOSE].image = park_is_open() ? SPR_OPEN : SPR_CLOSED;
     window_park_entrance_widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + !park_is_open() * 2
         + widget_is_pressed(w, WIDX_CLOSE_LIGHT);

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -52,7 +52,6 @@ void GameState::InitAll(int32_t mapSize)
     map_init(mapSize);
     _park->Initialise();
     finance_init();
-    reset_park_entry();
     banner_init();
     ride_init_all();
     reset_sprite_list();

--- a/src/openrct2/actions/ParkSetNameAction.hpp
+++ b/src/openrct2/actions/ParkSetNameAction.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../config/Config.h"
 #include "../core/MemoryStream.h"
 #include "../drawing/Drawing.h"
@@ -53,49 +54,19 @@ public:
         {
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_PARK, STR_INVALID_NAME_FOR_PARK);
         }
-
-        // TODO create a version of user_string_allocate that only tests so we do not have to free it straight afterwards
-        auto stringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, _name.c_str());
-        if (stringId == 0)
-        {
-            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_PARK, STR_INVALID_NAME_FOR_PARK);
-        }
-        user_string_free(stringId);
-
         return MakeResult();
     }
 
     GameActionResult::Ptr Execute() const override
     {
         // Do a no-op if new name is the same as the current name is the same
-        std::string oldName = GetCurrentParkName();
-        if (_name == oldName)
+        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+        if (_name != park.Name)
         {
-            return MakeResult();
+            park.Name = _name;
+            scrolling_text_invalidate();
+            gfx_invalidate_screen();
         }
-
-        // Allocate new string for park name
-        auto newNameId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, _name.c_str());
-        if (newNameId == 0)
-        {
-            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_PARK, STR_INVALID_NAME_FOR_PARK);
-        }
-
-        // Replace park name with new string id
-        user_string_free(gParkName);
-        gParkName = newNameId;
-
-        scrolling_text_invalidate();
-        gfx_invalidate_screen();
-
         return MakeResult();
-    }
-
-private:
-    std::string GetCurrentParkName() const
-    {
-        char buffer[128];
-        format_string(buffer, sizeof(buffer), gParkName, &gParkNameArgs);
-        return buffer;
     }
 };

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -102,9 +102,7 @@ static void screenshot_get_rendered_palette(rct_palette* palette)
 
 static std::string screenshot_get_park_name()
 {
-    char buffer[512];
-    format_string(buffer, sizeof(buffer), gParkName, &gParkNameArgs);
-    return buffer;
+    return GetContext()->GetGameState()->GetPark().Name;
 }
 
 static std::string screenshot_get_directory()

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -1291,6 +1291,32 @@ static void format_string_part(utf8** dest, size_t* size, rct_string_id format, 
     }
 }
 
+std::string format_string(rct_string_id format, const void* args)
+{
+    std::string buffer(256, 0);
+    size_t len{};
+    for (;;)
+    {
+        format_string(buffer.data(), buffer.size(), format, args);
+        len = buffer.find('\0');
+        if (len == std::string::npos)
+        {
+            len = buffer.size();
+        }
+        if (len >= buffer.size() - 1)
+        {
+            // Null terminator to close to end of buffer, grow buffer and try again
+            buffer.resize(buffer.size() * 2);
+        }
+        else
+        {
+            buffer.resize(len);
+            break;
+        }
+    }
+    return buffer;
+}
+
 /**
  * Writes a formatted string to a buffer.
  *  rct2: 0x006C2555

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -18,6 +18,7 @@
 #include "StringIds.h"
 
 #include <cstring>
+#include <string>
 
 bool utf8_is_format_code(int32_t codepoint);
 bool utf8_is_colour_code(int32_t codepoint);
@@ -25,6 +26,7 @@ bool utf8_should_use_sprite_for_codepoint(int32_t codepoint);
 int32_t utf8_get_format_code_arg_length(int32_t codepoint);
 void utf8_remove_formatting(utf8* string, bool allowColours);
 
+std::string format_string(rct_string_id format, const void* args);
 void format_string(char* dest, size_t size, rct_string_id format, const void* args);
 void format_string_raw(char* dest, size_t size, const char* src, const void* args);
 void format_string_to_upper(char* dest, size_t size, rct_string_id format, const void* args);

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -12,6 +12,7 @@
 #    include "DiscordService.h"
 
 #    include "../Context.h"
+#    include "../GameState.h"
 #    include "../OpenRCT2.h"
 #    include "../core/Console.hpp"
 #    include "../core/String.hpp"
@@ -56,9 +57,12 @@ DiscordService::~DiscordService()
 
 static std::string GetParkName()
 {
-    utf8 parkName[128] = {};
-    format_string(parkName, sizeof(parkName), gParkName, &gParkNameArgs);
-    return std::string(parkName);
+    auto gameState = OpenRCT2::GetContext()->GetGameState();
+    if (gameState != nullptr)
+    {
+        return gameState->GetPark().Name;
+    }
+    return {};
 }
 
 void DiscordService::Update()

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -7,7 +7,9 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "../../Context.h"
 #include "../../Game.h"
+#include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../drawing/LightFX.h"
 #include "../../interface/Viewport.h"
@@ -269,8 +271,10 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
 
                 if (gParkFlags & PARK_FLAGS_PARK_OPEN)
                 {
-                    set_format_arg(0, rct_string_id, gParkName);
-                    set_format_arg(2, uint32_t, gParkNameArgs);
+                    const auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                    auto name = park.Name.c_str();
+                    set_format_arg(0, rct_string_id, STR_STRING);
+                    set_format_arg(2, const char*, name);
                 }
                 else
                 {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2476,12 +2476,8 @@ private:
             }
         }
 
-        rct_string_id stringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, parkName.c_str());
-        if (stringId != 0)
-        {
-            gParkName = stringId;
-            gParkNameArgs = 0;
-        }
+        auto& park = GetContext()->GetGameState()->GetPark();
+        park.Name = parkName;
     }
 
     void ImportParkFlags()

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../GameState.h"
 #include "../OpenRCT2.h"
 #include "../common.h"
 #include "../config/Config.h"
@@ -198,10 +199,8 @@ void S6Exporter::Export()
     _s6.next_free_tile_element_pointer_index = gNextFreeTileElementPointerIndex;
 
     ExportSprites();
+    ExportParkName();
 
-    _s6.park_name = gParkName;
-    // pad_013573D6
-    _s6.park_name_args = gParkNameArgs;
     _s6.initial_cash = gInitialCash;
     _s6.current_loan = gBankLoan;
     _s6.park_flags = gParkFlags;
@@ -442,6 +441,23 @@ uint32_t S6Exporter::GetLoanHash(money32 initialCash, money32 bankLoan, uint32_t
     value += maxBankLoan;
     value = ror32(value, 3);
     return value;
+}
+
+void S6Exporter::ExportParkName()
+{
+    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+    auto stringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, park.Name.c_str());
+    if (stringId != 0)
+    {
+        _s6.park_name = stringId;
+        _s6.park_name_args = 0;
+    }
+    else
+    {
+        log_warning("Unable to allocate user string for park name during S6 export.");
+        _s6.park_name = STR_UNNAMED_PARK;
+        _s6.park_name_args = 0;
+    }
 }
 
 void S6Exporter::ExportRides()

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -36,6 +36,7 @@ public:
     void SaveScenario(const utf8* path);
     void SaveScenario(IStream* stream);
     void Export();
+    void ExportParkName();
     void ExportRides();
     void ExportRide(rct2_ride* dst, const Ride* src);
     void ExportSprites();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -215,9 +215,6 @@ public:
         ImportTileElements();
         ImportSprites();
 
-        gParkName = _s6.park_name;
-        // pad_013573D6
-        gParkNameArgs = _s6.park_name_args;
         gInitialCash = _s6.initial_cash;
         gBankLoan = _s6.current_loan;
         gParkFlags = _s6.park_flags;
@@ -451,6 +448,16 @@ public:
         gWidePathTileLoopX = _s6.wide_path_tile_loop_x;
         gWidePathTileLoopY = _s6.wide_path_tile_loop_y;
         // pad_13CE778
+
+        // Park name, must be after user strings are loaded
+        // Eventually format_string should be something that the S6 user strings can be passed directly to
+        {
+            char parkName[128]{};
+            format_string(parkName, sizeof(parkName), _s6.park_name, &_s6.park_name_args);
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            park.Name = parkName;
+            user_string_free(_s6.park_name);
+        }
 
         // Fix and set dynamic variables
         map_strip_ghost_flag_from_elements();

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -125,7 +125,7 @@ void scenario_begin()
             }
             if (localisedStringIds[1] != STR_NONE)
             {
-                park_set_name(language_get_string(localisedStringIds[1]));
+                park.Name = language_get_string(localisedStringIds[1]);
             }
             if (localisedStringIds[2] != STR_NONE)
             {
@@ -135,12 +135,9 @@ void scenario_begin()
     }
 
     // Set the last saved game path
-    char parkName[128];
-    format_string(parkName, 128, gParkName, &gParkNameArgs);
-
     char savePath[MAX_PATH];
     platform_get_user_directory(savePath, "save", sizeof(savePath));
-    safe_strcat_path(savePath, parkName, sizeof(savePath));
+    safe_strcat_path(savePath, park.Name.c_str(), sizeof(savePath));
     path_append_extension(savePath, ".sv6", sizeof(savePath));
     gScenarioSavePath = savePath;
 
@@ -579,10 +576,12 @@ static bool scenario_prepare_rides_for_save()
  */
 bool scenario_prepare_for_save()
 {
-    gS6Info.entry.flags = 255;
+    auto& park = GetContext()->GetGameState()->GetPark();
+    auto parkName = park.Name.c_str();
 
+    gS6Info.entry.flags = 255;
     if (gS6Info.name[0] == 0)
-        format_string(gS6Info.name, 64, gParkName, &gParkNameArgs);
+        String::Set(gS6Info.name, sizeof(gS6Info.name), parkName);
 
     gS6Info.objective_type = gScenarioObjectiveType;
     gS6Info.objective_arg_1 = gScenarioObjectiveYear;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -44,8 +44,6 @@
 
 using namespace OpenRCT2;
 
-rct_string_id gParkName;
-uint32_t gParkNameArgs;
 uint32_t gParkFlags;
 uint16_t gParkRating;
 money16 gParkEntranceFee;
@@ -78,17 +76,6 @@ int32_t _suggestedGuestMaximum;
  * approximately 1 guest per second can be generated (+60 guests in one minute).
  */
 int32_t _guestGenerationProbability;
-
-/**
- *
- *  rct2: 0x00667104
- */
-void reset_park_entry()
-{
-    gParkName = 0;
-    reset_park_entrance();
-    gPeepSpawns.clear();
-}
 
 /**
  * Choose a random peep spawn and iterates through until defined spawn is found.
@@ -193,16 +180,6 @@ void update_park_fences_around_tile(const CoordsXY coords)
     update_park_fences({ coords.x, coords.y - 32 });
 }
 
-void park_set_name(const char* name)
-{
-    auto nameId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, name);
-    if (nameId != 0)
-    {
-        user_string_free(gParkName);
-        gParkName = nameId;
-    }
-}
-
 void set_forced_park_rating(int32_t rating)
 {
     _forcedParkRating = rating;
@@ -278,8 +255,8 @@ money32 Park::GetCompanyValue() const
 
 void Park::Initialise()
 {
+    Name = format_string(STR_UNNAMED_PARK, nullptr);
     gUnk13CA740 = 0;
-    gParkName = STR_UNNAMED_PARK;
     gStaffHandymanColour = COLOUR_BRIGHT_RED;
     gStaffMechanicColour = COLOUR_LIGHT_BLUE;
     gStaffSecurityColour = COLOUR_YELLOW;
@@ -302,10 +279,8 @@ void Park::Initialise()
 
     gParkEntranceFee = MONEY(10, 00);
 
-    for (auto& peepSpawn : gPeepSpawns)
-    {
-        peepSpawn.x = PEEP_SPAWN_UNDEFINED;
-    }
+    gPeepSpawns.clear();
+    reset_park_entrance();
 
     gResearchPriorities = (1 << RESEARCH_CATEGORY_TRANSPORT) | (1 << RESEARCH_CATEGORY_GENTLE)
         | (1 << RESEARCH_CATEGORY_ROLLERCOASTER) | (1 << RESEARCH_CATEGORY_THRILL) | (1 << RESEARCH_CATEGORY_WATER)

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -53,6 +53,8 @@ namespace OpenRCT2
     class Park final
     {
     public:
+        std::string Name;
+
         Park() = default;
         Park(const Park&) = delete;
 
@@ -87,8 +89,6 @@ namespace OpenRCT2
     };
 } // namespace OpenRCT2
 
-extern rct_string_id gParkName;
-extern uint32_t gParkNameArgs;
 extern uint32_t gParkFlags;
 extern uint16_t gParkRating;
 extern money16 gParkEntranceFee;
@@ -114,8 +114,6 @@ int32_t get_forced_park_rating();
 int32_t park_is_open();
 int32_t park_calculate_size();
 
-void reset_park_entry();
-
 void update_park_fences(CoordsXY coords);
 void update_park_fences_around_tile(CoordsXY coords);
 
@@ -123,7 +121,6 @@ uint8_t calculate_guest_initial_happiness(uint8_t percentage);
 
 void park_set_open(bool open);
 int32_t park_entrance_get_index(int32_t x, int32_t y, int32_t z);
-void park_set_name(const char* name);
 void park_set_entrance_fee(money32 value);
 money16 park_get_entrance_fee();
 


### PR DESCRIPTION
When looking at the new save format, I have come to the conclusion that it is not necessary to store strings in a user table. Strings should be stored on the objects they relate to as `std::string`.

Starting with park name, I have moved it to be stored as a simple `std::string` in the `Park` class. When exporting back to S6, it allocates the user string for backwards compatibility. In rare the occurrence all user strings are used up, the park name gets saved as "unnamed park".

The benefit now is that the park name can share the same name as a ride.