### PR TITLE
Audio clean-up and style/usage fixes

### DIFF
--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -10,12 +10,9 @@
 #include "AudioContext.h"
 #include "AudioFormat.h"
 
-#include <SDL.h>
 #include <algorithm>
 #include <cmath>
-#include <openrct2/audio/AudioChannel.h>
 #include <openrct2/audio/AudioSource.h>
-#include <openrct2/audio/audio.h>
 #include <openrct2/common.h>
 #include <speex/speex_resampler.h>
 
@@ -118,12 +115,12 @@ namespace OpenRCT2::Audio
             return false;
         }
 
-        [[nodiscard]] virtual int32_t GetLoop() const override
+        [[nodiscard]] int32_t GetLoop() const override
         {
             return _loop;
         }
 
-        virtual void SetLoop(int32_t value) override
+        void SetLoop(int32_t value) override
         {
             _loop = value;
         }
@@ -227,7 +224,7 @@ namespace OpenRCT2::Audio
 
         void Play(IAudioSource* source, int32_t loop) override
         {
-            _source = static_cast<ISDLAudioSource*>(source);
+            _source = dynamic_cast<ISDLAudioSource*>(source);
             _loop = loop;
             _offset = 0;
             _done = false;

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -18,10 +18,12 @@
 
 namespace OpenRCT2::Audio
 {
-    class AudioChannelImpl : public ISDLAudioChannel
+    template<typename AudioSource_ = ISDLAudioSource> class AudioChannelImpl : public ISDLAudioChannel
     {
+        static_assert(std::is_base_of_v<IAudioSource, AudioSource_>);
+
     private:
-        ISDLAudioSource* _source = nullptr;
+        AudioSource_* _source = nullptr;
         SpeexResamplerState* _resampler = nullptr;
 
         int32_t _group = MIXER_GROUP_SOUND;
@@ -63,9 +65,12 @@ namespace OpenRCT2::Audio
             }
         }
 
-        [[nodiscard]] IAudioSource* GetSource() const override { return _source; }
+        [[nodiscard]] IAudioSource* GetSource() const override
+        {
+            return _source;
+        }
 
-            [[nodiscard]] SpeexResamplerState* GetResampler() const override
+        [[nodiscard]] SpeexResamplerState* GetResampler() const override
         {
             return _resampler;
         }
@@ -75,21 +80,30 @@ namespace OpenRCT2::Audio
             _resampler = value;
         }
 
-        [[nodiscard]] int32_t GetGroup() const override { return _group; }
+        [[nodiscard]] int32_t GetGroup() const override
+        {
+            return _group;
+        }
 
         void SetGroup(int32_t group) override
         {
             _group = group;
         }
 
-        [[nodiscard]] double GetRate() const override { return _rate; }
+        [[nodiscard]] double GetRate() const override
+        {
+            return _rate;
+        }
 
         void SetRate(double rate) override
         {
             _rate = std::max(0.001, rate);
         }
 
-        [[nodiscard]] uint64_t GetOffset() const override { return _offset; }
+        [[nodiscard]] uint64_t GetOffset() const override
+        {
+            return _offset;
+        }
 
         bool SetOffset(uint64_t offset) override
         {
@@ -103,30 +117,42 @@ namespace OpenRCT2::Audio
             return false;
         }
 
-        [[nodiscard]] int32_t GetLoop() const override { return _loop; }
+        [[nodiscard]] int32_t GetLoop() const override
+        {
+            return _loop;
+        }
 
         void SetLoop(int32_t value) override
         {
             _loop = value;
         }
 
-        [[nodiscard]] int32_t GetVolume() const override { return _volume; }
+        [[nodiscard]] int32_t GetVolume() const override
+        {
+            return _volume;
+        }
 
-            [[nodiscard]] float GetVolumeL() const override
+        [[nodiscard]] float GetVolumeL() const override
         {
             return _volume_l;
         }
 
-        [[nodiscard]] float GetVolumeR() const override { return _volume_r; }
+        [[nodiscard]] float GetVolumeR() const override
+        {
+            return _volume_r;
+        }
 
-            [[nodiscard]] float GetOldVolumeL() const override
+        [[nodiscard]] float GetOldVolumeL() const override
         {
             return _oldvolume_l;
         }
 
-        [[nodiscard]] float GetOldVolumeR() const override { return _oldvolume_r; }
+        [[nodiscard]] float GetOldVolumeR() const override
+        {
+            return _oldvolume_r;
+        }
 
-            [[nodiscard]] int32_t GetOldVolume() const override
+        [[nodiscard]] int32_t GetOldVolume() const override
         {
             return _oldvolume;
         }
@@ -136,7 +162,10 @@ namespace OpenRCT2::Audio
             _volume = std::clamp(volume, 0, MIXER_VOLUME_MAX);
         }
 
-        [[nodiscard]] float GetPan() const override { return _pan; }
+        [[nodiscard]] float GetPan() const override
+        {
+            return _pan;
+        }
 
         void SetPan(float pan) override
         {
@@ -155,21 +184,30 @@ namespace OpenRCT2::Audio
             }
         }
 
-        [[nodiscard]] bool IsStopping() const override { return _stopping; }
+        [[nodiscard]] bool IsStopping() const override
+        {
+            return _stopping;
+        }
 
         void SetStopping(bool value) override
         {
             _stopping = value;
         }
 
-        [[nodiscard]] bool IsDone() const override { return _done; }
+        [[nodiscard]] bool IsDone() const override
+        {
+            return _done;
+        }
 
         void SetDone(bool value) override
         {
             _done = value;
         }
 
-        [[nodiscard]] bool DeleteOnDone() const override { return _deleteondone; }
+        [[nodiscard]] bool DeleteOnDone() const override
+        {
+            return _deleteondone;
+        }
 
         void SetDeleteOnDone(bool value) override
         {
@@ -181,11 +219,14 @@ namespace OpenRCT2::Audio
             _deletesourceondone = value;
         }
 
-        [[nodiscard]] bool IsPlaying() const override { return !_done; }
+        [[nodiscard]] bool IsPlaying() const override
+        {
+            return !_done;
+        }
 
         void Play(IAudioSource* source, int32_t loop) override
         {
-            _source = dynamic_cast<ISDLAudioSource*>(source);
+            _source = static_cast<AudioSource_*>(source);
             _loop = loop;
             _offset = 0;
             _done = false;
@@ -198,7 +239,8 @@ namespace OpenRCT2::Audio
             _oldvolume_r = _volume_r;
         }
 
-        [[nodiscard]] AudioFormat GetFormat() const override {
+        [[nodiscard]] AudioFormat GetFormat() const override
+        {
             AudioFormat result = {};
             // The second check is there because NullAudioSource does not implement GetFormat. Avoid calling it.
             if (_source != nullptr && _source->GetLength() > 0)

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -63,12 +63,9 @@ namespace OpenRCT2::Audio
             }
         }
 
-        [[nodiscard]] IAudioSource* GetSource() const override
-        {
-            return _source;
-        }
+        [[nodiscard]] IAudioSource* GetSource() const override { return _source; }
 
-        [[nodiscard]] SpeexResamplerState* GetResampler() const override
+            [[nodiscard]] SpeexResamplerState* GetResampler() const override
         {
             return _resampler;
         }
@@ -78,30 +75,21 @@ namespace OpenRCT2::Audio
             _resampler = value;
         }
 
-        [[nodiscard]] int32_t GetGroup() const override
-        {
-            return _group;
-        }
+        [[nodiscard]] int32_t GetGroup() const override { return _group; }
 
         void SetGroup(int32_t group) override
         {
             _group = group;
         }
 
-        [[nodiscard]] double GetRate() const override
-        {
-            return _rate;
-        }
+        [[nodiscard]] double GetRate() const override { return _rate; }
 
         void SetRate(double rate) override
         {
             _rate = std::max(0.001, rate);
         }
 
-        [[nodiscard]] uint64_t GetOffset() const override
-        {
-            return _offset;
-        }
+        [[nodiscard]] uint64_t GetOffset() const override { return _offset; }
 
         bool SetOffset(uint64_t offset) override
         {
@@ -115,42 +103,30 @@ namespace OpenRCT2::Audio
             return false;
         }
 
-        [[nodiscard]] int32_t GetLoop() const override
-        {
-            return _loop;
-        }
+        [[nodiscard]] int32_t GetLoop() const override { return _loop; }
 
         void SetLoop(int32_t value) override
         {
             _loop = value;
         }
 
-        [[nodiscard]] int32_t GetVolume() const override
-        {
-            return _volume;
-        }
+        [[nodiscard]] int32_t GetVolume() const override { return _volume; }
 
-        [[nodiscard]] float GetVolumeL() const override
+            [[nodiscard]] float GetVolumeL() const override
         {
             return _volume_l;
         }
 
-        [[nodiscard]] float GetVolumeR() const override
-        {
-            return _volume_r;
-        }
+        [[nodiscard]] float GetVolumeR() const override { return _volume_r; }
 
-        [[nodiscard]] float GetOldVolumeL() const override
+            [[nodiscard]] float GetOldVolumeL() const override
         {
             return _oldvolume_l;
         }
 
-        [[nodiscard]] float GetOldVolumeR() const override
-        {
-            return _oldvolume_r;
-        }
+        [[nodiscard]] float GetOldVolumeR() const override { return _oldvolume_r; }
 
-        [[nodiscard]] int32_t GetOldVolume() const override
+            [[nodiscard]] int32_t GetOldVolume() const override
         {
             return _oldvolume;
         }
@@ -160,10 +136,7 @@ namespace OpenRCT2::Audio
             _volume = std::clamp(volume, 0, MIXER_VOLUME_MAX);
         }
 
-        [[nodiscard]] float GetPan() const override
-        {
-            return _pan;
-        }
+        [[nodiscard]] float GetPan() const override { return _pan; }
 
         void SetPan(float pan) override
         {
@@ -182,30 +155,21 @@ namespace OpenRCT2::Audio
             }
         }
 
-        [[nodiscard]] bool IsStopping() const override
-        {
-            return _stopping;
-        }
+        [[nodiscard]] bool IsStopping() const override { return _stopping; }
 
         void SetStopping(bool value) override
         {
             _stopping = value;
         }
 
-        [[nodiscard]] bool IsDone() const override
-        {
-            return _done;
-        }
+        [[nodiscard]] bool IsDone() const override { return _done; }
 
         void SetDone(bool value) override
         {
             _done = value;
         }
 
-        [[nodiscard]] bool DeleteOnDone() const override
-        {
-            return _deleteondone;
-        }
+        [[nodiscard]] bool DeleteOnDone() const override { return _deleteondone; }
 
         void SetDeleteOnDone(bool value) override
         {
@@ -217,10 +181,7 @@ namespace OpenRCT2::Audio
             _deletesourceondone = value;
         }
 
-        [[nodiscard]] bool IsPlaying() const override
-        {
-            return !_done;
-        }
+        [[nodiscard]] bool IsPlaying() const override { return !_done; }
 
         void Play(IAudioSource* source, int32_t loop) override
         {
@@ -237,8 +198,7 @@ namespace OpenRCT2::Audio
             _oldvolume_r = _volume_r;
         }
 
-        [[nodiscard]] AudioFormat GetFormat() const override
-        {
+        [[nodiscard]] AudioFormat GetFormat() const override {
             AudioFormat result = {};
             // The second check is there because NullAudioSource does not implement GetFormat. Avoid calling it.
             if (_source != nullptr && _source->GetLength() > 0)

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -24,11 +24,12 @@ namespace OpenRCT2::Audio
         SDL_AudioFormat format;
         int32_t channels;
 
-        [[nodiscard]] int32_t BytesPerSample() const {
+        [[nodiscard]] int32_t BytesPerSample() const
+        {
             return (SDL_AUDIO_BITSIZE(format)) / 8; // NOLINT(hicpp-signed-bitwise)
         }
 
-            [[nodiscard]] int32_t GetByteRate() const
+        [[nodiscard]] int32_t GetByteRate() const
         {
             return BytesPerSample() * channels;
         }

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -24,12 +24,11 @@ namespace OpenRCT2::Audio
         SDL_AudioFormat format;
         int32_t channels;
 
-        [[nodiscard]] int32_t BytesPerSample() const
-        {
+        [[nodiscard]] int32_t BytesPerSample() const {
             return (SDL_AUDIO_BITSIZE(format)) / 8; // NOLINT(hicpp-signed-bitwise)
         }
 
-        [[nodiscard]] int32_t GetByteRate() const
+            [[nodiscard]] int32_t GetByteRate() const
         {
             return BytesPerSample() * channels;
         }

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -26,7 +26,7 @@ namespace OpenRCT2::Audio
 
         [[nodiscard]] int32_t BytesPerSample() const
         {
-            return (SDL_AUDIO_BITSIZE(format)) / 8;
+            return (SDL_AUDIO_BITSIZE(format)) / 8; // NOLINT(hicpp-signed-bitwise)
         }
 
         [[nodiscard]] int32_t GetByteRate() const

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -381,7 +381,7 @@ namespace OpenRCT2::Audio
         int32_t ApplyVolume(const IAudioChannel* channel, void* buffer, size_t len)
         {
             float volumeAdjust = _volume;
-            volumeAdjust *= gConfigSound.master_sound_enabled ? (static_cast<float>(gConfigSound.master_volume) / 100.0f) : 0;
+            volumeAdjust *= gConfigSound.master_sound_enabled ? (static_cast<float>(gConfigSound.master_volume) / 100.0f) : 0.0f;
 
             switch (channel->GetGroup())
             {
@@ -429,7 +429,7 @@ namespace OpenRCT2::Audio
 
         static void EffectPanS16(const IAudioChannel* channel, int16_t* data, int32_t length)
         {
-            const float dt = 1.0f / static_cast<float>(length * 2);
+            const float dt = 1.0f / static_cast<float>(length * 2.0f);
             float volumeL = channel->GetOldVolumeL();
             float volumeR = channel->GetOldVolumeR();
             const float d_left = dt * (channel->GetVolumeL() - channel->GetOldVolumeL());
@@ -437,8 +437,8 @@ namespace OpenRCT2::Audio
 
             for (int32_t i = 0; i < length * 2; i += 2)
             {
-                data[i + 0] = volumeL * static_cast<float>(data[i + 0]);
-                data[i + 1] = volumeR * static_cast<float>(data[i + 1]);
+                data[i + 0] = static_cast<int16_t>(volumeL * static_cast<float>(data[i + 0]));
+                data[i + 1] = static_cast<int16_t>(volumeR * static_cast<float>(data[i + 1]));
                 volumeL += d_left;
                 volumeR += d_right;
             }
@@ -453,7 +453,7 @@ namespace OpenRCT2::Audio
 
             for (int32_t i = 0; i < length * 2; i += 2)
             {
-                float t = static_cast<float>(i) / static_cast<float>(length * 2);
+                float t = static_cast<float>(i) / static_cast<float>(length * 2.0f);
                 data[i] = static_cast<uint8_t>(data[i] * ((1.0 - t) * oldVolumeL + t * volumeL));
                 data[i + 1] = static_cast<uint8_t>(data[i + 1] * ((1.0 - t) * oldVolumeR + t * volumeR));
             }
@@ -467,8 +467,8 @@ namespace OpenRCT2::Audio
             float endvolume_f = static_cast<float>(endvolume) / SDL_MIX_MAXVOLUME;
             for (int32_t i = 0; i < length; i++)
             {
-                float t = (float)i / length;
-                data[i] = static_cast<float>(data[i]) * ((1 - t) * startvolume_f + t * endvolume_f);
+                float t = static_cast<float>(i) / length;
+                data[i] = static_cast<int16_t>(data[i] * ((1.0f - t) * startvolume_f + t * endvolume_f));
             }
         }
 
@@ -481,7 +481,7 @@ namespace OpenRCT2::Audio
             for (int32_t i = 0; i < length; i++)
             {
                 float t = static_cast<float>(i) / length;
-                data[i] = static_cast<float>(data[i]) * ((1 - t) * startvolume_f + t * endvolume_f);
+                data[i] = static_cast<uint8_t>(data[i] * ((1.0f - t) * startvolume_f + t * endvolume_f));
             }
         }
 

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -255,7 +255,7 @@ namespace OpenRCT2::Audio
         void MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t length)
         {
             int32_t byteRate = _format.GetByteRate();
-            int32_t numSamples = length / byteRate;
+            auto numSamples = static_cast<int32_t>(length / byteRate);
             double rate = 1;
             if (_format.format == AUDIO_S16SYS)
             {
@@ -281,7 +281,7 @@ namespace OpenRCT2::Audio
 
             // Read raw PCM from channel
             int32_t readSamples = numSamples * rate;
-            size_t readLength = (size_t)(readSamples / cvt.len_ratio) * byteRate;
+            auto readLength = static_cast<size_t>(readSamples / cvt.len_ratio) * byteRate;
             _channelBuffer.resize(readLength);
             size_t bytesRead = channel->Read(_channelBuffer.data(), readLength);
 
@@ -309,7 +309,7 @@ namespace OpenRCT2::Audio
             // Apply effects
             if (rate != 1)
             {
-                int32_t inRate = bufferLen / byteRate;
+                auto inRate = static_cast<int32_t>(bufferLen / byteRate);
                 int32_t outRate = numSamples;
                 if (bytesRead != readLength)
                 {

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -437,8 +437,8 @@ namespace OpenRCT2::Audio
 
             for (int32_t i = 0; i < length * 2; i += 2)
             {
-                data[i] = static_cast<float>(data[i]) * volumeL;
-                data[i + 1] = static_cast<float>(data[i + 1]) * volumeR;
+                data[i + 0] = volumeL * static_cast<float>(data[i + 0]);
+                data[i + 1] = volumeR * static_cast<float>(data[i + 1]);
                 volumeL += d_left;
                 volumeR += d_right;
             }

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -22,9 +22,6 @@
 #include <openrct2/audio/audio.h>
 #include <openrct2/common.h>
 #include <openrct2/config/Config.h>
-#include <openrct2/core/Guard.hpp>
-#include <openrct2/localisation/Localisation.h>
-#include <openrct2/platform/platform.h>
 #include <speex/speex_resampler.h>
 #include <vector>
 
@@ -57,7 +54,7 @@ namespace OpenRCT2::Audio
             _nullSource = AudioSource::CreateNull();
         }
 
-        ~AudioMixerImpl()
+        ~AudioMixerImpl() override
         {
             Close();
             delete _nullSource;
@@ -246,19 +243,19 @@ namespace OpenRCT2::Audio
             if (_settingSoundVolume != gConfigSound.sound_volume)
             {
                 _settingSoundVolume = gConfigSound.sound_volume;
-                _adjustSoundVolume = powf(_settingSoundVolume / 100.f, 10.f / 6.f);
+                _adjustSoundVolume = powf(static_cast<float>(_settingSoundVolume) / 100.f, 10.f / 6.f);
             }
             if (_settingMusicVolume != gConfigSound.ride_music_volume)
             {
                 _settingMusicVolume = gConfigSound.ride_music_volume;
-                _adjustMusicVolume = powf(_settingMusicVolume / 100.f, 10.f / 6.f);
+                _adjustMusicVolume = powf(static_cast<float>(_settingMusicVolume) / 100.f, 10.f / 6.f);
             }
         }
 
         void MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t length)
         {
             int32_t byteRate = _format.GetByteRate();
-            int32_t numSamples = static_cast<int32_t>(length / byteRate);
+            int32_t numSamples = length / byteRate;
             double rate = 1;
             if (_format.format == AUDIO_S16SYS)
             {
@@ -283,8 +280,8 @@ namespace OpenRCT2::Audio
             }
 
             // Read raw PCM from channel
-            int32_t readSamples = static_cast<int32_t>(numSamples * rate);
-            size_t readLength = static_cast<size_t>(readSamples / cvt.len_ratio) * byteRate;
+            int32_t readSamples = numSamples * rate;
+            size_t readLength = (size_t)(readSamples / cvt.len_ratio) * byteRate;
             _channelBuffer.resize(readLength);
             size_t bytesRead = channel->Read(_channelBuffer.data(), readLength);
 
@@ -312,7 +309,7 @@ namespace OpenRCT2::Audio
             // Apply effects
             if (rate != 1)
             {
-                int32_t inRate = static_cast<int32_t>(bufferLen / byteRate);
+                int32_t inRate = bufferLen / byteRate;
                 int32_t outRate = numSamples;
                 if (bytesRead != readLength)
                 {
@@ -384,7 +381,7 @@ namespace OpenRCT2::Audio
         int32_t ApplyVolume(const IAudioChannel* channel, void* buffer, size_t len)
         {
             float volumeAdjust = _volume;
-            volumeAdjust *= gConfigSound.master_sound_enabled ? (gConfigSound.master_volume / 100.0f) : 0;
+            volumeAdjust *= gConfigSound.master_sound_enabled ? (static_cast<float>(gConfigSound.master_volume) / 100.0f) : 0;
 
             switch (channel->GetGroup())
             {
@@ -402,14 +399,14 @@ namespace OpenRCT2::Audio
                     break;
             }
 
-            int32_t startVolume = static_cast<int32_t>(channel->GetOldVolume() * volumeAdjust);
-            int32_t endVolume = static_cast<int32_t>(channel->GetVolume() * volumeAdjust);
+            int32_t startVolume = channel->GetOldVolume() * volumeAdjust;
+            int32_t endVolume = channel->GetVolume() * volumeAdjust;
             if (channel->IsStopping())
             {
                 endVolume = 0;
             }
 
-            int32_t mixVolume = static_cast<int32_t>(channel->GetVolume() * volumeAdjust);
+            int32_t mixVolume = channel->GetVolume() * volumeAdjust;
             if (startVolume != endVolume)
             {
                 // Set to max since we are adjusting the volume ourselves
@@ -432,7 +429,7 @@ namespace OpenRCT2::Audio
 
         static void EffectPanS16(const IAudioChannel* channel, int16_t* data, int32_t length)
         {
-            const float dt = 1.0f / (length * 2);
+            const float dt = 1.0f / static_cast<float>(length * 2);
             float volumeL = channel->GetOldVolumeL();
             float volumeR = channel->GetOldVolumeR();
             const float d_left = dt * (channel->GetVolumeL() - channel->GetOldVolumeL());
@@ -440,8 +437,8 @@ namespace OpenRCT2::Audio
 
             for (int32_t i = 0; i < length * 2; i += 2)
             {
-                data[i] = static_cast<int16_t>(data[i] * volumeL);
-                data[i + 1] = static_cast<int16_t>(data[i + 1] * volumeR);
+                data[i] = static_cast<float>(data[i]) * volumeL;
+                data[i + 1] = static_cast<float>(data[i + 1]) * volumeR;
                 volumeL += d_left;
                 volumeR += d_right;
             }
@@ -456,7 +453,7 @@ namespace OpenRCT2::Audio
 
             for (int32_t i = 0; i < length * 2; i += 2)
             {
-                float t = static_cast<float>(i) / (length * 2);
+                float t = static_cast<float>(i) / static_cast<float>(length * 2);
                 data[i] = static_cast<uint8_t>(data[i] * ((1.0 - t) * oldVolumeL + t * volumeL));
                 data[i + 1] = static_cast<uint8_t>(data[i + 1] * ((1.0 - t) * oldVolumeR + t * volumeR));
             }
@@ -470,8 +467,8 @@ namespace OpenRCT2::Audio
             float endvolume_f = static_cast<float>(endvolume) / SDL_MIX_MAXVOLUME;
             for (int32_t i = 0; i < length; i++)
             {
-                float t = static_cast<float>(i) / length;
-                data[i] = static_cast<int16_t>(data[i] * ((1 - t) * startvolume_f + t * endvolume_f));
+                float t = (float)i / length;
+                data[i] = static_cast<float>(data[i]) * ((1 - t) * startvolume_f + t * endvolume_f);
             }
         }
 
@@ -484,7 +481,7 @@ namespace OpenRCT2::Audio
             for (int32_t i = 0; i < length; i++)
             {
                 float t = static_cast<float>(i) / length;
-                data[i] = static_cast<uint8_t>(data[i] * ((1 - t) * startvolume_f + t * endvolume_f));
+                data[i] = static_cast<float>(data[i]) * ((1 - t) * startvolume_f + t * endvolume_f);
             }
         }
 

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -381,7 +381,8 @@ namespace OpenRCT2::Audio
         int32_t ApplyVolume(const IAudioChannel* channel, void* buffer, size_t len)
         {
             float volumeAdjust = _volume;
-            volumeAdjust *= gConfigSound.master_sound_enabled ? (static_cast<float>(gConfigSound.master_volume) / 100.0f) : 0.0f;
+            volumeAdjust *= gConfigSound.master_sound_enabled ? (static_cast<float>(gConfigSound.master_volume) / 100.0f)
+                                                              : 0.0f;
 
             switch (channel->GetGroup())
             {

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -35,12 +35,9 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
-        [[nodiscard]] uint64_t GetLength() const override
-        {
-            return _dataLength;
-        }
+        [[nodiscard]] uint64_t GetLength() const override { return _dataLength; }
 
-        [[nodiscard]] AudioFormat GetFormat() const override
+            [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -35,6 +35,12 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
+        [[nodiscard]] uint64_t GetLength() const override
+        {
+            return _dataLength;
+        }
+
+        [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -30,17 +30,17 @@ namespace OpenRCT2::Audio
         uint64_t _dataLength = 0;
 
     public:
-        ~FileAudioSource()
+        ~FileAudioSource() override
         {
             Unload();
         }
 
-        uint64_t GetLength() const override
+        [[nodiscard]] uint64_t GetLength() const override
         {
             return _dataLength;
         }
 
-        AudioFormat GetFormat() const override
+        [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }
@@ -107,7 +107,7 @@ namespace OpenRCT2::Audio
 
             uint64_t chunkStart = SDL_RWtell(rw);
 
-            WaveFormat waveFormat;
+            WaveFormat waveFormat{};
             SDL_RWread(rw, &waveFormat, sizeof(waveFormat), 1);
             SDL_RWseek(rw, chunkStart + fmtChunkSize, RW_SEEK_SET);
             if (waveFormat.encoding != pcmformat)
@@ -144,7 +144,7 @@ namespace OpenRCT2::Audio
         }
 
     private:
-        uint32_t FindChunk(SDL_RWops* rw, uint32_t wantedId)
+        static uint32_t FindChunk(SDL_RWops* rw, uint32_t wantedId)
         {
             uint32_t subchunkId = SDL_ReadLE32(rw);
             uint32_t subchunkSize = SDL_ReadLE32(rw);

--- a/src/openrct2-ui/audio/FileAudioSource.cpp
+++ b/src/openrct2-ui/audio/FileAudioSource.cpp
@@ -35,9 +35,6 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
-        [[nodiscard]] uint64_t GetLength() const override { return _dataLength; }
-
-            [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -41,12 +41,9 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
-        [[nodiscard]] uint64_t GetLength() const override
-        {
-            return _length;
-        }
+        [[nodiscard]] uint64_t GetLength() const override { return _length; }
 
-        [[nodiscard]] AudioFormat GetFormat() const override
+            [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -41,9 +41,12 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
-        [[nodiscard]] uint64_t GetLength() const override { return _length; }
+        [[nodiscard]] uint64_t GetLength() const override
+        {
+            return _length;
+        }
 
-            [[nodiscard]] AudioFormat GetFormat() const override
+        [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -12,7 +12,6 @@
 
 #include <SDL.h>
 #include <algorithm>
-#include <openrct2/audio/AudioMixer.h>
 #include <openrct2/audio/AudioSource.h>
 #include <openrct2/common.h>
 #include <vector>
@@ -37,7 +36,7 @@ namespace OpenRCT2::Audio
         }
 
     public:
-        ~MemoryAudioSource()
+        ~MemoryAudioSource() override
         {
             Unload();
         }
@@ -126,7 +125,7 @@ namespace OpenRCT2::Audio
                     SDL_RWread(rw, &pcmSize, sizeof(pcmSize), 1);
                     _length = pcmSize;
 
-                    WaveFormatEx waveFormat;
+                    WaveFormatEx waveFormat{};
                     SDL_RWread(rw, &waveFormat, sizeof(waveFormat), 1);
                     _format.freq = waveFormat.frequency;
                     _format.format = AUDIO_S16LSB;


### PR DESCRIPTION
- use appropriate static casts
- use appropriate dynamic cast
- remove unused headers
- mark 'pure' getters as 'nodiscard'
- remove redundant virtual
- mark override
- default initialize some structs