### PR TITLE
Make Viewport::screen_to_map_pos() return coords

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1296,7 +1296,9 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, int32_t x,
             && mapCoords.y == windowTileInspectorToolMap.y)
         {
             return;
-        }
+         }
+    mapX = mapCoords.x;
+    mapY = mapCoords.y;
     }
 
     windowTileInspectorTileSelected = true;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1297,8 +1297,8 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, int32_t x,
         {
             return;
         }
-    mapX = mapCoords.x;
-    mapY = mapCoords.y;
+        mapX = mapCoords.x;
+        mapY = mapCoords.y;
     }
 
     windowTileInspectorTileSelected = true;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1296,7 +1296,7 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, int32_t x,
             && mapCoords.y == windowTileInspectorToolMap.y)
         {
             return;
-         }
+        }
     mapX = mapCoords.x;
     mapY = mapCoords.y;
     }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1234,7 +1234,9 @@ static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex wid
     // Even if Ctrl was pressed, fall back to normal selection when there was nothing under the cursor
     if (clickedElement == nullptr)
     {
-        screen_pos_to_map_pos(&mapX, &mapY, nullptr);
+        CoordsXY mapCoords = screen_pos_to_map_pos(mapX, mapY, nullptr);
+        mapX = mapCoords.x;
+        mapY = mapCoords.y;
     }
 
     if (mapX != LOCATION_NULL)
@@ -1282,15 +1284,16 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, int32_t x,
     // Even if Ctrl was pressed, fall back to normal selection when there was nothing under the cursor
     if (clickedElement == nullptr)
     {
-        screen_pos_to_map_pos(&mapX, &mapY, nullptr);
+        CoordsXY mapCoords = screen_pos_to_map_pos(mapX, mapY, nullptr);
 
-        if (mapX == LOCATION_NULL)
+        if (mapCoords.x == LOCATION_NULL)
         {
             return;
         }
 
         // Tile is already selected
-        if (windowTileInspectorTileSelected && mapX == windowTileInspectorToolMap.x && mapY == windowTileInspectorToolMap.y)
+        if (windowTileInspectorTileSelected && mapCoords.x == windowTileInspectorToolMap.x
+            && mapCoords.y == windowTileInspectorToolMap.y)
         {
             return;
         }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2088,8 +2088,8 @@ static void top_toolbar_tool_update_land(int16_t x, int16_t y)
     {
         int32_t selectionType;
         // Get selection type and map coordinates from mouse x,y position
-        mapTile = { x, y };
-        screen_pos_to_map_pos(&mapTile.x, &mapTile.y, &selectionType);
+        CoordsXY mapCoords = screen_pos_to_map_pos(x, y, &selectionType);
+        mapTile = { static_cast<int16_t>(mapCoords.x), static_cast<int16_t>(mapCoords.y) };
         screen_get_map_xy_side(x, y, &mapTile.x, &mapTile.y, &side);
 
         if (mapTile.x == LOCATION_NULL)

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -317,31 +317,27 @@ static void window_view_clipping_tool_update(rct_window* w, rct_widgetindex widg
         return;
     }
 
-    int16_t mapX = screenCoords.x;
-    int16_t mapY = screenCoords.y;
     int32_t direction;
-    screen_pos_to_map_pos(&mapX, &mapY, &direction);
-    if (mapX != LOCATION_NULL)
+    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords.x, screenCoords.y, &direction);
+    if (mapCoords.x != LOCATION_NULL)
     {
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
         map_invalidate_tile_full(gMapSelectPositionA.x, gMapSelectPositionA.y);
-        gMapSelectPositionA.x = gMapSelectPositionB.x = mapX;
-        gMapSelectPositionA.y = gMapSelectPositionB.y = mapY;
-        map_invalidate_tile_full(mapX, mapY);
+        gMapSelectPositionA.x = gMapSelectPositionB.x = mapCoords.x;
+        gMapSelectPositionA.y = gMapSelectPositionB.y = mapCoords.y;
+        map_invalidate_tile_full(mapCoords.x, mapCoords.y);
         gMapSelectType = MAP_SELECT_TYPE_FULL;
     }
 }
 
 static void window_view_clipping_tool_down(rct_window* w, rct_widgetindex widgetIndex, ScreenCoordsXY screenCoords)
 {
-    int16_t mapX = screenCoords.x;
-    int16_t mapY = screenCoords.y;
     int32_t direction;
-    screen_pos_to_map_pos(&mapX, &mapY, &direction);
-    if (mapX != LOCATION_NULL)
+    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords.x, screenCoords.y, &direction);
+    if (mapCoords.x != LOCATION_NULL)
     {
         _dragging = true;
-        _selectionStart = { mapX, mapY };
+        _selectionStart = { static_cast<int16_t>(mapCoords.x), static_cast<int16_t>(mapCoords.y) };
     }
 }
 
@@ -352,18 +348,16 @@ static void window_view_clipping_tool_drag(rct_window* w, rct_widgetindex widget
         return;
     }
 
-    int16_t mapX = screenCoords.x;
-    int16_t mapY = screenCoords.y;
     int32_t direction;
-    screen_pos_to_map_pos(&mapX, &mapY, &direction);
-    if (mapX != LOCATION_NULL)
+    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords.x, screenCoords.y, &direction);
+    if (mapCoords.x != LOCATION_NULL)
     {
         map_invalidate_selection_rect();
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-        gMapSelectPositionA.x = std::min(_selectionStart.x, mapX);
-        gMapSelectPositionB.x = std::max(_selectionStart.x, mapX);
-        gMapSelectPositionA.y = std::min(_selectionStart.y, mapY);
-        gMapSelectPositionB.y = std::max(_selectionStart.y, mapY);
+        gMapSelectPositionA.x = std::min(_selectionStart.x, static_cast<int16_t>(mapCoords.x));
+        gMapSelectPositionB.x = std::max(_selectionStart.x, static_cast<int16_t>(mapCoords.x));
+        gMapSelectPositionA.y = std::min(_selectionStart.y, static_cast<int16_t>(mapCoords.y));
+        gMapSelectPositionB.y = std::max(_selectionStart.y, static_cast<int16_t>(mapCoords.y));
         gMapSelectType = MAP_SELECT_TYPE_FULL;
         map_invalidate_selection_rect();
     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -997,23 +997,27 @@ static void viewport_paint_weather_gloom(rct_drawpixelinfo* dpi)
  *
  *  rct2: 0x0068958D
  */
-void screen_pos_to_map_pos(int16_t* x, int16_t* y, int32_t* direction)
+CoordsXY screen_pos_to_map_pos(int16_t x, int16_t y, int32_t* direction)
 {
-    screen_get_map_xy(*x, *y, x, y, nullptr);
-    if (*x == LOCATION_NULL)
-        return;
+    int16_t mapX = 0;
+    int16_t mapY = 0;
+    screen_get_map_xy(x, y, &mapX, &mapY, nullptr);
+    if (mapX == LOCATION_NULL)
+        return {};
+
+    CoordsXY mapCoords = {mapX, mapY};
 
     int32_t my_direction;
-    int32_t dist_from_centre_x = abs(*x % 32);
-    int32_t dist_from_centre_y = abs(*y % 32);
+    int32_t dist_from_centre_x = abs(mapCoords.x % 32);
+    int32_t dist_from_centre_y = abs(mapCoords.y % 32);
     if (dist_from_centre_x > 8 && dist_from_centre_x < 24 && dist_from_centre_y > 8 && dist_from_centre_y < 24)
     {
         my_direction = 4;
     }
     else
     {
-        int16_t mod_x = *x & 0x1F;
-        int16_t mod_y = *y & 0x1F;
+        int16_t mod_x = mapCoords.x & 0x1F;
+        int16_t mod_y = mapCoords.y & 0x1F;
         if (mod_x <= 16)
         {
             if (mod_y < 16)
@@ -1038,10 +1042,11 @@ void screen_pos_to_map_pos(int16_t* x, int16_t* y, int32_t* direction)
         }
     }
 
-    *x = *x & ~0x1F;
-    *y = *y & ~0x1F;
+    mapCoords.x = mapCoords.x & ~0x1F;
+    mapCoords.y = mapCoords.y & ~0x1F;
     if (direction != nullptr)
         *direction = my_direction;
+    return mapCoords;
 }
 
 LocationXY16 screen_coord_to_viewport_coord(rct_viewport* viewport, uint16_t x, uint16_t y)

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1005,7 +1005,7 @@ CoordsXY screen_pos_to_map_pos(int16_t x, int16_t y, int32_t* direction)
     if (mapX == LOCATION_NULL)
         return {};
 
-    CoordsXY mapCoords = {mapX, mapY};
+    CoordsXY mapCoords = { mapX, mapY };
 
     int32_t my_direction;
     int32_t dist_from_centre_x = abs(mapCoords.x % 32);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -141,7 +141,7 @@ void viewport_adjust_for_map_height(int16_t* x, int16_t* y, int16_t* z);
 
 LocationXY16 screen_coord_to_viewport_coord(rct_viewport* viewport, uint16_t x, uint16_t y);
 LocationXY16 viewport_coord_to_map_coord(int32_t x, int32_t y, int32_t z);
-void screen_pos_to_map_pos(int16_t* x, int16_t* y, int32_t* direction);
+CoordsXY screen_pos_to_map_pos(int16_t x, int16_t y, int32_t* direction);
 
 void show_gridlines();
 void hide_gridlines();


### PR DESCRIPTION
As proposed by @duncanspumpkin on #10131

> This is horrible. We should refactor this.
>
> mapX and mapY are CoordsXY values but you need to set them to screenCoords.x and screenCoords.y if clickedElement is nullptr below as screen_pos_to_map_pos is a horrible function that takes in screen coords and spits out coordsxy to the same variable.

Notes to future:
- Make `screen_get_map_xy_side` and `screen_get_map_xy` return `CoordsXY`.
- Make `screen_pos_to_map_pos`, `screen_get_map_xy_side` receive `ScreenCoordsXY`