### PR TITLE
Android: fix Gradle, CMake, asset copying; upgrade to AndroidX, fullscreen mode

### DIFF
--- a/src/openrct2-android/.gitignore
+++ b/src/openrct2-android/.gitignore
@@ -40,3 +40,7 @@ captures/
 
 # NDK
 .externalNativeBuild/
+app/.cxx/
+
+# Assets - copied from /bin/data
+app/src/main/assets/openrct2/

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId 'website.openrct2'
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
 
         versionCode 2
@@ -94,6 +94,14 @@ dependencies {
     implementation 'commons-io:commons-io:2.6'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.gms:play-services-analytics:17.0.0'
+}
+
+allprojects {
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '28.0.2'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId 'website.openrct2'
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 29
 
         versionCode 2
-        versionName '0.2.4'
+        versionName '0.2.5'
 
         externalNativeBuild {
             cmake {
@@ -18,6 +18,10 @@ android {
                 targets 'openrct2', 'openrct2-ui', 'openrct2-cli'
             }
         }
+    }
+
+    sourceSets {
+        main.assets.srcDirs += 'src/main/assets/'
     }
 
     signingConfigs {
@@ -77,41 +81,19 @@ android {
     }
 }
 
-apply plugin: 'de.undercouch.download'
+delete {
+    delete 'src/main/assets/openrct2'
+}
 
-android.applicationVariants.all { variant ->
-    variant.mergeAssets.doLast {
-        copy {
-            from '../../../data'
-            into "$variant.mergeAssets.outputDir/data"
-        }
-        download {
-            src 'https://github.com/OpenRCT2/openrct2-dependencies-android/releases/download/v0.8/g2.dat'
-            dest "$variant.mergeAssets.outputDir/data"
-        }
-        download {
-            src 'https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip'
-            dest new File(buildDir, 'title-sequence.zip')
-        }
-        copy {
-            from zipTree(new File(buildDir, 'title-sequence.zip'))
-            into "$variant.mergeAssets.outputDir/data/title"
-        }
-        download {
-            src 'https://github.com/OpenRCT2/objects/releases/download/v1.0.12/objects.zip'
-            dest new File(buildDir, 'objects.zip')
-        }
-        copy {
-            from zipTree(new File(buildDir, 'objects.zip'))
-            into "$variant.mergeAssets.outputDir/data/object"
-        }
-    }
+copy {
+    from '../../../bin/data'
+    into 'src/main/assets/openrct2'
 }
 
 dependencies {
-    compile 'commons-io:commons-io:2.5'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.google.android.gms:play-services-analytics:10.2.1'
+    implementation 'commons-io:commons-io:2.6'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.gms:play-services-analytics:17.0.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -51,9 +51,18 @@ ExternalProject_Add(libs
     LOG_INSTALL 1
 )
 
+# Files must be copied individually as the old Windows console does not support wildcards in the copy command
+# Doing multiple individual commands looks "less bad" than one massive line
 add_custom_command(TARGET libs POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/*.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+#    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/*.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libcrypto.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libfreetype.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libjansson.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libpng16.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libSDL2-2.0.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libspeexdsp.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/libs/lib/libssl.so" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 add_library(freetype SHARED IMPORTED)
@@ -130,12 +139,13 @@ include_directories("${CMAKE_BINARY_DIR}/libs/include/SDL2")
 # now build app's shared lib
 include_directories(./ndk_helper
                     ${ANDROID_NDK}/sources/android/cpufeatures)
-add_definitions(-DDISABLE_HTTP -DDISABLE_TWITCH -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
+add_definitions(-DDISABLE_HTTP -DDISABLE_DISCORD_RPC -DDISABLE_HTTP_TWITCH -DDISABLE_NETWORK -DDISABLE_TWITCH -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
 
 # Fix SpeexDSP compilation
 add_definitions(-DHAVE_STDINT_H)
 
-set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wno-unknown-pragmas -Wno-unused-function -Wno-missing-braces ")
+# -Werror -Wall
+set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Wundef -Wmissing-declarations -Winit-self  -Wno-unknown-pragmas -Wno-unused-function -Wno-missing-braces ")
 set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -Wno-comment -Wshadow  -Wmissing-declarations -Wnonnull")
 set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fPIC")
 
@@ -165,16 +175,13 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${ORCT2_ROOT}/src/openrct2-cli/*.hpp")
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})
-target_link_libraries(openrct2
-                        android log dl z SDL2
-                        png jansson icu icuuc icudata ssl crypto
-                      )
+target_link_libraries(openrct2 android stdc++ log dl z SDL2 png jansson icu icuuc icudata ssl crypto)
 
 add_library(openrct2-ui SHARED ${OPENRCT2_GUI_SOURCES})
-add_executable(openrct2-cli ${OPENRCT2_CLI_SOURCES})
+target_link_libraries(openrct2-ui openrct2 android stdc++ GLESv1_CM GLESv2 SDL2main speexdsp)
 
-target_link_libraries(openrct2-ui openrct2 GLESv1_CM GLESv2 SDL2main speexdsp)
-target_link_libraries(openrct2-cli openrct2)
+add_executable(openrct2-cli ${OPENRCT2_CLI_SOURCES})
+target_link_libraries(openrct2-cli openrct2 android stdc++ GLESv1_CM GLESv2)
 
 target_include_directories(openrct2-ui PRIVATE "${ORCT2_ROOT}/src")
 target_include_directories(openrct2-cli PRIVATE "${ORCT2_ROOT}/src")

--- a/src/openrct2-android/app/src/main/java/website/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/website/openrct2/GameActivity.java
@@ -1,5 +1,7 @@
 package website.openrct2;
 
+import android.view.View;
+
 import org.libsdl.app.SDLActivity;
 
 public class GameActivity extends SDLActivity {
@@ -20,6 +22,23 @@ public class GameActivity extends SDLActivity {
                 "openrct2",
                 "openrct2-ui"
         };
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+
+        // Set app to fullscreen mode
+        if (hasFocus) {
+            getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            );
+        }
     }
 
     protected String[] getArguments() {

--- a/src/openrct2-android/app/src/main/java/website/openrct2/MainActivity.java
+++ b/src/openrct2-android/app/src/main/java/website/openrct2/MainActivity.java
@@ -8,9 +8,9 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -146,7 +146,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void startGame() {
-        copyAssets();
+        copyAssets(); // TODO Don't copy/enumerate assets on every startup
         Intent intent = new Intent(this, GameActivity.class);
         if (getIntent().hasExtra("commandLineArgs")) {
             intent.putExtra("commandLineArgs", getIntent().getStringArrayExtra("commandLineArgs"));
@@ -155,10 +155,13 @@ public class MainActivity extends AppCompatActivity {
         finish();
     }
 
+    // TODO Don't copy/enumerate assets on every startup
+    // When building, ensure OpenRCT2 assets are inside their own directory within the APK assets,
+    // so that we do not attempt to copy files out of the standard Android asset folders - webkit, etc.
     private void copyAssets() {
         File dataDir = new File("/sdcard/openrct2/");
         try {
-            copyAsset(getAssets(), "data", dataDir, "");
+            copyAsset(getAssets(), "openrct2", dataDir, "");
         } catch (IOException e) {
             Log.e(TAG, "Error extracting files", e);
             return;
@@ -167,6 +170,7 @@ public class MainActivity extends AppCompatActivity {
         assetsCopied = true;
     }
 
+    // srcPath cannot be the empty string
     private void copyAsset(AssetManager assets, String srcPath, File dataDir, String destPath) throws IOException {
         String[] list = assets.list(srcPath);
 
@@ -188,7 +192,9 @@ public class MainActivity extends AppCompatActivity {
         }
 
         for (String fileName : list) {
-            copyAsset(assets, srcPath + File.separator + fileName, dataDir, destPath + File.separator + fileName);
+            // This ternary expression makes sure that this string does not begin with a slash
+            String destination = destPath + (destPath.equals("") ? "" : File.separator) + fileName;
+            copyAsset(assets, srcPath + File.separator + fileName, dataDir, destination);
         }
     }
 

--- a/src/openrct2-android/build.gradle
+++ b/src/openrct2-android/build.gradle
@@ -9,8 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'de.undercouch:gradle-download-task:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/src/openrct2-android/gradle.properties
+++ b/src/openrct2-android/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 15 05:32:00 CEST 2017
+#Tue Dec 17 14:39:20 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip


### PR DESCRIPTION
Android build now functions again. Compiled on Windows, tested on a Pixel 2 XL running Android 10.

Gradle now pulls from the main OpenRCT2 /bin/data folder to insert the assets into the APK. MainActivity now properly copies assets from within the APK. Dependencies have been updated and the support library has been upgraded to AndroidX. CMake libraries now link properly. Network (multiplayer), Discord, and HTTP_Twitch were disabled, in addition to the already-disabled HTTP, OpenGL, and Twitch, due to compile-time errors. Revision number incremented.

-Werror and -Wall were disabled (in Android only) for the time being due to compile-time errors caused by the disabled features.