### PR TITLE
Support NetBSD and simplify platform ifdefs.

### DIFF
--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if (defined(__linux__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__EMSCRIPTEN__)) && !defined(__ANDROID__)
+#if (defined(__unix__) || defined(__EMSCRIPTEN__)) && !defined(__ANDROID__) && !defined(__APPLE__)
 
 #    include "UiContext.h"
 
@@ -393,4 +393,4 @@ namespace OpenRCT2::Ui
     }
 } // namespace OpenRCT2::Ui
 
-#endif // __linux__ || __OpenBSD__
+#endif // (defined(__unix__) || defined(__EMSCRIPTEN__)) && !defined(__ANDROID__) && !defined(__APPLE__)

--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -56,6 +56,9 @@
 #ifdef __FreeBSD__
 #    define OPENRCT2_PLATFORM "FreeBSD"
 #endif
+#ifdef __NetBSD__
+#    define OPENRCT2_PLATFORM "NetBSD"
+#endif
 #ifdef __ANDROID__
 #    define OPENRCT2_PLATFORM "Android"
 #endif

--- a/src/openrct2/platform/Linux.cpp
+++ b/src/openrct2/platform/Linux.cpp
@@ -11,7 +11,7 @@
 
 // Despite the name, this file contains support for more OSs besides Linux, provided the necessary ifdefs remain small.
 // Otherwise, they should be spun off into their own files.
-#if (defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && !defined(__ANDROID__)
+#if defined(__unix__) && !defined(__ANDROID__) && !defined(__APPLE__)
 
 #    ifdef __FreeBSD__
 #        include <sys/sysctl.h>

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -130,7 +130,11 @@ namespace Platform
             log_fatal("failed to read /proc/self/exe");
         }
 #    elif defined(__FreeBSD__) || defined(__NetBSD__)
+#        if defined(__FreeBSD__)
         const int32_t mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#        else
+        const int32_t mib[] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#        endif
         auto exeLen = sizeof(exePath);
         if (sysctl(mib, 4, exePath, &exeLen, nullptr, 0) == -1)
         {

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -7,16 +7,16 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__linux__) && !defined(__ANDROID__))
+#if defined(__unix__) && !defined(__ANDROID__) && !defined(__APPLE__)
 
 #    include <limits.h>
 #    include <pwd.h>
 #    include <vector>
-#    if defined(__FreeBSD__)
+#    if defined(__FreeBSD__) || defined(__NetBSD__)
 #        include <stddef.h>
 #        include <sys/param.h>
 #        include <sys/sysctl.h>
-#    endif // __FreeBSD__
+#    endif // __FreeBSD__ || __NetBSD__
 #    if defined(__linux__)
 // for PATH_MAX
 #        include <linux/limits.h>
@@ -129,7 +129,7 @@ namespace Platform
         {
             log_fatal("failed to read /proc/self/exe");
         }
-#    elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__) || defined(__NetBSD__)
         const int32_t mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
         auto exeLen = sizeof(exePath);
         if (sysctl(mib, 4, exePath, &exeLen, nullptr, 0) == -1)


### PR DESCRIPTION
For files intended to support unixy freedesktopy systems, reduce the ifdef down to `__unix__ && !__APPLE__ && !__ANDROID__`, rather than naming linux and all the BSDs and so on by hand.

Should simplify adding support for systems like illumos in the future.

NetBSD support depends on #10270