### PR TITLE
Fix #8585: Part of track missing on air powered vertical coaster (#8635)

### DIFF
--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -671,8 +671,9 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
 
                 paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
+                break;
             }
-            break;
+            [[fallthrough]];
         case 1:
         case 2:
         case 3:

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -658,16 +658,20 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
     switch (trackSequence)
     {
         case 0:
-            bbHeight = bbHeights12[trackSequence];
-            sub_98197C_rotated(session, direction, supportsImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
-            sub_98199C_rotated(session, direction, trackImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
+            // HACK this might be a mistake in original code
+            if (direction & 1)
+            {
+                bbHeight = bbHeights12[trackSequence];
+                sub_98197C_rotated(session, direction, supportsImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
+                sub_98199C_rotated(session, direction, trackImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
 
-            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-            paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
+                paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_6);
 
-            paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
-            paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
+                paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
+                paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
+            }
             break;
         case 1:
         case 2:


### PR DESCRIPTION
@deurklink as original reporter of #8585, can you please check?

This work addresses a possible regression found by testpaint and tracked in https://github.com/OpenRCT2/OpenRCT2/issues/10204