### PR TITLE
Remapped keypad Enter to return scancode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,8 @@
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 - Fix: [#9675] Guest entry point limit can be bypassed in scenario editor.
 - Fix: [#9683] Cannot raise water level if part of the tool's area of effect is off of the map.
+- Fix: [#9684] Entering custom size for water/land tool allows confirmation with main enter key, but not numpad enter key.
+- Fix: [#9690] The keyboard shortcut for rotating the game view can be set to Enter or KP Enter, but not both.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
 - Fix: [#9729] Peeps do not take into account height difference when deciding to pathfind to a ride entrance (original bug).
 - Fix: [#9902] Doors/Portcullis do not check to make sure doors are open causing double opens.

--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -106,13 +106,15 @@ void TextComposition::HandleMessage(const SDL_Event* e)
 
             uint16_t modifier = e->key.keysym.mod;
             SDL_Keycode key = e->key.keysym.sym;
+            SDL_Scancode scancode = e->key.keysym.scancode;
             if (key == SDLK_KP_ENTER)
             {
                 // Map Keypad enter to regular enter.
                 key = SDLK_RETURN;
+                scancode = SDL_SCANCODE_RETURN;
             }
 
-            GetContext()->GetUiContext()->SetKeysPressed(key, e->key.keysym.scancode);
+            GetContext()->GetUiContext()->SetKeysPressed(key, scancode);
 
             // Text input
             if (_session.Buffer == nullptr)


### PR DESCRIPTION
I added a scancode override for keypad Enter. This affected not only issues #9684 and #9690, but also the keyboard shortcut settings. The keypad Enter shortcut settings are now defined as Enter.

Fix #9684: Entering custom size for water/land tool allows confirmation
with main enter key, but not numpad enter key

Fix #9690: The keyboard shortcut for rotating the game view can be set
to Enter or KP Enter, but not both