### PR TITLE
Fix #9878. Prevent peeps from aimlessly wanderings/drowing

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5056,6 +5056,7 @@ void Guest::UpdateRideLeaveExit()
             MoveTo((*loc).x, (*loc).y, ride->stations[current_ride_station].Height * 8);
             Invalidate();
         }
+        return;
     }
 
     OnExitRide(current_ride);


### PR DESCRIPTION
Mistake made whilst refactoring