### PR TITLE
Make socket status atomic

### DIFF
--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -197,7 +197,7 @@ private:
 class TcpSocket final : public ITcpSocket, protected Socket
 {
 private:
-    std::atomic<SOCKET_STATUS> _status = SOCKET_STATUS_CLOSED;
+    std::atomic<SOCKET_STATUS> _status = ATOMIC_VAR_INIT(SOCKET_STATUS_CLOSED);
     uint16_t _listeningPort = 0;
     SOCKET _socket = INVALID_SOCKET;
 

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -9,6 +9,7 @@
 
 #ifndef DISABLE_NETWORK
 
+#    include <atomic>
 #    include <chrono>
 #    include <cmath>
 #    include <cstring>
@@ -196,7 +197,7 @@ private:
 class TcpSocket final : public ITcpSocket, protected Socket
 {
 private:
-    SOCKET_STATUS _status = SOCKET_STATUS_CLOSED;
+    std::atomic<SOCKET_STATUS> _status = SOCKET_STATUS_CLOSED;
     uint16_t _listeningPort = 0;
     SOCKET _socket = INVALID_SOCKET;
 


### PR DESCRIPTION
`TcpSocket::ConnectAsync` will call `Connect` and modify `_status` from
a different thread and must ensure it doesn't introduce a data race.