### PR TITLE
Cleanup OpenGL code and fix HiDpi OpenGL window size

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyPaletteShader.h
@@ -28,7 +28,7 @@ public:
     ApplyPaletteShader();
     ~ApplyPaletteShader() override;
 
-    void SetTexture(GLuint texture);
+    static void SetTexture(GLuint texture);
     void SetPalette(const vec4* glPalette);
 
     void Draw();

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.h
@@ -31,7 +31,8 @@ public:
     ApplyTransparencyShader();
     ~ApplyTransparencyShader() override;
 
-    void SetTextures(GLuint opaqueTex, GLuint opaqueDepth, GLuint transparentTex, GLuint transparentDepth, GLuint paletteTex);
+    static void SetTextures(
+        GLuint opaqueTex, GLuint opaqueDepth, GLuint transparentTex, GLuint transparentDepth, GLuint paletteTex);
     void Draw();
 
 private:

--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -27,7 +27,7 @@ public:
         : _numInstances(0)
     {
     }
-    bool empty() const
+    [[nodiscard]] bool empty() const
     {
         return _numInstances == 0;
     }
@@ -51,7 +51,7 @@ public:
         }
         return _instances[_numInstances++] = value;
     }
-    size_t size() const
+    [[nodiscard]] size_t size() const
     {
         return _numInstances;
     }
@@ -114,9 +114,9 @@ struct DrawRectCommand
 
     enum
     {
-        FLAG_NO_TEXTURE = (1 << 2),
-        FLAG_MASK = (1 << 3),
-        FLAG_CROSS_HATCH = (1 << 4),
+        FLAG_NO_TEXTURE = (1U << 2U),
+        FLAG_MASK = (1U << 3U),
+        FLAG_CROSS_HATCH = (1U << 4U),
     };
 };
 

--- a/src/openrct2-ui/drawing/engines/opengl/DrawRectShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawRectShader.h
@@ -14,7 +14,6 @@
 #include "OpenGLShaderProgram.h"
 
 #include <SDL_pixels.h>
-#include <vector>
 
 class DrawRectShader final : public OpenGLShaderProgram
 {

--- a/src/openrct2-ui/drawing/engines/opengl/GLSLTypes.h
+++ b/src/openrct2-ui/drawing/engines/opengl/GLSLTypes.h
@@ -15,136 +15,98 @@
 
 #pragma pack(push, 1)
 
-struct ivec2
+namespace detail
 {
-    union
+    template<typename T_> struct vec2
     {
-        GLint x;
-        GLint s;
-        GLint r;
-    };
-    union
-    {
-        GLint y;
-        GLint t;
-        GLint g;
-    };
-};
+        using ValueType = T_;
 
-struct vec2
-{
-    union
-    {
-        GLfloat x;
-        GLfloat s;
-        GLfloat r;
+        union
+        {
+            ValueType x;
+            ValueType s;
+            ValueType r;
+        };
+        union
+        {
+            ValueType y;
+            ValueType t;
+            ValueType g;
+        };
     };
-    union
-    {
-        GLfloat y;
-        GLfloat t;
-        GLfloat g;
-    };
-};
 
-struct ivec3
-{
-    union
-    {
-        GLint x;
-        GLint s;
-        GLint r;
-    };
-    union
-    {
-        GLint y;
-        GLint t;
-        GLint g;
-    };
-    union
-    {
-        GLint z;
-        GLint p;
-        GLint b;
-    };
-};
+    template struct vec2<GLfloat>;
+    template struct vec2<GLint>;
 
-struct vec3f
-{
-    union
+    template<typename T_> struct vec3
     {
-        GLfloat x;
-        GLfloat s;
-        GLfloat r;
-    };
-    union
-    {
-        GLfloat y;
-        GLfloat t;
-        GLfloat g;
-    };
-    union
-    {
-        GLfloat z;
-        GLfloat p;
-        GLfloat b;
-    };
-};
+        using ValueType = T_;
 
-struct ivec4
-{
-    union
-    {
-        GLint x;
-        GLint s;
-        GLint r;
+        union
+        {
+            ValueType x;
+            ValueType s;
+            ValueType r;
+        };
+        union
+        {
+            ValueType y;
+            ValueType t;
+            ValueType g;
+        };
+        union
+        {
+            ValueType z;
+            ValueType p;
+            ValueType b;
+        };
     };
-    union
-    {
-        GLint y;
-        GLint t;
-        GLint g;
-    };
-    union
-    {
-        GLint z;
-        GLint p;
-        GLint b;
-    };
-    union
-    {
-        GLint w;
-        GLint q;
-        GLint a;
-    };
-};
 
-struct vec4
-{
-    union
+    template struct vec3<GLfloat>;
+    template struct vec3<GLint>;
+
+    template<typename T_> struct vec4
     {
-        GLfloat x;
-        GLfloat s;
-        GLfloat r;
+        using ValueType = T_;
+
+        union
+        {
+            ValueType x;
+            ValueType s;
+            ValueType r;
+        };
+        union
+        {
+            ValueType y;
+            ValueType t;
+            ValueType g;
+        };
+        union
+        {
+            ValueType z;
+            ValueType p;
+            ValueType b;
+        };
+        union
+        {
+            ValueType w;
+            ValueType q;
+            ValueType a;
+        };
     };
-    union
-    {
-        GLfloat y;
-        GLfloat t;
-        GLfloat g;
-    };
-    union
-    {
-        GLfloat z;
-        GLfloat p;
-        GLfloat b;
-    };
-    union
-    {
-        GLfloat w;
-        GLfloat q;
-        GLfloat a;
-    };
-};
+
+    template struct vec4<GLfloat>;
+    template struct vec4<GLint>;
+
+} // namespace detail
+
+using vec2 = detail::vec2<GLfloat>;
+using ivec2 = detail::vec2<GLint>;
+
+using vec3 = detail::vec3<GLfloat>;
+using ivec3 = detail::vec3<GLint>;
+
+using vec4 = detail::vec4<GLfloat>;
+using ivec4 = detail::vec4<GLint>;
 
 #pragma pack(pop)

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -65,7 +65,7 @@ BasicTextureInfo TextureCache::GetOrLoadImageTexture(uint32_t image)
 {
     uint32_t index;
 
-    image &= 0x7FFFF;
+    image &= 0x7FFFFUL;
 
     // Try to read cached texture first.
     {
@@ -97,7 +97,7 @@ BasicTextureInfo TextureCache::GetOrLoadImageTexture(uint32_t image)
 
 BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(uint32_t image, uint8_t* palette)
 {
-    GlyphId glyphId;
+    GlyphId glyphId{};
     glyphId.Image = image;
 
     // Try to read cached texture first.
@@ -203,7 +203,7 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
         }
 
         // Initial capacity will be 12 which covers most cases of a fully visible park.
-        _atlasesTextureCapacity = (_atlasesTextureCapacity + 6) << 1;
+        _atlasesTextureCapacity = (_atlasesTextureCapacity + 6) << 1UL;
     }
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
@@ -275,8 +275,8 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
         throw std::runtime_error("more texture atlases required, but device limit reached!");
     }
 
-    int32_t atlasIndex = (int32_t)_atlases.size();
-    int32_t atlasSize = (int32_t)powf(2, (float)Atlas::CalculateImageSizeOrder(imageWidth, imageHeight));
+    auto atlasIndex = static_cast<int32_t>(_atlases.size());
+    int32_t atlasSize = powf(2, (float)Atlas::CalculateImageSizeOrder(imageWidth, imageHeight));
 
 #    ifdef DEBUG
     log_verbose("new texture atlas #%d (size %d) allocated", atlasIndex, atlasSize);
@@ -294,7 +294,7 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
 
 rct_drawpixelinfo TextureCache::GetImageAsDPI(uint32_t image, uint32_t tertiaryColour)
 {
-    auto g1Element = gfx_get_g1_element(image & 0x7FFFF);
+    auto g1Element = gfx_get_g1_element(image & 0x7FFFFUL);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 
@@ -305,7 +305,7 @@ rct_drawpixelinfo TextureCache::GetImageAsDPI(uint32_t image, uint32_t tertiaryC
 
 rct_drawpixelinfo TextureCache::GetGlyphAsDPI(uint32_t image, uint8_t* palette)
 {
-    auto g1Element = gfx_get_g1_element(image & 0x7FFFF);
+    auto g1Element = gfx_get_g1_element(image & 0x7FFFFUL);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -35,8 +35,8 @@ struct GlyphId
         size_t operator()(const GlyphId& k) const
         {
             size_t hash = k.Image * 7;
-            hash += (k.Palette & 0xFFFFFFFF) * 13;
-            hash += (k.Palette >> 32) * 23;
+            hash += (k.Palette & 0xFFFFFFFFUL) * 13;
+            hash += (k.Palette >> 32UL) * 23;
             return hash;
         }
     };
@@ -111,14 +111,14 @@ public:
 
     AtlasTextureInfo Allocate(int32_t actualWidth, int32_t actualHeight)
     {
-        assert(_freeSlots.size() > 0);
+        assert(!_freeSlots.empty());
 
         GLuint slot = _freeSlots.back();
         _freeSlots.pop_back();
 
         auto bounds = GetSlotCoordinates(slot, actualWidth, actualHeight);
 
-        AtlasTextureInfo info;
+        AtlasTextureInfo info{};
         info.index = _index;
         info.slot = slot;
         info.bounds = bounds;
@@ -136,15 +136,15 @@ public:
 
     // Checks if specified image would be tightly packed in this atlas
     // by checking if it is within the right power of 2 range
-    bool IsImageSuitable(int32_t actualWidth, int32_t actualHeight) const
+    [[nodiscard]] bool IsImageSuitable(int32_t actualWidth, int32_t actualHeight) const
     {
         int32_t imageOrder = CalculateImageSizeOrder(actualWidth, actualHeight);
-        int32_t atlasOrder = (int32_t)log2(_imageSize);
+        int32_t atlasOrder = log2(_imageSize);
 
         return imageOrder == atlasOrder;
     }
 
-    int32_t GetFreeSlots() const
+    [[nodiscard]] int32_t GetFreeSlots() const
     {
         return (int32_t)_freeSlots.size();
     }
@@ -162,7 +162,7 @@ public:
     }
 
 private:
-    ivec4 GetSlotCoordinates(GLuint slot, int32_t actualWidth, int32_t actualHeight) const
+    [[nodiscard]] ivec4 GetSlotCoordinates(GLuint slot, int32_t actualWidth, int32_t actualHeight) const
     {
         int32_t row = slot / _cols;
         int32_t col = slot % _cols;
@@ -175,7 +175,7 @@ private:
         };
     }
 
-    vec4 NormalizeCoordinates(const ivec4& coords) const
+    [[nodiscard]] vec4 NormalizeCoordinates(const ivec4& coords) const
     {
         return vec4{
             coords.x / (float)_atlasWidth,
@@ -231,8 +231,8 @@ private:
     AtlasTextureInfo LoadImageTexture(uint32_t image);
     AtlasTextureInfo LoadGlyphTexture(uint32_t image, uint8_t* palette);
     AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
-    rct_drawpixelinfo GetImageAsDPI(uint32_t image, uint32_t tertiaryColour);
-    rct_drawpixelinfo GetGlyphAsDPI(uint32_t image, uint8_t* palette);
+    static rct_drawpixelinfo GetImageAsDPI(uint32_t image, uint32_t tertiaryColour);
+    static rct_drawpixelinfo GetGlyphAsDPI(uint32_t image, uint8_t* palette);
     void FreeTextures();
 
     static rct_drawpixelinfo CreateDPI(int32_t width, int32_t height);

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -98,7 +98,7 @@ void window_map_tooltip_update_visibility()
 
     if (_cursorHoldDuration < 25 || stringId == STR_NONE
         || input_test_place_object_modifier(
-               (PLACE_OBJECT_MODIFIER)(PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z))
+            (PLACE_OBJECT_MODIFIER)(PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z))
         || window_find_by_class(WC_ERROR) != nullptr)
     {
         window_close_by_class(WC_MAP_TOOLTIP);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2322,8 +2322,9 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     bool selectionShouldBeExpanded;
     int32_t rideTypeIterator, rideTypeIteratorMax;
     if (gCheatsShowVehiclesFromOtherTrackTypes
-        && !(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
-             || ride->type == RIDE_TYPE_MINI_GOLF))
+        && !(
+            ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
+            || ride->type == RIDE_TYPE_MINI_GOLF))
     {
         selectionShouldBeExpanded = true;
         rideTypeIterator = 0;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -869,8 +869,9 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_DOWN_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_UP) | (1ULL << WIDX_SLOPE_UP_STEEP);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(
+                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }
@@ -881,8 +882,9 @@ static void window_ride_construction_resize(rct_window* w)
         case TRACK_SLOPE_UP_60:
             disabledWidgets |= (1ULL << WIDX_SLOPE_DOWN_STEEP) | (1ULL << WIDX_SLOPE_DOWN);
             if (!is_track_enabled(TRACK_SLOPE_LONG)
-                && !(is_track_enabled(TRACK_SLOPE_STEEP_LONG)
-                     && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
+                && !(
+                    is_track_enabled(TRACK_SLOPE_STEEP_LONG)
+                    && !track_piece_direction_is_diagonal(_currentTrackPieceDirection)))
             {
                 disabledWidgets |= (1ULL << WIDX_LEVEL);
             }

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -239,8 +239,8 @@ private:
             : CREATE_CROSSING_MODE_PATH_OVER_TRACK;
         if (!entrancePath
             && !map_can_construct_with_clear_at(
-                   _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile, GetFlags(), &res->Cost,
-                   crossingMode))
+                _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile, GetFlags(), &res->Cost,
+                crossingMode))
         {
             return MakeResult(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_FOOTPATH_HERE, gGameCommandErrorText, gCommonFormatArgs);
         }
@@ -304,8 +304,8 @@ private:
             : CREATE_CROSSING_MODE_PATH_OVER_TRACK;
         if (!entrancePath
             && !map_can_construct_with_clear_at(
-                   _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile,
-                   GAME_COMMAND_FLAG_APPLY | GetFlags(), &res->Cost, crossingMode))
+                _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile,
+                GAME_COMMAND_FLAG_APPLY | GetFlags(), &res->Cost, crossingMode))
         {
             return MakeResult(GA_ERROR::NO_CLEARANCE, STR_CANT_BUILD_FOOTPATH_HERE, gGameCommandErrorText, gCommonFormatArgs);
         }

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
@@ -148,8 +148,8 @@ private:
             : CREATE_CROSSING_MODE_PATH_OVER_TRACK;
         if (!entrancePath
             && !map_can_construct_with_clear_at(
-                   _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile, GetFlags(), &res->Cost,
-                   crossingMode))
+                _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile, GetFlags(), &res->Cost,
+                crossingMode))
         {
             return MakeResult(
                 GA_ERROR::NO_CLEARANCE, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, gGameCommandErrorText,
@@ -216,8 +216,8 @@ private:
             : CREATE_CROSSING_MODE_PATH_OVER_TRACK;
         if (!entrancePath
             && !map_can_construct_with_clear_at(
-                   _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile,
-                   GAME_COMMAND_FLAG_APPLY | GetFlags(), &res->Cost, crossingMode))
+                _loc.x, _loc.y, zLow, zHigh, &map_place_non_scenery_clear_func, quarterTile,
+                GAME_COMMAND_FLAG_APPLY | GetFlags(), &res->Cost, crossingMode))
         {
             return MakeResult(
                 GA_ERROR::NO_CLEARANCE, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, gGameCommandErrorText,

--- a/src/openrct2/actions/RideSetVehiclesAction.hpp
+++ b/src/openrct2/actions/RideSetVehiclesAction.hpp
@@ -223,8 +223,9 @@ private:
         int32_t rideTypeIterator, rideTypeIteratorMax;
 
         if (gCheatsShowVehiclesFromOtherTrackTypes
-            && !(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
-                 || ride->type == RIDE_TYPE_MINI_GOLF))
+            && !(
+                ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_FLAT_RIDE) || ride->type == RIDE_TYPE_MAZE
+                || ride->type == RIDE_TYPE_MINI_GOLF))
         {
             selectionShouldBeExpanded = true;
             rideTypeIterator = 0;

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -79,11 +79,11 @@ private:
 public:
     explicit ObjectFileIndex(IObjectRepository& objectRepository, const IPlatformEnvironment& env)
         : FileIndex(
-              "object index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_OBJECTS), std::string(PATTERN),
-              std::vector<std::string>{
-                  env.GetDirectoryPath(DIRBASE::OPENRCT2, DIRID::OBJECT),
-                  env.GetDirectoryPath(DIRBASE::USER, DIRID::OBJECT),
-              })
+            "object index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_OBJECTS), std::string(PATTERN),
+            std::vector<std::string>{
+                env.GetDirectoryPath(DIRBASE::OPENRCT2, DIRID::OBJECT),
+                env.GetDirectoryPath(DIRBASE::USER, DIRID::OBJECT),
+            })
         , _objectRepository(objectRepository)
     {
     }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -874,8 +874,8 @@ static bool TrackDesignPlaceSceneryElementRemoveGhost(
             if (!(!scenery_small_entry_has_flag(small_scenery, SMALL_SCENERY_FLAG_FULL_TILE)
                   && scenery_small_entry_has_flag(small_scenery, SMALL_SCENERY_FLAG_DIAGONAL))
                 && scenery_small_entry_has_flag(
-                       small_scenery,
-                       SMALL_SCENERY_FLAG_DIAGONAL | SMALL_SCENERY_FLAG_HALF_SPACE | SMALL_SCENERY_FLAG_THREE_QUARTERS))
+                    small_scenery,
+                    SMALL_SCENERY_FLAG_DIAGONAL | SMALL_SCENERY_FLAG_HALF_SPACE | SMALL_SCENERY_FLAG_THREE_QUARTERS))
             {
                 quadrant = 0;
             }

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -63,12 +63,12 @@ private:
 public:
     explicit TrackDesignFileIndex(const IPlatformEnvironment& env)
         : FileIndex(
-              "track design index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_TRACKS), std::string(PATTERN),
-              std::vector<std::string>({
-                  env.GetDirectoryPath(DIRBASE::RCT1, DIRID::TRACK),
-                  env.GetDirectoryPath(DIRBASE::RCT2, DIRID::TRACK),
-                  env.GetDirectoryPath(DIRBASE::USER, DIRID::TRACK),
-              }))
+            "track design index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_TRACKS), std::string(PATTERN),
+            std::vector<std::string>({
+                env.GetDirectoryPath(DIRBASE::RCT1, DIRID::TRACK),
+                env.GetDirectoryPath(DIRBASE::RCT2, DIRID::TRACK),
+                env.GetDirectoryPath(DIRBASE::USER, DIRID::TRACK),
+            }))
     {
     }
 

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -133,12 +133,12 @@ private:
 public:
     explicit ScenarioFileIndex(const IPlatformEnvironment& env)
         : FileIndex(
-              "scenario index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_SCENARIOS), std::string(PATTERN),
-              std::vector<std::string>({
-                  env.GetDirectoryPath(DIRBASE::RCT1, DIRID::SCENARIO),
-                  env.GetDirectoryPath(DIRBASE::RCT2, DIRID::SCENARIO),
-                  env.GetDirectoryPath(DIRBASE::USER, DIRID::SCENARIO),
-              }))
+            "scenario index", MAGIC_NUMBER, VERSION, env.GetFilePath(PATHID::CACHE_SCENARIOS), std::string(PATTERN),
+            std::vector<std::string>({
+                env.GetDirectoryPath(DIRBASE::RCT1, DIRID::SCENARIO),
+                env.GetDirectoryPath(DIRBASE::RCT2, DIRID::SCENARIO),
+                env.GetDirectoryPath(DIRBASE::USER, DIRID::SCENARIO),
+            }))
     {
     }
 


### PR DESCRIPTION
This fixes an issue where the framebuffer size of the OpenGL engine was set incorrectly. 
Furthermore, this commit improves type safety and code-deduplication. 

![image](https://user-images.githubusercontent.com/675432/67158489-ebb90480-f338-11e9-9f57-8a7cf6dd5461.png)
