### PR TITLE
Avoid dereferencing map_get_surface_element_at nullptr on libopenrct2

### DIFF
--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1197,6 +1197,12 @@ static CoordsXYZD place_park_entrance_get_map_position(ScreenCoordsXY screenCoor
         return parkEntranceMapPosition;
 
     auto surfaceElement = map_get_surface_element_at(mapCoords);
+    if (surfaceElement == nullptr)
+    {
+        parkEntranceMapPosition.x = LOCATION_NULL;
+        return parkEntranceMapPosition;
+    }
+
     parkEntranceMapPosition.z = surfaceElement->GetWaterHeight() * 8;
     if (parkEntranceMapPosition.z == 0)
     {
@@ -1541,6 +1547,8 @@ static constexpr const uint8_t RideColourKey[] = {
 static uint16_t map_window_get_pixel_colour_peep(CoordsXY c)
 {
     auto* surfaceElement = map_get_surface_element_at(c);
+    if (surfaceElement == nullptr)
+        return 0;
     uint16_t colour = TerrainColour[surfaceElement->GetSurfaceStyle()];
     if (surfaceElement->GetWaterHeight() > 0)
         colour = WaterColour;
@@ -1580,6 +1588,9 @@ static uint16_t map_window_get_pixel_colour_ride(CoordsXY c)
     TileElement* tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(c));
     do
     {
+        if (tileElement == nullptr)
+            break;
+
         if (tileElement->IsGhost())
         {
             colourA = MAP_COLOUR(PALETTE_INDEX_21);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2186,6 +2186,8 @@ static bool ride_get_place_position_from_screen_position(int32_t screenX, int32_
         if (_trackPlaceShiftState)
         {
             auto surfaceElement = map_get_surface_element_at(mapX >> 5, mapY >> 5);
+            if (surfaceElement == nullptr)
+                return false;
             mapZ = floor2(surfaceElement->base_height * 8, 16);
             mapZ += _trackPlaceShiftZ;
             mapZ = std::max<int16_t>(mapZ, 16);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -422,6 +422,8 @@ static int32_t window_track_place_get_base_z(int32_t x, int32_t y)
     uint32_t z;
 
     auto surfaceElement = map_get_surface_element_at(x >> 5, y >> 5);
+    if (surfaceElement == nullptr)
+        return 0;
     z = surfaceElement->base_height * 8;
 
     // Increase Z above slope

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -102,6 +102,9 @@ public:
         }
 
         auto* surfaceElement = map_get_surface_element_at(_coords);
+        if (surfaceElement == nullptr)
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
+
         TileElement* tileElement = CheckFloatingStructures(reinterpret_cast<TileElement*>(surfaceElement), _height);
         if (tileElement != nullptr)
         {
@@ -155,6 +158,9 @@ public:
         }
 
         auto* surfaceElement = map_get_surface_element_at(_coords);
+        if (surfaceElement == nullptr)
+            return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
+
         cost += GetSurfaceHeightChangeCost(surfaceElement);
         SetSurfaceHeight(reinterpret_cast<TileElement*>(surfaceElement));
 

--- a/src/openrct2/actions/LandSmoothAction.hpp
+++ b/src/openrct2/actions/LandSmoothAction.hpp
@@ -368,27 +368,43 @@ private:
                 // Smooth the 4 corners
                 { // top-left
                     auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
-                    int32_t z = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByCorner(
-                        isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, -32, 0, 2);
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t z = std::clamp(
+                            (uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByCorner(
+                            isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, -32, 0, 2);
+                    }
                 }
                 { // bottom-left
                     auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetBottom() });
-                    int32_t z = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByCorner(
-                        isExecuting, { validRange.GetLeft(), validRange.GetBottom() }, z, -32, 32, 1, 3);
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t z = std::clamp(
+                            (uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByCorner(
+                            isExecuting, { validRange.GetLeft(), validRange.GetBottom() }, z, -32, 32, 1, 3);
+                    }
                 }
                 { // bottom-right
                     auto surfaceElement = map_get_surface_element_at({ validRange.GetRight(), validRange.GetBottom() });
-                    int32_t z = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByCorner(
-                        isExecuting, { validRange.GetRight(), validRange.GetBottom() }, z, 32, 32, 2, 0);
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t z = std::clamp(
+                            (uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByCorner(
+                            isExecuting, { validRange.GetRight(), validRange.GetBottom() }, z, 32, 32, 2, 0);
+                    }
                 }
                 { // top-right
                     auto surfaceElement = map_get_surface_element_at({ validRange.GetRight(), validRange.GetTop() });
-                    int32_t z = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByCorner(
-                        isExecuting, { validRange.GetRight(), validRange.GetTop() }, z, 32, -32, 3, 1);
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t z = std::clamp(
+                            (uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByCorner(
+                            isExecuting, { validRange.GetRight(), validRange.GetTop() }, z, 32, -32, 3, 1);
+                    }
                 }
 
                 // Smooth the edges
@@ -396,27 +412,39 @@ private:
                 for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
                 {
                     auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), y });
-                    z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
-                    z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByEdge(isExecuting, { validRange.GetLeft(), y }, z1, z2, -32, 0, 0, 1, 3, 2);
+                    if (surfaceElement != nullptr)
+                    {
+                        z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
+                        z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByEdge(isExecuting, { validRange.GetLeft(), y }, z1, z2, -32, 0, 0, 1, 3, 2);
+                    }
 
                     surfaceElement = map_get_surface_element_at({ validRange.GetRight(), y });
-                    z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
-                    z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByEdge(isExecuting, { validRange.GetRight(), y }, z1, z2, 32, 0, 2, 3, 1, 0);
+                    if (surfaceElement != nullptr)
+                    {
+                        z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
+                        z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByEdge(isExecuting, { validRange.GetRight(), y }, z1, z2, 32, 0, 2, 3, 1, 0);
+                    }
                 }
 
                 for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
                 {
                     auto surfaceElement = map_get_surface_element_at({ x, validRange.GetTop() });
-                    z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
-                    z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByEdge(isExecuting, { x, validRange.GetTop() }, z1, z2, 0, -32, 0, 3, 1, 2);
+                    if (surfaceElement != nullptr)
+                    {
+                        z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
+                        z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 2), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByEdge(isExecuting, { x, validRange.GetTop() }, z1, z2, 0, -32, 0, 3, 1, 2);
+                    }
 
                     surfaceElement = map_get_surface_element_at({ x, validRange.GetBottom() });
-                    z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
-                    z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
-                    res->Cost += SmoothLandRowByEdge(isExecuting, { x, validRange.GetBottom() }, z1, z2, 0, 32, 1, 2, 0, 3);
+                    if (surfaceElement != nullptr)
+                    {
+                        z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
+                        z2 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
+                        res->Cost += SmoothLandRowByEdge(isExecuting, { x, validRange.GetBottom() }, z1, z2, 0, 32, 1, 2, 0, 3);
+                    }
                 }
                 break;
             }
@@ -426,6 +454,8 @@ private:
             case MAP_SELECT_TYPE_CORNER_3:
             {
                 auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
+                if (surfaceElement == nullptr)
+                    break;
                 uint8_t newBaseZ = surfaceElement->base_height;
                 uint8_t newSlope = surfaceElement->GetSlope();
 
@@ -523,6 +553,8 @@ private:
                 // TODO: Handle smoothing by edge
                 // Get the two corners to raise
                 auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
+                if (surfaceElement == nullptr)
+                    break;
                 uint8_t newBaseZ = surfaceElement->base_height;
                 uint8_t oldSlope = surfaceElement->GetSlope();
                 uint8_t newSlope = oldSlope;

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -143,7 +143,10 @@ public:
             if (!(flags & GAME_COMMAND_FLAG_GHOST))
             {
                 SurfaceElement* surfaceElement = map_get_surface_element_at(entranceLoc);
-                surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
+                if (surfaceElement != nullptr)
+                {
+                    surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
+                }
             }
 
             TileElement* newElement = tile_element_insert({ entranceLoc.x / 32, entranceLoc.y / 32, zLow }, 0b1111);

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -765,10 +765,13 @@ private:
             if (x != PEEP_SPAWN_UNDEFINED)
             {
                 auto* surfaceElement = map_get_surface_element_at({ x, y });
-                surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
-                update_park_fences_around_tile({ x, y });
-                uint16_t baseHeight = surfaceElement->base_height * 8;
-                map_invalidate_tile(x, y, baseHeight, baseHeight + 16);
+                if (surfaceElement != nullptr)
+                {
+                    surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
+                    update_park_fences_around_tile({ x, y });
+                    uint16_t baseHeight = surfaceElement->base_height * 8;
+                    map_invalidate_tile(x, y, baseHeight, baseHeight + 16);
+                }
             }
         }
 

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -309,6 +309,8 @@ public:
             if ((rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER) && !byte_9D8150)
             {
                 auto surfaceElement = map_get_surface_element_at(mapLoc);
+                if (surfaceElement == nullptr)
+                    return std::make_unique<TrackPlaceActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
 
                 uint8_t waterHeight = surfaceElement->GetWaterHeight() * 2;
                 if (waterHeight == 0)
@@ -351,6 +353,9 @@ public:
 
             // 6c5648 12 push
             auto surfaceElement = map_get_surface_element_at(mapLoc);
+            if (surfaceElement == nullptr)
+                return std::make_unique<TrackPlaceActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
+
             if (!gCheatsDisableSupportLimits)
             {
                 int32_t ride_height = clearanceZ - surfaceElement->base_height;
@@ -506,6 +511,8 @@ public:
 
             // 6c5648 12 push
             auto surfaceElement = map_get_surface_element_at(mapLoc);
+            if (surfaceElement == nullptr)
+                return std::make_unique<TrackPlaceActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
 
             int32_t supportHeight = baseZ - surfaceElement->base_height;
             if (supportHeight < 0)
@@ -673,8 +680,11 @@ public:
             if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_MUST_BE_ON_WATER)
             {
                 auto* waterSurfaceElement = map_get_surface_element_at(mapLoc);
-                waterSurfaceElement->SetHasTrackThatNeedsWater(true);
-                tileElement = reinterpret_cast<TileElement*>(waterSurfaceElement);
+                if (waterSurfaceElement != nullptr)
+                {
+                    waterSurfaceElement->SetHasTrackThatNeedsWater(true);
+                    tileElement = reinterpret_cast<TileElement*>(waterSurfaceElement);
+                }
             }
 
             if (!gCheatsDisableClearanceChecks || !(GetFlags() & GAME_COMMAND_FLAG_GHOST))

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5415,13 +5415,16 @@ void Guest::UpdateWalking()
     {
         auto surfaceElement = map_get_surface_element_at({ next_x, next_y });
 
-        int32_t water_height = surfaceElement->GetWaterHeight();
-        if (water_height)
+        if (surfaceElement != nullptr)
         {
-            water_height *= 16;
-            MoveTo(x, y, water_height);
-            SetState(PEEP_STATE_FALLING);
-            return;
+            int32_t water_height = surfaceElement->GetWaterHeight();
+            if (water_height)
+            {
+                water_height *= 16;
+                MoveTo(x, y, water_height);
+                SetState(PEEP_STATE_FALLING);
+                return;
+            }
         }
     }
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -517,6 +517,8 @@ static uint8_t staff_handyman_direction_to_uncut_grass(Peep* peep, uint8_t valid
     if (!(peep->GetNextIsSurface()))
     {
         auto surfaceElement = map_get_surface_element_at({ peep->next_x, peep->next_y });
+        if (surfaceElement == nullptr)
+            return INVALID_DIRECTION;
 
         if (peep->next_z != surfaceElement->base_height)
             return INVALID_DIRECTION;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1391,6 +1391,8 @@ static int32_t track_design_place_maze(TrackDesign* td6, int16_t x, int16_t y, i
             }
 
             auto surfaceElement = map_get_surface_element_at(mapCoord);
+            if (surfaceElement == nullptr)
+                continue;
             int16_t map_height = surfaceElement->base_height * 8;
             if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
             {

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2423,7 +2423,10 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
     for (const TileCoordsXY* tile = tiles.begin(); tile != tiles.end(); ++tile)
     {
         auto surfaceElement = map_get_surface_element_at((*tile).x, (*tile).y);
-        surfaceElement->SetOwnership(ownership);
-        update_park_fences_around_tile({ (*tile).x * 32, (*tile).y * 32 });
+        if (surfaceElement != nullptr)
+        {
+            surfaceElement->SetOwnership(ownership);
+            update_park_fences_around_tile({ (*tile).x * 32, (*tile).y * 32 });
+        }
     }
 }

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -117,10 +117,13 @@ void mapgen_generate_blank(mapgen_settings* settings)
         for (x = 1; x < settings->mapSize - 1; x++)
         {
             auto surfaceElement = map_get_surface_element_at(x, y);
-            surfaceElement->SetSurfaceStyle(settings->floor);
-            surfaceElement->SetEdgeStyle(settings->wall);
-            surfaceElement->base_height = settings->height;
-            surfaceElement->clearance_height = settings->height;
+            if (surfaceElement != nullptr)
+            {
+                surfaceElement->SetSurfaceStyle(settings->floor);
+                surfaceElement->SetEdgeStyle(settings->wall);
+                surfaceElement->base_height = settings->height;
+                surfaceElement->clearance_height = settings->height;
+            }
         }
     }
 
@@ -165,10 +168,13 @@ void mapgen_generate(mapgen_settings* settings)
         for (x = 1; x < mapSize - 1; x++)
         {
             auto surfaceElement = map_get_surface_element_at(x, y);
-            surfaceElement->SetSurfaceStyle(floorTexture);
-            surfaceElement->SetEdgeStyle(wallTexture);
-            surfaceElement->base_height = settings->height;
-            surfaceElement->clearance_height = settings->height;
+            if (surfaceElement != nullptr)
+            {
+                surfaceElement->SetSurfaceStyle(floorTexture);
+                surfaceElement->SetEdgeStyle(wallTexture);
+                surfaceElement->base_height = settings->height;
+                surfaceElement->clearance_height = settings->height;
+            }
         }
     }
 
@@ -212,7 +218,7 @@ void mapgen_generate(mapgen_settings* settings)
         {
             auto surfaceElement = map_get_surface_element_at(x, y);
 
-            if (surfaceElement->base_height < waterLevel + 6)
+            if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel + 6)
                 surfaceElement->SetSurfaceStyle(beachTexture);
         }
     }
@@ -308,6 +314,8 @@ static void mapgen_place_trees()
         for (int32_t x = 1; x < gMapSize - 1; x++)
         {
             auto* surfaceElement = map_get_surface_element_at(x, y);
+            if (surfaceElement == nullptr)
+                continue;
 
             // Exclude water tiles
             if (surfaceElement->GetWaterHeight() > 0)
@@ -342,6 +350,8 @@ static void mapgen_place_trees()
 
         int32_t type = -1;
         auto* surfaceElement = map_get_surface_element_at(pos.x, pos.y);
+        if (surfaceElement != nullptr)
+            continue;
         switch (surfaceElement->GetSurfaceStyle())
         {
             case TERRAIN_GRASS:
@@ -390,7 +400,7 @@ static void mapgen_set_water_level(int32_t waterLevel)
         for (x = 1; x < mapSize - 1; x++)
         {
             auto surfaceElement = map_get_surface_element_at(x, y);
-            if (surfaceElement->base_height < waterLevel)
+            if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel)
                 surfaceElement->SetWaterHeight(waterLevel / 2);
         }
     }
@@ -452,6 +462,8 @@ static void mapgen_set_height()
             uint8_t baseHeight = (q00 + q01 + q10 + q11) / 4;
 
             auto surfaceElement = map_get_surface_element_at(x, y);
+            if (surfaceElement == nullptr)
+                continue;
             surfaceElement->base_height = std::max(2, baseHeight * 2);
             surfaceElement->clearance_height = surfaceElement->base_height;
 
@@ -811,6 +823,8 @@ void mapgen_generate_from_heightmap(mapgen_settings* settings)
         {
             // The x and y axis are flipped in the world, so this uses y for x and x for y.
             auto* const surfaceElement = map_get_surface_element_at(y + 1, x + 1);
+            if (surfaceElement == nullptr)
+                continue;
 
             // Read value from bitmap, and convert its range
             uint8_t value = dest[x + y * _heightMapData.width];

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -14,6 +14,12 @@
 
 #include <algorithm>
 
+static uint8_t getBaseHeightOrZero(int32_t x, int32_t y)
+{
+    auto surfaceElement = map_get_surface_element_at(x, y);
+    return surfaceElement ? surfaceElement->base_height : 0;
+}
+
 /**
  * Not perfect, this still leaves some particular tiles unsmoothed.
  */
@@ -26,14 +32,16 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
         for (x = l; x < r; x++)
         {
             auto surfaceElement = map_get_surface_element_at(x, y);
+            if (surfaceElement == nullptr)
+                continue;
             surfaceElement->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
 
             // Raise to edge height - 2
             highest = surfaceElement->base_height;
-            highest = std::max(highest, map_get_surface_element_at(x - 1, y + 0)->base_height);
-            highest = std::max(highest, map_get_surface_element_at(x + 1, y + 0)->base_height);
-            highest = std::max(highest, map_get_surface_element_at(x + 0, y - 1)->base_height);
-            highest = std::max(highest, map_get_surface_element_at(x + 0, y + 1)->base_height);
+            highest = std::max(highest, getBaseHeightOrZero(x - 1, y + 0));
+            highest = std::max(highest, getBaseHeightOrZero(x + 1, y + 0));
+            highest = std::max(highest, getBaseHeightOrZero(x + 0, y - 1));
+            highest = std::max(highest, getBaseHeightOrZero(x + 0, y + 1));
             if (surfaceElement->base_height < highest - 2)
             {
                 raisedLand = 1;
@@ -42,10 +50,10 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
 
             // Check corners
             doubleCorner = -1;
-            cornerHeights[0] = map_get_surface_element_at(x - 1, y - 1)->base_height;
-            cornerHeights[1] = map_get_surface_element_at(x + 1, y - 1)->base_height;
-            cornerHeights[2] = map_get_surface_element_at(x + 1, y + 1)->base_height;
-            cornerHeights[3] = map_get_surface_element_at(x - 1, y + 1)->base_height;
+            cornerHeights[0] = getBaseHeightOrZero(x - 1, y - 1);
+            cornerHeights[1] = getBaseHeightOrZero(x + 1, y - 1);
+            cornerHeights[2] = getBaseHeightOrZero(x + 1, y + 1);
+            cornerHeights[3] = getBaseHeightOrZero(x - 1, y + 1);
             highest = surfaceElement->base_height;
             for (i = 0; i < 4; i++)
                 highest = std::max(highest, cornerHeights[i]);
@@ -67,24 +75,16 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
                         {
                             default:
                             case 0:
-                                highestOnLowestSide = std::max(
-                                    map_get_surface_element_at(x + 1, y)->base_height,
-                                    map_get_surface_element_at(x, y + 1)->base_height);
+                                highestOnLowestSide = std::max(getBaseHeightOrZero(x + 1, y), getBaseHeightOrZero(x, y + 1));
                                 break;
                             case 1:
-                                highestOnLowestSide = std::max(
-                                    map_get_surface_element_at(x - 1, y)->base_height,
-                                    map_get_surface_element_at(x, y + 1)->base_height);
+                                highestOnLowestSide = std::max(getBaseHeightOrZero(x - 1, y), getBaseHeightOrZero(x, y + 1));
                                 break;
                             case 2:
-                                highestOnLowestSide = std::max(
-                                    map_get_surface_element_at(x - 1, y)->base_height,
-                                    map_get_surface_element_at(x, y - 1)->base_height);
+                                highestOnLowestSide = std::max(getBaseHeightOrZero(x - 1, y), getBaseHeightOrZero(x, y - 1));
                                 break;
                             case 3:
-                                highestOnLowestSide = std::max(
-                                    map_get_surface_element_at(x + 1, y)->base_height,
-                                    map_get_surface_element_at(x, y - 1)->base_height);
+                                highestOnLowestSide = std::max(getBaseHeightOrZero(x + 1, y), getBaseHeightOrZero(x, y - 1));
                                 break;
                         }
 
@@ -147,36 +147,36 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
                 uint8_t slope = surfaceElement->GetSlope();
                 // Corners
                 auto surfaceElement2 = map_get_surface_element_at(x + 1, y + 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_N_CORNER_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x - 1, y + 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_W_CORNER_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x + 1, y - 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_E_CORNER_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x - 1, y - 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_S_CORNER_UP;
 
                 // Sides
                 surfaceElement2 = map_get_surface_element_at(x + 1, y + 0);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NE_SIDE_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x - 1, y + 0);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SW_SIDE_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x + 0, y - 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SE_SIDE_UP;
 
                 surfaceElement2 = map_get_surface_element_at(x + 0, y + 1);
-                if (surfaceElement2->base_height > surfaceElement->base_height)
+                if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NW_SIDE_UP;
 
                 // Raise
@@ -201,6 +201,8 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
 int32_t tile_smooth(int32_t x, int32_t y)
 {
     auto* const surfaceElement = map_get_surface_element_at(x, y);
+    if (surfaceElement == nullptr)
+        return 0;
 
     // +-----+-----+-----+
     // |  W  | NW  |  N  |
@@ -240,8 +242,8 @@ int32_t tile_smooth(int32_t x, int32_t y)
 
             // Get neighbour height. If the element is not valid (outside of map) assume the same height
             auto* neighbourSurfaceElement = map_get_surface_element_at(x + x_offset, y + y_offset);
-            neighbourHeightOffset.baseheight[index] = neighbourSurfaceElement ? neighbourSurfaceElement->base_height
-                                                                              : surfaceElement->base_height;
+            neighbourHeightOffset.baseheight[index] = neighbourSurfaceElement != nullptr ? neighbourSurfaceElement->base_height
+                                                                                         : surfaceElement->base_height;
 
             // Make the height relative to the current surface element
             neighbourHeightOffset.baseheight[index] -= surfaceElement->base_height;


### PR DESCRIPTION
Helps #9014 

There are multiple places on `MapHelpers.cpp` where the call to `map_get_surface_element_at` is done directly on the function parameters, didn't know what to do with those.