### PR TITLE
Fixed the exit code always being 0, Issue #9477

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -132,6 +132,7 @@ The following people are not part of the development team, but have been contrib
 * Steve Xu (stevexu-umich)
 * (aw20368)
 * Jim Armstrong (41northstudios)
+* Matthew Michaud (Sonic7662)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -28,6 +28,10 @@ int main(int argc, const char** argv)
         // Run OpenRCT2 with a plain context
         auto context = CreateContext();
         context->RunOpenRCT2(argc, argv);
+        return EXIT_SUCCESS;
     }
-    return gExitCode;
+    else
+    {
+        return EXIT_FAILURE;
+    }
 }

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -59,8 +59,12 @@ int main(int argc, const char** argv)
 
             context->RunOpenRCT2(argc, argv);
         }
+        return EXIT_SUCCESS;
     }
-    return gExitCode;
+    else
+    {
+        return EXIT_FAILURE;
+    }
 }
 
 #ifdef __ANDROID__

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -238,8 +238,12 @@ namespace OpenRCT2
             if (Initialise())
             {
                 Launch();
+                return EXIT_SUCCESS;
             }
-            return gExitCode;
+            else
+            {
+                return EXIT_FAILURE;
+            }
         }
 
         void WriteLine(const std::string& s) override

--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -9,7 +9,6 @@
 
 #include "OpenRCT2.h"
 
-int32_t gExitCode;
 int32_t gOpenRCT2StartupAction = STARTUP_ACTION_TITLE;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
 utf8 gExePath[MAX_PATH];

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -34,9 +34,6 @@ enum
     SCREEN_FLAGS_EDITOR = (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER),
 };
 
-/** The exit code for OpenRCT2 when it exits. */
-extern int32_t gExitCode;
-
 extern int32_t gOpenRCT2StartupAction;
 extern utf8 gOpenRCT2StartupActionPath[512];
 extern utf8 gExePath[MAX_PATH];


### PR DESCRIPTION
Replaced the uninitialized gExitCode with EXIT_SUCCESS and EXIT_FAILURE where applicable and removed all unneeded declarations of gExitCode in the game files.

OpenRCT2\test\testpaint\main.cpp also uses the name gExitCode but does so correctly and independently from the game so is left unchanged.