### PR TITLE
Fixed compilation errors with Visual Studio 2019 Preview 2.0

### DIFF
--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -10,8 +10,9 @@
 #pragma once
 
 #include "../common.h"
-#include <algorithm>
 #include "IStream.hpp"
+
+#include <algorithm>
 
 namespace MEMORY_ACCESS
 {

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include <algorithm>
 #include "IStream.hpp"
 
 namespace MEMORY_ACCESS


### PR DESCRIPTION
Fix errors where "std::max" was not recognized while compiling with the latest Visual Studio (2019 16.4.0 Preview 2.0) due to a missing "#include" statement.

![image](https://user-images.githubusercontent.com/44857895/69486367-e6a81300-0e18-11ea-90af-758b99d020dc.png)