### PR TITLE
Make lights work for all rotations.

### DIFF
--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -210,9 +210,6 @@ void lightfx_prepare_light_list()
             continue;
         }
 
-        //  entry->x >>= _current_view_zoom_front;
-        //  entry->y >>= _current_view_zoom_front;
-
         uint32_t lightIntensityOccluded = 0x0;
 
         int32_t dirVecX = 707;
@@ -320,36 +317,6 @@ void lightfx_prepare_light_list()
                     mapCoord = info.Loc;
                     interactionType = info.SpriteType;
                     tileElement = info.Element;
-
-                    // RCT2_GLOBAL(0x9AC154, uint16_t) = VIEWPORT_INTERACTION_MASK_NONE;
-                    // RCT2_GLOBAL(0x9AC148, uint8_t) = 0;
-                    // RCT2_GLOBAL(0x9AC138 + 4, int16_t) = screenX;
-                    // RCT2_GLOBAL(0x9AC138 + 6, int16_t) = screenY;
-                    // if (screenX >= 0 && screenX < (int32_t)myviewport->width && screenY >= 0 && screenY <
-                    // (int32_t)myviewport->height)
-                    //{
-                    //  screenX <<= myviewport->zoom;
-                    //  screenY <<= myviewport->zoom;
-                    //  screenX += (int32_t)myviewport->view_x;
-                    //  screenY += (int32_t)myviewport->view_y;
-                    //  RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_ZOOM, uint16_t) = myviewport->zoom;
-                    //  screenX &= (0xFFFF << myviewport->zoom) & 0xFFFF;
-                    //  screenY &= (0xFFFF << myviewport->zoom) & 0xFFFF;
-                    //  RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_PAINT_X, int16_t) = screenX;
-                    //  RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_PAINT_Y, int16_t) = screenY;
-                    //  rct_drawpixelinfo* dpi = RCT2_ADDRESS(RCT2_ADDRESS_VIEWPORT_DPI, rct_drawpixelinfo);
-                    //  dpi->y = RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_PAINT_Y, int16_t);
-                    //  dpi->height = 1;
-                    //  dpi->zoom_level = RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_ZOOM, uint16_t);
-                    //  dpi->x = RCT2_GLOBAL(RCT2_ADDRESS_VIEWPORT_PAINT_X, int16_t);
-                    //  dpi->width = 1;
-                    //  RCT2_GLOBAL(0xEE7880, uint32_t) = 0xF1A4CC;
-                    //  RCT2_GLOBAL(0x140E9A8, rct_drawpixelinfo*) = dpi;
-                    //  painter_setup();
-                    //  viewport_paint_setup();
-                    //  paint_session_arrange(gPaintSession);
-                    //  sub_68862C();
-                    //}
                 }
 
                 int32_t minDist = 0;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -16,21 +16,18 @@
 #    include "../config/Config.h"
 #    include "../interface/Viewport.h"
 #    include "../interface/Window.h"
+#    include "../interface/Window_internal.h"
+#    include "../paint/Paint.h"
 #    include "../ride/Ride.h"
 #    include "../util/Util.h"
 #    include "../world/Climate.h"
 #    include "../world/Map.h"
 #    include "../world/Sprite.h"
 #    include "Drawing.h"
-#include "../paint/Paint.h"
-#include "../interface/Window_internal.h"
 
 #    include <algorithm>
 #    include <cmath>
 #    include <cstring>
-
-struct InteractionInfo;
-InteractionInfo set_interaction_info_from_paint_session(paint_session* session, uint16_t filter);
 
 static uint8_t _bakedLightTexture_lantern_0[32 * 32];
 static uint8_t _bakedLightTexture_lantern_1[64 * 64];
@@ -272,6 +269,7 @@ void lightfx_prepare_light_list()
         };
         // clang-format on
 
+        // Light occlusion code
         if (true)
         {
             int32_t totalSamplePoints = 5;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -293,10 +293,7 @@ void lightfx_prepare_light_list()
                 auto* w = window_get_main();
                 if (w != nullptr)
                 {
-                    //  get_map_coordinates_from_pos(entry->x + offsetPattern[pat*2] / mapFrontDiv, entry->y +
-                    //  offsetPattern[pat*2+1] / mapFrontDiv, VIEWPORT_INTERACTION_MASK_NONE, &mapCoord.x, &mapCoord.y,
-                    //  &interactionType, &tileElement, NULL);
-
+                    // based on get_map_coordinates_from_pos_window
                     rct_drawpixelinfo dpi;
                     dpi.x = entry->viewCoords.x + offsetPattern[0 + pat * 2] / mapFrontDiv;
                     dpi.y = entry->viewCoords.y + offsetPattern[1 + pat * 2] / mapFrontDiv;
@@ -313,6 +310,8 @@ void lightfx_prepare_light_list()
                     //  log_warning("[%i, %i]", dpi->x, dpi->y);
 
                     mapCoord = info.Loc;
+                    mapCoord.x += tileOffsetX;
+                    mapCoord.y += tileOffsetY;
                     interactionType = info.SpriteType;
                     tileElement = info.Element;
                 }

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -47,6 +47,7 @@ static uint32_t _lightPolution_front = 0;
 struct lightlist_entry
 {
     int16_t x, y, z;
+    ScreenCoordsXY viewCoords;
     uint8_t lightType;
     uint8_t lightIntensity;
     uint32_t lightID;
@@ -191,13 +192,8 @@ void lightfx_prepare_light_list()
                                /* .y = */ entry->y,
                                /* .z = */ entry->z };
 
-        auto screenCoords = translate_3d_to_2d_with_z(_current_view_rotation_front, coord_3d);
-
-        entry->x = screenCoords.x; // - (_current_view_x_front);
-        entry->y = screenCoords.y; // - (_current_view_y_front);
-
-        int32_t posOnScreenX = entry->x - _current_view_x_front;
-        int32_t posOnScreenY = entry->y - _current_view_y_front;
+        int32_t posOnScreenX = entry->viewCoords.x - _current_view_x_front;
+        int32_t posOnScreenY = entry->viewCoords.y - _current_view_y_front;
 
         posOnScreenX >>= _current_view_zoom_front;
         posOnScreenY >>= _current_view_zoom_front;
@@ -276,7 +272,7 @@ void lightfx_prepare_light_list()
         // clang-format on
 #    endif // LIGHTFX_UNKNOWN_PART_1
 
-        if (true)
+        if (false)
         {
             int32_t totalSamplePoints = 5;
             int32_t startSamplePoint = 1;
@@ -435,8 +431,8 @@ void lightfx_prepare_light_list()
 
             entry->lightIntensity = std::min<uint32_t>(
                 0xFF, (entry->lightIntensity * lightIntensityOccluded) / (totalSamplePoints * 100));
-            entry->lightIntensity = std::max<uint32_t>(0x00, entry->lightIntensity - _current_view_zoom_front * 5);
         }
+        entry->lightIntensity = std::max<uint32_t>(0x00, entry->lightIntensity - _current_view_zoom_front * 5);
 
         if (_current_view_zoom_front > 0)
         {
@@ -516,8 +512,8 @@ void lightfx_render_lights_to_frontbuffer()
 
         lightlist_entry* entry = &_LightListFront[light];
 
-        int32_t inRectCentreX = entry->x;
-        int32_t inRectCentreY = entry->y;
+        int32_t inRectCentreX = entry->viewCoords.x;
+        int32_t inRectCentreY = entry->viewCoords.y;
 
         if (entry->z != 0x7FFF)
         {
@@ -690,6 +686,7 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
         entry->x = x;
         entry->y = y;
         entry->z = z;
+        entry->viewCoords = translate_3d_to_2d_with_z(get_current_rotation(), { x, y, z });
         entry->lightType = lightType;
         entry->lightIntensity = 0xFF;
         entry->lightID = lightID;
@@ -704,6 +701,7 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
     entry->x = x;
     entry->y = y;
     entry->z = z;
+    entry->viewCoords = translate_3d_to_2d_with_z(get_current_rotation(), { x, y, z });
     entry->lightType = lightType;
     entry->lightIntensity = 0xFF;
     entry->lightID = lightID;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -54,21 +54,12 @@ paint_entry* gNextFreePaintStruct;
 uint8_t gCurrentRotation;
 
 static uint32_t _currentImageType;
-
-struct InteractionInfo
+InteractionInfo::InteractionInfo(const paint_struct* ps)
+    : Loc(ps->map_x, ps->map_y)
+    , Element(ps->tileElement)
+    , SpriteType(ps->sprite_type)
 {
-    InteractionInfo() = default;
-    InteractionInfo(const paint_struct* ps)
-        : Loc(ps->map_x, ps->map_y)
-        , Element(ps->tileElement)
-        , SpriteType(ps->sprite_type)
-    {
-    }
-    CoordsXY Loc;
-    TileElement* Element = nullptr;
-    uint8_t SpriteType;
-};
-
+}
 static void viewport_paint_weather_gloom(rct_drawpixelinfo* dpi);
 
 /**
@@ -1566,7 +1557,7 @@ static bool is_sprite_interacted_with(rct_drawpixelinfo* dpi, int32_t imageId, i
  *
  *  rct2: 0x0068862C
  */
-static InteractionInfo set_interaction_info_from_paint_session(paint_session* session, uint16_t filter)
+InteractionInfo set_interaction_info_from_paint_session(paint_session* session, uint16_t filter)
 {
     paint_struct* ps = &session->PaintHead;
     rct_drawpixelinfo* dpi = &session->DPI;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -168,6 +168,7 @@ void get_map_coordinates_from_pos_window(
     rct_window* window, ScreenCoordsXY screenCoords, int32_t flags, CoordsXY& mapCoords, int32_t* interactionType,
     TileElement** tileElement, rct_viewport** viewport);
 
+InteractionInfo set_interaction_info_from_paint_session(paint_session* session, uint16_t filter);
 int32_t viewport_interaction_get_item_left(ScreenCoordsXY screenCoords, viewport_interaction_info* info);
 int32_t viewport_interaction_left_over(ScreenCoordsXY screenCoords);
 int32_t viewport_interaction_left_click(ScreenCoordsXY screenCoords);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -98,6 +98,15 @@ struct viewport_interaction_info
     };
 };
 
+struct InteractionInfo
+{
+    InteractionInfo() = default;
+    InteractionInfo(const paint_struct* ps);
+    CoordsXY Loc;
+    TileElement* Element = nullptr;
+    uint8_t SpriteType;
+};
+
 #define MAX_VIEWPORT_COUNT WINDOW_LIMIT_MAX
 #define MAX_ZOOM_LEVEL 3
 


### PR DESCRIPTION
Mistake made with the coordinates confusing viewport and screen coordinates. In addition occlusion code that is depretiated was culling all lights in two rotations due to dead code.