### PR TITLE
Allow sandbox mode map resize in pause mode #9955

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
 - Fix: [#9902] Doors/Portcullis do not check to make sure doors are open causing double opens.
 - Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).
+- Fix: [#9955] Resizing map in while pause mode does not work and may result in freezes.
 - Fix: [#9957] When using 'no money' cheat, guests complain of running out of cash.
 - Fix: [#9970] Wait for quarter load fails.
 - Fix: [#10017] Ghost elements influencing ride excitement.

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1541,28 +1541,33 @@ void map_restore_provisional_elements()
 void map_remove_out_of_range_elements()
 {
     int32_t mapMaxXY = gMapSizeMaxXY;
-    //#9955 ensure that we can remove elements
+    // Ensure that we can remove elements
     bool buildState = gCheatsBuildInPauseMode;
     CheatsSet(CheatType::BuildInPauseMode, true);
 
-    for (int32_t y = 0; y < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); y += 32)
+    // Since we might lack cheat permission, check if the cheat has really been turned on.
+    if (gCheatsBuildInPauseMode)
     {
-        for (int32_t x = 0; x < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); x += 32)
+        for (int32_t y = 0; y < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); y += 32)
         {
-            if (x == 0 || y == 0 || x >= mapMaxXY || y >= mapMaxXY)
+            for (int32_t x = 0; x < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); x += 32)
             {
-                // Note this purposely does not use LandSetRightsAction as X Y coordinates are outside of normal range.
-                auto surfaceElement = map_get_surface_element_at({ x, y });
-                if (surfaceElement != nullptr)
+                if (x == 0 || y == 0 || x >= mapMaxXY || y >= mapMaxXY)
                 {
-                    surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
-                    update_park_fences_around_tile({ x, y });
+                    // Note this purposely does not use LandSetRightsAction as X Y coordinates are outside of normal range.
+                    auto surfaceElement = map_get_surface_element_at({ x, y });
+                    if (surfaceElement != nullptr)
+                    {
+                        surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
+                        update_park_fences_around_tile({ x, y });
+                    }
+                    clear_elements_at({ x, y });
                 }
-                clear_elements_at({ x, y });
             }
         }
     }
-    //#9955 reset cheat state
+
+    //#Reset cheat state
     CheatsSet(CheatType::BuildInPauseMode, buildState);
 }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1543,6 +1543,7 @@ void map_remove_out_of_range_elements()
     int32_t mapMaxXY = gMapSizeMaxXY;
     //#9955 ensure that we can remove elements
     bool buildState = gCheatsBuildInPauseMode;
+    CheatsSet(CheatType::BuildInPauseMode, true);
 
     for (int32_t y = 0; y < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); y += 32)
     {

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1541,6 +1541,8 @@ void map_restore_provisional_elements()
 void map_remove_out_of_range_elements()
 {
     int32_t mapMaxXY = gMapSizeMaxXY;
+    //#9955 ensure that we can remove elements
+    bool buildState = gCheatsBuildInPauseMode;
 
     for (int32_t y = 0; y < (MAXIMUM_MAP_SIZE_TECHNICAL * 32); y += 32)
     {
@@ -1559,6 +1561,8 @@ void map_remove_out_of_range_elements()
             }
         }
     }
+    //#9955 reset cheat state
+    CheatsSet(CheatType::BuildInPauseMode, buildState);
 }
 
 static void map_extend_boundary_surface_extend_tile(const SurfaceElement& sourceTile, SurfaceElement& destTile)


### PR DESCRIPTION
Since map_remove_out_of_range_elements is the culprit for causing the infinite loop, I toggled BuildInPauseMode to be on for the duration of the call.