### PR TITLE
Make floor2 and ceil2 constexpr functions

### DIFF
--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -59,14 +59,14 @@ constexpr bool is_power_of_2(int v)
 constexpr int floor2(const int x, const int y)
 {
     assert(is_power_of_2(y));
-    return ((x) & (~((y)-1)));
+    return x & ~(y - 1);
 }
 
 // Rounds an integer up to the given power of 2. y must be a power of 2.
 constexpr int ceil2(const int x, const int y)
 {
     assert(is_power_of_2(y));
-    return (((x) + (y)-1) & (~((y)-1)));
+    return (x + y - 1) & ~(y - 1);
 }
 
 // Gets the name of a symbol as a C string

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -50,11 +50,24 @@ const constexpr auto ror32 = ror<uint32_t>;
 const constexpr auto rol64 = rol<uint64_t>;
 const constexpr auto ror64 = ror<uint64_t>;
 
+constexpr bool is_power_of_2(int v)
+{
+    return v && ((v & (v - 1)) == 0);
+}
+
 // Rounds an integer down to the given power of 2. y must be a power of 2.
-#define floor2(x, y) ((x) & (~((y)-1)))
+constexpr int floor2(const int x, const int y)
+{
+    assert(is_power_of_2(y));
+    return ((x) & (~((y)-1)));
+}
 
 // Rounds an integer up to the given power of 2. y must be a power of 2.
-#define ceil2(x, y) (((x) + (y)-1) & (~((y)-1)))
+constexpr int ceil2(const int x, const int y)
+{
+    assert(is_power_of_2(y));
+    return (((x) + (y)-1) & (~((y)-1)));
+}
 
 // Gets the name of a symbol as a C string
 #define nameof(symbol) #symbol

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <stdexcept>
 
 using namespace Numerics;
 
@@ -58,14 +59,16 @@ constexpr bool is_power_of_2(int v)
 // Rounds an integer down to the given power of 2. y must be a power of 2.
 constexpr int floor2(const int x, const int y)
 {
-    assert(is_power_of_2(y));
+    if (!is_power_of_2(y))
+        throw std::logic_error("floor2 should only operate on power of 2");
     return x & ~(y - 1);
 }
 
 // Rounds an integer up to the given power of 2. y must be a power of 2.
 constexpr int ceil2(const int x, const int y)
 {
-    assert(is_power_of_2(y));
+    if (!is_power_of_2(y))
+        throw std::logic_error("ceil2 should only operate on power of 2");
     return (x + y - 1) & ~(y - 1);
 }
 


### PR DESCRIPTION
Based on the discussion here https://github.com/OpenRCT2/OpenRCT2/pull/10303#discussion_r352280292 , it seemed worth turning these functions into `constexpr` ones for improved readability and also because we can now guarantee users are sending in a power of two.