### PR TITLE
Change value of COORDS_NULL to a less likely to collide value.

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4282,7 +4282,7 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
             *position++ = exit;
         }
     }
-    (*position++).x = COORDS_NULL;
+    (*position++).setNull();
 
     // Enumerate entrance and exit positions
     for (position = positions; !(*position).isNull(); position++)

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -373,7 +373,7 @@ int8_t ride_get_first_valid_station_exit(Ride* ride)
 {
     for (int32_t i = 0; i < MAX_STATIONS; i++)
     {
-        if (ride->stations[i].Exit.x != COORDS_NULL)
+        if (!ride->stations[i].Exit.isNull())
         {
             return i;
         }

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -59,7 +59,7 @@ struct LocationXYZ16
 assert_struct_size(LocationXYZ16, 6);
 #pragma pack(pop)
 
-constexpr int32_t COORDS_NULL = -1;
+constexpr int32_t COORDS_NULL = 0xFFFF8000;
 
 struct ScreenCoordsXY
 {


### PR DESCRIPTION
It will also now match `LOCATION_NULL`. As this change should only affect in memory coords there should be no save, replay, network issues.

This will now allow replacing of instances of `LOCATION_NULL` with `.setNull()` and `.isNull()` without causing cascading issues up and down the codebase due to the different values.

@tupaschoal 