### PR TITLE
Fix possible cause for desyncs on ride crashes

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "18"
+#define NETWORK_STREAM_VERSION "19"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5371,9 +5371,9 @@ static void vehicle_update_crash(rct_vehicle* vehicle)
                 curVehicle->crash_z++;
                 if ((scenario_rand() & 0xFFFF) <= 0x1555)
                 {
-                    sprite_misc_explosion_cloud_create(
-                        curVehicle->x + ((scenario_rand() & 2) - 1), curVehicle->y + ((scenario_rand() & 2) - 1),
-                        curVehicle->z);
+                    auto xOffset = (scenario_rand() & 2) - 1;
+                    auto yOffset = (scenario_rand() & 2) - 1;
+                    sprite_misc_explosion_cloud_create(curVehicle->x + xOffset, curVehicle->y + yOffset, curVehicle->z);
                 }
             }
             if (curVehicle->var_C8 + 7281 > 0xFFFF)


### PR DESCRIPTION
`scenario_rand` was used twice between two sequence points. The order of evaluation is unspecified in C++, meaning that these calls could be done in both forward and reverse order. Storing them in variables guarantees their order, making this cross-platform.