### PR TITLE
Fix desync regression

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -132,6 +132,10 @@ namespace GameActions
                         "%08X\n",
                         queued.uniqueId, queued.tick, currentTick);
                 }
+                else if (queued.tick > currentTick)
+                {
+                    return;
+                }
             }
 
             // Remove ghost scenery so it doesn't interfere with incoming network command
@@ -293,7 +297,9 @@ namespace GameActions
         MemoryStream& output = ctx.output;
 
         char temp[128] = {};
-        snprintf(temp, sizeof(temp), "[%s] GA: %s (%08X) (", GetRealm(), action->GetName(), action->GetType());
+        snprintf(
+            temp, sizeof(temp), "[%s] Tick: %u, GA: %s (%08X) (", GetRealm(), gCurrentTicks, action->GetName(),
+            action->GetType());
 
         output.Write(temp, strlen(temp));
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "8"
+#define NETWORK_STREAM_VERSION "9"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
This one goes on me, it ignored at which specific tick the action has to run on client. I've also added the tick to the action logging which made it really easy to spot this one.