### PR TITLE
Fix #8136. Fix incorrect calculation of excessive lateral G penalty.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
+- Fix: [#8136] Excessive lateral G penalty is too excessive.
 - Fix: [#9574] Text overflow in scenario objective window when using CJK languages.
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1631,7 +1631,7 @@ static void ride_ratings_apply_max_lateral_g_penalty(
 
 static rating_tuple ride_ratings_get_excessive_lateral_g_penalty(Ride* ride)
 {
-    rating_tuple result = { 0 };
+    rating_tuple result{};
     if (ride->max_lateral_g > FIXED_2DP(2, 80))
     {
         result.intensity = FIXED_2DP(3, 75);


### PR DESCRIPTION
Fix #8136. Fix incorrect calculation of excessive lateral G penalty.

This penalty had been modified for OpenRCT2 moving it from before certain other penalties were applied to after. The move accidently removed the ride type multiplier which caused a very large penalty to be applied. In addition the excitement penalty applied to the whole calculation instead of just the gforce bonus. This caused an excessive penalty to the excitement.

Below pictures are from the new calculations.

![image](https://user-images.githubusercontent.com/1277401/62005797-73271b00-b130-11e9-9edb-a0829da8439a.png)

![image](https://user-images.githubusercontent.com/1277401/62005817-ac5f8b00-b130-11e9-8873-d22fe4b30960.png)
