### PR TITLE
Fix #10396: Function returning TileCoordsXYZD'z coord in a CoordsXYZD object

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3711,7 +3711,7 @@ void ride_construction_toolupdate_entrance_exit(ScreenCoordsXY screenCoords)
     gMapSelectArrowDirection = direction_reverse(entranceOrExitCoords.direction);
     gMapSelectArrowPosition.x = entranceOrExitCoords.x;
     gMapSelectArrowPosition.y = entranceOrExitCoords.y;
-    gMapSelectArrowPosition.z = entranceOrExitCoords.z * 8;
+    gMapSelectArrowPosition.z = entranceOrExitCoords.z;
     map_invalidate_selection_rect();
 
     entranceOrExitCoords.direction = direction_reverse(gRideEntranceExitPlaceDirection);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6226,7 +6226,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
     word_F4418C = coords->x;
     word_F4418E = coords->y;
 
-    entranceExitCoords = { coords->ToTileStart(), stationHeight, INVALID_DIRECTION };
+    entranceExitCoords = { coords->ToTileStart(), stationHeight * 8, INVALID_DIRECTION };
 
     if (ride->type == RIDE_TYPE_NULL)
     {


### PR DESCRIPTION
Closes #10396 