### PR TITLE
Issue #9902

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7460,7 +7460,7 @@ static void vehicle_update_scenery_door(rct_vehicle* vehicle)
         return;
     }
 
-    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == '\0'))
+    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == 0))
     {
         tileElement->SetAnimationIsBackwards(false);
         tileElement->SetAnimationFrame(1);
@@ -7541,7 +7541,7 @@ static void vehicle_update_handle_scenery_door(rct_vehicle* vehicle)
         return;
     }
 
-    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == '\0'))
+    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == 0))
     {
         tileElement->SetAnimationIsBackwards(true);
         tileElement->SetAnimationFrame(1);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7459,6 +7459,7 @@ static void vehicle_update_scenery_door(rct_vehicle* vehicle)
     {
         return;
     }
+
     if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == '\0'))
     {
         tileElement->SetAnimationIsBackwards(false);
@@ -7466,6 +7467,7 @@ static void vehicle_update_scenery_door(rct_vehicle* vehicle)
         map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, x, y, z);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
+
     if (vehicle->next_vehicle_on_train == SPRITE_INDEX_NULL)
     {
         tileElement->SetAnimationIsBackwards(false);
@@ -7546,6 +7548,7 @@ static void vehicle_update_handle_scenery_door(rct_vehicle* vehicle)
         map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, x, y, z);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
+
     if (vehicle->next_vehicle_on_train == SPRITE_INDEX_NULL)
     {
         tileElement->SetAnimationIsBackwards(true);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7459,15 +7459,14 @@ static void vehicle_update_scenery_door(rct_vehicle* vehicle)
     {
         return;
     }
-
-    if (vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL)
+    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == '\0'))
     {
         tileElement->SetAnimationIsBackwards(false);
         tileElement->SetAnimationFrame(1);
         map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, x, y, z);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
-    else
+    if (vehicle->next_vehicle_on_train == SPRITE_INDEX_NULL)
     {
         tileElement->SetAnimationIsBackwards(false);
         tileElement->SetAnimationFrame(6);
@@ -7540,14 +7539,14 @@ static void vehicle_update_handle_scenery_door(rct_vehicle* vehicle)
         return;
     }
 
-    if (vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL)
+    if ((vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL) && (tileElement->GetAnimationFrame() == '\0'))
     {
         tileElement->SetAnimationIsBackwards(true);
         tileElement->SetAnimationFrame(1);
         map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, x, y, z);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
-    else
+    if (vehicle->next_vehicle_on_train == SPRITE_INDEX_NULL)
     {
         tileElement->SetAnimationIsBackwards(true);
         tileElement->SetAnimationFrame(6);


### PR DESCRIPTION
RE: https://github.com/OpenRCT2/OpenRCT2/issues/9902

Portcullises now open and close correctly. I discovered that the red colored castle wall doors do not make sound when opening and closing, but it seems like an unrelated issue given that the animation works.

[Here's a save file to demonstrate](https://drive.google.com/open?id=1VPlvfJqjAiQMUvaOSzkLdQFCpAN7kcwD). 