### PR TITLE
Make Map::check_max_allowable_land_rights_for_tile() receive CoordsXYZ

### DIFF
--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -745,7 +745,7 @@ private:
                     continue;
 
                 int32_t base_z = surfaceElement->base_height;
-                int32_t destOwnership = check_max_allowable_land_rights_for_tile(coords.x >> 5, coords.y >> 5, base_z);
+                int32_t destOwnership = check_max_allowable_land_rights_for_tile({ coords, base_z << 3 });
 
                 // only own tiles that were not set to 0
                 if (destOwnership != OWNERSHIP_UNOWNED)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1236,7 +1236,7 @@ static void footpath_fix_ownership(int32_t x, int32_t y)
     if (surfaceElement != nullptr)
     {
         // If the tile is not safe to own construction rights of, erase them.
-        if (check_max_allowable_land_rights_for_tile(x >> 5, y >> 5, surfaceElement->base_height) == OWNERSHIP_UNOWNED)
+        if (check_max_allowable_land_rights_for_tile({ x, y, surfaceElement->base_height << 3 }) == OWNERSHIP_UNOWNED)
         {
             ownership = OWNERSHIP_UNOWNED;
         }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2355,9 +2355,9 @@ WallElement* map_get_wall_element_at(CoordsXYZD wallCoords)
     return nullptr;
 }
 
-uint16_t check_max_allowable_land_rights_for_tile(uint8_t x, uint8_t y, uint8_t base_z)
+uint16_t check_max_allowable_land_rights_for_tile(const CoordsXYZ& tileMapPos)
 {
-    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(tileMapPos);
     uint16_t destOwnership = OWNERSHIP_OWNED;
 
     // Sometimes done deliberately.
@@ -2366,6 +2366,7 @@ uint16_t check_max_allowable_land_rights_for_tile(uint8_t x, uint8_t y, uint8_t 
         return OWNERSHIP_OWNED;
     }
 
+    auto tilePos = TileCoordsXYZ{ tileMapPos };
     do
     {
         int32_t type = tileElement->GetType();
@@ -2375,7 +2376,7 @@ uint16_t check_max_allowable_land_rights_for_tile(uint8_t x, uint8_t y, uint8_t 
         {
             destOwnership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;
             // Do not own construction rights if too high/below surface
-            if (tileElement->base_height - 3 > base_z || tileElement->base_height < base_z)
+            if (tileElement->base_height - 3 > tilePos.z || tileElement->base_height < tilePos.z)
             {
                 destOwnership = OWNERSHIP_UNOWNED;
                 break;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -243,7 +243,7 @@ TileElement* map_get_track_element_at_with_direction_from_ride(
 bool map_is_location_at_edge(const CoordsXY& loc);
 void map_obstruction_set_error_text(TileElement* tileElement);
 
-uint16_t check_max_allowable_land_rights_for_tile(uint8_t x, uint8_t y, uint8_t base_z);
+uint16_t check_max_allowable_land_rights_for_tile(const CoordsXYZ& tileMapPos);
 
 void FixLandOwnershipTiles(std::initializer_list<TileCoordsXY> tiles);
 void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tiles, uint8_t ownership);


### PR DESCRIPTION
I thought it would be better to consistently wrap it into a `CoordsXYZ` than to send a `CoordsXY` and a `z`, let me know what you think