### PR TITLE
Create new ImageId struct

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -176,7 +176,7 @@ void TextureCache::GeneratePaletteTexture()
         GLint y = PaletteToY(i);
         uint16_t image = palette_to_g1_offset[i];
         auto element = gfx_get_g1_element(image);
-        gfx_draw_sprite_software(&dpi, image, -element->x_offset, y - element->y_offset, 0);
+        gfx_draw_sprite_software(&dpi, ImageId(image), -element->x_offset, y - element->y_offset, 0);
     }
 
     glBindTexture(GL_TEXTURE_RECTANGLE, _paletteTexture);
@@ -299,7 +299,7 @@ rct_drawpixelinfo TextureCache::GetImageAsDPI(uint32_t image, uint32_t tertiaryC
     int32_t height = g1Element->height;
 
     rct_drawpixelinfo dpi = CreateDPI(width, height);
-    gfx_draw_sprite_software(&dpi, image, -g1Element->x_offset, -g1Element->y_offset, tertiaryColour);
+    gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(image), -g1Element->x_offset, -g1Element->y_offset, tertiaryColour);
     return dpi;
 }
 
@@ -310,7 +310,7 @@ rct_drawpixelinfo TextureCache::GetGlyphAsDPI(uint32_t image, uint8_t* palette)
     int32_t height = g1Element->height;
 
     rct_drawpixelinfo dpi = CreateDPI(width, height);
-    gfx_draw_sprite_palette_set_software(&dpi, image, -g1Element->x_offset, -g1Element->y_offset, palette, nullptr);
+    gfx_draw_sprite_palette_set_software(&dpi, ImageId::FromUInt32(image), -g1Element->x_offset, -g1Element->y_offset, palette, nullptr);
     return dpi;
 }
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -176,7 +176,7 @@ void TextureCache::GeneratePaletteTexture()
         GLint y = PaletteToY(i);
         uint16_t image = palette_to_g1_offset[i];
         auto element = gfx_get_g1_element(image);
-        gfx_draw_sprite_software(&dpi, ImageId(image), -element->x_offset, y - element->y_offset, 0);
+        gfx_draw_sprite_software(&dpi, ImageId(image), -element->x_offset, y - element->y_offset);
     }
 
     glBindTexture(GL_TEXTURE_RECTANGLE, _paletteTexture);
@@ -299,7 +299,7 @@ rct_drawpixelinfo TextureCache::GetImageAsDPI(uint32_t image, uint32_t tertiaryC
     int32_t height = g1Element->height;
 
     rct_drawpixelinfo dpi = CreateDPI(width, height);
-    gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(image), -g1Element->x_offset, -g1Element->y_offset, tertiaryColour);
+    gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(image, tertiaryColour), -g1Element->x_offset, -g1Element->y_offset);
     return dpi;
 }
 
@@ -310,7 +310,8 @@ rct_drawpixelinfo TextureCache::GetGlyphAsDPI(uint32_t image, uint8_t* palette)
     int32_t height = g1Element->height;
 
     rct_drawpixelinfo dpi = CreateDPI(width, height);
-    gfx_draw_sprite_palette_set_software(&dpi, ImageId::FromUInt32(image), -g1Element->x_offset, -g1Element->y_offset, palette, nullptr);
+    gfx_draw_sprite_palette_set_software(
+        &dpi, ImageId::FromUInt32(image), -g1Element->x_offset, -g1Element->y_offset, palette, nullptr);
     return dpi;
 }
 

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -238,14 +238,14 @@ static bool sprite_file_export(int32_t spriteIndex, const char* outPath)
     if (spriteHeader->flags & G1_FLAG_RLE_COMPRESSION)
     {
         gfx_rle_sprite_to_buffer(
-            spriteHeader->offset, pixels, (uint8_t*)spriteFilePalette, &dpi, IMAGE_TYPE_DEFAULT, 0, spriteHeader->height, 0,
+            spriteHeader->offset, pixels, (uint8_t*)spriteFilePalette, &dpi, ImageId(), 0, spriteHeader->height, 0,
             spriteHeader->width);
     }
     else
     {
         gfx_bmp_sprite_to_buffer(
             (uint8_t*)spriteFilePalette, spriteHeader->offset, pixels, spriteHeader, &dpi, spriteHeader->height,
-            spriteHeader->width, IMAGE_TYPE_DEFAULT);
+            spriteHeader->width, ImageId());
     }
 
     auto const pixels8 = dpi.bits;

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -15,6 +15,7 @@
 #include "../core/Guard.hpp"
 #include "../object/Object.h"
 #include "../platform/platform.h"
+#include "../sprites.h"
 #include "../util/Util.h"
 #include "../world/Water.h"
 
@@ -464,6 +465,32 @@ const translucent_window_palette TranslucentWindowPalettes[COLOUR_COUNT] = {
     {PALETTE_TRANSLUCENT_LIGHT_PINK,        PALETTE_TRANSLUCENT_LIGHT_PINK_HIGHLIGHT,       PALETTE_TRANSLUCENT_LIGHT_PINK_SHADOW},
 };
 // clang-format on
+
+ImageCatalogue ImageId::GetCatalogue() const
+{
+    auto index = GetIndex();
+    if (index == SPR_TEMP)
+    {
+        return ImageCatalogue::TEMPORARY;
+    }
+    else if (index < SPR_RCTC_G1_END)
+    {
+        return ImageCatalogue::G1;
+    }
+    else if (index < SPR_G2_END)
+    {
+        return ImageCatalogue::G2;
+    }
+    else if (index < SPR_CSG_END)
+    {
+        return ImageCatalogue::CSG;
+    }
+    else if (index < SPR_IMAGE_LIST_END)
+    {
+        return ImageCatalogue::OBJECT;
+    }
+    return ImageCatalogue::UNKNOWN;
+}
 
 void (*mask_fn)(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -286,22 +286,22 @@ public:
 
     ImageId() = default;
 
-    explicit ImageId(uint32_t index)
+    explicit constexpr ImageId(uint32_t index)
         : _value(index & MASK_INDEX)
     {
     }
 
-    ImageId(uint32_t index, uint8_t primaryColourOrPalette)
+    constexpr ImageId(uint32_t index, uint8_t primaryColourOrPalette)
         : ImageId(ImageId(index).WithPrimary(primaryColourOrPalette))
     {
     }
 
-    ImageId(uint32_t index, colour_t primaryColour, colour_t secondaryColour)
+    constexpr ImageId(uint32_t index, colour_t primaryColour, colour_t secondaryColour)
         : ImageId(ImageId(index).WithPrimary(primaryColour).WithSecondary(secondaryColour))
     {
     }
 
-    ImageId(uint32_t index, colour_t primaryColour, colour_t secondaryColour, colour_t tertiaryColour)
+    constexpr ImageId(uint32_t index, colour_t primaryColour, colour_t secondaryColour, colour_t tertiaryColour)
         : ImageId(ImageId(index).WithPrimary(primaryColour).WithSecondary(secondaryColour).WithTertiary(tertiaryColour))
     {
     }
@@ -368,28 +368,28 @@ public:
 
     ImageCatalogue GetCatalogue() const;
 
-    ImageId WithIndex(uint32_t index)
+    constexpr ImageId WithIndex(uint32_t index)
     {
         ImageId result = *this;
         result._value = (_value & ~MASK_INDEX) | (index & MASK_INDEX);
         return result;
     }
 
-    ImageId WithPrimary(colour_t colour)
+    constexpr ImageId WithPrimary(colour_t colour)
     {
         ImageId result = *this;
         result._value = (_value & ~MASK_PRIMARY) | ((colour << SHIFT_PRIMARY) & MASK_PRIMARY) | FLAG_PRIMARY;
         return result;
     }
 
-    ImageId WithSecondary(colour_t colour)
+    constexpr ImageId WithSecondary(colour_t colour)
     {
         ImageId result = *this;
         result._value = (_value & ~MASK_SECONDARY) | ((colour << SHIFT_SECONDARY) & MASK_SECONDARY) | FLAG_SECONDARY;
         return result;
     }
 
-    ImageId WithTertiary(colour_t tertiary)
+    constexpr ImageId WithTertiary(colour_t tertiary)
     {
         ImageId result = *this;
         result._value &= ~FLAG_PRIMARY;

--- a/src/openrct2/drawing/DrawingFast.cpp
+++ b/src/openrct2/drawing/DrawingFast.cpp
@@ -176,15 +176,16 @@ static void FASTCALL DrawRLESprite1(
  * Transfers readied images onto buffers
  * This function copies the sprite data onto the screen
  *  rct2: 0x0067AA18
+ * @param imageId Only flags are used.
  */
 void FASTCALL gfx_rle_sprite_to_buffer(
     const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const uint8_t* RESTRICT palette_pointer,
-    const rct_drawpixelinfo* RESTRICT dpi, int32_t image_type, int32_t source_y_start, int32_t height, int32_t source_x_start,
+    const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,
     int32_t width)
 {
-    if (image_type & IMAGE_TYPE_REMAP)
+    if (imageId.HasPrimary())
     {
-        if (image_type & IMAGE_TYPE_TRANSPARENT)
+        if (imageId.IsBlended())
         {
             DrawRLESpriteHelper1(IMAGE_TYPE_REMAP | IMAGE_TYPE_TRANSPARENT);
         }
@@ -193,7 +194,7 @@ void FASTCALL gfx_rle_sprite_to_buffer(
             DrawRLESpriteHelper1(IMAGE_TYPE_REMAP);
         }
     }
-    else if (image_type & IMAGE_TYPE_TRANSPARENT)
+    else if (imageId.IsBlended())
     {
         DrawRLESpriteHelper1(IMAGE_TYPE_TRANSPARENT);
     }

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -53,7 +53,7 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < FONT_SPRITE_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(SPR_CHAR_START + FONT_SPRITE_BASE_TINY + i), -1, 0, 0);
+        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(SPR_CHAR_START + FONT_SPRITE_BASE_TINY + i), -1, 0);
 
         for (int32_t x = 0; x < 8; x++)
         {
@@ -75,7 +75,7 @@ void scrolling_text_initialise_bitmaps()
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
         gfx_draw_sprite_software(
-            &dpi, ImageId::FromUInt32(SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i), -1, 0, 0);
+            &dpi, ImageId::FromUInt32(SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i), -1, 0);
 
         for (int32_t x = 0; x < 8; x++)
         {

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -53,7 +53,7 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < FONT_SPRITE_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(&dpi, SPR_CHAR_START + FONT_SPRITE_BASE_TINY + i, -1, 0, 0);
+        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(SPR_CHAR_START + FONT_SPRITE_BASE_TINY + i), -1, 0, 0);
 
         for (int32_t x = 0; x < 8; x++)
         {
@@ -74,7 +74,8 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < SPR_G2_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(&dpi, SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i, -1, 0, 0);
+        gfx_draw_sprite_software(
+            &dpi, ImageId::FromUInt32(SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i), -1, 0, 0);
 
         for (int32_t x = 0; x < 8; x++)
         {

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -730,7 +730,7 @@ void X8DrawingContext::DrawLine(uint32_t colour, int32_t x1, int32_t y1, int32_t
 
 void X8DrawingContext::DrawSprite(uint32_t image, int32_t x, int32_t y, uint32_t tertiaryColour)
 {
-    gfx_draw_sprite_software(_dpi, image, x, y, tertiaryColour);
+    gfx_draw_sprite_software(_dpi, ImageId::FromUInt32(image), x, y, tertiaryColour);
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(int32_t x, int32_t y, uint32_t maskImage, uint32_t colourImage)
@@ -743,14 +743,12 @@ void X8DrawingContext::DrawSpriteSolid(uint32_t image, int32_t x, int32_t y, uin
     uint8_t palette[256];
     std::fill_n(palette, sizeof(palette), colour);
     palette[0] = 0;
-
-    image &= 0x7FFFF;
-    gfx_draw_sprite_palette_set_software(_dpi, image | IMAGE_TYPE_REMAP, x, y, palette, nullptr);
+    gfx_draw_sprite_palette_set_software(_dpi, ImageId::FromUInt32((image & 0x7FFFF) | IMAGE_TYPE_REMAP), x, y, palette, nullptr);
 }
 
 void X8DrawingContext::DrawGlyph(uint32_t image, int32_t x, int32_t y, uint8_t* palette)
 {
-    gfx_draw_sprite_palette_set_software(_dpi, image, x, y, palette, nullptr);
+    gfx_draw_sprite_palette_set_software(_dpi, ImageId::FromUInt32(image), x, y, palette, nullptr);
 }
 
 void X8DrawingContext::SetDPI(rct_drawpixelinfo* dpi)

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -730,7 +730,7 @@ void X8DrawingContext::DrawLine(uint32_t colour, int32_t x1, int32_t y1, int32_t
 
 void X8DrawingContext::DrawSprite(uint32_t image, int32_t x, int32_t y, uint32_t tertiaryColour)
 {
-    gfx_draw_sprite_software(_dpi, ImageId::FromUInt32(image), x, y, tertiaryColour);
+    gfx_draw_sprite_software(_dpi, ImageId::FromUInt32(image, tertiaryColour), x, y);
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(int32_t x, int32_t y, uint32_t maskImage, uint32_t colourImage)
@@ -743,7 +743,8 @@ void X8DrawingContext::DrawSpriteSolid(uint32_t image, int32_t x, int32_t y, uin
     uint8_t palette[256];
     std::fill_n(palette, sizeof(palette), colour);
     palette[0] = 0;
-    gfx_draw_sprite_palette_set_software(_dpi, ImageId::FromUInt32((image & 0x7FFFF) | IMAGE_TYPE_REMAP), x, y, palette, nullptr);
+    gfx_draw_sprite_palette_set_software(
+        _dpi, ImageId::FromUInt32((image & 0x7FFFF) | IMAGE_TYPE_REMAP), x, y, palette, nullptr);
 }
 
 void X8DrawingContext::DrawGlyph(uint32_t image, int32_t x, int32_t y, uint8_t* palette)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6072,7 +6072,7 @@ void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int3
 
     for (int32_t i = 0; i < num_images; ++i)
     {
-        gfx_draw_sprite_software(&dpi, vehicle_type->base_image_id + i, 0, 0, 0);
+        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(vehicle_type->base_image_id + i), 0, 0, 0);
     }
     int32_t al = -1;
     for (int32_t i = 99; i != 0; --i)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6072,7 +6072,7 @@ void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int3
 
     for (int32_t i = 0; i < num_images; ++i)
     {
-        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(vehicle_type->base_image_id + i), 0, 0, 0);
+        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(vehicle_type->base_image_id + i), 0, 0);
     }
     int32_t al = -1;
     for (int32_t i = 99; i != 0; --i)


### PR DESCRIPTION
Create new struct to represent an image + colour to replace our `uint32_t` image ids. When all is converted we can expand the struct to a large size so that we can increase the image limit.