### PR TITLE
Fix #9683: Cannot raise/lower water level if part of the tool's area of effect is off of the map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 - Fix: [#9675] Guest entry point limit can be bypassed in scenario editor.
+- Fix: [#9683] Cannot raise water level if part of the tool's area of effect is off of the map.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
 - Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).

--- a/src/openrct2/actions/WaterLowerAction.hpp
+++ b/src/openrct2/actions/WaterLowerAction.hpp
@@ -72,7 +72,7 @@ private:
         res->Position.z = z;
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
 
-        uint8_t minHeight = GetLowestHeight();
+        uint8_t minHeight = GetLowestHeight(validRange);
         bool hasChanged = false;
         for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
         {
@@ -119,12 +119,13 @@ private:
     }
 
 private:
-    uint8_t GetLowestHeight() const
+    uint8_t GetLowestHeight(MapRange validRange) const
     {
+        // The lowest height to lower the water to is the highest water level in the selection
         uint8_t minHeight{ 0 };
-        for (int32_t y = _range.GetTop(); y <= _range.GetBottom(); y += 32)
+        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
         {
-            for (int32_t x = _range.GetLeft(); x <= _range.GetRight(); x += 32)
+            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
                 auto* surfaceElement = map_get_surface_element_at({ x, y });
                 if (surfaceElement == nullptr)

--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -73,7 +73,7 @@ private:
         res->Position.z = z;
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_LANDSCAPING;
 
-        uint8_t maxHeight = GetHighestHeight();
+        uint8_t maxHeight = GetHighestHeight(validRange);
         bool hasChanged = false;
         for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
         {
@@ -126,12 +126,13 @@ private:
     }
 
 private:
-    uint8_t GetHighestHeight() const
+    uint8_t GetHighestHeight(MapRange validRange) const
     {
+        // The highest height to raise the water to is the lowest water level in the selection
         uint8_t maxHeight{ 255 };
-        for (int32_t y = _range.GetTop(); y <= _range.GetBottom(); y += 32)
+        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
         {
-            for (int32_t x = _range.GetLeft(); x <= _range.GetRight(); x += 32)
+            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
                 auto* surfaceElement = map_get_surface_element_at({ x, y });
                 if (surfaceElement == nullptr)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fixes #9683 

The water raise/lower actions failed at the edge of the map because `GetLowestHeight` and `GetHighestHeight` were checking outside of the map. This passes in the `validRange` already computed to fix that.