### PR TITLE
Avoid dereferencing map_get_path_element_at nullptr on libopenrct2

### DIFF
--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -761,7 +761,7 @@ bool Peep::Place(TileCoordsXYZ location, bool apply)
 {
     auto* pathElement = map_get_path_element_at(location);
     TileElement* tileElement = reinterpret_cast<TileElement*>(pathElement);
-    if (!pathElement)
+    if (!tileElement)
     {
         tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(location.x, location.y));
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9884,6 +9884,9 @@ void vehicle_update_crossings(const rct_vehicle* vehicle)
         while (true)
         {
             auto* pathElement = map_get_path_element_at({ xyElement.x / 32, xyElement.y / 32, xyElement.element->base_height });
+            if (pathElement == nullptr)
+                break;
+
             auto ride = get_ride(vehicle->ride);
 
             // Many New Element parks have invisible rides hacked into the path.


### PR DESCRIPTION
Helps #9014