### PR TITLE
Fix #10420: Money effect causing false positive desync

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 - Fix: [#10325] Crash when banners have no text.
+- Fix: [#10420] Money effect causing false positive desync.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -260,6 +260,15 @@ rct_sprite_checksum sprite_checksum()
                 copy.generic.sprite_left = copy.generic.sprite_right = copy.generic.sprite_top = copy.generic.sprite_bottom = 0;
                 copy.generic.sprite_width = copy.generic.sprite_height_negative = copy.generic.sprite_height_positive = 0;
 
+                // Next in quadrant might be a misc sprite, set first non-misc sprite in quadrant.
+                while (auto* nextSprite = get_sprite(copy.generic.next_in_quadrant))
+                {
+                    if (nextSprite->generic.sprite_identifier == SPRITE_IDENTIFIER_MISC)
+                        copy.generic.next_in_quadrant = nextSprite->generic.next_in_quadrant;
+                    else
+                        break;
+                }
+
                 if (copy.generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
                 {
                     // Name is pointer and will not be the same across clients


### PR DESCRIPTION
The sprite hash currently excludes misc sprites which are usually effects such as money or smoke particles and they have no influence in the game state however the next_in_quadrant field could still point to a misc sprite causing false positives in cases where the effect sprite is updated differently per client such as the money effect, also the field is only relevant for rendering order. I choose this approach to not invalidate the current replays if I were to fully exclude the field from the hash, this should keep the CI still happy and solves the issue for the time being.