### PR TITLE
Remove user string pool

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -235,12 +235,12 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
             if (ride->status == RIDE_STATUS_CLOSED)
             {
                 set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                set_map_tooltip_format_arg(2, rct_string_id, ride->name);
-                set_map_tooltip_format_arg(4, uint32_t, ride->name_arguments);
+                ride->FormatNameTo(gMapTooltipFormatArgs + 2);
             }
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_RIDE:
+        {
             if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
                 return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
             if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)
@@ -299,15 +299,13 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
                     return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
 
-                set_map_tooltip_format_arg(2, rct_string_id, ride->name);
-                set_map_tooltip_format_arg(4, uint32_t, ride->name_arguments);
+                ride->FormatNameTo(gMapTooltipFormatArgs + 2);
                 return info->type;
             }
 
-            set_map_tooltip_format_arg(4, rct_string_id, ride->name);
-            set_map_tooltip_format_arg(6, uint32_t, ride->name_arguments);
+            auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 4);
             set_map_tooltip_format_arg(
-                10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].capitalised);
+                4 + nameArgLen, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].capitalised);
 
             if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
                 stationIndex = tileElement->AsEntrance()->GetStationIndex();
@@ -318,9 +316,9 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
                 if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
                     stationIndex--;
             stationIndex++;
-            set_map_tooltip_format_arg(12, uint16_t, stationIndex);
+            set_map_tooltip_format_arg(4 + nameArgLen + 2, uint16_t, stationIndex);
             return info->type;
-
+        }
         case VIEWPORT_INTERACTION_ITEM_WALL:
             sceneryEntry = tileElement->AsWall()->GetEntry();
             if (sceneryEntry->wall.scrolling_mode != SCROLLING_MODE_NONE)

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -218,22 +218,16 @@ static void window_ride_demolish_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    Ride* ride = get_ride(w->number);
-
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
-    set_format_arg(6, money32, _demolishRideCost);
-
-    int32_t x = w->x + WW / 2;
-    int32_t y = w->y + (WH / 2) - 3;
-
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    auto ride = get_ride(w->number);
+    if (ride != nullptr)
     {
-        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, STR_DEMOLISH_RIDE_ID, COLOUR_BLACK);
-    }
-    else
-    {
-        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, STR_DEMOLISH_RIDE_ID_MONEY, COLOUR_BLACK);
+        auto stringId = (gParkFlags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID : STR_DEMOLISH_RIDE_ID_MONEY;
+        auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs);
+        set_format_arg(nameArgLen, money32, _demolishRideCost);
+
+        int32_t x = w->x + WW / 2;
+        int32_t y = w->y + (WH / 2) - 3;
+        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, stringId, COLOUR_BLACK);
     }
 }
 
@@ -241,21 +235,15 @@ static void window_ride_refurbish_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    Ride* ride = get_ride(w->number);
-
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
-    set_format_arg(6, money32, _demolishRideCost / 2);
-
-    int32_t x = w->x + WW / 2;
-    int32_t y = w->y + (WH / 2) - 3;
-
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
+    auto ride = get_ride(w->number);
+    if (ride != nullptr)
     {
-        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, STR_REFURBISH_RIDE_ID_NO_MONEY, COLOUR_BLACK);
-    }
-    else
-    {
-        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, STR_REFURBISH_RIDE_ID_MONEY, COLOUR_BLACK);
+        auto stringId = (gParkFlags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY : STR_REFURBISH_RIDE_ID_MONEY;
+        auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs);
+        set_format_arg(nameArgLen, money32, _demolishRideCost / 2);
+
+        int32_t x = w->x + WW / 2;
+        int32_t y = w->y + (WH / 2) - 3;
+        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, stringId, COLOUR_BLACK);
     }
 }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1181,7 +1181,8 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
         }
 
         // Ride name
-        gfx_draw_string_left(dpi, stringId, &ride->name, COLOUR_BLACK, 15, y);
+        ride->FormatNameTo(gCommonFormatArgs);
+        gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 15, y);
     }
 }
 

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1144,9 +1144,6 @@ static void window_editor_objective_options_rides_paint(rct_window* w, rct_drawp
  */
 static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    rct_string_id stringId;
-    Ride* ride;
-
     int32_t colour = ColourMapA[w->colours[1]].mid_light;
     gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1, colour);
 
@@ -1161,18 +1158,15 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
         gfx_fill_rect_inset(dpi, 2, y, 11, y + 10, w->colours[1], INSET_RECT_F_E0);
 
         // Highlighted
+        auto stringId = STR_BLACK_STRING;
         if (i == w->selected_list_item)
         {
             stringId = STR_WINDOW_COLOUR_2_STRINGID;
             gfx_filter_rect(dpi, 0, y, w->width, y + 11, PALETTE_DARKEN_1);
         }
-        else
-        {
-            stringId = STR_BLACK_STRING;
-        }
 
         // Checkbox mark
-        ride = get_ride(w->list_item_positions[i]);
+        auto ride = get_ride(w->list_item_positions[i]);
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
         {
             gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK
@@ -1181,8 +1175,9 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
         }
 
         // Ride name
-        ride->FormatNameTo(gCommonFormatArgs);
-        gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 15, y);
+        uint32_t args[32]{};
+        ride->FormatNameTo(args);
+        gfx_draw_string_left(dpi, stringId, args, COLOUR_BLACK, 15, y);
     }
 }
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1191,8 +1191,14 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
             case ADVERTISING_CAMPAIGN_RIDE:
             {
                 auto ride = get_ride(campaign->RideId);
-                set_format_arg(0, rct_string_id, ride->name);
-                set_format_arg(2, uint32_t, ride->name_arguments);
+                if (ride != nullptr)
+                {
+                    ride->FormatNameTo(gCommonFormatArgs);
+                }
+                else
+                {
+                    set_format_arg(0, rct_string_id, STR_NONE);
+                }
                 break;
             }
             case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1702,20 +1702,15 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     y = w->y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
-    rct_string_id ride_string_id = STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE;
-    uint32_t ride_string_arguments = 0;
-    if (peep->favourite_ride != 0xFF)
+    set_format_arg(0, rct_string_id, STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
+    if (peep->favourite_ride != RIDE_ID_NULL)
     {
         auto ride = get_ride(peep->favourite_ride);
         if (ride != nullptr)
         {
-            ride_string_arguments = ride->name_arguments;
-            ride_string_id = ride->name;
+            ride->FormatNameTo(gCommonFormatArgs);
         }
     }
-    set_format_arg(0, rct_string_id, ride_string_id);
-    set_format_arg(2, uint32_t, ride_string_arguments);
-
     gfx_draw_string_left_clipped(dpi, STR_FAVOURITE_RIDE, gCommonFormatArgs, COLOUR_BLACK, x, y, w->width - 14);
 }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1749,8 +1749,7 @@ void window_guest_rides_scroll_paint(rct_window* w, rct_drawpixelinfo* dpi, int3
         auto ride = get_ride(w->list_item_positions[list_index]);
         if (ride != nullptr)
         {
-            set_format_arg(0, rct_string_id, ride->name);
-            set_format_arg(2, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs);
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1);
         }
     }
@@ -1961,8 +1960,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
             break;
         case SHOP_ITEM_PHOTO:
             ride = get_ride(peep->photo1_ride_ref);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
         case SHOP_ITEM_UMBRELLA:
             set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour) | ShopItems[item].Image);
@@ -1978,8 +1976,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                 case VOUCHER_TYPE_RIDE_FREE:
                     ride = get_ride(peep->voucher_arguments);
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_RIDE_FREE);
-                    set_format_arg(8, rct_string_id, ride->name);
-                    set_format_arg(10, uint32_t, ride->name_arguments);
+                    ride->FormatNameTo(gCommonFormatArgs + 8);
                     break;
                 case VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_HALF_PRICE);
@@ -2000,18 +1997,15 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
             break;
         case SHOP_ITEM_PHOTO2:
             ride = get_ride(peep->photo2_ride_ref);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
         case SHOP_ITEM_PHOTO3:
             ride = get_ride(peep->photo3_ride_ref);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
         case SHOP_ITEM_PHOTO4:
             ride = get_ride(peep->photo4_ride_ref);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
     }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1080,11 +1080,8 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Draw the centred label
-    uint32_t argument1, argument2;
     Peep* peep = GET_PEEP(w->number);
-    get_arguments_from_action(peep, &argument1, &argument2);
-    set_format_arg(0, uint32_t, argument1);
-    set_format_arg(4, uint32_t, argument2);
+    peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_ACTION_LBL];
     int32_t x = (widget->left + widget->right) / 2 + w->x;
     int32_t y = w->y + widget->top - 1;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -886,7 +886,7 @@ static int32_t window_guest_list_is_peep_in_filter(Peep* peep)
 
     if (_window_guest_list_filter_arguments.GetFirstStringId() == STR_NONE && _window_guest_list_selected_filter == 1)
     {
-        set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_NONE);
+        set_format_arg_on(peepArgs.args, 0, rct_string_id, STR_NONE);
     }
 
     if (_window_guest_list_filter_arguments == peepArgs)

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -774,11 +774,7 @@ static void window_guest_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
                                 gfx_draw_sprite(dpi, STR_ENTER_SELECTION_SIZE, 112, y + 1, 0);
 
                             // Action
-
-                            get_arguments_from_action(peep, &argument_1, &argument_2);
-
-                            set_format_arg(0, uint32_t, argument_1);
-                            set_format_arg(4, uint32_t, argument_2);
+                            peep->FormatActionTo(gCommonFormatArgs);
                             gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 133, y, 314);
                             break;
                         case VIEW_THOUGHTS:

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -136,6 +136,26 @@ static rct_window_event_list window_guest_list_events = {
 };
 // clang-format on
 
+struct FilterArguments
+{
+    uint8_t args[12]{};
+
+    rct_string_id GetFirstStringId()
+    {
+        rct_string_id firstStrId{};
+        std::memcpy(&firstStrId, args, sizeof(firstStrId));
+        return firstStrId;
+    }
+};
+static bool operator==(const FilterArguments& l, const FilterArguments& r)
+{
+    return std::memcmp(l.args, r.args, sizeof(l.args)) == 0;
+}
+static bool operator!=(const FilterArguments& l, const FilterArguments& r)
+{
+    return !(l == r);
+}
+
 static uint32_t _window_guest_list_last_find_groups_tick;
 static uint32_t _window_guest_list_last_find_groups_selected_view;
 static uint32_t _window_guest_list_last_find_groups_wait;
@@ -148,11 +168,10 @@ static uint32_t _window_guest_list_selected_view;    // 0x00F1EE13
 static int32_t _window_guest_list_num_pages;         // 0x00F1EE08
 static int32_t _window_guest_list_num_groups;        // 0x00F1AF22
 static bool _window_guest_list_tracking_only;
-static uint16_t _window_guest_list_filter_arguments[4];
+static FilterArguments _window_guest_list_filter_arguments;
 
 static uint16_t _window_guest_list_groups_num_guests[240];
-static uint32_t _window_guest_list_groups_argument_1[240];
-static uint32_t _window_guest_list_groups_argument_2[240];
+static FilterArguments _window_guest_list_groups_arguments[240];
 static uint8_t _window_guest_list_groups_guest_faces[240 * 58];
 static uint8_t _window_guest_list_group_index[240];
 
@@ -161,7 +180,7 @@ static char _window_guest_list_filter_name[32];
 static int32_t window_guest_list_is_peep_in_filter(Peep* peep);
 static void window_guest_list_find_groups();
 
-static void get_arguments_from_peep(Peep* peep, uint32_t* argument_1, uint32_t* argument_2);
+static FilterArguments get_arguments_from_peep(const Peep* peep);
 
 static bool guest_should_be_visible(Peep* peep);
 
@@ -235,61 +254,60 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
     _window_guest_list_selected_page = 0;
     _window_guest_list_num_pages = 1;
     _window_guest_list_tracking_only = false;
+    _window_guest_list_filter_arguments = {};
 
     switch (type)
     {
         case GLFT_GUESTS_ON_RIDE:
         {
-            Ride* ride = get_ride(index & 0x000000FF);
-            _window_guest_list_filter_arguments[0] = STR_ON_RIDE;
-            if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE))
+            auto ride = get_ride(index & 0xFF);
+            if (ride != nullptr)
             {
-                _window_guest_list_filter_arguments[0] = STR_IN_RIDE;
-            }
-            _window_guest_list_filter_arguments[1] = ride->name;
-            _window_guest_list_filter_arguments[2] = ride->name_arguments_type_name;
-            _window_guest_list_filter_arguments[3] = ride->name_arguments_number;
+                set_format_arg_on(
+                    _window_guest_list_filter_arguments.args, 0, rct_string_id,
+                    ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_IN_RIDE : STR_ON_RIDE);
+                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
 
-            _window_guest_list_selected_filter = 0;
-            _window_guest_list_highlighted_index = 0xFFFF;
-            _window_guest_list_selected_tab = 0;
-            _window_guest_list_selected_view = 0;
+                _window_guest_list_selected_filter = 0;
+                _window_guest_list_highlighted_index = 0xFFFF;
+                _window_guest_list_selected_tab = 0;
+                _window_guest_list_selected_view = 0;
+            }
             break;
         }
         case GLFT_GUESTS_IN_QUEUE:
         {
-            Ride* ride = get_ride(index & 0x000000FF);
-            _window_guest_list_filter_arguments[0] = STR_QUEUING_FOR;
-            _window_guest_list_filter_arguments[1] = ride->name;
-            _window_guest_list_filter_arguments[2] = ride->name_arguments_type_name;
-            _window_guest_list_filter_arguments[3] = ride->name_arguments_number;
+            auto ride = get_ride(index & 0xFF);
+            if (ride != nullptr)
+            {
+                set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_QUEUING_FOR);
+                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
 
-            _window_guest_list_selected_filter = 0;
-            _window_guest_list_highlighted_index = 0xFFFF;
-            _window_guest_list_selected_tab = 0;
-            _window_guest_list_selected_view = 0;
+                _window_guest_list_selected_filter = 0;
+                _window_guest_list_highlighted_index = 0xFFFF;
+                _window_guest_list_selected_tab = 0;
+                _window_guest_list_selected_view = 0;
+            }
             break;
         }
         case GLFT_GUESTS_THINKING_ABOUT_RIDE:
         {
-            Ride* ride = get_ride(index & 0x000000FF);
-            _window_guest_list_filter_arguments[0] = STR_NONE;
-            _window_guest_list_filter_arguments[1] = ride->name;
-            _window_guest_list_filter_arguments[2] = ride->name_arguments_type_name;
-            _window_guest_list_filter_arguments[3] = ride->name_arguments_number;
+            auto ride = get_ride(index & 0xFF);
+            if (ride != nullptr)
+            {
+                set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_NONE);
+                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
 
-            _window_guest_list_selected_filter = 1;
-            _window_guest_list_highlighted_index = 0xFFFF;
-            _window_guest_list_selected_tab = 0;
-            _window_guest_list_selected_view = 1;
+                _window_guest_list_selected_filter = 1;
+                _window_guest_list_highlighted_index = 0xFFFF;
+                _window_guest_list_selected_tab = 0;
+                _window_guest_list_selected_view = 1;
+            }
             break;
         }
         case GLFT_GUESTS_THINKING_X:
         {
-            _window_guest_list_filter_arguments[0] = PeepThoughts[(index & 0x000000FF)];
-            _window_guest_list_filter_arguments[1] = 0;
-            _window_guest_list_filter_arguments[2] = 0;
-            _window_guest_list_filter_arguments[3] = 0;
+            set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, PeepThoughts[index & 0xFF]);
 
             _window_guest_list_selected_filter = 1;
             _window_guest_list_highlighted_index = 0xFFFF;
@@ -572,8 +590,7 @@ static void window_guest_list_scrollmousedown(rct_window* w, int32_t scrollIndex
             i = y / SUMMARISED_GUEST_ROW_HEIGHT;
             if (i < _window_guest_list_num_groups)
             {
-                std::memcpy(_window_guest_list_filter_arguments + 0, &_window_guest_list_groups_argument_1[i], 4);
-                std::memcpy(_window_guest_list_filter_arguments + 2, &_window_guest_list_groups_argument_2[i], 4);
+                _window_guest_list_filter_arguments = _window_guest_list_groups_arguments[i];
                 _window_guest_list_selected_filter = _window_guest_list_selected_view;
                 _window_guest_list_selected_tab = PAGE_INDIVIDUAL;
                 window_guest_list_widgets[WIDX_TRACKING].type = WWT_FLATBTN;
@@ -677,7 +694,7 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         if (_window_guest_list_selected_filter != -1)
         {
-            if (_window_guest_list_filter_arguments[0] != 0xFFFF)
+            if (_window_guest_list_filter_arguments.GetFirstStringId() != STR_NONE)
             {
                 format = filterNames[_window_guest_list_selected_filter]; // Not sure whether the index will ever be 2
             }
@@ -695,7 +712,7 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         format = STR_ALL_GUESTS_SUMMARISED;
     }
-    gfx_draw_string_left_clipped(dpi, format, _window_guest_list_filter_arguments, COLOUR_BLACK, x, y, 310);
+    gfx_draw_string_left_clipped(dpi, format, _window_guest_list_filter_arguments.args, COLOUR_BLACK, x, y, 310);
 
     // Number of guests (list items)
     if (_window_guest_list_selected_tab == PAGE_INDIVIDUAL)
@@ -719,7 +736,6 @@ static void window_guest_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
     rct_string_id format;
     Peep* peep;
     rct_peep_thought* thought;
-    uint32_t argument_1, argument_2;
 
     // Background fill
     gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1, ColourMapA[w->colours[1]].mid_light);
@@ -831,14 +847,15 @@ static void window_guest_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
                             j * 8, y + 12, 0);
 
                     // Draw action
-                    set_format_arg(0, uint32_t, _window_guest_list_groups_argument_1[i]);
-                    set_format_arg(4, uint32_t, _window_guest_list_groups_argument_2[i]);
-                    set_format_arg(10, uint32_t, numGuests);
+                    std::memcpy(
+                        gCommonFormatArgs, _window_guest_list_groups_arguments[i].args,
+                        std::min(sizeof(gCommonFormatArgs), sizeof(_window_guest_list_groups_arguments[i].args)));
                     gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y, 414);
 
                     // Draw guest count
-                    set_format_arg(8, rct_string_id, STR_GUESTS_COUNT_COMMA_SEP);
-                    gfx_draw_string_right(dpi, format, gCommonFormatArgs + 8, COLOUR_BLACK, 326, y);
+                    set_format_arg(0, rct_string_id, STR_GUESTS_COUNT_COMMA_SEP);
+                    set_format_arg(2, uint32_t, numGuests);
+                    gfx_draw_string_right(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 326, y);
                 }
                 y += SUMMARISED_GUEST_ROW_HEIGHT;
             }
@@ -861,21 +878,18 @@ static void window_guest_list_textinput(rct_window* w, rct_widgetindex widgetInd
  */
 static int32_t window_guest_list_is_peep_in_filter(Peep* peep)
 {
-    char temp;
-
-    temp = _window_guest_list_selected_view;
+    char temp = _window_guest_list_selected_view;
     _window_guest_list_selected_view = _window_guest_list_selected_filter;
-    uint32_t argument1, argument2;
-    get_arguments_from_peep(peep, &argument1, &argument2);
+    auto peepArgs = get_arguments_from_peep(peep);
 
     _window_guest_list_selected_view = temp;
 
-    if (_window_guest_list_filter_arguments[0] == 0xFFFF && _window_guest_list_selected_filter == 1)
-        argument1 |= 0xFFFF;
+    if (_window_guest_list_filter_arguments.GetFirstStringId() == STR_NONE && _window_guest_list_selected_filter == 1)
+    {
+        set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_NONE);
+    }
 
-    uint32_t check1 = _window_guest_list_filter_arguments[0] | (_window_guest_list_filter_arguments[1] << 16);
-    uint32_t check2 = _window_guest_list_filter_arguments[2] | (_window_guest_list_filter_arguments[3] << 16);
-    if (argument1 == check1 && argument2 == check2)
+    if (_window_guest_list_filter_arguments == peepArgs)
     {
         return 0;
     }
@@ -889,37 +903,27 @@ static int32_t window_guest_list_is_peep_in_filter(Peep* peep)
  * argument_1 (0x013CE952) gCommonFormatArgs
  * argument_2 (0x013CE954) gCommonFormatArgs + 2
  */
-static void get_arguments_from_peep(Peep* peep, uint32_t* argument_1, uint32_t* argument_2)
+static FilterArguments get_arguments_from_peep(const Peep* peep)
 {
+    FilterArguments result;
     switch (_window_guest_list_selected_view)
     {
         case VIEW_ACTIONS:
-            get_arguments_from_action(peep, argument_1, argument_2);
+            peep->FormatActionTo(result.args);
             break;
         case VIEW_THOUGHTS:
         {
-            rct_peep_thought* thought = &peep->thoughts[0];
+            auto thought = &peep->thoughts[0];
             if (thought->freshness <= 5 && thought->type != PEEP_THOUGHT_TYPE_NONE)
             {
-                // HACK The out arguments here are used to draw the group text so we just return
-                //      gCommonFormatArgs as two uint32_ts.
-                std::memset(gCommonFormatArgs, 0, sizeof(*argument_1) + sizeof(*argument_2));
+                std::memset(gCommonFormatArgs, 0, sizeof(gCommonFormatArgs));
                 peep_thought_set_format_args(thought);
-                std::memcpy(argument_1, gCommonFormatArgs, sizeof(*argument_1));
-                std::memcpy(argument_2, gCommonFormatArgs + sizeof(*argument_1), sizeof(*argument_2));
-            }
-            else
-            {
-                *argument_1 = 0;
-                *argument_2 = 0;
+                std::memcpy(result.args, gCommonFormatArgs, std::min(sizeof(gCommonFormatArgs), sizeof(result.args)));
             }
             break;
         }
-        default:
-            *argument_1 = 0;
-            *argument_2 = 0;
-            break;
     }
+    return result;
 }
 
 /**
@@ -965,10 +969,8 @@ static void window_guest_list_find_groups()
         _window_guest_list_groups_num_guests[groupIndex] = 1;
         peep->flags &= ~(SPRITE_FLAGS_PEEP_VISIBLE);
 
-        get_arguments_from_peep(
-            peep, &_window_guest_list_groups_argument_1[groupIndex], &_window_guest_list_groups_argument_2[groupIndex]);
-        std::memcpy(_window_guest_list_filter_arguments + 0, &_window_guest_list_groups_argument_1[groupIndex], 4);
-        std::memcpy(_window_guest_list_filter_arguments + 2, &_window_guest_list_groups_argument_2[groupIndex], 4);
+        _window_guest_list_groups_arguments[groupIndex] = get_arguments_from_peep(peep);
+        _window_guest_list_filter_arguments = _window_guest_list_groups_arguments[groupIndex];
 
         _window_guest_list_group_index[groupIndex] = groupIndex;
         faceIndex = groupIndex * 56;
@@ -981,11 +983,9 @@ static void window_guest_list_find_groups()
             if (peep2->outside_of_park != 0 || !(peep2->flags & SPRITE_FLAGS_PEEP_VISIBLE))
                 continue;
 
-            uint32_t argument1, argument2;
             // Get and check if in same group
-            get_arguments_from_peep(peep2, &argument1, &argument2);
-            if (argument1 != _window_guest_list_groups_argument_1[groupIndex]
-                || argument2 != _window_guest_list_groups_argument_2[groupIndex])
+            auto argument12 = get_arguments_from_peep(peep2);
+            if (argument12 != _window_guest_list_groups_arguments[groupIndex])
                 continue;
 
             // Assign guest
@@ -999,13 +999,13 @@ static void window_guest_list_find_groups()
                 - SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY;
         }
 
-        if (_window_guest_list_filter_arguments[0] == 0)
+        if (_window_guest_list_filter_arguments.GetFirstStringId() == 0)
         {
             _window_guest_list_num_groups--;
             continue;
         }
 
-        int32_t curr_num_guests = _window_guest_list_groups_num_guests[groupIndex];
+        auto curr_num_guests = _window_guest_list_groups_num_guests[groupIndex];
         int32_t swap_position = 0;
         // This section places the groups in size order.
         bool gotoNextPeep = false;
@@ -1025,23 +1025,13 @@ static void window_guest_list_find_groups()
             continue;
         }
 
-        int32_t argument_1 = _window_guest_list_groups_argument_1[groupIndex];
-        int32_t argument_2 = _window_guest_list_groups_argument_2[groupIndex];
-        int32_t bl = _window_guest_list_group_index[groupIndex];
+        auto arguments12 = _window_guest_list_groups_arguments[groupIndex];
+        auto bl = _window_guest_list_group_index[groupIndex];
 
         do
         {
-            int32_t temp = curr_num_guests;
-            curr_num_guests = _window_guest_list_groups_num_guests[swap_position];
-            _window_guest_list_groups_num_guests[swap_position] = temp;
-
-            temp = argument_1;
-            argument_1 = _window_guest_list_groups_argument_1[swap_position];
-            _window_guest_list_groups_argument_1[swap_position] = temp;
-
-            temp = argument_2;
-            argument_2 = _window_guest_list_groups_argument_2[swap_position];
-            _window_guest_list_groups_argument_2[swap_position] = temp;
+            std::swap(curr_num_guests, _window_guest_list_groups_num_guests[swap_position]);
+            std::swap(arguments12, _window_guest_list_groups_arguments[swap_position]);
 
             uint8_t temp_faces[56];
             std::memcpy(temp_faces, &(_window_guest_list_groups_guest_faces[groupIndex * 56]), 56);
@@ -1050,9 +1040,7 @@ static void window_guest_list_find_groups()
                 &(_window_guest_list_groups_guest_faces[swap_position * 56]), 56);
             std::memcpy(&(_window_guest_list_groups_guest_faces[swap_position * 56]), temp_faces, 56);
 
-            temp = _window_guest_list_group_index[swap_position];
-            _window_guest_list_group_index[swap_position] = bl;
-            bl = temp;
+            std::swap(bl, _window_guest_list_group_index[swap_position]);
         } while (++swap_position <= groupIndex);
     }
 }

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -417,11 +417,15 @@ static void window_maze_construction_tooldown(rct_window* w, rct_widgetindex wid
  */
 static void window_maze_construction_invalidate(rct_window* w)
 {
-    Ride* ride = get_ride(_currentRideIndex);
-
-    // Set window title arguments
-    set_format_arg(4, rct_string_id, ride->name);
-    set_format_arg(6, uint32_t, ride->name_arguments);
+    auto ride = get_ride(_currentRideIndex);
+    if (ride != nullptr)
+    {
+        ride->FormatNameTo(gCommonFormatArgs + 4);
+    }
+    else
+    {
+        set_format_arg(4, rct_string_id, STR_NONE);
+    }
 }
 
 /**

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -288,8 +288,17 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
                     if (ride == nullptr)
                         break;
 
+                    // HACK until dropdown items have longer argument buffers
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    ride->FormatNameTo(&gDropdownItemsArgs[i]);
+                    if (ride->custom_name.empty())
+                    {
+                        ride->FormatNameTo(&gDropdownItemsArgs[i]);
+                    }
+                    else
+                    {
+                        gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
+                        set_format_arg_on((uint8_t*)&gDropdownItemsArgs[i], 0, const char*, ride->custom_name.c_str());
+                    }
                     numItems++;
                 }
 

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -103,16 +103,11 @@ static int32_t ride_value_compare(const void* a, const void* b)
 
 static int32_t ride_name_compare(const void* a, const void* b)
 {
-    char rideAName[256], rideBName[256];
-    Ride *rideA, *rideB;
-
-    rideA = get_ride(*((uint8_t*)a));
-    rideB = get_ride(*((uint8_t*)b));
-
-    format_string(rideAName, 256, rideA->name, &rideA->name_arguments);
-    format_string(rideBName, 256, rideB->name, &rideB->name_arguments);
-
-    return _strcmpi(rideAName, rideBName);
+    auto rideA = get_ride(*((uint8_t*)a));
+    auto rideB = get_ride(*((uint8_t*)b));
+    auto rideAName = rideA->GetName();
+    auto rideBName = rideB->GetName();
+    return _strcmpi(rideAName.c_str(), rideBName.c_str());
 }
 
 /**
@@ -289,9 +284,12 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
                     if (window_new_campaign_rides[i] == RIDE_ID_NULL)
                         break;
 
-                    Ride* ride = get_ride(window_new_campaign_rides[i]);
+                    auto ride = get_ride(window_new_campaign_rides[i]);
+                    if (ride == nullptr)
+                        break;
+
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = ((uint64_t)ride->name_arguments << 16ULL) | ride->name;
+                    ride->FormatNameTo(&gDropdownItemsArgs[i]);
                     numItems++;
                 }
 
@@ -356,9 +354,12 @@ static void window_new_campaign_invalidate(rct_window* w)
             window_new_campaign_widgets[WIDX_RIDE_LABEL].text = STR_MARKETING_RIDE;
             if (w->campaign.ride_id != SELECTED_RIDE_UNDEFINED)
             {
-                Ride* ride = get_ride(w->campaign.ride_id);
-                window_new_campaign_widgets[WIDX_RIDE_DROPDOWN].text = ride->name;
-                set_format_arg(0, uint32_t, ride->name_arguments);
+                auto ride = get_ride(w->campaign.ride_id);
+                if (ride != nullptr)
+                {
+                    window_new_campaign_widgets[WIDX_RIDE_DROPDOWN].text = STR_STRINGID;
+                    ride->FormatNameTo(gCommonFormatArgs);
+                }
             }
             break;
         case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2286,9 +2286,8 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     bool selectionShouldBeExpanded;
     int32_t rideTypeIterator, rideTypeIteratorMax;
     if (gCheatsShowVehiclesFromOtherTrackTypes
-        && !(
-            ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
-            || ride->type == RIDE_TYPE_MINI_GOLF))
+        && !(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
+             || ride->type == RIDE_TYPE_MINI_GOLF))
     {
         selectionShouldBeExpanded = true;
         rideTypeIterator = 0;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2569,9 +2569,8 @@ static void window_ride_main_invalidate(rct_window* w)
     if (ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK))
         w->disabled_widgets |= (1 << WIDX_DEMOLISH);
 
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
-    set_format_arg(6, uint16_t, RideNaming[ride->type].name);
+    ride->FormatNameTo(gCommonFormatArgs);
+
     uint32_t spriteIds[] = {
         SPR_CLOSED,
         SPR_OPEN,
@@ -3013,8 +3012,7 @@ static void window_ride_vehicle_invalidate(rct_window* w)
     ride = get_ride(w->number);
     rideEntry = ride->GetRideEntry();
 
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     // Widget setup
     carsPerTrain = ride->num_cars_per_train - rideEntry->zero_cars;
@@ -3571,8 +3569,7 @@ static void window_ride_operating_invalidate(rct_window* w)
 
     ride = get_ride(w->number);
 
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     // Widget setup
     w->pressed_widgets &= ~(
@@ -4147,8 +4144,8 @@ static void window_ride_maintenance_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+
+    ride->FormatNameTo(gCommonFormatArgs);
 
     window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL].text = RideInspectionIntervalNames[ride->inspection_interval];
 
@@ -4699,8 +4696,7 @@ static void window_ride_colour_invalidate(rct_window* w)
     ride = get_ride(w->number);
     rideEntry = ride->GetRideEntry();
 
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     // Track colours
     int32_t colourScheme = w->ride_colour;
@@ -5213,8 +5209,7 @@ static void window_ride_music_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     // Set selected music
     window_ride_music_widgets[WIDX_MUSIC].text = MusicStyleNames[ride->music];
@@ -5541,8 +5536,7 @@ static void window_ride_measurements_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     window_ride_measurements_widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN_NOT_POSSIBLE;
     window_ride_measurements_widgets[WIDX_SAVE_TRACK_DESIGN].type = WWT_EMPTY;
@@ -5989,9 +5983,7 @@ static void window_ride_graphs_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     ride = get_ride(w->number);
-
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     // Set pressed graph button type
     w->pressed_widgets &= ~(1 << WIDX_GRAPH_VELOCITY);
@@ -6524,8 +6516,7 @@ static void window_ride_income_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     rideEntry = ride->GetRideEntry();
 
@@ -6799,8 +6790,7 @@ static void window_ride_customer_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    set_format_arg(0, rct_string_id, ride->name);
-    set_format_arg(2, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs);
 
     window_ride_customer_widgets[WIDX_SHOW_GUESTS_THOUGHTS].type = WWT_FLATBTN;
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1974,13 +1974,13 @@ static void window_ride_init_viewport(rct_window* w)
  */
 static void window_ride_rename(rct_window* w)
 {
-    Ride* ride;
-
-    ride = get_ride(w->number);
-    set_format_arg(16, uint32_t, ride->name_arguments);
-    window_text_input_open(
-        w, WIDX_RENAME, STR_RIDE_ATTRACTION_NAME, STR_ENTER_NEW_NAME_FOR_THIS_RIDE_ATTRACTION, ride->name, ride->name_arguments,
-        32);
+    auto ride = get_ride(w->number);
+    if (ride != nullptr)
+    {
+        auto rideName = ride->GetName();
+        window_text_input_raw_open(
+            w, WIDX_RENAME, STR_RIDE_ATTRACTION_NAME, STR_ENTER_NEW_NAME_FOR_THIS_RIDE_ATTRACTION, rideName.c_str(), 32);
+    }
 }
 
 /**
@@ -2286,8 +2286,9 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     bool selectionShouldBeExpanded;
     int32_t rideTypeIterator, rideTypeIteratorMax;
     if (gCheatsShowVehiclesFromOtherTrackTypes
-        && !(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
-             || ride->type == RIDE_TYPE_MINI_GOLF))
+        && !(
+            ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
+            || ride->type == RIDE_TYPE_MINI_GOLF))
     {
         selectionShouldBeExpanded = true;
         rideTypeIterator = 0;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3012,7 +3012,8 @@ static void window_ride_vehicle_invalidate(rct_window* w)
     ride = get_ride(w->number);
     rideEntry = ride->GetRideEntry();
 
-    ride->FormatNameTo(gCommonFormatArgs);
+    w->widgets[WIDX_TITLE].text = STR_ARG_20_STRINGID;
+    ride->FormatNameTo(gCommonFormatArgs + 20);
 
     // Widget setup
     carsPerTrain = ride->num_cars_per_train - rideEntry->zero_cars;
@@ -4696,7 +4697,8 @@ static void window_ride_colour_invalidate(rct_window* w)
     ride = get_ride(w->number);
     rideEntry = ride->GetRideEntry();
 
-    ride->FormatNameTo(gCommonFormatArgs);
+    w->widgets[WIDX_TITLE].text = STR_ARG_16_STRINGID;
+    ride->FormatNameTo(gCommonFormatArgs + 16);
 
     // Track colours
     int32_t colourScheme = w->ride_colour;
@@ -6516,7 +6518,9 @@ static void window_ride_income_invalidate(rct_window* w)
     window_ride_set_pressed_tab(w);
 
     Ride* ride = get_ride(w->number);
-    ride->FormatNameTo(gCommonFormatArgs);
+
+    w->widgets[WIDX_TITLE].text = STR_ARG_14_STRINGID;
+    ride->FormatNameTo(gCommonFormatArgs + 14);
 
     rideEntry = ride->GetRideEntry();
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -864,8 +864,9 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_DOWN_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_UP) | (1ULL << WIDX_SLOPE_UP_STEEP);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(
+                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }
@@ -876,8 +877,9 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_UP_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_DOWN_STEEP) | (1ULL << WIDX_SLOPE_DOWN);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(
+                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }
@@ -2236,12 +2238,13 @@ static void window_ride_construction_tooldown(rct_window* w, rct_widgetindex wid
  */
 static void window_ride_construction_invalidate(rct_window* w)
 {
-    Ride* ride;
-    rct_string_id stringId;
+    auto ride = get_ride(_currentRideIndex);
+    if (ride == nullptr)
+    {
+        return;
+    }
 
-    ride = get_ride(_currentRideIndex);
-
-    stringId = STR_RIDE_CONSTRUCTION_SPECIAL;
+    rct_string_id stringId = STR_RIDE_CONSTRUCTION_SPECIAL;
     if (_currentTrackCurve & 0x100)
     {
         stringId = RideConfigurationStringIds[_currentTrackCurve & 0xFF];
@@ -2284,8 +2287,7 @@ static void window_ride_construction_invalidate(rct_window* w)
     }
 
     // Set window title arguments
-    set_format_arg(4, rct_string_id, ride->name);
-    set_format_arg(6, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs + 4);
 }
 
 /**

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -864,9 +864,8 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_DOWN_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_UP) | (1ULL << WIDX_SLOPE_UP_STEEP);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(
-                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }
@@ -877,9 +876,8 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_UP_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_DOWN_STEEP) | (1ULL << WIDX_SLOPE_DOWN);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(
-                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -608,8 +608,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         ride = get_ride(w->list_item_positions[i]);
 
         // Ride name
-        set_format_arg(0, rct_string_id, ride->name);
-        set_format_arg(2, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(gCommonFormatArgs);
         gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y - 1, 159);
 
         // Ride information

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -781,7 +781,6 @@ void window_ride_list_refresh_list(rct_window* w)
 {
     int32_t i;
     Ride *ride, *otherRide;
-    char bufferA[128], bufferB[128];
     int32_t list_index = 0;
 
     FOR_ALL_RIDES (i, ride)
@@ -800,17 +799,19 @@ void window_ride_list_refresh_list(rct_window* w)
         switch (w->list_information_type)
         {
             case INFORMATION_TYPE_STATUS:
-                format_string_to_upper(bufferA, 128, ride->name, &ride->name_arguments);
+            {
+                auto strA = ride->GetName();
                 while (--current_list_position >= 0)
                 {
                     otherRide = get_ride(w->list_item_positions[current_list_position]);
-                    format_string_to_upper(bufferB, 128, otherRide->name, &otherRide->name_arguments);
-                    if (strcmp(bufferA, bufferB) >= 0)
+                    auto strB = ride->GetName();
+                    if (_strcmpi(strA.c_str(), strB.c_str()) >= 0)
                         break;
 
                     window_bubble_list_item(w, current_list_position);
                 }
                 break;
+            }
             case INFORMATION_TYPE_POPULARITY:
                 while (--current_list_position >= 0)
                 {

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -131,6 +131,8 @@ static rct_window_event_list window_sign_small_events = {
 };
 // clang-format on
 
+static void window_sign_show_text_input(rct_window* w, const rct_banner* banner);
+
 /**
  *
  *  rct2: 0x006BA305
@@ -206,8 +208,6 @@ static void window_sign_mouseup(rct_window* w, rct_widgetindex widgetIndex)
     int32_t x = banner->x << 5;
     int32_t y = banner->y << 5;
 
-    rct_string_id string_id;
-
     TileElement* tile_element = map_get_first_element_at(x / 32, y / 32);
 
     switch (widgetIndex)
@@ -240,17 +240,7 @@ static void window_sign_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             break;
         }
         case WIDX_SIGN_TEXT:
-            if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
-            {
-                Ride* ride = get_ride(banner->ride_index);
-                set_format_arg(16, uint32_t, ride->name_arguments);
-                string_id = ride->name;
-            }
-            else
-            {
-                string_id = gBanners[w->number].string_idx;
-            }
-            window_text_input_open(w, WIDX_SIGN_TEXT, STR_SIGN_TEXT_TITLE, STR_SIGN_TEXT_PROMPT, string_id, 0, 32);
+            window_sign_show_text_input(w, banner);
             break;
     }
 }
@@ -464,8 +454,6 @@ static void window_sign_small_mouseup(rct_window* w, rct_widgetindex widgetIndex
     int32_t x = banner->x << 5;
     int32_t y = banner->y << 5;
 
-    rct_string_id string_id;
-
     TileElement* tile_element = map_get_first_element_at(x / 32, y / 32);
 
     switch (widgetIndex)
@@ -494,17 +482,7 @@ static void window_sign_small_mouseup(rct_window* w, rct_widgetindex widgetIndex
         }
         break;
         case WIDX_SIGN_TEXT:
-            if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
-            {
-                Ride* ride = get_ride(banner->ride_index);
-                set_format_arg(16, uint32_t, ride->name_arguments);
-                string_id = ride->name;
-            }
-            else
-            {
-                string_id = gBanners[w->number].string_idx;
-            }
-            window_text_input_open(w, WIDX_SIGN_TEXT, STR_SIGN_TEXT_TITLE, STR_SIGN_TEXT_PROMPT, string_id, 0, 32);
+            window_sign_show_text_input(w, banner);
             break;
     }
 }
@@ -567,4 +545,22 @@ static void window_sign_small_invalidate(rct_window* w)
 
     main_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(w->list_information_type) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
     text_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(w->var_492) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
+}
+
+static void window_sign_show_text_input(rct_window* w, const rct_banner* banner)
+{
+    std::string inputText;
+    if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
+    {
+        auto ride = get_ride(banner->ride_index);
+        if (ride != nullptr)
+        {
+            inputText = ride->GetName();
+        }
+    }
+    else
+    {
+        inputText = format_string(gBanners[w->number].string_idx, nullptr);
+    }
+    window_text_input_raw_open(w, WIDX_SIGN_TEXT, STR_SIGN_TEXT_TITLE, STR_SIGN_TEXT_PROMPT, inputText.c_str(), 32);
 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -955,9 +955,7 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw the centred label
     uint32_t argument1, argument2;
     Peep* peep = GET_PEEP(w->number);
-    get_arguments_from_action(peep, &argument1, &argument2);
-    set_format_arg(0, uint32_t, argument1);
-    set_format_arg(4, uint32_t, argument2);
+    peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
     int32_t x = (widget->left + widget->right) / 2 + w->x;
     int32_t y = w->y + widget->top;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -953,7 +953,6 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Draw the centred label
-    uint32_t argument1, argument2;
     Peep* peep = GET_PEEP(w->number);
     peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -698,9 +698,7 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
                 set_format_arg(2, uint32_t, peep->id);
                 gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 0, y, nameColumnSize);
 
-                get_arguments_from_action(peep, &argument_1, &argument_2);
-                set_format_arg(0, uint32_t, argument_1);
-                set_format_arg(4, uint32_t, argument_2);
+                peep->FormatActionTo(gCommonFormatArgs);
                 gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, actionOffset, y, actionColumnSize);
 
                 // True if a patrol path is set for the worker

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -660,7 +660,6 @@ static constexpr const uint32_t staffCostumeSprites[] = {
 void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
     int32_t spriteIndex, y, i, staffOrderIcon_x, staffOrders, staffOrderSprite;
-    uint32_t argument_1, argument_2;
     uint8_t selectedTab;
     Peep* peep;
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1876,8 +1876,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 rct_string_id rideType = RideNaming[ride->type].name;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, &rideType, COLOUR_DARK_GREEN, x, y);
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_TRACK_RIDE_ID, &rideId, COLOUR_DARK_GREEN, x, y + 11);
-                set_format_arg(0, rct_string_id, ride->name);
-                set_format_arg(0 + sizeof(rct_string_id), uint32_t, ride->name_arguments);
+                ride->FormatNameTo(gCommonFormatArgs);
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, gCommonFormatArgs, COLOUR_DARK_GREEN, x, y + 22);
                 // Track
                 int16_t trackType = trackElement->GetTrackType();

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -629,10 +629,17 @@ static void window_title_command_editor_tool_down(rct_window* w, rct_widgetindex
         else if (spriteIdentifier == SPRITE_IDENTIFIER_VEHICLE)
         {
             validSprite = true;
-            rct_vehicle* vehicle = GET_VEHICLE(spriteIndex);
-            Ride* ride = get_ride(vehicle->ride);
-            set_format_arg(16, uint32_t, ride->name_arguments);
-            format_string(command.SpriteName, USER_STRING_MAX_LENGTH, ride->name, &ride->name_arguments);
+            auto vehicle = GET_VEHICLE(spriteIndex);
+            if (vehicle != nullptr)
+            {
+                auto ride = get_ride(vehicle->ride);
+                if (ride != nullptr)
+                {
+                    uint8_t formatArgs[32]{};
+                    ride->FormatNameTo(formatArgs);
+                    format_string(command.SpriteName, USER_STRING_MAX_LENGTH, STR_STRINGID, formatArgs);
+                }
+            }
         }
         else if (spriteIdentifier == SPRITE_IDENTIFIER_LITTER)
         {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -302,16 +302,6 @@ namespace Editor
             }
         }
 
-        //
-        {
-            int32_t i;
-            Ride* ride;
-            FOR_ALL_RIDES (i, ride)
-            {
-                user_string_free(ride->name);
-            }
-        }
-
         ride_init_all();
 
         //

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -138,16 +138,7 @@ public:
         ride->subtype = rideEntryIndex;
         ride->SetColourPreset(_colour1);
         ride->overall_view.xy = RCT_XY8_UNDEFINED;
-
-        // Ride name
-        if (rideEntryIndex == RIDE_ENTRY_INDEX_NULL)
-        {
-            ride_set_name_to_track_default(ride, rideEntry);
-        }
-        else
-        {
-            ride_set_name_to_default(ride, rideEntry);
-        }
+        ride->SetNameToDefault();
 
         for (int32_t i = 0; i < MAX_STATIONS; i++)
         {

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -79,9 +79,6 @@ public:
 
     GameActionResult::Ptr Execute() const override
     {
-        rct_string_id newUserStringId = user_string_allocate(
-            USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, _name.c_str());
-
         Ride* ride = get_ride(_rideIndex);
         if (ride->type == RIDE_TYPE_NULL)
         {
@@ -89,8 +86,7 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_RIDE_ATTRACTION, STR_NONE);
         }
 
-        user_string_free(ride->name);
-        ride->name = newUserStringId;
+        ride->custom_name = _name;
 
         scrolling_text_invalidate();
         gfx_invalidate_screen();

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -59,20 +59,11 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_RIDE_ATTRACTION, STR_NONE);
         }
 
-        if (_name.empty())
+        if (!_name.empty() && Ride::NameExists(_name, ride->id))
         {
             return std::make_unique<GameActionResult>(
-                GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_RIDE_ATTRACTION, STR_INVALID_RIDE_ATTRACTION_NAME);
+                GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_RIDE_ATTRACTION, STR_ERROR_EXISTING_NAME);
         }
-
-        rct_string_id newUserStringId = user_string_allocate(
-            USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, _name.c_str());
-        if (newUserStringId == 0)
-        {
-            // TODO: Probably exhausted, introduce new error.
-            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_CANT_RENAME_RIDE_ATTRACTION, STR_NONE);
-        }
-        user_string_free(newUserStringId);
 
         return std::make_unique<GameActionResult>();
     }
@@ -86,7 +77,14 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_CANT_RENAME_RIDE_ATTRACTION, STR_NONE);
         }
 
-        ride->custom_name = _name;
+        if (_name.empty())
+        {
+            ride->SetNameToDefault();
+        }
+        else
+        {
+            ride->custom_name = _name;
+        }
 
         scrolling_text_invalidate();
         gfx_invalidate_screen();

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -61,8 +61,7 @@ public:
         GameActionResult::Ptr res = std::make_unique<GameActionResult>();
         Ride* ride = get_ride(_rideIndex);
         res->ErrorTitle = _StatusErrorTitles[_status];
-        set_format_arg_on(res->ErrorMessageArgs.data(), 6, rct_string_id, ride->name);
-        set_format_arg_on(res->ErrorMessageArgs.data(), 8, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(res->ErrorMessageArgs.data() + 6);
 
         if (_rideIndex >= MAX_RIDES || _rideIndex < 0)
         {
@@ -110,8 +109,7 @@ public:
 
         Ride* ride = get_ride(_rideIndex);
         res->ErrorTitle = _StatusErrorTitles[_status];
-        set_format_arg_on(res->ErrorMessageArgs.data(), 6, rct_string_id, ride->name);
-        set_format_arg_on(res->ErrorMessageArgs.data(), 8, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(res->ErrorMessageArgs.data() + 6);
 
         if (ride->type == RIDE_TYPE_NULL)
         {

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -190,14 +190,13 @@ template<> struct DataSerializerTraits<NetworkRideId_t>
 
         stream->Write(rideId, strlen(rideId));
 
-        Ride* ride = get_ride(val.id);
-        if (ride)
+        auto ride = get_ride(val.id);
+        if (ride != nullptr)
         {
-            char rideName[256] = {};
-            format_string(rideName, 256, ride->name, &ride->name_arguments);
+            auto rideName = ride->GetName();
 
             stream->Write(" \"", 2);
-            stream->Write(rideName, strlen(rideName));
+            stream->Write(rideName.c_str(), rideName.size());
             stream->Write("\"", 1);
         }
     }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -141,11 +141,10 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
             int32_t i;
             FOR_ALL_RIDES (i, ride)
             {
-                char name[128];
-                format_string(name, 128, ride->name, &ride->name_arguments);
+                auto name = ride->GetName();
                 console.WriteFormatLine(
                     "ride: %03d type: %02u subtype %03u operating mode: %02u name: %s", i, ride->type, ride->subtype,
-                    ride->mode, name);
+                    ride->mode, name.c_str());
             }
         }
         else if (argv[0] == "set")

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -74,8 +74,7 @@ static void marketing_raise_finished_notification(const MarketingCampaign& campa
         if (campaign.Type == ADVERTISING_CAMPAIGN_RIDE_FREE || campaign.Type == ADVERTISING_CAMPAIGN_RIDE)
         {
             Ride* ride = get_ride(campaign.RideId);
-            set_format_arg(0, rct_string_id, ride->name);
-            set_format_arg(2, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs);
         }
         else if (campaign.Type == ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE)
         {

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -165,8 +165,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
 
         if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
         {
-            set_format_arg(2, rct_string_id, ride->name);
-            set_format_arg(4, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 2);
         }
         else
         {

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -314,9 +314,12 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
         rct_string_id stringId = banner->string_idx;
         if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
         {
-            Ride* ride = get_ride(banner->ride_index);
-            stringId = ride->name;
-            set_format_arg(0, uint32_t, ride->name_arguments);
+            auto ride = get_ride(banner->ride_index);
+            if (ride != nullptr)
+            {
+                stringId = STR_STRINGID;
+                ride->FormatNameTo(gCommonFormatArgs);
+            }
         }
         utf8 signString[256];
         format_string(signString, sizeof(signString), stringId, gCommonFormatArgs);
@@ -433,9 +436,11 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
     set_format_arg(0, rct_string_id, banner->string_idx);
     if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
     {
-        Ride* ride = get_ride(banner->ride_index);
-        set_format_arg(0, rct_string_id, ride->name);
-        set_format_arg(2, uint32_t, ride->name_arguments);
+        auto ride = get_ride(banner->ride_index);
+        if (ride != nullptr)
+        {
+            ride->FormatNameTo(gCommonFormatArgs);
+        }
     }
     utf8 signString[256];
     rct_string_id stringId = STR_SCROLLING_SIGN_TEXT;

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -454,8 +454,7 @@ static void sub_6A4101(
             if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN))
             {
                 set_format_arg(0, rct_string_id, STR_RIDE_ENTRANCE_NAME);
-                set_format_arg(2, rct_string_id, ride->name);
-                set_format_arg(4, uint32_t, ride->name_arguments);
+                ride->FormatNameTo(gCommonFormatArgs + 2);
             }
             else
             {

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -436,9 +436,11 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     set_format_arg(0, rct_string_id, banner->string_idx);
     if (banner->flags & BANNER_FLAG_LINKED_TO_RIDE)
     {
-        Ride* ride = get_ride(banner->ride_index);
-        set_format_arg(0, rct_string_id, ride->name);
-        set_format_arg(2, uint32_t, ride->name_arguments);
+        auto ride = get_ride(banner->ride_index);
+        if (ride != nullptr)
+        {
+            ride->FormatNameTo(gCommonFormatArgs);
+        }
     }
 
     utf8 signString[256];

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3848,8 +3848,7 @@ void Guest::UpdateRideAdvanceThroughEntrance()
                 ride->current_issues |= RIDE_ISSUE_GUESTS_STUCK;
                 ride->last_issue_time = gCurrentTicks;
 
-                set_format_arg(0, rct_string_id, ride->name);
-                set_format_arg(2, uint32_t, ride->name_arguments);
+                ride->FormatNameTo(gCommonFormatArgs);
                 if (gConfigNotifications.ride_warnings)
                 {
                     news_item_add_to_queue(NEWS_ITEM_RIDE, STR_GUESTS_GETTING_STUCK_ON_RIDE, current_ride);
@@ -4012,8 +4011,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
     {
         set_format_arg(0, rct_string_id, name_string_idx);
         set_format_arg(2, uint32_t, id);
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(gCommonFormatArgs + 6);
 
         rct_string_id msg_string;
         if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE))
@@ -5159,8 +5157,7 @@ void Guest::UpdateRideLeaveExit()
     {
         set_format_arg(0, rct_string_id, name_string_idx);
         set_format_arg(2, uint32_t, id);
-        set_format_arg(6, rct_string_id, ride->name);
-        set_format_arg(8, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(gCommonFormatArgs + 6);
 
         if (gConfigNotifications.guest_left_ride)
         {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2007,7 +2007,7 @@ void Peep::FormatActionTo(void* argsV) const
  * argument_1 (esi & ebx)
  * argument_2 (esi+2)
  */
-void peep_thought_set_format_args(rct_peep_thought* thought)
+void peep_thought_set_format_args(const rct_peep_thought* thought)
 {
     set_format_arg(0, rct_string_id, PeepThoughts[thought->type]);
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1848,6 +1848,7 @@ void Peep::FormatActionTo(void* argsV) const
                 set_format_arg_on(args, 0, rct_string_id, STR_ON_RIDE);
                 set_format_arg_on(args, 2, rct_string_id, STR_NONE);
             }
+            break;
         }
         case PEEP_STATE_BUYING:
         {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1974,9 +1974,15 @@ void peep_thought_set_format_args(rct_peep_thought* thought)
     uint8_t flags = PeepThoughtToActionMap[thought->type].flags;
     if (flags & 1)
     {
-        Ride* ride = get_ride(thought->item);
-        set_format_arg(2, rct_string_id, ride->name);
-        set_format_arg(4, uint32_t, ride->name_arguments);
+        auto ride = get_ride(thought->item);
+        if (ride != nullptr)
+        {
+            ride->FormatNameTo(gCommonFormatArgs + 2);
+        }
+        else
+        {
+            set_format_arg(2, rct_string_id, STR_NONE);
+        }
     }
     else if (flags & 2)
     {
@@ -2357,8 +2363,7 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
         {
             set_format_arg(0, rct_string_id, peep->name_string_idx);
             set_format_arg(2, uint32_t, peep->id);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             if (gConfigNotifications.guest_queuing_for_ride)
             {
                 news_item_add_to_queue(NEWS_ITEM_PEEP_ON_RIDE, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, peep->sprite_index);
@@ -2801,8 +2806,7 @@ static void peep_interact_with_path(Peep* peep, int16_t x, int16_t y, TileElemen
                     {
                         set_format_arg(0, rct_string_id, peep->name_string_idx);
                         set_format_arg(2, uint32_t, peep->id);
-                        set_format_arg(6, rct_string_id, ride->name);
-                        set_format_arg(8, uint32_t, ride->name_arguments);
+                        ride->FormatNameTo(gCommonFormatArgs + 6);
                         if (gConfigNotifications.guest_queuing_for_ride)
                         {
                             news_item_add_to_queue(
@@ -2911,8 +2915,7 @@ static bool peep_interact_with_shop(Peep* peep, int16_t x, int16_t y, TileElemen
         {
             set_format_arg(0, rct_string_id, peep->name_string_idx);
             set_format_arg(2, uint32_t, peep->id);
-            set_format_arg(6, rct_string_id, ride->name);
-            set_format_arg(8, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs + 6);
             rct_string_id string_id = ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_PEEP_TRACKING_PEEP_IS_IN_X
                                                                                              : STR_PEEP_TRACKING_PEEP_IS_ON_X;
             if (gConfigNotifications.guest_used_facility)

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -958,7 +958,7 @@ void peep_stop_crowd_noise();
 void peep_update_crowd_noise();
 void peep_update_days_in_queue();
 void peep_applause();
-void peep_thought_set_format_args(rct_peep_thought* thought);
+void peep_thought_set_format_args(const rct_peep_thought* thought);
 int32_t get_peep_face_sprite_small(Peep* peep);
 int32_t get_peep_face_sprite_large(Peep* peep);
 void game_command_pickup_guest(

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -718,6 +718,7 @@ public: // Peep
     void RemoveFromQueue();
     void RemoveFromRide();
     void InsertNewThought(PeepThoughtType thought_type, uint8_t thought_arguments);
+    void FormatActionTo(void* args) const;
 
     // TODO: Make these private again when done refactoring
 public: // Peep
@@ -957,7 +958,6 @@ void peep_stop_crowd_noise();
 void peep_update_crowd_noise();
 void peep_update_days_in_queue();
 void peep_applause();
-void get_arguments_from_action(Peep* peep, uint32_t* argument_1, uint32_t* argument_2);
 void peep_thought_set_format_args(rct_peep_thought* thought);
 int32_t get_peep_face_sprite_small(Peep* peep);
 int32_t get_peep_face_sprite_large(Peep* peep);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -781,18 +781,10 @@ private:
         }
 
         // Ride name
-        dst->name = 0;
         if (is_user_string_id(src->name))
         {
-            std::string rideName = GetUserString(src->name);
-            if (!rideName.empty())
-            {
-                rct_string_id rideNameStringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER, rideName.c_str());
-                if (rideNameStringId != 0)
-                {
-                    dst->name = rideNameStringId;
-                }
-            }
+            auto rideName = GetUserString(src->name);
+            dst->custom_name = rct2_to_utf8(rideName, RCT2_LANGUAGE_ID_ENGLISH_UK);
         }
 
         dst->status = src->status;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -3051,10 +3051,9 @@ private:
         Ride* ride;
         FOR_ALL_RIDES (i, ride)
         {
-            if (ride->name == 0)
+            if (ride->custom_name.empty())
             {
-                auto rideEntry = get_ride_entry(ride->subtype);
-                ride_set_name_to_default(ride, rideEntry);
+                ride->SetNameToDefault();
             }
         }
     }

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -496,8 +496,27 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
 
     // pad_046;
     dst->status = src->status;
-    dst->name = src->name;
-    dst->name_arguments = src->name_arguments;
+    if (src->custom_name.empty())
+    {
+        // Default name with number
+        dst->name = RideNaming[src->type].name;
+        dst->name_arguments_number = src->default_name_number;
+    }
+    else
+    {
+        // Custom name, allocate user string for ride
+        auto rideName = utf8_to_rct2(src->custom_name);
+        auto stringId = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, rideName.c_str());
+        if (stringId != 0)
+        {
+            dst->name = stringId;
+            dst->name_arguments = 0;
+        }
+        else
+        {
+            log_warning("Unable to allocate user string for ride: %s.", src->custom_name.c_str());
+        }
+    }
 
     dst->overall_view = src->overall_view;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -523,8 +523,16 @@ public:
 
         // pad_046;
         dst->status = src->status;
-        dst->name = src->name;
-        dst->name_arguments = src->name_arguments;
+
+        dst->default_name_number = src->name_arguments_number;
+        if (is_user_string_id(src->name))
+        {
+            dst->custom_name = GetUserString(src->name);
+        }
+        else
+        {
+            dst->default_name_number = src->name_arguments_number;
+        }
 
         dst->overall_view = src->overall_view;
 
@@ -1449,6 +1457,12 @@ public:
         dst->sprite_right = src->sprite_right;
         dst->sprite_bottom = src->sprite_bottom;
         dst->sprite_direction = src->sprite_direction;
+    }
+
+    std::string GetUserString(rct_string_id stringId)
+    {
+        const char* originalString = _s6.custom_strings[(stringId - USER_STRING_START) % 1024];
+        return rct2_to_utf8(originalString, RCT2_LANGUAGE_ID_ENGLISH_UK);
     }
 };
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3416,103 +3416,109 @@ static void ride_shop_connected(Ride* ride)
 
 static void ride_track_set_map_tooltip(TileElement* tileElement)
 {
-    ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
+    auto rideIndex = tileElement->AsTrack()->GetRideIndex();
     auto ride = get_ride(rideIndex);
-
-    set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-    ride->FormatNameTo(gCommonFormatArgs + 2);
-
-    rct_string_id formatSecondary;
-    int32_t arg1 = 0;
-    ride_get_status(ride, &formatSecondary, &arg1);
-    set_map_tooltip_format_arg(8, rct_string_id, formatSecondary);
-    set_map_tooltip_format_arg(10, uint32_t, arg1);
+    if (ride != nullptr)
+    {
+        set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
+        auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+        ride->FormatStatusTo(gMapTooltipFormatArgs + 2 + nameArgLen);
+    }
 }
 
 static void ride_queue_banner_set_map_tooltip(TileElement* tileElement)
 {
-    ride_id_t rideIndex = tileElement->AsPath()->GetRideIndex();
+    auto rideIndex = tileElement->AsPath()->GetRideIndex();
     auto ride = get_ride(rideIndex);
-
-    set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-    ride->FormatNameTo(gCommonFormatArgs + 2);
-
-    rct_string_id formatSecondary;
-    int32_t arg1 = 0;
-    ride_get_status(ride, &formatSecondary, &arg1);
-    set_map_tooltip_format_arg(8, rct_string_id, formatSecondary);
-    set_map_tooltip_format_arg(10, uint32_t, arg1);
+    if (ride != nullptr)
+    {
+        set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
+        auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+        ride->FormatStatusTo(gMapTooltipFormatArgs + 2 + nameArgLen);
+    }
 }
 
 static void ride_station_set_map_tooltip(TileElement* tileElement)
 {
-    ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
+    auto rideIndex = tileElement->AsTrack()->GetRideIndex();
     auto ride = get_ride(rideIndex);
-    auto stationIndex = tileElement->AsTrack()->GetStationIndex();
-    for (int32_t i = stationIndex; i >= 0; i--)
-        if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
-            stationIndex--;
-
-    set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-    set_map_tooltip_format_arg(2, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_STATION : STR_RIDE_STATION_X);
-    ride->FormatNameTo(gCommonFormatArgs + 4);
-    set_map_tooltip_format_arg(10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].capitalised);
-    set_map_tooltip_format_arg(12, uint16_t, stationIndex + 1);
-
-    rct_string_id formatSecondary;
-    int32_t arg1;
-    ride_get_status(ride, &formatSecondary, &arg1);
-    set_map_tooltip_format_arg(14, rct_string_id, formatSecondary);
-    set_map_tooltip_format_arg(16, uint32_t, arg1);
-}
-
-static void ride_entrance_set_map_tooltip(TileElement* tileElement)
-{
-    ride_id_t rideIndex = tileElement->AsEntrance()->GetRideIndex();
-    auto ride = get_ride(rideIndex);
-
-    // Get the station
-    auto stationIndex = tileElement->AsEntrance()->GetStationIndex();
-    for (int32_t i = stationIndex; i >= 0; i--)
-        if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
-            stationIndex--;
-
-    if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
+    if (ride != nullptr)
     {
-        // Get the queue length
-        int32_t queueLength = 0;
-        if (!ride_get_entrance_location(ride, stationIndex).isNull())
-            queueLength = ride->stations[stationIndex].QueueLength;
-
-        set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-        set_map_tooltip_format_arg(2, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_ENTRANCE : STR_RIDE_STATION_X_ENTRANCE);
-        ride->FormatNameTo(gMapTooltipFormatArgs + 4);
-        set_map_tooltip_format_arg(12, uint16_t, stationIndex + 1);
-        if (queueLength == 0)
-        {
-            set_map_tooltip_format_arg(14, rct_string_id, STR_QUEUE_EMPTY);
-        }
-        else if (queueLength == 1)
-        {
-            set_map_tooltip_format_arg(14, rct_string_id, STR_QUEUE_ONE_PERSON);
-        }
-        else
-        {
-            set_map_tooltip_format_arg(14, rct_string_id, STR_QUEUE_PEOPLE);
-        }
-        set_map_tooltip_format_arg(16, uint16_t, queueLength);
-    }
-    else
-    {
-        // Get the station
-        stationIndex = tileElement->AsEntrance()->GetStationIndex();
+        auto stationIndex = tileElement->AsTrack()->GetStationIndex();
         for (int32_t i = stationIndex; i >= 0; i--)
             if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
                 stationIndex--;
 
-        set_map_tooltip_format_arg(0, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_EXIT : STR_RIDE_STATION_X_EXIT);
-        ride->FormatNameTo(gCommonFormatArgs + 2);
-        set_map_tooltip_format_arg(10, uint16_t, stationIndex + 1);
+        size_t argPos = 0;
+        set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
+        argPos += sizeof(rct_string_id);
+        set_map_tooltip_format_arg(argPos, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_STATION : STR_RIDE_STATION_X);
+        argPos += sizeof(rct_string_id);
+        argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
+        set_map_tooltip_format_arg(
+            argPos, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].capitalised);
+        argPos += sizeof(rct_string_id);
+        set_map_tooltip_format_arg(argPos, uint16_t, stationIndex + 1);
+        argPos += sizeof(uint16_t);
+        ride->FormatStatusTo(gMapTooltipFormatArgs + argPos);
+    }
+}
+
+static void ride_entrance_set_map_tooltip(TileElement* tileElement)
+{
+    auto rideIndex = tileElement->AsEntrance()->GetRideIndex();
+    auto ride = get_ride(rideIndex);
+    if (ride != nullptr)
+    {
+        // Get the station
+        auto stationIndex = tileElement->AsEntrance()->GetStationIndex();
+        for (int32_t i = stationIndex; i >= 0; i--)
+            if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
+                stationIndex--;
+
+        if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
+        {
+            // Get the queue length
+            int32_t queueLength = 0;
+            if (!ride_get_entrance_location(ride, stationIndex).isNull())
+                queueLength = ride->stations[stationIndex].QueueLength;
+
+            size_t argPos = 0;
+            set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
+            argPos += sizeof(rct_string_id);
+            set_map_tooltip_format_arg(
+                argPos, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_ENTRANCE : STR_RIDE_STATION_X_ENTRANCE);
+            argPos += sizeof(rct_string_id);
+            argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
+            set_map_tooltip_format_arg(argPos, uint16_t, stationIndex + 1);
+            argPos += sizeof(uint16_t);
+            if (queueLength == 0)
+            {
+                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_EMPTY);
+            }
+            else if (queueLength == 1)
+            {
+                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_ONE_PERSON);
+            }
+            else
+            {
+                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_PEOPLE);
+            }
+            argPos += sizeof(rct_string_id);
+            set_map_tooltip_format_arg(argPos, uint16_t, queueLength);
+        }
+        else
+        {
+            // Get the station
+            stationIndex = tileElement->AsEntrance()->GetStationIndex();
+            for (int32_t i = stationIndex; i >= 0; i--)
+                if (ride->stations[i].Start.xy == RCT_XY8_UNDEFINED)
+                    stationIndex--;
+
+            set_map_tooltip_format_arg(0, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_EXIT : STR_RIDE_STATION_X_EXIT);
+            auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+            set_map_tooltip_format_arg(2 + nameArgLen, uint16_t, stationIndex + 1);
+        }
     }
 }
 
@@ -7866,7 +7872,7 @@ std::string Ride::GetName() const
     return format_string(STR_STRINGID, args);
 }
 
-void Ride::FormatNameTo(void* argsV) const
+size_t Ride::FormatNameTo(void* argsV) const
 {
     auto args = (uint8_t*)argsV;
     if (!custom_name.empty())
@@ -7874,6 +7880,7 @@ void Ride::FormatNameTo(void* argsV) const
         auto str = custom_name.c_str();
         set_format_arg_on(args, 0, rct_string_id, STR_STRING);
         set_format_arg_on(args, 2, void*, str);
+        return sizeof(rct_string_id) + sizeof(void*);
     }
     else
     {
@@ -7905,5 +7912,16 @@ void Ride::FormatNameTo(void* argsV) const
         set_format_arg_on(args, 0, rct_string_id, 1);
         set_format_arg_on(args, 2, rct_string_id, rideTypeName);
         set_format_arg_on(args, 4, uint16_t, default_name_number);
+        return sizeof(rct_string_id) + sizeof(rct_string_id) + sizeof(uint16_t);
     }
+}
+
+void Ride::FormatStatusTo(void* argsV) const
+{
+    auto args = (uint8_t*)argsV;
+    rct_string_id stringId{};
+    int32_t arg32{};
+    ride_get_status(this, &stringId, &arg32);
+    set_format_arg_on(args, 0, rct_string_id, stringId);
+    set_format_arg_on(args, 2, uint32_t, arg32);
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7903,7 +7903,10 @@ size_t Ride::FormatNameTo(void* argsV) const
             if (rideEntry != nullptr)
             {
                 auto rideGroup = RideGroupManager::GetRideGroup(type, rideEntry);
-                rideTypeName = rideGroup->Naming.name;
+                if (rideGroup != nullptr)
+                {
+                    rideTypeName = rideGroup->Naming.name;
+                }
             }
         }
         set_format_arg_on(args, 0, rct_string_id, 1);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7888,7 +7888,7 @@ size_t Ride::FormatNameTo(void* argsV) const
     }
     else
     {
-        rct_string_id rideTypeName{};
+        auto rideTypeName = RideNaming[type].name;
         if (RideGroupManager::RideTypeIsIndependent(type))
         {
             auto rideEntry = GetRideEntry();
@@ -7897,20 +7897,13 @@ size_t Ride::FormatNameTo(void* argsV) const
                 rideTypeName = rideEntry->naming.name;
             }
         }
-        else
+        else if (RideGroupManager::RideTypeHasRideGroups(type))
         {
-            if (RideGroupManager::RideTypeHasRideGroups(type))
+            auto rideEntry = GetRideEntry();
+            if (rideEntry != nullptr)
             {
-                auto rideEntry = GetRideEntry();
-                if (rideEntry != nullptr)
-                {
-                    auto rideGroup = RideGroupManager::GetRideGroup(type, rideEntry);
-                    rideTypeName = rideGroup->Naming.name;
-                }
-            }
-            else
-            {
-                rideTypeName = RideNaming[type].name;
+                auto rideGroup = RideGroupManager::GetRideGroup(type, rideEntry);
+                rideTypeName = rideGroup->Naming.name;
             }
         }
         set_format_arg_on(args, 0, rct_string_id, 1);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5701,7 +5701,7 @@ static bool ride_with_colour_config_exists(uint8_t ride_type, const TrackColour*
     return false;
 }
 
-static bool ride_name_exists(char* name)
+bool Ride::NameExists(const std::string_view& name, ride_id_t excludeRideId)
 {
     char buffer[256]{};
     uint32_t formatArgs[32]{};
@@ -5710,11 +5710,14 @@ static bool ride_name_exists(char* name)
     int32_t i;
     FOR_ALL_RIDES (i, ride)
     {
-        ride->FormatNameTo(formatArgs);
-        format_string(buffer, 256, STR_STRINGID, formatArgs);
-        if ((strcmp(buffer, name) == 0) && ride_has_any_track_elements(ride))
+        if (i != excludeRideId)
         {
-            return true;
+            ride->FormatNameTo(formatArgs);
+            format_string(buffer, 256, STR_STRINGID, formatArgs);
+            if (std::string_view(buffer) == name && ride_has_any_track_elements(ride))
+            {
+                return true;
+            }
         }
     }
     return false;
@@ -5800,13 +5803,14 @@ void Ride::SetNameToDefault()
     uint8_t rideNameArgs[32]{};
 
     // Increment default name number until we find a unique name
+    custom_name = {};
     default_name_number = 0;
     do
     {
         default_name_number++;
         FormatNameTo(rideNameArgs);
         format_string(rideNameBuffer, 256, STR_STRINGID, &rideNameArgs);
-    } while (ride_name_exists(rideNameBuffer));
+    } while (Ride::NameExists(rideNameBuffer, id));
 }
 
 /**

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -195,16 +195,8 @@ struct Ride
     VehicleColour vehicle_colours[MAX_CARS_PER_TRAIN];
     // 0 = closed, 1 = open, 2 = test
     uint8_t status;
-    rct_string_id name;
-    union
-    {
-        uint32_t name_arguments;
-        struct
-        {
-            rct_string_id name_arguments_type_name;
-            uint16_t name_arguments_number;
-        };
-    };
+    std::string custom_name;
+    uint16_t default_name_number;
     LocationXY8 overall_view;
     uint16_t vehicles[MAX_VEHICLES_PER_RIDE]; // Points to the first car in the train
     uint8_t depart_flags;
@@ -415,6 +407,10 @@ public:
 
     void QueueInsertGuestAtFront(int32_t stationIndex, Peep* peep);
     Peep* GetQueueHeadGuest(int32_t stationIndex) const;
+
+    void SetNameToDefault();
+    std::string GetName() const;
+    void FormatNameTo(void* args) const;
 
     static void UpdateAll();
 };
@@ -1092,9 +1088,7 @@ int32_t ride_get_random_colour_preset_index(uint8_t ride_type);
 money32 ride_get_common_price(Ride* forRide);
 rct_ride_name get_ride_naming(const uint8_t rideType, rct_ride_entry* rideEntry);
 money32 ride_create_command(int32_t type, int32_t subType, int32_t flags, ride_id_t* outRideIndex, uint8_t* outRideColour);
-void ride_set_name_to_default(Ride* ride, rct_ride_entry* rideEntry);
 
-void ride_set_name_to_track_default(Ride* ride, rct_ride_entry* rideEntry);
 void ride_clear_for_construction(Ride* ride);
 void ride_entrance_exit_place_provisional_ghost();
 void ride_entrance_exit_remove_ghost();

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -410,7 +410,8 @@ public:
 
     void SetNameToDefault();
     std::string GetName() const;
-    void FormatNameTo(void* args) const;
+    size_t FormatNameTo(void* args) const;
+    void FormatStatusTo(void* args) const;
 
     static void UpdateAll();
 };

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -414,6 +414,7 @@ public:
     void FormatStatusTo(void* args) const;
 
     static void UpdateAll();
+    static bool NameExists(const std::string_view& name, ride_id_t excludeRideId = RIDE_ID_NULL);
 };
 
 #pragma pack(push, 1)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1721,14 +1721,7 @@ static bool track_design_place_preview(rct_track_td6* td6, money32* cost, Ride**
     }
 
     auto ride = get_ride(rideIndex);
-    rct_string_id new_ride_name = user_string_allocate(USER_STRING_HIGH_ID_NUMBER | USER_STRING_DUPLICATION_PERMITTED, "");
-    if (new_ride_name != 0)
-    {
-        rct_string_id old_name = ride->name;
-        ride->name = new_ride_name;
-        user_string_free(old_name);
-    }
-
+    ride->custom_name = {};
     ride->entrance_style = td6->entrance_style;
 
     for (int32_t i = 0; i < RCT12_NUM_COLOUR_SCHEMES; i++)
@@ -1796,9 +1789,7 @@ static bool track_design_place_preview(rct_track_td6* td6, money32* cost, Ride**
     else
     {
         _currentTrackPieceDirection = backup_rotation;
-        user_string_free(ride->name);
-        ride->type = RIDE_TYPE_NULL;
-        ride->measurement = {};
+        ride->Delete();
         byte_9D8150 = false;
         return false;
     }

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -182,12 +182,10 @@ bool track_design_save(ride_id_t rideIndex)
         }
     }
 
-    utf8 track_name[256];
-    format_string(track_name, sizeof(track_name), ride->name, &ride->name_arguments);
-
+    auto trackName = ride->GetName();
     auto intent = Intent(WC_LOADSAVE);
     intent.putExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK);
-    intent.putExtra(INTENT_EXTRA_PATH, std::string{ track_name });
+    intent.putExtra(INTENT_EXTRA_PATH, trackName);
     intent.putExtra(INTENT_EXTRA_CALLBACK, (void*)track_design_save_callback);
     context_open_intent(&intent);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3466,8 +3466,7 @@ static void vehicle_check_if_missing(rct_vehicle* vehicle)
 
     vehicleIndex++;
     set_format_arg(2, uint16_t, vehicleIndex);
-    set_format_arg(4, rct_string_id, ride->name);
-    set_format_arg(6, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs + 4);
     set_format_arg(10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].singular);
 
     news_item_add_to_queue(NEWS_ITEM_RIDE, STR_NEWS_VEHICLE_HAS_STALLED, vehicle->ride);
@@ -5148,8 +5147,7 @@ static void vehicle_kill_all_passengers(rct_vehicle* vehicle)
 
     if (numFatalities != 0)
     {
-        set_format_arg(2, rct_string_id, ride->name);
-        set_format_arg(4, uint32_t, ride->name_arguments);
+        ride->FormatNameTo(gCommonFormatArgs + 2);
         news_item_add_to_queue(NEWS_ITEM_RIDE, STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
 
         if (gParkRatingCasualtyPenalty < 500)
@@ -6134,8 +6132,7 @@ void vehicle_set_map_toolbar(const rct_vehicle* vehicle)
 
     set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
     set_map_tooltip_format_arg(2, rct_string_id, STR_MAP_TOOLTIP_STRINGID_STRINGID);
-    set_map_tooltip_format_arg(4, rct_string_id, ride->name);
-    set_map_tooltip_format_arg(6, uint32_t, ride->name_arguments);
+    ride->FormatNameTo(gCommonFormatArgs + 4);
     set_map_tooltip_format_arg(10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].vehicle].capitalised);
     set_map_tooltip_format_arg(12, uint16_t, vehicleIndex + 1);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3466,8 +3466,8 @@ static void vehicle_check_if_missing(rct_vehicle* vehicle)
 
     vehicleIndex++;
     set_format_arg(2, uint16_t, vehicleIndex);
-    ride->FormatNameTo(gCommonFormatArgs + 4);
-    set_format_arg(10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].singular);
+    auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs + 4);
+    set_format_arg(4 + nameArgLen, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].singular);
 
     news_item_add_to_queue(NEWS_ITEM_RIDE, STR_NEWS_VEHICLE_HAS_STALLED, vehicle->ride);
 }
@@ -6121,27 +6121,29 @@ GForces vehicle_get_g_forces(const rct_vehicle* vehicle)
 
 void vehicle_set_map_toolbar(const rct_vehicle* vehicle)
 {
-    Ride* ride;
-    int32_t vehicleIndex;
+    auto ride = get_ride(vehicle->ride);
+    if (ride != nullptr)
+    {
+        vehicle = vehicle->GetHead();
 
-    ride = get_ride(vehicle->ride);
-    vehicle = vehicle->GetHead();
-    for (vehicleIndex = 0; vehicleIndex < 32; vehicleIndex++)
-        if (ride->vehicles[vehicleIndex] == vehicle->sprite_index)
-            break;
+        int32_t vehicleIndex;
+        for (vehicleIndex = 0; vehicleIndex < 32; vehicleIndex++)
+            if (ride->vehicles[vehicleIndex] == vehicle->sprite_index)
+                break;
 
-    set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-    set_map_tooltip_format_arg(2, rct_string_id, STR_MAP_TOOLTIP_STRINGID_STRINGID);
-    ride->FormatNameTo(gCommonFormatArgs + 4);
-    set_map_tooltip_format_arg(10, rct_string_id, RideComponentNames[RideNameConvention[ride->type].vehicle].capitalised);
-    set_map_tooltip_format_arg(12, uint16_t, vehicleIndex + 1);
-
-    rct_string_id formatSecondary;
-    int32_t arg1;
-    ride_get_status(ride, &formatSecondary, &arg1);
-    set_map_tooltip_format_arg(14, rct_string_id, formatSecondary);
-    // TODO: odd cast
-    set_map_tooltip_format_arg(16, uint32_t, (uint16_t)arg1);
+        size_t argPos = 0;
+        set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
+        argPos += sizeof(rct_string_id);
+        set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_STRINGID);
+        argPos += sizeof(rct_string_id);
+        argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
+        set_map_tooltip_format_arg(
+            argPos, rct_string_id, RideComponentNames[RideNameConvention[ride->type].vehicle].capitalised);
+        argPos += sizeof(rct_string_id);
+        set_map_tooltip_format_arg(argPos, uint16_t, vehicleIndex + 1);
+        argPos += sizeof(uint16_t);
+        ride->FormatStatusTo(gMapTooltipFormatArgs + argPos);
+    }
 }
 
 rct_vehicle* vehicle_get_head(const rct_vehicle* vehicle)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1298,8 +1298,7 @@ void map_obstruction_set_error_text(TileElement* tileElement)
         case TILE_ELEMENT_TYPE_TRACK:
             ride = get_ride(tileElement->AsTrack()->GetRideIndex());
             errorStringId = STR_X_IN_THE_WAY;
-            set_format_arg(0, rct_string_id, ride->name);
-            set_format_arg(2, uint32_t, ride->name_arguments);
+            ride->FormatNameTo(gCommonFormatArgs);
             break;
         case TILE_ELEMENT_TYPE_SMALL_SCENERY:
             sceneryEntry = tileElement->AsSmallScenery()->GetEntry();

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -55,9 +55,8 @@ protected:
         Ride* ride;
         FOR_ALL_RIDES ((*outRideIndex), ride)
         {
-            char thisName[256];
-            format_string(thisName, sizeof(thisName), ride->name, &ride->name_arguments);
-            if (!_strnicmp(thisName, name, sizeof(thisName)))
+            auto thisName = ride->GetName();
+            if (!_strnicmp(thisName.c_str(), name, sizeof(thisName)))
                 return ride;
         }
 


### PR DESCRIPTION
Continuation of #9589 but this time for ride names and everything else.

PR to check CI pass.

This PR will form a single changeset to remove the user string pool from OpenRCT2. It will create one only to export to SV6 where there is a restriction of 1024 custom strings. These will get stored in the following order of priority: park name, ride names, banners, staff, guests with notifications, all other guests.