### PR TITLE
Fix #9701: GetRideEntry nullptr can cause stack overflow

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -255,13 +255,7 @@ void get_ride_entry_name(char* name, int32_t index)
 
 rct_ride_entry* Ride::GetRideEntry() const
 {
-    rct_ride_entry* rideEntry = get_ride_entry(subtype);
-    if (rideEntry == nullptr)
-    {
-        auto rideName = GetName();
-        log_error("Invalid ride subtype for ride %s", rideName.c_str());
-    }
-    return rideEntry;
+    return get_ride_entry(subtype);
 }
 
 /**


### PR DESCRIPTION
GetName calls GetRideEntry so we can't log the name of the ride. I don't think the log is necessary as we now assume rides can have a null ride entry and all callers should check for this.