### PR TITLE
Fix CoordsXY sum and subtract operators

### DIFF
--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -105,12 +105,12 @@ struct CoordsXY
 
     const CoordsXY operator+(const CoordsXY& rhs) const
     {
-        return { rhs.x + x, rhs.y + y };
+        return { x + rhs.x, y + rhs.y };
     }
 
     const CoordsXY operator-(const CoordsXY& rhs) const
     {
-        return { rhs.x - x, rhs.y - y };
+        return { x - rhs.x, y - rhs.y };
     }
 
     CoordsXY Rotate(int32_t direction) const


### PR DESCRIPTION
I found this out when developing #10127 
Luckily, it doesn't make a difference for `operator+`, which was being used in a handful of places, and it does make a huge difference for `operator-`, which was not being used anywhere.