### PR TITLE
ifdef-out WinNT 6.0+ APIs

### DIFF
--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -38,7 +38,7 @@
 static std::wstring SHGetPathFromIDListLongPath(LPCITEMIDLIST pidl)
 {
     std::wstring pszPath(MAX_PATH, 0);
-    while (!SHGetPathFromIDListEx(pidl, &pszPath[0], (DWORD)pszPath.size(), 0))
+    while (!SHGetPathFromIDListW(pidl, &pszPath[0]))
     {
         if (pszPath.size() >= SHRT_MAX)
         {

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -706,6 +706,7 @@ namespace String
     std::string ToUpper(const std::string_view& src)
     {
 #ifdef _WIN32
+#    if _WIN32_WINNT >= 0x0600
         auto srcW = ToWideChar(src);
 
         // Measure how long the destination needs to be
@@ -731,6 +732,10 @@ namespace String
         {
             return String::ToUtf8(dstW);
         }
+#    else
+        log_warning("String::ToUpper not supported");
+        return std::string(src);
+#    endif
 #else
         icu::UnicodeString str = icu::UnicodeString::fromUTF8(std::string(src));
         str.toUpper();

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -394,6 +394,7 @@ uint8_t platform_get_locale_temperature_format()
 
 uint8_t platform_get_locale_date_format()
 {
+#    if _WIN32_WINNT >= 0x0600
     // Retrieve short date format, eg "MM/dd/yyyy"
     wchar_t dateFormat[20];
     if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SSHORTDATE, dateFormat, (int)std::size(dateFormat)) == 0)
@@ -437,6 +438,7 @@ uint8_t platform_get_locale_date_format()
             return DATE_FORMAT_YEAR_MONTH_DAY;
         }
     }
+#    endif
 
     // Default fallback
     return DATE_FORMAT_DAY_MONTH_YEAR;
@@ -640,6 +642,7 @@ fail:
 
 static void windows_remove_file_association(const utf8* extension)
 {
+#    if _WIN32_WINNT >= 0x0600
     // [HKEY_CURRENT_USER\Software\Classes]
     HKEY hRootKey;
     if (RegOpenKeyW(HKEY_CURRENT_USER, SOFTWARE_CLASSES, &hRootKey) == ERROR_SUCCESS)
@@ -653,6 +656,7 @@ static void windows_remove_file_association(const utf8* extension)
 
         RegCloseKey(hRootKey);
     }
+#    endif
 }
 
 void platform_setup_file_associations()
@@ -693,6 +697,7 @@ void platform_remove_file_associations()
 
 bool platform_setup_uri_protocol()
 {
+#    if _WIN32_WINNT >= 0x0600
     log_verbose("Setting up URI protocol...");
 
     // [HKEY_CURRENT_USER\Software\Classes]
@@ -734,6 +739,7 @@ bool platform_setup_uri_protocol()
             }
         }
     }
+#    endif
 
     log_verbose("URI protocol setup failed");
     return false;


### PR DESCRIPTION
Occasionally I need to build a binary compatible with WinNT 5.1, e.g.
when testing out Wine or ReactOS. There are just a few minor changes
required to have a working build, but as they are not part of the
repository, I always end up doing them from scratch. I would like to
upstream them instead so I don't have to recreate them each time, even
if this is not the most common use case.