### PR TITLE
Refactor ride remove LocationXY8

### DIFF
--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -521,9 +521,7 @@ public:
                     if (trackBlock->index != 0)
                         break;
                     ride->lifecycle_flags |= RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
-                    ride->cable_lift_x = mapLoc.x;
-                    ride->cable_lift_y = mapLoc.y;
-                    ride->cable_lift_z = baseZ;
+                    ride->CableLiftLoc = { mapLoc, baseZ * 8 };
                     break;
                 case TRACK_ELEM_BLOCK_BRAKES:
                     ride->num_block_brakes++;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -954,7 +954,7 @@ private:
             dst->inversions = src->num_inversions & 0x1F;
         dst->sheltered_eighths = src->num_inversions >> 5;
         dst->boat_hire_return_direction = src->boat_hire_return_direction;
-        dst->boat_hire_return_position = src->boat_hire_return_position;
+        dst->boat_hire_return_position = { src->boat_hire_return_position.x, src->boat_hire_return_position.y };
         dst->chairlift_bullwheel_rotation = src->chairlift_bullwheel_rotation;
         for (int i = 0; i < 2; i++)
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -964,11 +964,11 @@ private:
 
         if (src->cur_test_track_location.isNull())
         {
-            dst->cur_test_track_location.setNull();
+            dst->CurTestTrackLocation.setNull();
         }
         else
         {
-            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y,
+            dst->CurTestTrackLocation = { src->cur_test_track_location.x, src->cur_test_track_location.y,
                                              src->cur_test_track_z / 2 };
         }
         dst->testing_flags = src->testing_flags;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -950,8 +950,8 @@ private:
         dst->chairlift_bullwheel_rotation = src->chairlift_bullwheel_rotation;
         for (int i = 0; i < 2; i++)
         {
-            dst->chairlift_bullwheel_location[i] = src->chairlift_bullwheel_location[i];
-            dst->chairlift_bullwheel_z[i] = src->chairlift_bullwheel_z[i] / 2;
+            dst->ChairliftBullwheelLocation[i] = { src->chairlift_bullwheel_location[i].x,
+                                                   src->chairlift_bullwheel_location[i].y, src->chairlift_bullwheel_z[i] / 2 };
         }
         dst->cur_test_track_z = src->cur_test_track_z / 2;
         dst->cur_test_track_location = src->cur_test_track_location;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -796,7 +796,15 @@ private:
         }
 
         // Station
-        dst->overall_view = src->overall_view;
+        if (src->overall_view.isNull())
+        {
+            dst->overall_view.setNull();
+        }
+        else
+        {
+            dst->overall_view = { src->overall_view.x, src->overall_view.y };
+        }
+
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {
             if (src->station_starts[i].isNull())

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -969,7 +969,7 @@ private:
         else
         {
             dst->CurTestTrackLocation = { src->cur_test_track_location.x, src->cur_test_track_location.y,
-                                             src->cur_test_track_z / 2 };
+                                          src->cur_test_track_z / 2 };
         }
         dst->testing_flags = src->testing_flags;
         dst->current_test_segment = src->current_test_segment;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -961,8 +961,17 @@ private:
             dst->ChairliftBullwheelLocation[i] = { src->chairlift_bullwheel_location[i].x,
                                                    src->chairlift_bullwheel_location[i].y, src->chairlift_bullwheel_z[i] / 2 };
         }
-        dst->cur_test_track_z = src->cur_test_track_z / 2;
-        dst->cur_test_track_location = src->cur_test_track_location;
+
+        if (src->cur_test_track_location.isNull())
+        {
+            dst->cur_test_track_location.setNull();
+            dst->cur_test_track_z = 0xFF;
+        }
+        else
+        {
+            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y };
+            dst->cur_test_track_z = src->cur_test_track_z / 2;
+        }
         dst->testing_flags = src->testing_flags;
         dst->current_test_segment = src->current_test_segment;
         dst->current_test_station = 0xFF;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -965,12 +965,11 @@ private:
         if (src->cur_test_track_location.isNull())
         {
             dst->cur_test_track_location.setNull();
-            dst->cur_test_track_z = 0xFF;
         }
         else
         {
-            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y };
-            dst->cur_test_track_z = src->cur_test_track_z / 2;
+            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y,
+                                             src->cur_test_track_z / 2 };
         }
         dst->testing_flags = src->testing_flags;
         dst->current_test_segment = src->current_test_segment;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -613,13 +613,12 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     if (src->cur_test_track_location.isNull())
     {
         dst->cur_test_track_location.setNull();
-        dst->cur_test_track_z = 0xFF;
     }
     else
     {
         dst->cur_test_track_location = { static_cast<uint8_t>(src->cur_test_track_location.x),
                                          static_cast<uint8_t>(src->cur_test_track_location.y) };
-        dst->cur_test_track_z = src->cur_test_track_z;
+        dst->cur_test_track_z = static_cast<uint8_t>(src->cur_test_track_location.z);
     }
 
     dst->turn_count_default = src->turn_count_default;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -610,15 +610,15 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     // pad_106[0x2];
     dst->testing_flags = src->testing_flags;
 
-    if (src->cur_test_track_location.isNull())
+    if (src->CurTestTrackLocation.isNull())
     {
         dst->cur_test_track_location.setNull();
     }
     else
     {
-        dst->cur_test_track_location = { static_cast<uint8_t>(src->cur_test_track_location.x),
-                                         static_cast<uint8_t>(src->cur_test_track_location.y) };
-        dst->cur_test_track_z = static_cast<uint8_t>(src->cur_test_track_location.z);
+        dst->cur_test_track_location = { static_cast<uint8_t>(src->CurTestTrackLocation.x),
+                                         static_cast<uint8_t>(src->CurTestTrackLocation.y) };
+        dst->cur_test_track_z = static_cast<uint8_t>(src->CurTestTrackLocation.z);
     }
 
     dst->turn_count_default = src->turn_count_default;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -590,7 +590,8 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->operation_option = src->operation_option;
 
     dst->boat_hire_return_direction = src->boat_hire_return_direction;
-    dst->boat_hire_return_position = src->boat_hire_return_position;
+    dst->boat_hire_return_position = { static_cast<uint8_t>(src->boat_hire_return_position.x),
+                                       static_cast<uint8_t>(src->boat_hire_return_position.y) };
 
     dst->special_track_elements = src->special_track_elements;
     // pad_0D6[2];

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -522,7 +522,14 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
         dst->name_arguments_number = src->default_name_number;
     }
 
-    dst->overall_view = src->overall_view;
+    if (src->overall_view.isNull())
+    {
+        dst->overall_view.setNull();
+    }
+    else
+    {
+        dst->overall_view = { static_cast<uint8_t>(src->overall_view.x), static_cast<uint8_t>(src->overall_view.y) };
+    }
 
     for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
     {

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -630,8 +630,9 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
 
     for (uint8_t i = 0; i < 2; i++)
     {
-        dst->chairlift_bullwheel_location[i] = src->chairlift_bullwheel_location[i];
-        dst->chairlift_bullwheel_z[i] = src->chairlift_bullwheel_z[i];
+        dst->chairlift_bullwheel_location[i] = { static_cast<uint8_t>(src->ChairliftBullwheelLocation[i].x),
+                                                 static_cast<uint8_t>(src->ChairliftBullwheelLocation[i].y) };
+        dst->chairlift_bullwheel_z[i] = static_cast<uint8_t>(src->ChairliftBullwheelLocation[i].z);
     }
 
     dst->ratings = src->ratings;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -609,7 +609,19 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->previous_lateral_g = src->previous_lateral_g;
     // pad_106[0x2];
     dst->testing_flags = src->testing_flags;
-    dst->cur_test_track_location = src->cur_test_track_location;
+
+    if (src->cur_test_track_location.isNull())
+    {
+        dst->cur_test_track_location.setNull();
+        dst->cur_test_track_z = 0xFF;
+    }
+    else
+    {
+        dst->cur_test_track_location = { static_cast<uint8_t>(src->cur_test_track_location.x),
+                                         static_cast<uint8_t>(src->cur_test_track_location.y) };
+        dst->cur_test_track_z = src->cur_test_track_z;
+    }
+
     dst->turn_count_default = src->turn_count_default;
     dst->turn_count_banked = src->turn_count_banked;
     dst->turn_count_sloped = src->turn_count_sloped;
@@ -624,7 +636,6 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->sheltered_length = src->sheltered_length;
     dst->var_11C = src->var_11C;
     dst->num_sheltered_sections = src->num_sheltered_sections;
-    dst->cur_test_track_z = src->cur_test_track_z;
 
     dst->cur_num_customers = src->cur_num_customers;
     dst->num_customers_timeout = src->num_customers_timeout;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -741,9 +741,9 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->total_air_time = src->total_air_time;
     dst->current_test_station = src->current_test_station;
     dst->num_circuits = src->num_circuits;
-    dst->cable_lift_x = src->cable_lift_x;
-    dst->cable_lift_y = src->cable_lift_y;
-    dst->cable_lift_z = src->cable_lift_z;
+    dst->cable_lift_x = static_cast<int16_t>(src->CableLiftLoc.x);
+    dst->cable_lift_y = static_cast<int16_t>(src->CableLiftLoc.y);
+    dst->cable_lift_z = static_cast<int16_t>(src->CableLiftLoc.z);
     // pad_1FD;
     dst->cable_lift = src->cable_lift;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -596,7 +596,7 @@ public:
         dst->operation_option = src->operation_option;
 
         dst->boat_hire_return_direction = src->boat_hire_return_direction;
-        dst->boat_hire_return_position = src->boat_hire_return_position;
+        dst->boat_hire_return_position = { src->boat_hire_return_position.x, src->boat_hire_return_position.y };
 
         dst->special_track_elements = src->special_track_elements;
         // pad_0D6[2];

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -760,9 +760,7 @@ public:
         dst->total_air_time = src->total_air_time;
         dst->current_test_station = src->current_test_station;
         dst->num_circuits = src->num_circuits;
-        dst->cable_lift_x = src->cable_lift_x;
-        dst->cable_lift_y = src->cable_lift_y;
-        dst->cable_lift_z = src->cable_lift_z;
+        dst->CableLiftLoc = { src->cable_lift_x, src->cable_lift_y, src->cable_lift_z };
         // pad_1FD;
         dst->cable_lift = src->cable_lift;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -517,7 +517,14 @@ public:
             dst->default_name_number = src->name_arguments_number;
         }
 
-        dst->overall_view = src->overall_view;
+        if (src->overall_view.isNull())
+        {
+            dst->overall_view.setNull();
+        }
+        else
+        {
+            dst->overall_view = { src->overall_view.x, src->overall_view.y };
+        }
 
         for (int32_t i = 0; i < RCT12_MAX_STATIONS_PER_RIDE; i++)
         {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -622,7 +622,7 @@ public:
         else
         {
             dst->CurTestTrackLocation = { src->cur_test_track_location.x, src->cur_test_track_location.y,
-                                             src->cur_test_track_z };
+                                          src->cur_test_track_z };
         }
 
         dst->turn_count_default = src->turn_count_default;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -617,11 +617,11 @@ public:
 
         if (src->cur_test_track_location.isNull())
         {
-            dst->cur_test_track_location.setNull();
+            dst->CurTestTrackLocation.setNull();
         }
         else
         {
-            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y,
+            dst->CurTestTrackLocation = { src->cur_test_track_location.x, src->cur_test_track_location.y,
                                              src->cur_test_track_z };
         }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -618,12 +618,11 @@ public:
         if (src->cur_test_track_location.isNull())
         {
             dst->cur_test_track_location.setNull();
-            dst->cur_test_track_z = 0xFF;
         }
         else
         {
-            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y };
-            dst->cur_test_track_z = src->cur_test_track_z;
+            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y,
+                                             src->cur_test_track_z };
         }
 
         dst->turn_count_default = src->turn_count_default;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -614,7 +614,18 @@ public:
         dst->previous_lateral_g = src->previous_lateral_g;
         // pad_106[0x2];
         dst->testing_flags = src->testing_flags;
-        dst->cur_test_track_location = src->cur_test_track_location;
+
+        if (src->cur_test_track_location.isNull())
+        {
+            dst->cur_test_track_location.setNull();
+            dst->cur_test_track_z = 0xFF;
+        }
+        else
+        {
+            dst->cur_test_track_location = { src->cur_test_track_location.x, src->cur_test_track_location.y };
+            dst->cur_test_track_z = src->cur_test_track_z;
+        }
+
         dst->turn_count_default = src->turn_count_default;
         dst->turn_count_banked = src->turn_count_banked;
         dst->turn_count_sloped = src->turn_count_sloped;
@@ -629,7 +640,6 @@ public:
         dst->sheltered_length = src->sheltered_length;
         dst->var_11C = src->var_11C;
         dst->num_sheltered_sections = src->num_sheltered_sections;
-        dst->cur_test_track_z = src->cur_test_track_z;
 
         dst->cur_num_customers = src->cur_num_customers;
         dst->num_customers_timeout = src->num_customers_timeout;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -636,8 +636,8 @@ public:
 
         for (uint8_t i = 0; i < 2; i++)
         {
-            dst->chairlift_bullwheel_location[i] = src->chairlift_bullwheel_location[i];
-            dst->chairlift_bullwheel_z[i] = src->chairlift_bullwheel_z[i];
+            dst->ChairliftBullwheelLocation[i] = { src->chairlift_bullwheel_location[i].x,
+                                                   src->chairlift_bullwheel_location[i].y, src->chairlift_bullwheel_z[i] };
         }
 
         dst->ratings = src->ratings;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2126,14 +2126,14 @@ void Ride::UpdateChairlift()
     if (old_chairlift_bullwheel_rotation == speed / 8)
         return;
 
-    x = chairlift_bullwheel_location[0].x * 32;
-    y = chairlift_bullwheel_location[0].y * 32;
-    z = chairlift_bullwheel_z[0] * 8;
+    x = ChairliftBullwheelLocation[0].x * 32;
+    y = ChairliftBullwheelLocation[0].y * 32;
+    z = ChairliftBullwheelLocation[0].z * 8;
     map_invalidate_tile_zoom1(x, y, z, z + (4 * 8));
 
-    x = chairlift_bullwheel_location[1].x * 32;
-    y = chairlift_bullwheel_location[1].y * 32;
-    z = chairlift_bullwheel_z[1] * 8;
+    x = ChairliftBullwheelLocation[1].x * 32;
+    y = ChairliftBullwheelLocation[1].y * 32;
+    z = ChairliftBullwheelLocation[1].z * 8;
     map_invalidate_tile_zoom1(x, y, z, z + (4 * 8));
 }
 
@@ -4203,9 +4203,9 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     {
         return false;
     }
-    ride->chairlift_bullwheel_location[0].x = trackBack.x >> 5;
-    ride->chairlift_bullwheel_location[0].y = trackBack.y >> 5;
-    ride->chairlift_bullwheel_z[0] = trackBack.element->base_height;
+    ride->ChairliftBullwheelLocation[0].x = trackBack.x >> 5;
+    ride->ChairliftBullwheelLocation[0].y = trackBack.y >> 5;
+    ride->ChairliftBullwheelLocation[0].z = trackBack.element->base_height;
 
     // Check front of the track
     track_get_front(input, &trackFront);
@@ -4214,9 +4214,9 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     {
         return false;
     }
-    ride->chairlift_bullwheel_location[1].x = trackFront.x >> 5;
-    ride->chairlift_bullwheel_location[1].y = trackFront.y >> 5;
-    ride->chairlift_bullwheel_z[1] = trackFront.element->base_height;
+    ride->ChairliftBullwheelLocation[1].x = trackFront.x >> 5;
+    ride->ChairliftBullwheelLocation[1].y = trackFront.y >> 5;
+    ride->ChairliftBullwheelLocation[1].z = trackFront.element->base_height;
     return true;
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5053,10 +5053,8 @@ static bool ride_create_cable_lift(ride_id_t rideIndex, bool isApplying)
         return true;
     }
 
-    int32_t x = ride->cable_lift_x;
-    int32_t y = ride->cable_lift_y;
-    int32_t z = ride->cable_lift_z;
-    auto tileElement = map_get_track_element_at(x, y, z);
+    auto cableLiftLoc = ride->CableLiftLoc;
+    auto tileElement = map_get_track_element_at(cableLiftLoc.x, cableLiftLoc.y, cableLiftLoc.z / 8);
     int32_t direction = tileElement->GetDirection();
 
     rct_vehicle* head = nullptr;
@@ -5071,7 +5069,8 @@ static bool ride_create_cable_lift(ride_id_t rideIndex, bool isApplying)
         int32_t remaining_distance = ebx;
         ebx -= edx;
 
-        rct_vehicle* current = cable_lift_segment_create(*ride, x, y, z, direction, var_44, remaining_distance, i == 0);
+        rct_vehicle* current = cable_lift_segment_create(
+            *ride, cableLiftLoc.x, cableLiftLoc.y, cableLiftLoc.z / 8, direction, var_44, remaining_distance, i == 0);
         current->next_vehicle_on_train = SPRITE_INDEX_NULL;
         if (i == 0)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2113,8 +2113,6 @@ void Ride::Update()
  */
 void Ride::UpdateChairlift()
 {
-    int32_t x, y, z;
-
     if (!(lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
         return;
     if ((lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
@@ -2126,15 +2124,11 @@ void Ride::UpdateChairlift()
     if (old_chairlift_bullwheel_rotation == speed / 8)
         return;
 
-    x = ChairliftBullwheelLocation[0].x * 32;
-    y = ChairliftBullwheelLocation[0].y * 32;
-    z = ChairliftBullwheelLocation[0].z * 8;
-    map_invalidate_tile_zoom1(x, y, z, z + (4 * 8));
+    auto bullwheelLoc = ChairliftBullwheelLocation[0].ToCoordsXYZ();
+    map_invalidate_tile_zoom1(bullwheelLoc.x, bullwheelLoc.y, bullwheelLoc.z, bullwheelLoc.z + (4 * 8));
 
-    x = ChairliftBullwheelLocation[1].x * 32;
-    y = ChairliftBullwheelLocation[1].y * 32;
-    z = ChairliftBullwheelLocation[1].z * 8;
-    map_invalidate_tile_zoom1(x, y, z, z + (4 * 8));
+    bullwheelLoc = ChairliftBullwheelLocation[1].ToCoordsXYZ();
+    map_invalidate_tile_zoom1(bullwheelLoc.x, bullwheelLoc.y, bullwheelLoc.z, bullwheelLoc.z + (4 * 8));
 }
 
 /**
@@ -4203,9 +4197,7 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     {
         return false;
     }
-    ride->ChairliftBullwheelLocation[0].x = trackBack.x >> 5;
-    ride->ChairliftBullwheelLocation[0].y = trackBack.y >> 5;
-    ride->ChairliftBullwheelLocation[0].z = trackBack.element->base_height;
+    ride->ChairliftBullwheelLocation[0] = TileCoordsXYZ{ CoordsXYZ{ trackBack.x, trackBack.y, trackBack.element->GetBaseZ() } };
 
     // Check front of the track
     track_get_front(input, &trackFront);
@@ -4214,9 +4206,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     {
         return false;
     }
-    ride->ChairliftBullwheelLocation[1].x = trackFront.x >> 5;
-    ride->ChairliftBullwheelLocation[1].y = trackFront.y >> 5;
-    ride->ChairliftBullwheelLocation[1].z = trackFront.element->base_height;
+    ride->ChairliftBullwheelLocation[1] = TileCoordsXYZ{ CoordsXYZ{ trackFront.x, trackFront.y,
+                                                                    trackFront.element->GetBaseZ() } };
     return true;
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -264,9 +264,9 @@ struct Ride
     fixed16_2dp previous_vertical_g;
     fixed16_2dp previous_lateral_g;
     uint32_t testing_flags;
-    // x y map location of the current track piece during a test
+    // x y z map location of the current track piece during a test
     // this is to prevent counting special tracks multiple times
-    LocationXY8 cur_test_track_location;
+    TileCoordsXYZ cur_test_track_location;
     // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
     uint16_t turn_count_default; // X = current turn count
     uint16_t turn_count_banked;
@@ -279,8 +279,6 @@ struct Ride
     // Unused always 0? Should affect nausea
     uint16_t var_11C;
     uint8_t num_sheltered_sections; // (?abY YYYY)
-    // see cur_test_track_location
-    uint8_t cur_test_track_z;
     // Customer counter in the current 960 game tick (about 30 seconds) interval
     uint16_t cur_num_customers;
     // Counts ticks to update customer intervals, resets each 960 game ticks.

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -288,8 +288,7 @@ struct Ride
     // Customer count in the last 10 * 960 game ticks (sliding window)
     uint16_t num_customers[CUSTOMER_HISTORY_SIZE];
     money16 price;
-    LocationXY8 chairlift_bullwheel_location[2];
-    uint8_t chairlift_bullwheel_z[2];
+    TileCoordsXYZ ChairliftBullwheelLocation[2];
     union
     {
         rating_tuple ratings;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -223,7 +223,7 @@ struct Ride
     uint8_t status;
     std::string custom_name;
     uint16_t default_name_number;
-    LocationXY8 overall_view;
+    TileCoordsXY overall_view;
     uint16_t vehicles[MAX_VEHICLES_PER_RIDE]; // Points to the first car in the train
     uint8_t depart_flags;
     uint8_t num_stations;
@@ -246,7 +246,7 @@ struct Ride
     };
 
     uint8_t boat_hire_return_direction;
-    LocationXY8 boat_hire_return_position;
+    TileCoordsXY boat_hire_return_position;
     // bits 0 through 4 are the number of helix sections
     // bit 5: spinning tunnel, water splash, or rapids
     // bit 6: log reverser, waterfall

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -369,9 +369,7 @@ struct Ride
     uint16_t total_air_time;
     uint8_t current_test_station;
     uint8_t num_circuits;
-    int16_t cable_lift_x;
-    int16_t cable_lift_y;
-    uint8_t cable_lift_z;
+    CoordsXYZ CableLiftLoc;
     uint16_t cable_lift;
     // These fields are used to warn users about issues.
     // Such issue can be hacked rides with incompatible options set.

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -266,7 +266,7 @@ struct Ride
     uint32_t testing_flags;
     // x y z map location of the current track piece during a test
     // this is to prevent counting special tracks multiple times
-    TileCoordsXYZ cur_test_track_location;
+    TileCoordsXYZ CurTestTrackLocation;
     // Next 3 variables are related (XXXX XYYY ZZZa aaaa)
     uint16_t turn_count_default; // X = current turn count
     uint16_t turn_count_banked;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -4567,7 +4567,7 @@ static void vehicle_update_boat_location(rct_vehicle* vehicle)
     if (ride == nullptr)
         return;
 
-    TileCoordsXY returnPosition = { ride->boat_hire_return_position.x, ride->boat_hire_return_position.y };
+    TileCoordsXY returnPosition = ride->boat_hire_return_position;
     uint8_t returnDirection = ride->boat_hire_return_direction & 3;
 
     TileCoordsXY location{ CoordsXY{ vehicle->x, vehicle->y } + CoordsDirectionDelta[returnDirection] };

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1594,12 +1594,10 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
     }
 
     // If we have already evaluated this track piece skip to next section
-    uint16_t map_location = (vehicle->track_x / 32) | ((vehicle->track_y / 32) << 8);
     TileCoordsXYZ curTrackLoc{ CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z } };
-    if (curTrackLoc.z != ride->cur_test_track_z || map_location != ride->cur_test_track_location.xy)
+    if (curTrackLoc != ride->cur_test_track_location)
     {
-        ride->cur_test_track_z = curTrackLoc.z;
-        ride->cur_test_track_location.xy = map_location;
+        ride->cur_test_track_location = curTrackLoc;
 
         if (ride_get_entrance_location(ride, ride->current_test_station).isNull())
             return;
@@ -3076,7 +3074,6 @@ void vehicle_test_reset(rct_vehicle* vehicle)
     ride->previous_lateral_g = 0;
     ride->testing_flags = 0;
     ride->cur_test_track_location.setNull();
-    ride->cur_test_track_z = 0xFF;
     ride->turn_count_default = 0;
     ride->turn_count_banked = 0;
     ride->turn_count_sloped = 0;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1595,9 +1595,10 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
 
     // If we have already evaluated this track piece skip to next section
     uint16_t map_location = (vehicle->track_x / 32) | ((vehicle->track_y / 32) << 8);
-    if (vehicle->track_z / 8 != ride->cur_test_track_z || map_location != ride->cur_test_track_location.xy)
+    TileCoordsXYZ curTrackLoc{ CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z } };
+    if (curTrackLoc.z != ride->cur_test_track_z || map_location != ride->cur_test_track_location.xy)
     {
-        ride->cur_test_track_z = vehicle->track_z / 8;
+        ride->cur_test_track_z = curTrackLoc.z;
         ride->cur_test_track_location.xy = map_location;
 
         if (ride_get_entrance_location(ride, ride->current_test_station).isNull())

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -8069,14 +8069,11 @@ loc_6DB41D:
     {
         TileCoordsXYZ curLocation{ CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z } };
 
-        if (curLocation.x == ride->chairlift_bullwheel_location[1].x && curLocation.y == ride->chairlift_bullwheel_location[1].y
-            && curLocation.z == ride->chairlift_bullwheel_z[1])
+        if (curLocation == ride->ChairliftBullwheelLocation[1])
         {
             vehicle->var_CD = 3;
         }
-        else if (
-            curLocation.x == ride->chairlift_bullwheel_location[0].x && curLocation.y == ride->chairlift_bullwheel_location[0].y
-            && curLocation.z == ride->chairlift_bullwheel_z[0])
+        else if (curLocation == ride->ChairliftBullwheelLocation[0])
         {
             vehicle->var_CD = 4;
         }
@@ -8465,14 +8462,11 @@ static bool vehicle_update_track_motion_backwards_get_new_track(
     {
         TileCoordsXYZ curLocation{ CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z } };
 
-        if (ride->chairlift_bullwheel_location[1].x == curLocation.x && ride->chairlift_bullwheel_location[1].y == curLocation.y
-            && ride->chairlift_bullwheel_z[1] == curLocation.z)
+        if (curLocation == ride->ChairliftBullwheelLocation[1])
         {
             vehicle->var_CD = 3;
         }
-        else if (
-            ride->chairlift_bullwheel_location[0].x == curLocation.x && ride->chairlift_bullwheel_location[0].y == curLocation.y
-            && ride->chairlift_bullwheel_z[0] == curLocation.z)
+        else if (curLocation == ride->ChairliftBullwheelLocation[0])
         {
             vehicle->var_CD = 4;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1595,9 +1595,9 @@ static void vehicle_update_measurements(rct_vehicle* vehicle)
 
     // If we have already evaluated this track piece skip to next section
     TileCoordsXYZ curTrackLoc{ CoordsXYZ{ vehicle->track_x, vehicle->track_y, vehicle->track_z } };
-    if (curTrackLoc != ride->cur_test_track_location)
+    if (curTrackLoc != ride->CurTestTrackLocation)
     {
-        ride->cur_test_track_location = curTrackLoc;
+        ride->CurTestTrackLocation = curTrackLoc;
 
         if (ride_get_entrance_location(ride, ride->current_test_station).isNull())
             return;
@@ -3073,7 +3073,7 @@ void vehicle_test_reset(rct_vehicle* vehicle)
     ride->previous_vertical_g = 0;
     ride->previous_lateral_g = 0;
     ride->testing_flags = 0;
-    ride->cur_test_track_location.setNull();
+    ride->CurTestTrackLocation.setNull();
     ride->turn_count_default = 0;
     ride->turn_count_banked = 0;
     ride->turn_count_sloped = 0;

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -231,7 +231,7 @@ uint8_t banner_get_closest_ride_index(int32_t x, int32_t y, int32_t z)
         if (ride_type_has_flag(ride.type, RIDE_TYPE_FLAG_IS_SHOP))
             continue;
 
-        LocationXY8 location = ride.overall_view;
+        auto location = ride.overall_view;
         if (location.isNull())
             continue;
 


### PR DESCRIPTION
Couple little changes to remove the last of the LocationXY infection from the ride struct. 
I found no instances or way in which the bullwheel could have a null value or the boat hire return position so have not provided conversions for such states in the import/export code.