### PR TITLE
Fix #7572: Queue paths connect to regular paths through fences

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#9918] Increase image list capacity by about 100k units.
 - Change: [#1349] Increase the number of ride music played simultaneously from 2 to 32.
 - Fix: [#4927] Giant screenshot cut off at bottom and top.
+- Fix: [#7572] Queue paths connect to regular paths through fences.
 - Fix: [#7690] Problem with guests freezing on certain tiles of path.
 - Fix: [#7883] Headless server log is stored incorrectly if server name contains CJK in Ubuntu
 - Fix: [#8136] Excessive lateral G penalty is too excessive.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -452,9 +452,9 @@ void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z)
 /**
  * Returns true if the edge of tile x, y specified by direction is occupied by a fence
  * between heights z0 and z1.
- * 
+ *
  * Note that there may still be a fence on the opposing tile.
- *  
+ *
  *  rct2: 0x006E59DC
  */
 bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t direction)
@@ -695,8 +695,7 @@ static TileElement* footpath_get_element(int32_t x, int32_t y, int32_t z0, int32
 /**
  * Attempt to connect a newly disconnected queue tile to the specified path tile
  */
-static bool footpath_reconnect_queue_to_path(
-    int32_t x, int32_t y, TileElement* tileElement, int32_t action, int32_t direction)
+static bool footpath_reconnect_queue_to_path(int32_t x, int32_t y, TileElement* tileElement, int32_t action, int32_t direction)
 {
     if (((tileElement->AsPath()->GetEdges() & (1 << direction)) == 0) ^ (action < 0))
         return false;


### PR DESCRIPTION
Fixes #7572 by checking `fence_in_the_way` for both sides of the fence.

The bug specifically occurred when queue is _removed_ (which also happens during the path construction preview), causing the newly disconnected queue piece to reconnect through a fence if the fence was not actually on its tile. 

Before:

<img width="329" alt="Screen Shot 2019-09-15 at 1 47 25 PM" src="https://user-images.githubusercontent.com/141427/64927487-40101800-d7c0-11e9-8976-b070a2ad48c6.png">

After:

<img width="357" alt="Screen Shot 2019-09-15 at 1 44 25 PM" src="https://user-images.githubusercontent.com/141427/64927492-42727200-d7c0-11e9-8deb-3316b207233a.png">

