### PR TITLE
Fix #10036: Do not allocate large chunks of memory for save file classification

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#9957] When using 'no money' cheat, guests complain of running out of cash.
 - Fix: [#9970] Wait for quarter load fails.
 - Fix: [#10017] Ghost elements influencing ride excitement.
+- Fix: [#10036] Do not allocate large chunks of memory for save file classification.
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 - Improved: [#9987] Minimum load rounding.
 

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -68,6 +68,9 @@ std::shared_ptr<SawyerChunk> SawyerChunkReader::ReadChunk()
     try
     {
         auto header = _stream->ReadValue<sawyercoding_chunk_header>();
+        if (header.length >= MAX_UNCOMPRESSED_CHUNK_SIZE)
+            throw SawyerChunkException(EXCEPTION_MSG_CORRUPT_CHUNK_SIZE);
+
         switch (header.encoding)
         {
             case CHUNK_ENCODING_NONE:


### PR DESCRIPTION
The issue is caused by sv4 files that have a large length field when treated as sv6. I simply added a check that the length can not exceed MAX_UNCOMPRESSED_CHUNK_SIZE.

There are two sv4 files that I found that would allocate over 5 GiB memory.
[MilleniumMines.zip](https://github.com/OpenRCT2/OpenRCT2/files/3682262/MilleniumMines.zip)
[IvoryTowers.zip](https://github.com/OpenRCT2/OpenRCT2/files/3682263/IvoryTowers.zip)