### PR TITLE
Fix output result of remove_unused_objects

### DIFF
--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -530,20 +530,23 @@ int32_t editor_remove_unused_objects()
     int32_t numUnselectedObjects = 0;
     for (int32_t i = 0; i < numObjects; i++)
     {
-        if (!(_objectSelectionFlags[i] & OBJECT_SELECTION_FLAG_IN_USE)
-            && !(_objectSelectionFlags[i] & OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
+        if (_objectSelectionFlags[i] & OBJECT_SELECTION_FLAG_SELECTED)
         {
-            const ObjectRepositoryItem* item = &items[i];
-            uint8_t objectType = object_entry_get_type(&item->ObjectEntry);
-
-            if (objectType >= OBJECT_TYPE_SCENERY_GROUP)
+            if (!(_objectSelectionFlags[i] & OBJECT_SELECTION_FLAG_IN_USE)
+                && !(_objectSelectionFlags[i] & OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
             {
-                continue;
-            }
+                const ObjectRepositoryItem* item = &items[i];
+                uint8_t objectType = object_entry_get_type(&item->ObjectEntry);
 
-            _numSelectedObjectsForType[objectType]--;
-            _objectSelectionFlags[i] &= ~OBJECT_SELECTION_FLAG_SELECTED;
-            numUnselectedObjects++;
+                if (objectType >= OBJECT_TYPE_SCENERY_GROUP)
+                {
+                    continue;
+                }
+
+                _numSelectedObjectsForType[objectType]--;
+                _objectSelectionFlags[i] &= ~OBJECT_SELECTION_FLAG_SELECTED;
+                numUnselectedObjects++;
+            }
         }
     }
     unload_unselected_objects();

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1714,6 +1714,8 @@ static int32_t peep_update_patrolling_find_bin(Peep* peep)
     if (!tileElement->AsPath()->HasAddition())
         return 0;
     rct_scenery_entry* sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
+    if (sceneryEntry == nullptr)
+        return 0;
 
     if (!(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BIN))
         return 0;


### PR DESCRIPTION
`remove_unused_objects` returned a nonsense number. Only process objects that are actually selected in (hidden) object manager.

Also fix a nullptr exception if a path addition doesn't exist.