### PR TITLE
Fix #9920: Ghost pieces break maps on multiplayer for the client

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2392,7 +2392,7 @@ static void window_ride_construction_draw_track_piece(
 }
 
 static TileElement _tempTrackTileElement;
-static TileElement _tempSideTrackTileElement = { 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static TileElement _tempSideTrackTileElement = { 0x80, 0x8F, 128, 128, 0, 0, 0, 0 };
 static TileElement* _backupTileElementArrays[5];
 
 /**

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -608,25 +608,6 @@ bool scenario_prepare_for_save()
  */
 void scenario_fix_ghosts(rct_s6_data* s6)
 {
-    // Build tile pointer cache (needed to get the first element at a certain location)
-    RCT12TileElement* tilePointers[MAX_TILE_TILE_ELEMENT_POINTERS];
-    for (size_t i = 0; i < MAX_TILE_TILE_ELEMENT_POINTERS; i++)
-    {
-        tilePointers[i] = TILE_UNDEFINED_TILE_ELEMENT;
-    }
-
-    RCT12TileElement* tileElement = s6->tile_elements;
-    RCT12TileElement** tile = tilePointers;
-    for (size_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
-    {
-        for (size_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
-        {
-            *tile++ = tileElement;
-            while (!(tileElement++)->IsLastForTile())
-                ;
-        }
-    }
-
     // Remove all ghost elements
     RCT12TileElement* destinationElement = s6->tile_elements;
 
@@ -634,8 +615,7 @@ void scenario_fix_ghosts(rct_s6_data* s6)
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            // This is the equivalent of map_get_first_element_at(x, y), but on S6 data.
-            RCT12TileElement* originalElement = tilePointers[x + y * MAXIMUM_MAP_SIZE_TECHNICAL];
+            RCT12TileElement* originalElement = reinterpret_cast<RCT12TileElement*>(map_get_first_element_at(x, y));
             do
             {
                 if (originalElement->IsGhost())

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -83,7 +83,6 @@ struct TileElementBase
 struct TileElement : public TileElementBase
 {
     uint8_t pad_04[4];
-    uint8_t pad_08[8];
 
     template<typename TType, TileElementType TClass> TType* as() const
     {
@@ -130,7 +129,7 @@ public:
 
     void ClearAs(uint8_t newType);
 };
-assert_struct_size(TileElement, 16);
+assert_struct_size(TileElement, 8);
 
 struct SurfaceElement : TileElementBase
 {
@@ -139,10 +138,6 @@ private:
     uint8_t terrain;      // 5 0xE0 Terrain Style, 0x1F Water height
     uint8_t grass_length; // 6
     uint8_t ownership;    // 7
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint8_t GetSlope() const;
@@ -171,7 +166,7 @@ public:
     bool HasTrackThatNeedsWater() const;
     void SetHasTrackThatNeedsWater(bool on);
 };
-assert_struct_size(SurfaceElement, 16);
+assert_struct_size(SurfaceElement, 8);
 
 struct PathElement : TileElementBase
 {
@@ -184,10 +179,6 @@ private:
         uint8_t additionStatus; // 7
         ride_id_t rideIndex;
     };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint8_t GetPathEntryIndex() const;
@@ -251,7 +242,7 @@ public:
     bool ShouldDrawPathOverSupports();
     void SetShouldDrawPathOverSupports(bool on);
 };
-assert_struct_size(PathElement, 16);
+assert_struct_size(PathElement, 8);
 
 struct TrackElement : TileElementBase
 {
@@ -277,10 +268,6 @@ struct TrackElement : TileElementBase
         uint16_t mazeEntry; // 5
     };
     ride_id_t rideIndex; // 7
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint8_t GetTrackType() const;
@@ -341,7 +328,7 @@ public:
     uint8_t GetDoorAState() const;
     uint8_t GetDoorBState() const;
 };
-assert_struct_size(TrackElement, 16);
+assert_struct_size(TrackElement, 8);
 
 struct SmallSceneryElement : TileElementBase
 {
@@ -350,11 +337,6 @@ private:
     uint8_t age;        // 5
     uint8_t colour_1;   // 6
     uint8_t colour_2;   // 7
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
-
 public:
     uint8_t GetEntryIndex() const;
     void SetEntryIndex(uint8_t newIndex);
@@ -371,17 +353,13 @@ public:
     bool NeedsSupports() const;
     void SetNeedsSupports();
 };
-assert_struct_size(SmallSceneryElement, 16);
+assert_struct_size(SmallSceneryElement, 8);
 
 struct LargeSceneryElement : TileElementBase
 {
 private:
     uint16_t entryIndex; // 4
     uint8_t colour[2];   // 6
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint32_t GetEntryIndex() const;
@@ -403,7 +381,7 @@ public:
     bool IsAccounted() const;
     void SetIsAccounted(bool isAccounted);
 };
-assert_struct_size(LargeSceneryElement, 16);
+assert_struct_size(LargeSceneryElement, 8);
 
 struct WallElement : TileElementBase
 {
@@ -416,10 +394,6 @@ private:
     };
     uint8_t colour_1;  // 6 0b_2221_1111 2 = colour_2 (uses flags for rest of colour2), 1 = colour_1
     uint8_t animation; // 7 0b_dfff_ft00 d = direction, f = frame num, t = across track flag (not used)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint8_t GetEntryIndex() const;
@@ -452,7 +426,7 @@ public:
     int32_t GetRCT1WallType(int32_t edge) const;
     colour_t GetRCT1WallColour() const;
 };
-assert_struct_size(WallElement, 16);
+assert_struct_size(WallElement, 8);
 
 struct EntranceElement : TileElementBase
 {
@@ -461,10 +435,6 @@ private:
     uint8_t index;        // 5. 0bUSSS????, S = station index.
     uint8_t pathType;     // 6
     ride_id_t rideIndex;  // 7
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad_08[8];
-#pragma clang diagnostic pop
 
 public:
     uint8_t GetEntranceType() const;
@@ -482,7 +452,7 @@ public:
     uint8_t GetPathType() const;
     void SetPathType(uint8_t newPathType);
 };
-assert_struct_size(EntranceElement, 16);
+assert_struct_size(EntranceElement, 8);
 
 struct BannerElement : TileElementBase
 {
@@ -493,7 +463,6 @@ private:
 #pragma clang diagnostic ignored "-Wunused-private-field"
     uint8_t flags;  // 6
     uint8_t unused; // 7
-    uint8_t pad_08[8];
 #pragma clang diagnostic pop
 public:
     Banner* GetBanner() const;
@@ -509,14 +478,13 @@ public:
     void SetAllowedEdges(uint8_t newEdges);
     void ResetAllowedEdges();
 };
-assert_struct_size(BannerElement, 16);
+assert_struct_size(BannerElement, 8);
 
 struct CorruptElement : TileElementBase
 {
     uint8_t pad[4];
-    uint8_t pad_08[8];
 };
-assert_struct_size(CorruptElement, 16);
+assert_struct_size(CorruptElement, 8);
 #pragma pack(pop)
 
 class QuarterTile


### PR DESCRIPTION
This reverts some things from #9903 as it broke multiplayer. I'm not exactly sure what the root cause is but reverting the function and struct size was necessary to get the expected behavior back. 

Things that I do know:
1. Reverting ```scenario_fix_ghosts``` fixed half of it, it seems that the way the pointer list is built doesn't quite match what gTileElementPointers have.
2. Reverting back to size of 8 fixed the other half of it, here I'm not sure what the issue really is.