### PR TITLE
Fix #9666: pause server if no clients are connected

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -50,7 +50,6 @@ static constexpr uint32_t CHUNK_SIZE = 1024 * 63;
 #    include "../ParkImporter.h"
 #    include "../Version.h"
 #    include "../actions/GameAction.h"
-#    include "../actions/PauseToggleAction.hpp"
 #    include "../config/Config.h"
 #    include "../core/Console.hpp"
 #    include "../core/FileStream.hpp"
@@ -661,12 +660,6 @@ bool Network::BeginServer(uint16_t port, const std::string& address)
     listening_port = port;
     _serverState.gamestateSnapshotsEnabled = gConfigNetwork.desync_debugging;
     _advertiser = CreateServerAdvertiser(listening_port);
-
-    if (gConfigNetwork.pause_server_if_no_clients)
-    {
-        auto pauseToggleAction = PauseToggleAction();
-        GameActions::Execute(&pauseToggleAction);
-    }
 
     return true;
 }
@@ -2043,12 +2036,6 @@ void Network::ProcessDisconnectedClients()
             it++;
         }
     }
-
-    if (gConfigNetwork.pause_server_if_no_clients && game_is_not_paused() && client_connection_list.empty())
-    {
-        auto pauseToggleAction = PauseToggleAction();
-        GameActions::Execute(&pauseToggleAction);
-    }
 }
 
 void Network::ProcessGameCommands()
@@ -2123,12 +2110,6 @@ void Network::EnqueueGameAction(const GameAction* action)
 
 void Network::AddClient(std::unique_ptr<ITcpSocket>&& socket)
 {
-    if (gConfigNetwork.pause_server_if_no_clients && game_is_paused())
-    {
-        auto pauseToggleAction = PauseToggleAction();
-        GameActions::Execute(&pauseToggleAction);
-    }
-
     // Log connection info.
     char addr[128];
     snprintf(addr, sizeof(addr), "Client joined from %s", socket->GetHostName());


### PR DESCRIPTION
I've simplified the code that deals with pausing the server while there are no clients. This also seems to fix a desync when this setting was enabled with very specific saves that uses smoke particles, I haven't quite figured out why but its probably related to when the game action was invoked to pause/unpause the game. Also minor cleanup around it.