### PR TITLE
Remove comparison of ScreenCoords with MONEY32_UNDEFINED

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -120,7 +120,7 @@ void game_handle_input()
     {
         game_handle_input_mouse(screenCoords, state);
     }
-    else if (screenCoords.x != MONEY32_UNDEFINED)
+    else
     {
         int32_t screenWidth = context_get_width();
         int32_t screenHeight = context_get_height();


### PR DESCRIPTION
As per investigation on the related issue, it seems like it:
- Doesn't make sense comparing a coordinate with this define
- The `x` is never set as `MONEY32_UNDEFINED`

Thus, I just removed the if, as I'd say it is very likely that it fell into this else very frequently, since it only wouldn't if it was equal to `MONEY32_UNDEFINED`

Closes #10121 