### PR TITLE
Prototype OSSpecific

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -701,11 +701,7 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
     safe_strcpy(ch, _shortenedDirectory, sizeof(buffer) - (ch - buffer));
 
     // Draw path text
-#ifdef __APPLE__
-    set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(buffer));
-#else
-    set_format_arg(0, uintptr_t, (uintptr_t)buffer);
-#endif
+    set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(buffer));
     gfx_draw_string_left_clipped(dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + 4, w->y + 20, w->width - 8);
 
     // Name button text

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -32,6 +32,7 @@
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/localisation/LocalisationService.h>
 #include <openrct2/network/network.h>
+#include <openrct2/platform/Platform2.h>
 #include <openrct2/platform/platform.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/sprites.h>
@@ -2114,11 +2115,7 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, &autosavesToKeep, w->colours[1],
                 w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
-#ifdef __APPLE__
-            set_format_arg(0, uintptr_t, (uintptr_t)macos_str_decomp_to_precomp(gConfigGeneral.rct1_path));
-#else
-            set_format_arg(0, uintptr_t, (uintptr_t)gConfigGeneral.rct1_path);
-#endif
+            set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
 
             rct_widget pathWidget = window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON];
 

--- a/src/openrct2/cmdline/CommandLine.cpp
+++ b/src/openrct2/cmdline/CommandLine.cpp
@@ -12,6 +12,7 @@
 #include "../OpenRCT2.h"
 #include "../core/Console.hpp"
 #include "../core/String.hpp"
+#include "../platform/Platform2.h"
 
 #include <algorithm>
 #include <cstring>
@@ -507,17 +508,7 @@ namespace CommandLine
 
     static bool HandleSpecialArgument([[maybe_unused]] const char* argument)
     {
-#ifdef __APPLE__
-        if (String::Equals(argument, "-NSDocumentRevisionsDebugMode"))
-        {
-            return true;
-        }
-        if (String::StartsWith(argument, "-psn_"))
-        {
-            return true;
-        }
-#endif
-        return false;
+        return Platform::HandleSpecialCommandLineArgument(argument);
     }
 
     const CommandLineOptionDefinition* FindOption(const CommandLineOptionDefinition* options, char shortName)

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -44,6 +44,16 @@ namespace Platform
         Guard::Assert(false, "GetCurrentExecutablePath() not implemented for Android.");
         return std::string();
     }
+
+    uintptr_t StrDecompToPrecomp(utf8* input)
+    {
+        return reinterpret_cast<uintptr_t>(input);
+    }
+
+    bool HandleSpecialCommandLineArgument(const char* argument)
+    {
+        return false;
+    }
 } // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -149,6 +149,16 @@ namespace Platform
 #    endif
         return exePath;
     }
+
+    uintptr_t StrDecompToPrecomp(utf8* input)
+    {
+        return reinterpret_cast<uintptr_t>(input);
+    }
+
+    bool HandleSpecialCommandLineArgument(const char* argument)
+    {
+        return false;
+    }
 } // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -315,6 +315,16 @@ namespace Platform
         } while (size >= wExePathCapacity);
         return String::ToUtf8(wExePath.get());
     }
+
+    uintptr_t StrDecompToPrecomp(utf8* input)
+    {
+        return reinterpret_cast<uintptr_t>(input);
+    }
+
+    bool HandleSpecialCommandLineArgument(const char* argument)
+    {
+        return false;
+    }
 } // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -11,6 +11,7 @@
 
 #    include "../OpenRCT2.h"
 #    include "../core/Path.hpp"
+#    include "../core/String.hpp"
 #    include "Platform2.h"
 
 // undefine `interface` and `abstract`, because it's causing conflicts with Objective-C's keywords
@@ -101,6 +102,33 @@ namespace Platform
             return std::string();
         }
     }
+
+    uintptr_t StrDecompToPrecomp(utf8* input)
+    {
+        @autoreleasepool {
+            if (input == NULL)
+            {
+                return NULL;
+            }
+
+            NSString* inputDecomp = [NSString stringWithUTF8String:input];
+            return reinterpret_cast<uintptr_t>(strdup([inputDecomp.precomposedStringWithCanonicalMapping cStringUsingEncoding:NSUTF8StringEncoding]));
+        }
+    }
+
+    bool HandleSpecialCommandLineArgument(const char* argument)
+    {
+        if (String::Equals(argument, "-NSDocumentRevisionsDebugMode"))
+        {
+            return true;
+        }
+        if (String::StartsWith(argument, "-psn_"))
+        {
+            return true;
+        }
+        return false;
+    }
+
 }
 
 #endif

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -46,4 +46,6 @@ namespace Platform
 #endif
 
     bool IsColourTerminalSupported();
+    bool HandleSpecialCommandLineArgument(const char* argument);
+    uintptr_t StrDecompToPrecomp(utf8* input);
 } // namespace Platform

--- a/src/openrct2/platform/macos.mm
+++ b/src/openrct2/platform/macos.mm
@@ -23,28 +23,6 @@
 #    include <mach-o/dyld.h>
 #    include <pwd.h>
 
-void macos_disallow_automatic_window_tabbing()
-{
-    @autoreleasepool {
-        if ([NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:)])
-        {
-            [NSWindow setAllowsAutomaticWindowTabbing:NO];
-        }
-    }
-}
-
-utf8* macos_str_decomp_to_precomp(utf8* input)
-{
-    @autoreleasepool {
-        if (input == NULL)
-        {
-            return NULL;
-        }
-
-        NSString* inputDecomp = [NSString stringWithUTF8String:input];
-        return strdup([inputDecomp.precomposedStringWithCanonicalMapping cStringUsingEncoding:NSUTF8StringEncoding]);
-    }
-}
 
 #    ifndef NO_TTF
 bool platform_get_font_path(TTFFontDescriptor* font, utf8* buffer, size_t size)

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -160,11 +160,6 @@ bool platform_setup_uri_protocol();
 __declspec(dllexport) int32_t StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int32_t nCmdShow);
 #endif // _WIN32
 
-#if defined(__APPLE__) && defined(__MACH__)
-void macos_disallow_automatic_window_tabbing();
-utf8* macos_str_decomp_to_precomp(utf8* input);
-#endif
-
 #ifdef __ANDROID__
 class AndroidClassLoader
 {


### PR DESCRIPTION
I once talked about OS specific things on https://github.com/OpenRCT2/OpenRCT2/pull/10198#pullrequestreview-313135711 and this is kind of what I was thinking about.

The idea is to remove the defines from the source code and move the implementation of OS specific stuff to their OS counterpart, like done here, so the actual implementation is agnostic to the OS and cleaner. I'm opening it here, as a PoC, for discussion.

(At the time, I didn't know there was `src/openrct2/platform`, hence why I did it in a separate folder/files. This could all be merged into `platform`)

---- Edit ----

This is the first part, I think it benefits from doing incrementally, just like all the other big projects, but my ultimate desire is that all places that branch out on ifdefs actually start calling something like `OSSpecific` and the code there is not ugly.

I removed these two specific `mac` calls to begin with.