### PR TITLE
Use CoordsXY on TopToolbar and TrackDesignPlace rotations

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2832,14 +2832,13 @@ static void top_toolbar_tool_update_scenery(int16_t x, int16_t y)
             for (rct_large_scenery_tile* tile = scenery->large_scenery.tiles; tile->x_offset != (int16_t)(uint16_t)0xFFFF;
                  tile++)
             {
-                LocationXY16 tileLocation = { tile->x_offset, tile->y_offset };
+                CoordsXY tileLocation = { tile->x_offset, tile->y_offset };
+                auto rotatedTileCoords = tileLocation.Rotate((parameter1 >> 8) & 0xFF);
 
-                rotate_map_coordinates(&tileLocation.x, &tileLocation.y, (parameter1 >> 8) & 0xFF);
+                rotatedTileCoords.x += mapTile.x;
+                rotatedTileCoords.y += mapTile.y;
 
-                tileLocation.x += mapTile.x;
-                tileLocation.y += mapTile.y;
-
-                gMapSelectionTiles.push_back({ tileLocation.x, tileLocation.y });
+                gMapSelectionTiles.push_back(rotatedTileCoords);
             }
 
             gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -543,8 +543,7 @@ static void window_track_place_draw_mini_preview_track(
         const rct_preview_track* trackBlock = trackBlockArray[trackType];
         while (trackBlock->index != 255)
         {
-            auto rotatedAndOffsetTrackBlock = map_offset_with_rotation(
-                { origin.x, origin.y }, { trackBlock->x, trackBlock->y }, rotation);
+            auto rotatedAndOffsetTrackBlock = origin + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
 
             if (pass == 0)
             {
@@ -589,8 +588,7 @@ static void window_track_place_draw_mini_preview_track(
         const rct_track_coordinates* track_coordinate = &TrackCoordinates[trackType];
 
         trackType *= 10;
-        auto rotatedAndOfffsetTrack = map_offset_with_rotation(
-            { origin.x, origin.y }, { track_coordinate->x, track_coordinate->y }, rotation);
+        auto rotatedAndOfffsetTrack = origin + CoordsXY{ track_coordinate->x, track_coordinate->y }.Rotate(rotation);
         rotation += track_coordinate->rotation_end - track_coordinate->rotation_begin;
         rotation &= 3;
         if (track_coordinate->rotation_end & 4)
@@ -599,15 +597,14 @@ static void window_track_place_draw_mini_preview_track(
         }
         if (!(rotation & 4))
         {
-            origin.x = rotatedAndOfffsetTrack.x + CoordsDirectionDelta[rotation].x;
-            origin.y = rotatedAndOfffsetTrack.x + CoordsDirectionDelta[rotation].y;
+            origin = rotatedAndOfffsetTrack + CoordsDirectionDelta[rotation];
         }
     }
 
     // Draw entrance and exit preview.
     for (const auto& entrance : td6->entrance_elements)
     {
-        auto rotatedAndOffsetEntrance = map_offset_with_rotation({ origin.x, origin.y }, { entrance.x, entrance.y }, rotation);
+        auto rotatedAndOffsetEntrance = origin + CoordsXY{ entrance.x, entrance.y }.Rotate(rotation);
 
         if (pass == 0)
         {
@@ -642,10 +639,7 @@ static void window_track_place_draw_mini_preview_maze(
     uint8_t rotation = (_currentTrackPieceDirection + get_current_rotation()) & 3;
     for (const auto& mazeElement : td6->maze_elements)
     {
-        CoordsXY mazeCoords{ mazeElement.x * 32, mazeElement.y * 32 };
-        auto rotatedMazeCoords = mazeCoords.Rotate(rotation);
-
-        rotatedMazeCoords += origin;
+        auto rotatedMazeCoords = origin + CoordsXY{ mazeElement.x * 32, mazeElement.y * 32 }.Rotate(rotation);
 
         if (pass == 0)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6977,8 +6977,9 @@ void sub_6CB945(Ride* ride)
             const rct_preview_track* trackBlock = get_track_def_from_ride(ride, tileElement->AsTrack()->GetTrackType());
             while ((++trackBlock)->index != 0xFF)
             {
-                LocationXYZ16 blockLocation = location;
-                map_offset_with_rotation(&blockLocation.x, &blockLocation.y, trackBlock->x, trackBlock->y, direction);
+                auto blockLocationXY = map_offset_with_rotation(
+                    { location.x, location.y }, { trackBlock->x, trackBlock->y }, direction);
+                CoordsXYZ blockLocation{ blockLocationXY.x, blockLocationXY.y, location.z };
 
                 bool trackFound = false;
                 tileElement = map_get_first_element_at(blockLocation.x >> 5, blockLocation.y >> 5);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6915,11 +6915,8 @@ void sub_6CB945(Ride* ride)
             if (ride->stations[stationId].Start.xy == RCT_XY8_UNDEFINED)
                 continue;
 
-            LocationXYZ16 location = {
-                (int16_t)(ride->stations[stationId].Start.x * 32),
-                (int16_t)(ride->stations[stationId].Start.y * 32),
-                (ride->stations[stationId].Height),
-            };
+            CoordsXYZ location = { ride->stations[stationId].Start.x * 32, ride->stations[stationId].Start.y * 32,
+                                   ride->stations[stationId].Height * 8 };
             uint8_t direction = 0xFF;
 
             bool specialTrack = false;
@@ -6977,9 +6974,7 @@ void sub_6CB945(Ride* ride)
             const rct_preview_track* trackBlock = get_track_def_from_ride(ride, tileElement->AsTrack()->GetTrackType());
             while ((++trackBlock)->index != 0xFF)
             {
-                auto blockLocationXY = map_offset_with_rotation(
-                    { location.x, location.y }, { trackBlock->x, trackBlock->y }, direction);
-                CoordsXYZ blockLocation{ blockLocationXY.x, blockLocationXY.y, location.z };
+                CoordsXYZ blockLocation = location + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(direction), 0 };
 
                 bool trackFound = false;
                 tileElement = map_get_first_element_at(blockLocation.x >> 5, blockLocation.y >> 5);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6917,6 +6917,7 @@ void sub_6CB945(Ride* ride)
 
             CoordsXYZ location = { ride->stations[stationId].Start.x * 32, ride->stations[stationId].Start.y * 32,
                                    ride->stations[stationId].Height * 8 };
+            auto tileHeight = TileCoordsXYZ(location).z;
             uint8_t direction = 0xFF;
 
             bool specialTrack = false;
@@ -6936,7 +6937,7 @@ void sub_6CB945(Ride* ride)
                 bool trackFound = false;
                 do
                 {
-                    if (tileElement->base_height != location.z)
+                    if (tileElement->base_height != tileHeight)
                         continue;
                     if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
                         continue;
@@ -6975,6 +6976,7 @@ void sub_6CB945(Ride* ride)
             while ((++trackBlock)->index != 0xFF)
             {
                 CoordsXYZ blockLocation = location + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(direction), 0 };
+                auto blockTileHeight = TileCoordsXYZ(blockLocation).z;
 
                 bool trackFound = false;
                 tileElement = map_get_first_element_at(blockLocation.x >> 5, blockLocation.y >> 5);
@@ -6982,7 +6984,7 @@ void sub_6CB945(Ride* ride)
                     break;
                 do
                 {
-                    if (blockLocation.z != tileElement->base_height)
+                    if (blockTileHeight != tileElement->base_height)
                         continue;
                     if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
                         continue;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1472,8 +1472,7 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
             case PTD_OPERATION_DRAW_OUTLINES:
                 for (const rct_preview_track* trackBlock = trackBlockArray[trackType]; trackBlock->index != 0xFF; trackBlock++)
                 {
-                    LocationXY16 tile = { x, y };
-                    map_offset_with_rotation(&tile.x, &tile.y, trackBlock->x, trackBlock->y, rotation);
+                    auto tile = map_offset_with_rotation({ x, y }, { trackBlock->x, trackBlock->y }, rotation);
                     track_design_update_max_min_coordinates(tile.x, tile.y, z);
                     track_design_add_selection_tile(tile.x, tile.y);
                 }
@@ -1552,16 +1551,13 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
                 int32_t tempZ = z - TrackCoordinates[trackType].z_begin;
                 for (const rct_preview_track* trackBlock = trackBlockArray[trackType]; trackBlock->index != 0xFF; trackBlock++)
                 {
-                    int16_t tmpX = x;
-                    int16_t tmpY = y;
-                    map_offset_with_rotation(&tmpX, &tmpY, trackBlock->x, trackBlock->y, rotation);
-                    CoordsXY tile = { tmpX, tmpY };
+                    auto tile = map_offset_with_rotation({ x, y }, { trackBlock->x, trackBlock->y }, rotation);
                     if (tile.x < 0 || tile.y < 0 || tile.x >= (256 * 32) || tile.y >= (256 * 32))
                     {
                         continue;
                     }
 
-                    auto surfaceElement = map_get_surface_element_at(tile);
+                    auto surfaceElement = map_get_surface_element_at({ tile.x, tile.y });
                     if (surfaceElement == nullptr)
                     {
                         return false;
@@ -1593,7 +1589,10 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
         }
 
         const rct_track_coordinates* track_coordinates = &TrackCoordinates[trackType];
-        map_offset_with_rotation(&x, &y, track_coordinates->x, track_coordinates->y, rotation);
+        auto offsetAndRotatedTrack = map_offset_with_rotation(
+            { x, y }, { track_coordinates->x, track_coordinates->y }, rotation);
+        x = offsetAndRotatedTrack.x;
+        y = offsetAndRotatedTrack.y;
         z -= track_coordinates->z_begin;
         z += track_coordinates->z_end;
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1472,7 +1472,7 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
             case PTD_OPERATION_DRAW_OUTLINES:
                 for (const rct_preview_track* trackBlock = trackBlockArray[trackType]; trackBlock->index != 0xFF; trackBlock++)
                 {
-                    auto tile = map_offset_with_rotation({ x, y }, { trackBlock->x, trackBlock->y }, rotation);
+                    auto tile = CoordsXY{ x, y } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     track_design_update_max_min_coordinates(tile.x, tile.y, z);
                     track_design_add_selection_tile(tile.x, tile.y);
                 }
@@ -1551,13 +1551,13 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
                 int32_t tempZ = z - TrackCoordinates[trackType].z_begin;
                 for (const rct_preview_track* trackBlock = trackBlockArray[trackType]; trackBlock->index != 0xFF; trackBlock++)
                 {
-                    auto tile = map_offset_with_rotation({ x, y }, { trackBlock->x, trackBlock->y }, rotation);
+                    auto tile = CoordsXY{ x, y } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     if (tile.x < 0 || tile.y < 0 || tile.x >= (256 * 32) || tile.y >= (256 * 32))
                     {
                         continue;
                     }
 
-                    auto surfaceElement = map_get_surface_element_at({ tile.x, tile.y });
+                    auto surfaceElement = map_get_surface_element_at(tile);
                     if (surfaceElement == nullptr)
                     {
                         return false;
@@ -1589,8 +1589,7 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
         }
 
         const rct_track_coordinates* track_coordinates = &TrackCoordinates[trackType];
-        auto offsetAndRotatedTrack = map_offset_with_rotation(
-            { x, y }, { track_coordinates->x, track_coordinates->y }, rotation);
+        auto offsetAndRotatedTrack = CoordsXY{ x, y } + CoordsXY{ track_coordinates->x, track_coordinates->y }.Rotate(rotation);
         x = offsetAndRotatedTrack.x;
         y = offsetAndRotatedTrack.y;
         z -= track_coordinates->z_begin;

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -224,6 +224,11 @@ struct CoordsXYZ : public CoordsXY
     {
     }
 
+    const CoordsXYZ operator+(const CoordsXYZ& rhs) const
+    {
+        return { x + rhs.x, y + rhs.y, z + rhs.z };
+    }
+
     bool operator==(const CoordsXYZ& other) const
     {
         return x == other.x && y == other.y && z == other.z;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2353,12 +2353,6 @@ TileElement* map_get_track_element_at_with_direction_from_ride(
     return nullptr;
 };
 
-TileCoordsXY map_offset_with_rotation(TileCoordsXY position, TileCoordsXY offset, uint8_t rotation)
-{
-    position += offset.Rotate(rotation);
-    return position;
-}
-
 WallElement* map_get_wall_element_at(int32_t x, int32_t y, int32_t z, int32_t direction)
 {
     TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2353,14 +2353,10 @@ TileElement* map_get_track_element_at_with_direction_from_ride(
     return nullptr;
 };
 
-void map_offset_with_rotation(int16_t* x, int16_t* y, int16_t offsetX, int16_t offsetY, uint8_t rotation)
+TileCoordsXY map_offset_with_rotation(TileCoordsXY position, TileCoordsXY offset, uint8_t rotation)
 {
-    TileCoordsXY offsets = { offsetX, offsetY };
-    TileCoordsXY newCoords = { *x, *y };
-    newCoords += offsets.Rotate(rotation);
-
-    *x = (int16_t)newCoords.x;
-    *y = (int16_t)newCoords.y;
+    position += offset.Rotate(rotation);
+    return position;
 }
 
 WallElement* map_get_wall_element_at(int32_t x, int32_t y, int32_t z, int32_t direction)

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -231,7 +231,7 @@ bool map_large_scenery_get_origin(
     int32_t x, int32_t y, int32_t z, int32_t direction, int32_t sequence, int32_t* outX, int32_t* outY, int32_t* outZ,
     LargeSceneryElement** outElement);
 
-void map_offset_with_rotation(int16_t* x, int16_t* y, int16_t offsetX, int16_t offsetY, uint8_t rotation);
+TileCoordsXY map_offset_with_rotation(TileCoordsXY position, TileCoordsXY offset, uint8_t rotation);
 ScreenCoordsXY translate_3d_to_2d_with_z(int32_t rotation, const CoordsXYZ& pos);
 
 TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -231,7 +231,6 @@ bool map_large_scenery_get_origin(
     int32_t x, int32_t y, int32_t z, int32_t direction, int32_t sequence, int32_t* outX, int32_t* outY, int32_t* outZ,
     LargeSceneryElement** outElement);
 
-TileCoordsXY map_offset_with_rotation(TileCoordsXY position, TileCoordsXY offset, uint8_t rotation);
 ScreenCoordsXY translate_3d_to_2d_with_z(int32_t rotation, const CoordsXYZ& pos);
 
 TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);


### PR DESCRIPTION
Helps #10267

So my goal was to just remove the usage of `LocationXY` from `TopToolbar` and `TrackDesignPlace`, but then to avoid casting like crazy, I had to also update `map_offset_with_rotation`.

I made it return `TileCoordsXY` as it was what was implemented inside, but it's very confusing because users on the outside sometimes use this type, and at other times, `CoordsXY`, so I'd appreciate some feedback on whether this is one of the cases where it's mixing up and shouldn't.