### PR TITLE
Avoid redefining JobPool::AddTask

### DIFF
--- a/src/openrct2/core/JobPool.hpp
+++ b/src/openrct2/core/JobPool.hpp
@@ -70,16 +70,11 @@ public:
         }
     }
 
-    void AddTask(std::function<void()> workFn, std::function<void()> completionFn)
+    void AddTask(std::function<void()> workFn, std::function<void()> completionFn = nullptr)
     {
         unique_lock lock(_mutex);
         _pending.emplace_back(workFn, completionFn);
         _condPending.notify_one();
-    }
-
-    void AddTask(std::function<void()> workFn)
-    {
-        return AddTask(workFn, nullptr);
     }
 
     void Join(std::function<void()> reportFn = nullptr)


### PR DESCRIPTION
This is the commit that was previously on my other PR (#9907).  