### PR TITLE
Clarify first Windows build instructions in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,10 +123,12 @@ The program can also be built as a command line program using CMake. This type o
 ### Windows:
 1. Check out the repository. This can be done using [GitHub Desktop](https://desktop.github.com) or [other tools](https://help.github.com/articles/which-remote-url-should-i-use).
 2. Open a new Developer Command Prompt for VS 2017, then navigate to the repository (e.g. `cd C:\GitHub\OpenRCT2`).
-3. Run `msbuild openrct2.proj /t:build /p:platform=x64`.
+3. To build the 64-bit version, use `msbuild openrct2.proj /t:build /p:platform=x64`.
+
+   To build the 32-bit version, use `msbuild openrct2.proj /t:build /p:platform=Win32`.
 4. Run the game, `bin\openrct2`
 
-Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`.
+Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`. Make sure to select the correct target platform for which you ran the build in point #3 (`Win32` for the 32-bit version, `x64` for the 64-bit version), otherwise the build will fail in Visual Studio.
 
 Other examples:
 ```


### PR DESCRIPTION
If you clone the OpenRCT2 repository and follow the first build instructions for Windows, it will be successful, but it fails if you open it in Visual Studio because it won't find any external libraries. This is because VS selects Win32 as the target platform by default, but msbuild will run with x64 as the target platform. It is not obvious for the first sight that this is the cause of the failing build.

I clarified the build instructions, so other developers won't have this problem at the beginning.