### PR TITLE
Remove conversion from UTF-8 to widechar and back again

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.2.3+ (in development)
 ------------------------------------------------------------------------
+- Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 
 0.2.3 (2019-07-10)

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -96,49 +96,25 @@ void platform_get_time_local(rct2_time* out_time)
     out_time->hour = timeinfo->tm_hour;
 }
 
-static size_t platform_utf8_to_multibyte(const utf8* path, char* buffer, size_t buffer_size)
-{
-    auto wpath = String::ToWideChar(path);
-    setlocale(LC_CTYPE, "UTF-8");
-    size_t len = wcstombs(NULL, wpath.c_str(), 0);
-    bool truncated = false;
-    if (len > buffer_size - 1)
-    {
-        truncated = true;
-        len = buffer_size - 1;
-    }
-    wcstombs(buffer, wpath.c_str(), len);
-    buffer[len] = '\0';
-    if (truncated)
-        log_warning("truncated string %s", buffer);
-    return len;
-}
-
 bool platform_file_exists(const utf8* path)
 {
-    char buffer[MAX_PATH];
-    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
-    bool exists = access(buffer, F_OK) != -1;
-    log_verbose("file '%s' exists = %i", buffer, exists);
+    bool exists = access(path, F_OK) != -1;
+    log_verbose("file '%s' exists = %i", path, exists);
     return exists;
 }
 
 bool platform_directory_exists(const utf8* path)
 {
-    char buffer[MAX_PATH];
-    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
     struct stat dirinfo;
-    int32_t result = stat(buffer, &dirinfo);
-    log_verbose("checking dir %s, result = %d, is_dir = %d", buffer, result, S_ISDIR(dirinfo.st_mode));
+    int32_t result = stat(path, &dirinfo);
+    log_verbose("checking dir %s, result = %d, is_dir = %d", path, result, S_ISDIR(dirinfo.st_mode));
     return result == 0 && S_ISDIR(dirinfo.st_mode);
 }
 
 bool platform_original_game_data_exists(const utf8* path)
 {
-    char buffer[MAX_PATH];
-    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
     char checkPath[MAX_PATH];
-    safe_strcpy(checkPath, buffer, MAX_PATH);
+    safe_strcpy(checkPath, path, MAX_PATH);
     safe_strcat_path(checkPath, "Data", MAX_PATH);
     safe_strcat_path(checkPath, "g1.dat", MAX_PATH);
     return platform_file_exists(checkPath);
@@ -147,7 +123,7 @@ bool platform_original_game_data_exists(const utf8* path)
 bool platform_original_rct1_data_exists(const utf8* path)
 {
     char buffer[MAX_PATH], checkPath1[MAX_PATH], checkPath2[MAX_PATH];
-    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
+    safe_strcpy(buffer, path, sizeof(path));
     safe_strcat_path(buffer, "Data", MAX_PATH);
     safe_strcpy(checkPath1, buffer, MAX_PATH);
     safe_strcpy(checkPath2, buffer, MAX_PATH);
@@ -186,7 +162,7 @@ bool platform_ensure_directory_exists(const utf8* path)
 {
     mode_t mask = openrct2_getumask();
     char buffer[MAX_PATH];
-    platform_utf8_to_multibyte(path, buffer, MAX_PATH);
+    safe_strcpy(buffer, path, sizeof(buffer));
 
     log_verbose("Create directory: %s", buffer);
     for (char* p = buffer + 1; *p != '\0'; p++)


### PR DESCRIPTION
I have tested this using non-ASCII characters like é, writing to both an EXT4 and FAT32 filesystem. This all appears to work correctly.