### PR TITLE
Fix #9953: Crash when hacked rides attempt to find the closest mechanic

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
 - Fix: [#9902] Doors/Portcullis do not check to make sure doors are open causing double opens.
 - Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).
+- Fix: [#9953] Crash when hacked rides attempt to find the closest mechanic.
 - Fix: [#9957] When using 'no money' cheat, guests complain of running out of cash.
 - Fix: [#9970] Wait for quarter load fails.
 - Fix: [#10017] Ghost elements influencing ride excitement.

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -356,6 +356,8 @@ TileElement* ride_get_station_exit_element(int32_t x, int32_t y, int32_t z)
     TileElement* tileElement = map_get_first_element_at(x, y);
     do
     {
+        if (tileElement == nullptr)
+            break;
         if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE && z == tileElement->base_height)
             return tileElement;
     } while (!(tileElement++)->IsLastForTile());


### PR DESCRIPTION
Missing nullptr check