### PR TITLE
Use integer math for guest initial happiness calculation

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -657,7 +657,10 @@ uint8_t Park::CalculateGuestInitialHappiness(uint8_t percentage)
     // This sequence can be defined as PI*(9+n)/2 (the value is floored)
     for (uint8_t n = 1; n < 55; n++)
     {
-        if ((3.14159 * (9 + n)) / 2 >= percentage)
+        // Avoid floating point math by rescaling PI up.
+        constexpr int32_t SCALE = 100000;
+        constexpr int32_t PI_SCALED = 314159; // PI * SCALE;
+        if (((PI_SCALED * (9 + n)) / SCALE) / 2 >= percentage)
         {
             return (9 + n) * 4;
         }


### PR DESCRIPTION
This ensures that every platform and compiler will yield the same result when it comes to calculating the initial happiness of guests where for floating point math the rounding can become an issue. This also checks compile time that the up scaled PI is correct.