### PR TITLE
Unconditionally deploy builds to transfer.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ matrix:
               export PUSH_BRANCH=master ;
               else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;
               fi
+            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-x86_64.tar.gz -o link && cat link && echo || echo "Failed transfer.sh upload"
             - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
               curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-linux-x86_64.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=9" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build";
-              else curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-x86_64.tar.gz -o link && cat link || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
               fi
         - os: linux
           name: Ubuntu i686 GCC Debug m32 no-build-shared-libs
@@ -71,9 +71,9 @@ matrix:
               export PUSH_BRANCH=master ;
               else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;
               fi
+            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-i686.tar.gz -o link && cat link && echo || echo "Failed transfer.sh upload"
             - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
               curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-linux-i686.tar.gz" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=4" --form "file=@openrct2-linux.tar.gz" "https://openrct2.org/altapi/?command=push-build";
-              else curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-linux.tar.gz https://transfer.sh/openrct2-linux-i686.tar.gz -o link && cat link || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
               fi
         - os: linux
           name: Ubuntu amd64 Clang
@@ -116,9 +116,9 @@ matrix:
               export PUSH_BRANCH=master ;
               else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;
               fi
+            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-macos.zip https://transfer.sh/openrct2-macos.zip -o link && cat link && echo || echo "Failed transfer.sh upload"
             - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
               curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-macos.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=3" --form "file=@openrct2-macos.zip" "https://openrct2.org/altapi/?command=push-build";
-              else curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-macos.zip https://transfer.sh/openrct2-macos.zip -o link && cat link || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
               fi
         - os: linux
           name: Android
@@ -164,8 +164,8 @@ matrix:
           after_success:
             # Only run Android jobs when triggered from cron or on tag, otherwise skip
             - if [[ "$OPENRCT2_ANDROID" != "true" ]] && [[ "z${TRAVIS_TAG}" == "z" ]] ; then exit 0 ; fi
-            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/arm/pr/app-arm-pr.apk https://transfer.sh/openrct2-android-arm.apk -o link && cat link || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
-            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/x86/pr/app-x86-pr.apk https://transfer.sh/openrct2-android-x86.apk -o link && cat link || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
+            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/arm/pr/app-arm-pr.apk https://transfer.sh/openrct2-android-arm.apk -o link && cat link && echo|| if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
+            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/x86/pr/app-x86-pr.apk https://transfer.sh/openrct2-android-x86.apk -o link && cat link && echo || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
             - if [[ "z${TRAVIS_TAG}" != "z" ]] ; then
               export PUSH_BRANCH=master ;
               else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;


### PR DESCRIPTION
We seem to be having trouble publishing our builds and they can get
lost. To address this at least partially, upload all the builds to
transfer.sh