### PR TITLE
Fix crash in dev builds due to sign issues

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1256,7 +1256,7 @@ static void sub_6E1F34(
                 assert(i < MAXIMUM_MAP_SIZE_TECHNICAL);
                 tileZ += scenery_entry->large_scenery.tiles[i].z_clearance;
             }
-            maxPossibleHeight -= tileZ;
+            maxPossibleHeight = std::max(0, maxPossibleHeight - tileZ);
         }
         can_raise_item = true;
     }


### PR DESCRIPTION
Small little crash I came across. This is due to changes that were made in #7868. I'm still not completely convinced that this fully fixes the issue as the behaviour is different to vanilla. Its a bit of a pain as adding up all z clearances is the absolute worst case but for the very vast majority of the cases it is excessive.