### PR TITLE
Make Map::map_get_first_element_at() use CoordsXY

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -527,7 +527,7 @@ static void viewport_interaction_remove_footpath(TileElement* tileElement, Coord
     if (w != nullptr)
         footpath_provisional_update();
 
-    tileElement2 = map_get_first_element_at(mapCoords.x / 32, mapCoords.y / 32);
+    tileElement2 = map_get_first_element_at(mapCoords);
     if (tileElement2 == nullptr)
         return;
     do

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -136,7 +136,7 @@ rct_window* window_banner_open(rct_windownumber number)
     int32_t view_x = banner->position.x << 5;
     int32_t view_y = banner->position.y << 5;
 
-    TileElement* tile_element = map_get_first_element_at(view_x / 32, view_y / 32);
+    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
     if (tile_element == nullptr)
         return nullptr;
     while (1)
@@ -177,7 +177,7 @@ static void window_banner_mouseup(rct_window* w, rct_widgetindex widgetIndex)
     int32_t x = banner->position.x << 5;
     int32_t y = banner->position.y << 5;
 
-    TileElement* tile_element = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tile_element = map_get_first_element_at({ x, y });
     if (tile_element == nullptr)
         return;
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1077,7 +1077,7 @@ static TileElement* footpath_get_tile_element_to_remove()
     z = (gFootpathConstructFromPosition.z >> 3) & 0xFF;
     zLow = z - 2;
 
-    tileElement = map_get_first_element_at(x, y);
+    tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     do
     {
         if (tileElement == nullptr)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2435,19 +2435,23 @@ static void sub_6CBCE2(
         int32_t baseZ = (originZ + trackBlock->z) >> 3;
         int32_t clearanceZ = ((trackBlock->var_07 + RideData5[ride->type].clearance_height) >> 3) + baseZ + 4;
 
-        auto tileCoords = TileCoordsXY{ coords };
+        auto centreTileCoords = TileCoordsXY{ coords };
+        auto eastTileCoords = centreTileCoords + TileDirectionDelta[2];
+        auto westTileCoords = centreTileCoords + TileDirectionDelta[0];
+        auto northTileCoords = centreTileCoords + TileDirectionDelta[1];
+        auto southTileCoords = centreTileCoords + TileDirectionDelta[3];
 
         // Replace map elements with temporary ones containing track
-        _backupTileElementArrays[0] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y + 0 }.ToCoordsXY());
-        _backupTileElementArrays[1] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 1, tileCoords.y + 0 }.ToCoordsXY());
-        _backupTileElementArrays[2] = map_get_first_element_at(TileCoordsXY{ tileCoords.x - 1, tileCoords.y + 0 }.ToCoordsXY());
-        _backupTileElementArrays[3] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y + 1 }.ToCoordsXY());
-        _backupTileElementArrays[4] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y - 1 }.ToCoordsXY());
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y + 0 }, &_tempTrackTileElement);
-        map_set_tile_element({ tileCoords.x + 1, tileCoords.y + 0 }, &_tempSideTrackTileElement);
-        map_set_tile_element({ tileCoords.x - 1, tileCoords.y + 0 }, &_tempSideTrackTileElement);
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y + 1 }, &_tempSideTrackTileElement);
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y - 1 }, &_tempSideTrackTileElement);
+        _backupTileElementArrays[0] = map_get_first_element_at(centreTileCoords.ToCoordsXY());
+        _backupTileElementArrays[1] = map_get_first_element_at(eastTileCoords.ToCoordsXY());
+        _backupTileElementArrays[2] = map_get_first_element_at(westTileCoords.ToCoordsXY());
+        _backupTileElementArrays[3] = map_get_first_element_at(northTileCoords.ToCoordsXY());
+        _backupTileElementArrays[4] = map_get_first_element_at(southTileCoords.ToCoordsXY());
+        map_set_tile_element(centreTileCoords, &_tempTrackTileElement);
+        map_set_tile_element(eastTileCoords, &_tempSideTrackTileElement);
+        map_set_tile_element(westTileCoords, &_tempSideTrackTileElement);
+        map_set_tile_element(northTileCoords, &_tempSideTrackTileElement);
+        map_set_tile_element(southTileCoords, &_tempSideTrackTileElement);
 
         // Set the temporary track element
         _tempTrackTileElement.SetType(TILE_ELEMENT_TYPE_TRACK);
@@ -2469,11 +2473,11 @@ static void sub_6CBCE2(
         sub_68B2B7(session, coords);
 
         // Restore map elements
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y + 0 }, _backupTileElementArrays[0]);
-        map_set_tile_element({ tileCoords.x + 1, tileCoords.y + 0 }, _backupTileElementArrays[1]);
-        map_set_tile_element({ tileCoords.x - 1, tileCoords.y + 0 }, _backupTileElementArrays[2]);
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y + 1 }, _backupTileElementArrays[3]);
-        map_set_tile_element({ tileCoords.x + 0, tileCoords.y - 1 }, _backupTileElementArrays[4]);
+        map_set_tile_element(centreTileCoords, _backupTileElementArrays[0]);
+        map_set_tile_element(eastTileCoords, _backupTileElementArrays[1]);
+        map_set_tile_element(westTileCoords, _backupTileElementArrays[2]);
+        map_set_tile_element(northTileCoords, _backupTileElementArrays[3]);
+        map_set_tile_element(southTileCoords, _backupTileElementArrays[4]);
 
         trackBlock++;
     }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2438,11 +2438,11 @@ static void sub_6CBCE2(
         auto tileCoords = TileCoordsXY{ coords };
 
         // Replace map elements with temporary ones containing track
-        _backupTileElementArrays[0] = map_get_first_element_at(tileCoords.x + 0, tileCoords.y + 0);
-        _backupTileElementArrays[1] = map_get_first_element_at(tileCoords.x + 1, tileCoords.y + 0);
-        _backupTileElementArrays[2] = map_get_first_element_at(tileCoords.x - 1, tileCoords.y + 0);
-        _backupTileElementArrays[3] = map_get_first_element_at(tileCoords.x + 0, tileCoords.y + 1);
-        _backupTileElementArrays[4] = map_get_first_element_at(tileCoords.x + 0, tileCoords.y - 1);
+        _backupTileElementArrays[0] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y + 0 }.ToCoordsXY());
+        _backupTileElementArrays[1] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 1, tileCoords.y + 0 }.ToCoordsXY());
+        _backupTileElementArrays[2] = map_get_first_element_at(TileCoordsXY{ tileCoords.x - 1, tileCoords.y + 0 }.ToCoordsXY());
+        _backupTileElementArrays[3] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y + 1 }.ToCoordsXY());
+        _backupTileElementArrays[4] = map_get_first_element_at(TileCoordsXY{ tileCoords.x + 0, tileCoords.y - 1 }.ToCoordsXY());
         map_set_tile_element({ tileCoords.x + 0, tileCoords.y + 0 }, &_tempTrackTileElement);
         map_set_tile_element({ tileCoords.x + 1, tileCoords.y + 0 }, &_tempSideTrackTileElement);
         map_set_tile_element({ tileCoords.x - 1, tileCoords.y + 0 }, &_tempSideTrackTileElement);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2436,10 +2436,10 @@ static void sub_6CBCE2(
         int32_t clearanceZ = ((trackBlock->var_07 + RideData5[ride->type].clearance_height) >> 3) + baseZ + 4;
 
         auto centreTileCoords = TileCoordsXY{ coords };
-        auto eastTileCoords = centreTileCoords + TileDirectionDelta[2];
-        auto westTileCoords = centreTileCoords + TileDirectionDelta[0];
-        auto northTileCoords = centreTileCoords + TileDirectionDelta[1];
-        auto southTileCoords = centreTileCoords + TileDirectionDelta[3];
+        auto eastTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_EAST];
+        auto westTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_WEST];
+        auto northTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_NORTH];
+        auto southTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_SOUTH];
 
         // Replace map elements with temporary ones containing track
         _backupTileElementArrays[0] = map_get_first_element_at(centreTileCoords.ToCoordsXY());

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -159,7 +159,7 @@ rct_window* window_sign_open(rct_windownumber number)
     int32_t view_x = banner->position.x << 5;
     int32_t view_y = banner->position.y << 5;
 
-    TileElement* tile_element = map_get_first_element_at(view_x / 32, view_y / 32);
+    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
     if (tile_element == nullptr)
         return nullptr;
 
@@ -217,7 +217,7 @@ static void window_sign_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             auto banner = GetBanner(w->number);
             int32_t x = banner->position.x << 5;
             int32_t y = banner->position.y << 5;
-            auto tile_element = map_get_first_element_at(x / 32, y / 32);
+            auto tile_element = map_get_first_element_at({ x, y });
             if (tile_element == nullptr)
                 return;
             while (1)
@@ -408,7 +408,7 @@ rct_window* window_sign_small_open(rct_windownumber number)
     int32_t view_x = banner->position.x << 5;
     int32_t view_y = banner->position.y << 5;
 
-    TileElement* tile_element = map_get_first_element_at(view_x / 32, view_y / 32);
+    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
     if (tile_element == nullptr)
         return nullptr;
 
@@ -465,7 +465,7 @@ static void window_sign_small_mouseup(rct_window* w, rct_widgetindex widgetIndex
             auto banner = GetBanner(w->number);
             int32_t x = banner->position.x << 5;
             int32_t y = banner->position.y << 5;
-            auto tile_element = map_get_first_element_at(x / 32, y / 32);
+            auto tile_element = map_get_first_element_at({ x, y });
             if (tile_element == nullptr)
                 return;
             while (true)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -576,8 +576,7 @@ static TileElement* window_tile_inspector_get_selected_element(rct_window* w)
     openrct2_assert(
         windowTileInspectorSelectedIndex >= 0 && windowTileInspectorSelectedIndex < windowTileInspectorElementCount,
         "Selected list item out of range");
-    return map_get_first_element_at(windowTileInspectorToolMap.x / 32, windowTileInspectorToolMap.y / 32)
-        + windowTileInspectorSelectedIndex;
+    return map_get_first_element_at(windowTileInspectorToolMap) + windowTileInspectorSelectedIndex;
 }
 
 static void window_tile_inspector_select_element_from_list(rct_window* w, int32_t index)
@@ -599,7 +598,7 @@ static void window_tile_inspector_load_tile(rct_window* w, TileElement* elementT
     windowTileInspectorSelectedIndex = -1;
     w->scrolls[0].v_top = 0;
 
-    TileElement* element = map_get_first_element_at(windowTileInspectorToolMap.x / 32, windowTileInspectorToolMap.y / 32);
+    TileElement* element = map_get_first_element_at(windowTileInspectorToolMap);
     int16_t numItems = 0;
     do
     {
@@ -2161,8 +2160,7 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
     if (!windowTileInspectorTileSelected)
         return;
 
-    const TileElement* tileElement = map_get_first_element_at(
-        windowTileInspectorToolMap.x / 32, windowTileInspectorToolMap.y / 32);
+    const TileElement* tileElement = map_get_first_element_at(windowTileInspectorToolMap);
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     do

--- a/src/openrct2/actions/BannerPlaceAction.hpp
+++ b/src/openrct2/actions/BannerPlaceAction.hpp
@@ -173,7 +173,7 @@ public:
 private:
     PathElement* GetValidPathElement() const
     {
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
         do
         {
             if (tileElement == nullptr)

--- a/src/openrct2/actions/BannerRemoveAction.hpp
+++ b/src/openrct2/actions/BannerRemoveAction.hpp
@@ -129,7 +129,7 @@ public:
 private:
     BannerElement* GetBannerElementAt() const
     {
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
 
         // Find the banner element at known z and position
         do

--- a/src/openrct2/actions/ClearAction.hpp
+++ b/src/openrct2/actions/ClearAction.hpp
@@ -240,7 +240,7 @@ private:
         {
             for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
             {
-                auto tileElement = map_get_first_element_at(TileCoordsXY{x, y}.ToCoordsXY());
+                auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
                 do
                 {
                     if (tileElement == nullptr)

--- a/src/openrct2/actions/ClearAction.hpp
+++ b/src/openrct2/actions/ClearAction.hpp
@@ -143,7 +143,7 @@ private:
         do
         {
             tileEdited = false;
-            tileElement = map_get_first_element_at(x, y);
+            tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (tileElement == nullptr)
                 return totalCost;
             do
@@ -240,7 +240,7 @@ private:
         {
             for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
             {
-                auto tileElement = map_get_first_element_at(x, y);
+                auto tileElement = map_get_first_element_at(TileCoordsXY{x, y}.ToCoordsXY());
                 do
                 {
                     if (tileElement == nullptr)

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -437,7 +437,7 @@ private:
         TileElement* tileElement;
         bool isSloped = slope & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
 
-        tileElement = map_get_first_element_at(x, y);
+        tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
         do
         {
             if (tileElement == nullptr)

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -204,7 +204,7 @@ private:
 
     TileElement* CheckTreeObstructions() const
     {
-        TileElement* tileElement = map_get_first_element_at(_coords.x / 32, _coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_coords);
         do
         {
             if (tileElement == nullptr)
@@ -227,7 +227,7 @@ private:
     money32 GetSmallSceneryRemovalCost() const
     {
         money32 cost{ 0 };
-        TileElement* tileElement = map_get_first_element_at(_coords.x / 32, _coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_coords);
         do
         {
             if (tileElement == nullptr)
@@ -246,7 +246,7 @@ private:
 
     void SmallSceneryRemoval() const
     {
-        TileElement* tileElement = map_get_first_element_at(_coords.x / 32, _coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_coords);
         do
         {
             if (tileElement == nullptr)
@@ -263,7 +263,7 @@ private:
 
     rct_string_id CheckRideSupports() const
     {
-        TileElement* tileElement = map_get_first_element_at(_coords.x / 32, _coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_coords);
         do
         {
             if (tileElement == nullptr)
@@ -320,7 +320,7 @@ private:
 
     TileElement* CheckUnremovableObstructions(TileElement * surfaceElement, uint8_t zCorner) const
     {
-        TileElement* tileElement = map_get_first_element_at(_coords.x / 32, _coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_coords);
         do
         {
             if (tileElement == nullptr)

--- a/src/openrct2/actions/LandSetRightsAction.hpp
+++ b/src/openrct2/actions/LandSetRightsAction.hpp
@@ -179,7 +179,7 @@ private:
                     return res;
                 }
 
-                TileElement* tileElement = map_get_first_element_at(loc.x / 32, loc.y / 32);
+                TileElement* tileElement = map_get_first_element_at(loc);
                 do
                 {
                     if (tileElement == nullptr)

--- a/src/openrct2/actions/LargeSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.hpp
@@ -163,7 +163,7 @@ public:
                 }
             }
 
-            TileElement* sceneryElement = map_get_first_element_at(currentTile.x / 32, currentTile.y / 32);
+            TileElement* sceneryElement = map_get_first_element_at(currentTile);
             bool element_found = false;
             if (sceneryElement != nullptr)
             {
@@ -207,7 +207,7 @@ public:
 private:
     TileElement* FindLargeSceneryElement() const
     {
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
         if (tileElement == nullptr)
             return nullptr;
 

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
@@ -65,7 +65,7 @@ public:
         }
 
         bool found = false;
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
 
         do
         {
@@ -125,7 +125,7 @@ public:
         }
 
         bool found = false;
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
 
         do
         {

--- a/src/openrct2/actions/SmallSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.hpp
@@ -135,7 +135,7 @@ public:
 private:
     TileElement* FindSceneryElement() const
     {
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
         if (!tileElement)
             return nullptr;
 

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -71,7 +71,7 @@ public:
 
         bool found = false;
         bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
-        TileElement* tileElement = map_get_first_element_at(_origin.x / 32, _origin.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_origin);
 
         do
         {
@@ -157,7 +157,7 @@ public:
             map_invalidate_tile_full(mapLoc.x, mapLoc.y);
 
             found = false;
-            tileElement = map_get_first_element_at(mapLoc.x / 32, mapLoc.y / 32);
+            tileElement = map_get_first_element_at(mapLoc);
             do
             {
                 if (tileElement == nullptr)
@@ -267,7 +267,7 @@ public:
 
         bool found = false;
         bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
-        TileElement* tileElement = map_get_first_element_at(_origin.x / 32, _origin.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_origin);
 
         do
         {
@@ -347,7 +347,7 @@ public:
             map_invalidate_tile_full(mapLoc.x, mapLoc.y);
 
             found = false;
-            tileElement = map_get_first_element_at(mapLoc.x / 32, mapLoc.y / 32);
+            tileElement = map_get_first_element_at(mapLoc);
             do
             {
                 if (tileElement == nullptr)

--- a/src/openrct2/actions/WallPlaceAction.hpp
+++ b/src/openrct2/actions/WallPlaceAction.hpp
@@ -619,7 +619,7 @@ private:
             return false;
         }
 
-        TileElement* tileElement = map_get_first_element_at(_loc.x / 32, _loc.y / 32);
+        TileElement* tileElement = map_get_first_element_at(_loc);
         do
         {
             if (tileElement == nullptr)

--- a/src/openrct2/actions/WallRemoveAction.hpp
+++ b/src/openrct2/actions/WallRemoveAction.hpp
@@ -96,7 +96,7 @@ public:
 private:
     TileElement* GetFirstWallElementAt(const CoordsXYZD& location, bool isGhost) const
     {
-        TileElement* tileElement = map_get_first_element_at(location.x / 32, location.y / 32);
+        TileElement* tileElement = map_get_first_element_at(location);
         if (!tileElement)
             return nullptr;
 

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -292,7 +292,7 @@ static CoordsXY GetEdgeTile(int32_t mapSize, int32_t rotation, EdgeType edgeType
 static int32_t GetHighestBaseClearanceZ(CoordsXY location)
 {
     int32_t z = 0;
-    auto element = map_get_first_element_at(location.x >> 5, location.y >> 5);
+    auto element = map_get_first_element_at(location);
     if (element != nullptr)
     {
         do

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -242,7 +242,7 @@ static void virtual_floor_get_tile_properties(
     //  * Surfaces, which may put us underground
     //  * Walls / banners, which are displayed as occupied edges
     //  * Ghost objects, which are displayed as lit squares
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -154,7 +154,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
     session->MapPosition.x = x;
     session->MapPosition.y = y;
 
-    TileElement* tile_element = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tile_element = map_get_first_element_at({ x, y });
     if (tile_element == nullptr)
         return;
     uint8_t rotation = session->CurrentRotation;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -956,7 +956,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
                 {
                     /* Peep happiness is affected once the peep has been waiting
                      * too long in a queue. */
-                    TileElement* tileElement = map_get_first_element_at(next_x / 32, next_y / 32);
+                    TileElement* tileElement = map_get_first_element_at({ next_x, next_y });
                     bool found = false;
                     do
                     {
@@ -1932,7 +1932,7 @@ std::bitset<MAX_RIDES> Guest::FindRidesToGoOn()
             {
                 if (map_is_location_valid({ tileX, tileY }))
                 {
-                    auto tileElement = map_get_first_element_at(tileX >> 5, tileY >> 5);
+                    auto tileElement = map_get_first_element_at({ tileX, tileY });
                     if (tileElement != nullptr)
                     {
                         do
@@ -2950,7 +2950,7 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
     {
         for (int16_t y = initial_y; y < final_y; y += 32)
         {
-            TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+            TileElement* tileElement = map_get_first_element_at({ x, y });
             if (tileElement == nullptr)
                 continue;
             do
@@ -3189,7 +3189,7 @@ template<typename T> static void peep_head_for_nearest_ride(Guest* peep, bool co
             {
                 if (map_is_location_valid({ x, y }))
                 {
-                    auto tileElement = map_get_first_element_at(x >> 5, y >> 5);
+                    auto tileElement = map_get_first_element_at({ x, y });
                     if (tileElement != nullptr)
                     {
                         do
@@ -4179,7 +4179,7 @@ void Guest::UpdateRideLeaveVehicle()
                 if (trackType == TRACK_ELEM_FLAT || trackType > TRACK_ELEM_MIDDLE_STATION)
                     continue;
 
-                TileElement* inner_map = map_get_first_element_at(vehicle->track_x / 32, vehicle->track_y / 32);
+                TileElement* inner_map = map_get_first_element_at({ vehicle->track_x, vehicle->track_y });
                 if (inner_map == nullptr)
                     continue;
                 for (;; inner_map++)
@@ -4942,7 +4942,7 @@ void Guest::UpdateRideMazePathfinding()
     };
     maze_type mazeType = maze_type::invalid;
 
-    auto tileElement = map_get_first_element_at(targetLoc.x / 32, targetLoc.y / 32);
+    auto tileElement = map_get_first_element_at(targetLoc);
     if (tileElement == nullptr)
         return;
     do
@@ -5038,7 +5038,7 @@ void Guest::UpdateRideLeaveExit()
     CoordsXY targetLoc = { x, y };
 
     // Find the station track element
-    TileElement* tileElement = map_get_first_element_at(targetLoc.x / 32, targetLoc.y / 32);
+    TileElement* tileElement = map_get_first_element_at(targetLoc);
     if (tileElement == nullptr)
         return;
     do
@@ -5462,7 +5462,7 @@ void Guest::UpdateWalking()
     if (GetNextIsSurface() || GetNextIsSloped())
         return;
 
-    TileElement* tileElement = map_get_first_element_at(next_x / 32, next_y / 32);
+    TileElement* tileElement = map_get_first_element_at({ next_x, next_y });
     if (tileElement == nullptr)
         return;
 
@@ -5880,7 +5880,7 @@ void Guest::UpdateUsingBin()
                 return;
             }
 
-            TileElement* tileElement = map_get_first_element_at(next_x / 32, next_y / 32);
+            TileElement* tileElement = map_get_first_element_at({ next_x, next_y });
             if (tileElement == nullptr)
                 return;
 
@@ -6050,7 +6050,7 @@ bool Guest::UpdateWalkingFindBench()
     if (!ShouldFindBench())
         return false;
 
-    TileElement* tileElement = map_get_first_element_at(next_x / 32, next_y / 32);
+    TileElement* tileElement = map_get_first_element_at({ next_x, next_y });
     if (tileElement == nullptr)
         return false;
 
@@ -6147,7 +6147,7 @@ bool Guest::UpdateWalkingFindBin()
     if (peep->GetNextIsSurface())
         return false;
 
-    TileElement* tileElement = map_get_first_element_at(peep->next_x / 32, peep->next_y / 32);
+    TileElement* tileElement = map_get_first_element_at({ peep->next_x, peep->next_y });
     if (tileElement == nullptr)
         return false;
 
@@ -6250,7 +6250,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     if (peep->GetNextIsSurface())
         return;
 
-    TileElement* tileElement = map_get_first_element_at(peep->next_x / 32, peep->next_y / 32);
+    TileElement* tileElement = map_get_first_element_at({ peep->next_x, peep->next_y });
     if (tileElement == nullptr)
         return;
 
@@ -6893,7 +6893,7 @@ void Guest::UpdateSpriteType()
     {
         if ((x & 0xFFE0) < 0x1FFF && (y & 0xFFE0) < 0x1FFF)
         {
-            TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+            TileElement* tileElement = map_get_first_element_at({ x, y });
             while (true)
             {
                 if (tileElement == nullptr)

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -236,7 +236,7 @@ static uint8_t footpath_element_next_in_direction(TileCoordsXYZ loc, PathElement
     }
 
     loc += TileDirectionDelta[chosenDirection];
-    nextTileElement = map_get_first_element_at(loc.x, loc.y);
+    nextTileElement = map_get_first_element_at(loc.ToCoordsXY());
     do
     {
         if (nextTileElement == nullptr)
@@ -287,7 +287,7 @@ static uint8_t footpath_element_dest_in_dir(
         return PATH_SEARCH_LIMIT_REACHED;
 
     loc += TileDirectionDelta[chosenDirection];
-    tileElement = map_get_first_element_at(loc.x, loc.y);
+    tileElement = map_get_first_element_at(loc.ToCoordsXY());
     if (tileElement == nullptr)
     {
         return PATH_SEARCH_FAILED;
@@ -649,7 +649,7 @@ static void peep_pathfind_heuristic_search(
 
     /* Get the next map element of interest in the direction of test_edge. */
     bool found = false;
-    TileElement* tileElement = map_get_first_element_at(loc.x, loc.y);
+    TileElement* tileElement = map_get_first_element_at(loc.ToCoordsXY());
     if (tileElement == nullptr)
     {
         return;
@@ -1188,7 +1188,7 @@ Direction peep_pathfind_choose_direction(TileCoordsXYZ loc, Peep* peep)
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
     // Get the path element at this location
-    TileElement* dest_tile_element = map_get_first_element_at(loc.x, loc.y);
+    TileElement* dest_tile_element = map_get_first_element_at(loc.ToCoordsXY());
     /* Where there are multiple matching map elements placed with zero
      * clearance, save the first one for later use to determine the path
      * slope - this maintains the original behaviour (which only processes
@@ -1722,7 +1722,7 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
 static void get_ride_queue_end(TileCoordsXYZ& loc)
 {
     TileCoordsXY queueEnd = { 0, 0 };
-    TileElement* tileElement = map_get_first_element_at(loc.x, loc.y);
+    TileElement* tileElement = map_get_first_element_at(loc.ToCoordsXY());
 
     if (tileElement == nullptr)
     {
@@ -1770,7 +1770,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
         }
         nextTile += TileDirectionDelta[direction];
 
-        tileElement = map_get_first_element_at(nextTile.x, nextTile.y);
+        tileElement = map_get_first_element_at(nextTile.ToCoordsXY());
         found = false;
         if (tileElement == nullptr)
             break;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -472,7 +472,7 @@ bool Peep::CheckForPath()
         return true;
     }
 
-    TileElement* tile_element = map_get_first_element_at(next_x / 32, next_y / 32);
+    TileElement* tile_element = map_get_first_element_at({ next_x, next_y });
 
     uint8_t map_type = TILE_ELEMENT_TYPE_PATH;
     if (GetNextIsSurface())
@@ -899,7 +899,7 @@ void Peep::UpdateFalling()
     }
 
     // If not drowning then falling. Note: peeps 'fall' after leaving a ride/enter the park.
-    TileElement* tile_element = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tile_element = map_get_first_element_at({ x, y });
     TileElement* saved_map = nullptr;
     int32_t saved_height = 0;
 
@@ -2540,7 +2540,7 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
             int16_t next_y = (y & 0xFFE0) + CoordsDirectionDelta[entranceDirection].y;
 
             // Make sure there is a path right behind the entrance, otherwise turn around
-            TileElement* nextTileElement = map_get_first_element_at(next_x / 32, next_y / 32);
+            TileElement* nextTileElement = map_get_first_element_at({ next_x, next_y });
             do
             {
                 if (nextTileElement == nullptr)
@@ -3096,7 +3096,7 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         return;
     }
 
-    TileElement* tileElement = map_get_first_element_at(newLoc.x / 32, newLoc.y / 32);
+    TileElement* tileElement = map_get_first_element_at(newLoc);
     if (tileElement == nullptr)
         return;
     int16_t base_z = std::max(0, (z / 8) - 2);

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -267,7 +267,7 @@ bool staff_can_ignore_wide_flag(Peep* staff, int32_t x, int32_t y, uint8_t z, Ti
         }
 
         /* Search through all adjacent map elements */
-        TileElement* test_element = map_get_first_element_at(adjac_x / 32, adjac_y / 32);
+        TileElement* test_element = map_get_first_element_at({ adjac_x, adjac_y });
         if (test_element == nullptr)
             return false;
         bool pathfound = false;
@@ -475,7 +475,7 @@ static uint8_t staff_handyman_direction_to_nearest_litter(Peep* peep)
 
     int16_t nextZ = ((peep->z + 8) & 0xFFF0) / 8;
 
-    TileElement* tileElement = map_get_first_element_at(nextTile.x / 32, nextTile.y / 32);
+    TileElement* tileElement = map_get_first_element_at(nextTile);
     if (tileElement == nullptr)
         return 0xFF;
     do
@@ -491,7 +491,7 @@ static uint8_t staff_handyman_direction_to_nearest_litter(Peep* peep)
     nextTile.x = (peep->x & 0xFFE0) + CoordsDirectionDelta[nextDirection].x;
     nextTile.y = (peep->y & 0xFFE0) + CoordsDirectionDelta[nextDirection].y;
 
-    tileElement = map_get_first_element_at(nextTile.x / 32, nextTile.y / 32);
+    tileElement = map_get_first_element_at(nextTile);
     if (tileElement == nullptr)
         return 0xFF;
 
@@ -1256,7 +1256,7 @@ void Staff::UpdateWatering()
         int32_t actionX = next_x + CoordsDirectionDelta[var_37].x;
         int32_t actionY = next_y + CoordsDirectionDelta[var_37].y;
 
-        TileElement* tile_element = map_get_first_element_at(actionX / 32, actionY / 32);
+        TileElement* tile_element = map_get_first_element_at({ actionX, actionY });
         if (tile_element == nullptr)
             return;
 
@@ -1323,7 +1323,7 @@ void Staff::UpdateEmptyingBin()
         if (action_frame != 11)
             return;
 
-        TileElement* tile_element = map_get_first_element_at(next_x / 32, next_y / 32);
+        TileElement* tile_element = map_get_first_element_at({ next_x, next_y });
         if (tile_element == nullptr)
             return;
 
@@ -1641,7 +1641,7 @@ static int32_t peep_update_patrolling_find_watering(Peep* peep)
         int32_t x = peep->next_x + CoordsDirectionDelta[chosen_position].x;
         int32_t y = peep->next_y + CoordsDirectionDelta[chosen_position].y;
 
-        TileElement* tile_element = map_get_first_element_at(x / 32, y / 32);
+        TileElement* tile_element = map_get_first_element_at({ x, y });
 
         // This seems to happen in some SV4 files.
         if (tile_element == nullptr)
@@ -1709,7 +1709,7 @@ static int32_t peep_update_patrolling_find_bin(Peep* peep)
     if (peep->GetNextIsSurface())
         return 0;
 
-    TileElement* tileElement = map_get_first_element_at(peep->next_x / 32, peep->next_y / 32);
+    TileElement* tileElement = map_get_first_element_at({ peep->next_x, peep->next_y });
     if (tileElement == nullptr)
         return 0;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2746,7 +2746,7 @@ private:
         {
             for (int32_t y = 0; y < RCT1_MAX_MAP_SIZE; y++)
             {
-                TileElement* tileElement = map_get_first_element_at(x, y);
+                TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
                 if (tileElement == nullptr)
                     continue;
                 do
@@ -3002,7 +3002,7 @@ private:
         {
             for (int32_t y = 0; y < RCT1_MAX_MAP_SIZE; y++)
             {
-                TileElement* tileElement = map_get_first_element_at(x, y);
+                TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
                 if (tileElement == nullptr)
                     continue;
                 do

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -502,7 +502,7 @@ bool track_block_get_next_from_zero(
         y += CoordsDirectionDelta[direction_start].y;
     }
 
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
     {
         output->element = nullptr;
@@ -629,7 +629,7 @@ bool track_block_get_previous_from_zero(
         y += CoordsDirectionDelta[direction].y;
     }
 
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
     {
         outTrackBeginEnd->end_x = x;
@@ -1166,7 +1166,7 @@ void ride_clear_blocked_tiles(Ride* ride)
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto element = map_get_first_element_at(x, y);
+            auto element = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (element != nullptr)
             {
                 do
@@ -3294,7 +3294,7 @@ static void ride_shop_connected(Ride* ride)
         return;
 
     TrackElement* trackElement = nullptr;
-    TileElement* tileElement = map_get_first_element_at(shopLoc.x, shopLoc.y);
+    TileElement* tileElement = map_get_first_element_at(shopLoc.ToCoordsXY());
     do
     {
         if (tileElement == nullptr)
@@ -3953,7 +3953,7 @@ static void sub_6B5952(Ride* ride)
 
         // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to
         // the ride or not.
-        TileElement* tileElement = map_get_first_element_at(location.x, location.y);
+        TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
         if (tileElement != nullptr)
         {
             do
@@ -4291,7 +4291,7 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
         int32_t y = (*position).y << 5;
         int32_t z = (*position).z;
 
-        TileElement* tileElement = map_get_first_element_at((*position).x, (*position).y);
+        TileElement* tileElement = map_get_first_element_at(position->ToCoordsXY());
         do
         {
             if (tileElement == nullptr)
@@ -4941,7 +4941,7 @@ static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
     int32_t z = ride->stations[stationIndex].Height;
 
     bool success = false;
-    TileElement* tileElement = map_get_first_element_at(location.x, location.y);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return success;
     do
@@ -5181,7 +5181,7 @@ static TileElement* loc_6B4F6B(ride_id_t rideIndex, int32_t x, int32_t y)
     if (ride == nullptr)
         return nullptr;
 
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -6258,7 +6258,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
             mapY = entranceExitCoords.y + CoordsDirectionDelta[entranceExitCoords.direction].y;
             if (map_is_location_valid({ mapX, mapY }))
             {
-                tileElement = map_get_first_element_at(mapX >> 5, mapY >> 5);
+                tileElement = map_get_first_element_at({ mapX, mapY });
                 if (tileElement == nullptr)
                     continue;
                 do
@@ -6316,7 +6316,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
             entranceMaxY = mapY;
             mapX -= CoordsDirectionDelta[entranceExitCoords.direction].x;
             mapY -= CoordsDirectionDelta[entranceExitCoords.direction].y;
-            tileElement = map_get_first_element_at(mapX >> 5, mapY >> 5);
+            tileElement = map_get_first_element_at({ mapX, mapY });
             if (tileElement == nullptr)
                 break;
             bool goToNextTile = false;
@@ -6663,7 +6663,7 @@ static int32_t ride_get_track_length(Ride* ride)
         trackStart = stationTileLoc.ToCoordsXY();
         auto z = ride->stations[i].Height;
 
-        tileElement = map_get_first_element_at(stationTileLoc.x, stationTileLoc.y);
+        tileElement = map_get_first_element_at(stationTileLoc.ToCoordsXY());
         if (tileElement == nullptr)
             continue;
         do
@@ -6927,7 +6927,7 @@ void sub_6CB945(Ride* ride)
                     location.x -= CoordsDirectionDelta[direction].x;
                     location.y -= CoordsDirectionDelta[direction].y;
                 }
-                tileElement = map_get_first_element_at(location.x >> 5, location.y >> 5);
+                tileElement = map_get_first_element_at(location);
                 if (tileElement == nullptr)
                     break;
 
@@ -6976,7 +6976,7 @@ void sub_6CB945(Ride* ride)
                 auto blockTileHeight = TileCoordsXYZ(blockLocation).z;
 
                 bool trackFound = false;
-                tileElement = map_get_first_element_at(blockLocation.x >> 5, blockLocation.y >> 5);
+                tileElement = map_get_first_element_at(blockLocation);
                 if (tileElement == nullptr)
                     break;
                 do
@@ -7043,7 +7043,7 @@ void sub_6CB945(Ride* ride)
 
         CoordsXY location = { locationCoords.x * 32, locationCoords.y * 32 };
 
-        TileElement* tileElement = map_get_first_element_at(location.x >> 5, location.y >> 5);
+        TileElement* tileElement = map_get_first_element_at(location);
         if (tileElement == nullptr)
             continue;
         do
@@ -7060,7 +7060,7 @@ void sub_6CB945(Ride* ride)
             nextLocation.y += CoordsDirectionDelta[tileElement->GetDirection()].y;
 
             bool shouldRemove = true;
-            TileElement* trackElement = map_get_first_element_at(nextLocation.x >> 5, nextLocation.y >> 5);
+            TileElement* trackElement = map_get_first_element_at(nextLocation);
             if (trackElement == nullptr)
                 continue;
             do
@@ -7308,7 +7308,7 @@ money16 ride_get_price(const Ride* ride)
 TileElement* get_station_platform(int32_t x, int32_t y, int32_t z, int32_t z_tolerance)
 {
     bool foundTileElement = false;
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement != nullptr)
     {
         do
@@ -7716,7 +7716,7 @@ void determine_ride_entrance_and_exit_locations()
             {
                 for (uint8_t y = 1; y < MAXIMUM_MAP_SIZE_TECHNICAL - 1; y++)
                 {
-                    TileElement* tileElement = map_get_first_element_at(x, y);
+                    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
 
                     if (tileElement != nullptr)
                     {

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -206,7 +206,7 @@ static void ride_ratings_update_state_2()
     int32_t z = gRideRatingsCalcData.proximity_z / 8;
     int32_t trackType = gRideRatingsCalcData.proximity_track_type;
 
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     if (tileElement == nullptr)
     {
         gRideRatingsCalcData.state = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
@@ -317,7 +317,7 @@ static void ride_ratings_update_state_5()
     int32_t z = gRideRatingsCalcData.proximity_z / 8;
     int32_t trackType = gRideRatingsCalcData.proximity_track_type;
 
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     if (tileElement == nullptr)
     {
         gRideRatingsCalcData.state = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
@@ -428,7 +428,7 @@ static void ride_ratings_score_close_proximity_in_direction(TileElement* inputTi
     if (x < 0 || y < 0 || x >= (32 * 256) || y >= (32 * 256))
         return;
 
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -482,7 +482,7 @@ static void ride_ratings_score_close_proximity_in_direction(TileElement* inputTi
 
 static void ride_ratings_score_close_proximity_loops_helper(TileElement* inputTileElement, int32_t x, int32_t y)
 {
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -558,7 +558,7 @@ static void ride_ratings_score_close_proximity(TileElement* inputTileElement)
     gRideRatingsCalcData.proximity_total++;
     int32_t x = gRideRatingsCalcData.proximity_x;
     int32_t y = gRideRatingsCalcData.proximity_y;
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -1453,7 +1453,7 @@ static int32_t ride_ratings_get_scenery_score(Ride* ride)
         for (int32_t xx = std::max(x - 5, 0); xx <= std::min(x + 5, 255); xx++)
         {
             // Count scenery items on this tile
-            TileElement* tileElement = map_get_first_element_at(xx, yy);
+            TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ xx, yy }.ToCoordsXY());
             if (tileElement == nullptr)
                 continue;
             do

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -339,7 +339,7 @@ TileElement* ride_get_station_start_track_element(Ride* ride, int32_t stationInd
     int32_t z = ride->stations[stationIndex].Height;
 
     // Find the station track element
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -355,7 +355,7 @@ TileElement* ride_get_station_start_track_element(Ride* ride, int32_t stationInd
 TileElement* ride_get_station_exit_element(int32_t x, int32_t y, int32_t z)
 {
     // Find the station track element
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     if (tileElement == nullptr)
         return nullptr;
     do

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -598,7 +598,7 @@ const rct_preview_track* get_track_def_from_ride_index(ride_id_t rideIndex, int3
 
 static TileElement* find_station_element(int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex)
 {
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return nullptr;
     do

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -279,7 +279,7 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
 
             CoordsXY mapLocation{ location.x * 32, location.y * 32 };
 
-            TileElement* tileElement = map_get_first_element_at(location.x, location.y);
+            TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
             if (tileElement == nullptr)
                 continue;
 
@@ -359,7 +359,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(const Ride& ride)
     {
         for (; x < 8192; x += 32)
         {
-            auto tileElement = map_get_first_element_at(x / 32, y / 32);
+            auto tileElement = map_get_first_element_at({ x, y });
             do
             {
                 if (tileElement == nullptr)
@@ -392,8 +392,8 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(const Ride& ride)
         return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
     }
 
-    CoordsXY entranceLoc = { location.x * 32, location.y * 32 };
-    auto tileElement = map_get_first_element_at(location.x, location.y);
+    CoordsXY entranceLoc = location.ToCoordsXY();
+    auto tileElement = map_get_first_element_at(entranceLoc);
     do
     {
         if (tileElement == nullptr)
@@ -421,8 +421,8 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(const Ride& ride)
         return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
     }
 
-    CoordsXY exitLoc = { location.x * 32, location.y * 32 };
-    tileElement = map_get_first_element_at(location.x, location.y);
+    CoordsXY exitLoc = location.ToCoordsXY();
+    tileElement = map_get_first_element_at(exitLoc);
     if (tileElement == nullptr)
         return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
     do
@@ -465,7 +465,7 @@ CoordsXYE TrackDesign::MazeGetFirstElement(const Ride& ride)
     {
         for (tile.x = 0; tile.x < 8192; tile.x += 32)
         {
-            tile.element = map_get_first_element_at(tile.x / 32, tile.y / 32);
+            tile.element = map_get_first_element_at({ tile.x, tile.y });
             do
             {
                 if (tile.element == nullptr)
@@ -1671,7 +1671,7 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
                 if (_trackDesignPlaceOperation != PTD_OPERATION_PLACE_QUERY)
                 {
                     auto tile = CoordsXY{ x, y } + CoordsDirectionDelta[rotation];
-                    TileElement* tile_element = map_get_first_element_at(tile.x >> 5, tile.y >> 5);
+                    TileElement* tile_element = map_get_first_element_at(tile);
                     z = gTrackPreviewOrigin.z / 8;
                     z += entrance.z;
                     if (tile_element == nullptr)

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -521,7 +521,7 @@ static void track_design_save_select_nearby_scenery_for_tile(ride_id_t rideIndex
     {
         for (int32_t x = cx - TRACK_NEARBY_SCENERY_DISTANCE; x <= cx + TRACK_NEARBY_SCENERY_DISTANCE; x++)
         {
-            tileElement = map_get_first_element_at(x, y);
+            tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (tileElement == nullptr)
                 continue;
             do

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1836,7 +1836,7 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
     {
         // Set tile_element to first element. Since elements aren't always ordered by base height,
         // we must start at the first element and iterate through each tile element.
-        auto tile_element = map_get_first_element_at(x / 32, y / 32);
+        auto tile_element = map_get_first_element_at({ x, y });
         if (tile_element == nullptr)
             return;
 
@@ -4642,7 +4642,7 @@ static void vehicle_update_boat_location(rct_vehicle* vehicle)
  */
 static bool vehicle_boat_is_location_accessible(const TileCoordsXYZ& location)
 {
-    TileElement* tileElement = map_get_first_element_at(location.x, location.y);
+    TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
     if (tileElement == nullptr)
         return false;
     do
@@ -5136,7 +5136,7 @@ static void vehicle_update_doing_circus_show(rct_vehicle* vehicle)
  */
 static TileElement* vehicle_check_collision(int16_t x, int16_t y, int16_t z)
 {
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
     {
         return nullptr;

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -110,7 +110,7 @@ static void chairlift_paint_util_draw_supports(paint_session* session, int32_t s
 static const TileElement* chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
     int32_t x, int32_t y, int32_t z, ride_id_t rideIndex)
 {
-    const TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    const TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
     {
         return nullptr;

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -79,7 +79,7 @@ size_t Banner::FormatTextTo(void* argsV) const
  */
 static uint8_t banner_get_ride_index_at(int32_t x, int32_t y, int32_t z)
 {
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     ride_id_t resultRideIndex = RIDE_ID_NULL;
     if (tileElement == nullptr)
         return resultRideIndex;
@@ -162,7 +162,7 @@ TileElement* banner_get_tile_element(BannerIndex bannerIndex)
     auto banner = GetBanner(bannerIndex);
     if (banner != nullptr)
     {
-        auto tileElement = map_get_first_element_at(banner->position.x, banner->position.y);
+        auto tileElement = map_get_first_element_at(banner->position.ToCoordsXY());
         if (tileElement != nullptr)
         {
             do
@@ -183,7 +183,7 @@ WallElement* banner_get_scrolling_wall_tile_element(BannerIndex bannerIndex)
     if (banner == nullptr)
         return nullptr;
 
-    auto tileElement = map_get_first_element_at(banner->position.x, banner->position.y);
+    auto tileElement = map_get_first_element_at(banner->position.ToCoordsXY());
     if (tileElement == nullptr)
         return nullptr;
 
@@ -267,7 +267,7 @@ void fix_duplicated_banners()
     {
         for (int x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto tileElement = map_get_first_element_at(x, y);
+            auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             if (tileElement != nullptr)
             {
                 do

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -136,7 +136,7 @@ void maze_entrance_hedge_replacement(int32_t x, int32_t y, TileElement* tileElem
     int32_t z = tileElement->base_height;
     ride_id_t rideIndex = tileElement->AsEntrance()->GetRideIndex();
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -174,7 +174,7 @@ void maze_entrance_hedge_removal(int32_t x, int32_t y, TileElement* tileElement)
     int32_t z = tileElement->base_height;
     ride_id_t rideIndex = tileElement->AsEntrance()->GetRideIndex();
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -113,7 +113,7 @@ static bool entrance_has_direction(TileElement* tileElement, int32_t direction)
 
 TileElement* map_get_footpath_element(int32_t x, int32_t y, int32_t z)
 {
-    TileElement* tileElement = map_get_first_element_at(x, y);
+    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
     do
     {
         if (tileElement == nullptr)
@@ -458,7 +458,7 @@ bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t dire
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return false;
     do
@@ -486,7 +486,7 @@ static TileElement* footpath_connect_corners_get_neighbour(int32_t x, int32_t y,
         return nullptr;
     }
 
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -660,7 +660,7 @@ static TileElement* footpath_get_element(int32_t x, int32_t y, int32_t z0, int32
     TileElement* tileElement;
     int32_t slope;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -786,7 +786,7 @@ static void loc_6A6D7E(
     }
     else
     {
-        TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+        TileElement* tileElement = map_get_first_element_at({ x, y });
         if (tileElement == nullptr)
             return;
         do
@@ -1076,7 +1076,7 @@ void footpath_chain_ride_queue(
 
         x += CoordsDirectionDelta[direction].x;
         y += CoordsDirectionDelta[direction].y;
-        tileElement = map_get_first_element_at(x >> 5, y >> 5);
+        tileElement = map_get_first_element_at({ x, y });
         if (tileElement != nullptr)
         {
             do
@@ -1203,7 +1203,7 @@ void footpath_update_queue_chains()
             if (location.isNull())
                 continue;
 
-            TileElement* tileElement = map_get_first_element_at(location.x, location.y);
+            TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
             if (tileElement != nullptr)
             {
                 do
@@ -1296,7 +1296,7 @@ static int32_t footpath_is_connected_to_map_edge_recurse(
     if (x >= gMapSizeUnits || y >= gMapSizeUnits)
         return FOOTPATH_SEARCH_SUCCESS;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return level == 1 ? FOOTPATH_SEARCH_NOT_FOUND : FOOTPATH_SEARCH_INCOMPLETE;
     do
@@ -1623,7 +1623,7 @@ void PathElement::SetShouldDrawPathOverSupports(bool on)
  */
 static void footpath_clear_wide(int32_t x, int32_t y)
 {
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -1642,7 +1642,7 @@ static void footpath_clear_wide(int32_t x, int32_t y)
  */
 static TileElement* footpath_can_be_wide(int32_t x, int32_t y, uint8_t height)
 {
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -1695,7 +1695,7 @@ void footpath_update_path_wide_flags(int32_t x, int32_t y)
     // footpath_clear_wide(x, y);
     // y -= 0x20;
 
-    TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -1935,7 +1935,7 @@ static void footpath_remove_edges_towards_here(
     x += CoordsDirectionDelta[direction].x;
     y += CoordsDirectionDelta[direction].y;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -1966,7 +1966,7 @@ static void footpath_remove_edges_towards(int32_t x, int32_t y, int32_t z0, int3
         return;
     }
 
-    TileElement* tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -2005,7 +2005,7 @@ static void footpath_remove_edges_towards(int32_t x, int32_t y, int32_t z0, int3
 // entrances and exits, shops, paths).
 bool tile_element_wants_path_connection_towards(TileCoordsXYZD coords, const TileElement* const elementToBeRemoved)
 {
-    TileElement* tileElement = map_get_first_element_at(coords.x, coords.y);
+    TileElement* tileElement = map_get_first_element_at(coords.ToCoordsXY());
     if (tileElement == nullptr)
         return false;
     do
@@ -2096,7 +2096,7 @@ static void footpath_fix_corners_around(int32_t x, int32_t y, TileElement* pathE
             if (xOffset == 0 && yOffset == 0)
                 continue;
 
-            TileElement* tileElement = map_get_first_element_at(x + xOffset, y + yOffset);
+            TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x + xOffset, y + yOffset }.ToCoordsXY());
             if (tileElement == nullptr)
                 continue;
             do

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -236,7 +236,7 @@ bool JumpingFountain::IsJumpingFountain(const int32_t newType, const CoordsXYZ n
     const int32_t pathBitFlagMask = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW
                                                                           : PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER;
 
-    TileElement* tileElement = map_get_first_element_at(newLoc.x / 32, newLoc.y / 32);
+    TileElement* tileElement = map_get_first_element_at(newLoc);
     if (tileElement == nullptr)
         return false;
     do

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -180,6 +180,11 @@ struct TileCoordsXY
     {
     }
 
+    const TileCoordsXY operator+(const TileCoordsXY& rhs) const
+    {
+        return { x + rhs.x, y + rhs.y };
+    }
+
     TileCoordsXY& operator+=(const TileCoordsXY rhs)
     {
         x += rhs.x;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -136,7 +136,7 @@ void map_init(int32_t size);
 void map_count_remaining_land_rights();
 void map_strip_ghost_flag_from_elements();
 void map_update_tile_pointers();
-TileElement* map_get_first_element_at(int32_t x, int32_t y);
+TileElement* map_get_first_element_at(const CoordsXY& elementPos);
 TileElement* map_get_nth_element_at(const CoordsXY& coords, int32_t n);
 void map_set_tile_element(const TileCoordsXY& tilePos, TileElement* elements);
 int32_t map_height_from_slope(const CoordsXY& coords, int32_t slope, bool isSloped);

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -90,7 +90,7 @@ void map_animation_invalidate_all()
 static bool map_animation_invalidate_ride_entrance(CoordsXYZ loc)
 {
     TileCoordsXYZ tileLoc{ loc };
-    auto tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    auto tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -127,7 +127,7 @@ static bool map_animation_invalidate_queue_banner(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -164,7 +164,7 @@ static bool map_animation_invalidate_small_scenery(CoordsXYZ loc)
     rct_sprite* sprite;
     Peep* peep;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -238,7 +238,7 @@ static bool map_animation_invalidate_park_entrance(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -268,7 +268,7 @@ static bool map_animation_invalidate_track_waterfall(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -297,7 +297,7 @@ static bool map_animation_invalidate_track_rapids(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -326,7 +326,7 @@ static bool map_animation_invalidate_track_onridephoto(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -367,7 +367,7 @@ static bool map_animation_invalidate_track_whirlpool(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -396,7 +396,7 @@ static bool map_animation_invalidate_track_spinningtunnel(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -434,7 +434,7 @@ static bool map_animation_invalidate_banner(CoordsXYZ loc)
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -461,7 +461,7 @@ static bool map_animation_invalidate_large_scenery(CoordsXYZ loc)
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do
@@ -496,7 +496,7 @@ static bool map_animation_invalidate_wall_door(CoordsXYZ loc)
         return false;
 
     bool removeAnimation = true;
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return removeAnimation;
     do
@@ -558,7 +558,7 @@ static bool map_animation_invalidate_wall(CoordsXYZ loc)
     rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
-    tileElement = map_get_first_element_at(tileLoc.x, tileLoc.y);
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
         return true;
     do

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -116,7 +116,7 @@ void update_park_fences(const CoordsXY coords)
     {
         bool fenceRequired = true;
 
-        TileElement* tileElement = map_get_first_element_at(coords.x / 32, coords.y / 32);
+        TileElement* tileElement = map_get_first_element_at(coords);
         if (tileElement == nullptr)
             return;
         // If an entrance element do not place flags around surface

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -72,7 +72,7 @@ void scenery_update_tile(int32_t x, int32_t y)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -198,7 +198,7 @@ void scenery_remove_ghost_tool_placement()
     if (gSceneryGhostType & SCENERY_GHOST_FLAG_1)
     {
         gSceneryGhostType &= ~SCENERY_GHOST_FLAG_1;
-        TileElement* tileElement = map_get_first_element_at(x / 32, y / 32);
+        TileElement* tileElement = map_get_first_element_at({ x, y });
 
         do
         {

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -710,7 +710,7 @@ static bool litter_can_be_at(int32_t x, int32_t y, int32_t z)
     if (!map_is_location_owned({ x, y, z }))
         return false;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return false;
     do

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -337,7 +337,7 @@ GameActionResult::Ptr tile_inspector_paste_element_at(CoordsXY loc, TileElement 
             windowTileInspectorElementCount++;
 
             // Select new element if there was none selected already
-            int16_t newIndex = (int16_t)(pastedElement - map_get_first_element_at(loc.x / 32, loc.y / 32));
+            int16_t newIndex = (int16_t)(pastedElement - map_get_first_element_at(loc));
             if (windowTileInspectorSelectedIndex == -1)
                 windowTileInspectorSelectedIndex = newIndex;
             else if (windowTileInspectorSelectedIndex >= newIndex)
@@ -354,7 +354,7 @@ GameActionResult::Ptr tile_inspector_sort_elements_at(CoordsXY loc, bool isExecu
 {
     if (isExecuting)
     {
-        const TileElement* const firstElement = map_get_first_element_at(loc.x / 32, loc.y / 32);
+        const TileElement* const firstElement = map_get_first_element_at(loc);
         if (firstElement == nullptr)
             return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
 
@@ -788,7 +788,7 @@ GameActionResult::Ptr tile_inspector_track_base_height_offset(
             map_invalidate_tile_full(elem.x, elem.y);
 
             bool found = false;
-            TileElement* tileElement = map_get_first_element_at(elem.x >> 5, elem.y >> 5);
+            TileElement* tileElement = map_get_first_element_at({ elem.x, elem.y });
             do
             {
                 if (tileElement == nullptr)
@@ -895,7 +895,7 @@ GameActionResult::Ptr tile_inspector_track_set_chain(
             map_invalidate_tile_full(elem.x, elem.y);
 
             bool found = false;
-            TileElement* tileElement = map_get_first_element_at(elem.x >> 5, elem.y >> 5);
+            TileElement* tileElement = map_get_first_element_at({ elem.x, elem.y });
             do
             {
                 if (tileElement == nullptr)

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -40,7 +40,7 @@ void wall_remove_at(int32_t x, int32_t y, int32_t z0, int32_t z1)
     z0 /= 8;
     z1 /= 8;
 repeat:
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do
@@ -76,7 +76,7 @@ void wall_remove_intersecting_walls(int32_t x, int32_t y, int32_t z0, int32_t z1
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at(x >> 5, y >> 5);
+    tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
         return;
     do

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -183,14 +183,15 @@ bool TrackElement::BlockBrakeClosed() const
     return (flags & TILE_ELEMENT_FLAG_BLOCK_BRAKE_CLOSED) != 0;
 }
 
-TileElement* map_get_first_element_at(int x, int y)
+TileElement* map_get_first_element_at(const CoordsXY& elementPos)
 {
-    if (x < 0 || y < 0 || x > 255 || y > 255)
+    if (elementPos.x < 0 || elementPos.y < 0 || elementPos.x > 255 || elementPos.y > 255)
     {
         log_error("Trying to access element outside of range");
         return nullptr;
     }
-    return gTileElementTilePointers[x + y * 256];
+    auto tileElementPos = TileCoordsXY{ elementPos };
+    return gTileElementTilePointers[tileElementPos.x + tileElementPos.y * 256];
 }
 
 bool ride_type_has_flag(int rideType, uint32_t flag)


### PR DESCRIPTION
This will need rebasing once #10409 is pushed, but is already rebased on all my other PRs.

It also showcases lots of places that receive `{x ,y}` on function name that can be refactored to use `CoordsXY`