### PR TITLE
Fix #9859. Actually keep the loading of a track design with try.

### DIFF
--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -568,10 +568,10 @@ rct_string_id TrackDesign::CreateTrackDesignScenery()
 
 std::unique_ptr<TrackDesign> track_design_open(const utf8* path)
 {
-    auto trackImporter = TrackImporter::Create(path);
-    trackImporter->Load(path);
     try
     {
+        auto trackImporter = TrackImporter::Create(path);
+        trackImporter->Load(path);
         return trackImporter->Import();
     }
     catch (const std::exception& e)


### PR DESCRIPTION
Mistake whilst implementing track desing importer and changing where code that could throw.