### PR TITLE
Fix SDL_Texture double free

### DIFF
--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -62,14 +62,6 @@ public:
 
     ~HardwareDisplayDrawingEngine() override
     {
-        if (_screenTexture != nullptr)
-        {
-            SDL_DestroyTexture(_screenTexture);
-        }
-        if (_scaledScreenTexture != nullptr)
-        {
-            SDL_DestroyTexture(_scaledScreenTexture);
-        }
         SDL_FreeFormat(_screenTextureFormat);
         SDL_DestroyRenderer(_sdlRenderer);
     }
@@ -85,6 +77,8 @@ public:
         {
             _useVsync = vsync;
             SDL_DestroyRenderer(_sdlRenderer);
+            _screenTexture = nullptr;
+            _scaledScreenTexture = nullptr;
             Initialise();
             Resize(_uiContext->GetWidth(), _uiContext->GetHeight());
         }


### PR DESCRIPTION
Double freeing of SDL_Texture caused assertion failure when calling  HardwareDisplayDrawingEngine::SetVSync. According to SDL documentation, SDL_DestroyRenderer frees the associated textures.