### PR TITLE
Refactor get_map_coordinates to enforce Coords struct

### DIFF
--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -122,7 +122,7 @@ static void window_title_command_editor_textinput(rct_window * w, rct_widgetinde
 static void scenario_select_callback(const utf8 * path);
 static int32_t get_command_info_index(int32_t index);
 static TITLE_COMMAND_ORDER get_command_info(int32_t index);
-static LocationXY16 get_location();
+static TileCoordsXY get_location();
 static uint8_t get_zoom();
 
 static rct_window_event_list window_title_command_editor_events = {
@@ -187,26 +187,25 @@ static TITLE_COMMAND_ORDER get_command_info(int32_t index)
     return _window_title_command_editor_orders[0];
 }
 
-static LocationXY16 get_location()
+static TileCoordsXY get_location()
 {
-    LocationXY16 mapCoord = {};
+    TileCoordsXY tileCoord = {};
     rct_window* w = window_get_main();
     if (w != nullptr)
     {
         int32_t interactionType;
         TileElement* tileElement;
-
+        CoordsXY mapCoord;
         get_map_coordinates_from_pos_window(
-            w, w->viewport->view_width / 2, w->viewport->view_height / 2, VIEWPORT_INTERACTION_MASK_TERRAIN, &mapCoord.x,
-            &mapCoord.y, &interactionType, &tileElement, nullptr);
+            w, { w->viewport->view_width / 2, w->viewport->view_height / 2 }, VIEWPORT_INTERACTION_MASK_TERRAIN, mapCoord,
+            &interactionType, &tileElement, nullptr);
         mapCoord.x -= 16;
-        mapCoord.x /= 32;
         mapCoord.y -= 16;
-        mapCoord.y /= 32;
-        mapCoord.x++;
-        mapCoord.y++;
+        tileCoord = TileCoordsXY{ mapCoord };
+        tileCoord.x++;
+        tileCoord.y++;
     }
-    return mapCoord;
+    return tileCoord;
 }
 
 static uint8_t get_zoom()
@@ -324,9 +323,9 @@ static void window_title_command_editor_mouseup(rct_window* w, rct_widgetindex w
         case WIDX_GET:
             if (command.Type == TITLE_SCRIPT_LOCATION)
             {
-                LocationXY16 mapCoord = get_location();
-                command.X = (uint8_t)mapCoord.x;
-                command.Y = (uint8_t)mapCoord.y;
+                auto tileCoord = get_location();
+                command.X = (uint8_t)tileCoord.x;
+                command.Y = (uint8_t)tileCoord.y;
                 snprintf(textbox1Buffer, BUF_SIZE, "%d", command.X);
                 snprintf(textbox2Buffer, BUF_SIZE, "%d", command.Y);
             }
@@ -463,9 +462,9 @@ static void window_title_command_editor_dropdown(rct_window* w, rct_widgetindex 
             {
                 case TITLE_SCRIPT_LOCATION:
                 {
-                    LocationXY16 mapCoord = get_location();
-                    command.X = (uint8_t)mapCoord.x;
-                    command.Y = (uint8_t)mapCoord.y;
+                    auto tileCoord = get_location();
+                    command.X = (uint8_t)tileCoord.x;
+                    command.Y = (uint8_t)tileCoord.y;
                     snprintf(textbox1Buffer, BUF_SIZE, "%d", command.X);
                     snprintf(textbox2Buffer, BUF_SIZE, "%d", command.Y);
                     break;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1626,21 +1626,20 @@ static InteractionInfo set_interaction_info_from_paint_session(paint_session* se
  * viewport: edi
  */
 void get_map_coordinates_from_pos(
+    ScreenCoordsXY screenCoords, int32_t flags, CoordsXY& mapCoords, int32_t* interactionType, TileElement** tileElement,
+    rct_viewport** viewport)
+{
+    rct_window* window = window_find_from_point(screenCoords);
+    get_map_coordinates_from_pos_window(window, screenCoords, flags, mapCoords, interactionType, tileElement, viewport);
+}
+
+void get_map_coordinates_from_pos(
     int32_t screenX, int32_t screenY, int32_t flags, int16_t* x, int16_t* y, int32_t* interactionType,
     TileElement** tileElement, rct_viewport** viewport)
 {
-    rct_window* window = window_find_from_point(ScreenCoordsXY(screenX, screenY));
-    get_map_coordinates_from_pos_window(window, screenX, screenY, flags, x, y, interactionType, tileElement, viewport);
-}
-
-void get_map_coordinates_from_pos_window(
-    rct_window* window, int32_t screenX, int32_t screenY, int32_t flags, int16_t* x, int16_t* y, int32_t* interactionType,
-    TileElement** tileElement, rct_viewport** viewport)
-{
-    ScreenCoordsXY screenCoords(screenX, screenY);
+    ScreenCoordsXY screenCoords{ screenX, screenY };
     CoordsXY mapCoords;
-
-    get_map_coordinates_from_pos_window(window, screenCoords, flags, mapCoords, interactionType, tileElement, viewport);
+    get_map_coordinates_from_pos(screenCoords, flags, mapCoords, interactionType, tileElement, viewport);
 
     if (x != nullptr)
         *x = mapCoords.x;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -154,9 +154,9 @@ void viewport_set_visibility(uint8_t mode);
 void get_map_coordinates_from_pos(
     int32_t screenX, int32_t screenY, int32_t flags, int16_t* x, int16_t* y, int32_t* interactionType,
     TileElement** tileElement, rct_viewport** viewport);
-void get_map_coordinates_from_pos_window(
-    rct_window* window, int32_t screenX, int32_t screenY, int32_t flags, int16_t* x, int16_t* y, int32_t* interactionType,
-    TileElement** tileElement, rct_viewport** viewport);
+void get_map_coordinates_from_pos(
+    ScreenCoordsXY screenCoords, int32_t flags, CoordsXY& mapCoords, int32_t* interactionType, TileElement** tileElement,
+    rct_viewport** viewport);
 void get_map_coordinates_from_pos_window(
     rct_window* window, ScreenCoordsXY screenCoords, int32_t flags, CoordsXY& mapCoords, int32_t* interactionType,
     TileElement** tileElement, rct_viewport** viewport);


### PR DESCRIPTION
Little bit of tidying up. Removed the overload on `get_map_coordinates_from_pos_window` refactored all uses to use the Coords structs. Added an overload to `get_map_coordinates_from_pos` to use Coords struct. Will slowly move code to use that struct.