### PR TITLE
Refactor MapAnimation to use CoordsXYZ

### DIFF
--- a/src/openrct2/actions/BannerPlaceAction.hpp
+++ b/src/openrct2/actions/BannerPlaceAction.hpp
@@ -158,7 +158,7 @@ public:
             bannerElement->SetGhost(true);
         }
         map_invalidate_tile_full(_loc.x, _loc.y);
-        map_animation_create(MAP_ANIMATION_TYPE_BANNER, _loc.x, _loc.y, bannerElement->base_height);
+        map_animation_create(MAP_ANIMATION_TYPE_BANNER, CoordsXYZ{ _loc, bannerElement->base_height * 8 });
 
         rct_scenery_entry* bannerEntry = get_banner_entry(_bannerType);
         if (bannerEntry == nullptr)

--- a/src/openrct2/actions/LargeSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.hpp
@@ -313,7 +313,7 @@ public:
             TileElement* newTileElement = tile_element_insert(
                 { curTile.x / 32, curTile.y / 32, zLow }, quarterTile.GetBaseQuarterOccupied());
             Guard::Assert(newTileElement != nullptr);
-            map_animation_create(MAP_ANIMATION_TYPE_LARGE_SCENERY, curTile.x, curTile.y, zLow);
+            map_animation_create(MAP_ANIMATION_TYPE_LARGE_SCENERY, { curTile, zLow * 8 });
             newTileElement->SetType(TILE_ELEMENT_TYPE_LARGE_SCENERY);
             newTileElement->clearance_height = zHigh;
             auto newSceneryElement = newTileElement->AsLargeScenery();

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -185,7 +185,7 @@ public:
 
             if (index == 0)
             {
-                map_animation_create(MAP_ANIMATION_TYPE_PARK_ENTRANCE, entranceLoc.x, entranceLoc.y, zLow);
+                map_animation_create(MAP_ANIMATION_TYPE_PARK_ENTRANCE, { entranceLoc, zLow * 8 });
             }
         }
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -218,7 +218,7 @@ public:
             ride->stations[_stationNum].LastPeepInQueue = SPRITE_INDEX_NULL;
             ride->stations[_stationNum].QueueLength = 0;
 
-            map_animation_create(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, _loc.x, _loc.y, z / 8);
+            map_animation_create(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, { _loc, z });
         }
 
         footpath_queue_chain_reset();

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -456,7 +456,7 @@ public:
         map_invalidate_tile_full(_loc.x, _loc.y);
         if (scenery_small_entry_has_flag(sceneryEntry, SMALL_SCENERY_FLAG_ANIMATED))
         {
-            map_animation_create(MAP_ANIMATION_TYPE_SMALL_SCENERY, _loc.x, _loc.y, sceneryElement->base_height);
+            map_animation_create(MAP_ANIMATION_TYPE_SMALL_SCENERY, CoordsXYZ{ _loc, sceneryElement->base_height * 8 });
         }
 
         return res;

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -597,16 +597,17 @@ public:
             switch (_trackType)
             {
                 case TRACK_ELEM_WATERFALL:
-                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_WATERFALL, mapLoc.x, mapLoc.y, tileElement->base_height);
+                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_WATERFALL, CoordsXYZ{ mapLoc, tileElement->base_height * 8 });
                     break;
                 case TRACK_ELEM_RAPIDS:
-                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_RAPIDS, mapLoc.x, mapLoc.y, tileElement->base_height);
+                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_RAPIDS, CoordsXYZ{ mapLoc, tileElement->base_height * 8 });
                     break;
                 case TRACK_ELEM_WHIRLPOOL:
-                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL, mapLoc.x, mapLoc.y, tileElement->base_height);
+                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL, CoordsXYZ{ mapLoc, tileElement->base_height * 8 });
                     break;
                 case TRACK_ELEM_SPINNING_TUNNEL:
-                    map_animation_create(MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, mapLoc.x, mapLoc.y, tileElement->base_height);
+                    map_animation_create(
+                        MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, CoordsXYZ{ mapLoc, tileElement->base_height * 8 });
                     break;
             }
             if (track_element_has_speed_setting(_trackType))

--- a/src/openrct2/actions/WallPlaceAction.hpp
+++ b/src/openrct2/actions/WallPlaceAction.hpp
@@ -397,7 +397,7 @@ public:
         TileElement* tileElement = tile_element_insert({ _loc.x / 32, _loc.y / 32, targetHeight / 8 }, 0b0000);
         assert(tileElement != nullptr);
 
-        map_animation_create(MAP_ANIMATION_TYPE_WALL, _loc.x, _loc.y, targetHeight / 8);
+        map_animation_create(MAP_ANIMATION_TYPE_WALL, CoordsXYZ{ _loc, targetHeight });
 
         tileElement->SetType(TILE_ELEMENT_TYPE_WALL);
         WallElement* wallElement = tileElement->AsWall();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7443,7 +7443,7 @@ static void vehicle_update_scenery_door(rct_vehicle* vehicle)
     {
         tileElement->SetAnimationIsBackwards(false);
         tileElement->SetAnimationFrame(1);
-        map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, wallCoords.x, wallCoords.y, wallCoords.z >> 3);
+        map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, wallCoords);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
 
@@ -7496,7 +7496,8 @@ static void vehicle_trigger_on_ride_photo(rct_vehicle* vehicle, TileElement* til
 {
     tileElement->AsTrack()->SetPhotoTimeout();
 
-    map_animation_create(MAP_ANIMATION_TYPE_TRACK_ONRIDEPHOTO, vehicle->track_x, vehicle->track_y, tileElement->base_height);
+    map_animation_create(
+        MAP_ANIMATION_TYPE_TRACK_ONRIDEPHOTO, { vehicle->track_x, vehicle->track_y, tileElement->base_height * 8 });
 }
 
 /**
@@ -7523,7 +7524,7 @@ static void vehicle_update_handle_scenery_door(rct_vehicle* vehicle)
     {
         tileElement->SetAnimationIsBackwards(true);
         tileElement->SetAnimationFrame(1);
-        map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, wallCoords.x, wallCoords.y, wallCoords.z >> 3);
+        map_animation_create(MAP_ANIMATION_TYPE_WALL_DOOR, wallCoords);
         vehicle_play_scenery_door_open_sound(vehicle, tileElement);
     }
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1160,7 +1160,7 @@ void footpath_chain_ride_queue(
             lastPathElement->AsPath()->SetHasQueueBanner(true);
             lastPathElement->AsPath()->SetQueueBannerDirection(lastPathDirection); // set the ride sign direction
 
-            map_animation_create(MAP_ANIMATION_TYPE_QUEUE_BANNER, lastPathX, lastPathY, lastPathElement->base_height);
+            map_animation_create(MAP_ANIMATION_TYPE_QUEUE_BANNER, { lastPathX, lastPathY, lastPathElement->base_height * 8 });
         }
     }
 }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -37,7 +37,7 @@ static bool DoesAnimationExist(int32_t type, const CoordsXYZ& location)
 {
     for (const auto& a : _mapAnimations)
     {
-        if (a.type == type && a.location.x == location.x && a.location.y == location.y && a.location.z == location.z)
+        if (a.type == type && a.location == location)
         {
             // Animation already exists
             return true;
@@ -89,7 +89,8 @@ void map_animation_invalidate_all()
  */
 static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
 {
-    auto tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    TileCoordsXY tileLoc{ loc };
+    auto tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -123,9 +124,10 @@ static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -156,12 +158,13 @@ static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
     rct_sprite* sprite;
     Peep* peep;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -232,9 +235,10 @@ static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -261,9 +265,10 @@ static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -289,9 +294,10 @@ static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -317,9 +323,10 @@ static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -357,9 +364,10 @@ static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -385,9 +393,10 @@ static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_spinningtunnel(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -422,9 +431,10 @@ static bool map_animation_invalidate_remove([[maybe_unused]] CoordsXYZ loc)
  */
 static bool map_animation_invalidate_banner(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -446,11 +456,12 @@ static bool map_animation_invalidate_banner(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -477,6 +488,7 @@ static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
@@ -484,7 +496,7 @@ static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
         return false;
 
     bool removeAnimation = true;
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return removeAnimation;
     do
@@ -541,11 +553,12 @@ static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_wall(CoordsXYZ loc)
 {
+    TileCoordsXY tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
+    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
@@ -621,7 +634,7 @@ void AutoCreateMapAnimations()
     while (tile_element_iterator_next(&it))
     {
         auto el = it.element;
-        auto loc = CoordsXYZ{ it.x * 32, it.y * 32, el->base_height * 8};
+        auto loc = CoordsXYZ{ it.x * 32, it.y * 32, el->base_height * 8 };
         switch (el->GetType())
         {
             case TILE_ELEMENT_TYPE_BANNER:

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -25,7 +25,7 @@
 #include "SmallScenery.h"
 #include "Sprite.h"
 
-using map_animation_invalidate_event_handler = bool (*)(int32_t x, int32_t y, int32_t baseZ);
+using map_animation_invalidate_event_handler = bool (*)(CoordsXYZ loc);
 
 static std::vector<MapAnimation> _mapAnimations;
 
@@ -46,15 +46,14 @@ static bool DoesAnimationExist(int32_t type, const CoordsXYZ& location)
     return false;
 }
 
-void map_animation_create(int32_t type, int32_t x, int32_t y, int32_t z)
+void map_animation_create(int32_t type, const CoordsXYZ loc)
 {
-    auto location = CoordsXYZ{ x, y, z };
-    if (!DoesAnimationExist(type, location))
+    if (!DoesAnimationExist(type, loc))
     {
         if (_mapAnimations.size() < MAX_ANIMATED_OBJECTS)
         {
             // Create new animation
-            _mapAnimations.push_back({ (uint8_t)type, location });
+            _mapAnimations.push_back({ (uint8_t)type, loc });
         }
         else
         {
@@ -88,14 +87,14 @@ void map_animation_invalidate_all()
  *
  *  rct2: 0x00666670
  */
-static bool map_animation_invalidate_ride_entrance(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
 {
-    auto tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    auto tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
             continue;
@@ -108,8 +107,8 @@ static bool map_animation_invalidate_ride_entrance(int32_t x, int32_t y, int32_t
             auto stationObj = ride_get_station_object(ride);
             if (stationObj != nullptr)
             {
-                int32_t height = (tileElement->base_height * 8) + stationObj->Height + 8;
-                map_invalidate_tile_zoom1(x, y, height, height + 16);
+                int32_t height = loc.z + stationObj->Height + 8;
+                map_invalidate_tile_zoom1(loc.x, loc.y, height, height + 16);
             }
         }
         return false;
@@ -122,16 +121,16 @@ static bool map_animation_invalidate_ride_entrance(int32_t x, int32_t y, int32_t
  *
  *  rct2: 0x006A7BD4
  */
-static bool map_animation_invalidate_queue_banner(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_PATH)
             continue;
@@ -143,8 +142,7 @@ static bool map_animation_invalidate_queue_banner(int32_t x, int32_t y, int32_t 
         int32_t direction = (tileElement->AsPath()->GetQueueBannerDirection() + get_current_rotation()) & 3;
         if (direction == TILE_ELEMENT_DIRECTION_NORTH || direction == TILE_ELEMENT_DIRECTION_EAST)
         {
-            baseZ = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, baseZ + 16, baseZ + 30);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 16, loc.z + 30);
         }
         return false;
     } while (!(tileElement++)->IsLastForTile());
@@ -156,19 +154,19 @@ static bool map_animation_invalidate_queue_banner(int32_t x, int32_t y, int32_t 
  *
  *  rct2: 0x006E32C9
  */
-static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
 {
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
     rct_sprite* sprite;
     Peep* peep;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_SMALL_SCENERY)
             continue;
@@ -184,7 +182,7 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
                 SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 | SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 | SMALL_SCENERY_FLAG_SWAMP_GOO
                     | SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
         {
-            map_invalidate_tile_zoom1(x, y, tileElement->base_height * 8, tileElement->clearance_height * 8);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, tileElement->clearance_height * 8);
             return false;
         }
 
@@ -194,8 +192,8 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
             if (!(gCurrentTicks & 0x3FF) && game_is_not_paused())
             {
                 int32_t direction = tileElement->GetDirection();
-                int32_t x2 = x - CoordsDirectionDelta[direction].x;
-                int32_t y2 = y - CoordsDirectionDelta[direction].y;
+                int32_t x2 = loc.x - CoordsDirectionDelta[direction].x;
+                int32_t y2 = loc.y - CoordsDirectionDelta[direction].y;
 
                 uint16_t spriteIdx = sprite_get_first_in_quadrant(x2, y2);
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
@@ -207,7 +205,7 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
                     peep = &sprite->peep;
                     if (peep->state != PEEP_STATE_WALKING)
                         continue;
-                    if (peep->z != tileElement->base_height * 8)
+                    if (peep->z != loc.z)
                         continue;
                     if (peep->action < PEEP_ACTION_NONE_1)
                         continue;
@@ -220,7 +218,7 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
                     break;
                 }
             }
-            map_invalidate_tile_zoom1(x, y, tileElement->base_height * 8, tileElement->clearance_height * 8);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, tileElement->clearance_height * 8);
             return false;
         }
 
@@ -232,16 +230,16 @@ static bool map_animation_invalidate_small_scenery(int32_t x, int32_t y, int32_t
  *
  *  rct2: 0x00666C63
  */
-static bool map_animation_invalidate_park_entrance(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
             continue;
@@ -250,8 +248,7 @@ static bool map_animation_invalidate_park_entrance(int32_t x, int32_t y, int32_t
         if (tileElement->AsEntrance()->GetSequenceIndex())
             continue;
 
-        baseZ = tileElement->base_height * 8;
-        map_invalidate_tile_zoom1(x, y, baseZ + 32, baseZ + 64);
+        map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 32, loc.z + 64);
         return false;
     } while (!(tileElement++)->IsLastForTile());
 
@@ -262,24 +259,23 @@ static bool map_animation_invalidate_park_entrance(int32_t x, int32_t y, int32_t
  *
  *  rct2: 0x006CE29E
  */
-static bool map_animation_invalidate_track_waterfall(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TRACK_ELEM_WATERFALL)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z + 14, z + 46);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 14, loc.z + 46);
             return false;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -291,24 +287,23 @@ static bool map_animation_invalidate_track_waterfall(int32_t x, int32_t y, int32
  *
  *  rct2: 0x006CE2F3
  */
-static bool map_animation_invalidate_track_rapids(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TRACK_ELEM_RAPIDS)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z + 14, z + 18);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 14, loc.z + 18);
             return false;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -320,23 +315,23 @@ static bool map_animation_invalidate_track_rapids(int32_t x, int32_t y, int32_t 
  *
  *  rct2: 0x006CE39D
  */
-static bool map_animation_invalidate_track_onridephoto(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TRACK_ELEM_ON_RIDE_PHOTO)
         {
-            map_invalidate_tile_zoom1(x, y, tileElement->base_height * 8, tileElement->clearance_height * 8);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, tileElement->clearance_height * 8);
             if (game_is_paused())
             {
                 return false;
@@ -360,24 +355,23 @@ static bool map_animation_invalidate_track_onridephoto(int32_t x, int32_t y, int
  *
  *  rct2: 0x006CE348
  */
-static bool map_animation_invalidate_track_whirlpool(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TRACK_ELEM_WHIRLPOOL)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z + 14, z + 18);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 14, loc.z + 18);
             return false;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -389,24 +383,23 @@ static bool map_animation_invalidate_track_whirlpool(int32_t x, int32_t y, int32
  *
  *  rct2: 0x006CE3FA
  */
-static bool map_animation_invalidate_track_spinningtunnel(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_track_spinningtunnel(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TRACK_ELEM_SPINNING_TUNNEL)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z + 14, z + 32);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z + 14, loc.z + 32);
             return false;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -418,8 +411,7 @@ static bool map_animation_invalidate_track_spinningtunnel(int32_t x, int32_t y, 
  *
  *  rct2: 0x0068DF8F
  */
-static bool map_animation_invalidate_remove(
-    [[maybe_unused]] int32_t x, [[maybe_unused]] int32_t y, [[maybe_unused]] int32_t baseZ)
+static bool map_animation_invalidate_remove([[maybe_unused]] CoordsXYZ loc)
 {
     return true;
 }
@@ -428,22 +420,20 @@ static bool map_animation_invalidate_remove(
  *
  *  rct2: 0x006BA2BB
  */
-static bool map_animation_invalidate_banner(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_banner(CoordsXYZ loc)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_BANNER)
             continue;
-
-        baseZ = tileElement->base_height * 8;
-        map_invalidate_tile_zoom1(x, y, baseZ, baseZ + 16);
+        map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, loc.z + 16);
         return false;
     } while (!(tileElement++)->IsLastForTile());
 
@@ -454,18 +444,18 @@ static bool map_animation_invalidate_banner(int32_t x, int32_t y, int32_t baseZ)
  *
  *  rct2: 0x006B94EB
  */
-static bool map_animation_invalidate_large_scenery(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
 {
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_LARGE_SCENERY)
             continue;
@@ -473,8 +463,7 @@ static bool map_animation_invalidate_large_scenery(int32_t x, int32_t y, int32_t
         sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
         if (sceneryEntry->large_scenery.flags & LARGE_SCENERY_FLAG_ANIMATED)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z, z + 16);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, loc.z + 16);
             wasInvalidated = true;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -486,7 +475,7 @@ static bool map_animation_invalidate_large_scenery(int32_t x, int32_t y, int32_t
  *
  *  rct2: 0x006E5B50
  */
-static bool map_animation_invalidate_wall_door(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
 {
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
@@ -495,12 +484,12 @@ static bool map_animation_invalidate_wall_door(int32_t x, int32_t y, int32_t bas
         return false;
 
     bool removeAnimation = true;
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return removeAnimation;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;
@@ -539,8 +528,7 @@ static bool map_animation_invalidate_wall_door(int32_t x, int32_t y, int32_t bas
         tileElement->AsWall()->SetAnimationFrame(currentFrame);
         if (invalidate)
         {
-            int32_t z = tileElement->base_height * 8;
-            map_invalidate_tile_zoom1(x, y, z, z + 32);
+            map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, loc.z + 32);
         }
     } while (!(tileElement++)->IsLastForTile());
 
@@ -551,18 +539,18 @@ static bool map_animation_invalidate_wall_door(int32_t x, int32_t y, int32_t bas
  *
  *  rct2: 0x006E5EE4
  */
-static bool map_animation_invalidate_wall(int32_t x, int32_t y, int32_t baseZ)
+static bool map_animation_invalidate_wall(CoordsXYZ loc)
 {
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at(loc.x >> 5, loc.y >> 5);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != baseZ)
+        if (tileElement->base_height != loc.z / 8)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;
@@ -574,8 +562,7 @@ static bool map_animation_invalidate_wall(int32_t x, int32_t y, int32_t baseZ)
                 && sceneryEntry->wall.scrolling_mode == SCROLLING_MODE_NONE))
             continue;
 
-        int32_t z = tileElement->base_height * 8;
-        map_invalidate_tile_zoom1(x, y, z, z + 16);
+        map_invalidate_tile_zoom1(loc.x, loc.y, loc.z, loc.z + 16);
         wasInvalidated = true;
     } while (!(tileElement++)->IsLastForTile());
 
@@ -610,7 +597,7 @@ static bool InvalidateMapAnimation(const MapAnimation& a)
 {
     if (a.type < std::size(_animatedObjectEventHandlers))
     {
-        return _animatedObjectEventHandlers[a.type](a.location.x, a.location.y, a.location.z);
+        return _animatedObjectEventHandlers[a.type](a.location);
     }
     return true;
 }
@@ -634,11 +621,11 @@ void AutoCreateMapAnimations()
     while (tile_element_iterator_next(&it))
     {
         auto el = it.element;
-        auto loc = CoordsXYZ{ it.x * 32, it.y * 32, el->base_height };
+        auto loc = CoordsXYZ{ it.x * 32, it.y * 32, el->base_height * 8};
         switch (el->GetType())
         {
             case TILE_ELEMENT_TYPE_BANNER:
-                map_animation_create(MAP_ANIMATION_TYPE_BANNER, loc.x, loc.y, loc.z);
+                map_animation_create(MAP_ANIMATION_TYPE_BANNER, loc);
                 break;
             case TILE_ELEMENT_TYPE_WALL:
             {
@@ -647,7 +634,7 @@ void AutoCreateMapAnimations()
                 if (entry != nullptr
                     && ((entry->wall.flags2 & WALL_SCENERY_2_ANIMATED) || entry->wall.scrolling_mode != SCROLLING_MODE_NONE))
                 {
-                    map_animation_create(MAP_ANIMATION_TYPE_WALL, loc.x, loc.y, loc.z);
+                    map_animation_create(MAP_ANIMATION_TYPE_WALL, loc);
                 }
                 break;
             }
@@ -657,7 +644,7 @@ void AutoCreateMapAnimations()
                 auto entry = sceneryEl->GetEntry();
                 if (entry != nullptr && scenery_small_entry_has_flag(entry, SMALL_SCENERY_FLAG_ANIMATED))
                 {
-                    map_animation_create(MAP_ANIMATION_TYPE_SMALL_SCENERY, loc.x, loc.y, loc.z);
+                    map_animation_create(MAP_ANIMATION_TYPE_SMALL_SCENERY, loc);
                 }
                 break;
             }
@@ -667,7 +654,7 @@ void AutoCreateMapAnimations()
                 auto entry = sceneryEl->GetEntry();
                 if (entry != nullptr && (entry->large_scenery.flags & LARGE_SCENERY_FLAG_ANIMATED))
                 {
-                    map_animation_create(MAP_ANIMATION_TYPE_LARGE_SCENERY, loc.x, loc.y, loc.z);
+                    map_animation_create(MAP_ANIMATION_TYPE_LARGE_SCENERY, loc);
                 }
                 break;
             }
@@ -676,7 +663,7 @@ void AutoCreateMapAnimations()
                 auto path = el->AsPath();
                 if (path->HasQueueBanner())
                 {
-                    map_animation_create(MAP_ANIMATION_TYPE_QUEUE_BANNER, loc.x, loc.y, loc.z);
+                    map_animation_create(MAP_ANIMATION_TYPE_QUEUE_BANNER, loc);
                 }
                 break;
             }
@@ -688,11 +675,11 @@ void AutoCreateMapAnimations()
                     case ENTRANCE_TYPE_PARK_ENTRANCE:
                         if (entrance->GetSequenceIndex() == 0)
                         {
-                            map_animation_create(MAP_ANIMATION_TYPE_PARK_ENTRANCE, loc.x, loc.y, loc.z);
+                            map_animation_create(MAP_ANIMATION_TYPE_PARK_ENTRANCE, loc);
                         }
                         break;
                     case ENTRANCE_TYPE_RIDE_ENTRANCE:
-                        map_animation_create(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, loc.x, loc.y, loc.z);
+                        map_animation_create(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, loc);
                         break;
                 }
                 break;
@@ -703,16 +690,16 @@ void AutoCreateMapAnimations()
                 switch (track->GetTrackType())
                 {
                     case TRACK_ELEM_WATERFALL:
-                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_WATERFALL, loc.x, loc.y, loc.z);
+                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_WATERFALL, loc);
                         break;
                     case TRACK_ELEM_RAPIDS:
-                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_RAPIDS, loc.x, loc.y, loc.z);
+                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_RAPIDS, loc);
                         break;
                     case TRACK_ELEM_WHIRLPOOL:
-                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL, loc.x, loc.y, loc.z);
+                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_WHIRLPOOL, loc);
                         break;
                     case TRACK_ELEM_SPINNING_TUNNEL:
-                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, loc.x, loc.y, loc.z);
+                        map_animation_create(MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, loc);
                         break;
                 }
                 break;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -89,13 +89,13 @@ void map_animation_invalidate_all()
  */
 static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     auto tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
     if (tileElement == nullptr)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
             continue;
@@ -124,7 +124,7 @@ static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -132,7 +132,7 @@ static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_PATH)
             continue;
@@ -158,7 +158,7 @@ static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
     rct_sprite* sprite;
@@ -169,7 +169,7 @@ static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_SMALL_SCENERY)
             continue;
@@ -235,7 +235,7 @@ static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -243,7 +243,7 @@ static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
             continue;
@@ -265,7 +265,7 @@ static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -273,7 +273,7 @@ static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
@@ -294,7 +294,7 @@ static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -302,7 +302,7 @@ static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
@@ -323,7 +323,7 @@ static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -331,7 +331,7 @@ static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
@@ -364,7 +364,7 @@ static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -372,7 +372,7 @@ static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
@@ -393,7 +393,7 @@ static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_track_spinningtunnel(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -401,7 +401,7 @@ static bool map_animation_invalidate_track_spinningtunnel(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
@@ -431,7 +431,7 @@ static bool map_animation_invalidate_remove([[maybe_unused]] CoordsXYZ loc)
  */
 static bool map_animation_invalidate_banner(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
     tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
@@ -439,7 +439,7 @@ static bool map_animation_invalidate_banner(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_BANNER)
             continue;
@@ -456,7 +456,7 @@ static bool map_animation_invalidate_banner(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
@@ -466,7 +466,7 @@ static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_LARGE_SCENERY)
             continue;
@@ -488,7 +488,7 @@ static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
@@ -501,7 +501,7 @@ static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
         return removeAnimation;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;
@@ -553,7 +553,7 @@ static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
  */
 static bool map_animation_invalidate_wall(CoordsXYZ loc)
 {
-    TileCoordsXY tileLoc{ loc };
+    TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
     rct_scenery_entry* sceneryEntry;
 
@@ -563,7 +563,7 @@ static bool map_animation_invalidate_wall(CoordsXYZ loc)
         return true;
     do
     {
-        if (tileElement->base_height != loc.z / 8)
+        if (tileElement->base_height != tileLoc.z)
             continue;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -39,7 +39,7 @@ enum
     MAP_ANIMATION_TYPE_COUNT
 };
 
-void map_animation_create(int32_t type, int32_t x, int32_t y, int32_t z);
+void map_animation_create(int32_t type, const CoordsXYZ loc);
 void map_animation_invalidate_all();
 const std::vector<MapAnimation>& GetMapAnimations();
 void AutoCreateMapAnimations();


### PR DESCRIPTION
Found another instance where CoordsXYZ z component was in TileCoordsXYZ format. Fixed that as well at the same time.