### PR TITLE
Fix #10028: Saved park--brakes all set to 0mph

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2128,8 +2128,14 @@ private:
                 dst2->SetDoorBState(src2->GetDoorBState());
                 dst2->SetStationIndex(src2->GetStationIndex());
                 dst2->SetHasGreenLight(src2->HasGreenLight());
-                dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
-                dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
+                if (track_element_has_speed_setting(dst2->GetTrackType()))
+                {
+                    dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
+                }
+                else
+                {
+                    dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
+                }
 
                 if (_s4.rides[src2->GetRideIndex()].type == RIDE_TYPE_MAZE)
                 {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2128,11 +2128,13 @@ private:
                 dst2->SetDoorBState(src2->GetDoorBState());
                 dst2->SetStationIndex(src2->GetStationIndex());
                 dst2->SetHasGreenLight(src2->HasGreenLight());
-                if (track_element_has_speed_setting(dst2->GetTrackType()))
+
+                auto trackType = dst2->GetTrackType();
+                if (track_element_has_speed_setting(trackType))
                 {
                     dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
                 }
-                else
+                else if (trackType == TRACK_ELEM_ON_RIDE_PHOTO)
                 {
                     dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
                 }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1056,8 +1056,14 @@ public:
                 dst2->SetInverted(src2->IsInverted());
                 dst2->SetStationIndex(src2->GetStationIndex());
                 dst2->SetHasGreenLight(src2->HasGreenLight());
-                dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
-                dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
+                if (track_element_has_speed_setting(dst2->GetTrackType()))
+                {
+                    dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
+                }
+                else
+                {
+                    dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
+                }
 
                 // Skipping IsHighlighted()
                 auto rideType = _s6.rides[src2->GetRideIndex()].type;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1056,11 +1056,13 @@ public:
                 dst2->SetInverted(src2->IsInverted());
                 dst2->SetStationIndex(src2->GetStationIndex());
                 dst2->SetHasGreenLight(src2->HasGreenLight());
-                if (track_element_has_speed_setting(dst2->GetTrackType()))
+
+                auto trackType = dst2->GetTrackType();
+                if (track_element_has_speed_setting(trackType))
                 {
                     dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
                 }
-                else
+                else if (trackType == TRACK_ELEM_ON_RIDE_PHOTO)
                 {
                     dst2->SetPhotoTimeout(src2->GetPhotoTimeout());
                 }


### PR DESCRIPTION
Issue was caused by BrakeBoosterSpeed and OnridePhotoBits sharing a field, and RCT12TrackElement::GetPhotoTimeout() now returning 0 if the element is not a photo.