### PR TITLE
Fix #10308: remove the last renmants of libsdl2-ttf references

### DIFF
--- a/dockerfiles/full/Dockerfile
+++ b/dockerfiles/full/Dockerfile
@@ -50,9 +50,8 @@ RUN yaourt -S --noconfirm mingw-w64-curl
 RUN yaourt -S --noconfirm mingw-w64-expat
 RUN yaourt -S --noconfirm mingw-w64-libdbus
 RUN yaourt -S --noconfirm mingw-w64-sdl2
-RUN yaourt -S --noconfirm mingw-w64-sdl2_ttf
 RUN yaourt -S --noconfirm wget unzip
-RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf
+RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2
 RUN yaourt -S --noconfirm lib32-speex
 #RUN git clone https://github.com/OpenRCT2/OpenRCT2
 #WORKDIR /tmp/OpenRCT2

--- a/dockerfiles/mingw-arch/Dockerfile
+++ b/dockerfiles/mingw-arch/Dockerfile
@@ -55,7 +55,6 @@ RUN pacman -S --noconfirm --noprogressbar \
         mingw-w64-openssl \
         mingw-w64-pkg-config \
         mingw-w64-sdl2 \
-        mingw-w64-sdl2_ttf \
         mingw-w64-tools \
         mingw-w64-winpthreads \
         mingw-w64-zlib \

--- a/dockerfiles/ubuntu_amd64/Dockerfile
+++ b/dockerfiles/ubuntu_amd64/Dockerfile
@@ -36,4 +36,4 @@ RUN \
 
 RUN apt-get -y upgrade
 # clang and gcc already installed
-RUN apt-get install --no-install-recommends -y ccache cmake libsdl2-dev libsdl2-ttf-dev pkg-config libjansson-dev libspeex-dev libspeexdsp-dev libcurl4-openssl-dev libcrypto++-dev libfontconfig1-dev libfreetype6-dev libpng-dev libzip-dev git libssl-dev ninja-build libicu-dev libgtest-dev
+RUN apt-get install --no-install-recommends -y ccache cmake libsdl2-dev pkg-config libjansson-dev libspeex-dev libspeexdsp-dev libcurl4-openssl-dev libcrypto++-dev libfontconfig1-dev libfreetype6-dev libpng-dev libzip-dev git libssl-dev ninja-build libicu-dev libgtest-dev

--- a/dockerfiles/ubuntu_i686/Dockerfile
+++ b/dockerfiles/ubuntu_i686/Dockerfile
@@ -6,4 +6,4 @@ RUN \
   update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 60
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt-get install --no-install-recommends -y ccache cmake curl ca-certificates libsdl2-dev:i386 libsdl2-ttf-dev:i386  pkg-config:i386  libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 libfontconfig1-dev:i386 libfreetype6-dev:i386 libpng-dev:i386 libzip-dev:i386 libssl-dev:i386 ninja-build libicu-dev:i386
+RUN apt-get install --no-install-recommends -y ccache cmake curl ca-certificates libsdl2-dev:i386 pkg-config:i386  libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 libfontconfig1-dev:i386 libfreetype6-dev:i386 libpng-dev:i386 libzip-dev:i386 libssl-dev:i386 ninja-build libicu-dev:i386

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -94,7 +94,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 		brew install wine
 		mac_os_install_mingw_32
 	else
-		brew install jansson sdl2 sdl2_ttf speex --universal
+		brew install jansson sdl2 speex --universal
 	fi
 elif [[ $(uname) == "Linux" ]]; then
 	# Clone discord-rpc for Discord's Rich Presence support


### PR DESCRIPTION
As per #5702, SDL2_ttf dependency is completely eliminated from
OpenRCT2. However, there are still references to it, which are
redundant and misleading. Clean up the remaining references to
libsdl2-ttf.

Closes: https://github.com/OpenRCT2/OpenRCT2/issues/10308