### PR TITLE
Fix #9603: Don't render audio when master volume is turned off

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance. (original bug)
+- Fix: [#9603] Don't render audio when master volume is turned off
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 
 0.2.3 (2019-07-10)

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -223,7 +223,8 @@ namespace OpenRCT2::Audio
             {
                 auto channel = *it;
                 int32_t group = channel->GetGroup();
-                if (group != MIXER_GROUP_SOUND || gConfigSound.sound_enabled)
+                if ((group != MIXER_GROUP_SOUND || gConfigSound.sound_enabled) && gConfigSound.master_sound_enabled
+                    && gConfigSound.master_volume != 0)
                 {
                     MixChannel(channel, dst, length);
                 }


### PR DESCRIPTION
This fix attempts to stop mixing channels when master volume is disabled, and offloads mixing to a dedicated job pool.  

I am not sure of the efficiency of the pool, as I've been unable to run measurement tools on my workstation.