### PR TITLE
Fix #10256: Desync because advancing ahead of server ticks during map change.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#10106] Ride circuits should not be used for modes that do not support it.
 - Fix: [#10149] Desync in headless mode with rides that create smoke particles.
 - Fix: [#10249] Desync because of ride crashes and simulation mode.
+- Fix: [#10256] Desync because of advancing ahead of server ticks during map change.
 - Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
 - Improved: [#9987] Minimum load rounding.
 - Improved: [#10125] Better support for high DPI screens.

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -245,6 +245,12 @@ void GameState::UpdateLogic()
     }
     else if (network_get_mode() == NETWORK_MODE_CLIENT)
     {
+        // Don't run past the server, this condition can happen during map changes.
+        if (network_get_server_tick() == gCurrentTicks)
+        {
+            return;
+        }
+
         // Check desync.
         bool desynced = network_check_desynchronisation();
         if (desynced)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
The reason the assert triggers and why people instantly desync during connect is because the map load assigns gCurrentTicks to the tick saved in the sv6 sent from the server, however network_update is called during UpdateLogic and would increment gCurrentTicks, now if the server is paused we would be ahead 1 tick already, now if the server sends the unpause action it would be the same tick to when the server was paused which is 1 tick behind the client tick. This also caused the game to sometimes advance even 10 ticks ahead because it would calculate server_get_tick() - gCurrentTick resulting in an underflow which is then clamped to max 10 updates.