### PR TITLE
Remove unused Map::rotate_map_coordinates() function

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -112,31 +112,6 @@ bool gMapLandRightsUpdateSuccess;
 static void clear_elements_at(const CoordsXY& loc);
 static ScreenCoordsXY translate_3d_to_2d(int32_t rotation, const CoordsXY& pos);
 
-void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation)
-{
-    int32_t temp;
-
-    switch (rotation)
-    {
-        case TILE_ELEMENT_DIRECTION_WEST:
-            break;
-        case TILE_ELEMENT_DIRECTION_NORTH:
-            temp = *x;
-            *x = *y;
-            *y = -temp;
-            break;
-        case TILE_ELEMENT_DIRECTION_EAST:
-            *x = -*x;
-            *y = -*y;
-            break;
-        case TILE_ELEMENT_DIRECTION_SOUTH:
-            temp = *y;
-            *y = *x;
-            *x = -temp;
-            break;
-    }
-}
-
 void tile_element_iterator_begin(tile_element_iterator* it)
 {
     it->x = 0;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -182,7 +182,6 @@ bool map_can_construct_with_clear_at(
     int32_t x, int32_t y, int32_t zLow, int32_t zHigh, CLEAR_FUNC clearFunc, QuarterTile quarterTile, uint8_t flags,
     money32* price, uint8_t crossingMode);
 int32_t map_can_construct_at(int32_t x, int32_t y, int32_t zLow, int32_t zHigh, QuarterTile bl);
-void rotate_map_coordinates(int16_t* x, int16_t* y, int32_t rotation);
 
 struct tile_element_iterator
 {


### PR DESCRIPTION
This is unused now, after all the recent changesets (#10326, #10328, #10329, #10332, #10333, #10334 and #10335)