### PR TITLE
Make Map::map_get_track_element_at*() use CoordsXYZ*

### DIFF
--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -125,8 +125,7 @@ public:
             }
         }
 
-        TileElement* tileElement = map_get_track_element_at_of_type_from_ride(
-            _loc.x, _loc.y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+        TileElement* tileElement = map_get_track_element_at_of_type_from_ride(_loc, TRACK_ELEM_MAZE, _rideIndex);
         if (tileElement == nullptr)
         {
             if (_mode != GC_SET_MAZE_TRACK_BUILD)
@@ -207,7 +206,7 @@ public:
         uint8_t baseHeight = _loc.z / 8;
         uint8_t clearanceHeight = (_loc.z + 32) / 8;
 
-        auto tileElement = map_get_track_element_at_of_type_from_ride(_loc.x, _loc.y, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+        auto tileElement = map_get_track_element_at_of_type_from_ride(_loc, TRACK_ELEM_MAZE, _rideIndex);
         if (tileElement == nullptr)
         {
             money32 price = (((RideTrackCosts[ride->type].track_price * TrackPricing[TRACK_ELEM_MAZE]) >> 16));
@@ -265,7 +264,7 @@ public:
                         uint16_t previousElementY = floor2(_loc.y, 32) - CoordsDirectionDelta[_loc.direction].y;
 
                         TileElement* previousTileElement = map_get_track_element_at_of_type_from_ride(
-                            previousElementX, previousElementY, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+                            { previousElementX, previousElementY, _loc.z }, TRACK_ELEM_MAZE, _rideIndex);
 
                         if (previousTileElement != nullptr)
                         {
@@ -291,7 +290,7 @@ public:
                     uint16_t previousSegmentY = _loc.y - CoordsDirectionDelta[_loc.direction].y / 2;
 
                     tileElement = map_get_track_element_at_of_type_from_ride(
-                        previousSegmentX, previousSegmentY, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+                        { previousSegmentX, previousSegmentY, _loc.z }, TRACK_ELEM_MAZE, _rideIndex);
 
                     map_invalidate_tile_full(floor2(previousSegmentX, 32), floor2(previousSegmentY, 32));
                     if (tileElement == nullptr)
@@ -320,7 +319,7 @@ public:
                         uint16_t nextElementY = floor2(previousSegmentY, 32) + CoordsDirectionDelta[direction1].y;
 
                         TileElement* tmp_tileElement = map_get_track_element_at_of_type_from_ride(
-                            nextElementX, nextElementY, baseHeight, TRACK_ELEM_MAZE, _rideIndex);
+                            { nextElementX, nextElementY, _loc.z }, TRACK_ELEM_MAZE, _rideIndex);
 
                         if (tmp_tileElement != nullptr)
                         {

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.hpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.hpp
@@ -59,7 +59,7 @@ private:
         res->Position.y += 16;
         res->ExpenditureType = RCT_EXPENDITURE_TYPE_RIDE_CONSTRUCTION;
 
-        TileElement* tileElement = map_get_track_element_at_of_type(_loc.x, _loc.y, _loc.z / 8, _trackType);
+        TileElement* tileElement = map_get_track_element_at_of_type(_loc, _trackType);
         if (tileElement == nullptr)
         {
             log_warning("Invalid game command for setting brakes speed. x = %d, y = %d", _loc.x, _loc.y);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -4884,7 +4884,7 @@ void Guest::UpdateRideMazePathfinding()
     int16_t stationHeight = ride->stations[0].Height;
 
     // Find the station track element
-    auto trackElement = map_get_track_element_at(targetLoc.x, targetLoc.y, stationHeight);
+    auto trackElement = map_get_track_element_at({ targetLoc, stationHeight << 3 });
     if (trackElement == nullptr)
     {
         return;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2339,11 +2339,10 @@ bool Staff::UpdateFixingMoveToStationEnd(bool firstRun, Ride* ride)
             return true;
         }
 
-        uint8_t stationZ = ride->stations[current_ride_station].Height;
-        uint16_t stationX = stationPosition.x * 32;
-        uint16_t stationY = stationPosition.y * 32;
+        auto stationTilePos = TileCoordsXYZ{ stationPosition, ride->stations[current_ride_station].Height };
+        auto stationPos = stationTilePos.ToCoordsXYZ();
 
-        auto tileElement = map_get_track_element_at(stationX, stationY, stationZ);
+        auto tileElement = map_get_track_element_at(stationPos);
         if (tileElement == nullptr)
         {
             log_error("Couldn't find tile_element");
@@ -2353,20 +2352,20 @@ bool Staff::UpdateFixingMoveToStationEnd(bool firstRun, Ride* ride)
         int32_t trackDirection = tileElement->GetDirection();
         CoordsXY offset = _StationFixingOffsets[trackDirection];
 
-        stationX += 16 + offset.x;
+        stationPos.x += 16 + offset.x;
         if (offset.x == 0)
         {
-            stationX = destination_x;
+            stationPos.x = destination_x;
         }
 
-        stationY += 16 + offset.y;
+        stationPos.y += 16 + offset.y;
         if (offset.y == 0)
         {
-            stationY = destination_y;
+            stationPos.y = destination_y;
         }
 
-        destination_x = stationX;
-        destination_y = stationY;
+        destination_x = stationPos.x;
+        destination_y = stationPos.y;
         destination_tolerance = 2;
     }
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2435,7 +2435,7 @@ bool Staff::UpdateFixingMoveToStationStart(bool firstRun, Ride* ride)
         CoordsXYE input;
         input.x = stationPosition.x * 32;
         input.y = stationPosition.y * 32;
-        input.element = map_get_track_element_at_from_ride(input.x, input.y, stationZ, current_ride);
+        input.element = map_get_track_element_at_from_ride({ input.x, input.y, stationZ << 3 }, current_ride);
         if (input.element == nullptr)
         {
             return true;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -243,7 +243,7 @@ static bool sub_6DF01A_loop(rct_vehicle* vehicle)
             _vehicleVAngleEndF64E36 = TrackDefinitions[trackType].vangle_end;
             _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_end;
             TileElement* trackElement = map_get_track_element_at_of_type_seq(
-                vehicle->track_x, vehicle->track_y, vehicle->track_z / 8, trackType, 0);
+                { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
 
             CoordsXYE input;
             CoordsXYE output;
@@ -321,7 +321,7 @@ static bool sub_6DF21B_loop(rct_vehicle* vehicle)
             _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_start;
 
             TileElement* trackElement = map_get_track_element_at_of_type_seq(
-                vehicle->track_x, vehicle->track_y, vehicle->track_z / 8, trackType, 0);
+                { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
 
             CoordsXYE input;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4692,15 +4692,13 @@ static void vehicle_unset_update_flag_b1(rct_vehicle* head)
 static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYElement)
 {
     rct_vehicle* vehicle = GET_VEHICLE(ride->vehicles[0]);
-    int32_t firstX = vehicle->track_x;
-    int32_t firstY = vehicle->track_y;
-    int32_t firstZ = vehicle->track_z;
-    auto firstElement = map_get_track_element_at(firstX, firstY, firstZ / 8);
+    auto firstPos = CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z };
+    auto firstElement = map_get_track_element_at(firstPos);
 
     assert(firstElement != nullptr);
 
-    int32_t x = firstX;
-    int32_t y = firstY;
+    int32_t x = firstPos.x;
+    int32_t y = firstPos.y;
     auto trackElement = firstElement;
     track_begin_end trackBeginEnd;
     while (track_block_get_previous(x, y, reinterpret_cast<TileElement*>(trackElement), &trackBeginEnd))
@@ -4708,7 +4706,7 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
         x = trackBeginEnd.end_x;
         y = trackBeginEnd.end_y;
         trackElement = trackBeginEnd.begin_element->AsTrack();
-        if (x == firstX && y == firstY && trackElement == firstElement)
+        if (x == firstPos.x && y == firstPos.y && trackElement == firstElement)
         {
             break;
         }
@@ -4752,8 +4750,8 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
         }
     }
 
-    outXYElement->x = firstX;
-    outXYElement->y = firstY;
+    outXYElement->x = firstPos.x;
+    outXYElement->y = firstPos.y;
     outXYElement->element = reinterpret_cast<TileElement*>(firstElement);
 }
 
@@ -4794,7 +4792,7 @@ static bool ride_create_vehicles(Ride* ride, CoordsXYE* element, int32_t isApply
         x = element->x - CoordsDirectionDelta[direction].x;
         y = element->y - CoordsDirectionDelta[direction].y;
 
-        tileElement = reinterpret_cast<TileElement*>(map_get_track_element_at(x, y, z));
+        tileElement = reinterpret_cast<TileElement*>(map_get_track_element_at({ x, y, z << 3 }));
 
         z = tileElement->base_height;
         direction = tileElement->GetDirection();
@@ -5054,7 +5052,7 @@ static bool ride_create_cable_lift(ride_id_t rideIndex, bool isApplying)
     }
 
     auto cableLiftLoc = ride->CableLiftLoc;
-    auto tileElement = map_get_track_element_at(cableLiftLoc.x, cableLiftLoc.y, cableLiftLoc.z / 8);
+    auto tileElement = map_get_track_element_at(cableLiftLoc);
     int32_t direction = tileElement->GetDirection();
 
     rct_vehicle* head = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4692,21 +4692,21 @@ static void vehicle_unset_update_flag_b1(rct_vehicle* head)
 static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYElement)
 {
     rct_vehicle* vehicle = GET_VEHICLE(ride->vehicles[0]);
-    auto firstPos = CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z };
-    auto firstElement = map_get_track_element_at(firstPos);
+    auto curTrackPos = CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z };
+    auto curTrackElement = map_get_track_element_at(curTrackPos);
 
-    assert(firstElement != nullptr);
+    assert(curTrackElement != nullptr);
 
-    int32_t x = firstPos.x;
-    int32_t y = firstPos.y;
-    auto trackElement = firstElement;
+    int32_t x = curTrackPos.x;
+    int32_t y = curTrackPos.y;
+    auto trackElement = curTrackElement;
     track_begin_end trackBeginEnd;
     while (track_block_get_previous(x, y, reinterpret_cast<TileElement*>(trackElement), &trackBeginEnd))
     {
         x = trackBeginEnd.end_x;
         y = trackBeginEnd.end_y;
         trackElement = trackBeginEnd.begin_element->AsTrack();
-        if (x == firstPos.x && y == firstPos.y && trackElement == firstElement)
+        if (x == curTrackPos.x && y == curTrackPos.y && trackElement == curTrackElement)
         {
             break;
         }
@@ -4750,9 +4750,9 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
         }
     }
 
-    outXYElement->x = firstPos.x;
-    outXYElement->y = firstPos.y;
-    outXYElement->element = reinterpret_cast<TileElement*>(firstElement);
+    outXYElement->x = curTrackPos.x;
+    outXYElement->y = curTrackPos.y;
+    outXYElement->element = reinterpret_cast<TileElement*>(curTrackElement);
 }
 
 /**

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4729,7 +4729,7 @@ static void ride_create_vehicles_find_first_block(Ride* ride, CoordsXYE* outXYEl
                 if (trackElement->HasChain())
                 {
                     TileElement* tileElement = map_get_track_element_at_of_type_seq(
-                        trackBeginEnd.begin_x, trackBeginEnd.begin_y, trackBeginEnd.begin_z / 8, trackType, 0);
+                        { trackBeginEnd.begin_x, trackBeginEnd.begin_y, trackBeginEnd.begin_z }, trackType, 0);
 
                     if (tileElement != nullptr)
                     {

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -807,7 +807,8 @@ bool track_remove_station_element(int32_t x, int32_t y, int32_t z, int32_t direc
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_3))
     {
-        TileElement* tileElement = map_get_track_element_at_with_direction_from_ride(x, y, z, direction, rideIndex);
+        TileElement* tileElement = map_get_track_element_at_with_direction_from_ride(
+            { x, y, z << 3, static_cast<Direction>(direction) }, rideIndex);
         if (tileElement != nullptr)
         {
             if (flags & GAME_COMMAND_FLAG_APPLY)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3099,7 +3099,7 @@ void vehicle_test_reset(rct_vehicle* vehicle)
 static bool vehicle_current_tower_element_is_top(rct_vehicle* vehicle)
 {
     TileElement* tileElement = map_get_track_element_at_of_type(
-        vehicle->track_x, vehicle->track_y, vehicle->track_z / 8, vehicle->track_type >> 2);
+        { vehicle->track_x, vehicle->track_y, vehicle->track_z }, vehicle->track_type >> 2);
     if (tileElement != nullptr)
     {
         while (!tileElement->IsLastForTile())
@@ -6630,7 +6630,7 @@ static void check_and_apply_block_section_stop_site(rct_vehicle* vehicle)
     int32_t trackType = vehicle->track_type >> 2;
 
     TileElement* trackElement = map_get_track_element_at_of_type(
-        vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType);
+        { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType);
 
     if (trackElement == nullptr)
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7846,7 +7846,7 @@ static void sub_6DBF3E(rct_vehicle* vehicle)
     if (map_is_location_valid({ vehicle->track_x, vehicle->track_y }))
     {
         tileElement = map_get_track_element_at_of_type_seq(
-            vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType, 0);
+            { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
     }
 
     if (tileElement == nullptr)
@@ -7925,7 +7925,7 @@ static bool vehicle_update_track_motion_forwards_get_new_track(
     _vehicleVAngleEndF64E36 = TrackDefinitions[trackType].vangle_end;
     _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_end;
     TileElement* tileElement = map_get_track_element_at_of_type_seq(
-        vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType, 0);
+        { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
 
     if (tileElement == nullptr)
     {
@@ -8360,7 +8360,7 @@ static bool vehicle_update_track_motion_backwards_get_new_track(
     _vehicleVAngleEndF64E36 = TrackDefinitions[trackType].vangle_start;
     _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_start;
     TileElement* tileElement = map_get_track_element_at_of_type_seq(
-        vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType, 0);
+        { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
 
     if (tileElement == nullptr)
         return false;
@@ -8820,7 +8820,7 @@ loc_6DC476:
         _vehicleVAngleEndF64E36 = TrackDefinitions[trackType].vangle_end;
         _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_end;
         tileElement = map_get_track_element_at_of_type_seq(
-            vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType, 0);
+            { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
     }
     int16_t x, y, z;
     int32_t direction;
@@ -9075,7 +9075,7 @@ loc_6DCA9A:
         _vehicleBankEndF64E37 = TrackDefinitions[trackType].bank_end;
 
         tileElement = map_get_track_element_at_of_type_seq(
-            vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3, trackType, 0);
+            { vehicle->track_x, vehicle->track_y, vehicle->track_z }, trackType, 0);
     }
     {
         track_begin_end trackBeginEnd;
@@ -9865,7 +9865,7 @@ void vehicle_update_crossings(const rct_vehicle* vehicle)
     xyElement.y = frontVehicle->track_y;
     z = frontVehicle->track_z;
     xyElement.element = map_get_track_element_at_of_type_seq(
-        frontVehicle->track_x, frontVehicle->track_y, frontVehicle->track_z >> 3, frontVehicle->track_type >> 2, 0);
+        { frontVehicle->track_x, frontVehicle->track_y, frontVehicle->track_z }, frontVehicle->track_type >> 2, 0);
 
     if (xyElement.element && vehicle->status != VEHICLE_STATUS_ARRIVING)
     {
@@ -9939,7 +9939,7 @@ void vehicle_update_crossings(const rct_vehicle* vehicle)
     xyElement.y = backVehicle->track_y;
     z = backVehicle->track_z;
     xyElement.element = map_get_track_element_at_of_type_seq(
-        backVehicle->track_x, backVehicle->track_y, backVehicle->track_z >> 3, backVehicle->track_type >> 2, 0);
+        { backVehicle->track_x, backVehicle->track_y, backVehicle->track_z }, backVehicle->track_type >> 2, 0);
 
     if (xyElement.element)
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2801,7 +2801,7 @@ static bool vehicle_can_depart_synchronised(rct_vehicle* vehicle)
     int32_t y = location.y * 32;
     int32_t z = ride->stations[station].Height;
 
-    auto tileElement = map_get_track_element_at(x, y, z);
+    auto tileElement = map_get_track_element_at({ x, y, z << 3 });
     if (tileElement == nullptr)
     {
         return false;
@@ -3978,7 +3978,7 @@ loc_6D8E36:
         return;
     }
 
-    auto trackElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z / 8);
+    auto trackElement = map_get_track_element_at({ vehicle->track_x, vehicle->track_y, vehicle->track_z });
 
     if (trackElement == nullptr)
     {
@@ -4248,7 +4248,7 @@ static void loc_6DA9F9(rct_vehicle* vehicle, int32_t x, int32_t y, int32_t bx, i
         vehicle->track_x = bx;
         vehicle->track_y = dx;
 
-        auto trackElement = map_get_track_element_at(vehicle->track_x, vehicle->track_y, vehicle->track_z >> 3);
+        auto trackElement = map_get_track_element_at({ vehicle->track_x, vehicle->track_y, vehicle->track_z });
 
         auto ride = get_ride(vehicle->ride);
         if (ride != nullptr)
@@ -6748,7 +6748,7 @@ static void vehicle_update_block_brakes_open_previous_section(rct_vehicle* vehic
     x = trackBeginEnd.begin_x;
     y = trackBeginEnd.begin_y;
     z = trackBeginEnd.begin_z;
-    auto trackElement = map_get_track_element_at(x, y, z >> 3);
+    auto trackElement = map_get_track_element_at({ x, y, z });
     if (trackElement == nullptr)
     {
         return;

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -301,6 +301,12 @@ struct TileCoordsXYZ : public TileCoordsXY
     {
     }
 
+    TileCoordsXYZ(TileCoordsXY c, int32_t z_)
+        : TileCoordsXY(c.x, c.y)
+        , z(z_)
+    {
+    }
+
     TileCoordsXYZ(CoordsXY c, int32_t z_)
         : TileCoordsXY(c)
         , z(z_)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2259,16 +2259,17 @@ TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t 
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TileElement* map_get_track_element_at_of_type_from_ride(int32_t x, int32_t y, int32_t z, int32_t trackType, ride_id_t rideIndex)
+TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPos, int32_t trackType, ride_id_t rideIndex)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
         if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
             continue;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2316,21 +2316,21 @@ TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_
  * @param z Base height.
  * @param direction The direction (0 - 3).
  */
-TileElement* map_get_track_element_at_with_direction_from_ride(
-    int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex)
+TileElement* map_get_track_element_at_with_direction_from_ride(const CoordsXYZD& trackPos, ride_id_t rideIndex)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
         if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
             continue;
-        if (tileElement->GetDirection() != direction)
+        if (tileElement->GetDirection() != trackPos.direction)
             continue;
 
         return tileElement;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2182,16 +2182,17 @@ TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence)
+TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, int32_t trackType, int32_t sequence)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement == nullptr)
             break;
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
         if (tileElement->AsTrack()->GetTrackType() != trackType)
             continue;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2288,16 +2288,17 @@ TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPo
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TileElement* map_get_track_element_at_from_ride(int32_t x, int32_t y, int32_t z, ride_id_t rideIndex)
+TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_id_t rideIndex)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
         if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
             continue;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2130,16 +2130,17 @@ void map_clear_all_elements()
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z)
+TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
 
         return tileElement->AsTrack();

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2155,16 +2155,17 @@ TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos)
  * @param y y units, not tiles.
  * @param z Base height.
  */
-TileElement* map_get_track_element_at_of_type(int32_t x, int32_t y, int32_t z, int32_t trackType)
+TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t trackType)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
+    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != z)
+        if (tileElement->base_height != trackTilePos.z)
             continue;
         if (tileElement->AsTrack()->GetTrackType() != trackType)
             continue;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -231,7 +231,7 @@ ScreenCoordsXY translate_3d_to_2d_with_z(int32_t rotation, const CoordsXYZ& pos)
 
 TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos);
 TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t trackType);
-TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence);
+TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, int32_t trackType, int32_t sequence);
 TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);
 TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);
 TileElement* map_get_track_element_at_of_type_from_ride(

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -235,7 +235,7 @@ TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, int
 TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);
 TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);
 TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPos, int32_t trackType, ride_id_t rideIndex);
-TileElement* map_get_track_element_at_from_ride(int32_t x, int32_t y, int32_t z, ride_id_t rideIndex);
+TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_with_direction_from_ride(
     int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex);
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -236,8 +236,7 @@ TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trac
 TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);
 TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPos, int32_t trackType, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_id_t rideIndex);
-TileElement* map_get_track_element_at_with_direction_from_ride(
-    int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex);
+TileElement* map_get_track_element_at_with_direction_from_ride(const CoordsXYZD& trackPos, ride_id_t rideIndex);
 
 bool map_is_location_at_edge(const CoordsXY& loc);
 void map_obstruction_set_error_text(TileElement* tileElement);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -234,8 +234,7 @@ TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t
 TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, int32_t trackType, int32_t sequence);
 TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);
 TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);
-TileElement* map_get_track_element_at_of_type_from_ride(
-    int32_t x, int32_t y, int32_t z, int32_t trackType, ride_id_t rideIndex);
+TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPos, int32_t trackType, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_from_ride(int32_t x, int32_t y, int32_t z, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_with_direction_from_ride(
     int32_t x, int32_t y, int32_t z, int32_t direction, ride_id_t rideIndex);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -229,7 +229,7 @@ bool map_large_scenery_get_origin(
 
 ScreenCoordsXY translate_3d_to_2d_with_z(int32_t rotation, const CoordsXYZ& pos);
 
-TrackElement* map_get_track_element_at(int32_t x, int32_t y, int32_t z);
+TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos);
 TileElement* map_get_track_element_at_of_type(int32_t x, int32_t y, int32_t z, int32_t trackType);
 TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence);
 TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -230,7 +230,7 @@ bool map_large_scenery_get_origin(
 ScreenCoordsXY translate_3d_to_2d_with_z(int32_t rotation, const CoordsXYZ& pos);
 
 TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos);
-TileElement* map_get_track_element_at_of_type(int32_t x, int32_t y, int32_t z, int32_t trackType);
+TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t trackType);
 TileElement* map_get_track_element_at_of_type_seq(int32_t x, int32_t y, int32_t z, int32_t trackType, int32_t sequence);
 TrackElement* map_get_track_element_at_of_type(CoordsXYZD location, int32_t trackType);
 TrackElement* map_get_track_element_at_of_type_seq(CoordsXYZD location, int32_t trackType, int32_t sequence);

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -82,7 +82,8 @@ TEST_F(TileElementWantsFootpathConnection, SlopedPath)
 TEST_F(TileElementWantsFootpathConnection, Stall)
 {
     // Stalls usually have one path direction flag, but can have multiple (info kiosk for example)
-    const TrackElement* const stallElement = map_get_track_element_at({ 19 << 5, 15 << 5, 14 << 3 });
+    auto tileCoords = TileCoordsXYZ{ 19, 15, 14 };
+    const TrackElement* const stallElement = map_get_track_element_at(tileCoords.ToCoordsXYZ());
     ASSERT_NE(stallElement, nullptr);
     EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 15, 14, 0 }, nullptr));
     EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 1 }, nullptr));

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -82,7 +82,7 @@ TEST_F(TileElementWantsFootpathConnection, SlopedPath)
 TEST_F(TileElementWantsFootpathConnection, Stall)
 {
     // Stalls usually have one path direction flag, but can have multiple (info kiosk for example)
-    const TrackElement* const stallElement = map_get_track_element_at(19 << 5, 15 << 5, 14);
+    const TrackElement* const stallElement = map_get_track_element_at({ 19 << 5, 15 << 5, 14 << 3 });
     ASSERT_NE(stallElement, nullptr);
     EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 15, 14, 0 }, nullptr));
     EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 1 }, nullptr));


### PR DESCRIPTION
By themselves, each function would be a very small PR and with lots of merge between each other, so I decided to do a PR grouping them all, but each on their own commit, let me know if that's too bad.