### PR TITLE
Fix #10126: window movement inversed

### DIFF
--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -69,7 +69,7 @@ struct ScreenCoordsXY
 
     const ScreenCoordsXY operator-(const ScreenCoordsXY& rhs) const
     {
-        return { rhs.x - x, rhs.y - y };
+        return { x - rhs.x, y - rhs.y };
     }
 };
 


### PR DESCRIPTION
Closes #10126 

Fixes regression introduced by #10120 

My bad, I just copied the implementation of the `operator-` of `CoordsXY` and it was reversed, for some reason.