### PR TITLE
[RFC] Change ride list to a table

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -87,7 +87,7 @@ static bool window_fits_on_screen(int32_t x, int32_t y, int32_t width, int32_t h
 
 rct_window* window_create(
     int32_t x, int32_t y, int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls,
-    uint16_t flags)
+    uint16_t flags, std::unique_ptr<rct_window> newWindow)
 {
     // Check if there are any window slots left
     // include WINDOW_LIMIT_RESERVED for items such as the main viewport and toolbars to not appear to be counted.
@@ -128,7 +128,12 @@ rct_window* window_create(
         }
     }
 
-    auto itNew = g_window_list.insert(itDestPos, std::make_unique<rct_window>());
+    if (newWindow == nullptr)
+    {
+        newWindow = std::make_unique<rct_window>();
+    }
+
+    auto itNew = g_window_list.insert(itDestPos, std::move(newWindow));
     auto w = itNew->get();
 
     // Setup window
@@ -175,7 +180,8 @@ rct_window* window_create(
 }
 
 rct_window* window_create_auto_pos(
-    int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags)
+    int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags,
+    std::unique_ptr<rct_window> newWindow)
 {
     auto uiContext = GetContext()->GetUiContext();
     auto screenWidth = uiContext->GetWidth();
@@ -314,7 +320,7 @@ foundSpace:
     if (x + width > screenWidth)
         x = screenWidth - width;
 
-    return window_create(x, y, width, height, event_handlers, cls, flags);
+    return window_create(x, y, width, height, event_handlers, cls, flags, std::move(newWindow));
 }
 
 rct_window* window_create_centred(

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -18,6 +18,8 @@
 #include <list>
 #include <memory>
 
+#undef CreateWindow
+
 struct rct_drawpixelinfo;
 struct rct_window;
 union rct_window_event;
@@ -594,11 +596,19 @@ void window_set_window_limit(int32_t value);
 
 rct_window* window_create(
     int32_t x, int32_t y, int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls,
-    uint16_t flags);
+    uint16_t flags, std::unique_ptr<rct_window> w = nullptr);
 rct_window* window_create_auto_pos(
-    int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags);
+    int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags,
+    std::unique_ptr<rct_window> w = nullptr);
 rct_window* window_create_centred(
     int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags);
+
+template<typename T>
+T* CreateWindow(int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint16_t flags)
+{
+    return static_cast<T*>(window_create_auto_pos(width, height, event_handlers, cls, flags, std::make_unique<T>()));
+}
+
 void window_close(rct_window* window);
 void window_close_by_class(rct_windowclass cls);
 void window_close_by_number(rct_windowclass cls, rct_windownumber number);

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -11,6 +11,7 @@
 
 #include "Window.h"
 
+#include <limits>
 #include <list>
 #include <memory>
 
@@ -24,6 +25,14 @@ enum class ListViewMessageKind
     GetColumn,
     GetCell,
     Select,
+    Sort,
+};
+
+namespace ListViewFlags
+{
+    constexpr uint8_t AlignRight = 1 << 0;
+    constexpr uint8_t SortAscending = 1 << 1;
+    constexpr uint8_t SortDescending = 1 << 2;
 };
 
 struct ListViewMessage
@@ -125,6 +134,8 @@ struct rct_window
     uint8_t visibility;                    // VISIBILITY_CACHE
     uint16_t viewport_smart_follow_sprite; // Smart following of sprites. Handles setting viewport target sprite etc
 
+    size_t _listViewColumnPressed = std::numeric_limits<size_t>::max();
+
     virtual ~rct_window() = default;
     virtual void OnClick(rct_widgetindex widgetIndex)
     {
@@ -134,6 +145,7 @@ struct rct_window
     }
 
     size_t GetListViewItemIndexAt(uint8_t scrollIndex, int32_t theY);
+    size_t GetListViewColumnAt(uint8_t scrollIndex, int32_t theX);
 };
 
 // rct2: 0x01420078

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -132,6 +132,8 @@ struct rct_window
     virtual void OnListViewMessage(ListViewMessage& msg)
     {
     }
+
+    size_t GetListViewItemIndexAt(uint8_t scrollIndex, int32_t theY);
 };
 
 // rct2: 0x01420078

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -17,6 +17,29 @@
 struct rct_research_item;
 struct rct_object_entry;
 
+enum class ListViewMessageKind
+{
+    None,
+    GetDetails,
+    GetColumn,
+    GetCell,
+    Select,
+};
+
+struct ListViewMessage
+{
+    ListViewMessageKind Kind{};
+    uint8_t ScrollIndex{};       // GetDetails
+    size_t Columns{};            // GetDetails
+    size_t Count{};              // GetDetails
+    size_t Width{};              // GetColumn
+    size_t Height{};             // GetDetails
+    size_t ItemIndex{};          // GetCell
+    size_t ColumnIndex{};        // GetColumn, GetCell
+    uint8_t Flags{};             // GetColumn, GetCell
+    uint8_t* FormatArgsBuffer{}; // GetColumn, GetCell
+};
+
 /**
  * Window structure
  * size: 0x4C0
@@ -101,6 +124,14 @@ struct rct_window
     uint8_t colours[6];                    // 0x4BA
     uint8_t visibility;                    // VISIBILITY_CACHE
     uint16_t viewport_smart_follow_sprite; // Smart following of sprites. Handles setting viewport target sprite etc
+
+    virtual ~rct_window() = default;
+    virtual void OnClick(rct_widgetindex widgetIndex)
+    {
+    }
+    virtual void OnListViewMessage(ListViewMessage& msg)
+    {
+    }
 };
 
 // rct2: 0x01420078


### PR DESCRIPTION
This is an attempt to create common code for implementing list views which provide headers, highlighting, selecting and sorting. I have done it with the ride list so far.

Based on how native Win32 list views work, a window listens for list view messages (a new window event handler) where it returns the data requested by the window manager. It will receive a message (item index, column index) for every visible cell and the handler will populate an argument buffer. The window no longer needs to handle the input or painting, it just provides the data to show.

At the moment I have hacked this into the scroll view events. I have tried to keep changes to the window system as minimal as possible but at the same time add initial plumbing to start making all the windows into sub classes of `rct_window`.

As for the ride list table, some columns are too narrow, what option is best?
* Use a good icon and tooltip.
* Add several views which show different wider columns.
* Double the height of each row and move status to underneath the ride name. (See how Locomotion does its vehicle list window).

![image](https://user-images.githubusercontent.com/1482259/62332792-e5915580-b4b8-11e9-911c-88ae631fa525.png)