### PR TITLE
Fix #9886: Object animations not working as multiplayer client

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2809,6 +2809,7 @@ bool Network::LoadMap(IStream* stream)
         importer->Import();
 
         sprite_position_tween_reset();
+        AutoCreateMapAnimations();
 
         // Read checksum
         [[maybe_unused]] uint32_t checksum = stream->ReadValue<uint32_t>();


### PR DESCRIPTION
The bug is a regression from #9705, this is a rather quick fix for the time being. We should look into making the code for loading/saving a map more general, there is currently quite some duplicate code all over the project doing more or less the same thing with a few exceptions when it comes to network.