### PR TITLE
Fix #8584: Duck spawn search now uses entire map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#7690] Problem with guests freezing on certain tiles of path.
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Fix: [#8136] Excessive lateral G penalty is too excessive.
+- Fix: [#8584] Duck spawning function does not check tiles with x or y coordinate of 0..64 (Original bug)
 - Fix: [#9179] Crash when modifying a ride occasionally.
 - Fix: [#9533] Door sounds not playing.
 - Fix: [#9574] Text overflow in scenario objective window when using CJK languages.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -435,12 +435,15 @@ static int32_t scenario_create_ducks()
     if (centreWaterZ == 0)
         return 0;
 
-    // Check 7x7 area around centre tile
-    CoordsXY innerPos{ centrePos.x - (32 * 3), centrePos.y - (32 * 3) };
+    // Check NxN area around centre tile defined by SquareSize
+    constexpr int32_t SquareSize = 7;
+    constexpr int32_t SquareCentre = SquareSize / 2;
+
+    CoordsXY innerPos{ centrePos.x - (32 * SquareCentre), centrePos.y - (32 * SquareCentre) };
     int32_t waterTiles = 0;
-    for (int32_t y = 0; y < 7; y++)
+    for (int32_t y = 0; y < SquareSize; y++)
     {
-        for (int32_t x = 0; x < 7; x++)
+        for (int32_t x = 0; x < SquareSize; x++)
         {
             if (!map_is_location_valid(innerPos))
                 continue;
@@ -454,7 +457,7 @@ static int32_t scenario_create_ducks()
 
             innerPos.x += 32;
         }
-        innerPos.x -= 224;
+        innerPos.x -= SquareSize * 32;
         innerPos.y += 32;
     }
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -422,21 +422,21 @@ void scenario_update()
  */
 static int32_t scenario_create_ducks()
 {
-    CoordsXY centerPos;
-    centerPos.x = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
-    centerPos.y = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
+    CoordsXY centrePos;
+    centrePos.x = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
+    centrePos.y = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
 
-    Guard::Assert(map_is_location_valid(centerPos));
+    Guard::Assert(map_is_location_valid(centrePos));
 
-    if (!map_is_location_in_park(centerPos))
+    if (!map_is_location_in_park(centrePos))
         return 0;
 
-    int32_t centreWaterZ = (tile_element_water_height(centerPos));
+    int32_t centreWaterZ = (tile_element_water_height(centrePos));
     if (centreWaterZ == 0)
         return 0;
 
     // Check 7x7 area around centre tile
-    CoordsXY innerPos{ centerPos.x - (32 * 3), centerPos.y - (32 * 3) };
+    CoordsXY innerPos{ centrePos.x - (32 * 3), centrePos.y - (32 * 3) };
     int32_t waterTiles = 0;
     for (int32_t y = 0; y < 7; y++)
     {
@@ -463,8 +463,8 @@ static int32_t scenario_create_ducks()
         return 0;
 
     // Set x, y to the centre of the tile
-    centerPos.x += 16;
-    centerPos.y += 16;
+    centrePos.x += 16;
+    centrePos.y += 16;
 
     int32_t duckCount = (scenario_rand() & 3) + 2;
     for (int32_t i = 0; i < duckCount; i++)
@@ -473,9 +473,9 @@ static int32_t scenario_create_ducks()
         innerPos.x = (r >> 16) & 0x7F;
         innerPos.y = (r & 0xFFFF) & 0x7F;
 
-        CoordsXY targetPos{ centerPos.x + innerPos.x - 64, centerPos.y + innerPos.y - 64 };
+        CoordsXY targetPos{ centrePos.x + innerPos.x - 64, centrePos.y + innerPos.y - 64 };
         Guard::Assert(map_is_location_valid(targetPos));
-        create_duck(targetPos.x, targetPos.y);
+        create_duck(targetPos);
     }
 
     return 1;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -305,42 +305,45 @@ uint32_t rct_duck::GetFrameImage(int32_t direction) const
     return imageId;
 }
 
-void create_duck(int32_t targetX, int32_t targetY)
+void create_duck(const CoordsXY& pos)
 {
     rct_sprite* sprite = create_sprite(SPRITE_IDENTIFIER_MISC);
-    if (sprite != nullptr)
+    if (sprite == nullptr)
+        return;
+
+    CoordsXY targetPos = pos;
+
+    int32_t offsetXY = scenario_rand() & 0x1E;
+    targetPos.x += offsetXY;
+    targetPos.y += offsetXY;
+
+    sprite->duck.sprite_identifier = SPRITE_IDENTIFIER_MISC;
+    sprite->duck.type = SPRITE_MISC_DUCK;
+    sprite->duck.sprite_width = 9;
+    sprite->duck.sprite_height_negative = 12;
+    sprite->duck.sprite_height_positive = 9;
+    sprite->duck.target_x = targetPos.x;
+    sprite->duck.target_y = targetPos.y;
+    uint8_t direction = scenario_rand() & 3;
+    switch (direction)
     {
-        sprite->duck.sprite_identifier = SPRITE_IDENTIFIER_MISC;
-        sprite->duck.type = SPRITE_MISC_DUCK;
-        sprite->duck.sprite_width = 9;
-        sprite->duck.sprite_height_negative = 12;
-        sprite->duck.sprite_height_positive = 9;
-        int32_t offsetXY = scenario_rand() & 0x1E;
-        targetX += offsetXY;
-        targetY += offsetXY;
-        sprite->duck.target_x = targetX;
-        sprite->duck.target_y = targetY;
-        uint8_t direction = scenario_rand() & 3;
-        switch (direction)
-        {
-            case 0:
-                targetX = 8191 - (scenario_rand() & 0x3F);
-                break;
-            case 1:
-                targetY = scenario_rand() & 0x3F;
-                break;
-            case 2:
-                targetX = scenario_rand() & 0x3F;
-                break;
-            case 3:
-                targetY = 8191 - (scenario_rand() & 0x3F);
-                break;
-        }
-        sprite->duck.sprite_direction = direction << 3;
-        sprite_move(targetX, targetY, 496, sprite);
-        sprite->duck.state = DUCK_STATE::FLY_TO_WATER;
-        sprite->duck.frame = 0;
+        case 0:
+            targetPos.x = 8191 - (scenario_rand() & 0x3F);
+            break;
+        case 1:
+            targetPos.y = scenario_rand() & 0x3F;
+            break;
+        case 2:
+            targetPos.x = scenario_rand() & 0x3F;
+            break;
+        case 3:
+            targetPos.y = 8191 - (scenario_rand() & 0x3F);
+            break;
     }
+    sprite->duck.sprite_direction = direction << 3;
+    sprite_move(targetPos.x, targetPos.y, 496, sprite);
+    sprite->duck.state = DUCK_STATE::FLY_TO_WATER;
+    sprite->duck.frame = 0;
 }
 
 void duck_update(rct_duck* duck)

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -227,7 +227,7 @@ void balloon_update(rct_balloon* balloon);
 ///////////////////////////////////////////////////////////////
 // Duck
 ///////////////////////////////////////////////////////////////
-void create_duck(int32_t targetX, int32_t targetY);
+void create_duck(const CoordsXY& pos);
 void duck_update(rct_duck* duck);
 void duck_press(rct_duck* duck);
 void duck_remove_all();


### PR DESCRIPTION
This one should be without crashes. I left a few asserts in there to be sure and they have no performance impact.