### PR TITLE
Fix #9574: Text overflow in scenario objective window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
+- Fix: [#9574] Text overflow in scenario objective window when using CJK languages.
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -124,7 +124,7 @@ static rct_widget window_park_stats_widgets[] = {
 
 static rct_widget window_park_objective_widgets[] = {
     MAIN_PARK_WIDGETS,
-    { WWT_BUTTON,           1,  7,      222,    209,    220,    STR_ENTER_NAME_INTO_SCENARIO_CHART,         STR_NONE },             // enter name
+    { WWT_BUTTON,           1,  7,      222,    207,    220,    STR_ENTER_NAME_INTO_SCENARIO_CHART,         STR_NONE },             // enter name
     { WIDGETS_END },
 };
 
@@ -1509,7 +1509,12 @@ static void window_park_objective_mouseup(rct_window* w, rct_widgetindex widgetI
  */
 static void window_park_objective_resize(rct_window* w)
 {
-    window_set_resize(w, 230, 226, 230, 226);
+#ifndef NO_TTF
+    if (gCurrentTTFFontSet != nullptr)
+        window_set_resize(w, 230, 270, 230, 270);
+    else
+#endif
+        window_set_resize(w, 230, 226, 230, 226);
 }
 
 /**
@@ -1544,9 +1549,13 @@ static void window_park_objective_invalidate(rct_window* w)
     window_park_set_pressed_tab(w);
     window_park_prepare_window_title_text();
 
-    //
+    // Show name input button on scenario completion.
     if (gParkFlags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
+    {
         window_park_objective_widgets[WIDX_ENTER_NAME].type = WWT_BUTTON;
+        window_park_objective_widgets[WIDX_ENTER_NAME].top = w->height - 19;
+        window_park_objective_widgets[WIDX_ENTER_NAME].bottom = w->height - 6;
+    }
     else
         window_park_objective_widgets[WIDX_ENTER_NAME].type = WWT_EMPTY;
 


### PR DESCRIPTION
As CJK languages use bigger font sizes, the objective window sometimes wasn't high enough to accommodate texts. This PR increases the window height slightly if TTF fonts are enabled. The 'enter name' button also sees a height increase to better accomodate its caption.

Before:
![Screenshot_20190720_131952](https://user-images.githubusercontent.com/604665/61578140-56686300-aaf2-11e9-9256-6ea774b8115f.png)

After:
![Screenshot_20190720_132511](https://user-images.githubusercontent.com/604665/61578141-5700f980-aaf2-11e9-9a93-0e924b3df836.png)

Aside from the button height, English is unaffected:
![Screenshot_20190720_132546](https://user-images.githubusercontent.com/604665/61578142-5700f980-aaf2-11e9-94f0-7d14ed719ac8.png)
