### PR TITLE
Use enum class for RCT2_SOUND

### DIFF
--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <openrct2/audio/AudioChannel.h>
 #include <openrct2/audio/AudioSource.h>
+#include <openrct2/audio/audio.h>
 #include <openrct2/common.h>
 #include <speex/speex_resampler.h>
 

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Audio
         uint8_t _settingSoundVolume = 0xFF;
         uint8_t _settingMusicVolume = 0xFF;
 
-        IAudioSource* _css1Sources[SOUND_MAXID] = { nullptr };
+        IAudioSource* _css1Sources[RCT2SoundCount] = { nullptr };
         IAudioSource* _musicSources[PATH_ID_END] = { nullptr };
 
         std::vector<uint8_t> _channelBuffer;
@@ -185,9 +185,9 @@ namespace OpenRCT2::Audio
             _volume = volume;
         }
 
-        IAudioSource* GetSoundSource(int32_t id) override
+        IAudioSource* GetSoundSource(RCT2Sound id) override
         {
-            return _css1Sources[id];
+            return _css1Sources[static_cast<uint32_t>(id)];
         }
 
         IAudioSource* GetMusicSource(int32_t id) override

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -185,7 +185,7 @@ namespace OpenRCT2::Audio
             _volume = volume;
         }
 
-        IAudioSource* GetSoundSource(RCT2Sound id) override
+        IAudioSource* GetSoundSource(SoundId id) override
         {
             return _css1Sources[static_cast<uint32_t>(id)];
         }

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1063,7 +1063,7 @@ static void input_widget_left(int32_t x, int32_t y, rct_window* w, rct_widgetind
         default:
             if (widget_is_enabled(w, widgetIndex) && !widget_is_disabled(w, widgetIndex))
             {
-                audio_play_sound(SOUND_CLICK_1, 0, w->x + ((widget->left + widget->right) / 2));
+                audio_play_sound(RCT2Sound::Click1, 0, w->x + ((widget->left + widget->right) / 2));
 
                 // Set new cursor down widget
                 gPressedWidget.window_classification = windowClass;
@@ -1345,7 +1345,7 @@ void input_state_widget_pressed(
 
             {
                 int32_t mid_point_x = (widget->left + widget->right) / 2 + w->x;
-                audio_play_sound(SOUND_CLICK_2, 0, mid_point_x);
+                audio_play_sound(RCT2Sound::Click2, 0, mid_point_x);
             }
             if (cursor_w_class != w->classification || cursor_w_number != w->number || widgetIndex != cursor_widgetIndex)
                 break;

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1063,7 +1063,7 @@ static void input_widget_left(int32_t x, int32_t y, rct_window* w, rct_widgetind
         default:
             if (widget_is_enabled(w, widgetIndex) && !widget_is_disabled(w, widgetIndex))
             {
-                audio_play_sound(RCT2Sound::Click1, 0, w->x + ((widget->left + widget->right) / 2));
+                audio_play_sound(SoundId::Click1, 0, w->x + ((widget->left + widget->right) / 2));
 
                 // Set new cursor down widget
                 gPressedWidget.window_classification = windowClass;
@@ -1345,7 +1345,7 @@ void input_state_widget_pressed(
 
             {
                 int32_t mid_point_x = (widget->left + widget->right) / 2 + w->x;
-                audio_play_sound(RCT2Sound::Click2, 0, mid_point_x);
+                audio_play_sound(SoundId::Click2, 0, mid_point_x);
             }
             if (cursor_w_class != w->classification || cursor_w_number != w->number || widgetIndex != cursor_widgetIndex)
                 break;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -141,7 +141,7 @@ rct_window* window_create(
     if (!(flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT)))
     {
         w->flags |= WF_WHITE_BORDER_MASK;
-        audio_play_sound(RCT2Sound::WindowOpen, 0, x + (width / 2));
+        audio_play_sound(SoundId::WindowOpen, 0, x + (width / 2));
     }
 
     w->number = 0;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -141,7 +141,7 @@ rct_window* window_create(
     if (!(flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT)))
     {
         w->flags |= WF_WHITE_BORDER_MASK;
-        audio_play_sound(SOUND_WINDOW_OPEN, 0, x + (width / 2));
+        audio_play_sound(RCT2Sound::WindowOpen, 0, x + (width / 2));
     }
 
     w->number = 0;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -698,7 +698,7 @@ static void window_editor_object_selection_scroll_mousedown(rct_window* w, int32
     window_invalidate(w);
 
     const CursorState* state = context_get_cursor_state();
-    audio_play_sound(RCT2Sound::Click1, 0, state->x);
+    audio_play_sound(SoundId::Click1, 0, state->x);
 
     if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
     {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -698,7 +698,7 @@ static void window_editor_object_selection_scroll_mousedown(rct_window* w, int32
     window_invalidate(w);
 
     const CursorState* state = context_get_cursor_state();
-    audio_play_sound(SOUND_CLICK_1, 0, state->x);
+    audio_play_sound(RCT2Sound::Click1, 0, state->x);
 
     if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
     {

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -143,7 +143,7 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message)
     w->error.var_480 = 0;
     if (!gDisableErrorWindowSound)
     {
-        audio_play_sound(SOUND_ERROR, 0, w->x + (w->width / 2));
+        audio_play_sound(RCT2Sound::Error, 0, w->x + (w->width / 2));
     }
 
     return w;

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -143,7 +143,7 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message)
     w->error.var_480 = 0;
     if (!gDisableErrorWindowSound)
     {
-        audio_play_sound(RCT2Sound::Error, 0, w->x + (w->width / 2));
+        audio_play_sound(SoundId::Error, 0, w->x + (w->width / 2));
     }
 
     return w;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -895,7 +895,8 @@ static void window_footpath_place_path_at_point(int32_t x, int32_t y)
             // Don't play sound if it is no cost to prevent multiple sounds. TODO: make this work in no money scenarios
             if (result->Cost != 0)
             {
-                audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(
+                    RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             }
         }
         else
@@ -983,7 +984,8 @@ static void window_footpath_construct()
     footpathPlaceAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
         if (result->Error == GA_ERROR::OK)
         {
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+            audio_play_sound_at_location(
+                RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
             if (gFootpathConstructSlope == 0)
             {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -895,7 +895,7 @@ static void window_footpath_place_path_at_point(int32_t x, int32_t y)
             // Don't play sound if it is no cost to prevent multiple sounds. TODO: make this work in no money scenarios
             if (result->Cost != 0)
             {
-                audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             }
         }
         else
@@ -983,7 +983,7 @@ static void window_footpath_construct()
     footpathPlaceAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
         if (result->Error == GA_ERROR::OK)
         {
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+            audio_play_sound_at_location(SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
             if (gFootpathConstructSlope == 0)
             {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -895,8 +895,7 @@ static void window_footpath_place_path_at_point(int32_t x, int32_t y)
             // Don't play sound if it is no cost to prevent multiple sounds. TODO: make this work in no money scenarios
             if (result->Cost != 0)
             {
-                audio_play_sound_at_location(
-                    RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             }
         }
         else
@@ -984,8 +983,7 @@ static void window_footpath_construct()
     footpathPlaceAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
         if (result->Error == GA_ERROR::OK)
         {
-            audio_play_sound_at_location(
-                RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
             if (gFootpathConstructSlope == 0)
             {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1316,7 +1316,8 @@ static void window_map_place_park_entrance_tool_down(int32_t x, int32_t y)
         money32 price = place_park_entrance(mapX, mapY, mapZ, direction);
         if (price != MONEY32_UNDEFINED)
         {
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
+            audio_play_sound_at_location(
+                RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
         }
     }
 }
@@ -1340,7 +1341,7 @@ static void window_map_set_peep_spawn_tool_down(int32_t x, int32_t y)
     bool result = place_peep_spawn({ mapX, mapY, mapZ, (uint8_t)direction });
     if (result)
     {
-        audio_play_sound_at_location(SOUND_PLACE_ITEM, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
+        audio_play_sound_at_location(RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
     }
 }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1316,7 +1316,7 @@ static void window_map_place_park_entrance_tool_down(int32_t x, int32_t y)
         money32 price = place_park_entrance(mapX, mapY, mapZ, direction);
         if (price != MONEY32_UNDEFINED)
         {
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
+            audio_play_sound_at_location(SoundId::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
         }
     }
 }
@@ -1340,7 +1340,7 @@ static void window_map_set_peep_spawn_tool_down(int32_t x, int32_t y)
     bool result = place_peep_spawn({ mapX, mapY, mapZ, (uint8_t)direction });
     if (result)
     {
-        audio_play_sound_at_location(RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
+        audio_play_sound_at_location(SoundId::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
     }
 }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1316,8 +1316,7 @@ static void window_map_place_park_entrance_tool_down(int32_t x, int32_t y)
         money32 price = place_park_entrance(mapX, mapY, mapZ, direction);
         if (price != MONEY32_UNDEFINED)
         {
-            audio_play_sound_at_location(
-                RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, gCommandPosition.x, gCommandPosition.y, gCommandPosition.z);
         }
     }
 }

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -374,7 +374,7 @@ static void window_maze_construction_entrance_tooldown(int32_t x, int32_t y, rct
         if (result->Error != GA_ERROR::OK)
             return;
 
-        audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+        audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
         Ride* ride = get_ride(rideIndex);
         if (ride_are_all_possible_entrances_and_exits_built(ride))
@@ -507,6 +507,6 @@ static void window_maze_construction_construct(int32_t direction)
     _currentTrackBegin.y = y;
     if (_rideConstructionState != RIDE_CONSTRUCTION_STATE_MAZE_MOVE)
     {
-        audio_play_sound_at_location(SOUND_PLACE_ITEM, x, y, z);
+        audio_play_sound_at_location(RCT2Sound::PlaceItem, x, y, z);
     }
 }

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -374,7 +374,7 @@ static void window_maze_construction_entrance_tooldown(int32_t x, int32_t y, rct
         if (result->Error != GA_ERROR::OK)
             return;
 
-        audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+        audio_play_sound_at_location(SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
         Ride* ride = get_ride(rideIndex);
         if (ride_are_all_possible_entrances_and_exits_built(ride))
@@ -507,6 +507,6 @@ static void window_maze_construction_construct(int32_t direction)
     _currentTrackBegin.y = y;
     if (_rideConstructionState != RIDE_CONSTRUCTION_STATE_MAZE_MOVE)
     {
-        audio_play_sound_at_location(RCT2Sound::PlaceItem, x, y, z);
+        audio_play_sound_at_location(SoundId::PlaceItem, x, y, z);
     }
 }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -774,7 +774,7 @@ static void window_new_ride_scrollmousedown(rct_window* w, int32_t scrollIndex, 
     _windowNewRideHighlightedItem[_windowNewRideCurrentTab] = item;
     w->new_ride.selected_ride_id = item.ride_type_and_entry;
 
-    audio_play_sound(SOUND_CLICK_1, 0, w->x + (w->width / 2));
+    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
     w->new_ride.selected_ride_countdown = 8;
     window_invalidate(w);
 }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -774,7 +774,7 @@ static void window_new_ride_scrollmousedown(rct_window* w, int32_t scrollIndex, 
     _windowNewRideHighlightedItem[_windowNewRideCurrentTab] = item;
     w->new_ride.selected_ride_id = item.ride_type_and_entry;
 
-    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     w->new_ride.selected_ride_countdown = 8;
     window_invalidate(w);
 }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -144,7 +144,7 @@ static void window_news_update(rct_window* w)
     }
 
     window_invalidate(w);
-    audio_play_sound(RCT2Sound::Click2, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click2, 0, w->x + (w->width / 2));
 
     j = w->news.var_480;
     w->news.var_480 = -1;
@@ -238,7 +238,7 @@ static void window_news_scrollmousedown(rct_window* w, int32_t scrollIndex, int3
         w->news.var_482 = buttonIndex;
         w->news.var_484 = 4;
         window_invalidate(w);
-        audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
+        audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     }
 }
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -144,7 +144,7 @@ static void window_news_update(rct_window* w)
     }
 
     window_invalidate(w);
-    audio_play_sound(SOUND_CLICK_2, 0, w->x + (w->width / 2));
+    audio_play_sound(RCT2Sound::Click2, 0, w->x + (w->width / 2));
 
     j = w->news.var_480;
     w->news.var_480 = -1;
@@ -238,7 +238,7 @@ static void window_news_scrollmousedown(rct_window* w, int32_t scrollIndex, int3
         w->news.var_482 = buttonIndex;
         w->news.var_484 = 4;
         window_invalidate(w);
-        audio_play_sound(SOUND_CLICK_1, 0, w->x + (w->width / 2));
+        audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
     }
 }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1828,7 +1828,7 @@ static void window_ride_construction_construct(rct_window* w)
     {
         return;
     }
-    audio_play_sound_at_location(RCT2Sound::PlaceItem, x, y, z);
+    audio_play_sound_at_location(SoundId::PlaceItem, x, y, z);
 
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -3812,7 +3812,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
                     || errorText == STR_CAN_ONLY_BUILD_THIS_ABOVE_GROUND || errorText == STR_TOO_HIGH_FOR_SUPPORTS
                     || zAttempts == 0 || z < 0)
                 {
-                    audio_play_sound(RCT2Sound::Error, 0, state->x);
+                    audio_play_sound(SoundId::Error, 0, state->x);
                     w = window_find_by_class(WC_RIDE_CONSTRUCTION);
                     if (w != nullptr)
                     {
@@ -3834,7 +3834,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
             {
                 window_close_by_class(WC_ERROR);
                 audio_play_sound_at_location(
-                    RCT2Sound::PlaceItem, _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z);
+                    SoundId::PlaceItem, _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z);
                 break;
             }
         }
@@ -3886,7 +3886,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
                 _currentTrackAlternative = saveCurrentTrackAlternative;
                 _currentTrackLiftHill = saveCurrentTrackLiftHill;
 
-                audio_play_sound(RCT2Sound::Error, 0, state->x);
+                audio_play_sound(SoundId::Error, 0, state->x);
                 break;
             }
             else if (zAttempts >= 0)
@@ -3925,7 +3925,7 @@ static void ride_construction_tooldown_entrance_exit(int32_t screenX, int32_t sc
         if (result->Error != GA_ERROR::OK)
             return;
 
-        audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+        audio_play_sound_at_location(SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
         Ride* ride = get_ride(gRideEntranceExitPlaceRideIndex);
         if (ride_are_all_possible_entrances_and_exits_built(ride))

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1828,7 +1828,7 @@ static void window_ride_construction_construct(rct_window* w)
     {
         return;
     }
-    audio_play_sound_at_location(SOUND_PLACE_ITEM, x, y, z);
+    audio_play_sound_at_location(RCT2Sound::PlaceItem, x, y, z);
 
     if (network_get_mode() != NETWORK_MODE_NONE)
     {
@@ -3812,7 +3812,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
                     || errorText == STR_CAN_ONLY_BUILD_THIS_ABOVE_GROUND || errorText == STR_TOO_HIGH_FOR_SUPPORTS
                     || zAttempts == 0 || z < 0)
                 {
-                    audio_play_sound(SOUND_ERROR, 0, state->x);
+                    audio_play_sound(RCT2Sound::Error, 0, state->x);
                     w = window_find_by_class(WC_RIDE_CONSTRUCTION);
                     if (w != nullptr)
                     {
@@ -3834,7 +3834,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
             {
                 window_close_by_class(WC_ERROR);
                 audio_play_sound_at_location(
-                    SOUND_PLACE_ITEM, _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z);
+                    RCT2Sound::PlaceItem, _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z);
                 break;
             }
         }
@@ -3886,7 +3886,7 @@ void ride_construction_tooldown_construct(int32_t screenX, int32_t screenY)
                 _currentTrackAlternative = saveCurrentTrackAlternative;
                 _currentTrackLiftHill = saveCurrentTrackLiftHill;
 
-                audio_play_sound(SOUND_ERROR, 0, state->x);
+                audio_play_sound(RCT2Sound::Error, 0, state->x);
                 break;
             }
             else if (zAttempts >= 0)
@@ -3925,7 +3925,7 @@ static void ride_construction_tooldown_entrance_exit(int32_t screenX, int32_t sc
         if (result->Error != GA_ERROR::OK)
             return;
 
-        audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+        audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
 
         Ride* ride = get_ride(gRideEntranceExitPlaceRideIndex);
         if (ride_are_all_possible_entrances_and_exits_built(ride))

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -889,7 +889,7 @@ void window_scenery_scrollmousedown(rct_window* w, int32_t scrollIndex, int32_t 
 
     gWindowSceneryPaintEnabled &= 0xFE;
     gWindowSceneryEyedropperEnabled = false;
-    audio_play_sound(4, 0, w->x + (w->width / 2));
+    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
     w->scenery.hover_counter = -16;
     gSceneryPlaceCost = MONEY32_UNDEFINED;
     window_invalidate(w);
@@ -1375,7 +1375,7 @@ bool window_scenery_set_selected_item(int32_t sceneryId)
             gWindowSceneryActiveTabIndex = tabIndex;
             gWindowSceneryTabSelections[tabIndex] = sceneryId;
 
-            audio_play_sound(SOUND_CLICK_1, 0, context_get_width() / 2);
+            audio_play_sound(RCT2Sound::Click1, 0, context_get_width() / 2);
             w->scenery.hover_counter = -16;
             gSceneryPlaceCost = MONEY32_UNDEFINED;
             window_invalidate(w);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -889,7 +889,7 @@ void window_scenery_scrollmousedown(rct_window* w, int32_t scrollIndex, int32_t 
 
     gWindowSceneryPaintEnabled &= 0xFE;
     gWindowSceneryEyedropperEnabled = false;
-    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     w->scenery.hover_counter = -16;
     gSceneryPlaceCost = MONEY32_UNDEFINED;
     window_invalidate(w);
@@ -1375,7 +1375,7 @@ bool window_scenery_set_selected_item(int32_t sceneryId)
             gWindowSceneryActiveTabIndex = tabIndex;
             gWindowSceneryTabSelections[tabIndex] = sceneryId;
 
-            audio_play_sound(RCT2Sound::Click1, 0, context_get_width() / 2);
+            audio_play_sound(SoundId::Click1, 0, context_get_width() / 2);
             w->scenery.hover_counter = -16;
             gSceneryPlaceCost = MONEY32_UNDEFINED;
             window_invalidate(w);

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -340,7 +340,7 @@ static void window_scenarioselect_scrollmousedown(rct_window* w, int32_t scrollI
                 y -= scenarioItemHeight;
                 if (y < 0 && !listItem.scenario.is_locked)
                 {
-                    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
+                    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
                     gFirstTimeSaving = true;
                     _callback(listItem.scenario.scenario->path);
                     if (_titleEditor)

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -340,7 +340,7 @@ static void window_scenarioselect_scrollmousedown(rct_window* w, int32_t scrollI
                 y -= scenarioItemHeight;
                 if (y < 0 && !listItem.scenario.is_locked)
                 {
-                    audio_play_sound(SOUND_CLICK_1, 0, w->x + (w->width / 2));
+                    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
                     gFirstTimeSaving = true;
                     _callback(listItem.scenario.scenario->path);
                     if (_titleEditor)

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1794,7 +1794,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                         if (result->Error == GA_ERROR::OK)
                         {
                             audio_play_sound_at_location(
-                                RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                                SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                         }
                     });
                     auto res = GameActions::Execute(&smallSceneryPlaceAction);
@@ -1823,7 +1823,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 {
                     return;
                 }
-                audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             });
             auto res = GameActions::Execute(&footpathSceneryPlaceAction);
             break;
@@ -1871,7 +1871,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 if (result->Error == GA_ERROR::OK)
                 {
                     audio_play_sound_at_location(
-                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                        SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                 }
             });
             auto res = GameActions::Execute(&wallPlaceAction);
@@ -1922,11 +1922,11 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 if (result->Error == GA_ERROR::OK)
                 {
                     audio_play_sound_at_location(
-                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                        SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                 }
                 else
                 {
-                    audio_play_sound_at_location(RCT2Sound::Error, loc.x, loc.y, gSceneryPlaceZ);
+                    audio_play_sound_at_location(SoundId::Error, loc.x, loc.y, gSceneryPlaceZ);
                 }
             });
             auto res = GameActions::Execute(&sceneryPlaceAction);
@@ -1950,7 +1950,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 if (result->Error == GA_ERROR::OK)
                 {
                     audio_play_sound_at_location(
-                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                        SoundId::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                     context_open_detail_window(WD_BANNER, bannerIndex);
                 }
             });

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1794,7 +1794,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                         if (result->Error == GA_ERROR::OK)
                         {
                             audio_play_sound_at_location(
-                                SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                                RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                         }
                     });
                     auto res = GameActions::Execute(&smallSceneryPlaceAction);
@@ -1823,7 +1823,8 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 {
                     return;
                 }
-                audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(
+                    RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             });
             auto res = GameActions::Execute(&footpathSceneryPlaceAction);
             break;
@@ -1870,7 +1871,8 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
             wallPlaceAction.SetCallback([](const GameAction* ga, const GameActionResult* result) {
                 if (result->Error == GA_ERROR::OK)
                 {
-                    audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                    audio_play_sound_at_location(
+                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                 }
             });
             auto res = GameActions::Execute(&wallPlaceAction);
@@ -1920,11 +1922,12 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
             sceneryPlaceAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
                 if (result->Error == GA_ERROR::OK)
                 {
-                    audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                    audio_play_sound_at_location(
+                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                 }
                 else
                 {
-                    audio_play_sound_at_location(SOUND_ERROR, loc.x, loc.y, gSceneryPlaceZ);
+                    audio_play_sound_at_location(RCT2Sound::Error, loc.x, loc.y, gSceneryPlaceZ);
                 }
             });
             auto res = GameActions::Execute(&sceneryPlaceAction);
@@ -1947,7 +1950,8 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
             bannerPlaceAction.SetCallback([=](const GameAction* ga, const GameActionResult* result) {
                 if (result->Error == GA_ERROR::OK)
                 {
-                    audio_play_sound_at_location(SOUND_PLACE_ITEM, result->Position.x, result->Position.y, result->Position.z);
+                    audio_play_sound_at_location(
+                        RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
                     context_open_detail_window(WD_BANNER, bannerIndex);
                 }
             });

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1823,8 +1823,7 @@ static void window_top_toolbar_scenery_tool_down(int16_t x, int16_t y, rct_windo
                 {
                     return;
                 }
-                audio_play_sound_at_location(
-                    RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
+                audio_play_sound_at_location(RCT2Sound::PlaceItem, result->Position.x, result->Position.y, result->Position.z);
             });
             auto res = GameActions::Execute(&footpathSceneryPlaceAction);
             break;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -341,7 +341,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
         if (cost != MONEY32_UNDEFINED)
         {
             window_close_by_class(WC_ERROR);
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, mapX, mapY, mapZ);
+            audio_play_sound_at_location(SoundId::PlaceItem, mapX, mapY, mapZ);
 
             _currentRideIndex = rideIndex;
             if (track_design_are_entrance_and_exit_placed())
@@ -368,7 +368,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
     }
 
     // Unable to build track
-    audio_play_sound_at_location(RCT2Sound::Error, mapX, mapY, mapZ);
+    audio_play_sound_at_location(SoundId::Error, mapX, mapY, mapZ);
 }
 
 /**

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -341,7 +341,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
         if (cost != MONEY32_UNDEFINED)
         {
             window_close_by_class(WC_ERROR);
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, mapX, mapY, mapZ);
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, mapX, mapY, mapZ);
 
             _currentRideIndex = rideIndex;
             if (track_design_are_entrance_and_exit_placed())
@@ -368,7 +368,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
     }
 
     // Unable to build track
-    audio_play_sound_at_location(SOUND_ERROR, mapX, mapY, mapZ);
+    audio_play_sound_at_location(RCT2Sound::Error, mapX, mapY, mapZ);
 }
 
 /**

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -247,7 +247,7 @@ static void window_track_list_select(rct_window* w, int32_t listIndex)
         return;
     }
 
-    audio_play_sound(SOUND_CLICK_1, 0, w->x + (w->width / 2));
+    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         if (listIndex == 0)

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -247,7 +247,7 @@ static void window_track_list_select(rct_window* w, int32_t listIndex)
         return;
     }
 
-    audio_play_sound(RCT2Sound::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         if (listIndex == 0)

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -108,8 +108,7 @@ void intro_update()
                 }
 
                 // Play long peep scream sound
-                _soundChannel = Mixer_Play_Effect(
-                    RCT2Sound::Scream1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
+                _soundChannel = Mixer_Play_Effect(RCT2Sound::Scream1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
 
                 gIntroState++;
                 _introStateCounter = 0;

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -55,7 +55,7 @@ void intro_update()
             _introStateCounter = -580;
 
             // Play the chain lift sound
-            _soundChannel = Mixer_Play_Effect(RCT2Sound::LiftBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.5f, 1, true);
+            _soundChannel = Mixer_Play_Effect(SoundId::LiftBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.5f, 1, true);
             _chainLiftFinished = false;
             gIntroState++;
             break;
@@ -94,7 +94,7 @@ void intro_update()
 
                 // Play the track friction sound
                 _soundChannel = Mixer_Play_Effect(
-                    RCT2Sound::TrackFrictionBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.25f, 0.75, true);
+                    SoundId::TrackFrictionBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.25f, 0.75, true);
             }
 
             // Check if logo is off the screen...ish
@@ -108,7 +108,7 @@ void intro_update()
                 }
 
                 // Play long peep scream sound
-                _soundChannel = Mixer_Play_Effect(RCT2Sound::Scream1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
+                _soundChannel = Mixer_Play_Effect(SoundId::Scream1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
 
                 gIntroState++;
                 _introStateCounter = 0;

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -55,7 +55,7 @@ void intro_update()
             _introStateCounter = -580;
 
             // Play the chain lift sound
-            _soundChannel = Mixer_Play_Effect(SOUND_LIFT_BM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.5f, 1, true);
+            _soundChannel = Mixer_Play_Effect(RCT2Sound::LiftBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.5f, 1, true);
             _chainLiftFinished = false;
             gIntroState++;
             break;
@@ -94,7 +94,7 @@ void intro_update()
 
                 // Play the track friction sound
                 _soundChannel = Mixer_Play_Effect(
-                    SOUND_TRACK_FRICTION_BM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.25f, 0.75, true);
+                    RCT2Sound::TrackFrictionBM, MIXER_LOOP_INFINITE, MIXER_VOLUME_MAX, 0.25f, 0.75, true);
             }
 
             // Check if logo is off the screen...ish
@@ -108,7 +108,8 @@ void intro_update()
                 }
 
                 // Play long peep scream sound
-                _soundChannel = Mixer_Play_Effect(SOUND_SCREAM_1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
+                _soundChannel = Mixer_Play_Effect(
+                    RCT2Sound::Scream1, MIXER_LOOP_NONE, MIXER_VOLUME_MAX, 0.5f, 1, false);
 
                 gIntroState++;
                 _introStateCounter = 0;

--- a/src/openrct2/actions/LandLowerAction.hpp
+++ b/src/openrct2/actions/LandLowerAction.hpp
@@ -88,7 +88,8 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(
+                RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t maxHeight = map_get_highest_land_height(

--- a/src/openrct2/actions/LandLowerAction.hpp
+++ b/src/openrct2/actions/LandLowerAction.hpp
@@ -88,8 +88,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(
-                RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t maxHeight = map_get_highest_land_height(

--- a/src/openrct2/actions/LandLowerAction.hpp
+++ b/src/openrct2/actions/LandLowerAction.hpp
@@ -88,7 +88,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(SoundId::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t maxHeight = map_get_highest_land_height(

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -89,7 +89,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(SoundId::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t minHeight = map_get_lowest_land_height(

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -89,7 +89,8 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(
+                RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t minHeight = map_get_lowest_land_height(

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -89,8 +89,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(
-                RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, tile_element_height(_coords.x, _coords.y));
         }
 
         uint8_t minHeight = map_get_lowest_land_height(

--- a/src/openrct2/actions/LandSetRightsAction.hpp
+++ b/src/openrct2/actions/LandSetRightsAction.hpp
@@ -123,7 +123,7 @@ private:
         if (isExecuting)
         {
             map_count_remaining_land_rights();
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, centre.x, centre.y, centre.z);
+            audio_play_sound_at_location(SoundId::PlaceItem, centre.x, centre.y, centre.z);
         }
         return res;
     }

--- a/src/openrct2/actions/LandSetRightsAction.hpp
+++ b/src/openrct2/actions/LandSetRightsAction.hpp
@@ -123,7 +123,7 @@ private:
         if (isExecuting)
         {
             map_count_remaining_land_rights();
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, centre.x, centre.y, centre.z);
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, centre.x, centre.y, centre.z);
         }
         return res;
     }

--- a/src/openrct2/actions/LandSmoothAction.hpp
+++ b/src/openrct2/actions/LandSmoothAction.hpp
@@ -633,7 +633,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(SOUND_PLACE_ITEM, _coords.x, _coords.y, centreZ);
+            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, centreZ);
         }
         res->Cost += result->Cost;
         return res;

--- a/src/openrct2/actions/LandSmoothAction.hpp
+++ b/src/openrct2/actions/LandSmoothAction.hpp
@@ -633,7 +633,7 @@ private:
 
         if (isExecuting)
         {
-            audio_play_sound_at_location(RCT2Sound::PlaceItem, _coords.x, _coords.y, centreZ);
+            audio_play_sound_at_location(SoundId::PlaceItem, _coords.x, _coords.y, centreZ);
         }
         res->Cost += result->Cost;
         return res;

--- a/src/openrct2/actions/WaterLowerAction.hpp
+++ b/src/openrct2/actions/WaterLowerAction.hpp
@@ -111,7 +111,7 @@ private:
 
         if (isExecuting && hasChanged)
         {
-            audio_play_sound_at_location(RCT2Sound::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
+            audio_play_sound_at_location(SoundId::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
         }
         // Force ride construction to recheck area
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_RECHECK;

--- a/src/openrct2/actions/WaterLowerAction.hpp
+++ b/src/openrct2/actions/WaterLowerAction.hpp
@@ -111,7 +111,7 @@ private:
 
         if (isExecuting && hasChanged)
         {
-            audio_play_sound_at_location(SOUND_LAYING_OUT_WATER, res->Position.x, res->Position.y, res->Position.z);
+            audio_play_sound_at_location(RCT2Sound::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
         }
         // Force ride construction to recheck area
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_RECHECK;

--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -119,7 +119,7 @@ private:
 
         if (isExecuting && hasChanged)
         {
-            audio_play_sound_at_location(SOUND_LAYING_OUT_WATER, res->Position.x, res->Position.y, res->Position.z);
+            audio_play_sound_at_location(RCT2Sound::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
         }
         // Force ride construction to recheck area
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_RECHECK;

--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -119,7 +119,7 @@ private:
 
         if (isExecuting && hasChanged)
         {
-            audio_play_sound_at_location(RCT2Sound::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
+            audio_play_sound_at_location(SoundId::LayingOutWater, res->Position.x, res->Position.y, res->Position.z);
         }
         // Force ride construction to recheck area
         _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_RECHECK;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -125,7 +125,7 @@ static int32_t SoundVolumeAdjust[RCT2SoundCount] =
 };
 // clang-format on
 
-AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ16* location);
+AudioParams audio_get_params_from_location(SoundId soundId, const LocationXYZ16* location);
 
 void audio_init()
 {
@@ -180,7 +180,7 @@ void audio_populate_devices()
     }
 }
 
-void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16_t z)
+void audio_play_sound_at_location(SoundId soundId, int16_t x, int16_t y, int16_t z)
 {
     if (gGameSoundsOff)
         return;
@@ -203,7 +203,7 @@ void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16
  * @param location The location at which the sound effect is to be played.
  * @return The audio parameters to be used when playing this sound effect.
  */
-AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ16* location)
+AudioParams audio_get_params_from_location(SoundId soundId, const LocationXYZ16* location)
 {
     int32_t volumeDown = 0;
     AudioParams params;
@@ -242,7 +242,7 @@ AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ1
     return params;
 }
 
-void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan)
+void audio_play_sound(SoundId soundId, int32_t volume, int32_t pan)
 {
     if (gGameSoundsOff)
         return;
@@ -434,11 +434,11 @@ void audio_stop_vehicle_sounds()
         if (vehicleSound.id != SOUND_ID_NULL)
         {
             vehicleSound.id = SOUND_ID_NULL;
-            if (vehicleSound.sound1_id != RCT2Sound::Null)
+            if (vehicleSound.sound1_id != SoundId::Null)
             {
                 Mixer_Stop_Channel(vehicleSound.sound1_channel);
             }
-            if (vehicleSound.sound2_id != RCT2Sound::Null)
+            if (vehicleSound.sound2_id != SoundId::Null)
             {
                 Mixer_Stop_Channel(vehicleSound.sound2_channel);
             }

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -228,7 +228,8 @@ AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ1
             int16_t vy = pos2.y - viewport->view_y;
             int16_t vx = pos2.x - viewport->view_x;
             params.pan = viewport->x + (vx >> viewport->zoom);
-            params.volume = SoundVolumeAdjust[static_cast<uint32_t>(soundId)] + ((-1024 * viewport->zoom - 1) * (1 << volumeDown)) + 1;
+            params.volume = SoundVolumeAdjust[static_cast<uint8_t>(soundId)]
+                + ((-1024 * viewport->zoom - 1) * (1 << volumeDown)) + 1;
 
             if (vy < 0 || vy >= viewport->view_height || vx < 0 || vx >= viewport->view_width || params.volume < -10000)
             {

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -57,75 +57,75 @@ rct_vehicle_sound_params gVehicleSoundParamsList[AUDIO_MAX_VEHICLE_SOUNDS];
 rct_vehicle_sound_params* gVehicleSoundParamsListEnd;
 
 // clang-format off
-static int32_t SoundVolumeAdjust[SOUND_MAXID] =
+static int32_t SoundVolumeAdjust[RCT2SoundCount] =
 {
-    0,      // SOUND_LIFT_CLASSIC
-    0,      // SOUND_TRACK_FRICTION_CLASSIC_WOOD
-    0,      // SOUND_FRICTION_CLASSIC
-    0,      // SOUND_SCREAM_1
-    0,      // SOUND_CLICK_1
-    0,      // SOUND_CLICK_2
-    0,      // SOUND_PLACE_ITEM
-    0,      // SOUND_SCREAM_2
-    0,      // SOUND_SCREAM_3
-    0,      // SOUND_SCREAM_4
-    0,      // SOUND_SCREAM_5
-    0,      // SOUND_SCREAM_6
-    0,      // SOUND_LIFT_FRICTION_WHEELS
-    -400,   // SOUND_PURCHASE
-    0,      // SOUND_CRASH
-    0,      // SOUND_LAYING_OUT_WATER
-    0,      // SOUND_WATER_1
-    0,      // SOUND_WATER_2
-    0,      // SOUND_TRAIN_WHISTLE
-    0,      // SOUND_TRAIN_DEPARTING
-    -1000,  // SOUND_WATER_SPLASH
-    0,      // SOUND_GO_KART_ENGINE
-    -800,   // SOUND_RIDE_LAUNCH_1
-    -1700,  // SOUND_RIDE_LAUNCH_2
-    -700,   // SOUND_COUGH_1
-    -700,   // SOUND_COUGH_2
-    -700,   // SOUND_COUGH_3
-    -700,   // SOUND_COUGH_4
-    0,      // SOUND_RAIN
-    0,      // SOUND_THUNDER_1
-    0,      // SOUND_THUNDER_2
-    0,      // SOUND_TRACK_FRICTION_TRAIN
-    0,      // SOUND_TRACK_FRICTION_WATER
-    0,      // SOUND_BALLOON_POP
-    -700,   // SOUND_MECHANIC_FIX
-    0,      // SOUND_SCREAM_7
-    -2500,  // SOUND_TOILET_FLUSH original value: -1000
-    0,      // SOUND_CLICK_3
-    0,      // SOUND_QUACK
-    0,      // SOUND_NEWS_ITEM
-    0,      // SOUND_WINDOW_OPEN
-    -900,   // SOUND_LAUGH_1
-    -900,   // SOUND_LAUGH_2
-    -900,   // SOUND_LAUGH_3
-    0,      // SOUND_APPLAUSE
-    -600,   // SOUND_HAUNTED_HOUSE_SCARE
-    -700,   // SOUND_HAUNTED_HOUSE_SCREAM_1
-    -700,   // SOUND_HAUNTED_HOUSE_SCREAM_2
-    -2550,  // SOUND_BLOCK_BRAKE_CLOSE
-    -2900,  // SOUND_BLOCK_BRAKE_RELEASE
-    0,      // SOUND_ERROR
-    -3400,  // SOUND_BRAKE_RELEASE
-    0,      // SOUND_LIFT_ARROW
-    0,      // SOUND_LIFT_WOOD
-    0,      // SOUND_TRACK_FRICTION_WOOD
-    0,      // SOUND_LIFT_WILD_MOUSE
-    0,      // SOUND_LIFT_BM
-    0,      // SOUND_TRACK_FRICTION_BM
-    0,      // SOUND_SCREAM_8
-    0,      // SOUND_TRAM
-    -2000,  // SOUND_DOOR_OPEN
-    -2700,  // SOUND_DOOR_CLOSE
-    -700    // SOUND_PORTCULLIS
+    0,      // LiftClassic
+    0,      // TrackFrictionClassicWood
+    0,      // FrictionClassic
+    0,      // Scream1
+    0,      // Click1
+    0,      // Click2
+    0,      // PlaceItem
+    0,      // Scream2
+    0,      // Scream3
+    0,      // Scream4
+    0,      // Scream5
+    0,      // Scream6
+    0,      // LiftFrictionWheels
+    -400,   // Purchase
+    0,      // Crash
+    0,      // LayingOutWater
+    0,      // Water1
+    0,      // Water2
+    0,      // TrainWhistle
+    0,      // TrainDeparting
+    -1000,  // WaterSplash
+    0,      // GoKartEngine
+    -800,   // RideLaunch1
+    -1700,  // RideLaunch2
+    -700,   // Cough1
+    -700,   // Cough2
+    -700,   // Cough3
+    -700,   // Cough4
+    0,      // Rain
+    0,      // Thunder1
+    0,      // Thunder2
+    0,      // TrackFrictionTrain
+    0,      // TrackFrictionWater
+    0,      // BalloonPop
+    -700,   // MechanicFix
+    0,      // Scream7
+    -2500,  // ToiletFlush original value: -1000
+    0,      // Click3
+    0,      // Quack
+    0,      // NewsItem
+    0,      // WindowOpen
+    -900,   // Laugh1
+    -900,   // Laugh2
+    -900,   // Laugh3
+    0,      // Applause
+    -600,   // HauntedHouseScare
+    -700,   // HauntedHouseScream1
+    -700,   // HauntedHouseScream2
+    -2550,  // BlockBrakeClose
+    -2900,  // BlockBrakeRelease
+    0,      // Error
+    -3400,  // BrakeRelease
+    0,      // LiftArrow
+    0,      // LiftWood
+    0,      // TrackFrictionWood
+    0,      // LiftWildMouse
+    0,      // LiftBM
+    0,      // TrackFrictionBM
+    0,      // Scream8
+    0,      // Tram
+    -2000,  // DoorOpen
+    -2700,  // DoorClose
+    -700    // Portcullis
 };
 // clang-format on
 
-AudioParams audio_get_params_from_location(int32_t soundId, const LocationXYZ16* location);
+AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ16* location);
 
 void audio_init()
 {
@@ -180,10 +180,10 @@ void audio_populate_devices()
     }
 }
 
-int32_t audio_play_sound_at_location(int32_t soundId, int16_t x, int16_t y, int16_t z)
+void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16_t z)
 {
     if (gGameSoundsOff)
-        return 0;
+        return;
 
     LocationXYZ16 location;
     location.x = x;
@@ -193,9 +193,8 @@ int32_t audio_play_sound_at_location(int32_t soundId, int16_t x, int16_t y, int1
     AudioParams params = audio_get_params_from_location(soundId, &location);
     if (params.in_range)
     {
-        soundId = audio_play_sound(soundId, params.volume, params.pan);
+        audio_play_sound(soundId, params.volume, params.pan);
     }
-    return soundId;
 }
 
 /**
@@ -204,7 +203,7 @@ int32_t audio_play_sound_at_location(int32_t soundId, int16_t x, int16_t y, int1
  * @param location The location at which the sound effect is to be played.
  * @return The audio parameters to be used when playing this sound effect.
  */
-AudioParams audio_get_params_from_location(int32_t soundId, const LocationXYZ16* location)
+AudioParams audio_get_params_from_location(RCT2Sound soundId, const LocationXYZ16* location)
 {
     int32_t volumeDown = 0;
     AudioParams params;
@@ -229,7 +228,7 @@ AudioParams audio_get_params_from_location(int32_t soundId, const LocationXYZ16*
             int16_t vy = pos2.y - viewport->view_y;
             int16_t vx = pos2.x - viewport->view_x;
             params.pan = viewport->x + (vx >> viewport->zoom);
-            params.volume = SoundVolumeAdjust[soundId] + ((-1024 * viewport->zoom - 1) * (1 << volumeDown)) + 1;
+            params.volume = SoundVolumeAdjust[static_cast<uint32_t>(soundId)] + ((-1024 * viewport->zoom - 1) * (1 << volumeDown)) + 1;
 
             if (vy < 0 || vy >= viewport->view_height || vx < 0 || vx >= viewport->view_width || params.volume < -10000)
             {
@@ -242,10 +241,10 @@ AudioParams audio_get_params_from_location(int32_t soundId, const LocationXYZ16*
     return params;
 }
 
-int32_t audio_play_sound(int32_t soundId, int32_t volume, int32_t pan)
+void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan)
 {
     if (gGameSoundsOff)
-        return 0;
+        return;
 
     int32_t mixerPan = 0;
     if (pan != AUDIO_PLAY_AT_CENTRE)
@@ -256,7 +255,6 @@ int32_t audio_play_sound(int32_t soundId, int32_t volume, int32_t pan)
     }
 
     Mixer_Play_Effect(soundId, MIXER_LOOP_NONE, DStoMixerVolume(volume), DStoMixerPan(mixerPan), 1, 1);
-    return 0;
 }
 
 void audio_start_title_music()
@@ -435,11 +433,11 @@ void audio_stop_vehicle_sounds()
         if (vehicleSound.id != SOUND_ID_NULL)
         {
             vehicleSound.id = SOUND_ID_NULL;
-            if (vehicleSound.sound1_id != SOUND_ID_NULL)
+            if (vehicleSound.sound1_id != RCT2Sound::Null)
             {
                 Mixer_Stop_Channel(vehicleSound.sound1_channel);
             }
-            if (vehicleSound.sound2_id != SOUND_ID_NULL)
+            if (vehicleSound.sound2_id != RCT2Sound::Null)
             {
                 Mixer_Stop_Channel(vehicleSound.sound2_channel);
             }

--- a/src/openrct2/audio/AudioMixer.cpp
+++ b/src/openrct2/audio/AudioMixer.cpp
@@ -37,12 +37,12 @@ void Mixer_Init(const char* device)
     audioContext->SetOutputDevice(std::string(device));
 }
 
-void* Mixer_Play_Effect(size_t id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone)
+void* Mixer_Play_Effect(RCT2Sound id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone)
 {
     IAudioChannel* channel = nullptr;
     if (gConfigSound.sound_enabled)
     {
-        if (id >= SOUND_MAXID)
+        if (static_cast<uint32_t>(id) >= RCT2SoundCount)
         {
             log_error("Tried to play an invalid sound id. %i", id);
         }
@@ -52,7 +52,7 @@ void* Mixer_Play_Effect(size_t id, int32_t loop, int32_t volume, float pan, doub
             if (mixer != nullptr)
             {
                 mixer->Lock();
-                IAudioSource* source = mixer->GetSoundSource((int32_t)id);
+                IAudioSource* source = mixer->GetSoundSource(id);
                 channel = mixer->Play(source, loop, deleteondone != 0, false);
                 if (channel != nullptr)
                 {

--- a/src/openrct2/audio/AudioMixer.cpp
+++ b/src/openrct2/audio/AudioMixer.cpp
@@ -37,7 +37,7 @@ void Mixer_Init(const char* device)
     audioContext->SetOutputDevice(std::string(device));
 }
 
-void* Mixer_Play_Effect(RCT2Sound id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone)
+void* Mixer_Play_Effect(SoundId id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone)
 {
     IAudioChannel* channel = nullptr;
     if (gConfigSound.sound_enabled)

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -15,7 +15,7 @@
 #define MIXER_LOOP_NONE 0
 #define MIXER_LOOP_INFINITE (-1)
 
-enum class RCT2Sound : uint8_t;
+enum class SoundId : uint8_t;
 
 enum MIXER_GROUP
 {
@@ -45,7 +45,7 @@ namespace OpenRCT2::Audio
         virtual bool LoadMusic(size_t pathid) abstract;
         virtual void SetVolume(float volume) abstract;
 
-        virtual IAudioSource* GetSoundSource(RCT2Sound id) abstract;
+        virtual IAudioSource* GetSoundSource(SoundId id) abstract;
         virtual IAudioSource* GetMusicSource(int32_t id) abstract;
     };
 } // namespace OpenRCT2::Audio
@@ -58,7 +58,7 @@ namespace OpenRCT2::Audio
 #endif
 
 void Mixer_Init(const char* device);
-void* Mixer_Play_Effect(RCT2Sound id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone);
+void* Mixer_Play_Effect(SoundId id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone);
 void Mixer_Stop_Channel(void* channel);
 void Mixer_Channel_Volume(void* channel, int32_t volume);
 void Mixer_Channel_Pan(void* channel, float pan);

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -10,13 +10,12 @@
 #pragma once
 
 #include "../common.h"
-#include "audio.h"
 
 #define MIXER_VOLUME_MAX 128
 #define MIXER_LOOP_NONE 0
 #define MIXER_LOOP_INFINITE (-1)
 
-enum class RCT_SOUND : uint32_t;
+enum class RCT2Sound : uint8_t;
 
 enum MIXER_GROUP
 {

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -10,10 +10,13 @@
 #pragma once
 
 #include "../common.h"
+#include "audio.h"
 
 #define MIXER_VOLUME_MAX 128
 #define MIXER_LOOP_NONE 0
 #define MIXER_LOOP_INFINITE (-1)
+
+enum class RCT_SOUND : uint32_t;
 
 enum MIXER_GROUP
 {
@@ -43,7 +46,7 @@ namespace OpenRCT2::Audio
         virtual bool LoadMusic(size_t pathid) abstract;
         virtual void SetVolume(float volume) abstract;
 
-        virtual IAudioSource* GetSoundSource(int32_t id) abstract;
+        virtual IAudioSource* GetSoundSource(RCT2Sound id) abstract;
         virtual IAudioSource* GetMusicSource(int32_t id) abstract;
     };
 } // namespace OpenRCT2::Audio
@@ -56,7 +59,7 @@ namespace OpenRCT2::Audio
 #endif
 
 void Mixer_Init(const char* device);
-void* Mixer_Play_Effect(size_t id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone);
+void* Mixer_Play_Effect(RCT2Sound id, int32_t loop, int32_t volume, float pan, double rate, int32_t deleteondone);
 void Mixer_Stop_Channel(void* channel);
 void Mixer_Channel_Volume(void* channel, int32_t volume);
 void Mixer_Channel_Pan(void* channel, float pan);

--- a/src/openrct2/audio/NullAudioSource.cpp
+++ b/src/openrct2/audio/NullAudioSource.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "AudioSource.h"
+#include "audio.h"
 
 namespace OpenRCT2::Audio
 {

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -20,7 +20,7 @@
 #define AUDIO_PLAY_AT_LOCATION 0x8001
 #define SOUND_ID_NULL 0xFFFF
 
-enum class RCT2Sound : uint8_t;
+enum class SoundId : uint8_t;
 
 struct audio_device
 {
@@ -58,11 +58,11 @@ struct rct_vehicle_sound
 {
     uint16_t id;
     int16_t volume;
-    RCT2Sound sound1_id;
+    SoundId sound1_id;
     int16_t sound1_volume;
     int16_t sound1_pan;
     uint16_t sound1_freq;
-    RCT2Sound sound2_id;
+    SoundId sound2_id;
     int16_t sound2_volume;
     int16_t sound2_pan;
     uint16_t sound2_freq;
@@ -80,7 +80,7 @@ struct rct_vehicle_sound_params
     uint16_t priority;
 };
 
-enum class RCT2Sound : uint8_t
+enum class SoundId : uint8_t
 {
     LiftClassic,
     TrackFrictionClassicWood,
@@ -149,7 +149,7 @@ enum class RCT2Sound : uint8_t
     Null = 255
 };
 
-constexpr uint8_t RCT2SoundCount = static_cast<uint32_t>(RCT2Sound::Portcullis) + 1;
+constexpr uint8_t RCT2SoundCount = static_cast<uint32_t>(SoundId::Portcullis) + 1;
 
 extern audio_device* gAudioDevices;
 extern int32_t gAudioDeviceCount;
@@ -201,7 +201,7 @@ void audio_pause_sounds();
  * @param pan The pan at which the sound effect should be played. If set to anything other than AUDIO_PLAY_AT_CENTRE, plays the
  * sound at a position relative to the centre of the viewport.
  */
-void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan);
+void audio_play_sound(SoundId soundId, int32_t volume, int32_t pan);
 /**
  * Plays the specified sound at a virtual location.
  * @param soundId The sound effect to play.
@@ -209,7 +209,7 @@ void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan);
  * @param y The y coordinate of the location.
  * @param z The z coordinate of the location.
  */
-void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16_t z);
+void audio_play_sound_at_location(SoundId soundId, int16_t x, int16_t y, int16_t z);
 /**
  * Populates the gAudioDevices array with the available audio devices.
  */

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -20,6 +20,8 @@
 #define AUDIO_PLAY_AT_LOCATION 0x8001
 #define SOUND_ID_NULL 0xFFFF
 
+enum class RCT2Sound : uint8_t;
+
 struct audio_device
 {
     char name[AUDIO_DEVICE_NAME_SIZE];
@@ -56,11 +58,11 @@ struct rct_vehicle_sound
 {
     uint16_t id;
     int16_t volume;
-    uint16_t sound1_id;
+    RCT2Sound sound1_id;
     int16_t sound1_volume;
     int16_t sound1_pan;
     uint16_t sound1_freq;
-    uint16_t sound2_id;
+    RCT2Sound sound2_id;
     int16_t sound2_volume;
     int16_t sound2_pan;
     uint16_t sound2_freq;
@@ -78,73 +80,76 @@ struct rct_vehicle_sound_params
     uint16_t priority;
 };
 
-enum RCT2_SOUND
+enum class RCT2Sound : uint8_t
 {
-    SOUND_LIFT_CLASSIC,
-    SOUND_TRACK_FRICTION_CLASSIC_WOOD,
-    SOUND_FRICTION_CLASSIC,
-    SOUND_SCREAM_1,
-    SOUND_CLICK_1,
-    SOUND_CLICK_2,
-    SOUND_PLACE_ITEM,
-    SOUND_SCREAM_2,
-    SOUND_SCREAM_3,
-    SOUND_SCREAM_4,
-    SOUND_SCREAM_5,
-    SOUND_SCREAM_6,
-    SOUND_LIFT_FRICTION_WHEELS,
-    SOUND_PURCHASE,
-    SOUND_CRASH,
-    SOUND_LAYING_OUT_WATER,
-    SOUND_WATER_1,
-    SOUND_WATER_2,
-    SOUND_TRAIN_WHISTLE,
-    SOUND_TRAIN_DEPARTING,
-    SOUND_WATER_SPLASH,
-    SOUND_GO_KART_ENGINE,
-    SOUND_RIDE_LAUNCH_1,
-    SOUND_RIDE_LAUNCH_2,
-    SOUND_COUGH_1,
-    SOUND_COUGH_2,
-    SOUND_COUGH_3,
-    SOUND_COUGH_4,
-    SOUND_RAIN,
-    SOUND_THUNDER_1,
-    SOUND_THUNDER_2,
-    SOUND_TRACK_FRICTION_TRAIN,
-    SOUND_TRACK_FRICTION_WATER,
-    SOUND_BALLOON_POP,
-    SOUND_MECHANIC_FIX,
-    SOUND_SCREAM_7,
-    SOUND_TOILET_FLUSH,
-    SOUND_CLICK_3,
-    SOUND_QUACK,
-    SOUND_NEWS_ITEM,
-    SOUND_WINDOW_OPEN,
-    SOUND_LAUGH_1,
-    SOUND_LAUGH_2,
-    SOUND_LAUGH_3,
-    SOUND_APPLAUSE,
-    SOUND_HAUNTED_HOUSE_SCARE,
-    SOUND_HAUNTED_HOUSE_SCREAM_1,
-    SOUND_HAUNTED_HOUSE_SCREAM_2,
-    SOUND_BLOCK_BRAKE_CLOSE,
-    SOUND_BLOCK_BRAKE_RELEASE,
-    SOUND_ERROR,
-    SOUND_BRAKE_RELEASE,
-    SOUND_LIFT_ARROW,
-    SOUND_LIFT_WOOD,
-    SOUND_TRACK_FRICTION_WOOD,
-    SOUND_LIFT_WILD_MOUSE,
-    SOUND_LIFT_BM,
-    SOUND_TRACK_FRICTION_BM,
-    SOUND_SCREAM_8,
-    SOUND_TRAM,
-    SOUND_DOOR_OPEN,
-    SOUND_DOOR_CLOSE,
-    SOUND_PORTCULLIS,
-    SOUND_MAXID
+    LiftClassic,
+    TrackFrictionClassicWood,
+    FrictionClassic,
+    Scream1,
+    Click1,
+    Click2,
+    PlaceItem,
+    Scream2,
+    Scream3,
+    Scream4,
+    Scream5,
+    Scream6,
+    LiftFrictionWheels,
+    Purchase,
+    Crash,
+    LayingOutWater,
+    Water1,
+    Water2,
+    TrainWhistle,
+    TrainDeparting,
+    WaterSplash,
+    GoKartEngine,
+    RideLaunch1,
+    RideLaunch2,
+    Cough1,
+    Cough2,
+    Cough3,
+    Cough4,
+    Rain,
+    Thunder1,
+    Thunder2,
+    TrackFrictionTrain,
+    TrackFrictionWater,
+    BalloonPop,
+    MechanicFix,
+    Scream7,
+    ToiletFlush,
+    Click3,
+    Quack,
+    NewsItem,
+    WindowOpen,
+    Laugh1,
+    Laugh2,
+    Laugh3,
+    Applause,
+    HauntedHouseScare,
+    HauntedHouseScream1,
+    HauntedHouseScream2,
+    BlockBrakeClose,
+    BlockBrakeRelease,
+    Error,
+    BrakeRelease,
+    LiftArrow,
+    LiftWood,
+    TrackFrictionWood,
+    LiftWildMouse,
+    LiftBM,
+    TrackFrictionBM,
+    Scream8,
+    Tram,
+    DoorOpen,
+    DoorClose,
+    Portcullis,
+    NoScream = 254,
+    Null = 255
 };
+
+constexpr uint8_t RCT2SoundCount = static_cast<uint32_t>(RCT2Sound::Portcullis) + 1;
 
 extern audio_device* gAudioDevices;
 extern int32_t gAudioDeviceCount;
@@ -195,18 +200,18 @@ void audio_pause_sounds();
  * @param volume The volume at which the sound effect should be played.
  * @param pan The pan at which the sound effect should be played. If set to anything other than AUDIO_PLAY_AT_CENTRE, plays the
  * sound at a position relative to the centre of the viewport.
- * @return 0 if the sound was not out of range; otherwise, soundId.
+ * 
  */
-int32_t audio_play_sound(int32_t soundId, int32_t volume, int32_t pan);
+void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan);
 /**
  * Plays the specified sound at a virtual location.
  * @param soundId The sound effect to play.
  * @param x The x coordinate of the location.
  * @param y The y coordinate of the location.
  * @param z The z coordinate of the location.
- * @return 0 if the sound was not out of range; otherwise, soundId.
+ * 
  */
-int32_t audio_play_sound_at_location(int32_t soundId, int16_t x, int16_t y, int16_t z);
+void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16_t z);
 /**
  * Populates the gAudioDevices array with the available audio devices.
  */

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -200,7 +200,6 @@ void audio_pause_sounds();
  * @param volume The volume at which the sound effect should be played.
  * @param pan The pan at which the sound effect should be played. If set to anything other than AUDIO_PLAY_AT_CENTRE, plays the
  * sound at a position relative to the centre of the viewport.
- * 
  */
 void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan);
 /**
@@ -209,7 +208,6 @@ void audio_play_sound(RCT2Sound soundId, int32_t volume, int32_t pan);
  * @param x The x coordinate of the location.
  * @param y The y coordinate of the location.
  * @param z The z coordinate of the location.
- * 
  */
 void audio_play_sound_at_location(RCT2Sound soundId, int16_t x, int16_t y, int16_t z);
 /**

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -235,7 +235,7 @@ void chat_history_add(const char* src)
 
     free(buffer);
 
-    Mixer_Play_Effect(RCT2Sound::NewsItem, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
+    Mixer_Play_Effect(SoundId::NewsItem, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
 }
 
 void chat_input(CHAT_INPUT input)

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -235,7 +235,7 @@ void chat_history_add(const char* src)
 
     free(buffer);
 
-    Mixer_Play_Effect(SOUND_NEWS_ITEM, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
+    Mixer_Play_Effect(RCT2Sound::NewsItem, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
 }
 
 void chat_input(CHAT_INPUT input)

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -80,7 +80,7 @@ void screenshot_check()
 
             if (!screenshotPath.empty())
             {
-                audio_play_sound(SOUND_WINDOW_OPEN, 100, context_get_width() / 2);
+                audio_play_sound(RCT2Sound::WindowOpen, 100, context_get_width() / 2);
             }
             else
             {

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -80,7 +80,7 @@ void screenshot_check()
 
             if (!screenshotPath.empty())
             {
-                audio_play_sound(RCT2Sound::WindowOpen, 100, context_get_width() / 2);
+                audio_play_sound(SoundId::WindowOpen, 100, context_get_width() / 2);
             }
             else
             {

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -100,7 +100,7 @@ static void news_item_tick_current()
     if (ticks == 1 && (gScreenFlags == SCREEN_FLAGS_PLAYING))
     {
         // Play sound
-        audio_play_sound(RCT2Sound::NewsItem, 0, context_get_width() / 2);
+        audio_play_sound(SoundId::NewsItem, 0, context_get_width() / 2);
     }
 }
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -100,7 +100,7 @@ static void news_item_tick_current()
     if (ticks == 1 && (gScreenFlags == SCREEN_FLAGS_PLAYING))
     {
         // Play sound
-        audio_play_sound(SOUND_NEWS_ITEM, 0, context_get_width() / 2);
+        audio_play_sound(RCT2Sound::NewsItem, 0, context_get_width() / 2);
     }
 }
 

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -12,6 +12,7 @@
 #include "RideObject.h"
 
 #include "../OpenRCT2.h"
+#include "../audio/audio.h"
 #include "../core/IStream.hpp"
 #include "../core/Memory.hpp"
 #include "../core/String.hpp"
@@ -22,7 +23,6 @@
 #include "../ride/RideGroupManager.h"
 #include "../ride/ShopItem.h"
 #include "../ride/Track.h"
-#include "../audio/audio.h"
 #include "ObjectJsonHelpers.h"
 #include "ObjectRepository.h"
 

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -443,7 +443,7 @@ void RideObject::ReadLegacyVehicle(
     vehicle->no_seating_rows = stream->ReadValue<uint8_t>();
     vehicle->spinning_inertia = stream->ReadValue<uint8_t>();
     vehicle->spinning_friction = stream->ReadValue<uint8_t>();
-    vehicle->friction_sound_id = stream->ReadValue<RCT2Sound>();
+    vehicle->friction_sound_id = stream->ReadValue<SoundId>();
     vehicle->log_flume_reverser_vehicle_type = stream->ReadValue<uint8_t>();
     vehicle->sound_range = stream->ReadValue<uint8_t>();
     vehicle->double_sound_frequency = stream->ReadValue<uint8_t>();
@@ -577,7 +577,7 @@ void RideObject::ReadJson(IReadObjectContext* context, const json_t* root)
         car.sprite_height_positive = 1;
         car.flags = VEHICLE_ENTRY_FLAG_SPINNING;
         car.car_visual = VEHICLE_VISUAL_FLAT_RIDE_OR_CAR_RIDE;
-        car.friction_sound_id = RCT2Sound::Null;
+        car.friction_sound_id = SoundId::Null;
         car.sound_range = 0xFF;
         car.draw_order = 6;
 
@@ -764,7 +764,7 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(const json_t* jCar)
     car.no_seating_rows = ObjectJsonHelpers::GetInteger(jCar, "numSeatRows");
     car.spinning_inertia = ObjectJsonHelpers::GetInteger(jCar, "spinningInertia");
     car.spinning_friction = ObjectJsonHelpers::GetInteger(jCar, "spinningFriction");
-    car.friction_sound_id = static_cast<RCT2Sound>(ObjectJsonHelpers::GetInteger(jCar, "frictionSoundId", 255));
+    car.friction_sound_id = static_cast<SoundId>(ObjectJsonHelpers::GetInteger(jCar, "frictionSoundId", 255));
     car.log_flume_reverser_vehicle_type = ObjectJsonHelpers::GetInteger(jCar, "logFlumeReverserVehicleType");
     car.sound_range = ObjectJsonHelpers::GetInteger(jCar, "soundRange", 255);
     car.double_sound_frequency = ObjectJsonHelpers::GetInteger(jCar, "doubleSoundFrequency");

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -22,6 +22,7 @@
 #include "../ride/RideGroupManager.h"
 #include "../ride/ShopItem.h"
 #include "../ride/Track.h"
+#include "../audio/audio.h"
 #include "ObjectJsonHelpers.h"
 #include "ObjectRepository.h"
 
@@ -442,7 +443,7 @@ void RideObject::ReadLegacyVehicle(
     vehicle->no_seating_rows = stream->ReadValue<uint8_t>();
     vehicle->spinning_inertia = stream->ReadValue<uint8_t>();
     vehicle->spinning_friction = stream->ReadValue<uint8_t>();
-    vehicle->friction_sound_id = stream->ReadValue<uint8_t>();
+    vehicle->friction_sound_id = stream->ReadValue<RCT2Sound>();
     vehicle->log_flume_reverser_vehicle_type = stream->ReadValue<uint8_t>();
     vehicle->sound_range = stream->ReadValue<uint8_t>();
     vehicle->double_sound_frequency = stream->ReadValue<uint8_t>();
@@ -576,7 +577,7 @@ void RideObject::ReadJson(IReadObjectContext* context, const json_t* root)
         car.sprite_height_positive = 1;
         car.flags = VEHICLE_ENTRY_FLAG_SPINNING;
         car.car_visual = VEHICLE_VISUAL_FLAT_RIDE_OR_CAR_RIDE;
-        car.friction_sound_id = 0xFF;
+        car.friction_sound_id = RCT2Sound::Null;
         car.sound_range = 0xFF;
         car.draw_order = 6;
 
@@ -763,7 +764,7 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(const json_t* jCar)
     car.no_seating_rows = ObjectJsonHelpers::GetInteger(jCar, "numSeatRows");
     car.spinning_inertia = ObjectJsonHelpers::GetInteger(jCar, "spinningInertia");
     car.spinning_friction = ObjectJsonHelpers::GetInteger(jCar, "spinningFriction");
-    car.friction_sound_id = ObjectJsonHelpers::GetInteger(jCar, "frictionSoundId", 255);
+    car.friction_sound_id = static_cast<RCT2Sound>(ObjectJsonHelpers::GetInteger(jCar, "frictionSoundId", 255));
     car.log_flume_reverser_vehicle_type = ObjectJsonHelpers::GetInteger(jCar, "logFlumeReverserVehicleType");
     car.sound_range = ObjectJsonHelpers::GetInteger(jCar, "soundRange", 255);
     car.double_sound_frequency = ObjectJsonHelpers::GetInteger(jCar, "doubleSoundFrequency");

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -709,7 +709,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
         {
             if (state == PEEP_STATE_WALKING || state == PEEP_STATE_SITTING)
             {
-                audio_play_sound_at_location(SOUND_CRASH, x, y, z);
+                audio_play_sound_at_location(RCT2Sound::Crash, x, y, z);
 
                 sprite_misc_explosion_cloud_create(x, y, z + 16);
                 sprite_misc_explosion_flare_create(x, y, z + 16);
@@ -1819,10 +1819,15 @@ void Guest::OnExitRide(ride_id_t rideIndex)
     {
         InsertNewThought(PEEP_THOUGHT_TYPE_WAS_GREAT, rideIndex);
 
-        int32_t laugh = scenario_rand() & 7;
-        if (laugh < 3)
+        RCT2Sound laughs[3] = {
+            RCT2Sound::Laugh1,
+            RCT2Sound::Laugh2,
+            RCT2Sound::Laugh3
+        };
+        int32_t laughType = scenario_rand() & 7;
+        if (laughType < 3)
         {
-            audio_play_sound_at_location(SOUND_LAUGH_1 + laugh, x, y, z);
+            audio_play_sound_at_location(laughs[laughType], x, y, z);
         }
     }
 
@@ -2364,7 +2369,7 @@ void Guest::SpendMoney(money16& peep_expend_type, money32 amount)
         }
     }
 
-    audio_play_sound_at_location(SOUND_PURCHASE, x, y, z);
+    audio_play_sound_at_location(RCT2Sound::Purchase, x, y, z);
 }
 
 void Guest::SetHasRidden(Ride* ride)
@@ -5253,7 +5258,7 @@ void Guest::UpdateRideShopInteract()
     // Do not play toilet flush sound on title screen as it's considered loud and annoying
     if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
     {
-        audio_play_sound_at_location(SOUND_TOILET_FLUSH, x, y, z);
+        audio_play_sound_at_location(RCT2Sound::ToiletFlush, x, y, z);
     }
 
     sub_state = PEEP_SHOP_LEAVE;
@@ -7040,7 +7045,7 @@ void Guest::UpdateSpriteType()
             if ((scenario_rand() & 0xFFFF) <= 13107)
             {
                 isBalloonPopped = true;
-                audio_play_sound_at_location(SOUND_BALLOON_POP, x, y, z);
+                audio_play_sound_at_location(RCT2Sound::BalloonPop, x, y, z);
             }
             create_balloon(x, y, z + 9, balloon_colour, isBalloonPopped);
         }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1819,11 +1819,7 @@ void Guest::OnExitRide(ride_id_t rideIndex)
     {
         InsertNewThought(PEEP_THOUGHT_TYPE_WAS_GREAT, rideIndex);
 
-        RCT2Sound laughs[3] = {
-            RCT2Sound::Laugh1,
-            RCT2Sound::Laugh2,
-            RCT2Sound::Laugh3
-        };
+        RCT2Sound laughs[3] = { RCT2Sound::Laugh1, RCT2Sound::Laugh2, RCT2Sound::Laugh3 };
         int32_t laughType = scenario_rand() & 7;
         if (laughType < 3)
         {

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -709,7 +709,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
         {
             if (state == PEEP_STATE_WALKING || state == PEEP_STATE_SITTING)
             {
-                audio_play_sound_at_location(RCT2Sound::Crash, x, y, z);
+                audio_play_sound_at_location(SoundId::Crash, x, y, z);
 
                 sprite_misc_explosion_cloud_create(x, y, z + 16);
                 sprite_misc_explosion_flare_create(x, y, z + 16);
@@ -1819,7 +1819,7 @@ void Guest::OnExitRide(ride_id_t rideIndex)
     {
         InsertNewThought(PEEP_THOUGHT_TYPE_WAS_GREAT, rideIndex);
 
-        RCT2Sound laughs[3] = { RCT2Sound::Laugh1, RCT2Sound::Laugh2, RCT2Sound::Laugh3 };
+        SoundId laughs[3] = { SoundId::Laugh1, SoundId::Laugh2, SoundId::Laugh3 };
         int32_t laughType = scenario_rand() & 7;
         if (laughType < 3)
         {
@@ -2365,7 +2365,7 @@ void Guest::SpendMoney(money16& peep_expend_type, money32 amount)
         }
     }
 
-    audio_play_sound_at_location(RCT2Sound::Purchase, x, y, z);
+    audio_play_sound_at_location(SoundId::Purchase, x, y, z);
 }
 
 void Guest::SetHasRidden(Ride* ride)
@@ -5254,7 +5254,7 @@ void Guest::UpdateRideShopInteract()
     // Do not play toilet flush sound on title screen as it's considered loud and annoying
     if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
     {
-        audio_play_sound_at_location(RCT2Sound::ToiletFlush, x, y, z);
+        audio_play_sound_at_location(SoundId::ToiletFlush, x, y, z);
     }
 
     sub_state = PEEP_SHOP_LEAVE;
@@ -7041,7 +7041,7 @@ void Guest::UpdateSpriteType()
             if ((scenario_rand() & 0xFFFF) <= 13107)
             {
                 isBalloonPopped = true;
-                audio_play_sound_at_location(RCT2Sound::BalloonPop, x, y, z);
+                audio_play_sound_at_location(SoundId::BalloonPop, x, y, z);
             }
             create_balloon(x, y, z + 9, balloon_colour, isBalloonPopped);
         }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -673,8 +673,14 @@ bool Peep::UpdateAction(int16_t* actionX, int16_t* actionY, int16_t* xy_distance
     // Create sick at location
     litter_create(x, y, z, sprite_direction, (sprite_index & 1) ? LITTER_TYPE_SICK_ALT : LITTER_TYPE_SICK);
 
-    int32_t sound_id = SOUND_COUGH_1 + (scenario_rand() & 3);
-    audio_play_sound_at_location(sound_id, x, y, z);
+    RCT2Sound coughs[4] = {
+        RCT2Sound::Cough1,
+        RCT2Sound::Cough2,
+        RCT2Sound::Cough3,
+        RCT2Sound::Cough4
+    };
+    auto soundId = coughs[scenario_rand() & 3];
+    audio_play_sound_at_location(soundId, x, y, z);
 
     Invalidate();
     *actionX = x;
@@ -1481,7 +1487,7 @@ void peep_applause()
     }
 
     // Play applause noise
-    audio_play_sound(SOUND_APPLAUSE, 0, context_get_width() / 2);
+    audio_play_sound(RCT2Sound::Applause, 0, context_get_width() / 2);
 }
 
 /**

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -673,12 +673,7 @@ bool Peep::UpdateAction(int16_t* actionX, int16_t* actionY, int16_t* xy_distance
     // Create sick at location
     litter_create(x, y, z, sprite_direction, (sprite_index & 1) ? LITTER_TYPE_SICK_ALT : LITTER_TYPE_SICK);
 
-    RCT2Sound coughs[4] = {
-        RCT2Sound::Cough1,
-        RCT2Sound::Cough2,
-        RCT2Sound::Cough3,
-        RCT2Sound::Cough4
-    };
+    RCT2Sound coughs[4] = { RCT2Sound::Cough1, RCT2Sound::Cough2, RCT2Sound::Cough3, RCT2Sound::Cough4 };
     auto soundId = coughs[scenario_rand() & 3];
     audio_play_sound_at_location(soundId, x, y, z);
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -673,7 +673,7 @@ bool Peep::UpdateAction(int16_t* actionX, int16_t* actionY, int16_t* xy_distance
     // Create sick at location
     litter_create(x, y, z, sprite_direction, (sprite_index & 1) ? LITTER_TYPE_SICK_ALT : LITTER_TYPE_SICK);
 
-    RCT2Sound coughs[4] = { RCT2Sound::Cough1, RCT2Sound::Cough2, RCT2Sound::Cough3, RCT2Sound::Cough4 };
+    SoundId coughs[4] = { SoundId::Cough1, SoundId::Cough2, SoundId::Cough3, SoundId::Cough4 };
     auto soundId = coughs[scenario_rand() & 3];
     audio_play_sound_at_location(soundId, x, y, z);
 
@@ -1482,7 +1482,7 @@ void peep_applause()
     }
 
     // Play applause noise
-    audio_play_sound(RCT2Sound::Applause, 0, context_get_width() / 2);
+    audio_play_sound(SoundId::Applause, 0, context_get_width() / 2);
 }
 
 /**

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2592,7 +2592,7 @@ bool Staff::UpdateFixingFixStationBrakes(bool firstRun, Ride* ride)
 
     if (action_frame == 0x13 || action_frame == 0x19 || action_frame == 0x1F || action_frame == 0x25 || action_frame == 0x2B)
     {
-        audio_play_sound_at_location(RCT2Sound::MechanicFix, x, y, z);
+        audio_play_sound_at_location(SoundId::MechanicFix, x, y, z);
     }
 
     return false;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2592,7 +2592,7 @@ bool Staff::UpdateFixingFixStationBrakes(bool firstRun, Ride* ride)
 
     if (action_frame == 0x13 || action_frame == 0x19 || action_frame == 0x1F || action_frame == 0x25 || action_frame == 0x2B)
     {
-        audio_play_sound_at_location(SOUND_MECHANIC_FIX, x, y, z);
+        audio_play_sound_at_location(RCT2Sound::MechanicFix, x, y, z);
     }
 
     return false;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1218,8 +1218,8 @@ private:
         dst->sound_vector_factor = src->sound_vector_factor;
         dst->spin_speed = src->spin_speed;
         dst->sound2_flags = src->sound2_flags;
-        dst->sound1_id = RCT12_SOUND_ID_NULL;
-        dst->sound2_id = RCT12_SOUND_ID_NULL;
+        dst->sound1_id = RCT2Sound::Null;
+        dst->sound2_id = RCT2Sound::Null;
         dst->var_C0 = src->var_C0;
         dst->var_C4 = src->var_C4;
         dst->animation_frame = src->animation_frame;
@@ -1227,7 +1227,7 @@ private:
         dst->var_CA = src->var_CA;
         dst->var_CE = src->var_CE;
         dst->var_D3 = src->var_D3;
-        dst->scream_sound_id = 255;
+        dst->scream_sound_id = RCT2Sound::Null;
         dst->vehicle_sprite_type = src->vehicle_sprite_type;
         dst->bank_rotation = src->bank_rotation;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1218,8 +1218,8 @@ private:
         dst->sound_vector_factor = src->sound_vector_factor;
         dst->spin_speed = src->spin_speed;
         dst->sound2_flags = src->sound2_flags;
-        dst->sound1_id = RCT2Sound::Null;
-        dst->sound2_id = RCT2Sound::Null;
+        dst->sound1_id = SoundId::Null;
+        dst->sound2_id = SoundId::Null;
         dst->var_C0 = src->var_C0;
         dst->var_C4 = src->var_C4;
         dst->animation_frame = src->animation_frame;
@@ -1227,7 +1227,7 @@ private:
         dst->var_CA = src->var_CA;
         dst->var_CE = src->var_CE;
         dst->var_D3 = src->var_D3;
-        dst->scream_sound_id = RCT2Sound::Null;
+        dst->scream_sound_id = SoundId::Null;
         dst->vehicle_sprite_type = src->vehicle_sprite_type;
         dst->bank_rotation = src->bank_rotation;
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -918,9 +918,9 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const rct_vehicle* 
     dst->crash_x = src->crash_x;
     dst->sound2_flags = src->sound2_flags;
     dst->spin_sprite = src->spin_sprite;
-    dst->sound1_id = src->sound1_id;
+    dst->sound1_id = static_cast<uint8_t>(src->sound1_id);
     dst->sound1_volume = src->sound1_volume;
-    dst->sound2_id = src->sound2_id;
+    dst->sound2_id = static_cast<uint8_t>(src->sound2_id);
     dst->sound2_volume = src->sound2_volume;
     dst->sound_vector_factor = src->sound_vector_factor;
     dst->time_waiting = src->time_waiting;
@@ -930,7 +930,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const rct_vehicle* 
     dst->animation_frame = src->animation_frame;
     dst->var_C8 = src->var_C8;
     dst->var_CA = src->var_CA;
-    dst->scream_sound_id = src->scream_sound_id;
+    dst->scream_sound_id = static_cast<uint8_t>(src->scream_sound_id);
     dst->var_CD = src->var_CD;
     dst->var_CE = src->var_CE;
     dst->var_CF = src->var_CF;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1183,9 +1183,9 @@ public:
         dst->crash_x = src->crash_x;
         dst->sound2_flags = src->sound2_flags;
         dst->spin_sprite = src->spin_sprite;
-        dst->sound1_id = static_cast<RCT2Sound>(src->sound1_id);
+        dst->sound1_id = static_cast<SoundId>(src->sound1_id);
         dst->sound1_volume = src->sound1_volume;
-        dst->sound2_id = static_cast<RCT2Sound>(src->sound2_id);
+        dst->sound2_id = static_cast<SoundId>(src->sound2_id);
         dst->sound2_volume = src->sound2_volume;
         dst->sound_vector_factor = src->sound_vector_factor;
         dst->time_waiting = src->time_waiting;
@@ -1195,7 +1195,7 @@ public:
         dst->animation_frame = src->animation_frame;
         dst->var_C8 = src->var_C8;
         dst->var_CA = src->var_CA;
-        dst->scream_sound_id = static_cast<RCT2Sound>(src->scream_sound_id);
+        dst->scream_sound_id = static_cast<SoundId>(src->scream_sound_id);
         dst->var_CD = src->var_CD;
         dst->var_CE = src->var_CE;
         dst->var_CF = src->var_CF;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1183,9 +1183,9 @@ public:
         dst->crash_x = src->crash_x;
         dst->sound2_flags = src->sound2_flags;
         dst->spin_sprite = src->spin_sprite;
-        dst->sound1_id = src->sound1_id;
+        dst->sound1_id = static_cast<RCT2Sound>(src->sound1_id);
         dst->sound1_volume = src->sound1_volume;
-        dst->sound2_id = src->sound2_id;
+        dst->sound2_id = static_cast<RCT2Sound>(src->sound2_id);
         dst->sound2_volume = src->sound2_volume;
         dst->sound_vector_factor = src->sound_vector_factor;
         dst->time_waiting = src->time_waiting;
@@ -1195,7 +1195,7 @@ public:
         dst->animation_frame = src->animation_frame;
         dst->var_C8 = src->var_C8;
         dst->var_CA = src->var_CA;
-        dst->scream_sound_id = src->scream_sound_id;
+        dst->scream_sound_id = static_cast<RCT2Sound>(src->scream_sound_id);
         dst->var_CD = src->var_CD;
         dst->var_CE = src->var_CE;
         dst->var_CF = src->var_CF;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -9,10 +9,10 @@
 
 #include "CableLift.h"
 
+#include "../audio/audio.h"
 #include "../rct12/RCT12.h"
 #include "../util/Util.h"
 #include "../world/Sprite.h"
-#include "../audio/audio.h"
 #include "Ride.h"
 #include "RideData.h"
 #include "Track.h"

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -12,6 +12,7 @@
 #include "../rct12/RCT12.h"
 #include "../util/Util.h"
 #include "../world/Sprite.h"
+#include "../audio/audio.h"
 #include "Ride.h"
 #include "RideData.h"
 #include "Track.h"
@@ -58,13 +59,13 @@ rct_vehicle* cable_lift_segment_create(
     current->spin_sprite = 0;
     current->spin_speed = 0;
     current->sound2_flags = 0;
-    current->sound1_id = RCT12_SOUND_ID_NULL;
-    current->sound2_id = RCT12_SOUND_ID_NULL;
+    current->sound1_id = RCT2Sound::Null;
+    current->sound2_id = RCT2Sound::Null;
     current->var_C4 = 0;
     current->animation_frame = 0;
     current->var_C8 = 0;
     current->var_CA = 0;
-    current->scream_sound_id = 0xFF;
+    current->scream_sound_id = RCT2Sound::Null;
     current->vehicle_sprite_type = 0;
     current->bank_rotation = 0;
     for (auto& peep : current->peep)

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -59,13 +59,13 @@ rct_vehicle* cable_lift_segment_create(
     current->spin_sprite = 0;
     current->spin_speed = 0;
     current->sound2_flags = 0;
-    current->sound1_id = RCT2Sound::Null;
-    current->sound2_id = RCT2Sound::Null;
+    current->sound1_id = SoundId::Null;
+    current->sound2_id = SoundId::Null;
     current->var_C4 = 0;
     current->animation_frame = 0;
     current->var_C8 = 0;
     current->var_CA = 0;
-    current->scream_sound_id = RCT2Sound::Null;
+    current->scream_sound_id = SoundId::Null;
     current->vehicle_sprite_type = 0;
     current->bank_rotation = 0;
     for (auto& peep : current->peep)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4515,13 +4515,13 @@ static rct_vehicle* vehicle_create_car(
     vehicle->spin_sprite = 0;
     vehicle->spin_speed = 0;
     vehicle->sound2_flags = 0;
-    vehicle->sound1_id = RCT2Sound::Null;
-    vehicle->sound2_id = RCT2Sound::Null;
+    vehicle->sound1_id = SoundId::Null;
+    vehicle->sound2_id = SoundId::Null;
     vehicle->next_vehicle_on_train = SPRITE_INDEX_NULL;
     vehicle->var_C4 = 0;
     vehicle->animation_frame = 0;
     vehicle->var_C8 = 0;
-    vehicle->scream_sound_id = RCT2Sound::Null;
+    vehicle->scream_sound_id = SoundId::Null;
     vehicle->vehicle_sprite_type = 0;
     vehicle->bank_rotation = 0;
     vehicle->target_seat_rotation = 4;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4515,13 +4515,13 @@ static rct_vehicle* vehicle_create_car(
     vehicle->spin_sprite = 0;
     vehicle->spin_speed = 0;
     vehicle->sound2_flags = 0;
-    vehicle->sound1_id = RCT12_SOUND_ID_NULL;
-    vehicle->sound2_id = RCT12_SOUND_ID_NULL;
+    vehicle->sound1_id = RCT2Sound::Null;
+    vehicle->sound2_id = RCT2Sound::Null;
     vehicle->next_vehicle_on_train = SPRITE_INDEX_NULL;
     vehicle->var_C4 = 0;
     vehicle->animation_frame = 0;
     vehicle->var_C8 = 0;
-    vehicle->scream_sound_id = 255;
+    vehicle->scream_sound_id = RCT2Sound::Null;
     vehicle->vehicle_sprite_type = 0;
     vehicle->bank_rotation = 0;
     vehicle->target_seat_rotation = 4;

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -1423,7 +1423,7 @@ const rct_ride_entry_vehicle CableLiftVehicle = {
     /* .no_seating_rows = */ 0,
     /* .spinning_inertia = */ 0,
     /* .spinning_friction = */ 255,
-    /* .friction_sound_id = */ 0,
+    /* .friction_sound_id = */ RCT2Sound::LiftClassic,
     /* .log_flume_reverser_vehicle_type = */ 0,
     /* .sound_range = */ 0,
     /* .double_sound_frequency = */ 0,
@@ -1450,97 +1450,97 @@ const uint16_t RideCrookedHouseLength[1] = {
 
 /* rct2: 0x0097D7C8, 0x0097D7C9, 0x0097D7CA */
 const rct_ride_lift_data RideLiftData[] = {
-    { SOUND_LIFT_FRICTION_WHEELS, 7, 7 }, // Spiral Roller coaster
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Stand Up Coaster
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Suspended Swinging
-    { SOUND_LIFT_BM, 5, 7 }, // Inverted
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 6 }, // Steel Mini Coaster
-    { 255,          5, 5 }, // Mini Railway
-    { 255,          5, 5 }, // Monorail
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 5 }, // Mini Suspended Coaster
-    { 255,          5, 5 }, // Boat Hire
-    { SOUND_LIFT_CLASSIC, 4, 5 }, // Wooden Wild Mine/Mouse
-    { SOUND_LIFT_CLASSIC, 4, 5 }, // Steeplechase/Motorbike/Soap Box D
-    { 255,          5, 5 }, // Car Ride
-    { 255,          5, 5 }, // Launched Freefall
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 5 }, // Bobsleigh Coaster
-    { 255,          5, 5 }, // Observation Tower
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Looping Roller Coaster
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 5 }, // Dinghy Slide
-    { SOUND_LIFT_ARROW, 4, 6 }, // Mine Train Coaster
-    { 255,          5, 5 }, // Chairlift
-    { SOUND_LIFT_ARROW, 4, 6 }, // Corkscrew Roller Coaster
-    { 255,          5, 5 }, // Maze
-    { 255,          5, 5 }, // Spiral Slide
-    { 255,          5, 5 }, // Go Karts
-    { 255,          5, 5 }, // Log Flume
-    { 255,          5, 5 }, // River Rapids
-    { 255,          5, 5 }, // Dodgems
-    { 255,          5, 5 }, // Pirate Ship
-    { 255,          5, 5 }, // Swinging Inverter Ship
-    { 255,          5, 5 }, // Food Stall
-    { 255,          5, 5 }, // (none)
-    { 255,          5, 5 }, // Drink Stall
-    { 255,          5, 5 }, // (none)
-    { 255,          5, 5 }, // Shop (all types)
-    { 255,          5, 5 }, // Merry Go Round
-    { 255,          5, 5 }, // Balloon Stall (maybe)
-    { 255,          5, 5 }, // Information Kiosk
-    { 255,          5, 5 }, // Bathroom
-    { 255,          5, 5 }, // Ferris Wheel
-    { 255,          5, 5 }, // Motion Simulator
-    { 255,          5, 5 }, // 3D Cinema
-    { 255,          5, 5 }, // Topspin
-    { 255,          5, 5 }, // Space Rings
-    { 255,          5, 5 }, // Reverse Freefall Coaster
-    { 255,          5, 5 }, // Elevator
-    { SOUND_LIFT_BM, 4, 5 }, // Vertical Drop Roller Coaster
-    { 255,          5, 5 }, // ATM
-    { 255,          5, 5 }, // Twist
-    { 255,          5, 5 }, // Haunted House
-    { 255,          5, 5 }, // First Aid
-    { 255,          5, 5 }, // Circus Show
-    { 255,          5, 5 }, // Ghost Train
-    { SOUND_LIFT_BM, 5, 8 }, // Twister Roller Coaster
-    { SOUND_LIFT_WOOD, 5, 7 }, // Wooden Roller Coaster
-    { SOUND_LIFT_WOOD, 3, 4 }, // Side-Friction Roller Coaster
-    { SOUND_LIFT_WILD_MOUSE, 4, 6 }, // Wild Mouse
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 6 }, // Multi Dimension Coaster
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 6 }, // (none)
-    { SOUND_LIFT_BM, 4, 6 }, // Flying Roller Coaster
-    { SOUND_LIFT_BM, 4, 6 }, // (none)
-    { SOUND_LIFT_CLASSIC, 3, 4 }, // Virginia Reel
-    { 255,          5, 5 }, // Splash Boats
-    { 255,          5, 5 }, // Mini Helicopters
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Lay-down Roller Coaster
-    { 255,          5, 5 }, // Suspended Monorail
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // (none)
-    { SOUND_LIFT_CLASSIC, 3, 4 }, // Reverser Roller Coaster
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Heartline Twister Roller Coaster
-    { 255,          5, 5 }, // Mini Golf
-    { SOUND_LIFT_CLASSIC, 5, 8 }, // Giga Coaster
-    { 255,          5, 5 }, // Roto-Drop
-    { 255,          5, 5 }, // Flying Saucers
-    { 255,          5, 5 }, // Crooked House
-    { 255,          5, 5 }, // Monorail Cycles
-    { SOUND_LIFT_FRICTION_WHEELS, 4, 6 }, // Compact Inverted Coaster
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Water Coaster
-    { 255,          5, 5 }, // Air Powered Vertical Coaster
-    { SOUND_LIFT_WILD_MOUSE, 4, 6 }, // Inverted Hairpin Coaster
-    { 255,          5, 5 }, // Magic Carpet
-    { 255,          5, 5 }, // Submarine Ride
-    { 255,          5, 5 }, // River Rafts
-    { 255,          5, 5 }, // (none)
-    { 255,          5, 5 }, // Enterprise
-    { 255,          5, 5 }, // (none)
-    { 255,          5, 5 }, // (none)
-    { 255,          5, 5 }, // (none)
-    { SOUND_LIFT_ARROW, 4, 7 }, // (none)
-    { SOUND_LIFT_CLASSIC, 4, 7 }, // Inverted Impulse Coaster
-    { SOUND_LIFT_CLASSIC, 4, 6 }, // Mini Roller Coaster
-    { 255,          5, 5 }, // Mine Ride
-    { SOUND_LIFT_WILD_MOUSE, 4, 6 }, // (none)
-    { 255,          4, 6 }  // LIM Launched Roller Coaster
+    { RCT2Sound::LiftFrictionWheels, 7, 7 }, // Spiral Roller coaster
+    { RCT2Sound::LiftClassic, 4, 6 }, // Stand Up Coaster
+    { RCT2Sound::LiftClassic, 4, 6 }, // Suspended Swinging
+    { RCT2Sound::LiftBM, 5, 7 }, // Inverted
+    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Steel Mini Coaster
+    { RCT2Sound::Null,          5, 5 }, // Mini Railway
+    { RCT2Sound::Null,          5, 5 }, // Monorail
+    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Mini Suspended Coaster
+    { RCT2Sound::Null,          5, 5 }, // Boat Hire
+    { RCT2Sound::LiftClassic, 4, 5 }, // Wooden Wild Mine/Mouse
+    { RCT2Sound::LiftClassic, 4, 5 }, // Steeplechase/Motorbike/Soap Box D
+    { RCT2Sound::Null,          5, 5 }, // Car Ride
+    { RCT2Sound::Null,          5, 5 }, // Launched Freefall
+    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Bobsleigh Coaster
+    { RCT2Sound::Null,          5, 5 }, // Observation Tower
+    { RCT2Sound::LiftClassic, 4, 6 }, // Looping Roller Coaster
+    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Dinghy Slide
+    { RCT2Sound::LiftArrow, 4, 6 }, // Mine Train Coaster
+    { RCT2Sound::Null,          5, 5 }, // Chairlift
+    { RCT2Sound::LiftArrow, 4, 6 }, // Corkscrew Roller Coaster
+    { RCT2Sound::Null,          5, 5 }, // Maze
+    { RCT2Sound::Null,          5, 5 }, // Spiral Slide
+    { RCT2Sound::Null,          5, 5 }, // Go Karts
+    { RCT2Sound::Null,          5, 5 }, // Log Flume
+    { RCT2Sound::Null,          5, 5 }, // River Rapids
+    { RCT2Sound::Null,          5, 5 }, // Dodgems
+    { RCT2Sound::Null,          5, 5 }, // Pirate Ship
+    { RCT2Sound::Null,          5, 5 }, // Swinging Inverter Ship
+    { RCT2Sound::Null,          5, 5 }, // Food Stall
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::Null,          5, 5 }, // Drink Stall
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::Null,          5, 5 }, // Shop (all types)
+    { RCT2Sound::Null,          5, 5 }, // Merry Go Round
+    { RCT2Sound::Null,          5, 5 }, // Balloon Stall (maybe)
+    { RCT2Sound::Null,          5, 5 }, // Information Kiosk
+    { RCT2Sound::Null,          5, 5 }, // Bathroom
+    { RCT2Sound::Null,          5, 5 }, // Ferris Wheel
+    { RCT2Sound::Null,          5, 5 }, // Motion Simulator
+    { RCT2Sound::Null,          5, 5 }, // 3D Cinema
+    { RCT2Sound::Null,          5, 5 }, // Topspin
+    { RCT2Sound::Null,          5, 5 }, // Space Rings
+    { RCT2Sound::Null,          5, 5 }, // Reverse Freefall Coaster
+    { RCT2Sound::Null,          5, 5 }, // Elevator
+    { RCT2Sound::LiftBM, 4, 5 }, // Vertical Drop Roller Coaster
+    { RCT2Sound::Null,          5, 5 }, // ATM
+    { RCT2Sound::Null,          5, 5 }, // Twist
+    { RCT2Sound::Null,          5, 5 }, // Haunted House
+    { RCT2Sound::Null,          5, 5 }, // First Aid
+    { RCT2Sound::Null,          5, 5 }, // Circus Show
+    { RCT2Sound::Null,          5, 5 }, // Ghost Train
+    { RCT2Sound::LiftBM, 5, 8 }, // Twister Roller Coaster
+    { RCT2Sound::LiftWood, 5, 7 }, // Wooden Roller Coaster
+    { RCT2Sound::LiftWood, 3, 4 }, // Side-Friction Roller Coaster
+    { RCT2Sound::LiftWildMouse, 4, 6 }, // Wild Mouse
+    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Multi Dimension Coaster
+    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // (none)
+    { RCT2Sound::LiftBM, 4, 6 }, // Flying Roller Coaster
+    { RCT2Sound::LiftBM, 4, 6 }, // (none)
+    { RCT2Sound::LiftClassic, 3, 4 }, // Virginia Reel
+    { RCT2Sound::Null,          5, 5 }, // Splash Boats
+    { RCT2Sound::Null,          5, 5 }, // Mini Helicopters
+    { RCT2Sound::LiftClassic, 4, 6 }, // Lay-down Roller Coaster
+    { RCT2Sound::Null,          5, 5 }, // Suspended Monorail
+    { RCT2Sound::LiftClassic, 4, 6 }, // (none)
+    { RCT2Sound::LiftClassic, 3, 4 }, // Reverser Roller Coaster
+    { RCT2Sound::LiftClassic, 4, 6 }, // Heartline Twister Roller Coaster
+    { RCT2Sound::Null,          5, 5 }, // Mini Golf
+    { RCT2Sound::LiftClassic, 5, 8 }, // Giga Coaster
+    { RCT2Sound::Null,          5, 5 }, // Roto-Drop
+    { RCT2Sound::Null,          5, 5 }, // Flying Saucers
+    { RCT2Sound::Null,          5, 5 }, // Crooked House
+    { RCT2Sound::Null,          5, 5 }, // Monorail Cycles
+    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Compact Inverted Coaster
+    { RCT2Sound::LiftClassic, 4, 6 }, // Water Coaster
+    { RCT2Sound::Null,          5, 5 }, // Air Powered Vertical Coaster
+    { RCT2Sound::LiftWildMouse, 4, 6 }, // Inverted Hairpin Coaster
+    { RCT2Sound::Null,          5, 5 }, // Magic Carpet
+    { RCT2Sound::Null,          5, 5 }, // Submarine Ride
+    { RCT2Sound::Null,          5, 5 }, // River Rafts
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::Null,          5, 5 }, // Enterprise
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::Null,          5, 5 }, // (none)
+    { RCT2Sound::LiftArrow, 4, 7 }, // (none)
+    { RCT2Sound::LiftClassic, 4, 7 }, // Inverted Impulse Coaster
+    { RCT2Sound::LiftClassic, 4, 6 }, // Mini Roller Coaster
+    { RCT2Sound::Null,          5, 5 }, // Mine Ride
+    { RCT2Sound::LiftWildMouse, 4, 6 }, // (none)
+    { RCT2Sound::Null,          4, 6 }  // LIM Launched Roller Coaster
 };
 
 /** rct2: 0x0097D7CB */

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -1423,7 +1423,7 @@ const rct_ride_entry_vehicle CableLiftVehicle = {
     /* .no_seating_rows = */ 0,
     /* .spinning_inertia = */ 0,
     /* .spinning_friction = */ 255,
-    /* .friction_sound_id = */ RCT2Sound::LiftClassic,
+    /* .friction_sound_id = */ SoundId::LiftClassic,
     /* .log_flume_reverser_vehicle_type = */ 0,
     /* .sound_range = */ 0,
     /* .double_sound_frequency = */ 0,
@@ -1450,97 +1450,97 @@ const uint16_t RideCrookedHouseLength[1] = {
 
 /* rct2: 0x0097D7C8, 0x0097D7C9, 0x0097D7CA */
 const rct_ride_lift_data RideLiftData[] = {
-    { RCT2Sound::LiftFrictionWheels, 7, 7 }, // Spiral Roller coaster
-    { RCT2Sound::LiftClassic, 4, 6 }, // Stand Up Coaster
-    { RCT2Sound::LiftClassic, 4, 6 }, // Suspended Swinging
-    { RCT2Sound::LiftBM, 5, 7 }, // Inverted
-    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Steel Mini Coaster
-    { RCT2Sound::Null,          5, 5 }, // Mini Railway
-    { RCT2Sound::Null,          5, 5 }, // Monorail
-    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Mini Suspended Coaster
-    { RCT2Sound::Null,          5, 5 }, // Boat Hire
-    { RCT2Sound::LiftClassic, 4, 5 }, // Wooden Wild Mine/Mouse
-    { RCT2Sound::LiftClassic, 4, 5 }, // Steeplechase/Motorbike/Soap Box D
-    { RCT2Sound::Null,          5, 5 }, // Car Ride
-    { RCT2Sound::Null,          5, 5 }, // Launched Freefall
-    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Bobsleigh Coaster
-    { RCT2Sound::Null,          5, 5 }, // Observation Tower
-    { RCT2Sound::LiftClassic, 4, 6 }, // Looping Roller Coaster
-    { RCT2Sound::LiftFrictionWheels, 4, 5 }, // Dinghy Slide
-    { RCT2Sound::LiftArrow, 4, 6 }, // Mine Train Coaster
-    { RCT2Sound::Null,          5, 5 }, // Chairlift
-    { RCT2Sound::LiftArrow, 4, 6 }, // Corkscrew Roller Coaster
-    { RCT2Sound::Null,          5, 5 }, // Maze
-    { RCT2Sound::Null,          5, 5 }, // Spiral Slide
-    { RCT2Sound::Null,          5, 5 }, // Go Karts
-    { RCT2Sound::Null,          5, 5 }, // Log Flume
-    { RCT2Sound::Null,          5, 5 }, // River Rapids
-    { RCT2Sound::Null,          5, 5 }, // Dodgems
-    { RCT2Sound::Null,          5, 5 }, // Pirate Ship
-    { RCT2Sound::Null,          5, 5 }, // Swinging Inverter Ship
-    { RCT2Sound::Null,          5, 5 }, // Food Stall
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::Null,          5, 5 }, // Drink Stall
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::Null,          5, 5 }, // Shop (all types)
-    { RCT2Sound::Null,          5, 5 }, // Merry Go Round
-    { RCT2Sound::Null,          5, 5 }, // Balloon Stall (maybe)
-    { RCT2Sound::Null,          5, 5 }, // Information Kiosk
-    { RCT2Sound::Null,          5, 5 }, // Bathroom
-    { RCT2Sound::Null,          5, 5 }, // Ferris Wheel
-    { RCT2Sound::Null,          5, 5 }, // Motion Simulator
-    { RCT2Sound::Null,          5, 5 }, // 3D Cinema
-    { RCT2Sound::Null,          5, 5 }, // Topspin
-    { RCT2Sound::Null,          5, 5 }, // Space Rings
-    { RCT2Sound::Null,          5, 5 }, // Reverse Freefall Coaster
-    { RCT2Sound::Null,          5, 5 }, // Elevator
-    { RCT2Sound::LiftBM, 4, 5 }, // Vertical Drop Roller Coaster
-    { RCT2Sound::Null,          5, 5 }, // ATM
-    { RCT2Sound::Null,          5, 5 }, // Twist
-    { RCT2Sound::Null,          5, 5 }, // Haunted House
-    { RCT2Sound::Null,          5, 5 }, // First Aid
-    { RCT2Sound::Null,          5, 5 }, // Circus Show
-    { RCT2Sound::Null,          5, 5 }, // Ghost Train
-    { RCT2Sound::LiftBM, 5, 8 }, // Twister Roller Coaster
-    { RCT2Sound::LiftWood, 5, 7 }, // Wooden Roller Coaster
-    { RCT2Sound::LiftWood, 3, 4 }, // Side-Friction Roller Coaster
-    { RCT2Sound::LiftWildMouse, 4, 6 }, // Wild Mouse
-    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Multi Dimension Coaster
-    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // (none)
-    { RCT2Sound::LiftBM, 4, 6 }, // Flying Roller Coaster
-    { RCT2Sound::LiftBM, 4, 6 }, // (none)
-    { RCT2Sound::LiftClassic, 3, 4 }, // Virginia Reel
-    { RCT2Sound::Null,          5, 5 }, // Splash Boats
-    { RCT2Sound::Null,          5, 5 }, // Mini Helicopters
-    { RCT2Sound::LiftClassic, 4, 6 }, // Lay-down Roller Coaster
-    { RCT2Sound::Null,          5, 5 }, // Suspended Monorail
-    { RCT2Sound::LiftClassic, 4, 6 }, // (none)
-    { RCT2Sound::LiftClassic, 3, 4 }, // Reverser Roller Coaster
-    { RCT2Sound::LiftClassic, 4, 6 }, // Heartline Twister Roller Coaster
-    { RCT2Sound::Null,          5, 5 }, // Mini Golf
-    { RCT2Sound::LiftClassic, 5, 8 }, // Giga Coaster
-    { RCT2Sound::Null,          5, 5 }, // Roto-Drop
-    { RCT2Sound::Null,          5, 5 }, // Flying Saucers
-    { RCT2Sound::Null,          5, 5 }, // Crooked House
-    { RCT2Sound::Null,          5, 5 }, // Monorail Cycles
-    { RCT2Sound::LiftFrictionWheels, 4, 6 }, // Compact Inverted Coaster
-    { RCT2Sound::LiftClassic, 4, 6 }, // Water Coaster
-    { RCT2Sound::Null,          5, 5 }, // Air Powered Vertical Coaster
-    { RCT2Sound::LiftWildMouse, 4, 6 }, // Inverted Hairpin Coaster
-    { RCT2Sound::Null,          5, 5 }, // Magic Carpet
-    { RCT2Sound::Null,          5, 5 }, // Submarine Ride
-    { RCT2Sound::Null,          5, 5 }, // River Rafts
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::Null,          5, 5 }, // Enterprise
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::Null,          5, 5 }, // (none)
-    { RCT2Sound::LiftArrow, 4, 7 }, // (none)
-    { RCT2Sound::LiftClassic, 4, 7 }, // Inverted Impulse Coaster
-    { RCT2Sound::LiftClassic, 4, 6 }, // Mini Roller Coaster
-    { RCT2Sound::Null,          5, 5 }, // Mine Ride
-    { RCT2Sound::LiftWildMouse, 4, 6 }, // (none)
-    { RCT2Sound::Null,          4, 6 }  // LIM Launched Roller Coaster
+    { SoundId::LiftFrictionWheels, 7, 7 }, // Spiral Roller coaster
+    { SoundId::LiftClassic, 4, 6 }, // Stand Up Coaster
+    { SoundId::LiftClassic, 4, 6 }, // Suspended Swinging
+    { SoundId::LiftBM, 5, 7 }, // Inverted
+    { SoundId::LiftFrictionWheels, 4, 6 }, // Steel Mini Coaster
+    { SoundId::Null,          5, 5 }, // Mini Railway
+    { SoundId::Null,          5, 5 }, // Monorail
+    { SoundId::LiftFrictionWheels, 4, 5 }, // Mini Suspended Coaster
+    { SoundId::Null,          5, 5 }, // Boat Hire
+    { SoundId::LiftClassic, 4, 5 }, // Wooden Wild Mine/Mouse
+    { SoundId::LiftClassic, 4, 5 }, // Steeplechase/Motorbike/Soap Box D
+    { SoundId::Null,          5, 5 }, // Car Ride
+    { SoundId::Null,          5, 5 }, // Launched Freefall
+    { SoundId::LiftFrictionWheels, 4, 5 }, // Bobsleigh Coaster
+    { SoundId::Null,          5, 5 }, // Observation Tower
+    { SoundId::LiftClassic, 4, 6 }, // Looping Roller Coaster
+    { SoundId::LiftFrictionWheels, 4, 5 }, // Dinghy Slide
+    { SoundId::LiftArrow, 4, 6 }, // Mine Train Coaster
+    { SoundId::Null,          5, 5 }, // Chairlift
+    { SoundId::LiftArrow, 4, 6 }, // Corkscrew Roller Coaster
+    { SoundId::Null,          5, 5 }, // Maze
+    { SoundId::Null,          5, 5 }, // Spiral Slide
+    { SoundId::Null,          5, 5 }, // Go Karts
+    { SoundId::Null,          5, 5 }, // Log Flume
+    { SoundId::Null,          5, 5 }, // River Rapids
+    { SoundId::Null,          5, 5 }, // Dodgems
+    { SoundId::Null,          5, 5 }, // Pirate Ship
+    { SoundId::Null,          5, 5 }, // Swinging Inverter Ship
+    { SoundId::Null,          5, 5 }, // Food Stall
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::Null,          5, 5 }, // Drink Stall
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::Null,          5, 5 }, // Shop (all types)
+    { SoundId::Null,          5, 5 }, // Merry Go Round
+    { SoundId::Null,          5, 5 }, // Balloon Stall (maybe)
+    { SoundId::Null,          5, 5 }, // Information Kiosk
+    { SoundId::Null,          5, 5 }, // Bathroom
+    { SoundId::Null,          5, 5 }, // Ferris Wheel
+    { SoundId::Null,          5, 5 }, // Motion Simulator
+    { SoundId::Null,          5, 5 }, // 3D Cinema
+    { SoundId::Null,          5, 5 }, // Topspin
+    { SoundId::Null,          5, 5 }, // Space Rings
+    { SoundId::Null,          5, 5 }, // Reverse Freefall Coaster
+    { SoundId::Null,          5, 5 }, // Elevator
+    { SoundId::LiftBM, 4, 5 }, // Vertical Drop Roller Coaster
+    { SoundId::Null,          5, 5 }, // ATM
+    { SoundId::Null,          5, 5 }, // Twist
+    { SoundId::Null,          5, 5 }, // Haunted House
+    { SoundId::Null,          5, 5 }, // First Aid
+    { SoundId::Null,          5, 5 }, // Circus Show
+    { SoundId::Null,          5, 5 }, // Ghost Train
+    { SoundId::LiftBM, 5, 8 }, // Twister Roller Coaster
+    { SoundId::LiftWood, 5, 7 }, // Wooden Roller Coaster
+    { SoundId::LiftWood, 3, 4 }, // Side-Friction Roller Coaster
+    { SoundId::LiftWildMouse, 4, 6 }, // Wild Mouse
+    { SoundId::LiftFrictionWheels, 4, 6 }, // Multi Dimension Coaster
+    { SoundId::LiftFrictionWheels, 4, 6 }, // (none)
+    { SoundId::LiftBM, 4, 6 }, // Flying Roller Coaster
+    { SoundId::LiftBM, 4, 6 }, // (none)
+    { SoundId::LiftClassic, 3, 4 }, // Virginia Reel
+    { SoundId::Null,          5, 5 }, // Splash Boats
+    { SoundId::Null,          5, 5 }, // Mini Helicopters
+    { SoundId::LiftClassic, 4, 6 }, // Lay-down Roller Coaster
+    { SoundId::Null,          5, 5 }, // Suspended Monorail
+    { SoundId::LiftClassic, 4, 6 }, // (none)
+    { SoundId::LiftClassic, 3, 4 }, // Reverser Roller Coaster
+    { SoundId::LiftClassic, 4, 6 }, // Heartline Twister Roller Coaster
+    { SoundId::Null,          5, 5 }, // Mini Golf
+    { SoundId::LiftClassic, 5, 8 }, // Giga Coaster
+    { SoundId::Null,          5, 5 }, // Roto-Drop
+    { SoundId::Null,          5, 5 }, // Flying Saucers
+    { SoundId::Null,          5, 5 }, // Crooked House
+    { SoundId::Null,          5, 5 }, // Monorail Cycles
+    { SoundId::LiftFrictionWheels, 4, 6 }, // Compact Inverted Coaster
+    { SoundId::LiftClassic, 4, 6 }, // Water Coaster
+    { SoundId::Null,          5, 5 }, // Air Powered Vertical Coaster
+    { SoundId::LiftWildMouse, 4, 6 }, // Inverted Hairpin Coaster
+    { SoundId::Null,          5, 5 }, // Magic Carpet
+    { SoundId::Null,          5, 5 }, // Submarine Ride
+    { SoundId::Null,          5, 5 }, // River Rafts
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::Null,          5, 5 }, // Enterprise
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::Null,          5, 5 }, // (none)
+    { SoundId::LiftArrow, 4, 7 }, // (none)
+    { SoundId::LiftClassic, 4, 7 }, // Inverted Impulse Coaster
+    { SoundId::LiftClassic, 4, 6 }, // Mini Roller Coaster
+    { SoundId::Null,          5, 5 }, // Mine Ride
+    { SoundId::LiftWildMouse, 4, 6 }, // (none)
+    { SoundId::Null,          4, 6 }  // LIM Launched Roller Coaster
 };
 
 /** rct2: 0x0097D7CB */

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -80,7 +80,7 @@ struct rct_ride_data_5
 
 struct rct_ride_lift_data
 {
-    RCT2Sound sound_id;
+    SoundId sound_id;
     uint8_t minimum_speed;
     uint8_t maximum_speed;
 };

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -80,7 +80,7 @@ struct rct_ride_data_5
 
 struct rct_ride_lift_data
 {
-    uint8_t sound_id;
+    RCT2Sound sound_id;
     uint8_t minimum_speed;
     uint8_t maximum_speed;
 };

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -81,12 +81,11 @@ static bool vehicle_update_motion_collision_detection(
     rct_vehicle* vehicle, int16_t x, int16_t y, int16_t z, uint16_t* otherVehicleIndex);
 static int32_t vehicle_get_sound_priority_factor(rct_vehicle* vehicle);
 static void vehicle_update_sound(rct_vehicle* vehicle);
-static int32_t vehicle_update_scream_sound(rct_vehicle* vehicle);
+static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle);
 
 static void vehicle_kill_all_passengers(rct_vehicle* vehicle);
 static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle);
 
-#define NO_SCREAM 254
 #define VEHICLE_INVALID_ID (-1)
 
 #define VEHICLE_MAX_SPIN_SPEED 1536
@@ -109,77 +108,77 @@ rct_vehicle* _vehicleFrontVehicle;
 LocationXYZ16 unk_F64E20;
 
 // clang-format off
-static constexpr const uint8_t byte_9A3A14[] = { SOUND_SCREAM_8, SOUND_SCREAM_1 };
-static constexpr const uint8_t byte_9A3A16[] = { SOUND_SCREAM_1, SOUND_SCREAM_6 };
-static constexpr const uint8_t byte_9A3A18[] = {
-    SOUND_SCREAM_3, SOUND_SCREAM_1, SOUND_SCREAM_5, SOUND_SCREAM_6,
-    SOUND_SCREAM_7, SOUND_SCREAM_2, SOUND_SCREAM_4
+static constexpr const RCT2Sound byte_9A3A14[] = { RCT2Sound::Scream8, RCT2Sound::Scream1 };
+static constexpr const RCT2Sound byte_9A3A16[] = { RCT2Sound::Scream1, RCT2Sound::Scream6 };
+static constexpr const RCT2Sound byte_9A3A18[] = {
+    RCT2Sound::Scream3, RCT2Sound::Scream1, RCT2Sound::Scream5, RCT2Sound::Scream6,
+    RCT2Sound::Scream7, RCT2Sound::Scream2, RCT2Sound::Scream4
 };
-static constexpr const uint8_t _soundParams[SOUND_MAXID][2] =
+static constexpr const uint8_t _soundParams[RCT2SoundCount][2] =
 {
-    { 1, 0 },   // SOUND_LIFT_CLASSIC
-    { 1, 0 },   // SOUND_TRACK_FRICTION_CLASSIC_WOOD
-    { 1, 0 },   // SOUND_FRICTION_CLASSIC
-    { 0, 1 },   // SOUND_SCREAM_1
-    { 0, 0 },   // SOUND_CLICK_1
-    { 0, 0 },   // SOUND_CLICK_2
-    { 0, 0 },   // SOUND_PLACE_ITEM
-    { 0, 1 },   // SOUND_SCREAM_2
-    { 0, 1 },   // SOUND_SCREAM_3
-    { 0, 1 },   // SOUND_SCREAM_4
-    { 0, 1 },   // SOUND_SCREAM_5
-    { 0, 1 },   // SOUND_SCREAM_6
-    { 1, 0 },   // SOUND_LIFT_FRICTION_WHEELS
-    { 0, 0 },   // SOUND_PURCHASE
-    { 0, 0 },   // SOUND_CRASH
-    { 0, 0 },   // SOUND_LAYING_OUT_WATER
-    { 0, 0 },   // SOUND_WATER_1
-    { 0, 0 },   // SOUND_WATER_2
-    { 0, 1 },   // SOUND_TRAIN_WHISTLE
-    { 0, 1 },   // SOUND_TRAIN_DEPARTING
-    { 0, 0 },   // SOUND_WATER_SPLASH
-    { 1, 0 },   // SOUND_GO_KART_ENGINE
-    { 0, 0 },   // SOUND_RIDE_LAUNCH_1
-    { 0, 0 },   // SOUND_RIDE_LAUNCH_2
-    { 0, 0 },   // SOUND_COUGH_1
-    { 0, 0 },   // SOUND_COUGH_2
-    { 0, 0 },   // SOUND_COUGH_3
-    { 0, 0 },   // SOUND_COUGH_4
-    { 1, 0 },   // SOUND_RAIN
-    { 0, 0 },   // SOUND_THUNDER_1
-    { 0, 0 },   // SOUND_THUNDER_2
-    { 1, 0 },   // SOUND_TRACK_FRICTION_TRAIN
-    { 1, 0 },   // SOUND_TRACK_FRICTION_WATER
-    { 0, 0 },   // SOUND_BALLOON_POP
-    { 0, 0 },   // SOUND_MECHANIC_FIX
-    { 0, 1 },   // SOUND_SCREAM_7
-    { 0, 0 },   // SOUND_TOILET_FLUSH
-    { 0, 0 },   // SOUND_CLICK_3
-    { 0, 0 },   // SOUND_QUACK
-    { 0, 0 },   // SOUND_NEWS_ITEM
-    { 0, 0 },   // SOUND_WINDOW_OPEN
-    { 0, 0 },   // SOUND_LAUGH_1
-    { 0, 0 },   // SOUND_LAUGH_2
-    { 0, 0 },   // SOUND_LAUGH_3
-    { 0, 0 },   // SOUND_APPLAUSE
-    { 0, 0 },   // SOUND_HAUNTED_HOUSE_SCARE
-    { 0, 0 },   // SOUND_HAUNTED_HOUSE_SCREAM_1
-    { 0, 0 },   // SOUND_HAUNTED_HOUSE_SCREAM_2
-    { 0, 0 },   // SOUND_BLOCK_BRAKE_CLOSE
-    { 0, 0 },   // SOUND_BLOCK_BRAKE_RELEASE
-    { 0, 0 },   // SOUND_ERROR
-    { 0, 0 },   // SOUND_BRAKE_RELEASE
-    { 1, 0 },   // SOUND_LIFT_ARROW
-    { 1, 0 },   // SOUND_LIFT_WOOD
-    { 1, 0 },   // SOUND_TRACK_FRICTION_WOOD
-    { 1, 0 },   // SOUND_LIFT_WILD_MOUSE
-    { 1, 0 },   // SOUND_LIFT_BM
-    { 1, 2 },   // SOUND_TRACK_FRICTION_BM
-    { 0, 1 },   // SOUND_SCREAM_8
-    { 0, 1 },   // SOUND_TRAM
-    { 0, 0 },   // SOUND_DOOR_OPEN
-    { 0, 0 },   // SOUND_DOOR_CLOSE
-    { 0, 0 }    // SOUND_PORTCULLIS
+    { 1, 0 },   // LiftClassic
+    { 1, 0 },   // TrackFrictionClassicWood
+    { 1, 0 },   // FrictionClassic
+    { 0, 1 },   // Scream1
+    { 0, 0 },   // Click1
+    { 0, 0 },   // Click2
+    { 0, 0 },   // PlaceItem
+    { 0, 1 },   // Scream2
+    { 0, 1 },   // Scream3
+    { 0, 1 },   // Scream4
+    { 0, 1 },   // Scream5
+    { 0, 1 },   // Scream6
+    { 1, 0 },   // LiftFrictionWheels
+    { 0, 0 },   // Purchase
+    { 0, 0 },   // Crash
+    { 0, 0 },   // LayingOutWater
+    { 0, 0 },   // Water1
+    { 0, 0 },   // Water2
+    { 0, 1 },   // TrainWhistle
+    { 0, 1 },   // TrainDeparting
+    { 0, 0 },   // WaterSplash
+    { 1, 0 },   // GoKartEngine
+    { 0, 0 },   // RideLaunch1
+    { 0, 0 },   // RideLaunch2
+    { 0, 0 },   // Cough1
+    { 0, 0 },   // Cough2
+    { 0, 0 },   // Cough3
+    { 0, 0 },   // Cough4
+    { 1, 0 },   // Rain
+    { 0, 0 },   // Thunder1
+    { 0, 0 },   // Thunder2
+    { 1, 0 },   // TrackFrictionTrain
+    { 1, 0 },   // TrackFrictionWater
+    { 0, 0 },   // BalloonPop
+    { 0, 0 },   // MechanicFix
+    { 0, 1 },   // Scream7
+    { 0, 0 },   // ToiletFlush
+    { 0, 0 },   // Click3
+    { 0, 0 },   // Quack
+    { 0, 0 },   // NewsItem
+    { 0, 0 },   // WindowOpen
+    { 0, 0 },   // Laugh1
+    { 0, 0 },   // Laugh2
+    { 0, 0 },   // Laugh3
+    { 0, 0 },   // Applause
+    { 0, 0 },   // HauntedHouseScare
+    { 0, 0 },   // HauntedHouseScream1
+    { 0, 0 },   // HauntedHouseScream2
+    { 0, 0 },   // BlockBrakeClose
+    { 0, 0 },   // BlockBrakeRelease
+    { 0, 0 },   // Error
+    { 0, 0 },   // BrakeRelease
+    { 1, 0 },   // LiftArrow
+    { 1, 0 },   // LiftWood
+    { 1, 0 },   // TrackFrictionWood
+    { 1, 0 },   // LiftWildMouse
+    { 1, 0 },   // LiftBM
+    { 1, 2 },   // TrackFrictionBM
+    { 0, 1 },   // Scream8
+    { 0, 1 },   // Tram
+    { 0, 0 },   // DoorOpen
+    { 0, 0 },   // DoorClose
+    { 0, 0 }    // Portcullis
 };
 
 static constexpr const uint8_t SpaceRingsTimeToSpriteMap[] =
@@ -691,16 +690,16 @@ static constexpr const LocationXY16 AvoidCollisionMoveOffset[] =
 };
 
 
-static constexpr const uint8_t DoorOpenSoundIds[] =
+static constexpr const RCT2Sound DoorOpenSoundIds[] =
 {
-    SOUND_DOOR_OPEN,
-    SOUND_PORTCULLIS
+    RCT2Sound::DoorOpen,
+    RCT2Sound::Portcullis
 };
 
-static constexpr const uint8_t DoorCloseSoundIds[] =
+static constexpr const RCT2Sound DoorCloseSoundIds[] =
 {
-    SOUND_DOOR_CLOSE,
-    SOUND_PORTCULLIS
+    RCT2Sound::DoorClose,
+    RCT2Sound::Portcullis
 };
 
 static const struct
@@ -873,7 +872,7 @@ static void vehicle_update_sound_params(rct_vehicle* vehicle)
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         return;
 
-    if (vehicle->sound1_id == RCT12_SOUND_ID_NULL && vehicle->sound2_id == RCT12_SOUND_ID_NULL)
+    if (vehicle->sound1_id == RCT2Sound::Null && vehicle->sound2_id == RCT2Sound::Null)
         return;
 
     if (vehicle->sprite_left == LOCATION_NULL)
@@ -1101,8 +1100,8 @@ static rct_vehicle_sound* vehicle_sounds_update_get_vehicle_sound(rct_vehicle_so
             if (vehicleSound->id == SOUND_ID_NULL)
             {
                 vehicleSound->id = sound_params->id;
-                vehicleSound->sound1_id = SOUND_ID_NULL;
-                vehicleSound->sound2_id = SOUND_ID_NULL;
+                vehicleSound->sound1_id = RCT2Sound::Null;
+                vehicleSound->sound2_id = RCT2Sound::Null;
                 vehicleSound->volume = 0x30;
                 return vehicleSound;
             }
@@ -1120,33 +1119,33 @@ static void vehicle_sounds_update_sound_1(
     volume = volume / 8;
     volume = std::max(volume - 0x1FFF, -10000);
 
-    if (vehicle->sound1_id == RCT12_SOUND_ID_NULL)
+    if (vehicle->sound1_id == RCT2Sound::Null)
     {
-        if (sound->sound1_id != SOUND_ID_NULL)
+        if (sound->sound1_id != RCT2Sound::Null)
         {
-            sound->sound1_id = SOUND_ID_NULL;
+            sound->sound1_id = RCT2Sound::Null;
             Mixer_Stop_Channel(sound->sound1_channel);
         }
         return;
     }
 
-    if (sound->sound1_id != SOUND_ID_NULL && vehicle->sound1_id != sound->sound1_id)
+    if (sound->sound1_id != RCT2Sound::Null && vehicle->sound1_id != sound->sound1_id)
     {
         Mixer_Stop_Channel(sound->sound1_channel);
     }
 
-    if ((sound->sound1_id == SOUND_ID_NULL) || (vehicle->sound1_id != sound->sound1_id))
+    if ((sound->sound1_id == RCT2Sound::Null) || (vehicle->sound1_id != sound->sound1_id))
     {
         sound->sound1_id = vehicle->sound1_id;
         sound->sound1_pan = sound_params->pan_x;
         sound->sound1_volume = volume;
         sound->sound1_freq = sound_params->frequency;
         uint16_t frequency = sound_params->frequency;
-        if (_soundParams[vehicle->sound1_id][1] & 2)
+        if (_soundParams[static_cast<uint8_t>(vehicle->sound1_id)][1] & 2)
         {
             frequency = (frequency / 2) + 4000;
         }
-        uint8_t looping = _soundParams[vehicle->sound1_id][0];
+        uint8_t looping = _soundParams[static_cast<uint8_t>(vehicle->sound1_id)][0];
         int32_t pan = sound_params->pan_x;
         sound->sound1_channel = Mixer_Play_Effect(
             vehicle->sound1_id, looping ? MIXER_LOOP_INFINITE : MIXER_LOOP_NONE, DStoMixerVolume(volume), DStoMixerPan(pan),
@@ -1167,7 +1166,7 @@ static void vehicle_sounds_update_sound_1(
     {
         sound->sound1_freq = sound_params->frequency;
         uint16_t frequency = sound_params->frequency;
-        if (_soundParams[vehicle->sound1_id][1] & 2)
+        if (_soundParams[static_cast<uint8_t>(vehicle->sound1_id)][1] & 2)
         {
             frequency = (frequency / 2) + 4000;
         }
@@ -1184,35 +1183,35 @@ static void vehicle_sounds_update_sound_2(
     volume = volume / 8;
     volume = std::max(volume - 0x1FFF, -10000);
 
-    if (vehicle->sound2_id == RCT12_SOUND_ID_NULL)
+    if (vehicle->sound2_id == RCT2Sound::Null)
     {
-        if (sound->sound2_id != SOUND_ID_NULL)
+        if (sound->sound2_id != RCT2Sound::Null)
         {
-            sound->sound2_id = SOUND_ID_NULL;
+            sound->sound2_id = RCT2Sound::Null;
             Mixer_Stop_Channel(sound->sound2_channel);
         }
         return;
     }
 
-    if (sound->sound2_id != SOUND_ID_NULL && vehicle->sound2_id != sound->sound2_id)
+    if (sound->sound2_id != RCT2Sound::Null && vehicle->sound2_id != sound->sound2_id)
     {
         Mixer_Stop_Channel(sound->sound2_channel);
     }
 
-    if ((sound->sound2_id == SOUND_ID_NULL) || (vehicle->sound2_id != sound->sound2_id))
+    if ((sound->sound2_id == RCT2Sound::Null) || (vehicle->sound2_id != sound->sound2_id))
     {
         sound->sound2_id = vehicle->sound2_id;
         sound->sound2_pan = sound_params->pan_x;
         sound->sound2_volume = volume;
         sound->sound2_freq = sound_params->frequency;
         uint16_t frequency = sound_params->frequency;
-        if (_soundParams[vehicle->sound2_id][1] & 1)
+        if (_soundParams[static_cast<uint8_t>(vehicle->sound2_id)][1] & 1)
         {
             frequency = 12649;
         }
         frequency = std::min((frequency * 2) - 3248, 25700);
 
-        uint8_t looping = _soundParams[vehicle->sound2_id][0];
+        uint8_t looping = _soundParams[static_cast<uint8_t>(vehicle->sound2_id)][0];
         int32_t pan = sound_params->pan_x;
         sound->sound2_channel = Mixer_Play_Effect(
             vehicle->sound2_id, looping ? MIXER_LOOP_INFINITE : MIXER_LOOP_NONE, DStoMixerVolume(volume), DStoMixerPan(pan),
@@ -1232,7 +1231,7 @@ static void vehicle_sounds_update_sound_2(
     if (!(gCurrentTicks & 3) && sound_params->frequency != sound->sound2_freq)
     {
         sound->sound2_freq = sound_params->frequency;
-        if (!(_soundParams[vehicle->sound2_id][1] & 1))
+        if (!(_soundParams[static_cast<uint8_t>(vehicle->sound2_id)][1] & 1))
         {
             uint16_t frequency = (sound_params->frequency * 2) - 3248;
             if (frequency > 25700)
@@ -1280,11 +1279,11 @@ void vehicle_sounds_update()
             if (keepPlaying)
                 continue;
 
-            if (vehicle_sound.sound1_id != SOUND_ID_NULL)
+            if (vehicle_sound.sound1_id != RCT2Sound::Null)
             {
                 Mixer_Stop_Channel(vehicle_sound.sound1_channel);
             }
-            if (vehicle_sound.sound2_id != SOUND_ID_NULL)
+            if (vehicle_sound.sound2_id != RCT2Sound::Null)
             {
                 Mixer_Stop_Channel(vehicle_sound.sound2_channel);
             }
@@ -1892,20 +1891,27 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
     ride->sheltered_length = add_clamp_int32_t(ride->sheltered_length, distance);
 }
 
-static uint16_t sub_6D7AC0(int32_t currentSoundId, int32_t currentVolume, int32_t targetSoundId, int32_t targetVolume)
+struct SoundIdVolume
 {
-    if (currentSoundId != 255)
+    RCT2Sound id;
+    uint8_t volume;
+};
+
+static SoundIdVolume sub_6D7AC0(
+    RCT2Sound currentSoundId, uint8_t currentVolume, RCT2Sound targetSoundId, uint8_t targetVolume)
+{
+    if (currentSoundId != RCT2Sound::Null)
     {
         if (currentSoundId == targetSoundId)
         {
-            currentVolume = std::min(currentVolume + 15, targetVolume);
-            return (currentVolume << 8) | currentSoundId;
+            currentVolume = std::min<int32_t>(currentVolume + 15, targetVolume);
+            return { currentSoundId, currentVolume };
         }
         else
         {
             currentVolume -= 9;
             if (currentVolume >= 80)
-                return (currentVolume << 8) | currentSoundId;
+                return { currentSoundId, currentVolume };
         }
     }
 
@@ -1913,7 +1919,7 @@ static uint16_t sub_6D7AC0(int32_t currentSoundId, int32_t currentVolume, int32_
     currentSoundId = targetSoundId;
     currentVolume = targetVolume == 255 ? 255 : targetVolume / 4;
 
-    return (currentVolume << 8) | currentSoundId;
+    return { currentSoundId, currentVolume };
 }
 
 /**
@@ -3187,14 +3193,15 @@ static void vehicle_update_departing(rct_vehicle* vehicle)
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            uint8_t soundId = (rideEntry->vehicles[0].sound_range == 4) ? SOUND_TRAM : SOUND_TRAIN_DEPARTING;
+            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? RCT2Sound::Tram
+                                                                     : RCT2Sound::TrainDeparting;
 
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->y, vehicle->z);
         }
 
         if (ride->mode == RIDE_MODE_UPWARD_LAUNCH || (ride->mode == RIDE_MODE_DOWNWARD_LAUNCH && vehicle->var_CE > 1))
         {
-            audio_play_sound_at_location(SOUND_RIDE_LAUNCH_2, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
         }
 
         if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
@@ -3399,7 +3406,7 @@ static void vehicle_finish_departing(rct_vehicle* vehicle)
         if (vehicle->var_CE >= 1 && (14 << 16) > vehicle->velocity)
             return;
 
-        audio_play_sound_at_location(SOUND_RIDE_LAUNCH_1, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(RCT2Sound::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
     }
 
     if (ride->mode == RIDE_MODE_UPWARD_LAUNCH)
@@ -3407,7 +3414,7 @@ static void vehicle_finish_departing(rct_vehicle* vehicle)
         if ((ride->launch_speed << 16) > vehicle->velocity)
             return;
 
-        audio_play_sound_at_location(SOUND_RIDE_LAUNCH_1, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(RCT2Sound::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
     }
 
     if (ride->mode != RIDE_MODE_RACE && ride->mode != RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED
@@ -3529,7 +3536,7 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle)
 
         train->sub_state = 2;
 
-        audio_play_sound_at_location(SOUND_CRASH, train->x, train->y, train->z);
+        audio_play_sound_at_location(RCT2Sound::Crash, train->x, train->y, train->z);
 
         sprite_misc_explosion_cloud_create(train->x, train->y, train->z);
 
@@ -3581,7 +3588,7 @@ static void vehicle_update_crash_setup(rct_vehicle* vehicle)
     int32_t num_peeps = vehicle_get_total_num_peeps(vehicle);
     if (num_peeps != 0)
     {
-        audio_play_sound_at_location(SOUND_HAUNTED_HOUSE_SCREAM_2, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(RCT2Sound::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
     }
 
     int32_t edx = vehicle->velocity >> 10;
@@ -3994,7 +4001,7 @@ loc_6D8E36:
 
     if ((ride->mode == RIDE_MODE_UPWARD_LAUNCH || ride->mode == RIDE_MODE_DOWNWARD_LAUNCH) && vehicle->var_CE < 2)
     {
-        audio_play_sound_at_location(SOUND_RIDE_LAUNCH_2, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(RCT2Sound::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
         vehicle->velocity = 0;
         vehicle->acceleration = 0;
         vehicle->SetState(VEHICLE_STATUS_DEPARTING, 1);
@@ -4962,24 +4969,24 @@ static void vehicle_update_haunted_house_operating(rct_vehicle* vehicle)
     switch (vehicle->current_time)
     {
         case 45:
-            audio_play_sound_at_location(SOUND_HAUNTED_HOUSE_SCARE, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 75:
             vehicle->vehicle_sprite_type = 1;
             vehicle->Invalidate();
             break;
         case 400:
-            audio_play_sound_at_location(SOUND_HAUNTED_HOUSE_SCREAM_1, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::HauntedHouseScream1, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 745:
-            audio_play_sound_at_location(SOUND_HAUNTED_HOUSE_SCARE, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 775:
             vehicle->vehicle_sprite_type = 1;
             vehicle->Invalidate();
             break;
         case 1100:
-            audio_play_sound_at_location(SOUND_HAUNTED_HOUSE_SCREAM_2, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
             break;
     }
 }
@@ -5222,7 +5229,7 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle)
     }
 
     vehicle->sub_state = 2;
-    audio_play_sound_at_location(SOUND_CRASH, vehicle->x, vehicle->y, vehicle->z);
+    audio_play_sound_at_location(RCT2Sound::Crash, vehicle->x, vehicle->y, vehicle->z);
 
     sprite_misc_explosion_cloud_create(vehicle->x, vehicle->y, vehicle->z);
     sprite_misc_explosion_flare_create(vehicle->x, vehicle->y, vehicle->z);
@@ -5280,7 +5287,7 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle)
     }
 
     vehicle->sub_state = 2;
-    audio_play_sound_at_location(SOUND_WATER_1, vehicle->x, vehicle->y, vehicle->z);
+    audio_play_sound_at_location(RCT2Sound::Water1, vehicle->x, vehicle->y, vehicle->z);
 
     crash_splash_create(vehicle->x, vehicle->y, vehicle->z);
     crash_splash_create(vehicle->x - 8, vehicle->y - 9, vehicle->z);
@@ -5404,10 +5411,11 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
     Ride* ride;
     rct_ride_entry* rideEntry;
     // frictionVolume (bl) should be set before hand
-    uint8_t frictionVolume = 255, frictionId = 255;
+    uint8_t frictionVolume = 255;
+    RCT2Sound frictionId = RCT2Sound::Null;
     // bh screamVolume should be set before hand
-    uint8_t screamId = 255, screamVolume = 255;
-    uint16_t soundIdVolume;
+    RCT2Sound screamId = RCT2Sound::Null;
+    uint8_t screamVolume = 255;
 
     ride = get_ride(vehicle->ride);
     rideEntry = get_ride_entry(vehicle->ride_subtype);
@@ -5433,18 +5441,18 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             screamId = vehicle->scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != 255)
+                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != RCT2Sound::Null)
                     goto loc_6D7A97;
 
                 if ((scenario_rand() & 0xFFFF) <= 0x5555)
                 {
-                    vehicle->scream_sound_id = SOUND_TRAIN_WHISTLE;
+                    vehicle->scream_sound_id = RCT2Sound::TrainWhistle;
                     screamVolume = 255;
                     break;
                 }
             }
-            if (screamId == NO_SCREAM)
-                screamId = 255;
+            if (screamId == RCT2Sound::NoScream)
+                screamId = RCT2Sound::Null;
             screamVolume = 255;
             break;
 
@@ -5452,18 +5460,18 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             screamId = vehicle->scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != 255)
+                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != RCT2Sound::Null)
                     goto loc_6D7A97;
 
                 if ((scenario_rand() & 0xFFFF) <= 0x5555)
                 {
-                    vehicle->scream_sound_id = SOUND_TRAM;
+                    vehicle->scream_sound_id = RCT2Sound::Tram;
                     screamVolume = 255;
                     break;
                 }
             }
-            if (screamId == NO_SCREAM)
-                screamId = 255;
+            if (screamId == RCT2Sound::NoScream)
+                screamId = RCT2Sound::Null;
             screamVolume = 255;
             break;
 
@@ -5471,34 +5479,34 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RIDERS_SCREAM))
             {
                 screamId = vehicle_update_scream_sound(vehicle);
-                if (screamId == NO_SCREAM)
-                    screamId = 255;
-                if (screamId == 255)
+                if (screamId == RCT2Sound::NoScream)
+                    screamId = RCT2Sound::Null;
+                if (screamId == RCT2Sound::Null)
                     goto loc_6D7A97;
                 break;
             }
 
         loc_6D7A97:
-            vehicle->scream_sound_id = 255;
+            vehicle->scream_sound_id = RCT2Sound::Null;
             if (ride->type < std::size(RideLiftData))
             {
                 // Get lift hill sound
                 screamId = RideLiftData[ride->type].sound_id;
                 screamVolume = 243;
                 if (!(vehicle->sound2_flags & VEHICLE_SOUND2_FLAGS_LIFT_HILL))
-                    screamId = 255;
+                    screamId = RCT2Sound::Null;
             }
     }
 
     // Friction sound
-    soundIdVolume = sub_6D7AC0(vehicle->sound1_id, vehicle->sound1_volume, frictionId, frictionVolume);
-    vehicle->sound1_id = soundIdVolume & 0xFF;
-    vehicle->sound1_volume = (soundIdVolume >> 8) & 0xFF;
+    auto soundIdVolume = sub_6D7AC0(vehicle->sound1_id, vehicle->sound1_volume, frictionId, frictionVolume);
+    vehicle->sound1_id = soundIdVolume.id;
+    vehicle->sound1_volume = soundIdVolume.volume;
 
     // Scream sound
     soundIdVolume = sub_6D7AC0(vehicle->sound2_id, vehicle->sound2_volume, screamId, screamVolume);
-    vehicle->sound2_id = soundIdVolume & 0xFF;
-    vehicle->sound2_volume = (soundIdVolume >> 8) & 0xFF;
+    vehicle->sound2_id = soundIdVolume.id;
+    vehicle->sound2_volume = soundIdVolume.volume;
 
     // Calculate Sound Vector (used for sound frequency calcs)
     int32_t soundDirection = SpriteDirectionToSoundDirection[vehicle->sprite_direction];
@@ -5512,7 +5520,7 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
  *
  *  rct2: 0x006D796B
  */
-static int32_t vehicle_update_scream_sound(rct_vehicle* vehicle)
+static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle)
 {
     uint32_t r;
     uint16_t spriteIndex;
@@ -5525,12 +5533,12 @@ static int32_t vehicle_update_scream_sound(rct_vehicle* vehicle)
 
     int32_t totalNumPeeps = vehicle_get_total_num_peeps(vehicle);
     if (totalNumPeeps == 0)
-        return 255;
+        return RCT2Sound::Null;
 
     if (vehicle->velocity < 0)
     {
         if (vehicle->velocity > -0x2C000)
-            return 255;
+            return RCT2Sound::Null;
 
         spriteIndex = vehicle->sprite_index;
         do
@@ -5545,11 +5553,11 @@ static int32_t vehicle_update_scream_sound(rct_vehicle* vehicle)
             if (vehicle2->vehicle_sprite_type <= 15)
                 goto produceScream;
         } while ((spriteIndex = vehicle2->next_vehicle_on_train) != SPRITE_INDEX_NULL);
-        return 255;
+        return RCT2Sound::Null;
     }
 
     if (vehicle->velocity < 0x2C000)
-        return 255;
+        return RCT2Sound::Null;
 
     spriteIndex = vehicle->sprite_index;
     do
@@ -5564,10 +5572,10 @@ static int32_t vehicle_update_scream_sound(rct_vehicle* vehicle)
         if (vehicle2->vehicle_sprite_type <= 23)
             goto produceScream;
     } while ((spriteIndex = vehicle2->next_vehicle_on_train) != SPRITE_INDEX_NULL);
-    return 255;
+    return RCT2Sound::Null;
 
 produceScream:
-    if (vehicle->scream_sound_id == 255)
+    if (vehicle->scream_sound_id == RCT2Sound::Null)
     {
         r = scenario_rand();
         if (totalNumPeeps >= (int32_t)(r % 16))
@@ -5584,13 +5592,13 @@ produceScream:
                     vehicle->scream_sound_id = byte_9A3A16[r % 2];
                     break;
                 default:
-                    vehicle->scream_sound_id = NO_SCREAM;
+                    vehicle->scream_sound_id = RCT2Sound::NoScream;
                     break;
             }
         }
         else
         {
-            vehicle->scream_sound_id = NO_SCREAM;
+            vehicle->scream_sound_id = RCT2Sound::NoScream;
         }
     }
     return vehicle->scream_sound_id;
@@ -6709,7 +6717,7 @@ static void vehicle_update_block_brakes_open_previous_section(rct_vehicle* vehic
         Ride* ride = get_ride(vehicle->ride);
         if (ride->IsBlockSectioned())
         {
-            audio_play_sound_at_location(SOUND_BLOCK_BRAKE_CLOSE, x, y, z);
+            audio_play_sound_at_location(RCT2Sound::BlockBrakeClose, x, y, z);
         }
     }
 }
@@ -7321,8 +7329,8 @@ static void vehicle_play_scenery_door_open_sound(rct_vehicle* vehicle, WallEleme
     int32_t doorSoundType = wall_entry_get_door_sound(wallEntry);
     if (doorSoundType != 0)
     {
-        int32_t soundId = DoorOpenSoundIds[doorSoundType - 1];
-        if (soundId != 255)
+        auto soundId = DoorOpenSoundIds[doorSoundType - 1];
+        if (soundId != RCT2Sound::Null)
         {
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->track_y, vehicle->track_z);
         }
@@ -7339,8 +7347,8 @@ static void vehicle_play_scenery_door_close_sound(rct_vehicle* vehicle, WallElem
     int32_t doorSoundType = wall_entry_get_door_sound(wallEntry);
     if (doorSoundType != 0)
     {
-        int32_t soundId = DoorCloseSoundIds[doorSoundType - 1];
-        if (soundId != 255)
+        auto soundId = DoorCloseSoundIds[doorSoundType - 1];
+        if (soundId != RCT2Sound::Null)
         {
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->track_y, vehicle->track_z);
         }
@@ -7473,7 +7481,7 @@ static void vehicle_update_play_water_splash_sound()
         return;
     }
 
-    audio_play_sound_at_location(SOUND_WATER_SPLASH, unk_F64E20.x, unk_F64E20.y, unk_F64E20.z);
+    audio_play_sound_at_location(RCT2Sound::WaterSplash, unk_F64E20.x, unk_F64E20.y, unk_F64E20.z);
 }
 
 /**
@@ -7889,7 +7897,7 @@ static bool vehicle_update_track_motion_forwards_get_new_track(
                 if (!(rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_POWERED))
                 {
                     audio_play_sound_at_location(
-                        SOUND_BLOCK_BRAKE_RELEASE, vehicle->track_x, vehicle->track_y, vehicle->track_z);
+                        RCT2Sound::BlockBrakeRelease, vehicle->track_x, vehicle->track_y, vehicle->track_z);
                 }
             }
             map_invalidate_element(vehicle->track_x, vehicle->track_z, tileElement);
@@ -8096,7 +8104,7 @@ loc_6DAEB9:
                 if (_vehicleF64E2C == 0)
                 {
                     _vehicleF64E2C++;
-                    audio_play_sound_at_location(SOUND_BRAKE_RELEASE, vehicle->x, vehicle->y, vehicle->z);
+                    audio_play_sound_at_location(RCT2Sound::BrakeRelease, vehicle->x, vehicle->y, vehicle->z);
                 }
             }
         }
@@ -9908,10 +9916,10 @@ void vehicle_claxon(const rct_vehicle* vehicle)
     switch (rideEntry->vehicles[vehicle->vehicle_type].sound_range)
     {
         case SOUND_RANGE_WHISTLE:
-            audio_play_sound_at_location(SOUND_TRAIN_WHISTLE, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::TrainWhistle, vehicle->x, vehicle->y, vehicle->z);
             break;
         case SOUND_RANGE_BELL:
-            audio_play_sound_at_location(SOUND_TRAM, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(RCT2Sound::Tram, vehicle->x, vehicle->y, vehicle->z);
             break;
     }
 }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -81,7 +81,7 @@ static bool vehicle_update_motion_collision_detection(
     rct_vehicle* vehicle, int16_t x, int16_t y, int16_t z, uint16_t* otherVehicleIndex);
 static int32_t vehicle_get_sound_priority_factor(rct_vehicle* vehicle);
 static void vehicle_update_sound(rct_vehicle* vehicle);
-static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle);
+static SoundId vehicle_update_scream_sound(rct_vehicle* vehicle);
 
 static void vehicle_kill_all_passengers(rct_vehicle* vehicle);
 static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle);
@@ -108,11 +108,11 @@ rct_vehicle* _vehicleFrontVehicle;
 LocationXYZ16 unk_F64E20;
 
 // clang-format off
-static constexpr const RCT2Sound byte_9A3A14[] = { RCT2Sound::Scream8, RCT2Sound::Scream1 };
-static constexpr const RCT2Sound byte_9A3A16[] = { RCT2Sound::Scream1, RCT2Sound::Scream6 };
-static constexpr const RCT2Sound byte_9A3A18[] = {
-    RCT2Sound::Scream3, RCT2Sound::Scream1, RCT2Sound::Scream5, RCT2Sound::Scream6,
-    RCT2Sound::Scream7, RCT2Sound::Scream2, RCT2Sound::Scream4
+static constexpr const SoundId byte_9A3A14[] = { SoundId::Scream8, SoundId::Scream1 };
+static constexpr const SoundId byte_9A3A16[] = { SoundId::Scream1, SoundId::Scream6 };
+static constexpr const SoundId byte_9A3A18[] = {
+    SoundId::Scream3, SoundId::Scream1, SoundId::Scream5, SoundId::Scream6,
+    SoundId::Scream7, SoundId::Scream2, SoundId::Scream4
 };
 static constexpr const uint8_t _soundParams[RCT2SoundCount][2] =
 {
@@ -690,16 +690,16 @@ static constexpr const LocationXY16 AvoidCollisionMoveOffset[] =
 };
 
 
-static constexpr const RCT2Sound DoorOpenSoundIds[] =
+static constexpr const SoundId DoorOpenSoundIds[] =
 {
-    RCT2Sound::DoorOpen,
-    RCT2Sound::Portcullis
+    SoundId::DoorOpen,
+    SoundId::Portcullis
 };
 
-static constexpr const RCT2Sound DoorCloseSoundIds[] =
+static constexpr const SoundId DoorCloseSoundIds[] =
 {
-    RCT2Sound::DoorClose,
-    RCT2Sound::Portcullis
+    SoundId::DoorClose,
+    SoundId::Portcullis
 };
 
 static const struct
@@ -872,7 +872,7 @@ static void vehicle_update_sound_params(rct_vehicle* vehicle)
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         return;
 
-    if (vehicle->sound1_id == RCT2Sound::Null && vehicle->sound2_id == RCT2Sound::Null)
+    if (vehicle->sound1_id == SoundId::Null && vehicle->sound2_id == SoundId::Null)
         return;
 
     if (vehicle->sprite_left == LOCATION_NULL)
@@ -1100,8 +1100,8 @@ static rct_vehicle_sound* vehicle_sounds_update_get_vehicle_sound(rct_vehicle_so
             if (vehicleSound->id == SOUND_ID_NULL)
             {
                 vehicleSound->id = sound_params->id;
-                vehicleSound->sound1_id = RCT2Sound::Null;
-                vehicleSound->sound2_id = RCT2Sound::Null;
+                vehicleSound->sound1_id = SoundId::Null;
+                vehicleSound->sound2_id = SoundId::Null;
                 vehicleSound->volume = 0x30;
                 return vehicleSound;
             }
@@ -1119,22 +1119,22 @@ static void vehicle_sounds_update_sound_1(
     volume = volume / 8;
     volume = std::max(volume - 0x1FFF, -10000);
 
-    if (vehicle->sound1_id == RCT2Sound::Null)
+    if (vehicle->sound1_id == SoundId::Null)
     {
-        if (sound->sound1_id != RCT2Sound::Null)
+        if (sound->sound1_id != SoundId::Null)
         {
-            sound->sound1_id = RCT2Sound::Null;
+            sound->sound1_id = SoundId::Null;
             Mixer_Stop_Channel(sound->sound1_channel);
         }
         return;
     }
 
-    if (sound->sound1_id != RCT2Sound::Null && vehicle->sound1_id != sound->sound1_id)
+    if (sound->sound1_id != SoundId::Null && vehicle->sound1_id != sound->sound1_id)
     {
         Mixer_Stop_Channel(sound->sound1_channel);
     }
 
-    if ((sound->sound1_id == RCT2Sound::Null) || (vehicle->sound1_id != sound->sound1_id))
+    if ((sound->sound1_id == SoundId::Null) || (vehicle->sound1_id != sound->sound1_id))
     {
         sound->sound1_id = vehicle->sound1_id;
         sound->sound1_pan = sound_params->pan_x;
@@ -1183,22 +1183,22 @@ static void vehicle_sounds_update_sound_2(
     volume = volume / 8;
     volume = std::max(volume - 0x1FFF, -10000);
 
-    if (vehicle->sound2_id == RCT2Sound::Null)
+    if (vehicle->sound2_id == SoundId::Null)
     {
-        if (sound->sound2_id != RCT2Sound::Null)
+        if (sound->sound2_id != SoundId::Null)
         {
-            sound->sound2_id = RCT2Sound::Null;
+            sound->sound2_id = SoundId::Null;
             Mixer_Stop_Channel(sound->sound2_channel);
         }
         return;
     }
 
-    if (sound->sound2_id != RCT2Sound::Null && vehicle->sound2_id != sound->sound2_id)
+    if (sound->sound2_id != SoundId::Null && vehicle->sound2_id != sound->sound2_id)
     {
         Mixer_Stop_Channel(sound->sound2_channel);
     }
 
-    if ((sound->sound2_id == RCT2Sound::Null) || (vehicle->sound2_id != sound->sound2_id))
+    if ((sound->sound2_id == SoundId::Null) || (vehicle->sound2_id != sound->sound2_id))
     {
         sound->sound2_id = vehicle->sound2_id;
         sound->sound2_pan = sound_params->pan_x;
@@ -1279,11 +1279,11 @@ void vehicle_sounds_update()
             if (keepPlaying)
                 continue;
 
-            if (vehicle_sound.sound1_id != RCT2Sound::Null)
+            if (vehicle_sound.sound1_id != SoundId::Null)
             {
                 Mixer_Stop_Channel(vehicle_sound.sound1_channel);
             }
-            if (vehicle_sound.sound2_id != RCT2Sound::Null)
+            if (vehicle_sound.sound2_id != SoundId::Null)
             {
                 Mixer_Stop_Channel(vehicle_sound.sound2_channel);
             }
@@ -1893,13 +1893,13 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
 
 struct SoundIdVolume
 {
-    RCT2Sound id;
+    SoundId id;
     uint8_t volume;
 };
 
-static SoundIdVolume sub_6D7AC0(RCT2Sound currentSoundId, uint8_t currentVolume, RCT2Sound targetSoundId, uint8_t targetVolume)
+static SoundIdVolume sub_6D7AC0(SoundId currentSoundId, uint8_t currentVolume, SoundId targetSoundId, uint8_t targetVolume)
 {
-    if (currentSoundId != RCT2Sound::Null)
+    if (currentSoundId != SoundId::Null)
     {
         if (currentSoundId == targetSoundId)
         {
@@ -3192,14 +3192,14 @@ static void vehicle_update_departing(rct_vehicle* vehicle)
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? RCT2Sound::Tram : RCT2Sound::TrainDeparting;
+            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? SoundId::Tram : SoundId::TrainDeparting;
 
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->y, vehicle->z);
         }
 
         if (ride->mode == RIDE_MODE_UPWARD_LAUNCH || (ride->mode == RIDE_MODE_DOWNWARD_LAUNCH && vehicle->var_CE > 1))
         {
-            audio_play_sound_at_location(RCT2Sound::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
         }
 
         if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
@@ -3404,7 +3404,7 @@ static void vehicle_finish_departing(rct_vehicle* vehicle)
         if (vehicle->var_CE >= 1 && (14 << 16) > vehicle->velocity)
             return;
 
-        audio_play_sound_at_location(RCT2Sound::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(SoundId::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
     }
 
     if (ride->mode == RIDE_MODE_UPWARD_LAUNCH)
@@ -3412,7 +3412,7 @@ static void vehicle_finish_departing(rct_vehicle* vehicle)
         if ((ride->launch_speed << 16) > vehicle->velocity)
             return;
 
-        audio_play_sound_at_location(RCT2Sound::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(SoundId::RideLaunch1, vehicle->x, vehicle->y, vehicle->z);
     }
 
     if (ride->mode != RIDE_MODE_RACE && ride->mode != RIDE_MODE_CONTINUOUS_CIRCUIT_BLOCK_SECTIONED
@@ -3534,7 +3534,7 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle)
 
         train->sub_state = 2;
 
-        audio_play_sound_at_location(RCT2Sound::Crash, train->x, train->y, train->z);
+        audio_play_sound_at_location(SoundId::Crash, train->x, train->y, train->z);
 
         sprite_misc_explosion_cloud_create(train->x, train->y, train->z);
 
@@ -3586,7 +3586,7 @@ static void vehicle_update_crash_setup(rct_vehicle* vehicle)
     int32_t num_peeps = vehicle_get_total_num_peeps(vehicle);
     if (num_peeps != 0)
     {
-        audio_play_sound_at_location(RCT2Sound::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(SoundId::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
     }
 
     int32_t edx = vehicle->velocity >> 10;
@@ -3999,7 +3999,7 @@ loc_6D8E36:
 
     if ((ride->mode == RIDE_MODE_UPWARD_LAUNCH || ride->mode == RIDE_MODE_DOWNWARD_LAUNCH) && vehicle->var_CE < 2)
     {
-        audio_play_sound_at_location(RCT2Sound::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
+        audio_play_sound_at_location(SoundId::RideLaunch2, vehicle->x, vehicle->y, vehicle->z);
         vehicle->velocity = 0;
         vehicle->acceleration = 0;
         vehicle->SetState(VEHICLE_STATUS_DEPARTING, 1);
@@ -4967,24 +4967,24 @@ static void vehicle_update_haunted_house_operating(rct_vehicle* vehicle)
     switch (vehicle->current_time)
     {
         case 45:
-            audio_play_sound_at_location(RCT2Sound::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 75:
             vehicle->vehicle_sprite_type = 1;
             vehicle->Invalidate();
             break;
         case 400:
-            audio_play_sound_at_location(RCT2Sound::HauntedHouseScream1, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::HauntedHouseScream1, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 745:
-            audio_play_sound_at_location(RCT2Sound::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::HauntedHouseScare, vehicle->x, vehicle->y, vehicle->z);
             break;
         case 775:
             vehicle->vehicle_sprite_type = 1;
             vehicle->Invalidate();
             break;
         case 1100:
-            audio_play_sound_at_location(RCT2Sound::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::HauntedHouseScream2, vehicle->x, vehicle->y, vehicle->z);
             break;
     }
 }
@@ -5227,7 +5227,7 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle)
     }
 
     vehicle->sub_state = 2;
-    audio_play_sound_at_location(RCT2Sound::Crash, vehicle->x, vehicle->y, vehicle->z);
+    audio_play_sound_at_location(SoundId::Crash, vehicle->x, vehicle->y, vehicle->z);
 
     sprite_misc_explosion_cloud_create(vehicle->x, vehicle->y, vehicle->z);
     sprite_misc_explosion_flare_create(vehicle->x, vehicle->y, vehicle->z);
@@ -5285,7 +5285,7 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle)
     }
 
     vehicle->sub_state = 2;
-    audio_play_sound_at_location(RCT2Sound::Water1, vehicle->x, vehicle->y, vehicle->z);
+    audio_play_sound_at_location(SoundId::Water1, vehicle->x, vehicle->y, vehicle->z);
 
     crash_splash_create(vehicle->x, vehicle->y, vehicle->z);
     crash_splash_create(vehicle->x - 8, vehicle->y - 9, vehicle->z);
@@ -5410,9 +5410,9 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
     rct_ride_entry* rideEntry;
     // frictionVolume (bl) should be set before hand
     uint8_t frictionVolume = 255;
-    RCT2Sound frictionId = RCT2Sound::Null;
+    SoundId frictionId = SoundId::Null;
     // bh screamVolume should be set before hand
-    RCT2Sound screamId = RCT2Sound::Null;
+    SoundId screamId = SoundId::Null;
     uint8_t screamVolume = 255;
 
     ride = get_ride(vehicle->ride);
@@ -5439,18 +5439,18 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             screamId = vehicle->scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != RCT2Sound::Null)
+                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != SoundId::Null)
                     goto loc_6D7A97;
 
                 if ((scenario_rand() & 0xFFFF) <= 0x5555)
                 {
-                    vehicle->scream_sound_id = RCT2Sound::TrainWhistle;
+                    vehicle->scream_sound_id = SoundId::TrainWhistle;
                     screamVolume = 255;
                     break;
                 }
             }
-            if (screamId == RCT2Sound::NoScream)
-                screamId = RCT2Sound::Null;
+            if (screamId == SoundId::NoScream)
+                screamId = SoundId::Null;
             screamVolume = 255;
             break;
 
@@ -5458,18 +5458,18 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             screamId = vehicle->scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != RCT2Sound::Null)
+                if (vehicle->velocity < 0x40000 || vehicle->scream_sound_id != SoundId::Null)
                     goto loc_6D7A97;
 
                 if ((scenario_rand() & 0xFFFF) <= 0x5555)
                 {
-                    vehicle->scream_sound_id = RCT2Sound::Tram;
+                    vehicle->scream_sound_id = SoundId::Tram;
                     screamVolume = 255;
                     break;
                 }
             }
-            if (screamId == RCT2Sound::NoScream)
-                screamId = RCT2Sound::Null;
+            if (screamId == SoundId::NoScream)
+                screamId = SoundId::Null;
             screamVolume = 255;
             break;
 
@@ -5477,22 +5477,22 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
             if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RIDERS_SCREAM))
             {
                 screamId = vehicle_update_scream_sound(vehicle);
-                if (screamId == RCT2Sound::NoScream)
-                    screamId = RCT2Sound::Null;
-                if (screamId == RCT2Sound::Null)
+                if (screamId == SoundId::NoScream)
+                    screamId = SoundId::Null;
+                if (screamId == SoundId::Null)
                     goto loc_6D7A97;
                 break;
             }
 
         loc_6D7A97:
-            vehicle->scream_sound_id = RCT2Sound::Null;
+            vehicle->scream_sound_id = SoundId::Null;
             if (ride->type < std::size(RideLiftData))
             {
                 // Get lift hill sound
                 screamId = RideLiftData[ride->type].sound_id;
                 screamVolume = 243;
                 if (!(vehicle->sound2_flags & VEHICLE_SOUND2_FLAGS_LIFT_HILL))
-                    screamId = RCT2Sound::Null;
+                    screamId = SoundId::Null;
             }
     }
 
@@ -5518,7 +5518,7 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
  *
  *  rct2: 0x006D796B
  */
-static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle)
+static SoundId vehicle_update_scream_sound(rct_vehicle* vehicle)
 {
     uint32_t r;
     uint16_t spriteIndex;
@@ -5531,12 +5531,12 @@ static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle)
 
     int32_t totalNumPeeps = vehicle_get_total_num_peeps(vehicle);
     if (totalNumPeeps == 0)
-        return RCT2Sound::Null;
+        return SoundId::Null;
 
     if (vehicle->velocity < 0)
     {
         if (vehicle->velocity > -0x2C000)
-            return RCT2Sound::Null;
+            return SoundId::Null;
 
         spriteIndex = vehicle->sprite_index;
         do
@@ -5551,11 +5551,11 @@ static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle)
             if (vehicle2->vehicle_sprite_type <= 15)
                 goto produceScream;
         } while ((spriteIndex = vehicle2->next_vehicle_on_train) != SPRITE_INDEX_NULL);
-        return RCT2Sound::Null;
+        return SoundId::Null;
     }
 
     if (vehicle->velocity < 0x2C000)
-        return RCT2Sound::Null;
+        return SoundId::Null;
 
     spriteIndex = vehicle->sprite_index;
     do
@@ -5570,10 +5570,10 @@ static RCT2Sound vehicle_update_scream_sound(rct_vehicle* vehicle)
         if (vehicle2->vehicle_sprite_type <= 23)
             goto produceScream;
     } while ((spriteIndex = vehicle2->next_vehicle_on_train) != SPRITE_INDEX_NULL);
-    return RCT2Sound::Null;
+    return SoundId::Null;
 
 produceScream:
-    if (vehicle->scream_sound_id == RCT2Sound::Null)
+    if (vehicle->scream_sound_id == SoundId::Null)
     {
         r = scenario_rand();
         if (totalNumPeeps >= (int32_t)(r % 16))
@@ -5590,13 +5590,13 @@ produceScream:
                     vehicle->scream_sound_id = byte_9A3A16[r % 2];
                     break;
                 default:
-                    vehicle->scream_sound_id = RCT2Sound::NoScream;
+                    vehicle->scream_sound_id = SoundId::NoScream;
                     break;
             }
         }
         else
         {
-            vehicle->scream_sound_id = RCT2Sound::NoScream;
+            vehicle->scream_sound_id = SoundId::NoScream;
         }
     }
     return vehicle->scream_sound_id;
@@ -6715,7 +6715,7 @@ static void vehicle_update_block_brakes_open_previous_section(rct_vehicle* vehic
         Ride* ride = get_ride(vehicle->ride);
         if (ride->IsBlockSectioned())
         {
-            audio_play_sound_at_location(RCT2Sound::BlockBrakeClose, x, y, z);
+            audio_play_sound_at_location(SoundId::BlockBrakeClose, x, y, z);
         }
     }
 }
@@ -7328,7 +7328,7 @@ static void vehicle_play_scenery_door_open_sound(rct_vehicle* vehicle, WallEleme
     if (doorSoundType != 0)
     {
         auto soundId = DoorOpenSoundIds[doorSoundType - 1];
-        if (soundId != RCT2Sound::Null)
+        if (soundId != SoundId::Null)
         {
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->track_y, vehicle->track_z);
         }
@@ -7346,7 +7346,7 @@ static void vehicle_play_scenery_door_close_sound(rct_vehicle* vehicle, WallElem
     if (doorSoundType != 0)
     {
         auto soundId = DoorCloseSoundIds[doorSoundType - 1];
-        if (soundId != RCT2Sound::Null)
+        if (soundId != SoundId::Null)
         {
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->track_y, vehicle->track_z);
         }
@@ -7479,7 +7479,7 @@ static void vehicle_update_play_water_splash_sound()
         return;
     }
 
-    audio_play_sound_at_location(RCT2Sound::WaterSplash, unk_F64E20.x, unk_F64E20.y, unk_F64E20.z);
+    audio_play_sound_at_location(SoundId::WaterSplash, unk_F64E20.x, unk_F64E20.y, unk_F64E20.z);
 }
 
 /**
@@ -7895,7 +7895,7 @@ static bool vehicle_update_track_motion_forwards_get_new_track(
                 if (!(rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_POWERED))
                 {
                     audio_play_sound_at_location(
-                        RCT2Sound::BlockBrakeRelease, vehicle->track_x, vehicle->track_y, vehicle->track_z);
+                        SoundId::BlockBrakeRelease, vehicle->track_x, vehicle->track_y, vehicle->track_z);
                 }
             }
             map_invalidate_element(vehicle->track_x, vehicle->track_z, tileElement);
@@ -8102,7 +8102,7 @@ loc_6DAEB9:
                 if (_vehicleF64E2C == 0)
                 {
                     _vehicleF64E2C++;
-                    audio_play_sound_at_location(RCT2Sound::BrakeRelease, vehicle->x, vehicle->y, vehicle->z);
+                    audio_play_sound_at_location(SoundId::BrakeRelease, vehicle->x, vehicle->y, vehicle->z);
                 }
             }
         }
@@ -9914,10 +9914,10 @@ void vehicle_claxon(const rct_vehicle* vehicle)
     switch (rideEntry->vehicles[vehicle->vehicle_type].sound_range)
     {
         case SOUND_RANGE_WHISTLE:
-            audio_play_sound_at_location(RCT2Sound::TrainWhistle, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::TrainWhistle, vehicle->x, vehicle->y, vehicle->z);
             break;
         case SOUND_RANGE_BELL:
-            audio_play_sound_at_location(RCT2Sound::Tram, vehicle->x, vehicle->y, vehicle->z);
+            audio_play_sound_at_location(SoundId::Tram, vehicle->x, vehicle->y, vehicle->z);
             break;
     }
 }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1897,8 +1897,7 @@ struct SoundIdVolume
     uint8_t volume;
 };
 
-static SoundIdVolume sub_6D7AC0(
-    RCT2Sound currentSoundId, uint8_t currentVolume, RCT2Sound targetSoundId, uint8_t targetVolume)
+static SoundIdVolume sub_6D7AC0(RCT2Sound currentSoundId, uint8_t currentVolume, RCT2Sound targetSoundId, uint8_t targetVolume)
 {
     if (currentSoundId != RCT2Sound::Null)
     {
@@ -3193,8 +3192,7 @@ static void vehicle_update_departing(rct_vehicle* vehicle)
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? RCT2Sound::Tram
-                                                                     : RCT2Sound::TrainDeparting;
+            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? RCT2Sound::Tram : RCT2Sound::TrainDeparting;
 
             audio_play_sound_at_location(soundId, vehicle->x, vehicle->y, vehicle->z);
         }

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -81,7 +81,7 @@ struct rct_ride_entry_vehicle
     uint8_t no_seating_rows;                 // 0x54 , 0x6E
     uint8_t spinning_inertia;                // 0x55 , 0x6F
     uint8_t spinning_friction;               // 0x56 , 0x70
-    SoundId friction_sound_id;             // 0x57 , 0x71
+    SoundId friction_sound_id;               // 0x57 , 0x71
     uint8_t log_flume_reverser_vehicle_type; // 0x58 , 0x72
     uint8_t sound_range;                     // 0x59 , 0x73
     uint8_t
@@ -219,9 +219,9 @@ struct rct_vehicle : rct_sprite_common
     };
     uint16_t sound2_flags; // 0xB8
     uint8_t spin_sprite;   // 0xBA lowest 3 bits not used for sprite selection (divide by 8 to use)
-    SoundId sound1_id;   // 0xBB
+    SoundId sound1_id;     // 0xBB
     uint8_t sound1_volume; // 0xBC
-    SoundId sound2_id;   // 0xBD
+    SoundId sound2_id;     // 0xBD
     uint8_t sound2_volume; // 0xBE
     int8_t sound_vector_factor;
     union

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -19,7 +19,7 @@
 #include <cstddef>
 #include <vector>
 
-enum class RCT2Sound : uint8_t;
+enum class SoundId : uint8_t;
 
 struct rct_vehicle_colour
 {
@@ -81,7 +81,7 @@ struct rct_ride_entry_vehicle
     uint8_t no_seating_rows;                 // 0x54 , 0x6E
     uint8_t spinning_inertia;                // 0x55 , 0x6F
     uint8_t spinning_friction;               // 0x56 , 0x70
-    RCT2Sound friction_sound_id;             // 0x57 , 0x71
+    SoundId friction_sound_id;             // 0x57 , 0x71
     uint8_t log_flume_reverser_vehicle_type; // 0x58 , 0x72
     uint8_t sound_range;                     // 0x59 , 0x73
     uint8_t
@@ -219,9 +219,9 @@ struct rct_vehicle : rct_sprite_common
     };
     uint16_t sound2_flags; // 0xB8
     uint8_t spin_sprite;   // 0xBA lowest 3 bits not used for sprite selection (divide by 8 to use)
-    RCT2Sound sound1_id;   // 0xBB
+    SoundId sound1_id;   // 0xBB
     uint8_t sound1_volume; // 0xBC
-    RCT2Sound sound2_id;   // 0xBD
+    SoundId sound2_id;   // 0xBD
     uint8_t sound2_volume; // 0xBE
     int8_t sound_vector_factor;
     union
@@ -242,7 +242,7 @@ struct rct_vehicle : rct_sprite_common
     uint8_t pad_C6[0x2];
     uint16_t var_C8;
     uint16_t var_CA;
-    RCT2Sound scream_sound_id; // 0xCC
+    SoundId scream_sound_id; // 0xCC
     uint8_t var_CD;
     union
     {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <vector>
 
+enum class RCT2Sound : uint8_t;
+
 struct rct_vehicle_colour
 {
     uint8_t body_colour;
@@ -79,7 +81,7 @@ struct rct_ride_entry_vehicle
     uint8_t no_seating_rows;                 // 0x54 , 0x6E
     uint8_t spinning_inertia;                // 0x55 , 0x6F
     uint8_t spinning_friction;               // 0x56 , 0x70
-    uint8_t friction_sound_id;               // 0x57 , 0x71
+    RCT2Sound friction_sound_id;               // 0x57 , 0x71
     uint8_t log_flume_reverser_vehicle_type; // 0x58 , 0x72
     uint8_t sound_range;                     // 0x59 , 0x73
     uint8_t
@@ -217,9 +219,9 @@ struct rct_vehicle : rct_sprite_common
     };
     uint16_t sound2_flags; // 0xB8
     uint8_t spin_sprite;   // 0xBA lowest 3 bits not used for sprite selection (divide by 8 to use)
-    uint8_t sound1_id;     // 0xBB
+    RCT2Sound sound1_id; // 0xBB
     uint8_t sound1_volume; // 0xBC
-    uint8_t sound2_id;     // 0xBD
+    RCT2Sound sound2_id; // 0xBD
     uint8_t sound2_volume; // 0xBE
     int8_t sound_vector_factor;
     union
@@ -240,7 +242,7 @@ struct rct_vehicle : rct_sprite_common
     uint8_t pad_C6[0x2];
     uint16_t var_C8;
     uint16_t var_CA;
-    uint8_t scream_sound_id; // 0xCC
+    RCT2Sound scream_sound_id; // 0xCC
     uint8_t var_CD;
     union
     {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -81,7 +81,7 @@ struct rct_ride_entry_vehicle
     uint8_t no_seating_rows;                 // 0x54 , 0x6E
     uint8_t spinning_inertia;                // 0x55 , 0x6F
     uint8_t spinning_friction;               // 0x56 , 0x70
-    RCT2Sound friction_sound_id;               // 0x57 , 0x71
+    RCT2Sound friction_sound_id;             // 0x57 , 0x71
     uint8_t log_flume_reverser_vehicle_type; // 0x58 , 0x72
     uint8_t sound_range;                     // 0x59 , 0x73
     uint8_t
@@ -219,9 +219,9 @@ struct rct_vehicle : rct_sprite_common
     };
     uint16_t sound2_flags; // 0xB8
     uint8_t spin_sprite;   // 0xBA lowest 3 bits not used for sprite selection (divide by 8 to use)
-    RCT2Sound sound1_id; // 0xBB
+    RCT2Sound sound1_id;   // 0xBB
     uint8_t sound1_volume; // 0xBC
-    RCT2Sound sound2_id; // 0xBD
+    RCT2Sound sound2_id;   // 0xBD
     uint8_t sound2_volume; // 0xBE
     int8_t sound_vector_factor;
     union

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -81,7 +81,7 @@ void rct_balloon::Pop()
 {
     popped = 1;
     frame = 0;
-    audio_play_sound_at_location(SOUND_BALLOON_POP, x, y, z);
+    audio_play_sound_at_location(RCT2Sound::BalloonPop, x, y, z);
 }
 
 void create_balloon(int32_t x, int32_t y, int32_t z, int32_t colour, bool isPopped)

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -81,7 +81,7 @@ void rct_balloon::Pop()
 {
     popped = 1;
     frame = 0;
-    audio_play_sound_at_location(RCT2Sound::BalloonPop, x, y, z);
+    audio_play_sound_at_location(SoundId::BalloonPop, x, y, z);
 }
 
 void create_balloon(int32_t x, int32_t y, int32_t z, int32_t colour, bool isPopped)

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -282,8 +282,7 @@ static void climate_update_rain_sound()
         // Start playing the rain sound
         if (gRainSoundChannel == nullptr)
         {
-            gRainSoundChannel = Mixer_Play_Effect(
-                RCT2Sound::Rain, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
+            gRainSoundChannel = Mixer_Play_Effect(RCT2Sound::Rain, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
         }
         if (_rainVolume == 1)
         {

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -59,7 +59,7 @@ static uint32_t _lightningTimer;
 static uint32_t _thunderTimer;
 static void* _thunderSoundChannels[MAX_THUNDER_INSTANCES];
 static THUNDER_STATUS _thunderStatus[MAX_THUNDER_INSTANCES] = { THUNDER_STATUS::NONE, THUNDER_STATUS::NONE };
-static RCT2Sound _thunderSoundId;
+static SoundId _thunderSoundId;
 static int32_t _thunderVolume;
 static int32_t _thunderStereoEcho = 0;
 
@@ -69,7 +69,7 @@ static void climate_update_rain_sound();
 static void climate_update_thunder_sound();
 static void climate_update_lightning();
 static void climate_update_thunder();
-static void climate_play_thunder(int32_t instanceIndex, RCT2Sound soundId, int32_t volume, int32_t pan);
+static void climate_play_thunder(int32_t instanceIndex, SoundId soundId, int32_t volume, int32_t pan);
 
 int32_t climate_celsius_to_fahrenheit(int32_t celsius)
 {
@@ -282,7 +282,7 @@ static void climate_update_rain_sound()
         // Start playing the rain sound
         if (gRainSoundChannel == nullptr)
         {
-            gRainSoundChannel = Mixer_Play_Effect(RCT2Sound::Rain, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
+            gRainSoundChannel = Mixer_Play_Effect(SoundId::Rain, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
         }
         if (_rainVolume == 1)
         {
@@ -371,7 +371,7 @@ static void climate_update_thunder()
             if (_thunderStatus[0] == THUNDER_STATUS::NONE && _thunderStatus[1] == THUNDER_STATUS::NONE)
             {
                 // Play thunder on left side
-                _thunderSoundId = (randomNumber & 0x20000) ? RCT2Sound::Thunder1 : RCT2Sound::Thunder2;
+                _thunderSoundId = (randomNumber & 0x20000) ? SoundId::Thunder1 : SoundId::Thunder2;
                 _thunderVolume = (-((int32_t)((randomNumber >> 18) & 0xFF))) * 8;
                 climate_play_thunder(0, _thunderSoundId, _thunderVolume, -10000);
 
@@ -383,7 +383,7 @@ static void climate_update_thunder()
         {
             if (_thunderStatus[0] == THUNDER_STATUS::NONE)
             {
-                _thunderSoundId = (randomNumber & 0x20000) ? RCT2Sound::Thunder1 : RCT2Sound::Thunder2;
+                _thunderSoundId = (randomNumber & 0x20000) ? SoundId::Thunder1 : SoundId::Thunder2;
                 int32_t pan = (((randomNumber >> 18) & 0xFF) - 128) * 16;
                 climate_play_thunder(0, _thunderSoundId, 0, pan);
             }
@@ -391,7 +391,7 @@ static void climate_update_thunder()
     }
 }
 
-static void climate_play_thunder(int32_t instanceIndex, RCT2Sound soundId, int32_t volume, int32_t pan)
+static void climate_play_thunder(int32_t instanceIndex, SoundId soundId, int32_t volume, int32_t pan)
 {
     _thunderSoundChannels[instanceIndex] = Mixer_Play_Effect(
         soundId, MIXER_LOOP_NONE, DStoMixerVolume(volume), DStoMixerPan(pan), 1, 0);

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -59,7 +59,7 @@ static uint32_t _lightningTimer;
 static uint32_t _thunderTimer;
 static void* _thunderSoundChannels[MAX_THUNDER_INSTANCES];
 static THUNDER_STATUS _thunderStatus[MAX_THUNDER_INSTANCES] = { THUNDER_STATUS::NONE, THUNDER_STATUS::NONE };
-static uint32_t _thunderSoundId;
+static RCT2Sound _thunderSoundId;
 static int32_t _thunderVolume;
 static int32_t _thunderStereoEcho = 0;
 
@@ -69,7 +69,7 @@ static void climate_update_rain_sound();
 static void climate_update_thunder_sound();
 static void climate_update_lightning();
 static void climate_update_thunder();
-static void climate_play_thunder(int32_t instanceIndex, int32_t soundId, int32_t volume, int32_t pan);
+static void climate_play_thunder(int32_t instanceIndex, RCT2Sound soundId, int32_t volume, int32_t pan);
 
 int32_t climate_celsius_to_fahrenheit(int32_t celsius)
 {
@@ -282,7 +282,8 @@ static void climate_update_rain_sound()
         // Start playing the rain sound
         if (gRainSoundChannel == nullptr)
         {
-            gRainSoundChannel = Mixer_Play_Effect(SOUND_RAIN, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
+            gRainSoundChannel = Mixer_Play_Effect(
+                RCT2Sound::Rain, MIXER_LOOP_INFINITE, DStoMixerVolume(-4000), 0.5f, 1, 0);
         }
         if (_rainVolume == 1)
         {
@@ -371,7 +372,7 @@ static void climate_update_thunder()
             if (_thunderStatus[0] == THUNDER_STATUS::NONE && _thunderStatus[1] == THUNDER_STATUS::NONE)
             {
                 // Play thunder on left side
-                _thunderSoundId = (randomNumber & 0x20000) ? SOUND_THUNDER_1 : SOUND_THUNDER_2;
+                _thunderSoundId = (randomNumber & 0x20000) ? RCT2Sound::Thunder1 : RCT2Sound::Thunder2;
                 _thunderVolume = (-((int32_t)((randomNumber >> 18) & 0xFF))) * 8;
                 climate_play_thunder(0, _thunderSoundId, _thunderVolume, -10000);
 
@@ -383,7 +384,7 @@ static void climate_update_thunder()
         {
             if (_thunderStatus[0] == THUNDER_STATUS::NONE)
             {
-                _thunderSoundId = (randomNumber & 0x20000) ? SOUND_THUNDER_1 : SOUND_THUNDER_2;
+                _thunderSoundId = (randomNumber & 0x20000) ? RCT2Sound::Thunder1 : RCT2Sound::Thunder2;
                 int32_t pan = (((randomNumber >> 18) & 0xFF) - 128) * 16;
                 climate_play_thunder(0, _thunderSoundId, 0, pan);
             }
@@ -391,7 +392,7 @@ static void climate_update_thunder()
     }
 }
 
-static void climate_play_thunder(int32_t instanceIndex, int32_t soundId, int32_t volume, int32_t pan)
+static void climate_play_thunder(int32_t instanceIndex, RCT2Sound soundId, int32_t volume, int32_t pan)
 {
     _thunderSoundChannels[instanceIndex] = Mixer_Play_Effect(
         soundId, MIXER_LOOP_NONE, DStoMixerVolume(volume), DStoMixerPan(pan), 1, 0);

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -367,7 +367,7 @@ void duck_update(rct_duck* duck)
 
 void duck_press(rct_duck* duck)
 {
-    audio_play_sound_at_location(SOUND_QUACK, duck->x, duck->y, duck->z);
+    audio_play_sound_at_location(RCT2Sound::Quack, duck->x, duck->y, duck->z);
 }
 
 void duck_remove_all()

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -367,7 +367,7 @@ void duck_update(rct_duck* duck)
 
 void duck_press(rct_duck* duck)
 {
-    audio_play_sound_at_location(RCT2Sound::Quack, duck->x, duck->y, duck->z);
+    audio_play_sound_at_location(SoundId::Quack, duck->x, duck->y, duck->z);
 }
 
 void duck_remove_all()

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -86,7 +86,7 @@ void crashed_vehicle_particle_update(rct_crashed_vehicle_particle* particle)
     if (waterZ != 0 && particle->z >= waterZ && z <= waterZ)
     {
         // Splash
-        audio_play_sound_at_location(RCT2Sound::Water2, particle->x, particle->y, waterZ);
+        audio_play_sound_at_location(SoundId::Water2, particle->x, particle->y, waterZ);
         crash_splash_create(particle->x, particle->y, waterZ);
         sprite_remove((rct_sprite*)particle);
         return;

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -86,7 +86,7 @@ void crashed_vehicle_particle_update(rct_crashed_vehicle_particle* particle)
     if (waterZ != 0 && particle->z >= waterZ && z <= waterZ)
     {
         // Splash
-        audio_play_sound_at_location(SOUND_WATER_2, particle->x, particle->y, waterZ);
+        audio_play_sound_at_location(RCT2Sound::Water2, particle->x, particle->y, waterZ);
         crash_splash_create(particle->x, particle->y, waterZ);
         sprite_remove((rct_sprite*)particle);
         return;


### PR DESCRIPTION
Continuing on from #9560. This switches to an enum class for all of the sounds.

Has not been clang formatted yet.