### PR TITLE
Fix #9675: Inconsistent number of guest entry points

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -133,6 +133,7 @@ The following people are not part of the development team, but have been contrib
 * (aw20368)
 * Jim Armstrong (41northstudios)
 * Kenny Castro-Monroy (kennycastro007)
+* Joseph Atkins-Turkish (Spacerat)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,11 +10,12 @@
 - Fix: [#9179] Crash when modifying a ride occasionally.
 - Fix: [#9533] Door sounds not playing.
 - Fix: [#9574] Text overflow in scenario objective window when using CJK languages.
+- Fix: [#9603] Don't render audio when master volume is turned off.
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
+- Fix: [#9675] Guest entry point limit can be bypassed in scenario editor.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
-- Fix: [#9603] Don't render audio when master volume is turned off.
 - Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 

--- a/src/openrct2/actions/PlacePeepSpawnAction.hpp
+++ b/src/openrct2/actions/PlacePeepSpawnAction.hpp
@@ -19,8 +19,6 @@
 #include "../world/Surface.h"
 #include "GameAction.h"
 
-static int32_t _nextPeepSpawnIndex = 0;
-
 DEFINE_GAME_ACTION(PlacePeepSpawnAction, GAME_COMMAND_PLACE_PEEP_SPAWN, GameActionResult)
 {
 private:
@@ -100,17 +98,14 @@ public:
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_LAND_PURCHASE;
         res->Position = CoordsXYZ{ _location.x, _location.y, _location.z / 8 };
 
-        // If we have reached our max peep spawns, use peep spawn next to last one set.
-        if (gPeepSpawns.size() >= MAX_PEEP_SPAWNS)
+        // If we have reached our max peep spawns, remove the oldest spawns
+        while (gPeepSpawns.size() >= MAX_PEEP_SPAWNS)
         {
-            auto peepSpawnIndex = _nextPeepSpawnIndex;
-            _nextPeepSpawnIndex = (peepSpawnIndex + 1) % (int32_t)gPeepSpawns.size();
-
-            // Before the new location is set, clear the old location
-            int32_t prevX = gPeepSpawns[peepSpawnIndex].x;
-            gPeepSpawns[peepSpawnIndex].x = PEEP_SPAWN_UNDEFINED;
-
-            map_invalidate_tile_full(prevX, gPeepSpawns[peepSpawnIndex].y);
+            auto oldestSpawn = gPeepSpawns.begin();
+            auto oldX = oldestSpawn->x;
+            auto oldY = oldestSpawn->y;
+            gPeepSpawns.erase(oldestSpawn);
+            map_invalidate_tile_full(oldX, oldY);
         }
 
         // Shift the spawn point to the middle of the tile


### PR DESCRIPTION
Fixes #9675 by removing old spawns from `gPeepSawn` when the limit is reached instead of invalidating them.

----

`_nextPeepSpawnIndex` invalidated old spawns[0] instead of removing them, while `gPeepSpawn` grew indefinitely[1]. If _all_ spawns were erased while shrinking the map[2], `_nextPeepSpawnIndex` would cycle back to zero and start invalidating previously invalidated spawns instead of the oldest valid ones.

[0]
https://github.com/OpenRCT2/OpenRCT2/blob/1efc774483ccfa749037c00a36d2f86a058ed942/src/openrct2/actions/PlacePeepSpawnAction.hpp#L104-L111

[1]
https://github.com/OpenRCT2/OpenRCT2/blob/1efc774483ccfa749037c00a36d2f86a058ed942/src/openrct2/actions/PlacePeepSpawnAction.hpp#L127

[2] https://github.com/OpenRCT2/OpenRCT2/blob/1efc774483ccfa749037c00a36d2f86a058ed942/src/openrct2/world/Map.cpp#L1711-L1718
