### PR TITLE
Fixing COORDS_NULL: Refactor stations

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1911,7 +1911,7 @@ static void window_ride_init_viewport(rct_window* w)
             }
         } while (count >= 0);
 
-        LocationXY8 location = ride->stations[stationIndex].Start;
+        auto location = ride->stations[stationIndex].Start;
 
         focus.coordinate.x = location.x * 32;
         focus.coordinate.y = location.y * 32;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -2121,7 +2121,7 @@ int32_t guest_path_finding(Guest* peep)
     if (numEntranceStations == 0)
     {
         // closestStationNum is always 0 here.
-        LocationXY8 entranceXY = ride->stations[closestStationNum].Start;
+        auto entranceXY = ride->stations[closestStationNum].Start;
         loc.x = entranceXY.x;
         loc.y = entranceXY.y;
         loc.z = ride->stations[closestStationNum].Height;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2333,7 +2333,7 @@ bool Staff::UpdateFixingMoveToStationEnd(bool firstRun, Ride* ride)
             return true;
         }
 
-        LocationXY8 stationPosition = ride->stations[current_ride_station].Start;
+        auto stationPosition = ride->stations[current_ride_station].Start;
         if (stationPosition.isNull())
         {
             return true;
@@ -2425,7 +2425,7 @@ bool Staff::UpdateFixingMoveToStationStart(bool firstRun, Ride* ride)
             return true;
         }
 
-        LocationXY8 stationPosition = ride->stations[current_ride_station].Start;
+        auto stationPosition = ride->stations[current_ride_station].Start;
         if (stationPosition.isNull())
         {
             return true;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -799,7 +799,7 @@ private:
         dst->overall_view = src->overall_view;
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {
-            if (src->station_starts->isNull())
+            if (src->station_starts[i].isNull())
             {
                 dst->stations[i].Start.setNull();
             }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -428,8 +428,7 @@ private:
                 case RCT1_RESEARCH_TYPE_THEME:
                     AddEntriesForSceneryTheme(researchItem->item);
                     break;
-                case RCT1_RESEARCH_TYPE_RIDE:
-                {
+                case RCT1_RESEARCH_TYPE_RIDE: {
                     uint8_t rideType = researchItem->item;
 
                     // Add all vehicles for this ride type
@@ -504,8 +503,7 @@ private:
         {
             switch (tileElement->GetType())
             {
-                case TILE_ELEMENT_TYPE_PATH:
-                {
+                case TILE_ELEMENT_TYPE_PATH: {
                     uint8_t pathType = tileElement->AsPath()->GetRCT1PathType();
                     uint8_t pathAdditionsType = tileElement->AsPath()->GetAddition();
 
@@ -519,8 +517,7 @@ private:
                 case TILE_ELEMENT_TYPE_LARGE_SCENERY:
                     AddEntryForLargeScenery(tileElement->AsLargeScenery()->GetEntryIndex());
                     break;
-                case TILE_ELEMENT_TYPE_WALL:
-                {
+                case TILE_ELEMENT_TYPE_WALL: {
                     for (int32_t edge = 0; edge < 4; edge++)
                     {
                         int32_t type = tileElement->AsWall()->GetRCT1WallType(edge);
@@ -799,7 +796,14 @@ private:
         dst->overall_view = src->overall_view;
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {
-            dst->stations[i].Start = src->station_starts[i];
+            if (src->station_starts->isNull())
+            {
+                dst->stations[i].Start.setNull();
+            }
+            else
+            {
+                dst->stations[i].Start = { src->station_starts[i].x, src->station_starts[i].y };
+            }
             dst->stations[i].Height = src->station_height[i] / 2;
             dst->stations[i].Length = src->station_length[i];
             dst->stations[i].Depart = src->station_light[i];
@@ -2022,8 +2026,7 @@ private:
 
         switch (tileElementType)
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
-            {
+            case TILE_ELEMENT_TYPE_SURFACE: {
                 auto dst2 = dst->AsSurface();
                 auto src2 = src->AsSurface();
 
@@ -2038,8 +2041,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_PATH:
-            {
+            case TILE_ELEMENT_TYPE_PATH: {
                 auto dst2 = dst->AsPath();
                 auto src2 = src->AsPath();
 
@@ -2109,8 +2111,7 @@ private:
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
-            {
+            case TILE_ELEMENT_TYPE_TRACK: {
                 auto dst2 = dst->AsTrack();
                 auto src2 = src->AsTrack();
 
@@ -2144,8 +2145,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
-            {
+            case TILE_ELEMENT_TYPE_SMALL_SCENERY: {
                 auto dst2 = dst->AsSmallScenery();
                 auto src2 = src->AsSmallScenery();
 
@@ -2175,8 +2175,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
-            {
+            case TILE_ELEMENT_TYPE_ENTRANCE: {
                 auto dst2 = dst->AsEntrance();
                 auto src2 = src->AsEntrance();
 
@@ -2198,8 +2197,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
-            {
+            case TILE_ELEMENT_TYPE_WALL: {
                 auto dst2 = dst->AsWall();
                 auto src2 = src->AsWall();
 
@@ -2210,8 +2208,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-            {
+            case TILE_ELEMENT_TYPE_LARGE_SCENERY: {
                 auto dst2 = dst->AsLargeScenery();
                 auto src2 = src->AsLargeScenery();
 
@@ -2223,8 +2220,7 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_BANNER:
-            {
+            case TILE_ELEMENT_TYPE_BANNER: {
                 auto dst2 = dst->AsBanner();
                 auto src2 = src->AsBanner();
 
@@ -2289,8 +2285,7 @@ private:
 
             switch (researchItem->type)
             {
-                case RCT1_RESEARCH_TYPE_THEME:
-                {
+                case RCT1_RESEARCH_TYPE_THEME: {
                     uint8_t rct1SceneryTheme = researchItem->item;
                     uint8_t sceneryGroupEntryIndex = _sceneryThemeTypeToEntryMap[rct1SceneryTheme];
                     if (sceneryGroupEntryIndex != 254 && sceneryGroupEntryIndex != 255)
@@ -2299,8 +2294,7 @@ private:
                     }
                     break;
                 }
-                case RCT1_RESEARCH_TYPE_RIDE:
-                {
+                case RCT1_RESEARCH_TYPE_RIDE: {
                     uint8_t rct1RideType = researchItem->item;
                     _researchRideTypeUsed[rct1RideType] = true;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -428,7 +428,8 @@ private:
                 case RCT1_RESEARCH_TYPE_THEME:
                     AddEntriesForSceneryTheme(researchItem->item);
                     break;
-                case RCT1_RESEARCH_TYPE_RIDE: {
+                case RCT1_RESEARCH_TYPE_RIDE:
+                {
                     uint8_t rideType = researchItem->item;
 
                     // Add all vehicles for this ride type
@@ -503,7 +504,8 @@ private:
         {
             switch (tileElement->GetType())
             {
-                case TILE_ELEMENT_TYPE_PATH: {
+                case TILE_ELEMENT_TYPE_PATH:
+                {
                     uint8_t pathType = tileElement->AsPath()->GetRCT1PathType();
                     uint8_t pathAdditionsType = tileElement->AsPath()->GetAddition();
 
@@ -517,7 +519,8 @@ private:
                 case TILE_ELEMENT_TYPE_LARGE_SCENERY:
                     AddEntryForLargeScenery(tileElement->AsLargeScenery()->GetEntryIndex());
                     break;
-                case TILE_ELEMENT_TYPE_WALL: {
+                case TILE_ELEMENT_TYPE_WALL:
+                {
                     for (int32_t edge = 0; edge < 4; edge++)
                     {
                         int32_t type = tileElement->AsWall()->GetRCT1WallType(edge);
@@ -2026,7 +2029,8 @@ private:
 
         switch (tileElementType)
         {
-            case TILE_ELEMENT_TYPE_SURFACE: {
+            case TILE_ELEMENT_TYPE_SURFACE:
+            {
                 auto dst2 = dst->AsSurface();
                 auto src2 = src->AsSurface();
 
@@ -2041,7 +2045,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_PATH: {
+            case TILE_ELEMENT_TYPE_PATH:
+            {
                 auto dst2 = dst->AsPath();
                 auto src2 = src->AsPath();
 
@@ -2111,7 +2116,8 @@ private:
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK: {
+            case TILE_ELEMENT_TYPE_TRACK:
+            {
                 auto dst2 = dst->AsTrack();
                 auto src2 = src->AsTrack();
 
@@ -2145,7 +2151,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY: {
+            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            {
                 auto dst2 = dst->AsSmallScenery();
                 auto src2 = src->AsSmallScenery();
 
@@ -2175,7 +2182,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE: {
+            case TILE_ELEMENT_TYPE_ENTRANCE:
+            {
                 auto dst2 = dst->AsEntrance();
                 auto src2 = src->AsEntrance();
 
@@ -2197,7 +2205,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL: {
+            case TILE_ELEMENT_TYPE_WALL:
+            {
                 auto dst2 = dst->AsWall();
                 auto src2 = src->AsWall();
 
@@ -2208,7 +2217,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY: {
+            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            {
                 auto dst2 = dst->AsLargeScenery();
                 auto src2 = src->AsLargeScenery();
 
@@ -2220,7 +2230,8 @@ private:
 
                 break;
             }
-            case TILE_ELEMENT_TYPE_BANNER: {
+            case TILE_ELEMENT_TYPE_BANNER:
+            {
                 auto dst2 = dst->AsBanner();
                 auto src2 = src->AsBanner();
 
@@ -2285,7 +2296,8 @@ private:
 
             switch (researchItem->type)
             {
-                case RCT1_RESEARCH_TYPE_THEME: {
+                case RCT1_RESEARCH_TYPE_THEME:
+                {
                     uint8_t rct1SceneryTheme = researchItem->item;
                     uint8_t sceneryGroupEntryIndex = _sceneryThemeTypeToEntryMap[rct1SceneryTheme];
                     if (sceneryGroupEntryIndex != 254 && sceneryGroupEntryIndex != 255)
@@ -2294,7 +2306,8 @@ private:
                     }
                     break;
                 }
-                case RCT1_RESEARCH_TYPE_RIDE: {
+                case RCT1_RESEARCH_TYPE_RIDE:
+                {
                     uint8_t rct1RideType = researchItem->item;
                     _researchRideTypeUsed[rct1RideType] = true;
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -532,7 +532,8 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
         }
         else
         {
-            dst->station_starts[i] = { static_cast<uint8_t>(src->stations[i].Start.x), static_cast<uint8_t>(src->stations[i].Start.y) };
+            dst->station_starts[i] = { static_cast<uint8_t>(src->stations[i].Start.x),
+                                       static_cast<uint8_t>(src->stations[i].Start.y) };
         }
         dst->station_heights[i] = src->stations[i].Height;
         dst->station_length[i] = src->stations[i].Length;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -526,7 +526,14 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
 
     for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
     {
-        dst->station_starts[i] = src->stations[i].Start;
+        if (src->stations[i].Start.isNull())
+        {
+            dst->station_starts[i].setNull();
+        }
+        else
+        {
+            dst->station_starts[i] = { src->stations[i].Start.x, src->stations[i].Start.y };
+        }
         dst->station_heights[i] = src->stations[i].Height;
         dst->station_length[i] = src->stations[i].Length;
         dst->station_depart[i] = src->stations[i].Depart;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -532,7 +532,7 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
         }
         else
         {
-            dst->station_starts[i] = { src->stations[i].Start.x, src->stations[i].Start.y };
+            dst->station_starts[i] = { static_cast<uint8_t>(src->stations[i].Start.x), static_cast<uint8_t>(src->stations[i].Start.y) };
         }
         dst->station_heights[i] = src->stations[i].Height;
         dst->station_length[i] = src->stations[i].Length;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -521,7 +521,7 @@ public:
 
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {
-            if (src->station_starts->isNull())
+            if (src->station_starts[i].isNull())
             {
                 dst->stations[i].Start.setNull();
             }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -521,7 +521,14 @@ public:
 
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {
-            dst->stations[i].Start = src->station_starts[i];
+            if (src->station_starts->isNull())
+            {
+                dst->stations[i].Start.setNull();
+            }
+            else
+            {
+                dst->stations[i].Start = { src->station_starts[i].x, src->station_starts[i].y };
+            }
             dst->stations[i].Height = src->station_heights[i];
             dst->stations[i].Length = src->station_length[i];
             dst->stations[i].Depart = src->station_depart[i];

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3289,14 +3289,12 @@ static void ride_entrance_exit_connected(Ride* ride)
 
 static void ride_shop_connected(Ride* ride)
 {
-    LocationXY8 coordinates = ride->stations[0].Start;
-    if (coordinates.isNull())
+    TileCoordsXY shopLoc = ride->stations[0].Start;
+    if (shopLoc.isNull())
         return;
 
-    TileCoordsXY loc = { coordinates.x, coordinates.y };
-
     TrackElement* trackElement = nullptr;
-    TileElement* tileElement = map_get_first_element_at(loc.x, loc.y);
+    TileElement* tileElement = map_get_first_element_at(shopLoc.x, shopLoc.y);
     do
     {
         if (tileElement == nullptr)
@@ -3346,8 +3344,8 @@ static void ride_shop_connected(Ride* ride)
         // Flip direction north<->south, east<->west
         uint8_t face_direction = direction_reverse(count);
 
-        int32_t y2 = loc.y - TileDirectionDelta[face_direction].y;
-        int32_t x2 = loc.x - TileDirectionDelta[face_direction].x;
+        int32_t y2 = shopLoc.y - TileDirectionDelta[face_direction].y;
+        int32_t x2 = shopLoc.x - TileDirectionDelta[face_direction].x;
 
         if (map_coord_is_connected({ x2, y2, tileElement->base_height }, face_direction))
             return;
@@ -4924,7 +4922,7 @@ void loc_6DDF9C(Ride* ride, TileElement* tileElement)
  */
 static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
 {
-    LocationXY8 location;
+    TileCoordsXY location;
     int32_t stationIndex;
     for (stationIndex = 0; stationIndex < MAX_STATIONS; stationIndex++)
     {
@@ -6234,7 +6232,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
         return entranceExitCoords;
     }
 
-    LocationXY8 stationStart = ride->stations[gRideEntranceExitPlaceStationIndex].Start;
+    auto stationStart = ride->stations[gRideEntranceExitPlaceStationIndex].Start;
     if (stationStart.isNull())
     {
         entranceExitCoords.x = LOCATION_NULL;
@@ -6657,12 +6655,11 @@ static int32_t ride_get_track_length(Ride* ride)
 
     for (int32_t i = 0; i < MAX_STATIONS && !foundTrack; i++)
     {
-        LocationXY8 location = ride->stations[i].Start;
-        if (location.isNull())
+        if (ride->stations[i].Start.isNull())
             continue;
 
-        x = location.x * 32;
-        y = location.y * 32;
+        x = ride->stations[i].Start.x * 32;
+        y = ride->stations[i].Start.y * 32;
         z = ride->stations[i].Height;
 
         tileElement = map_get_first_element_at(x >> 5, y >> 5);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3257,7 +3257,7 @@ static void ride_entrance_exit_connected(Ride* ride)
 {
     for (int32_t i = 0; i < MAX_STATIONS; ++i)
     {
-        LocationXY8 station_start = ride->stations[i].Start;
+        auto station_start = ride->stations[i].Start;
         auto entrance = ride_get_entrance_location(ride, i);
         auto exit = ride_get_exit_location(ride, i);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6650,19 +6650,20 @@ static int32_t ride_get_track_length(Ride* ride)
     TileElement* tileElement = nullptr;
     track_circuit_iterator it, slowIt;
     ride_id_t rideIndex;
-    int32_t x = 0, y = 0, z, trackType, result;
+    int32_t trackType, result;
+    CoordsXY trackStart;
     bool foundTrack = false;
 
     for (int32_t i = 0; i < MAX_STATIONS && !foundTrack; i++)
     {
-        if (ride->stations[i].Start.isNull())
+        const auto& stationTileLoc = ride->stations[i].Start;
+        if (stationTileLoc.isNull())
             continue;
 
-        x = ride->stations[i].Start.x * 32;
-        y = ride->stations[i].Start.y * 32;
-        z = ride->stations[i].Height;
+        trackStart = stationTileLoc.ToCoordsXY();
+        auto z = ride->stations[i].Height;
 
-        tileElement = map_get_first_element_at(x >> 5, y >> 5);
+        tileElement = map_get_first_element_at(stationTileLoc.x, stationTileLoc.y);
         if (tileElement == nullptr)
             continue;
         do
@@ -6693,7 +6694,7 @@ static int32_t ride_get_track_length(Ride* ride)
 
         bool moveSlowIt = true;
         result = 0;
-        track_circuit_iterator_begin(&it, { x, y, tileElement });
+        track_circuit_iterator_begin(&it, { trackStart.x, trackStart.y, tileElement });
         slowIt = it;
         while (track_circuit_iterator_next(&it))
         {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -162,7 +162,7 @@ struct rct_ride_entry
 
 struct RideStation
 {
-    LocationXY8 Start;
+    TileCoordsXY Start;
     uint8_t Height;
     uint8_t Length;
     uint8_t Depart;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1433,7 +1433,7 @@ static int32_t ride_ratings_get_scenery_score(Ride* ride)
     }
     else
     {
-        LocationXY8 location = ride->stations[i].Start;
+        auto location = ride->stations[i].Start;
         x = location.x;
         y = location.y;
     }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -417,12 +417,12 @@ TileCoordsXYZD ride_get_exit_location(const Ride* ride, const int32_t stationInd
 
 void ride_clear_entrance_location(Ride* ride, const int32_t stationIndex)
 {
-    ride->stations[stationIndex].Entrance.x = COORDS_NULL;
+    ride->stations[stationIndex].Entrance.setNull();
 }
 
 void ride_clear_exit_location(Ride* ride, const int32_t stationIndex)
 {
-    ride->stations[stationIndex].Exit.x = COORDS_NULL;
+    ride->stations[stationIndex].Exit.setNull();
 }
 
 void ride_set_entrance_location(Ride* ride, const int32_t stationIndex, const TileCoordsXYZD location)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9282,16 +9282,14 @@ loc_6DCE62:
 
 loc_6DCE68:
     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION;
-    regs.al = vehicle->track_x >> 5;
-    regs.ah = vehicle->track_y >> 5;
-    regs.dl = vehicle->track_z >> 3;
+
     for (int32_t i = 0; i < MAX_STATIONS; i++)
     {
-        if ((uint16_t)regs.ax != ride->stations[i].Start.xy)
+        if (((vehicle->track_x >> 5) != ride->stations[i].Start.x) && ((vehicle->track_y >> 5) != ride->stations[i].Start.y))
         {
             continue;
         }
-        if ((uint16_t)regs.dl != ride->stations[i].Height)
+        if ((vehicle->track_z >> 3) != ride->stations[i].Height)
         {
             continue;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2797,7 +2797,7 @@ static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle)
         return false;
 
     int32_t station = vehicle->current_station;
-    LocationXY8 location = ride->stations[station].Start;
+    auto location = ride->stations[station].Start;
     int32_t x = location.x * 32;
     int32_t y = location.y * 32;
     int32_t z = ride->stations[station].Height;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9285,7 +9285,8 @@ loc_6DCE68:
 
     for (int32_t i = 0; i < MAX_STATIONS; i++)
     {
-        if (((vehicle->track_x >> 5) != ride->stations[i].Start.x) && ((vehicle->track_y >> 5) != ride->stations[i].Start.y))
+        auto trackLoc = TileCoordsXY(CoordsXY{ vehicle->track_x, vehicle->track_y });
+        if (trackLoc != ride->stations[i].Start)
         {
             continue;
         }

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -234,6 +234,11 @@ struct TileCoordsXY
     {
         return x == COORDS_NULL;
     };
+
+    void setNull()
+    {
+        x = COORDS_NULL;
+    }
 };
 
 struct CoordsXYZ : public CoordsXY

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -230,6 +230,16 @@ struct TileCoordsXY
         return rotatedCoords;
     }
 
+    bool operator==(const TileCoordsXY& other) const
+    {
+        return x == other.x && y == other.y;
+    }
+
+    bool operator!=(const TileCoordsXY& other) const
+    {
+        return !(*this == other);
+    }
+
     bool isNull() const
     {
         return x == COORDS_NULL;


### PR DESCRIPTION
Moving the internal stations.Start to TileCoordsXY so that we can use the preferred NULL value in next refactor.