### PR TITLE
Fix #5249: No collision detection when building ride entrance at heights > 85.5m

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#10305] Add two shortcuts for increasing and decreasing the scaling factor.
 - Feature: [#10189] Make Track Designs work in multiplayer.
 - Change: [#1164] Use available translations for shortcut key bindings.
+- Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 - Fix: [#10325] Crash when banners have no text.
 - Fix: [#10420] Money effect causing false positive desync.

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -105,7 +105,7 @@ public:
             return MakeResult(GA_ERROR::NOT_OWNED, errorTitle);
         }
 
-        int8_t clear_z = (z / 8) + (_isExit ? 5 : 7);
+        auto clear_z = (z / 8) + (_isExit ? 5 : 7);
         auto cost = MONEY32_UNDEFINED;
         if (!map_can_construct_with_clear_at(
                 _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 }, GetFlags(), &cost,
@@ -173,7 +173,7 @@ public:
             wall_remove_at_z(_loc.x, _loc.y, z);
         }
 
-        int8_t clear_z = (z / 8) + (_isExit ? 5 : 7);
+        auto clear_z = (z / 8) + (_isExit ? 5 : 7);
         auto cost = MONEY32_UNDEFINED;
         if (!map_can_construct_with_clear_at(
                 _loc.x, _loc.y, z / 8, clear_z, &map_place_non_scenery_clear_func, { 0b1111, 0 },


### PR DESCRIPTION
When doing https://github.com/OpenRCT2/OpenRCT2/issues/10468 , I remembered a similar bug, so I decided to look into that one as well. As I expected, it was caused by an overflowing 8-bit signed integer.