### PR TITLE
Fix #9985: Mistake from #9128

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3724,7 +3724,7 @@ STR_6273    :Music
 STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
-STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{STRINGID}
+STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
 STR_6278    :Autosave amount
 STR_6279    :{SMALLFONT}{BLACK}Number of autosaves that should be kept
 STR_6280    :{SMALLFONT}{BLACK}Chat


### PR DESCRIPTION
This was likely a test for working with STRINGID before creating a new string entry, and slipped in the previous PR. Station numbers are now displayed correctly for ride entrances and exits.