### PR TITLE
Fix importing user strings with umlauts

### DIFF
--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -96,7 +96,7 @@ const char* format_get_token(uint32_t code)
     return nullptr;
 }
 
-bool utf8_should_use_sprite_for_codepoint(int32_t codepoint)
+bool utf8_should_use_sprite_for_codepoint(char32_t codepoint)
 {
     switch (codepoint)
     {

--- a/src/openrct2/localisation/Language.h
+++ b/src/openrct2/localisation/Language.h
@@ -99,7 +99,7 @@ utf8* utf8_write_codepoint(utf8* dst, uint32_t codepoint);
 int32_t utf8_insert_codepoint(utf8* dst, uint32_t codepoint);
 bool utf8_is_codepoint_start(const utf8* text);
 void utf8_remove_format_codes(utf8* text, bool allowcolours);
-int32_t utf8_get_codepoint_length(int32_t codepoint);
+int32_t utf8_get_codepoint_length(char32_t codepoint);
 int32_t utf8_length(const utf8* text);
 
 std::string rct2_to_utf8(const std::string_view& src, RCT2LanguageId languageId);

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -20,10 +20,10 @@
 #include <cstring>
 #include <string>
 
-bool utf8_is_format_code(int32_t codepoint);
-bool utf8_is_colour_code(int32_t codepoint);
-bool utf8_should_use_sprite_for_codepoint(int32_t codepoint);
-int32_t utf8_get_format_code_arg_length(int32_t codepoint);
+bool utf8_is_format_code(char32_t codepoint);
+bool utf8_is_colour_code(char32_t codepoint);
+bool utf8_should_use_sprite_for_codepoint(char32_t codepoint);
+int32_t utf8_get_format_code_arg_length(char32_t codepoint);
 void utf8_remove_formatting(utf8* string, bool allowColours);
 
 std::string format_string(rct_string_id format, const void* args);

--- a/src/openrct2/localisation/UTF8.cpp
+++ b/src/openrct2/localisation/UTF8.cpp
@@ -101,7 +101,7 @@ bool utf8_is_codepoint_start(const utf8* text)
     return false;
 }
 
-int32_t utf8_get_codepoint_length(int32_t codepoint)
+int32_t utf8_get_codepoint_length(char32_t codepoint)
 {
     if (codepoint <= 0x7F)
     {
@@ -166,7 +166,7 @@ size_t get_string_size(const utf8* text)
  */
 int32_t get_string_length(const utf8* text)
 {
-    int32_t codepoint;
+    char32_t codepoint;
     const utf8* ch = text;
 
     int32_t count = 0;
@@ -184,14 +184,14 @@ int32_t get_string_length(const utf8* text)
     return count;
 }
 
-int32_t utf8_get_format_code_arg_length(int32_t codepoint)
+int32_t utf8_get_format_code_arg_length(char32_t codepoint)
 {
     switch (codepoint)
     {
         case FORMAT_MOVE_X:
         case FORMAT_ADJUST_PALETTE:
-        case 3:
-        case 4:
+        case FORMAT_3:
+        case FORMAT_4:
             return 1;
         case FORMAT_NEWLINE_X_Y:
             return 2;
@@ -209,7 +209,7 @@ void utf8_remove_formatting(utf8* string, bool allowColours)
 
     while (true)
     {
-        uint32_t code = utf8_get_next(readPtr, (const utf8**)&readPtr);
+        char32_t code = utf8_get_next(readPtr, (const utf8**)&readPtr);
 
         if (code == 0)
         {
@@ -223,7 +223,7 @@ void utf8_remove_formatting(utf8* string, bool allowColours)
     }
 }
 
-bool utf8_is_format_code(int32_t codepoint)
+bool utf8_is_format_code(char32_t codepoint)
 {
     if (codepoint < 32)
         return true;
@@ -236,7 +236,7 @@ bool utf8_is_format_code(int32_t codepoint)
     return false;
 }
 
-bool utf8_is_colour_code(int32_t codepoint)
+bool utf8_is_colour_code(char32_t codepoint)
 {
     return codepoint >= FORMAT_COLOUR_CODE_START && codepoint <= FORMAT_COLOUR_CODE_END;
 }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -204,8 +204,6 @@ public:
         SetDefaultNames();
         determine_ride_entrance_and_exit_locations();
 
-        // Importing the strings is done later on, although that approach needs looking at.
-        // game_convert_strings_to_utf8();
         game_convert_news_items_to_utf8();
         map_count_remaining_land_rights();
     }
@@ -782,8 +780,7 @@ private:
         // Ride name
         if (is_user_string_id(src->name))
         {
-            auto rideName = GetUserString(src->name);
-            dst->custom_name = rct2_to_utf8(rideName, RCT2_LANGUAGE_ID_ENGLISH_UK);
+            dst->custom_name = GetUserString(src->name);
         }
 
         dst->status = src->status;


### PR DESCRIPTION
The problem was caused by unsigned characters getting interpreted as signed ones. For example, 'ä' was interpreted as `-28`, and thus discarded as a format code. `char32_t` is unsigned and also a better fit for the functions in question.

There was also a bug in the S4 importer, which meant that ride names were converted twice.