### PR TITLE
Use CoordsXYZ for gMapSelectArrowPosition

### DIFF
--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -493,9 +493,7 @@ static void window_footpath_update_provisional_path_for_bridge_mode(rct_window* 
         gFootpathProvisionalFlags ^= PROVISIONAL_PATH_FLAG_SHOW_ARROW;
         CoordsXYZ footpathLoc;
         footpath_get_next_path_info(&type, footpathLoc, &slope);
-        gMapSelectArrowPosition.x = footpathLoc.x;
-        gMapSelectArrowPosition.y = footpathLoc.y;
-        gMapSelectArrowPosition.z = footpathLoc.z;
+        gMapSelectArrowPosition = footpathLoc;
         gMapSelectArrowDirection = gFootpathConstructDirection;
         if (gFootpathProvisionalFlags & PROVISIONAL_PATH_FLAG_SHOW_ARROW)
         {
@@ -811,10 +809,6 @@ static void window_footpath_set_selection_start_bridge_at_point(ScreenCoordsXY s
     gMapSelectPositionA.y = y;
     gMapSelectPositionB.y = y;
 
-    gMapSelectArrowDirection = direction;
-    gMapSelectArrowPosition.x = x;
-    gMapSelectArrowPosition.y = y;
-
     int32_t z = tileElement->GetBaseZ();
 
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_SURFACE)
@@ -828,7 +822,8 @@ static void window_footpath_set_selection_start_bridge_at_point(ScreenCoordsXY s
             z += (2 * 8); // Add another 2 for a steep slope
     }
 
-    gMapSelectArrowPosition.z = z;
+    gMapSelectArrowPosition = CoordsXYZ{ x, y, z };
+    gMapSelectArrowDirection = direction;
 
     map_invalidate_selection_rect();
 }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1249,9 +1249,7 @@ static void window_map_place_park_entrance_tool_update(ScreenCoordsXY screenCoor
     gMapSelectionTiles.push_back({ parkEntrancePosition.x - CoordsDirectionDelta[sideDirection].x,
                                    parkEntrancePosition.y - CoordsDirectionDelta[sideDirection].y });
 
-    gMapSelectArrowPosition.x = parkEntrancePosition.x;
-    gMapSelectArrowPosition.y = parkEntrancePosition.y;
-    gMapSelectArrowPosition.z = parkEntrancePosition.z;
+    gMapSelectArrowPosition = parkEntrancePosition;
     gMapSelectArrowDirection = parkEntrancePosition.direction;
 
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT | MAP_SELECT_FLAG_ENABLE_ARROW;
@@ -1297,10 +1295,8 @@ static void window_map_set_peep_spawn_tool_update(ScreenCoordsXY screenCoords)
     gMapSelectPositionA.y = mapY;
     gMapSelectPositionB.x = mapX;
     gMapSelectPositionB.y = mapY;
+    gMapSelectArrowPosition = CoordsXYZ{ mapX, mapY, mapZ };
     gMapSelectArrowDirection = direction_reverse(direction);
-    gMapSelectArrowPosition.x = mapX;
-    gMapSelectArrowPosition.y = mapY;
-    gMapSelectArrowPosition.z = mapZ;
     map_invalidate_selection_rect();
 }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2611,13 +2611,11 @@ void sub_6C94D8()
             z = _currentTrackBegin.z;
             direction = _currentTrackPieceDirection;
             type = _currentTrackPieceType;
-            gMapSelectArrowPosition.x = x;
-            gMapSelectArrowPosition.y = y;
-            gMapSelectArrowPosition.z = z;
             if (direction >= 4)
                 direction += 4;
             if (_rideConstructionState == RIDE_CONSTRUCTION_STATE_BACK)
                 direction = direction_reverse(direction);
+            gMapSelectArrowPosition = CoordsXYZ{ x, y, z };
             gMapSelectArrowDirection = direction;
             gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
             if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ARROW)
@@ -2655,9 +2653,7 @@ void sub_6C94D8()
             x = _currentTrackBegin.x & 0xFFE0;
             y = _currentTrackBegin.y & 0xFFE0;
             z = _currentTrackBegin.z + 15;
-            gMapSelectArrowPosition.x = x;
-            gMapSelectArrowPosition.y = y;
-            gMapSelectArrowPosition.z = z;
+            gMapSelectArrowPosition = CoordsXYZ{ x, y, z };
             gMapSelectArrowDirection = 4;
             if (((_currentTrackBegin.x & 0x1F) | (_currentTrackBegin.y & 0x1F)) != 0)
             {
@@ -3499,10 +3495,8 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_GREEN;
+    gMapSelectArrowPosition = CoordsXYZ{ *mapCoords, z };
     gMapSelectArrowDirection = _currentTrackPieceDirection;
-    gMapSelectArrowPosition.x = mapCoords->x;
-    gMapSelectArrowPosition.y = mapCoords->y;
-    gMapSelectArrowPosition.z = z;
     gMapSelectionTiles.clear();
     gMapSelectionTiles.push_back(*mapCoords);
 
@@ -3709,10 +3703,8 @@ void ride_construction_toolupdate_entrance_exit(ScreenCoordsXY screenCoords)
     gMapSelectType = MAP_SELECT_TYPE_FULL;
     gMapSelectPositionA = entranceOrExitCoords;
     gMapSelectPositionB = entranceOrExitCoords;
+    gMapSelectArrowPosition = entranceOrExitCoords;
     gMapSelectArrowDirection = direction_reverse(entranceOrExitCoords.direction);
-    gMapSelectArrowPosition.x = entranceOrExitCoords.x;
-    gMapSelectArrowPosition.y = entranceOrExitCoords.y;
-    gMapSelectArrowPosition.z = entranceOrExitCoords.z;
     map_invalidate_selection_rect();
 
     entranceOrExitCoords.direction = direction_reverse(gRideEntranceExitPlaceDirection);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1278,9 +1278,7 @@ static int32_t track_design_place_maze(TrackDesign* td6, int16_t x, int16_t y, i
     if (_trackDesignPlaceOperation == PTD_OPERATION_DRAW_OUTLINES)
     {
         gMapSelectionTiles.clear();
-        gMapSelectArrowPosition.x = x;
-        gMapSelectArrowPosition.y = y;
-        gMapSelectArrowPosition.z = tile_element_height({ x, y });
+        gMapSelectArrowPosition = CoordsXYZ{ x, y, tile_element_height({ x, y }) };
         gMapSelectArrowDirection = _currentTrackPieceDirection;
     }
 
@@ -1484,9 +1482,7 @@ static bool track_design_place_ride(TrackDesign* td6, int16_t x, int16_t y, int1
     if (_trackDesignPlaceOperation == PTD_OPERATION_DRAW_OUTLINES)
     {
         gMapSelectionTiles.clear();
-        gMapSelectArrowPosition.x = x;
-        gMapSelectArrowPosition.y = y;
-        gMapSelectArrowPosition.z = tile_element_height({ x, y });
+        gMapSelectArrowPosition = CoordsXYZ{ x, y, tile_element_height({ x, y }) };
         gMapSelectArrowDirection = _currentTrackPieceDirection;
     }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -73,7 +73,7 @@ uint16_t gMapSelectFlags;
 uint16_t gMapSelectType;
 CoordsXY gMapSelectPositionA;
 CoordsXY gMapSelectPositionB;
-LocationXYZ16 gMapSelectArrowPosition;
+CoordsXYZ gMapSelectArrowPosition;
 uint8_t gMapSelectArrowDirection;
 
 uint8_t gMapGroundFlags;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -99,7 +99,7 @@ extern uint16_t gMapSelectFlags;
 extern uint16_t gMapSelectType;
 extern CoordsXY gMapSelectPositionA;
 extern CoordsXY gMapSelectPositionB;
-extern LocationXYZ16 gMapSelectArrowPosition;
+extern CoordsXYZ gMapSelectArrowPosition;
 extern uint8_t gMapSelectArrowDirection;
 
 extern uint8_t gMapGroundFlags;

--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -93,7 +93,7 @@ uint16_t gMapSelectFlags;
 uint16_t gMapSelectType;
 CoordsXY gMapSelectPositionA;
 CoordsXY gMapSelectPositionB;
-LocationXYZ16 gMapSelectArrowPosition;
+CoordsXYZ gMapSelectArrowPosition;
 uint8_t gMapSelectArrowDirection;
 
 void entrance_paint(paint_session* session, uint8_t direction, int height, const TileElement* tile_element)


### PR DESCRIPTION
This turns `gMapSelectArrowPosition` and `gMapSelectArrowDirection` into a single, non-LocationXYZ variable. They were always assigned to/from together, so it also makes the code more consistent.

Helps #10267