### PR TITLE
Fix #10228: Can't import RCT1 Deluxe from Steam

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.2.4+ (in development)
 ------------------------------------------------------------------------
 - Change: [#1164] Use available translations for shortcut key bindings.
+- Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -123,7 +123,7 @@ bool platform_original_game_data_exists(const utf8* path)
 bool platform_original_rct1_data_exists(const utf8* path)
 {
     char buffer[MAX_PATH], checkPath1[MAX_PATH], checkPath2[MAX_PATH];
-    safe_strcpy(buffer, path, sizeof(path));
+    safe_strcpy(buffer, path, MAX_PATH);
     safe_strcat_path(buffer, "Data", MAX_PATH);
     safe_strcpy(checkPath1, buffer, MAX_PATH);
     safe_strcpy(checkPath2, buffer, MAX_PATH);


### PR DESCRIPTION
Use size of buffer rather than the size of a pointer which would always return 4 or 8 for the buffer size.