### PR TITLE
Fix #9970: Wait for quarter load fails

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#9970] Wait for quarter load fails.
 - Fix: [#10017] Ghost elements influencing ride excitement.
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
+- Improved: [#9987] Minimum load rounding.
 
 0.2.3 (2019-07-10)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Two commits:
* First commit only fixes the bug. Brings behaviour in line with vanilla.
* Second commit contains a refactor. This change will make rides will actually wait for >= 25% load (described in #9970), unlike vanilla.

Will squash if both commits approved.
Assuming network version bump + changelog entry (can repro in v0.0.5).