### PR TITLE
Use ScreenCoordsXY for windows/Map

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -658,7 +658,7 @@ static Peep* viewport_interaction_get_closest_peep(int32_t x, int32_t y, int32_t
  *
  *  rct2: 0x0068A15E
  */
-void sub_68A15E(int32_t screenX, int32_t screenY, int16_t* x, int16_t* y)
+CoordsXY sub_68A15E(ScreenCoordsXY screenCoords)
 {
     int16_t mapX, mapY;
     CoordsXY initialPos{};
@@ -666,15 +666,15 @@ void sub_68A15E(int32_t screenX, int32_t screenY, int16_t* x, int16_t* y)
     TileElement* tileElement;
     rct_viewport* viewport;
     get_map_coordinates_from_pos(
-        screenX, screenY, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER, &mapX, &mapY, &interactionType,
-        &tileElement, &viewport);
+        screenCoords.x, screenCoords.y, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER, &mapX, &mapY,
+        &interactionType, &tileElement, &viewport);
     initialPos.x = mapX;
     initialPos.y = mapY;
 
     if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE)
     {
-        *x = LOCATION_NULL;
-        return;
+        initialPos.x = LOCATION_NULL;
+        return initialPos;
     }
 
     int16_t waterHeight = 0;
@@ -683,7 +683,7 @@ void sub_68A15E(int32_t screenX, int32_t screenY, int16_t* x, int16_t* y)
         waterHeight = tileElement->AsSurface()->GetWaterHeight() << 4;
     }
 
-    LocationXY16 initialVPPos = screen_coord_to_viewport_coord(viewport, { screenX, screenY });
+    LocationXY16 initialVPPos = screen_coord_to_viewport_coord(viewport, screenCoords);
     CoordsXY mapPos = initialPos + CoordsXY{ 16, 16 };
 
     for (int32_t i = 0; i < 5; i++)
@@ -698,6 +698,5 @@ void sub_68A15E(int32_t screenX, int32_t screenY, int16_t* x, int16_t* y)
         mapPos.y = std::clamp(mapPos.y, initialPos.y, initialPos.y + 31);
     }
 
-    *x = mapPos.x & ~0x1F;
-    *y = mapPos.y & ~0x1F;
+    return { mapPos.x & ~0x1F, mapPos.y & ~0x1F };
 }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1203,10 +1203,10 @@ static CoordsXYZD place_park_entrance_get_map_position(ScreenCoordsXY screenCoor
         parkEntranceMapPosition.z = surfaceElement->base_height * 8;
         if ((surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) != 0)
         {
-            parkEntranceMapPosition.z++;
+            parkEntranceMapPosition.z += 16;
             if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT)
             {
-                parkEntranceMapPosition.z++;
+                parkEntranceMapPosition.z += 16;
             }
         }
     }
@@ -1228,7 +1228,7 @@ static void window_map_place_park_entrance_tool_update(ScreenCoordsXY screenCoor
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     CoordsXYZD parkEntrancePosition = place_park_entrance_get_map_position(screenCoords);
-    if (parkEntrancePosition.x == -1)
+    if (parkEntrancePosition.x == LOCATION_NULL)
     {
         park_entrance_remove_ghost();
         return;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2176,7 +2176,9 @@ static bool ride_get_place_position_from_screen_position(int32_t screenX, int32_
 
     if (!_trackPlaceCtrlState)
     {
-        sub_68A15E(screenX, screenY, &mapX, &mapY);
+        const CoordsXY mapCoords = sub_68A15E({ screenX, screenY });
+        mapX = mapCoords.x;
+        mapY = mapCoords.y;
         if (mapX == LOCATION_NULL)
             return false;
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1585,7 +1585,9 @@ static void sub_6E1F34(
             // If CTRL not pressed
             if (!gSceneryCtrlPressed)
             {
-                sub_68A15E(x, y, grid_x, grid_y);
+                const CoordsXY mapCoords = sub_68A15E({ x, y });
+                *grid_x = mapCoords.x;
+                *grid_y = mapCoords.y;
 
                 if (*grid_x == LOCATION_NULL)
                     return;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -168,7 +168,7 @@ int32_t viewport_interaction_get_item_right(int32_t x, int32_t y, viewport_inter
 int32_t viewport_interaction_right_over(int32_t x, int32_t y);
 int32_t viewport_interaction_right_click(int32_t x, int32_t y);
 
-void sub_68A15E(int32_t screenX, int32_t screenY, int16_t* x, int16_t* y);
+CoordsXY sub_68A15E(ScreenCoordsXY screenCoords);
 void sub_68B2B7(paint_session* session, int32_t x, int32_t y);
 
 void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom);


### PR DESCRIPTION
- Refactor `place_park_entrance_get_map_position()` to receive `ScreenCoordsXY` and return `CoordsXYZD`
- Refactor `sub_68A15E()` to receive `ScreenCoordsXY` and return `CoordsXY`. Some of its usage are narrowing the result on purpose, as same variable is used for contexts where `int16_t` is still a hard requirement.