### PR TITLE
Add nullptr checks for get_ride in libopenrct2

### DIFF
--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -266,7 +266,7 @@ private:
                         int32_t maxHeight = rideEntry->max_height;
                         if (maxHeight == 0)
                         {
-                            maxHeight = RideData5[get_ride(rideIndex)->type].max_height;
+                            maxHeight = RideData5[ride->type].max_height;
                         }
                         int32_t zDelta = tileElement->clearance_height - _height;
                         if (zDelta >= 0 && zDelta / 2 > maxHeight)

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -181,6 +181,14 @@ public:
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
         res->ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
 
+        auto ride = get_ride(_rideIndex);
+        if (ride == nullptr)
+        {
+            res->Error = GA_ERROR::INVALID_PARAMETERS;
+            res->ErrorMessage = STR_NONE;
+            return res;
+        }
+
         if (!map_check_free_elements_and_reorganise(1))
         {
             res->Error = GA_ERROR::NO_FREE_ELEMENTS;
@@ -198,13 +206,9 @@ public:
         uint8_t baseHeight = _loc.z / 8;
         uint8_t clearanceHeight = (_loc.z + 32) / 8;
 
-        TileElement* tileElement = map_get_track_element_at_of_type_from_ride(
-            _loc.x, _loc.y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+        auto tileElement = map_get_track_element_at_of_type_from_ride(_loc.x, _loc.y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
         if (tileElement == nullptr)
         {
-            Ride* ride = get_ride(_rideIndex);
-            openrct2_assert(ride != nullptr, "Invalid ride index: %d\n", uint32_t(_rideIndex));
-
             money32 price = (((RideTrackCosts[ride->type].track_price * TrackPricing[TRACK_ELEM_MAZE]) >> 16));
             res->Cost = price / 2 * 10;
 
@@ -333,7 +337,6 @@ public:
 
         if ((tileElement->AsTrack()->GetMazeEntry() & 0x8888) == 0x8888)
         {
-            Ride* ride = get_ride(_rideIndex);
             tile_element_remove(tileElement);
             sub_6CB945(ride);
             ride->maze_tiles--;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -785,7 +785,10 @@ void lightfx_add_lights_magic_vehicles()
                 -10, -10, -9, -8, -7, -6, -4, -2, 0, 2,  4,  6,  7,  8,  9,  10,
             };
 
-            Ride* ride = get_ride(vehicle->ride);
+            auto ride = get_ride(vehicle->ride);
+            if (ride == nullptr)
+                continue;
+
             switch (ride->type)
             {
                 case RIDE_TYPE_OBSERVATION_TOWER:

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -708,8 +708,8 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep
         if (peep->state == PEEP_STATE_ON_RIDE || peep->state == PEEP_STATE_ENTERING_RIDE
             || (peep->state == PEEP_STATE_LEAVING_RIDE && peep->x == LOCATION_NULL))
         {
-            Ride* ride = get_ride(peep->current_ride);
-            if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
+            auto ride = get_ride(peep->current_ride);
+            if (ride != nullptr && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
             {
                 auto train = GET_VEHICLE(ride->vehicles[peep->current_train]);
                 if (train != nullptr)

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -73,8 +73,11 @@ static void marketing_raise_finished_notification(const MarketingCampaign& campa
         // This sets the string parameters for the marketing types that have an argument.
         if (campaign.Type == ADVERTISING_CAMPAIGN_RIDE_FREE || campaign.Type == ADVERTISING_CAMPAIGN_RIDE)
         {
-            Ride* ride = get_ride(campaign.RideId);
-            ride->FormatNameTo(gCommonFormatArgs);
+            auto ride = get_ride(campaign.RideId);
+            if (ride != nullptr)
+            {
+                ride->FormatNameTo(gCommonFormatArgs);
+            }
         }
         else if (campaign.Type == ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE)
         {

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -302,8 +302,8 @@ static uint8_t footpath_element_dest_in_dir(
                 if (loc.z != tileElement->base_height)
                     continue;
                 ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-                Ride* ride = get_ride(rideIndex);
-                if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
+                auto ride = get_ride(rideIndex);
+                if (ride != nullptr && ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
                 {
                     *outRideIndex = rideIndex;
                     return PATH_SEARCH_SHOP_ENTRANCE;
@@ -670,8 +670,8 @@ static void peep_pathfind_heuristic_search(
                 /* For peeps heading for a shop, the goal is the shop
                  * tile. */
                 rideIndex = tileElement->AsTrack()->GetRideIndex();
-                Ride* ride = get_ride(rideIndex);
-                if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
+                auto ride = get_ride(rideIndex);
+                if (ride == nullptr || !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
                     continue;
 
                 found = true;
@@ -2038,9 +2038,8 @@ int32_t guest_path_finding(Guest* peep)
 
     // Peep is heading for a ride.
     ride_id_t rideIndex = peep->guest_heading_to_ride_id;
-    Ride* ride = get_ride(rideIndex);
-
-    if (ride->status != RIDE_STATUS_OPEN)
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr || ride->status != RIDE_STATUS_OPEN)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
         if (gPathFindDebug)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -690,9 +690,12 @@ void peep_decrement_num_riders(Peep* peep)
 {
     if (peep->state == PEEP_STATE_ON_RIDE || peep->state == PEEP_STATE_ENTERING_RIDE)
     {
-        Ride* ride = get_ride(peep->current_ride);
-        ride->num_riders = std::max(0, ride->num_riders - 1);
-        ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+        auto ride = get_ride(peep->current_ride);
+        if (ride != nullptr)
+        {
+            ride->num_riders = std::max(0, ride->num_riders - 1);
+            ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+        }
     }
 }
 
@@ -711,9 +714,12 @@ void peep_window_state_update(Peep* peep)
     {
         if (peep->state == PEEP_STATE_ON_RIDE || peep->state == PEEP_STATE_ENTERING_RIDE)
         {
-            Ride* ride = get_ride(peep->current_ride);
-            ride->num_riders++;
-            ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+            auto ride = get_ride(peep->current_ride);
+            if (ride != nullptr)
+            {
+                ride->num_riders++;
+                ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+            }
         }
 
         window_invalidate_by_number(WC_PEEP, peep->sprite_index);
@@ -2371,6 +2377,8 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
     uint8_t entranceType = tile_element->AsEntrance()->GetEntranceType();
     ride_id_t rideIndex = tile_element->AsEntrance()->GetRideIndex();
     auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
 
     // Store some details to determine when to override the default
     // behaviour (defined below) for when staff attempt to enter a ride
@@ -2942,9 +2950,8 @@ static void peep_interact_with_path(Peep* peep, int16_t x, int16_t y, TileElemen
 static bool peep_interact_with_shop(Peep* peep, int16_t x, int16_t y, TileElement* tile_element)
 {
     ride_id_t rideIndex = tile_element->AsTrack()->GetRideIndex();
-    Ride* ride = get_ride(rideIndex);
-
-    if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr || !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
         return false;
 
     auto guest = peep->AsGuest();
@@ -3555,7 +3562,9 @@ static void peep_release_balloon(Guest* peep, int16_t spawn_height)
  */
 void Peep::RemoveFromQueue()
 {
-    Ride* ride = get_ride(current_ride);
+    auto ride = get_ride(current_ride);
+    if (ride == nullptr)
+        return;
 
     auto& station = ride->stations[current_ride_station];
     // Make sure we don't underflow, building while paused might reset it to 0 where peeps have

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1414,9 +1414,8 @@ void Staff::UpdateSweeping()
  */
 void Staff::UpdateHeadingToInspect()
 {
-    Ride* ride = get_ride(current_ride);
-
-    if (ride->type == RIDE_TYPE_NULL)
+    auto ride = get_ride(current_ride);
+    if (ride == nullptr)
     {
         SetState(PEEP_STATE_FALLING);
         return;
@@ -1527,9 +1526,8 @@ void Staff::UpdateHeadingToInspect()
  */
 void Staff::UpdateAnswering()
 {
-    Ride* ride = get_ride(current_ride);
-
-    if (ride->type == RIDE_TYPE_NULL || ride->mechanic_status != RIDE_MECHANIC_STATUS_HEADING)
+    auto ride = get_ride(current_ride);
+    if (ride == nullptr || ride->mechanic_status != RIDE_MECHANIC_STATUS_HEADING)
     {
         SetState(PEEP_STATE_FALLING);
         return;
@@ -2073,9 +2071,8 @@ static constexpr const uint32_t FixingSubstatesForBreakdown[9] = {
  */
 void Staff::UpdateFixing(int32_t steps)
 {
-    Ride* ride = get_ride(current_ride);
-
-    if (ride->type == RIDE_TYPE_NULL)
+    auto ride = get_ride(current_ride);
+    if (ride == nullptr)
     {
         SetState(PEEP_STATE_FALLING);
         return;
@@ -2754,10 +2751,13 @@ bool Staff::UpdateFixingLeaveByEntranceExit(bool firstRun, Ride* ride)
  */
 void Staff::UpdateRideInspected(ride_id_t rideIndex)
 {
-    Ride* ride = get_ride(rideIndex);
-    ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
-
-    ride->reliability += ((100 - ride->reliability_percentage) / 4) * (scenario_rand() & 0xFF);
-    ride->last_inspection = 0;
-    ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE | RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    auto ride = get_ride(rideIndex);
+    if (ride != nullptr)
+    {
+        ride->lifecycle_flags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+        ride->reliability += ((100 - ride->reliability_percentage) / 4) * (scenario_rand() & 0xFF);
+        ride->last_inspection = 0;
+        ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAINTENANCE | RIDE_INVALIDATE_RIDE_MAIN
+            | RIDE_INVALIDATE_RIDE_LIST;
+    }
 }

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -27,18 +27,16 @@ static void cable_lift_update_travelling(rct_vehicle* vehicle);
 static void cable_lift_update_arriving(rct_vehicle* vehicle);
 
 rct_vehicle* cable_lift_segment_create(
-    ride_id_t rideIndex, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance,
-    bool head)
+    Ride& ride, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance, bool head)
 {
-    Ride* ride = get_ride(rideIndex);
     rct_vehicle* current = &(create_sprite(SPRITE_IDENTIFIER_VEHICLE)->vehicle);
     current->sprite_identifier = SPRITE_IDENTIFIER_VEHICLE;
-    current->ride = rideIndex;
+    current->ride = ride.id;
     current->ride_subtype = RIDE_ENTRY_INDEX_NULL;
     if (head)
     {
         move_sprite_to_list((rct_sprite*)current, SPRITE_LIST_VEHICLE_HEAD);
-        ride->cable_lift = current->sprite_index;
+        ride.cable_lift = current->sprite_index;
     }
     current->type = head ? VEHICLE_TYPE_HEAD : VEHICLE_TYPE_TAIL;
     current->var_44 = var_44;
@@ -79,7 +77,7 @@ rct_vehicle* cable_lift_segment_create(
 
     z = z * 8;
     current->track_z = z;
-    z += RideData5[ride->type].z_offset;
+    z += RideData5[ride.type].z_offset;
 
     sprite_move(16, 16, z, (rct_sprite*)current);
     current->track_type = (TRACK_ELEM_CABLE_LIFT_HILL << 2) | (current->sprite_direction >> 3);

--- a/src/openrct2/ride/CableLift.h
+++ b/src/openrct2/ride/CableLift.h
@@ -14,8 +14,7 @@
 #include "Vehicle.h"
 
 rct_vehicle* cable_lift_segment_create(
-    ride_id_t rideIndex, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance,
-    bool head);
+    Ride& ride, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance, bool head);
 void cable_lift_update(rct_vehicle* vehicle);
 int32_t cable_lift_update_track_motion(rct_vehicle* cableLift);
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -636,13 +636,16 @@ static void ride_remove_station(Ride* ride, int32_t x, int32_t y, int32_t z)
  */
 bool track_add_station_element(int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex, int32_t flags)
 {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return false;
+
     int32_t stationX0 = x;
     int32_t stationY0 = y;
     int32_t stationX1 = x;
     int32_t stationY1 = y;
     int32_t stationLength = 1;
 
-    Ride* ride = get_ride(rideIndex);
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_3))
     {
         if (ride->num_stations >= MAX_STATIONS)
@@ -787,6 +790,10 @@ bool track_add_station_element(int32_t x, int32_t y, int32_t z, int32_t directio
  */
 bool track_remove_station_element(int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex, int32_t flags)
 {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return false;
+
     int32_t removeX = x;
     int32_t removeY = y;
     int32_t stationX0 = x;
@@ -796,7 +803,6 @@ bool track_remove_station_element(int32_t x, int32_t y, int32_t z, int32_t direc
     int32_t stationLength = 0;
     int32_t byte_F441D1 = -1;
 
-    Ride* ride = get_ride(rideIndex);
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_3))
     {
         TileElement* tileElement = map_get_track_element_at_with_direction_from_ride(x, y, z, direction, rideIndex);
@@ -1111,9 +1117,13 @@ bool track_element_is_block_start(TileElement* trackElement)
 
 int32_t track_get_actual_bank(TileElement* tileElement, int32_t bank)
 {
-    Ride* ride = get_ride(tileElement->AsTrack()->GetRideIndex());
-    bool isInverted = tileElement->AsTrack()->IsInverted();
-    return track_get_actual_bank_2(ride->type, isInverted, bank);
+    auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+    if (ride != nullptr)
+    {
+        bool isInverted = tileElement->AsTrack()->IsInverted();
+        return track_get_actual_bank_2(ride->type, isInverted, bank);
+    }
+    return bank;
 }
 
 int32_t track_get_actual_bank_2(int32_t rideType, bool isInverted, int32_t bank)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1721,6 +1721,9 @@ static bool track_design_place_preview(rct_track_td6* td6, money32* cost, Ride**
     }
 
     auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return false;
+
     ride->custom_name = {};
     ride->entrance_style = td6->entrance_style;
 
@@ -1872,7 +1875,7 @@ static money32 place_track_design(int16_t x, int16_t y, int16_t z, uint8_t flags
     auto ride = get_ride(rideIndex);
     if (ride == nullptr)
     {
-        log_warning("Invalid game command for track placement, ride id = %d", ride->id);
+        log_warning("Invalid game command for track placement, ride id = %d", rideIndex);
         return MONEY32_UNDEFINED;
     }
 

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -150,9 +150,8 @@ static void track_design_save_callback(int32_t result, [[maybe_unused]] const ut
  */
 bool track_design_save(ride_id_t rideIndex)
 {
-    Ride* ride = get_ride(rideIndex);
-
-    if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr || !(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
     {
         context_show_error(STR_CANT_SAVE_TRACK_DESIGN, gGameCommandErrorText);
         return false;
@@ -753,8 +752,14 @@ static bool track_design_save_copy_scenery_to_td6(rct_track_td6* td6)
  */
 static rct_track_td6* track_design_save_to_td6(ride_id_t rideIndex)
 {
-    rct_track_td6* td6 = (rct_track_td6*)calloc(1, sizeof(rct_track_td6));
-    Ride* ride = get_ride(rideIndex);
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return nullptr;
+
+    auto td6 = (rct_track_td6*)calloc(1, sizeof(rct_track_td6));
+    if (td6 == nullptr)
+        return nullptr;
+
     td6->type = ride->type;
     auto object = object_entry_get_entry(OBJECT_TYPE_RIDE, ride->subtype);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1355,7 +1355,10 @@ void vehicle_update_all()
  */
 static bool vehicle_close_restraints(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return true;
+
     bool restraintsClosed = true;
     uint16_t vehicle_id = vehicle->sprite_index;
 
@@ -1416,8 +1419,11 @@ static bool vehicle_open_restraints(rct_vehicle* vehicle)
         vehicle->var_4E = 0;
         vehicle->swing_sprite = 0;
 
-        Ride* ride = get_ride(vehicle->ride);
-        rct_ride_entry* rideEntry = get_ride_entry(vehicle->ride_subtype);
+        auto ride = get_ride(vehicle->ride);
+        if (ride == nullptr)
+            continue;
+
+        auto rideEntry = get_ride_entry(vehicle->ride_subtype);
         if (rideEntry == nullptr)
         {
             continue;
@@ -2040,7 +2046,10 @@ static void vehicle_update(rct_vehicle* vehicle)
  */
 static void vehicle_update_moving_to_end_of_station(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     int32_t flags, station;
 
     switch (ride->mode)
@@ -2150,7 +2159,9 @@ static void train_ready_to_depart(rct_vehicle* vehicle, uint8_t num_peeps_on_tra
     if (num_peeps_on_train != num_used_seats)
         return;
 
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     if (ride->status == RIDE_STATUS_OPEN && !(ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
         && !(vehicle->update_flags & VEHICLE_UPDATE_FLAG_TRAIN_READY_DEPART))
@@ -2429,7 +2440,10 @@ static void vehicle_update_waiting_for_passengers(rct_vehicle* vehicle)
  */
 static void vehicle_update_dodgems_mode(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     rct_ride_entry* rideEntry = get_ride_entry(vehicle->ride_subtype);
     if (rideEntry == nullptr)
     {
@@ -2715,9 +2729,9 @@ static bool try_add_synchronised_station(int32_t x, int32_t y, int32_t z)
         return false;
     }
 
-    ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-    Ride* ride = get_ride(rideIndex);
-    if (!(ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS))
+    auto rideIndex = tileElement->AsTrack()->GetRideIndex();
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr || !(ride->depart_flags & RIDE_DEPART_SYNCHRONISE_WITH_ADJACENT_STATIONS))
     {
         /* Ride is not set to synchronise with adjacent stations. */
         return false;
@@ -2800,7 +2814,10 @@ static bool try_add_synchronised_station(int32_t x, int32_t y, int32_t z)
  */
 static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return false;
+
     int32_t station = vehicle->current_station;
     LocationXY8 location = ride->stations[station].Start;
     int32_t x = location.x * 32;
@@ -3018,7 +3035,10 @@ void vehicle_peep_easteregg_here_we_are(const rct_vehicle* vehicle)
  */
 void vehicle_update_test_finish(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     ride->lifecycle_flags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
     vehicle->update_flags &= ~VEHICLE_UPDATE_FLAG_TESTING;
     ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
@@ -3057,7 +3077,10 @@ void vehicle_test_reset(rct_vehicle* vehicle)
 {
     vehicle->update_flags |= VEHICLE_UPDATE_FLAG_TESTING;
 
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     ride->lifecycle_flags |= RIDE_LIFECYCLE_TEST_IN_PROGRESS;
     ride->lifecycle_flags &= ~RIDE_LIFECYCLE_NO_RAW_STATS;
     ride->max_speed = 0;
@@ -3146,7 +3169,10 @@ static void vehicle_update_travelling_boat_hire_setup(rct_vehicle* vehicle)
 static void vehicle_update_departing_boat_hire(rct_vehicle* vehicle)
 {
     vehicle->lost_time_out = 0;
-    Ride* ride = get_ride(vehicle->ride);
+
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     ride->stations[vehicle->current_station].Depart &= STATION_DEPART_FLAG;
     uint8_t waitingTime = std::max(ride->min_waiting_time, static_cast<uint8_t>(3));
@@ -3397,7 +3423,9 @@ static void vehicle_update_departing(rct_vehicle* vehicle)
  */
 static void vehicle_finish_departing(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     if (ride->mode == RIDE_MODE_DOWNWARD_LAUNCH)
     {
@@ -3440,7 +3468,9 @@ static void vehicle_finish_departing(rct_vehicle* vehicle)
  */
 static void vehicle_check_if_missing(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     if (ride->lifecycle_flags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
         return;
@@ -3495,7 +3525,10 @@ static void vehicle_simulate_crash(rct_vehicle* vehicle)
 static void vehicle_update_collision_setup(rct_vehicle* vehicle)
 {
     auto ride = get_ride(vehicle->ride);
-    if (ride != nullptr && ride->status == RIDE_STATUS_SIMULATING)
+    if (ride == nullptr)
+        return;
+
+    if (ride->status == RIDE_STATUS_SIMULATING)
     {
         vehicle_simulate_crash(vehicle);
         return;
@@ -4031,7 +4064,10 @@ static void vehicle_update_unloading_passengers(rct_vehicle* vehicle)
         }
     }
 
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     if (ride->mode == RIDE_MODE_FORWARD_ROTATION || ride->mode == RIDE_MODE_BACKWARD_ROTATION)
     {
         uint8_t seat = ((-vehicle->vehicle_sprite_type) >> 3) & 0xF;
@@ -4113,7 +4149,9 @@ static void vehicle_update_unloading_passengers(rct_vehicle* vehicle)
  */
 static void vehicle_update_waiting_for_cable_lift(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     rct_vehicle* cableLift = GET_VEHICLE(ride->cable_lift);
 
@@ -4130,7 +4168,9 @@ static void vehicle_update_waiting_for_cable_lift(rct_vehicle* vehicle)
  */
 static void vehicle_update_travelling_cable_lift(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
     if (vehicle->sub_state == 0)
     {
@@ -4230,8 +4270,11 @@ static void loc_6DA9F9(rct_vehicle* vehicle, int32_t x, int32_t y, int32_t bx, i
 
         auto trackElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3);
 
-        Ride* ride = get_ride(vehicle->ride);
-        vehicle->track_type = (trackElement->GetTrackType() << 2) | (ride->boat_hire_return_direction & 3);
+        auto ride = get_ride(vehicle->ride);
+        if (ride != nullptr)
+        {
+            vehicle->track_type = (trackElement->GetTrackType() << 2) | (ride->boat_hire_return_direction & 3);
+        }
 
         vehicle->track_progress = 0;
         vehicle->SetState(VEHICLE_STATUS_TRAVELLING, vehicle->sub_state);
@@ -4403,7 +4446,9 @@ static void vehicle_update_motion_boat_hire(rct_vehicle* vehicle)
                 if (!vehicle_boat_is_location_accessible(TileCoordsXYZ(CoordsXYZ{ x, y, vehicle->track_z })))
                 {
                     // loc_6DA939:
-                    Ride* ride = get_ride(vehicle->ride);
+                    auto ride = get_ride(vehicle->ride);
+                    if (ride == nullptr)
+                        return;
 
                     bool do_loc_6DAA97 = false;
                     if (vehicle->sub_state != 1)
@@ -4536,7 +4581,10 @@ static void vehicle_update_motion_boat_hire(rct_vehicle* vehicle)
  */
 static void vehicle_update_boat_location(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     LocationXY8 returnPosition = ride->boat_hire_return_position;
     uint8_t returnDirection = ride->boat_hire_return_direction & 3;
 
@@ -4642,8 +4690,13 @@ static bool vehicle_boat_is_location_accessible(const TileCoordsXYZ& location)
  */
 static void vehicle_update_swinging(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
-    rct_ride_entry* rideEntry = get_ride_entry(vehicle->ride_subtype);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = get_ride_entry(vehicle->ride_subtype);
+    if (rideEntry == nullptr)
+        return;
 
     // SubState for this ride means swinging state
     // 0 == first swing
@@ -4714,7 +4767,10 @@ static void vehicle_update_ferris_wheel_rotating(rct_vehicle* vehicle)
     if (_vehicleBreakdown == 0)
         return;
 
-    Ride* ride = get_ride(vehicle->ride);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
     if ((vehicle->ferris_wheel_var_1 -= 1) != 0)
         return;
 
@@ -4829,8 +4885,11 @@ static void vehicle_update_rotating(rct_vehicle* vehicle)
     if (_vehicleBreakdown == 0)
         return;
 
-    Ride* ride = get_ride(vehicle->ride);
-    rct_ride_entry* rideEntry = get_ride_entry(vehicle->ride_subtype);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = get_ride_entry(vehicle->ride_subtype);
     if (rideEntry == nullptr)
     {
         return;
@@ -5133,8 +5192,11 @@ static TileElement* vehicle_check_collision(int16_t x, int16_t y, int16_t z)
  */
 static void vehicle_kill_all_passengers(rct_vehicle* vehicle)
 {
-    uint16_t numFatalities = 0;
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
 
+    uint16_t numFatalities = 0;
     uint16_t spriteId = vehicle->sprite_index;
     for (rct_vehicle* curVehicle; spriteId != SPRITE_INDEX_NULL; spriteId = curVehicle->next_vehicle_on_train)
     {
@@ -5142,7 +5204,6 @@ static void vehicle_kill_all_passengers(rct_vehicle* vehicle)
         numFatalities += curVehicle->num_peeps;
     }
 
-    Ride* ride = get_ride(vehicle->ride);
     set_format_arg(0, uint16_t, numFatalities);
 
     uint8_t crashType = numFatalities == 0 ? RIDE_CRASH_TYPE_NO_FATALITIES : RIDE_CRASH_TYPE_FATALITIES;
@@ -5193,7 +5254,10 @@ static void vehicle_kill_all_passengers(rct_vehicle* vehicle)
 static void vehicle_crash_on_land(rct_vehicle* vehicle)
 {
     auto ride = get_ride(vehicle->ride);
-    if (ride != nullptr && ride->status == RIDE_STATUS_SIMULATING)
+    if (ride == nullptr)
+        return;
+
+    if (ride->status == RIDE_STATUS_SIMULATING)
     {
         vehicle_simulate_crash(vehicle);
         return;
@@ -5251,7 +5315,10 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle)
 static void vehicle_crash_on_water(rct_vehicle* vehicle)
 {
     auto ride = get_ride(vehicle->ride);
-    if (ride != nullptr && ride->status == RIDE_STATUS_SIMULATING)
+    if (ride == nullptr)
+        return;
+
+    if (ride->status == RIDE_STATUS_SIMULATING)
     {
         vehicle_simulate_crash(vehicle);
         return;
@@ -5404,8 +5471,6 @@ static void vehicle_update_crash(rct_vehicle* vehicle)
  */
 static void vehicle_update_sound(rct_vehicle* vehicle)
 {
-    Ride* ride;
-    rct_ride_entry* rideEntry;
     // frictionVolume (bl) should be set before hand
     uint8_t frictionVolume = 255;
     SoundId frictionId = SoundId::Null;
@@ -5413,13 +5478,13 @@ static void vehicle_update_sound(rct_vehicle* vehicle)
     SoundId screamId = SoundId::Null;
     uint8_t screamVolume = 255;
 
-    ride = get_ride(vehicle->ride);
-    rideEntry = get_ride_entry(vehicle->ride_subtype);
-
-    if (rideEntry == nullptr)
-    {
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
         return;
-    }
+
+    auto rideEntry = get_ride_entry(vehicle->ride_subtype);
+    if (rideEntry == nullptr)
+        return;
 
     rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle->vehicle_type];
 
@@ -6560,13 +6625,13 @@ static void apply_block_brakes(rct_vehicle* vehicle, bool is_block_brake_closed)
  */
 static void check_and_apply_block_section_stop_site(rct_vehicle* vehicle)
 {
-    Ride* ride = get_ride(vehicle->ride);
-    rct_ride_entry_vehicle* vehicleEntry = vehicle_get_vehicle_entry(vehicle);
-
-    if (vehicleEntry == nullptr)
-    {
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
         return;
-    }
+
+    auto vehicleEntry = vehicle_get_vehicle_entry(vehicle);
+    if (vehicleEntry == nullptr)
+        return;
 
     // Is chair lift type
     if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_CHAIRLIFT)
@@ -6711,8 +6776,8 @@ static void vehicle_update_block_brakes_open_previous_section(rct_vehicle* vehic
     int32_t trackType = trackElement->GetTrackType();
     if (trackType == TRACK_ELEM_BLOCK_BRAKES || trackType == TRACK_ELEM_END_STATION)
     {
-        Ride* ride = get_ride(vehicle->ride);
-        if (ride->IsBlockSectioned())
+        auto ride = get_ride(vehicle->ride);
+        if (ride != nullptr && ride->IsBlockSectioned())
         {
             audio_play_sound_at_location(SoundId::BlockBrakeClose, x, y, z);
         }
@@ -8046,10 +8111,14 @@ loc_6DB41D:
         vehicle_trigger_on_ride_photo(vehicle, tileElement);
     }
     {
-        uint16_t rideType = get_ride(tileElement->AsTrack()->GetRideIndex())->type;
-        if (trackType == TRACK_ELEM_ROTATION_CONTROL_TOGGLE && rideType == RIDE_TYPE_STEEL_WILD_MOUSE)
+        ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+        if (ride != nullptr)
         {
-            vehicle->update_flags ^= VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE;
+            uint16_t rideType = ride->type;
+            if (trackType == TRACK_ELEM_ROTATION_CONTROL_TOGGLE && rideType == RIDE_TYPE_STEEL_WILD_MOUSE)
+            {
+                vehicle->update_flags ^= VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE;
+            }
         }
     }
     // Change from original: this used to check if the vehicle allowed doors.

--- a/src/openrct2/ride/gentle/CircusShow.cpp
+++ b/src/openrct2/ride/gentle/CircusShow.cpp
@@ -22,8 +22,13 @@ static void paint_circus_show_tent(
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)
     {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -36,9 +36,13 @@ static void paint_crooked_house_structure(
 {
     const TileElement* original_tile_element = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    Ride* ride = get_ride(original_tile_element->AsTrack()->GetRideIndex());
+    auto ride = get_ride(original_tile_element->AsTrack()->GetRideIndex());
+    if (ride == nullptr)
+        return;
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -54,15 +54,15 @@ static void paint_ferris_wheel_structure(
 
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
-    rct_vehicle* vehicle = nullptr;
-    if (rideEntry == nullptr)
-    {
-        log_error("Error drawing Ferris Wheel, rideEntry is NULL.");
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
         return;
-    }
 
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
+    rct_vehicle* vehicle = nullptr;
     int8_t xOffset = !(direction & 1) ? axisOffset : 0;
     int8_t yOffset = (direction & 1) ? axisOffset : 0;
 

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -38,14 +38,14 @@ static void paint_haunted_house_structure(
 
     uint8_t frameNum = 0;
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
-
-    if (rideEntry == nullptr)
-    {
-        log_error("Error drawing haunted house, rideEntry is NULL.");
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
         return;
-    }
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -29,15 +29,15 @@ static void paint_merry_go_round_structure(
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
     height += 7;
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
-    rct_vehicle* vehicle = nullptr;
-
-    if (rideEntry == nullptr)
-    {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
         return;
-    }
 
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
+    rct_vehicle* vehicle = nullptr;
     uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1204,7 +1204,14 @@ void vehicle_visual_mini_golf_player(
         return;
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(get_ride(vehicle->ride)->subtype);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     rct_sprite* sprite = get_sprite(vehicle->peep[0]);
 
     uint8_t frame = mini_golf_peep_animation_frames[vehicle->mini_golf_current_animation][vehicle->animation_frame];
@@ -1237,8 +1244,13 @@ void vehicle_visual_mini_golf_ball(
         return;
     }
 
-    Ride* ride = get_ride(vehicle->ride);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    auto ride = get_ride(vehicle->ride);
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
 
     uint32_t image_id = rideEntry->vehicles[0].base_image_id;
     sub_98197C(session, image_id, 0, 0, 1, 1, 0, z, 0, 0, z + 3);

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -87,7 +87,9 @@ static void spiral_slide_paint_tile_front(
 {
     uint32_t image_id = 0;
 
-    Ride* ride = get_ride(rideIndex);
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
 
     if (direction == 1)
     {

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -29,21 +29,17 @@ static void facility_paint_setup(
     bool hasSupports = wooden_a_supports_paint_setup(
         session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
 
+    auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
-    {
-        log_error("Error drawing facility, rideEntry is NULL.");
         return;
-    }
 
-    rct_ride_entry_vehicle* firstVehicleEntry = &rideEntry->vehicles[0];
+    auto firstVehicleEntry = &rideEntry->vehicles[0];
     if (firstVehicleEntry == nullptr)
-    {
-        log_error("Error drawing facility, firstVehicleEntry is NULL.");
         return;
-    }
 
     uint32_t imageId = session->TrackColours[SCHEME_TRACK];
     imageId |= firstVehicleEntry->base_image_id;

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -29,15 +29,17 @@ static void shop_paint_setup(
     bool hasSupports = wooden_a_supports_paint_setup(
         session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
-    rct_ride_entry_vehicle* firstVehicleEntry = &rideEntry->vehicles[0];
-
-    if (rideEntry == nullptr || firstVehicleEntry == nullptr)
-    {
-        log_error("Error drawing shop, rideEntry or firstVehicleEntry is NULL.");
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
         return;
-    }
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
+    auto firstVehicleEntry = &rideEntry->vehicles[0];
+    if (firstVehicleEntry == nullptr)
+        return;
 
     uint32_t imageId = session->TrackColours[SCHEME_TRACK];
     if (imageId & IMAGE_TYPE_REMAP_2_PLUS)

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -22,13 +22,13 @@ static void paint_3d_cinema_structure(
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    Ride* ride = get_ride(rideIndex);
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
-
-    if (rideEntry == nullptr)
-    {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
         return;
-    }
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)
     {

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -33,8 +33,13 @@ enum
 static void paint_motionsimulator_vehicle(
     paint_session* session, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height, const TileElement* tileElement)
 {
-    Ride* ride = get_ride(tileElement->AsTrack()->GetRideIndex());
-    rct_ride_entry* rideEntry = ride->GetRideEntry();
+    auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+    if (ride == nullptr)
+        return;
+
+    auto rideEntry = ride->GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
 
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -175,13 +175,15 @@ static void chairlift_paint_station_ne_sw(
     paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
+
     const LocationXY16 pos = session->MapPosition;
     uint8_t trackType = tileElement->AsTrack()->GetTrackType();
-    Ride* ride = get_ride(rideIndex);
     uint32_t imageId;
 
     bool isStart = chairlift_paint_util_is_first_track(rideIndex, tileElement, pos, trackType);
-    ;
     bool isEnd = chairlift_paint_util_is_last_track(rideIndex, tileElement, pos, trackType);
 
     auto stationObj = ride_get_station_object(ride);
@@ -266,13 +268,15 @@ static void chairlift_paint_station_se_nw(
     paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return;
+
     const LocationXY16 pos = session->MapPosition;
     uint8_t trackType = tileElement->AsTrack()->GetTrackType();
-    Ride* ride = get_ride(rideIndex);
     uint32_t imageId;
 
     bool isStart = chairlift_paint_util_is_first_track(rideIndex, tileElement, pos, trackType);
-    ;
     bool isEnd = chairlift_paint_util_is_last_track(rideIndex, tileElement, pos, trackType);
 
     auto stationObj = ride_get_station_object(ride);

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -45,11 +45,12 @@ money32 place_provisional_track_piece(
     ride_id_t rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndAlternativeState, int32_t x, int32_t y,
     int32_t z)
 {
-    Ride* ride;
-    money32 result;
+    auto ride = get_ride(rideIndex);
+    if (ride == nullptr)
+        return MONEY32_UNDEFINED;
 
+    money32 result;
     ride_construction_remove_ghosts();
-    ride = get_ride(rideIndex);
     if (ride->type == RIDE_TYPE_MAZE)
     {
         int32_t flags = GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -87,8 +87,8 @@ static uint8_t banner_get_ride_index_at(int32_t x, int32_t y, int32_t z)
             continue;
 
         ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-        Ride* ride = get_ride(rideIndex);
-        if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
+        auto ride = get_ride(rideIndex);
+        if (ride == nullptr || ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IS_SHOP))
             continue;
 
         if ((tileElement->clearance_height * 8) + 32 <= z)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -801,8 +801,8 @@ static void loc_6A6D7E(
                 case TILE_ELEMENT_TYPE_TRACK:
                     if (z == tileElement->base_height)
                     {
-                        Ride* ride = get_ride(tileElement->AsTrack()->GetRideIndex());
-                        if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
+                        auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+                        if (ride == nullptr || !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
                         {
                             continue;
                         }
@@ -929,8 +929,8 @@ static void loc_6A6C85(
 
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
     {
-        Ride* ride = get_ride(tileElement->AsTrack()->GetRideIndex());
-        if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
+        auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+        if (ride == nullptr || !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
         {
             return;
         }
@@ -2005,7 +2005,10 @@ bool tile_element_wants_path_connection_towards(TileCoordsXYZD coords, const Til
             case TILE_ELEMENT_TYPE_TRACK:
                 if (tileElement->base_height == coords.z)
                 {
-                    Ride* ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+                    auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
+                    if (ride == nullptr)
+                        continue;
+
                     if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
                         break;
 
@@ -2090,9 +2093,9 @@ void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
 {
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
     {
-        ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-        Ride* ride = get_ride(rideIndex);
-        if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
+        auto rideIndex = tileElement->AsTrack()->GetRideIndex();
+        auto ride = get_ride(rideIndex);
+        if (ride == nullptr || !ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE))
             return;
     }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1297,8 +1297,11 @@ void map_obstruction_set_error_text(TileElement* tileElement)
             break;
         case TILE_ELEMENT_TYPE_TRACK:
             ride = get_ride(tileElement->AsTrack()->GetRideIndex());
-            errorStringId = STR_X_IN_THE_WAY;
-            ride->FormatNameTo(gCommonFormatArgs);
+            if (ride != nullptr)
+            {
+                errorStringId = STR_X_IN_THE_WAY;
+                ride->FormatNameTo(gCommonFormatArgs);
+            }
             break;
         case TILE_ELEMENT_TYPE_SMALL_SCENERY:
             sceneryEntry = tileElement->AsSmallScenery()->GetEntry();


### PR DESCRIPTION
Cover all remaining uses of `get_ride`, starting with `libopenrct2`.