### PR TITLE
Fix desync in headless mode with rides that create smoke particles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,7 +30,8 @@
 - Fix: [#9994] Game action tick collision during server connect and map load.
 - Fix: [#10017] Ghost elements influencing ride excitement.
 - Fix: [#10036] Do not allocate large chunks of memory for save file classification.
-- Fix: [#10106]: Ride circuits should not be used for modes that do not support it.
+- Fix: [#10106] Ride circuits should not be used for modes that do not support it.
+- Fix: [#10149] Desync in headless mode with rides that create smoke particles.
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 - Improved: [#9987] Minimum load rounding.
 - Improved: [#10125] Better support for high DPI screens.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "21"
+#define NETWORK_STREAM_VERSION "22"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7399,6 +7399,11 @@ bool ride_has_adjacent_station(Ride* ride)
 bool ride_has_station_shelter(Ride* ride)
 {
     auto stationObj = ride_get_station_object(ride);
+    if (network_get_mode() != NETWORK_MODE_NONE)
+    {
+        // The server might run in headless mode so no images will be loaded, only check for stations.
+        return stationObj != nullptr;
+    }
     return stationObj != nullptr && stationObj->BaseImageId != 0;
 }
 


### PR DESCRIPTION
ride_has_station_shelter checked that BaseImageId != 0 but when the server runs in headless mode this is always 0 while on clients its non-zero. To compensate for network play it will only check if the station object exists.