### PR TITLE
Fix #9179: Crash when modifying a ride occasionally

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: [#7690] Problem with guests freezing on certain tiles of path.
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Fix: [#8136] Excessive lateral G penalty is too excessive.
+- Fix: [#9179] Crash when modifying a ride occasionally.
 - Fix: [#9574] Text overflow in scenario objective window when using CJK languages.
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1142,7 +1142,7 @@ bool ride_try_get_origin_element(const Ride* ride, CoordsXYE* output);
 int32_t ride_find_track_gap(const Ride* ride, CoordsXYE* input, CoordsXYE* output);
 void ride_construct_new(ride_list_item listItem);
 void ride_construct(Ride* ride);
-int32_t ride_modify(CoordsXYE* input);
+bool ride_modify(CoordsXYE* input);
 void ride_remove_peeps(Ride* ride);
 void ride_clear_blocked_tiles(Ride* ride);
 Staff* ride_get_mechanic(Ride* ride);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2318,6 +2318,54 @@ TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t 
     return nullptr;
 }
 
+TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType)
+{
+    auto tileElement = map_get_first_element_at(location.x / 32, location.y / 32);
+    if (tileElement != nullptr)
+    {
+        do
+        {
+            auto trackElement = tileElement->AsTrack();
+            if (trackElement != nullptr)
+            {
+                if (trackElement->base_height != location.z / 8)
+                    continue;
+                if (trackElement->GetDirection() != location.direction)
+                    continue;
+                if (trackElement->GetTrackType() != trackType)
+                    continue;
+                return trackElement;
+            }
+        } while (!(tileElement++)->IsLastForTile());
+    }
+    return nullptr;
+}
+
+TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence)
+{
+    auto tileElement = map_get_first_element_at(location.x / 32, location.y / 32);
+    if (tileElement != nullptr)
+    {
+        do
+        {
+            auto trackElement = tileElement->AsTrack();
+            if (trackElement != nullptr)
+            {
+                if (trackElement->base_height != location.z / 8)
+                    continue;
+                if (trackElement->GetDirection() != location.direction)
+                    continue;
+                if (trackElement->GetTrackType() != trackType)
+                    continue;
+                if (trackElement->GetSequenceIndex() != sequence)
+                    continue;
+                return trackElement;
+            }
+        } while (!(tileElement++)->IsLastForTile());
+    }
+    return nullptr;
+}
+
 /**
  * Gets the track element at x, y, z that is the given track type and sequence.
  * @param x x units, not tiles.

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -240,6 +240,8 @@ CoordsXY translate_3d_to_2d_with_z(int32_t rotation, CoordsXYZ pos);
 TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);
 TileElement* map_get_track_element_at_of_type(int32_t x, int32_t y, int32_t z, int32_t trackType);
 TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence);
+TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);
+TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);
 TileElement* map_get_track_element_at_of_type_from_ride(
     int32_t x, int32_t y, int32_t z, int32_t trackType, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_from_ride(int32_t x, int32_t y, int32_t z, ride_id_t rideIndex);


### PR DESCRIPTION
Add lots of nullptr and tile element checks in the ride_modify call chain.