### PR TITLE
Duck improvements and fixes

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3724,7 +3724,7 @@ STR_6273    :Music
 STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
-STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
+STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{STRINGID}
 STR_6278    :Autosave amount
 STR_6279    :{SMALLFONT}{BLACK}Number of autosaves that should be kept
 STR_6280    :{SMALLFONT}{BLACK}Chat
@@ -3778,6 +3778,7 @@ STR_6327    :Transparent background for giant screenshots
 STR_6328    :{SMALLFONT}{BLACK}With this option enabled, giant screenshots will have a transparent background instead of the default black colour.
 STR_6329    :{STRING}{STRINGID}
 STR_6330    :Downloading [{STRING}] from {STRING} ({COMMA16} / {COMMA16})
+STR_6331    :Create Ducks
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3724,7 +3724,7 @@ STR_6273    :Music
 STR_6274    :Can't set colour scheme...
 STR_6275    :{WINDOW_COLOUR_2}Station style:
 STR_6276    :{RED}{STRINGID} has guests getting stuck, possibly due to invalid ride type or operating mode.
-STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{STRINGID}
+STR_6277    :{WINDOW_COLOUR_2}Station index: {BLACK}{COMMA16}
 STR_6278    :Autosave amount
 STR_6279    :{SMALLFONT}{BLACK}Number of autosaves that should be kept
 STR_6280    :{SMALLFONT}{BLACK}Chat

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3779,6 +3779,7 @@ STR_6328    :{SMALLFONT}{BLACK}With this option enabled, giant screenshots will 
 STR_6329    :{STRING}{STRINGID}
 STR_6330    :Downloading [{STRING}] from {STRING} ({COMMA16} / {COMMA16})
 STR_6331    :Create Ducks
+STR_6332    :Remove Ducks
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -128,6 +128,7 @@ enum WINDOW_CHEATS_WIDGET_IDX
     WIDX_OPEN_CLOSE_PARK,
     WIDX_CREATE_DUCKS,
     WIDX_PARK_PARAMETERS,
+    WIDX_REMOVE_DUCKS,
     WIDX_OWN_ALL_LAND,
     WIDX_FORCE_PARK_RATING,
     WIDX_PARK_RATING_SPINNER,
@@ -270,8 +271,9 @@ static rct_widget window_cheats_misc_widgets[] =
     MAIN_CHEATS_WIDGETS,
     { WWT_GROUPBOX,         1,      XPL(0) - GROUP_SPACE,   WPL(1) + GROUP_SPACE,   YPL(0),         HPL(7.25),      STR_CHEAT_GENERAL_GROUP,            STR_NONE },                             // General group
     { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(1),         HPL(1),         STR_CHEAT_OPEN_PARK,                STR_CHEAT_OPEN_PARK_TIP },              // open / close park
-    { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(2),         HPL(2),         STR_CREATE_DUCKS,                   STR_CREATE_DUCKS },           // Create ducks
+    { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(2),         HPL(2),         STR_CREATE_DUCKS,                   STR_CREATE_DUCKS },                     // Create ducks
     { WWT_BUTTON,           1,      XPL(1),                 WPL(1),                 YPL(1),         HPL(1),         STR_CHEAT_PARK_PARAMETERS,          STR_CHEAT_PARK_PARAMETERS_TIP },        // Park parameters
+    { WWT_BUTTON,           1,      XPL(1),                 WPL(1),                 YPL(2),         HPL(2),         STR_REMOVE_DUCKS,                   STR_REMOVE_DUCKS },                     // Remove ducks
     { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(3),         HPL(3),         STR_CHEAT_OWN_ALL_LAND,             STR_CHEAT_OWN_ALL_LAND_TIP },           // Own all land
     { WWT_CHECKBOX,         1,      XPL(0),                 WPL(0),                 YPL(5),         HPL(5),         STR_FORCE_PARK_RATING,              STR_NONE },                             // Force park rating
       SPINNER_WIDGETS      (1,      XPL(1),                 WPL(1) - 10,            YPL(5) + 2,     HPL(5) - 3,     STR_NONE,                           STR_NONE),                              // park rating (3 widgets)
@@ -538,6 +540,7 @@ static uint64_t window_cheats_page_enabled_widgets[] = {
     (1ULL << WIDX_FREEZE_WEATHER) |
     (1ULL << WIDX_OPEN_CLOSE_PARK) |
     (1ULL << WIDX_CREATE_DUCKS) |
+    (1ULL << WIDX_REMOVE_DUCKS) |
     (1ULL << WIDX_WEATHER) |
     (1ULL << WIDX_WEATHER_DROPDOWN_BUTTON) |
     (1ULL << WIDX_CLEAR_GRASS) |
@@ -930,6 +933,9 @@ static void window_cheats_misc_mouseup(rct_window* w, rct_widgetindex widgetInde
             break;
         case WIDX_CREATE_DUCKS:
             CheatsSet(CheatType::CreateDucks, CHEATS_DUCK_INCREMENT);
+            break;
+        case WIDX_REMOVE_DUCKS:
+            CheatsSet(CheatType::RemoveDucks);
             break;
         case WIDX_CLEAR_GRASS:
             CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_CLEAR_0);

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -126,6 +126,7 @@ enum WINDOW_CHEATS_WIDGET_IDX
 
     WIDX_GENERAL_GROUP = WIDX_TAB_CONTENT,
     WIDX_OPEN_CLOSE_PARK,
+    WIDX_CREATE_DUCKS,
     WIDX_PARK_PARAMETERS,
     WIDX_OWN_ALL_LAND,
     WIDX_FORCE_PARK_RATING,
@@ -269,6 +270,7 @@ static rct_widget window_cheats_misc_widgets[] =
     MAIN_CHEATS_WIDGETS,
     { WWT_GROUPBOX,         1,      XPL(0) - GROUP_SPACE,   WPL(1) + GROUP_SPACE,   YPL(0),         HPL(7.25),      STR_CHEAT_GENERAL_GROUP,            STR_NONE },                             // General group
     { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(1),         HPL(1),         STR_CHEAT_OPEN_PARK,                STR_CHEAT_OPEN_PARK_TIP },              // open / close park
+    { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(2),         HPL(2),         STR_CREATE_DUCKS,                   STR_CREATE_DUCKS },           // Create ducks
     { WWT_BUTTON,           1,      XPL(1),                 WPL(1),                 YPL(1),         HPL(1),         STR_CHEAT_PARK_PARAMETERS,          STR_CHEAT_PARK_PARAMETERS_TIP },        // Park parameters
     { WWT_BUTTON,           1,      XPL(0),                 WPL(0),                 YPL(3),         HPL(3),         STR_CHEAT_OWN_ALL_LAND,             STR_CHEAT_OWN_ALL_LAND_TIP },           // Own all land
     { WWT_CHECKBOX,         1,      XPL(0),                 WPL(0),                 YPL(5),         HPL(5),         STR_FORCE_PARK_RATING,              STR_NONE },                             // Force park rating
@@ -535,6 +537,7 @@ static uint64_t window_cheats_page_enabled_widgets[] = {
     MAIN_CHEAT_ENABLED_WIDGETS |
     (1ULL << WIDX_FREEZE_WEATHER) |
     (1ULL << WIDX_OPEN_CLOSE_PARK) |
+    (1ULL << WIDX_CREATE_DUCKS) |
     (1ULL << WIDX_WEATHER) |
     (1ULL << WIDX_WEATHER_DROPDOWN_BUTTON) |
     (1ULL << WIDX_CLEAR_GRASS) |
@@ -924,6 +927,9 @@ static void window_cheats_misc_mouseup(rct_window* w, rct_widgetindex widgetInde
             break;
         case WIDX_OPEN_CLOSE_PARK:
             CheatsSet(CheatType::OpenClosePark);
+            break;
+        case WIDX_CREATE_DUCKS:
+            CheatsSet(CheatType::CreateDucks, CHEATS_DUCK_INCREMENT);
             break;
         case WIDX_CLEAR_GRASS:
             CheatsSet(CheatType::SetGrassLength, GRASS_LENGTH_CLEAR_0);

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -84,6 +84,7 @@ enum class CheatType : int32_t
     IgnoreResearchStatus,
     EnableAllDrawableTrackPieces,
     CreateDucks,
+    RemoveDucks,
     Count,
 };
 

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -83,6 +83,7 @@ enum class CheatType : int32_t
     DisableRideValueAging,
     IgnoreResearchStatus,
     EnableAllDrawableTrackPieces,
+    CreateDucks,
     Count,
 };
 
@@ -108,6 +109,7 @@ enum
 
 #define CHEATS_GIVE_GUESTS_MONEY MONEY(1000, 00)
 #define CHEATS_TRAM_INCREMENT 250
+#define CHEATS_DUCK_INCREMENT 20
 #define CHEATS_STAFF_FAST_SPEED 0xFF
 #define CHEATS_STAFF_NORMAL_SPEED 0x60
 #define CHEATS_STAFF_FREEZE_SPEED 0

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -233,6 +233,9 @@ public:
             case CheatType::CreateDucks:
                 CreateDucks(_param1);
                 break;
+            case CheatType::RemoveDucks:
+                duck_remove_all();
+                break;
             default:
             {
                 log_error("Unabled cheat: %d", _cheatType.id);

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -230,6 +230,9 @@ public:
             case CheatType::EnableAllDrawableTrackPieces:
                 gCheatsEnableAllDrawableTrackPieces = _param1 != 0;
                 break;
+            case CheatType::CreateDucks:
+                CreateDucks(_param1);
+                break;
             default:
             {
                 log_error("Unabled cheat: %d", _cheatType.id);
@@ -343,6 +346,8 @@ private:
                 return { { 0, 5 }, { 0, 0 } };
             case CheatType::SetForcedParkRating:
                 return { { 0, 999 }, { 0, 0 } };
+            case CheatType::CreateDucks:
+                return { { 0, 100 }, { 0, 0 } };
             default:
                 return { { 0, 0 }, { 0, 0 } };
         }
@@ -771,5 +776,18 @@ private:
     {
         auto parkSetParameter = ParkSetParameterAction(isOpen ? ParkParameter::Open : ParkParameter::Close);
         GameActions::ExecuteNested(&parkSetParameter);
+    }
+
+    void CreateDucks(int count) const
+    {
+        for (int i = 0; i < count; i++)
+        {
+            // 100 attempts at finding some water to create a few ducks at
+            for (int32_t attempts = 0; attempts < 100; attempts++)
+            {
+                if (scenario_create_ducks())
+                    break;
+            }
+        }
     }
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3969,6 +3969,7 @@ enum
     STR_DOWNLOADING_OBJECTS_FROM = 6330,
 
     STR_CREATE_DUCKS = 6331,
+    STR_REMOVE_DUCKS = 6332,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3968,6 +3968,8 @@ enum
     STR_STRING_STRINGID = 6329,
     STR_DOWNLOADING_OBJECTS_FROM = 6330,
 
+    STR_CREATE_DUCKS = 6331,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -184,7 +184,7 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
         }
 
         case SPRITE_MISC_DUCK:
-            if (dpi->zoom_level == 0)
+            if (dpi->zoom_level <= 1)
             {
                 const rct_duck* duck = &misc->duck;
                 uint32_t imageId = duck_get_frame_image(&misc->duck, imageDirection);

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -82,7 +82,6 @@ money32 gScenarioCompanyValueRecord;
 
 char gScenarioFileName[MAX_PATH];
 
-static int32_t scenario_create_ducks();
 static void scenario_objective_check();
 
 using namespace OpenRCT2;
@@ -420,7 +419,7 @@ void scenario_update()
  *
  *  rct2: 0x006744A9
  */
-static int32_t scenario_create_ducks()
+bool scenario_create_ducks()
 {
     CoordsXY centrePos;
     centrePos.x = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
@@ -429,11 +428,11 @@ static int32_t scenario_create_ducks()
     Guard::Assert(map_is_location_valid(centrePos));
 
     if (!map_is_location_in_park(centrePos))
-        return 0;
+        return false;
 
     int32_t centreWaterZ = (tile_element_water_height(centrePos));
     if (centreWaterZ == 0)
-        return 0;
+        return false;
 
     // Check NxN area around centre tile defined by SquareSize
     constexpr int32_t SquareSize = 7;
@@ -463,7 +462,7 @@ static int32_t scenario_create_ducks()
 
     // Must be at least 25 water tiles of the same height in 7x7 area
     if (waterTiles < 25)
-        return 0;
+        return false;
 
     // Set x, y to the centre of the tile
     centrePos.x += 16;
@@ -481,7 +480,7 @@ static int32_t scenario_create_ducks()
         create_duck(targetPos);
     }
 
-    return 1;
+    return true;
 }
 
 const random_engine_t::state_type& scenario_rand_state()

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -421,9 +421,14 @@ void scenario_update()
  */
 bool scenario_create_ducks()
 {
+    // Check NxN area around centre tile defined by SquareSize
+    constexpr int32_t SquareSize = 7;
+    constexpr int32_t SquareCentre = SquareSize / 2;
+    constexpr int32_t SquareTileSize = SquareCentre * 32;
+
     CoordsXY centrePos;
-    centrePos.x = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
-    centrePos.y = 64 + (scenario_rand_max(MAXIMUM_MAP_SIZE_PRACTICAL) * 32);
+    centrePos.x = SquareTileSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
+    centrePos.y = SquareTileSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
 
     Guard::Assert(map_is_location_valid(centrePos));
 
@@ -433,10 +438,6 @@ bool scenario_create_ducks()
     int32_t centreWaterZ = (tile_element_water_height(centrePos));
     if (centreWaterZ == 0)
         return false;
-
-    // Check NxN area around centre tile defined by SquareSize
-    constexpr int32_t SquareSize = 7;
-    constexpr int32_t SquareCentre = SquareSize / 2;
 
     CoordsXY innerPos{ centrePos.x - (32 * SquareCentre), centrePos.y - (32 * SquareCentre) };
     int32_t waterTiles = 0;
@@ -472,10 +473,11 @@ bool scenario_create_ducks()
     for (int32_t i = 0; i < duckCount; i++)
     {
         int32_t r = scenario_rand();
-        innerPos.x = (r >> 16) & 0x7F;
-        innerPos.y = (r & 0xFFFF) & 0x7F;
+        innerPos.x = (r >> 16) & (SquareTileSize - 1);
+        innerPos.y = (r & 0xFFFF) & (SquareTileSize - 1);
 
-        CoordsXY targetPos{ centrePos.x + innerPos.x - 64, centrePos.y + innerPos.y - 64 };
+        CoordsXY targetPos{ centrePos.x + innerPos.x - SquareTileSize, centrePos.y + innerPos.y - SquareTileSize };
+
         Guard::Assert(map_is_location_valid(targetPos));
         create_duck(targetPos);
     }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -469,12 +469,12 @@ bool scenario_create_ducks()
     centrePos.x += 16;
     centrePos.y += 16;
 
-    int32_t duckCount = (scenario_rand() & 3) + 2;
-    for (int32_t i = 0; i < duckCount; i++)
+    uint32_t duckCount = (scenario_rand() % 4) + 2;
+    for (uint32_t i = 0; i < duckCount; i++)
     {
-        int32_t r = scenario_rand();
-        innerPos.x = (r >> 16) & (SquareRadiusSize - 1);
-        innerPos.y = (r & 0xFFFF) & (SquareRadiusSize - 1);
+        uint32_t r = scenario_rand();
+        innerPos.x = (r >> 16) % SquareRadiusSize;
+        innerPos.y = (r & 0xFFFF) % SquareRadiusSize;
 
         CoordsXY targetPos{ centrePos.x + innerPos.x - SquareRadiusSize, centrePos.y + innerPos.y - SquareRadiusSize };
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -424,11 +424,11 @@ bool scenario_create_ducks()
     // Check NxN area around centre tile defined by SquareSize
     constexpr int32_t SquareSize = 7;
     constexpr int32_t SquareCentre = SquareSize / 2;
-    constexpr int32_t SquareTileSize = SquareCentre * 32;
+    constexpr int32_t SquareRadiusSize = SquareCentre * 32;
 
     CoordsXY centrePos;
-    centrePos.x = SquareTileSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
-    centrePos.y = SquareTileSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
+    centrePos.x = SquareRadiusSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
+    centrePos.y = SquareRadiusSize + (scenario_rand_max(MAXIMUM_MAP_SIZE_TECHNICAL - SquareCentre) * 32);
 
     Guard::Assert(map_is_location_valid(centrePos));
 
@@ -473,10 +473,10 @@ bool scenario_create_ducks()
     for (int32_t i = 0; i < duckCount; i++)
     {
         int32_t r = scenario_rand();
-        innerPos.x = (r >> 16) & (SquareTileSize - 1);
-        innerPos.y = (r & 0xFFFF) & (SquareTileSize - 1);
+        innerPos.x = (r >> 16) & (SquareRadiusSize - 1);
+        innerPos.y = (r & 0xFFFF) & (SquareRadiusSize - 1);
 
-        CoordsXY targetPos{ centrePos.x + innerPos.x - SquareTileSize, centrePos.y + innerPos.y - SquareTileSize };
+        CoordsXY targetPos{ centrePos.x + innerPos.x - SquareRadiusSize, centrePos.y + innerPos.y - SquareRadiusSize };
 
         Guard::Assert(map_is_location_valid(targetPos));
         create_duck(targetPos);

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -395,6 +395,7 @@ extern char gScenarioFileName[260];
 void load_from_sc6(const char* path);
 void scenario_begin();
 void scenario_update();
+bool scenario_create_ducks();
 
 const random_engine_t::state_type& scenario_rand_state();
 void scenario_rand_seed(random_engine_t::result_type s0, random_engine_t::result_type s1);

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -124,7 +124,7 @@ void rct_duck::UpdateFlyToWater()
     int32_t manhattanDistanceN = abs(target_x - newX) + abs(target_y - newY);
 
     auto surfaceElement = map_get_surface_element_at({ target_x, target_y });
-    int32_t waterHeight = surfaceElement->GetWaterHeight();
+    int32_t waterHeight = surfaceElement != nullptr ? surfaceElement->GetWaterHeight() : 0;
     if (waterHeight == 0)
     {
         state = DUCK_STATE::FLY_AWAY;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -91,7 +91,7 @@ rct_duck* rct_sprite::AsDuck()
 
 void rct_duck::Invalidate()
 {
-    invalidate_sprite_0((rct_sprite*)this);
+    invalidate_sprite_1((rct_sprite*)this);
 }
 
 void rct_duck::Remove()
@@ -384,7 +384,7 @@ void duck_remove_all()
         nextSpriteIndex = sprite->next;
         if (sprite->type == SPRITE_MISC_DUCK)
         {
-            invalidate_sprite_0((rct_sprite*)sprite);
+            invalidate_sprite_1((rct_sprite*)sprite);
             sprite_remove((rct_sprite*)sprite);
         }
     }

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -96,6 +96,7 @@ void rct_duck::Invalidate()
 
 void rct_duck::Remove()
 {
+    Invalidate();
     sprite_remove((rct_sprite*)this);
 }
 
@@ -383,6 +384,7 @@ void duck_remove_all()
         nextSpriteIndex = sprite->next;
         if (sprite->type == SPRITE_MISC_DUCK)
         {
+            invalidate_sprite_0((rct_sprite*)sprite);
             sprite_remove((rct_sprite*)sprite);
         }
     }


### PR DESCRIPTION
This PR introduces two new cheats to create and remove ducks which helps debugging them a bit better as they would only spawn during a certain time of year. This PR also fixes #10093 which now uses the correct search size for all the positions, previously it was hardcoded to 0x7F which was too big for for the selection within the 7x7 radius.

![openrct2_2019-10-15_17-37-50](https://user-images.githubusercontent.com/5415177/66848150-d9c01600-ef74-11e9-9069-a52ee013a492.jpg)

I also enabled duck drawing with zoom level 1, I don't think there will be ever enough ducks to have an actual performance impact.

