### PR TITLE
Fix: tile inspector hotkey does not work with debugging tools disabled

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 - Fix: [#9625] Show correct cost in scenery selection.
+- Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 
 0.2.3 (2019-07-10)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -754,7 +754,7 @@ static void shortcut_highlight_path_issues_toggle()
 
 static void shortcut_open_tile_inspector()
 {
-    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO || !gConfigGeneral.debugging_tools)
+    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO || !gConfigInterface.toolbar_show_cheats)
         return;
 
     context_open_window(WC_TILE_INSPECTOR);


### PR DESCRIPTION
This was a minor regression from when some debugging tools were moved to cheats.