### PR TITLE
Build versioned AppImages

### DIFF
--- a/scripts/linux/build-appimage.sh
+++ b/scripts/linux/build-appimage.sh
@@ -26,6 +26,8 @@ OLD_CWD=$(readlink -f .)
 
 pushd "$BUILD_DIR"
 
+export VERSION=$(cd "$REPO_ROOT" && git describe --tags)
+
 # standard linuxdeploy pattern
 #see https://docs.appimage.org/packaging-guide/from-source/index.html for more information
 cmake "$REPO_ROOT" -DCMAKE_INSTALL_PREFIX=/usr -G Ninja -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This tiny PR makes sure AppImages built by the build script contain a version number, both in the AppImage's filename as well as in the metadata (i.e., the desktop file embedded in the AppImage).

The script still works just fine as-is, by the way.