### PR TITLE
Fix out of bounds access opening the in-game console at startup

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -127,7 +127,11 @@ void InGameConsole::HistoryAdd(const utf8* src)
 
 void InGameConsole::ScrollToEnd()
 {
-    _consoleScrollPos = std::max<int32_t>(0, (int32_t)_consoleLines.size() - GetNumVisibleLines());
+    const int32_t maxLines = GetNumVisibleLines();
+    if (maxLines == 0)
+        _consoleScrollPos = 0;
+    else
+        _consoleScrollPos = std::max<int32_t>(0, (int32_t)_consoleLines.size() - maxLines);
 }
 
 void InGameConsole::RefreshCaret()
@@ -349,6 +353,8 @@ int32_t InGameConsole::GetNumVisibleLines() const
 {
     const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
     const int32_t consoleHeight = _consoleBottom - _consoleTop;
+    if (consoleHeight == 0)
+        return 0;
     const int32_t drawableHeight = consoleHeight - 2 * lineHeight - 4; // input line, separator - padding
     return drawableHeight / lineHeight;
 }


### PR DESCRIPTION
The issue is that the values of _consoleBottom and _consoleTop would be zero leading to consoleHeight  being 0 leading to negative values. This PR handles this specific case where the console contains already some entries before the console fully initialized the UI.