### PR TITLE
Rename some bits to allow unity builds of libopenrct2

### DIFF
--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -151,7 +151,7 @@ private:
 
     void DownloadObject(const rct_object_entry& entry, const std::string name, const std::string url)
     {
-        using namespace OpenRCT2::Network;
+        using namespace OpenRCT2::Networking;
         try
         {
             std::printf("Downloading %s\n", url.c_str());
@@ -190,7 +190,7 @@ private:
 
     void NextDownload()
     {
-        using namespace OpenRCT2::Network;
+        using namespace OpenRCT2::Networking;
 
         if (!_downloadingObjects || _currentDownloadIndex >= _entries.size())
         {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -100,7 +100,7 @@ namespace OpenRCT2
 #endif
         StdInOutConsole _stdInOutConsole;
 #ifndef DISABLE_HTTP
-        Network::Http::Http _http;
+        Networking::Http::Http _http;
 #endif
 
         // Game states
@@ -721,7 +721,7 @@ namespace OpenRCT2
 #ifndef DISABLE_HTTP
                         // Download park and open it using its temporary filename
                         void* data;
-                        size_t dataSize = Network::Http::DownloadPark(gOpenRCT2StartupActionPath, &data);
+                        size_t dataSize = Networking::Http::DownloadPark(gOpenRCT2StartupActionPath, &data);
                         if (dataSize == 0)
                         {
                             title_load();

--- a/src/openrct2/cmdline/ScreenshotCommands.cpp
+++ b/src/openrct2/cmdline/ScreenshotCommands.cpp
@@ -10,21 +10,21 @@
 #include "../interface/Screenshot.h"
 #include "CommandLine.hpp"
 
-static ScreenshotOptions options;
+static ScreenshotOptions _options;
 
 // clang-format off
 static constexpr const CommandLineOptionDefinition ScreenshotOptionsDef[]
 {
-    { CMDLINE_TYPE_INTEGER, &options.weather,       NAC, "weather",       "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
-    { CMDLINE_TYPE_SWITCH,  &options.hide_guests,   NAC, "no-peeps",      "hide peeps" },
-    { CMDLINE_TYPE_SWITCH,  &options.hide_sprites,  NAC, "no-sprites",    "hide all sprites (e.g. balloons, vehicles, guests)" },
-    { CMDLINE_TYPE_SWITCH,  &options.clear_grass,   NAC, "clear-grass",   "set all grass to be clear of weeds" },
-    { CMDLINE_TYPE_SWITCH,  &options.mowed_grass,   NAC, "mowed-grass",   "set all grass to be mowed" },
-    { CMDLINE_TYPE_SWITCH,  &options.water_plants,  NAC, "water-plants",  "water plants for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &options.fix_vandalism, NAC, "fix-vandalism", "fix vandalism for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &options.remove_litter, NAC, "remove-litter", "remove litter for the screenshot" },
-    { CMDLINE_TYPE_SWITCH,  &options.tidy_up_park,  NAC, "tidy-up-park",  "clear grass, water plants, fix vandalism and remove litter" },
-    { CMDLINE_TYPE_SWITCH,  &options.transparent,   NAC, "transparent",   "make the background transparent" },
+    { CMDLINE_TYPE_INTEGER, &_options.weather,       NAC, "weather",       "weather to be used (0 = default, 1 = sunny, ..., 6 = thunder)." },
+    { CMDLINE_TYPE_SWITCH,  &_options.hide_guests,   NAC, "no-peeps",      "hide peeps" },
+    { CMDLINE_TYPE_SWITCH,  &_options.hide_sprites,  NAC, "no-sprites",    "hide all sprites (e.g. balloons, vehicles, guests)" },
+    { CMDLINE_TYPE_SWITCH,  &_options.clear_grass,   NAC, "clear-grass",   "set all grass to be clear of weeds" },
+    { CMDLINE_TYPE_SWITCH,  &_options.mowed_grass,   NAC, "mowed-grass",   "set all grass to be mowed" },
+    { CMDLINE_TYPE_SWITCH,  &_options.water_plants,  NAC, "water-plants",  "water plants for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.fix_vandalism, NAC, "fix-vandalism", "fix vandalism for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.remove_litter, NAC, "remove-litter", "remove litter for the screenshot" },
+    { CMDLINE_TYPE_SWITCH,  &_options.tidy_up_park,  NAC, "tidy-up-park",  "clear grass, water plants, fix vandalism and remove litter" },
+    { CMDLINE_TYPE_SWITCH,  &_options.transparent,   NAC, "transparent",   "make the background transparent" },
     OptionTableEnd
 };
 
@@ -43,7 +43,7 @@ static exitcode_t HandleScreenshot(CommandLineArgEnumerator* argEnumerator)
 {
     const char** argv = (const char**)argEnumerator->GetArguments() + argEnumerator->GetIndex();
     int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex();
-    int32_t result = cmdline_for_screenshot(argv, argc, &options);
+    int32_t result = cmdline_for_screenshot(argv, argc, &_options);
     if (result < 0)
     {
         return EXITCODE_FAIL;

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -498,61 +498,61 @@ int32_t cmdline_for_gfxbench(const char** argv, int32_t argc)
     return 1;
 }
 
-static void ApplyOptions(const ScreenshotOptions* _options, rct_viewport& viewport)
+static void ApplyOptions(const ScreenshotOptions* options, rct_viewport& viewport)
 {
-    if (_options->weather != 0)
+    if (options->weather != 0)
     {
-        if (_options->weather < 1 || _options->weather > 6)
+        if (options->weather < 1 || options->weather > 6)
         {
             throw std::runtime_error("Weather can only be set to an integer value from 1 till 6.");
         }
 
-        uint8_t customWeather = _options->weather - 1;
+        uint8_t customWeather = options->weather - 1;
         climate_force_weather(customWeather);
     }
 
-    if (_options->hide_guests)
+    if (options->hide_guests)
     {
         viewport.flags |= VIEWPORT_FLAG_INVISIBLE_PEEPS;
     }
 
-    if (_options->hide_sprites)
+    if (options->hide_sprites)
     {
         viewport.flags |= VIEWPORT_FLAG_INVISIBLE_SPRITES;
     }
 
-    if (_options->mowed_grass)
+    if (options->mowed_grass)
     {
         CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_MOWED);
     }
 
-    if (_options->clear_grass || _options->tidy_up_park)
+    if (options->clear_grass || options->tidy_up_park)
     {
         CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_CLEAR_0);
     }
 
-    if (_options->water_plants || _options->tidy_up_park)
+    if (options->water_plants || options->tidy_up_park)
     {
         CheatsSet(CheatType::WaterPlants);
     }
 
-    if (_options->fix_vandalism || _options->tidy_up_park)
+    if (options->fix_vandalism || options->tidy_up_park)
     {
         CheatsSet(CheatType::FixVandalism);
     }
 
-    if (_options->remove_litter || _options->tidy_up_park)
+    if (options->remove_litter || options->tidy_up_park)
     {
         CheatsSet(CheatType::RemoveLitter);
     }
 
-    if (_options->transparent || gConfigGeneral.transparent_screenshot)
+    if (options->transparent || gConfigGeneral.transparent_screenshot)
     {
         viewport.flags |= VIEWPORT_FLAG_TRANSPARENT_BACKGROUND;
     }
 }
 
-int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOptions* _options)
+int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOptions* options)
 {
     // Don't include options in the count (they have been handled by CommandLine::ParseOptions already)
     for (int32_t i = 0; i < argc; i++)
@@ -675,7 +675,7 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
             }
         }
 
-        ApplyOptions(_options, viewport);
+        ApplyOptions(options, viewport);
 
         dpi = RenderViewport(nullptr, viewport);
         auto renderedPalette = screenshot_get_rendered_palette();

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -498,61 +498,61 @@ int32_t cmdline_for_gfxbench(const char** argv, int32_t argc)
     return 1;
 }
 
-static void ApplyOptions(const ScreenshotOptions* options, rct_viewport& viewport)
+static void ApplyOptions(const ScreenshotOptions* _options, rct_viewport& viewport)
 {
-    if (options->weather != 0)
+    if (_options->weather != 0)
     {
-        if (options->weather < 1 || options->weather > 6)
+        if (_options->weather < 1 || _options->weather > 6)
         {
             throw std::runtime_error("Weather can only be set to an integer value from 1 till 6.");
         }
 
-        uint8_t customWeather = options->weather - 1;
+        uint8_t customWeather = _options->weather - 1;
         climate_force_weather(customWeather);
     }
 
-    if (options->hide_guests)
+    if (_options->hide_guests)
     {
         viewport.flags |= VIEWPORT_FLAG_INVISIBLE_PEEPS;
     }
 
-    if (options->hide_sprites)
+    if (_options->hide_sprites)
     {
         viewport.flags |= VIEWPORT_FLAG_INVISIBLE_SPRITES;
     }
 
-    if (options->mowed_grass)
+    if (_options->mowed_grass)
     {
         CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_MOWED);
     }
 
-    if (options->clear_grass || options->tidy_up_park)
+    if (_options->clear_grass || _options->tidy_up_park)
     {
         CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_CLEAR_0);
     }
 
-    if (options->water_plants || options->tidy_up_park)
+    if (_options->water_plants || _options->tidy_up_park)
     {
         CheatsSet(CheatType::WaterPlants);
     }
 
-    if (options->fix_vandalism || options->tidy_up_park)
+    if (_options->fix_vandalism || _options->tidy_up_park)
     {
         CheatsSet(CheatType::FixVandalism);
     }
 
-    if (options->remove_litter || options->tidy_up_park)
+    if (_options->remove_litter || _options->tidy_up_park)
     {
         CheatsSet(CheatType::RemoveLitter);
     }
 
-    if (options->transparent || gConfigGeneral.transparent_screenshot)
+    if (_options->transparent || gConfigGeneral.transparent_screenshot)
     {
         viewport.flags |= VIEWPORT_FLAG_TRANSPARENT_BACKGROUND;
     }
 }
 
-int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOptions* options)
+int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOptions* _options)
 {
     // Don't include options in the count (they have been handled by CommandLine::ParseOptions already)
     for (int32_t i = 0; i < argc; i++)
@@ -675,7 +675,7 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
             }
         }
 
-        ApplyOptions(options, viewport);
+        ApplyOptions(_options, viewport);
 
         dpi = RenderViewport(nullptr, viewport);
         auto renderedPalette = screenshot_get_rendered_palette();

--- a/src/openrct2/network/Http.cpp
+++ b/src/openrct2/network/Http.cpp
@@ -27,7 +27,7 @@
 
 #    define OPENRCT2_USER_AGENT "OpenRCT2/" OPENRCT2_VERSION
 
-namespace OpenRCT2::Network::Http
+namespace OpenRCT2::Networking::Http
 {
     Http::Http()
     {
@@ -221,6 +221,6 @@ namespace OpenRCT2::Network::Http
         return dataSize;
     }
 
-} // namespace OpenRCT2::Network::Http
+} // namespace OpenRCT2::Networking::Http
 
 #endif

--- a/src/openrct2/network/Http.h
+++ b/src/openrct2/network/Http.h
@@ -17,7 +17,7 @@
 #    include <map>
 #    include <string>
 
-namespace OpenRCT2::Network::Http
+namespace OpenRCT2::Networking::Http
 {
     enum class Status
     {
@@ -68,6 +68,6 @@ namespace OpenRCT2::Network::Http
      */
     size_t DownloadPark(const char* url, void** outData);
 
-} // namespace OpenRCT2::Network::Http
+} // namespace OpenRCT2::Networking::Http
 
 #endif // DISABLE_HTTP

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -164,7 +164,7 @@ private:
 
     void SendRegistration(bool forceIPv4)
     {
-        using namespace OpenRCT2::Network;
+        using namespace OpenRCT2::Networking;
 
         _lastAdvertiseTime = platform_get_ticks();
 
@@ -199,7 +199,7 @@ private:
 
     void SendHeartbeat()
     {
-        using namespace OpenRCT2::Network;
+        using namespace OpenRCT2::Networking;
 
         Http::Request request;
         request.url = GetMasterServerUrl();

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -330,7 +330,7 @@ std::future<std::vector<ServerListEntry>> ServerList::FetchOnlineServerListAsync
 #    ifdef DISABLE_HTTP
     return {};
 #    else
-    using namespace OpenRCT2::Network;
+    using namespace OpenRCT2::Networking;
 
     auto p = std::make_shared<std::promise<std::vector<ServerListEntry>>>();
     auto f = p->get_future();

--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -44,7 +44,7 @@ void twitch_update()
 #    include <vector>
 
 using namespace OpenRCT2;
-using namespace OpenRCT2::Network;
+using namespace OpenRCT2::Networking;
 
 bool gTwitchEnable = false;
 

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -1295,9 +1295,9 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
             miniature_railway_right_quarter_turn_3_tile_track_floor, nullptr, defaultRightQuarterTurn3TilesBoundLengths,
             miniature_railway_right_quarter_turn_3_tile_bound_offsets);
 
-        static constexpr const int8_t right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
+        static constexpr const int8_t _right_quarter_turn_3_tiles_sprite_map[] = { 0, -1, 1, 2 };
 
-        int32_t index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
+        int32_t index = _right_quarter_turn_3_tiles_sprite_map[trackSequence];
 
         uint32_t imageId = miniature_railway_track_pieces_flat_quarter_turn_3_tiles[direction][index]
             | session->TrackColours[SCHEME_TRACK];


### PR DESCRIPTION
Some names are clashing when doing a unity build, renaming them solves
the problem.