### PR TITLE
Fix #9762: Update network logic also from title screen

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -228,6 +228,8 @@ void GameState::UpdateLogic()
 
     GetContext()->GetReplayManager()->Update();
 
+    network_update();
+
     if (network_get_mode() == NETWORK_MODE_SERVER)
     {
         if (network_gamestate_snapshots_enabled())


### PR DESCRIPTION
I forgot that there is no common loop, back to calling updates more often than required.