### PR TITLE
Fix #9926: Africa - Oasis park has wrong peep spawn

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,8 +10,9 @@
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
-- Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance. (original bug)
-- Fix: [#9603] Don't render audio when master volume is turned off
+- Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
+- Fix: [#9603] Don't render audio when master volume is turned off.
+- Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 
 0.2.3 (2019-07-10)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -911,6 +911,12 @@ public:
         {
             _s6.peep_spawns[0].y = 1296;
         }
+        // #9926: Africa - Oasis has peeps spawning on the edge underground near the entrance
+        else if (String::Equals(_s6.scenario_filename, "Africa - Oasis.SC6"))
+        {
+            _s6.peep_spawns[0].y = 2128;
+            _s6.peep_spawns[0].z = 7;
+        }
 
         gPeepSpawns.clear();
         for (size_t i = 0; i < RCT12_MAX_PEEP_SPAWNS; i++)


### PR DESCRIPTION
I also noticed that this same scenario has a single tile outside of the park whose ownership is set to build rights. To avoid breaking existing parks and since there are no side effects, I left it unchanged. This made me realize though that these peep-spawn fixes could break parks that have been saved under the same name and with their entry points moved.

Also ping @Gymnasiast since you probably have access to more RCT2 installations, perhaps another filename may need to be checked too ("WW Africa - Oasis.SC6" I guess?).