### PR TITLE
Fix some compilation warnings

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -61,6 +61,7 @@ void TextureCache::InvalidateImage(uint32_t image)
     }
 }
 
+// Note: for performance reasons, this returns a BasicTextureInfo over an AtlasTextureInfo (also to not expose the cache)
 BasicTextureInfo TextureCache::GetOrLoadImageTexture(uint32_t image)
 {
     uint32_t index;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -521,8 +521,12 @@ static void join_server(std::string address)
     {
         if (endBracketIndex != std::string::npos || dotIndex != std::string::npos)
         {
-            std::sscanf(&address[colonIndex + 1], "%d", &port);
-            address = address.substr(0, colonIndex);
+            auto ret = std::sscanf(&address[colonIndex + 1], "%d", &port);
+            assert(ret);
+            if (ret > 0)
+            {
+                address = address.substr(0, colonIndex);
+            }
         }
     }
 

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -442,7 +442,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                                                                      : STR_WINDOW_COLOUR_2_STRINGID;
 
     // Text for each tab
-    for (int32_t i = 0; i < 8; i++)
+    for (uint32_t i = 0; i < std::size(ScenarioOriginStringIds); i++)
     {
         rct_widget* widget = &window_scenarioselect_widgets[WIDX_TAB1 + i];
         if (widget->type == WWT_EMPTY)

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -608,7 +608,7 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
             }
 
             json_t* path = json_object_get(sprite_description, "path");
-            if (!path || !json_is_string(path))
+            if (!json_is_string(path))
             {
                 fprintf(stderr, "Error: no path provided for sprite %lu\n", (unsigned long)i);
                 json_decref(sprite_list);

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -621,7 +621,7 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
             // Get palette option, if present
             bool keep_palette = false;
             json_t* palette = json_object_get(sprite_description, "palette");
-            if (palette && json_is_string(palette))
+            if (json_is_string(palette))
             {
                 const char* option = json_string_value(palette);
                 if (strncmp(option, "keep", 4) == 0)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -9,7 +9,7 @@ static constexpr uint32_t InvalidTick = 0xFFFFFFFF;
 
 struct GameStateSnapshot_t
 {
-    GameStateSnapshot_t& operator=(GameStateSnapshot_t&& mv)
+    GameStateSnapshot_t& operator=(GameStateSnapshot_t&& mv) noexcept
     {
         tick = mv.tick;
         storedSprites = std::move(mv.storedSprites);

--- a/src/openrct2/actions/WallPlaceAction.hpp
+++ b/src/openrct2/actions/WallPlaceAction.hpp
@@ -55,15 +55,13 @@ private:
     int32_t _wallType{ -1 };
     CoordsXYZ _loc;
     Direction _edge{ INVALID_DIRECTION };
-    int32_t _primaryColour;
-    int32_t _secondaryColour;
-    int32_t _tertiaryColour;
+    int32_t _primaryColour{ 0 };
+    int32_t _secondaryColour{ 0 };
+    int32_t _tertiaryColour{ 0 };
     BannerIndex _bannerId{ BANNER_INDEX_NULL };
 
 public:
-    WallPlaceAction()
-    {
-    }
+    WallPlaceAction() = default;
 
     WallPlaceAction(
         int32_t wallType, CoordsXYZ loc, uint8_t edge, int32_t primaryColour, int32_t secondaryColour, int32_t tertiaryColour)

--- a/src/openrct2/actions/WallPlaceAction.hpp
+++ b/src/openrct2/actions/WallPlaceAction.hpp
@@ -55,9 +55,9 @@ private:
     int32_t _wallType{ -1 };
     CoordsXYZ _loc;
     Direction _edge{ INVALID_DIRECTION };
-    int32_t _primaryColour{ 0 };
-    int32_t _secondaryColour{ 0 };
-    int32_t _tertiaryColour{ 0 };
+    int32_t _primaryColour{ COLOUR_BLACK };
+    int32_t _secondaryColour{ COLOUR_BLACK };
+    int32_t _tertiaryColour{ COLOUR_BLACK };
     BannerIndex _bannerId{ BANNER_INDEX_NULL };
 
 public:

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -49,7 +49,7 @@ MemoryStream::MemoryStream(const void* data, size_t dataSize)
 {
 }
 
-MemoryStream::MemoryStream(MemoryStream&& mv)
+MemoryStream::MemoryStream(MemoryStream&& mv) noexcept
 {
     *this = std::move(mv);
 }
@@ -65,7 +65,7 @@ MemoryStream::~MemoryStream()
     _data = nullptr;
 }
 
-MemoryStream& MemoryStream::operator=(MemoryStream&& mv)
+MemoryStream& MemoryStream::operator=(MemoryStream&& mv) noexcept
 {
     _access = mv._access;
     _dataCapacity = mv._dataCapacity;

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -36,13 +36,13 @@ private:
 public:
     MemoryStream() = default;
     MemoryStream(const MemoryStream& copy);
-    MemoryStream(MemoryStream&& mv);
+    MemoryStream(MemoryStream&& mv) noexcept;
     explicit MemoryStream(size_t capacity);
     MemoryStream(void* data, size_t dataSize, uint8_t access = MEMORY_ACCESS::READ);
     MemoryStream(const void* data, size_t dataSize);
     virtual ~MemoryStream();
 
-    MemoryStream& operator=(MemoryStream&& mv);
+    MemoryStream& operator=(MemoryStream&& mv) noexcept;
 
     const void* GetData() const override;
     void* GetDataCopy() const;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1353,6 +1353,11 @@ void Network::BeginServerLog()
     {
         format_string(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
     }
+    else
+    {
+        logMessage[0] = '\0';
+        assert(0 && "Uninitialized mode");
+    }
     AppendServerLog(logMessage);
 }
 
@@ -1375,6 +1380,11 @@ void Network::CloseServerLog()
     else if (GetMode() == NETWORK_MODE_SERVER)
     {
         format_string(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
+    }
+    else
+    {
+        logMessage[0] = '\0';
+        assert(0 && "Uninitialized mode");
     }
     AppendServerLog(logMessage);
     _server_log_fs.close();

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1356,7 +1356,7 @@ void Network::BeginServerLog()
     else
     {
         logMessage[0] = '\0';
-        assert(0 && "Uninitialized mode");
+        Guard::Assert(false, "Unknown network mode!");
     }
     AppendServerLog(logMessage);
 }
@@ -1384,7 +1384,7 @@ void Network::CloseServerLog()
     else
     {
         logMessage[0] = '\0';
-        assert(0 && "Uninitialized mode");
+        Guard::Assert(false, "Unknown network mode!");
     }
     AppendServerLog(logMessage);
     _server_log_fs.close();

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -168,8 +168,8 @@ void S6Exporter::Export()
         auto temp = utf8_to_rct2(gS6Info.details);
         safe_strcpy(_s6.info.details, temp.data(), sizeof(_s6.info.details));
     }
-    uint32_t researchedTrackPiecesA[128];
-    uint32_t researchedTrackPiecesB[128];
+    uint32_t researchedTrackPiecesA[128] = {};
+    uint32_t researchedTrackPiecesB[128] = {};
 
     for (int32_t i = 0; i < OBJECT_ENTRY_COUNT; i++)
     {


### PR DESCRIPTION
I was exploring the solution a bit and have found plenty of warnings, they're probably not all applicable, but I'm creating this draft PR to see whether this is something you're interested in having fixed/dealt with.

- The loop tried to access `ScenarioOriginStringIds[7]`, which doesn't exist.
- `json_is_string` already checks for `palette` pointer validity
- `WallPlaceAction` had uninitialized member variables