### PR TITLE
Fix #10376: No ratings generated when a shop and track intersect

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 - Fix: [#10313] Path furniture can be placed on level crossings.
 - Fix: [#10325] Crash when banners have no text.
+- Fix: [#10376] No ratings generated when a shop and track intersect.
 - Fix: [#10420] Money effect causing false positive desync.
 - Fix: [#10477] Large Scenery cannot be placed higher using SHIFT.
 - Fix: [#10489] Hosts last player action not being synchronized.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -220,6 +220,12 @@ static void ride_ratings_update_state_2()
             continue;
         if (tileElement->base_height != z)
             continue;
+        if (tileElement->AsTrack()->GetRideIndex() != ride->id)
+        {
+            // Only check that the track belongs to the same ride if ride does not have buildable track
+            if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_TRACK))
+                continue;
+        }
 
         if (trackType == 255
             || (tileElement->AsTrack()->GetSequenceIndex() == 0 && trackType == tileElement->AsTrack()->GetTrackType()))
@@ -331,6 +337,12 @@ static void ride_ratings_update_state_5()
             continue;
         if (tileElement->base_height != z)
             continue;
+        if (tileElement->AsTrack()->GetRideIndex() != ride->id)
+        {
+            // Only check that the track belongs to the same ride if ride does not have buildable track
+            if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_TRACK))
+                continue;
+        }
 
         if (trackType == 255 || trackType == tileElement->AsTrack()->GetTrackType())
         {


### PR DESCRIPTION
Just limiting rides with no buildable track for now so that you still get ratings for rides that change track type. This may cause behaviour changes to hacked flat rides but I am hoping they aren't nearly as common.