### PR TITLE
Fix #10410. Fix Tile Inspector incorrect highlighting

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1224,6 +1224,7 @@ static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex wid
 
     CoordsXY mapCoords;
     TileElement* clickedElement = nullptr;
+    bool mouseOnViewport = false;
     if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z))
     {
         get_map_coordinates_from_pos(screenCoords, ViewportInteractionFlags, mapCoords, nullptr, &clickedElement, nullptr);
@@ -1232,10 +1233,15 @@ static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex wid
     // Even if Ctrl was pressed, fall back to normal selection when there was nothing under the cursor
     if (clickedElement == nullptr)
     {
-        mapCoords = screen_pos_to_map_pos(screenCoords, nullptr);
+        auto mouseCoords = screen_pos_to_map_pos(screenCoords, nullptr);
+        if (mouseCoords)
+        {
+            mouseOnViewport = true;
+            mapCoords = *mouseCoords;
+        }
     }
 
-    if (mapCoords.x != LOCATION_NULL)
+    if (mouseOnViewport)
     {
         gMapSelectPositionA = gMapSelectPositionB = mapCoords;
     }
@@ -1277,13 +1283,14 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, ScreenCoor
     // Even if Ctrl was pressed, fall back to normal selection when there was nothing under the cursor
     if (clickedElement == nullptr)
     {
-        mapCoords = screen_pos_to_map_pos(screenCoords, nullptr);
+        auto mouseCoords = screen_pos_to_map_pos(screenCoords, nullptr);
 
-        if (mapCoords.x == LOCATION_NULL)
+        if (!mouseCoords)
         {
             return;
         }
 
+        mapCoords = *mouseCoords;
         // Tile is already selected
         if (windowTileInspectorTileSelected && mapCoords.x == windowTileInspectorToolMap.x
             && mapCoords.y == windowTileInspectorToolMap.y)

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -318,13 +318,13 @@ static void window_view_clipping_tool_update(rct_window* w, rct_widgetindex widg
     }
 
     int32_t direction;
-    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
-    if (mapCoords.x != LOCATION_NULL)
+    auto mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
+    if (mapCoords)
     {
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
         map_invalidate_tile_full(gMapSelectPositionA.x, gMapSelectPositionA.y);
-        gMapSelectPositionA = gMapSelectPositionB = mapCoords;
-        map_invalidate_tile_full(mapCoords.x, mapCoords.y);
+        gMapSelectPositionA = gMapSelectPositionB = *mapCoords;
+        map_invalidate_tile_full(mapCoords->x, mapCoords->y);
         gMapSelectType = MAP_SELECT_TYPE_FULL;
     }
 }
@@ -332,11 +332,11 @@ static void window_view_clipping_tool_update(rct_window* w, rct_widgetindex widg
 static void window_view_clipping_tool_down(rct_window* w, rct_widgetindex widgetIndex, ScreenCoordsXY screenCoords)
 {
     int32_t direction;
-    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
-    if (mapCoords.x != LOCATION_NULL)
+    auto mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
+    if (mapCoords)
     {
         _dragging = true;
-        _selectionStart = { static_cast<int16_t>(mapCoords.x), static_cast<int16_t>(mapCoords.y) };
+        _selectionStart = { static_cast<int16_t>(mapCoords->x), static_cast<int16_t>(mapCoords->y) };
     }
 }
 
@@ -348,15 +348,15 @@ static void window_view_clipping_tool_drag(rct_window* w, rct_widgetindex widget
     }
 
     int32_t direction;
-    CoordsXY mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
-    if (mapCoords.x != LOCATION_NULL)
+    auto mapCoords = screen_pos_to_map_pos(screenCoords, &direction);
+    if (mapCoords)
     {
         map_invalidate_selection_rect();
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-        gMapSelectPositionA.x = std::min(_selectionStart.x, static_cast<int16_t>(mapCoords.x));
-        gMapSelectPositionB.x = std::max(_selectionStart.x, static_cast<int16_t>(mapCoords.x));
-        gMapSelectPositionA.y = std::min(_selectionStart.y, static_cast<int16_t>(mapCoords.y));
-        gMapSelectPositionB.y = std::max(_selectionStart.y, static_cast<int16_t>(mapCoords.y));
+        gMapSelectPositionA.x = std::min(_selectionStart.x, static_cast<int16_t>(mapCoords->x));
+        gMapSelectPositionB.x = std::max(_selectionStart.x, static_cast<int16_t>(mapCoords->x));
+        gMapSelectPositionA.y = std::min(_selectionStart.y, static_cast<int16_t>(mapCoords->y));
+        gMapSelectPositionB.y = std::max(_selectionStart.y, static_cast<int16_t>(mapCoords->y));
         gMapSelectType = MAP_SELECT_TYPE_FULL;
         map_invalidate_selection_rect();
     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -987,11 +987,11 @@ static void viewport_paint_weather_gloom(rct_drawpixelinfo* dpi)
  *
  *  rct2: 0x0068958D
  */
-CoordsXY screen_pos_to_map_pos(ScreenCoordsXY screenCoords, int32_t* direction)
+std::optional<CoordsXY> screen_pos_to_map_pos(ScreenCoordsXY screenCoords, int32_t* direction)
 {
     auto mapCoords = screen_get_map_xy(screenCoords, nullptr);
     if (!mapCoords)
-        return {};
+        return std::nullopt;
 
     int32_t my_direction;
     int32_t dist_from_centre_x = abs(mapCoords->x % 32);
@@ -1030,7 +1030,7 @@ CoordsXY screen_pos_to_map_pos(ScreenCoordsXY screenCoords, int32_t* direction)
 
     if (direction != nullptr)
         *direction = my_direction;
-    return mapCoords->ToTileStart();
+    return { mapCoords->ToTileStart() };
 }
 
 ScreenCoordsXY screen_coord_to_viewport_coord(rct_viewport* viewport, ScreenCoordsXY screenCoords)

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -151,7 +151,7 @@ CoordsXYZ viewport_adjust_for_map_height(const ScreenCoordsXY startCoords);
 
 ScreenCoordsXY screen_coord_to_viewport_coord(rct_viewport* viewport, ScreenCoordsXY screenCoords);
 CoordsXY viewport_coord_to_map_coord(int32_t x, int32_t y, int32_t z);
-CoordsXY screen_pos_to_map_pos(ScreenCoordsXY screenCoords, int32_t* direction);
+std::optional<CoordsXY> screen_pos_to_map_pos(ScreenCoordsXY screenCoords, int32_t* direction);
 
 void show_gridlines();
 void hide_gridlines();


### PR DESCRIPTION
Mistake made when refactoring not passing the error up through the chain and silently working.