### PR TITLE
Fixed process exit code

### DIFF
--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -18,6 +18,7 @@ using namespace OpenRCT2;
  */
 int main(int argc, const char** argv)
 {
+    int32_t rc = EXIT_SUCCESS;
     int runGame = cmdline_run(argv, argc);
     core_init();
     if (runGame == 1)
@@ -27,9 +28,11 @@ int main(int argc, const char** argv)
 
         // Run OpenRCT2 with a plain context
         auto context = CreateContext();
-        if((context->RunOpenRCT2(argc, argv)) == EXIT_SUCCESS) {
-            return EXIT_SUCCESS;
-        }
+        rc = context->RunOpenRCT2(argc, argv);
     }
-    return EXIT_FAILURE;
+    else if (runGame == -1)
+    {
+        rc = EXIT_FAILURE;
+    }
+    return rc;
 }

--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -27,7 +27,9 @@ int main(int argc, const char** argv)
 
         // Run OpenRCT2 with a plain context
         auto context = CreateContext();
-        context->RunOpenRCT2(argc, argv);
+        if((context->RunOpenRCT2(argc, argv)) == EXIT_SUCCESS) {
+            return EXIT_SUCCESS;
+        }
     }
-    return gExitCode;
+    return EXIT_FAILURE;
 }

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -39,6 +39,7 @@ int main(int argc, const char** argv)
 #endif
 {
     std::unique_ptr<IContext> context;
+    int32_t rc = EXIT_SUCCESS;
     int runGame = cmdline_run(argv, argc);
     core_init();
     RegisterBitmapReader();
@@ -57,11 +58,13 @@ int main(int argc, const char** argv)
             auto uiContext = to_shared(CreateUiContext(env));
             context = CreateContext(env, audioContext, uiContext);
         }
-        if (context->RunOpenRCT2(argc, argv) == EXIT_SUCCESS) {
-            return EXIT_SUCCESS;
-        }
+        rc = context->RunOpenRCT2(argc, argv);
     }
-    return EXIT_FAILURE;
+    else if (runGame == -1)
+    {
+        rc = EXIT_FAILURE;
+    }
+    return rc;
 }
 
 #ifdef __ANDROID__

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -38,6 +38,7 @@ int NormalisedMain(int argc, const char** argv)
 int main(int argc, const char** argv)
 #endif
 {
+    std::unique_ptr<IContext> context;
     int runGame = cmdline_run(argv, argc);
     core_init();
     RegisterBitmapReader();
@@ -46,8 +47,7 @@ int main(int argc, const char** argv)
         if (gOpenRCT2Headless)
         {
             // Run OpenRCT2 with a plain context
-            auto context = CreateContext();
-            context->RunOpenRCT2(argc, argv);
+            context = CreateContext();
         }
         else
         {
@@ -55,12 +55,13 @@ int main(int argc, const char** argv)
             auto env = to_shared(CreatePlatformEnvironment());
             auto audioContext = to_shared(CreateAudioContext());
             auto uiContext = to_shared(CreateUiContext(env));
-            auto context = CreateContext(env, audioContext, uiContext);
-
-            context->RunOpenRCT2(argc, argv);
+            context = CreateContext(env, audioContext, uiContext);
+        }
+        if (context->RunOpenRCT2(argc, argv) == EXIT_SUCCESS) {
+            return EXIT_SUCCESS;
         }
     }
-    return gExitCode;
+    return EXIT_FAILURE;
 }
 
 #ifdef __ANDROID__

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -243,8 +243,9 @@ namespace OpenRCT2
             if (Initialise())
             {
                 Launch();
+                return EXIT_SUCCESS;
             }
-            return gExitCode;
+            return EXIT_FAILURE;
         }
 
         void WriteLine(const std::string& s) override

--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -9,7 +9,6 @@
 
 #include "OpenRCT2.h"
 
-int32_t gExitCode;
 int32_t gOpenRCT2StartupAction = STARTUP_ACTION_TITLE;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
 utf8 gExePath[MAX_PATH];

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -34,9 +34,6 @@ enum
     SCREEN_FLAGS_EDITOR = (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER),
 };
 
-/** The exit code for OpenRCT2 when it exits. */
-extern int32_t gExitCode;
-
 extern int32_t gOpenRCT2StartupAction;
 extern utf8 gOpenRCT2StartupActionPath[512];
 extern utf8 gExePath[MAX_PATH];


### PR DESCRIPTION
Addresses issue #9477 

Was able to verify that it still builds and returned EXIT_FAILURE if I didn't provide it the path to language files/rct2 installation.

~$ ./openrct2
An RCT2 install directory must be specified! Please edit "game_path" in /home/lgupta/.config/OpenRCT2/config.ini.

~$ echo $?
1
