### PR TITLE
Reduce LocationXY usage in vehicle.cpp.

### DIFF
--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -495,7 +495,7 @@ extern uint8_t _vehicleVAngleEndF64E36;
 extern uint8_t _vehicleBankEndF64E37;
 extern uint8_t _vehicleF64E2C;
 extern rct_vehicle* _vehicleFrontVehicle;
-extern LocationXYZ16 unk_F64E20;
+extern CoordsXYZ unk_F64E20;
 
 /** Helper macro until rides are stored in this module. */
 #define GET_VEHICLE(sprite_index) &(get_sprite(sprite_index)->vehicle)


### PR DESCRIPTION
Note changed logic on boat hire (Now uses `ToTileCentre()` before didn't do the `& ~0x1F`)
and chairlift (Now actually checks the z coordinate of the bullwheel when going backwards {not sure if that is even possible}).
Both likely minor bugs