### PR TITLE
Redownload dependencies after cleaning build

### DIFF
--- a/openrct2.targets
+++ b/openrct2.targets
@@ -153,7 +153,7 @@
               if (!String.IsNullOrEmpty(CheckFile))
               {
                   string checkSha1 = GetSha1FromCheckFile(CheckFile, Name);
-                  if (String.Equals(checkSha1, Sha1, StringComparison.OrdinalIgnoreCase))
+                  if (String.Equals(checkSha1, Sha1, StringComparison.OrdinalIgnoreCase) && Directory.Exists(OutputDirectory))
                   {
                       Log.LogMessage(MessageImportance.Normal, String.Format("{0} up to date", Name));
                       return true;


### PR DESCRIPTION
If the dependencies `SHA` did not change, doing `msbuild openrct2.proj /t:clean` and then trying to build again would pop-up an RCT with missing objects, title and replays

The check is naive, as it just sees if the directory exists, but not that it's empty, but I'm trying to make it work in cases where the user is just manipulating the repo via `msbuild`, not manually.