### PR TITLE
Make map_get_surface_element_at only accept Coords objects

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2180,7 +2180,7 @@ static std::optional<CoordsXY> ride_get_place_position_from_screen_position(Scre
         _trackPlaceZ = 0;
         if (_trackPlaceShiftState)
         {
-            auto surfaceElement = map_get_surface_element_at(mapCoords.x >> 5, mapCoords.y >> 5);
+            auto surfaceElement = map_get_surface_element_at(mapCoords);
             if (surfaceElement == nullptr)
                 return std::nullopt;
             auto mapZ = floor2(surfaceElement->base_height * 8, 16);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1360,7 +1360,7 @@ static void sub_6E1F34(
                     // If SHIFT pressed
                     if (gSceneryShiftPressed)
                     {
-                        auto* surfaceElement = map_get_surface_element_at(*grid_x / 32, *grid_y / 32);
+                        auto* surfaceElement = map_get_surface_element_at(CoordsXY{ *grid_x, *grid_y });
 
                         if (surfaceElement == nullptr)
                         {
@@ -1449,7 +1449,7 @@ static void sub_6E1F34(
                 // If SHIFT pressed
                 if (gSceneryShiftPressed)
                 {
-                    auto surfaceElement = map_get_surface_element_at(*grid_x / 32, *grid_y / 32);
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ *grid_x, *grid_y });
 
                     if (surfaceElement == nullptr)
                     {
@@ -1561,7 +1561,7 @@ static void sub_6E1F34(
                 // If SHIFT pressed
                 if (gSceneryShiftPressed)
                 {
-                    auto* surfaceElement = map_get_surface_element_at(*grid_x / 32, *grid_y / 32);
+                    auto* surfaceElement = map_get_surface_element_at(CoordsXY{ *grid_x, *grid_y });
 
                     if (surfaceElement == nullptr)
                     {
@@ -1629,7 +1629,7 @@ static void sub_6E1F34(
                 // If SHIFT pressed
                 if (gSceneryShiftPressed)
                 {
-                    auto* surfaceElement = map_get_surface_element_at(*grid_x / 32, *grid_y / 32);
+                    auto* surfaceElement = map_get_surface_element_at(CoordsXY{ *grid_x, *grid_y });
 
                     if (surfaceElement == nullptr)
                     {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -475,7 +475,7 @@ static int32_t window_track_place_get_base_z(int32_t x, int32_t y)
 {
     uint32_t z;
 
-    auto surfaceElement = map_get_surface_element_at(x >> 5, y >> 5);
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
     if (surfaceElement == nullptr)
         return 0;
     z = surfaceElement->base_height * 8;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -490,7 +490,7 @@ void game_fix_save_vars()
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto* surfaceElement = map_get_surface_element_at(x, y);
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
 
             if (surfaceElement == nullptr)
             {

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -490,7 +490,7 @@ void game_fix_save_vars()
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
 
             if (surfaceElement == nullptr)
             {

--- a/src/openrct2/actions/LandLowerAction.hpp
+++ b/src/openrct2/actions/LandLowerAction.hpp
@@ -97,7 +97,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto* surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
 

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -98,7 +98,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto* surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
                 uint8_t height = surfaceElement->base_height;

--- a/src/openrct2/actions/LandSmoothAction.hpp
+++ b/src/openrct2/actions/LandSmoothAction.hpp
@@ -118,7 +118,7 @@ private:
             return 0;
         }
         auto surfaceElement = map_get_surface_element_at(loc);
-        auto nextSurfaceElement = map_get_surface_element_at({ loc.x + stepX, loc.y + stepY });
+        auto nextSurfaceElement = map_get_surface_element_at(CoordsXY{ loc.x + stepX, loc.y + stepY });
         if (surfaceElement == nullptr || nextSurfaceElement == nullptr)
         {
             return 0;
@@ -156,7 +156,7 @@ private:
             else
             {
                 surfaceElement = nextSurfaceElement;
-                nextSurfaceElement = map_get_surface_element_at({ nextLoc.x + stepX, nextLoc.y + stepY });
+                nextSurfaceElement = map_get_surface_element_at(CoordsXY{ nextLoc.x + stepX, nextLoc.y + stepY });
                 if (nextSurfaceElement == nullptr)
                 {
                     shouldContinue &= ~0x3;
@@ -270,7 +270,7 @@ private:
             return 0;
         }
         auto surfaceElement = map_get_surface_element_at(loc);
-        auto nextSurfaceElement = map_get_surface_element_at({ loc.x + stepX, loc.y + stepY });
+        auto nextSurfaceElement = map_get_surface_element_at(CoordsXY{ loc.x + stepX, loc.y + stepY });
         if (surfaceElement == nullptr || nextSurfaceElement == nullptr)
         {
             return 0;
@@ -299,7 +299,7 @@ private:
             else
             {
                 surfaceElement = nextSurfaceElement;
-                nextSurfaceElement = map_get_surface_element_at({ nextLoc.x + stepX, nextLoc.y + stepY });
+                nextSurfaceElement = map_get_surface_element_at(CoordsXY{ nextLoc.x + stepX, nextLoc.y + stepY });
                 if (nextSurfaceElement == nullptr)
                 {
                     shouldContinue = false;
@@ -367,7 +367,7 @@ private:
 
                 // Smooth the 4 corners
                 { // top-left
-                    auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
@@ -377,7 +377,7 @@ private:
                     }
                 }
                 { // bottom-left
-                    auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetBottom() });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetLeft(), validRange.GetBottom() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
@@ -387,7 +387,7 @@ private:
                     }
                 }
                 { // bottom-right
-                    auto surfaceElement = map_get_surface_element_at({ validRange.GetRight(), validRange.GetBottom() });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetRight(), validRange.GetBottom() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
@@ -397,7 +397,7 @@ private:
                     }
                 }
                 { // top-right
-                    auto surfaceElement = map_get_surface_element_at({ validRange.GetRight(), validRange.GetTop() });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetRight(), validRange.GetTop() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
@@ -411,7 +411,7 @@ private:
                 int32_t z1, z2;
                 for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += 32)
                 {
-                    auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), y });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetLeft(), y });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 3), minHeight, maxHeight);
@@ -419,7 +419,7 @@ private:
                         res->Cost += SmoothLandRowByEdge(isExecuting, { validRange.GetLeft(), y }, z1, z2, -32, 0, 0, 1, 3, 2);
                     }
 
-                    surfaceElement = map_get_surface_element_at({ validRange.GetRight(), y });
+                    surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetRight(), y });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
@@ -430,7 +430,7 @@ private:
 
                 for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
                 {
-                    auto surfaceElement = map_get_surface_element_at({ x, validRange.GetTop() });
+                    auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, validRange.GetTop() });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 1), minHeight, maxHeight);
@@ -438,7 +438,7 @@ private:
                         res->Cost += SmoothLandRowByEdge(isExecuting, { x, validRange.GetTop() }, z1, z2, 0, -32, 0, 3, 1, 2);
                     }
 
-                    surfaceElement = map_get_surface_element_at({ x, validRange.GetBottom() });
+                    surfaceElement = map_get_surface_element_at(CoordsXY{ x, validRange.GetBottom() });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp((uint8_t)tile_element_get_corner_height(surfaceElement, 0), minHeight, maxHeight);
@@ -453,7 +453,7 @@ private:
             case MAP_SELECT_TYPE_CORNER_2:
             case MAP_SELECT_TYPE_CORNER_3:
             {
-                auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
                 if (surfaceElement == nullptr)
                     break;
                 uint8_t newBaseZ = surfaceElement->base_height;
@@ -552,7 +552,7 @@ private:
             {
                 // TODO: Handle smoothing by edge
                 // Get the two corners to raise
-                auto surfaceElement = map_get_surface_element_at({ validRange.GetLeft(), validRange.GetTop() });
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
                 if (surfaceElement == nullptr)
                     break;
                 uint8_t newBaseZ = surfaceElement->base_height;

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -364,7 +364,7 @@ private:
         {
             for (x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
             {
-                auto surfaceElement = map_get_surface_element_at(x, y);
+                auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
 
@@ -764,7 +764,7 @@ private:
             int32_t y = spawn.y;
             if (x != PEEP_SPAWN_UNDEFINED)
             {
-                auto* surfaceElement = map_get_surface_element_at({ x, y });
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement != nullptr)
                 {
                     surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -364,7 +364,7 @@ private:
         {
             for (x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
             {
-                auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+                auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
                 if (surfaceElement == nullptr)
                     continue;
 

--- a/src/openrct2/actions/SurfaceSetStyleAction.hpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.hpp
@@ -124,7 +124,7 @@ public:
                         continue;
                 }
 
-                auto surfaceElement = map_get_surface_element_at({ x, y });
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                 {
                     continue;
@@ -195,7 +195,7 @@ public:
                         continue;
                 }
 
-                auto surfaceElement = map_get_surface_element_at({ x, y });
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                 {
                     continue;

--- a/src/openrct2/actions/WaterLowerAction.hpp
+++ b/src/openrct2/actions/WaterLowerAction.hpp
@@ -78,7 +78,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto* surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
 
@@ -127,7 +127,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto* surfaceElement = map_get_surface_element_at({ x, y });
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
 

--- a/src/openrct2/actions/WaterRaiseAction.hpp
+++ b/src/openrct2/actions/WaterRaiseAction.hpp
@@ -79,7 +79,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto surfaceElement = map_get_surface_element_at(x / 32, y / 32);
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
                 uint8_t height = surfaceElement->GetWaterHeight();
@@ -134,7 +134,7 @@ private:
         {
             for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += 32)
             {
-                auto* surfaceElement = map_get_surface_element_at({ x, y });
+                auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement == nullptr)
                     continue;
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -30,7 +30,7 @@
 bool gPaintWidePathsAsGhost = false;
 
 // clang-format off
-const uint8_t PathSlopeToLandSlope[] = 
+const uint8_t PathSlopeToLandSlope[] =
 {
     TILE_ELEMENT_SLOPE_SW_SIDE_UP,
     TILE_ELEMENT_SLOPE_NW_SIDE_UP,
@@ -858,7 +858,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
 
     int16_t x = session->MapPosition.x, y = session->MapPosition.y;
 
-    auto surface = map_get_surface_element_at({ session->MapPosition.x, session->MapPosition.y });
+    auto surface = map_get_surface_element_at(CoordsXY{ session->MapPosition.x, session->MapPosition.y });
 
     uint16_t bl = height / 8;
     if (surface == nullptr)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5412,7 +5412,7 @@ void Guest::UpdateWalking()
 
     if (GetNextIsSurface())
     {
-        auto surfaceElement = map_get_surface_element_at({ next_x, next_y });
+        auto surfaceElement = map_get_surface_element_at(CoordsXY{ next_x, next_y });
 
         if (surfaceElement != nullptr)
         {
@@ -6435,7 +6435,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
 {
     TileElement* tileElement;
 
-    auto surfaceElement = map_get_surface_element_at({ peep->next_x, peep->next_y });
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ peep->next_x, peep->next_y });
 
     tileElement = reinterpret_cast<TileElement*>(surfaceElement);
     if (tileElement == nullptr)
@@ -6474,7 +6474,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at({ x, y });
+    surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
 
     tileElement = reinterpret_cast<TileElement*>(surfaceElement);
     if (tileElement == nullptr)
@@ -6590,7 +6590,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at({ x, y });
+    surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
 
     // TODO: extract loop A
     tileElement = reinterpret_cast<TileElement*>(surfaceElement);
@@ -6707,7 +6707,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, uint8_t* rideToV
         return false;
     }
 
-    surfaceElement = map_get_surface_element_at({ x, y });
+    surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
 
     // TODO: extract loop A
     tileElement = reinterpret_cast<TileElement*>(surfaceElement);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -765,7 +765,7 @@ bool Peep::Place(TileCoordsXYZ location, bool apply)
     TileElement* tileElement = reinterpret_cast<TileElement*>(pathElement);
     if (!pathElement)
     {
-        tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(location.x, location.y));
+        tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(TileCoordsXY{ location.x, location.y }));
     }
 
     if (!tileElement)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -765,8 +765,7 @@ bool Peep::Place(TileCoordsXYZ location, bool apply)
     TileElement* tileElement = reinterpret_cast<TileElement*>(pathElement);
     if (!pathElement)
     {
-        tileElement = reinterpret_cast<TileElement*>(
-            map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY()));
+        tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(location.ToCoordsXYZ()));
     }
 
     if (!tileElement)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -765,7 +765,8 @@ bool Peep::Place(TileCoordsXYZ location, bool apply)
     TileElement* tileElement = reinterpret_cast<TileElement*>(pathElement);
     if (!pathElement)
     {
-        tileElement = reinterpret_cast<TileElement*>(map_get_surface_element_at(TileCoordsXY{ location.x, location.y }));
+        tileElement = reinterpret_cast<TileElement*>(
+            map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY()));
     }
 
     if (!tileElement)

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -516,7 +516,7 @@ static uint8_t staff_handyman_direction_to_uncut_grass(Peep* peep, uint8_t valid
 {
     if (!(peep->GetNextIsSurface()))
     {
-        auto surfaceElement = map_get_surface_element_at({ peep->next_x, peep->next_y });
+        auto surfaceElement = map_get_surface_element_at(CoordsXY{ peep->next_x, peep->next_y });
         if (surfaceElement == nullptr)
             return INVALID_DIRECTION;
 
@@ -1208,7 +1208,7 @@ void Staff::UpdateMowing()
         if (var_37 != 7)
             continue;
 
-        auto surfaceElement = map_get_surface_element_at(next_x / 32, next_y / 32);
+        auto surfaceElement = map_get_surface_element_at(CoordsXY{ next_x, next_y });
         if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
         {
             surfaceElement->SetGrassLength(GRASS_LENGTH_MOWED);
@@ -1777,7 +1777,7 @@ static int32_t peep_update_patrolling_find_grass(Peep* peep)
     if (!(peep->GetNextIsSurface()))
         return 0;
 
-    auto surfaceElement = map_get_surface_element_at({ peep->next_x, peep->next_y });
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ peep->next_x, peep->next_y });
     if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
     {
         if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1)
@@ -1915,7 +1915,7 @@ void Staff::UpdatePatrolling()
 
     if (GetNextIsSurface())
     {
-        auto surfaceElement = map_get_surface_element_at({ next_x, next_y });
+        auto surfaceElement = map_get_surface_element_at(CoordsXY{ next_x, next_y });
 
         if (surfaceElement != nullptr)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -979,7 +979,7 @@ static void vehicle_update_sound_params(rct_vehicle* vehicle)
 
     if (vehicle->x != LOCATION_NULL)
     {
-        auto surfaceElement = map_get_surface_element_at({ vehicle->x, vehicle->y });
+        auto surfaceElement = map_get_surface_element_at(CoordsXY{ vehicle->x, vehicle->y });
 
         // vehicle underground
         if (surfaceElement != nullptr && surfaceElement->base_height * 8 > vehicle->z)
@@ -1830,7 +1830,7 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
         return;
     }
 
-    auto surfaceElement = map_get_surface_element_at({ x, y });
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
     // If vehicle above ground.
     if (surfaceElement != nullptr && surfaceElement->base_height * 8 <= z)
     {
@@ -7206,7 +7206,7 @@ static void vehicle_update_spinning_car(rct_vehicle* vehicle)
  */
 static void steam_particle_create(int16_t x, int16_t y, int16_t z)
 {
-    auto surfaceElement = map_get_surface_element_at({ x, y });
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
     if (surfaceElement != nullptr && z > surfaceElement->base_height * 8)
     {
         rct_steam_particle* steam = &create_sprite(SPRITE_IDENTIFIER_MISC)->steam_particle;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -123,7 +123,7 @@ void rct_duck::UpdateFlyToWater()
     int32_t newY = y + DuckMoveOffset[direction].y;
     int32_t manhattanDistanceN = abs(target_x - newX) + abs(target_y - newY);
 
-    auto surfaceElement = map_get_surface_element_at({ target_x, target_y });
+    auto surfaceElement = map_get_surface_element_at(CoordsXY{ target_x, target_y });
     int32_t waterHeight = surfaceElement != nullptr ? surfaceElement->GetWaterHeight() : 0;
     if (waterHeight == 0)
     {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1231,7 +1231,7 @@ void footpath_update_queue_chains()
  */
 static void footpath_fix_ownership(int32_t x, int32_t y)
 {
-    const auto* surfaceElement = map_get_surface_element_at({ x, y });
+    const auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
     uint16_t ownership;
 
     // Unlikely to be NULL unless deliberate.

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -177,6 +177,11 @@ struct TileCoordsXY
         return *this;
     }
 
+    CoordsXY ToCoordsXY() const
+    {
+        return { x * 32, y * 32 };
+    }
+
     TileCoordsXY Rotate(int32_t direction) const
     {
         TileCoordsXY rotatedCoords;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -203,8 +203,9 @@ void map_set_tile_elements(int32_t x, int32_t y, TileElement* elements)
     gTileElementTilePointers[x + y * MAXIMUM_MAP_SIZE_TECHNICAL] = elements;
 }
 
-SurfaceElement* map_get_surface_element_at(const TileCoordsXY& tileCoords)
+SurfaceElement* map_get_surface_element_at(const CoordsXY& coords)
 {
+    auto tileCoords = TileCoordsXY{ coords };
     TileElement* tileElement = map_get_first_element_at(tileCoords.x, tileCoords.y);
 
     if (tileElement == nullptr)
@@ -220,11 +221,6 @@ SurfaceElement* map_get_surface_element_at(const TileCoordsXY& tileCoords)
     }
 
     return tileElement->AsSurface();
-}
-
-SurfaceElement* map_get_surface_element_at(const CoordsXY& coords)
-{
-    return map_get_surface_element_at(TileCoordsXY(coords));
 }
 
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc)
@@ -327,7 +323,7 @@ void map_count_remaining_land_rights()
     {
         for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
         {
-            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             // Surface elements are sometimes hacked out to save some space for other map elements
             if (surfaceElement == nullptr)
             {
@@ -1474,7 +1470,7 @@ void map_update_tiles()
             interleaved_xy >>= 1;
         }
 
-        auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+        auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
         if (surfaceElement != nullptr)
         {
             surfaceElement->UpdateGrassLength({ x * 32, y * 32 });
@@ -1617,8 +1613,8 @@ void map_extend_boundary_surface()
     y = gMapSize - 2;
     for (x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
     {
-        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x, y - 1 });
-        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x, y - 1 }.ToCoordsXY());
+        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
 
         if (existingTileElement && newTileElement)
         {
@@ -1631,8 +1627,8 @@ void map_extend_boundary_surface()
     x = gMapSize - 2;
     for (y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
-        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x - 1, y });
-        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x - 1, y }.ToCoordsXY());
+        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
 
         if (existingTileElement && newTileElement)
         {
@@ -2398,7 +2394,7 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
 {
     for (const TileCoordsXY* tile = tiles.begin(); tile != tiles.end(); ++tile)
     {
-        auto surfaceElement = map_get_surface_element_at(*tile);
+        auto surfaceElement = map_get_surface_element_at(tile->ToCoordsXY());
         if (surfaceElement != nullptr)
         {
             surfaceElement->SetOwnership(ownership);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -203,9 +203,9 @@ void map_set_tile_elements(int32_t x, int32_t y, TileElement* elements)
     gTileElementTilePointers[x + y * MAXIMUM_MAP_SIZE_TECHNICAL] = elements;
 }
 
-SurfaceElement* map_get_surface_element_at(int32_t x, int32_t y)
+SurfaceElement* map_get_surface_element_at(const TileCoordsXY& tileCoords)
 {
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(tileCoords.x, tileCoords.y);
 
     if (tileElement == nullptr)
         return nullptr;
@@ -224,7 +224,7 @@ SurfaceElement* map_get_surface_element_at(int32_t x, int32_t y)
 
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords)
 {
-    return map_get_surface_element_at(coords.x / 32, coords.y / 32);
+    return map_get_surface_element_at(TileCoordsXY(coords));
 }
 
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc)
@@ -327,7 +327,7 @@ void map_count_remaining_land_rights()
     {
         for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
         {
-            auto* surfaceElement = map_get_surface_element_at(x, y);
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             // Surface elements are sometimes hacked out to save some space for other map elements
             if (surfaceElement == nullptr)
             {
@@ -874,7 +874,7 @@ uint8_t map_get_lowest_land_height(const MapRange& range)
     {
         for (int32_t xi = validRange.GetLeft(); xi <= validRange.GetRight(); xi += 32)
         {
-            auto* surfaceElement = map_get_surface_element_at({ xi, yi });
+            auto* surfaceElement = map_get_surface_element_at(CoordsXY{ xi, yi });
             if (surfaceElement != nullptr && min_height > surfaceElement->base_height)
             {
                 min_height = surfaceElement->base_height;
@@ -895,7 +895,7 @@ uint8_t map_get_highest_land_height(const MapRange& range)
     {
         for (int32_t xi = validRange.GetLeft(); xi <= validRange.GetRight(); xi += 32)
         {
-            auto* surfaceElement = map_get_surface_element_at({ xi, yi });
+            auto* surfaceElement = map_get_surface_element_at(CoordsXY{ xi, yi });
             if (surfaceElement != nullptr)
             {
                 uint8_t base_height = surfaceElement->base_height;
@@ -1474,7 +1474,7 @@ void map_update_tiles()
             interleaved_xy >>= 1;
         }
 
-        auto* surfaceElement = map_get_surface_element_at(x, y);
+        auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
         if (surfaceElement != nullptr)
         {
             surfaceElement->UpdateGrassLength({ x * 32, y * 32 });
@@ -1553,7 +1553,7 @@ void map_remove_out_of_range_elements()
             if (x == 0 || y == 0 || x >= mapMaxXY || y >= mapMaxXY)
             {
                 // Note this purposely does not use LandSetRightsAction as X Y coordinates are outside of normal range.
-                auto surfaceElement = map_get_surface_element_at({ x, y });
+                auto surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
                 if (surfaceElement != nullptr)
                 {
                     surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
@@ -1617,8 +1617,8 @@ void map_extend_boundary_surface()
     y = gMapSize - 2;
     for (x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
     {
-        existingTileElement = map_get_surface_element_at(x, y - 1);
-        newTileElement = map_get_surface_element_at(x, y);
+        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x, y - 1 });
+        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y });
 
         if (existingTileElement && newTileElement)
         {
@@ -1631,8 +1631,8 @@ void map_extend_boundary_surface()
     x = gMapSize - 2;
     for (y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
-        existingTileElement = map_get_surface_element_at(x - 1, y);
-        newTileElement = map_get_surface_element_at(x, y);
+        existingTileElement = map_get_surface_element_at(TileCoordsXY{ x - 1, y });
+        newTileElement = map_get_surface_element_at(TileCoordsXY{ x, y });
 
         if (existingTileElement && newTileElement)
         {
@@ -2398,7 +2398,7 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
 {
     for (const TileCoordsXY* tile = tiles.begin(); tile != tiles.end(); ++tile)
     {
-        auto surfaceElement = map_get_surface_element_at((*tile).x, (*tile).y);
+        auto surfaceElement = map_get_surface_element_at(*tile);
         if (surfaceElement != nullptr)
         {
             surfaceElement->SetOwnership(ownership);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -143,7 +143,6 @@ TileElement* map_get_nth_element_at(int32_t x, int32_t y, int32_t n);
 void map_set_tile_elements(int32_t x, int32_t y, TileElement* elements);
 int32_t map_height_from_slope(const CoordsXY& coords, int32_t slope, bool isSloped);
 BannerElement* map_get_banner_element_at(int32_t x, int32_t y, int32_t z, uint8_t direction);
-SurfaceElement* map_get_surface_element_at(const TileCoordsXY& tileCoords);
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords);
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc);
 WallElement* map_get_wall_element_at(CoordsXYZD wallCoords);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -143,7 +143,7 @@ TileElement* map_get_nth_element_at(int32_t x, int32_t y, int32_t n);
 void map_set_tile_elements(int32_t x, int32_t y, TileElement* elements);
 int32_t map_height_from_slope(const CoordsXY& coords, int32_t slope, bool isSloped);
 BannerElement* map_get_banner_element_at(int32_t x, int32_t y, int32_t z, uint8_t direction);
-SurfaceElement* map_get_surface_element_at(int32_t x, int32_t y);
+SurfaceElement* map_get_surface_element_at(const TileCoordsXY& tileCoords);
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords);
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc);
 WallElement* map_get_wall_element_at(CoordsXYZD wallCoords);

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -116,7 +116,7 @@ void mapgen_generate_blank(mapgen_settings* settings)
     {
         for (x = 1; x < settings->mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(settings->floor);
@@ -167,7 +167,7 @@ void mapgen_generate(mapgen_settings* settings)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(floorTexture);
@@ -216,7 +216,7 @@ void mapgen_generate(mapgen_settings* settings)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
 
             if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel + 6)
                 surfaceElement->SetSurfaceStyle(beachTexture);
@@ -304,16 +304,16 @@ static void mapgen_place_trees()
         }
     }
 
-    CoordsXY tmp, pos;
+    TileCoordsXY tmp, pos;
 
-    std::vector<CoordsXY> availablePositions;
+    std::vector<TileCoordsXY> availablePositions;
 
     // Create list of available tiles
     for (int32_t y = 1; y < gMapSize - 1; y++)
     {
         for (int32_t x = 1; x < gMapSize - 1; x++)
         {
-            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement == nullptr)
                 continue;
 
@@ -399,7 +399,7 @@ static void mapgen_set_water_level(int32_t waterLevel)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel)
                 surfaceElement->SetWaterHeight(waterLevel / 2);
         }
@@ -461,7 +461,7 @@ static void mapgen_set_height()
 
             uint8_t baseHeight = (q00 + q01 + q10 + q11) / 4;
 
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->base_height = std::max(2, baseHeight * 2);
@@ -823,7 +823,7 @@ void mapgen_generate_from_heightmap(mapgen_settings* settings)
         {
             // The x and y axis are flipped in the world, so this uses y for x and x for y.
             auto* const surfaceElement = map_get_surface_element_at(
-                TileCoordsXY{ static_cast<int32_t>(y + 1), static_cast<int32_t>(x + 1) });
+                TileCoordsXY{ static_cast<int32_t>(y + 1), static_cast<int32_t>(x + 1) }.ToCoordsXY());
             if (surfaceElement == nullptr)
                 continue;
 

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -116,7 +116,7 @@ void mapgen_generate_blank(mapgen_settings* settings)
     {
         for (x = 1; x < settings->mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(settings->floor);
@@ -167,7 +167,7 @@ void mapgen_generate(mapgen_settings* settings)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(floorTexture);
@@ -216,7 +216,7 @@ void mapgen_generate(mapgen_settings* settings)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
 
             if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel + 6)
                 surfaceElement->SetSurfaceStyle(beachTexture);
@@ -313,7 +313,7 @@ static void mapgen_place_trees()
     {
         for (int32_t x = 1; x < gMapSize - 1; x++)
         {
-            auto* surfaceElement = map_get_surface_element_at(x, y);
+            auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
 
@@ -349,7 +349,7 @@ static void mapgen_place_trees()
         pos = availablePositions[i];
 
         int32_t type = -1;
-        auto* surfaceElement = map_get_surface_element_at(pos.x, pos.y);
+        auto* surfaceElement = map_get_surface_element_at(pos.ToCoordsXY());
         if (surfaceElement != nullptr)
             continue;
         switch (surfaceElement->GetSurfaceStyle())
@@ -399,7 +399,7 @@ static void mapgen_set_water_level(int32_t waterLevel)
     {
         for (x = 1; x < mapSize - 1; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr && surfaceElement->base_height < waterLevel)
                 surfaceElement->SetWaterHeight(waterLevel / 2);
         }
@@ -461,7 +461,7 @@ static void mapgen_set_height()
 
             uint8_t baseHeight = (q00 + q01 + q10 + q11) / 4;
 
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->base_height = std::max(2, baseHeight * 2);
@@ -822,7 +822,8 @@ void mapgen_generate_from_heightmap(mapgen_settings* settings)
         for (uint32_t x = 0; x < _heightMapData.width; x++)
         {
             // The x and y axis are flipped in the world, so this uses y for x and x for y.
-            auto* const surfaceElement = map_get_surface_element_at(y + 1, x + 1);
+            auto* const surfaceElement = map_get_surface_element_at(
+                TileCoordsXY{ static_cast<int32_t>(y + 1), static_cast<int32_t>(x + 1) });
             if (surfaceElement == nullptr)
                 continue;
 

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -16,7 +16,7 @@
 
 static uint8_t getBaseHeightOrZero(int32_t x, int32_t y)
 {
-    auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+    auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     return surfaceElement ? surfaceElement->base_height : 0;
 }
 
@@ -31,7 +31,7 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
     {
         for (x = l; x < r; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
@@ -146,36 +146,36 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
             {
                 uint8_t slope = surfaceElement->GetSlope();
                 // Corners
-                auto surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 1 });
+                auto surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_N_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 1 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_W_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y - 1 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y - 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_E_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y - 1 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y - 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_S_CORNER_UP;
 
                 // Sides
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 0 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 0 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NE_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 0 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 0 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SW_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y - 1 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y - 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SE_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y + 1 });
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y + 1 }.ToCoordsXY());
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NW_SIDE_UP;
 
@@ -200,7 +200,7 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
  */
 int32_t tile_smooth(int32_t x, int32_t y)
 {
-    auto* const surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
+    auto* const surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     if (surfaceElement == nullptr)
         return 0;
 
@@ -241,7 +241,7 @@ int32_t tile_smooth(int32_t x, int32_t y)
                 continue;
 
             // Get neighbour height. If the element is not valid (outside of map) assume the same height
-            auto* neighbourSurfaceElement = map_get_surface_element_at(TileCoordsXY{ x + x_offset, y + y_offset });
+            auto* neighbourSurfaceElement = map_get_surface_element_at(TileCoordsXY{ x + x_offset, y + y_offset }.ToCoordsXY());
             neighbourHeightOffset.baseheight[index] = neighbourSurfaceElement != nullptr ? neighbourSurfaceElement->base_height
                                                                                          : surfaceElement->base_height;
 

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -16,7 +16,7 @@
 
 static uint8_t getBaseHeightOrZero(int32_t x, int32_t y)
 {
-    auto surfaceElement = map_get_surface_element_at(x, y);
+    auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
     return surfaceElement ? surfaceElement->base_height : 0;
 }
 
@@ -31,7 +31,7 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
     {
         for (x = l; x < r; x++)
         {
-            auto surfaceElement = map_get_surface_element_at(x, y);
+            auto surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
@@ -146,36 +146,36 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
             {
                 uint8_t slope = surfaceElement->GetSlope();
                 // Corners
-                auto surfaceElement2 = map_get_surface_element_at(x + 1, y + 1);
+                auto surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_N_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x - 1, y + 1);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_W_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x + 1, y - 1);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_E_CORNER_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x - 1, y - 1);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_S_CORNER_UP;
 
                 // Sides
-                surfaceElement2 = map_get_surface_element_at(x + 1, y + 0);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 1, y + 0 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NE_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x - 1, y + 0);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x - 1, y + 0 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SW_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x + 0, y - 1);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_SE_SIDE_UP;
 
-                surfaceElement2 = map_get_surface_element_at(x + 0, y + 1);
+                surfaceElement2 = map_get_surface_element_at(TileCoordsXY{ x + 0, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->base_height > surfaceElement->base_height)
                     slope |= TILE_ELEMENT_SLOPE_NW_SIDE_UP;
 
@@ -200,7 +200,7 @@ int32_t map_smooth(int32_t l, int32_t t, int32_t r, int32_t b)
  */
 int32_t tile_smooth(int32_t x, int32_t y)
 {
-    auto* const surfaceElement = map_get_surface_element_at(x, y);
+    auto* const surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y });
     if (surfaceElement == nullptr)
         return 0;
 
@@ -241,7 +241,7 @@ int32_t tile_smooth(int32_t x, int32_t y)
                 continue;
 
             // Get neighbour height. If the element is not valid (outside of map) assume the same height
-            auto* neighbourSurfaceElement = map_get_surface_element_at(x + x_offset, y + y_offset);
+            auto* neighbourSurfaceElement = map_get_surface_element_at(TileCoordsXY{ x + x_offset, y + y_offset });
             neighbourHeightOffset.baseheight[index] = neighbourSurfaceElement != nullptr ? neighbourSurfaceElement->base_height
                                                                                          : surfaceElement->base_height;
 

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -136,7 +136,7 @@ protected:
     static ::testing::AssertionResult AssertIsStartPosition(const char*, const TileCoordsXYZ& location)
     {
         const uint32_t expectedSurfaceStyle = 11u;
-        const uint32_t style = map_get_surface_element_at(location.x, location.y)->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y })->GetSurfaceStyle();
 
         if (style != expectedSurfaceStyle)
             return ::testing::AssertionFailure()
@@ -151,7 +151,7 @@ protected:
     {
         const uint32_t forbiddenSurfaceStyle = 8u;
 
-        const uint32_t style = map_get_surface_element_at(location.x, location.y)->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y })->GetSurfaceStyle();
 
         if (style == forbiddenSurfaceStyle)
             return ::testing::AssertionFailure()

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -136,8 +136,7 @@ protected:
     static ::testing::AssertionResult AssertIsStartPosition(const char*, const TileCoordsXYZ& location)
     {
         const uint32_t expectedSurfaceStyle = 11u;
-        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY())
-                                   ->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(location.ToCoordsXYZ())->GetSurfaceStyle();
 
         if (style != expectedSurfaceStyle)
             return ::testing::AssertionFailure()
@@ -152,8 +151,7 @@ protected:
     {
         const uint32_t forbiddenSurfaceStyle = 8u;
 
-        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY())
-                                   ->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(location.ToCoordsXYZ())->GetSurfaceStyle();
 
         if (style == forbiddenSurfaceStyle)
             return ::testing::AssertionFailure()

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -136,7 +136,8 @@ protected:
     static ::testing::AssertionResult AssertIsStartPosition(const char*, const TileCoordsXYZ& location)
     {
         const uint32_t expectedSurfaceStyle = 11u;
-        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y })->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY())
+                                   ->GetSurfaceStyle();
 
         if (style != expectedSurfaceStyle)
             return ::testing::AssertionFailure()
@@ -151,7 +152,8 @@ protected:
     {
         const uint32_t forbiddenSurfaceStyle = 8u;
 
-        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y })->GetSurfaceStyle();
+        const uint32_t style = map_get_surface_element_at(TileCoordsXY{ location.x, location.y }.ToCoordsXY())
+                                   ->GetSurfaceStyle();
 
         if (style == forbiddenSurfaceStyle)
             return ::testing::AssertionFailure()


### PR DESCRIPTION
This abstracts away the `/ 32` from all of the calls. Every place that was calling the `x, y` alternative was moved to call the `TileCoordsXY` one and the others that were already calling with `CoordsXY` were just made explicit to disambiguate.