### PR TITLE
Fix desync because of ride status

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Fix: [#10036] Do not allocate large chunks of memory for save file classification.
 - Fix: [#10106] Ride circuits should not be used for modes that do not support it.
 - Fix: [#10149] Desync in headless mode with rides that create smoke particles.
+- Fix: [#10249] Desync because of ride crashes and simulation mode.
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 - Improved: [#9987] Minimum load rounding.
 - Improved: [#10125] Better support for high DPI screens.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2103,6 +2103,7 @@ void Ride::Update()
     // If ride is simulating but crashed, reset the vehicles
     if (status == RIDE_STATUS_SIMULATING && (lifecycle_flags & RIDE_LIFECYCLE_CRASHED))
     {
+        // We require this to execute right away during the simulation, always ignore network and queue.
         auto gameAction = RideSetStatusAction(id, RIDE_STATUS_SIMULATING);
         GameActions::ExecuteNested(&gameAction);
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -17,6 +17,7 @@
 #include "../OpenRCT2.h"
 #include "../actions/RideEntranceExitRemoveAction.hpp"
 #include "../actions/RideSetSetting.hpp"
+#include "../actions/RideSetStatus.hpp"
 #include "../actions/RideSetVehiclesAction.hpp"
 #include "../actions/TrackRemoveAction.hpp"
 #include "../audio/AudioMixer.h"
@@ -2102,7 +2103,8 @@ void Ride::Update()
     // If ride is simulating but crashed, reset the vehicles
     if (status == RIDE_STATUS_SIMULATING && (lifecycle_flags & RIDE_LIFECYCLE_CRASHED))
     {
-        ride_set_status(this, RIDE_STATUS_SIMULATING);
+        auto gameAction = RideSetStatusAction(id, RIDE_STATUS_SIMULATING);
+        GameActions::ExecuteNested(&gameAction);
     }
 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -13,6 +13,7 @@
 #include "../Editor.h"
 #include "../Game.h"
 #include "../OpenRCT2.h"
+#include "../actions/RideSetStatus.hpp"
 #include "../audio/AudioMixer.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
@@ -3528,7 +3529,8 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
-            ride_set_status(ride, RIDE_STATUS_CLOSED);
+            auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
+            GameActions::ExecuteNested(&gameAction);
         }
     }
 
@@ -5260,7 +5262,8 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
-            ride_set_status(ride, RIDE_STATUS_CLOSED);
+            auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
+            GameActions::ExecuteNested(&gameAction);
         }
     }
     ride->lifecycle_flags |= RIDE_LIFECYCLE_CRASHED;
@@ -5321,7 +5324,8 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
-            ride_set_status(ride, RIDE_STATUS_CLOSED);
+            auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
+            GameActions::ExecuteNested(&gameAction);
         }
     }
     ride->lifecycle_flags |= RIDE_LIFECYCLE_CRASHED;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3529,6 +3529,7 @@ static void vehicle_update_collision_setup(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
+            // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
             GameActions::ExecuteNested(&gameAction);
         }
@@ -5262,6 +5263,7 @@ static void vehicle_crash_on_land(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
+            // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
             GameActions::ExecuteNested(&gameAction);
         }
@@ -5324,6 +5326,7 @@ static void vehicle_crash_on_water(rct_vehicle* vehicle)
 
         if (ride->status != RIDE_STATUS_CLOSED)
         {
+            // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(ride->id, RIDE_STATUS_CLOSED);
             GameActions::ExecuteNested(&gameAction);
         }


### PR DESCRIPTION
ride_set_status requires a round trip, clients without permission to set the ride status would get an error whenever a vehicle crashes. Client and Server now use the nested variant during simulation, we expect it to be deterministic.