### PR TITLE
Fix #10325: Crash when banners have no text

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
+- Fix: [#10325] Crash when banners have no text.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -189,8 +189,8 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
 
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
 
-        uint16_t string_width = gfx_get_string_width(entrance_string);
-        uint16_t scroll = (gCurrentTicks / 2) % string_width;
+        uint16_t stringWidth = gfx_get_string_width(entrance_string);
+        uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
         sub_98199C(
             session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, stationObj->ScrollingMode, COLOUR_BLACK), 0,
@@ -298,8 +298,8 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
 
                 gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
 
-                uint16_t string_width = gfx_get_string_width(park_name);
-                uint16_t scroll = (gCurrentTicks / 2) % string_width;
+                uint16_t stringWidth = gfx_get_string_width(park_name);
+                uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
                 if (entrance->scrolling_mode == SCROLLING_MODE_NONE)
                     break;

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -440,8 +440,8 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
 
-    uint16_t string_width = gfx_get_string_width(signString);
-    uint16_t scroll = (gCurrentTicks / 2) % string_width;
+    uint16_t stringWidth = gfx_get_string_width(signString);
+    uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
     sub_98199C(
         session, scrolling_text_setup(session, STR_SCROLLING_SIGN_TEXT, scroll, scrollMode, textColour), 0, 0, 1, 1, 21,
         height + 25, boxoffset.x, boxoffset.y, boxoffset.z);

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -472,8 +472,8 @@ static void sub_6A4101(
 
             gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
 
-            uint16_t string_width = gfx_get_string_width(gCommonStringFormatBuffer);
-            uint16_t scroll = (gCurrentTicks / 2) % string_width;
+            uint16_t stringWidth = gfx_get_string_width(gCommonStringFormatBuffer);
+            uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
             sub_98199C(
                 session, scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, scroll, scrollingMode, COLOUR_BLACK), 0, 0, 1, 1,

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -442,8 +442,8 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
 
-        uint16_t string_width = gfx_get_string_width(signString);
-        uint16_t scroll = (gCurrentTicks / 2) % string_width;
+        uint16_t stringWidth = gfx_get_string_width(signString);
+        uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
         sub_98199C(
             session, scrolling_text_setup(session, STR_SCROLLING_SIGN_TEXT, scroll, scrollingMode, secondaryColour), 0, 0, 1, 1,


### PR DESCRIPTION
This fixes a integer division by zero, it is not clear why the width would result 0, could be various reasons such as invalid UTF-8 or corrupted parks.