### PR TITLE
Refactor to reduce usage of LocationXY8 and sLocationXY8

### DIFF
--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -239,8 +239,8 @@ static void window_view_clipping_mouseup(rct_window* w, rct_widgetindex widgetIn
             _dragging = false;
 
             // Reset clip selection to show all tiles
-            _previousClipSelectionA = TileCoordsXY{ gClipSelectionA.x, gClipSelectionA.y };
-            _previousClipSelectionB = TileCoordsXY{ gClipSelectionB.x, gClipSelectionB.y };
+            _previousClipSelectionA = gClipSelectionA;
+            _previousClipSelectionB = gClipSelectionB;
             gClipSelectionA = { 0, 0 };
             gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
             gfx_invalidate_screen();
@@ -303,8 +303,8 @@ static void window_view_clipping_update(rct_window* w)
     if (_toolActive && !window_view_clipping_tool_is_active())
     {
         _toolActive = false;
-        gClipSelectionA = { static_cast<uint8_t>(_previousClipSelectionA.x), static_cast<uint8_t>(_previousClipSelectionA.y) };
-        gClipSelectionB = { static_cast<uint8_t>(_previousClipSelectionB.x), static_cast<uint8_t>(_previousClipSelectionB.y) };
+        gClipSelectionA = _previousClipSelectionA;
+        gClipSelectionB = _previousClipSelectionB;
     }
 
     widget_invalidate(w, WIDX_CLIP_HEIGHT_SLIDER);
@@ -364,8 +364,8 @@ static void window_view_clipping_tool_drag(rct_window* w, rct_widgetindex widget
 
 static void window_view_clipping_tool_up(struct rct_window*, rct_widgetindex, ScreenCoordsXY)
 {
-    gClipSelectionA = { uint8_t(gMapSelectPositionA.x / 32), uint8_t(gMapSelectPositionA.y / 32) };
-    gClipSelectionB = { uint8_t(gMapSelectPositionB.x / 32), uint8_t(gMapSelectPositionB.y / 32) };
+    gClipSelectionA = TileCoordsXY{ gMapSelectPositionA };
+    gClipSelectionB = TileCoordsXY{ gMapSelectPositionB };
     _toolActive = false;
     tool_cancel();
     gfx_invalidate_screen();

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -156,8 +156,8 @@ public:
         }
         else
         {
-            x2 += ScenerySubTileOffsets[quadrant & 3].x - 1;
-            y2 += ScenerySubTileOffsets[quadrant & 3].y - 1;
+            x2 += SceneryQuadrantOffsets[quadrant & 3].x - 1;
+            y2 += SceneryQuadrantOffsets[quadrant & 3].y - 1;
         }
         landHeight = tile_element_height({ x2, y2 });
         waterHeight = tile_element_water_height({ x2, y2 });
@@ -349,8 +349,8 @@ public:
         }
         else
         {
-            x2 += ScenerySubTileOffsets[quadrant & 3].x - 1;
-            y2 += ScenerySubTileOffsets[quadrant & 3].y - 1;
+            x2 += SceneryQuadrantOffsets[quadrant & 3].x - 1;
+            y2 += SceneryQuadrantOffsets[quadrant & 3].y - 1;
         }
         landHeight = tile_element_height({ x2, y2 });
         waterHeight = tile_element_water_height({ x2, y2 });

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -123,7 +123,7 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
 
             for (int32_t j = 1; j < numPeepLoadingPositions; j += 4 * 2)
             {
-                std::array<sLocationXY8, 3> entry;
+                std::array<CoordsXY, 3> entry;
                 entry[0].x = stream->ReadValue<int8_t>();
                 entry[0].y = stream->ReadValue<int8_t>();
                 entry[1].x = stream->ReadValue<int8_t>();
@@ -804,13 +804,13 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(const json_t* jCar)
                 {
                     size_t j;
                     json_t* waypoint;
-                    std::array<sLocationXY8, 3> entry;
+                    std::array<CoordsXY, 3> entry;
                     json_array_foreach(route, j, waypoint)
                     {
                         if (json_is_array(waypoint) && json_array_size(waypoint) >= 2)
                         {
-                            auto x = (int8_t)json_integer_value(json_array_get(waypoint, 0));
-                            auto y = (int8_t)json_integer_value(json_array_get(waypoint, 1));
+                            int32_t x = json_integer_value(json_array_get(waypoint, 0));
+                            int32_t y = json_integer_value(json_array_get(waypoint, 1));
                             entry[j] = { x, y };
                         }
                     }

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -20,7 +20,7 @@ private:
     rct_ride_entry _legacyType = {};
     vehicle_colour_preset_list _presetColours = {};
     std::vector<int8_t> _peepLoadingPositions[MAX_VEHICLES_PER_RIDE_ENTRY];
-    std::vector<std::array<sLocationXY8, 3>> _peepLoadingWaypoints[MAX_VEHICLES_PER_RIDE_ENTRY];
+    std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[MAX_VEHICLES_PER_RIDE_ENTRY];
 
 public:
     explicit RideObject(const rct_object_entry& entry)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -27,8 +27,8 @@ using namespace OpenRCT2;
 
 // Globals for paint clipping
 uint8_t gClipHeight = 128; // Default to middle value
-LocationXY8 gClipSelectionA = { 0, 0 };
-LocationXY8 gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
+TileCoordsXY gClipSelectionA = { 0, 0 };
+TileCoordsXY gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
 
 static constexpr const uint8_t BoundBoxDebugColours[] = {
     0,   // NONE

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -178,8 +178,8 @@ extern paint_session gPaintSession;
 
 // Globals for paint clipping
 extern uint8_t gClipHeight;
-extern LocationXY8 gClipSelectionA;
-extern LocationXY8 gClipSelectionB;
+extern TileCoordsXY gClipSelectionA;
+extern TileCoordsXY gClipSelectionB;
 
 /** rct2: 0x00993CC4. The white ghost that indicates not-yet-built elements. */
 #define CONSTRUCTION_MARKER (COLOUR_DARK_GREEN << 19 | COLOUR_GREY << 24 | IMAGE_TYPE_REMAP)

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -115,9 +115,9 @@ void scenery_paint(paint_session* session, uint8_t direction, int32_t height, co
     else
     {
         // 6DFFC2:
-        uint8_t ecx = (tileElement->AsSmallScenery()->GetSceneryQuadrant() + rotation) & 3;
-        x_offset = ScenerySubTileOffsets[ecx].x;
-        y_offset = ScenerySubTileOffsets[ecx].y;
+        uint8_t quadrant = (tileElement->AsSmallScenery()->GetSceneryQuadrant() + rotation) & 3;
+        x_offset = SceneryQuadrantOffsets[quadrant].x;
+        y_offset = SceneryQuadrantOffsets[quadrant].y;
         boxoffset.x = x_offset;
         boxoffset.y = y_offset;
     }

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -224,14 +224,14 @@ struct tile_descriptor
 
 struct tile_surface_boundary_data
 {
-    int32_t       bit_1;
-    int32_t       bit_8;
-    int32_t       bit_4;
-    int32_t       bit_2;
-    uint32_t       image[5];
-    LocationXY8  offset;
-    LocationXY16 box_offset;
-    LocationXY16 box_size;
+    int32_t  bit_1;
+    int32_t  bit_8;
+    int32_t  bit_4;
+    int32_t  bit_2;
+    uint32_t image[5];
+    CoordsXY offset;
+    CoordsXY box_offset;
+    CoordsXY box_size;
 };
 
 static constexpr const tile_surface_boundary_data _tileSurfaceBoundaries[4] =
@@ -534,8 +534,8 @@ static void viewport_surface_draw_tile_side_bottom(
 {
     int16_t cornerHeight1, neighbourCornerHeight1, cornerHeight2, neighbourCornerHeight2;
 
-    LocationXY8 offset = { 0, 0 };
-    LocationXY8 bounds = { 0, 0 };
+    CoordsXY offset = { 0, 0 };
+    CoordsXY bounds = { 0, 0 };
     LocationXY16 tunnelBounds = { 1, 1 };
     LocationXY16 tunnelTopBoundBoxOffset = { 0, 0 };
 
@@ -751,8 +751,8 @@ static void viewport_surface_draw_tile_side_top(
 
     int16_t al, ah, cl, ch, dl = 0, waterHeight;
 
-    sLocationXY8 offset = { 0, 0 };
-    sLocationXY8 bounds = { 0, 0 };
+    CoordsXY offset = { 0, 0 };
+    CoordsXY bounds = { 0, 0 };
 
     switch (edge)
     {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -95,7 +95,7 @@ struct rct_ride_entry_vehicle
                                             // it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
     uint8_t peep_loading_waypoint_segments; // 0x61 new
     uint8_t pad_62[6] = {};                 // 0x62 , 0x7B
-    std::vector<std::array<sLocationXY8, 3>> peep_loading_waypoints = {};
+    std::vector<std::array<CoordsXY, 3>> peep_loading_waypoints = {};
     std::vector<int8_t> peep_loading_positions = {}; // previously 0x61 , 0x7B
 };
 #ifdef __TESTPAINT__

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -66,7 +66,7 @@ int16_t gSceneryCtrlPressZ;
 money32 gClearSceneryCost;
 
 // rct2: 0x009A3E74
-const LocationXY8 ScenerySubTileOffsets[] = { { 7, 7 }, { 7, 23 }, { 23, 23 }, { 23, 7 } };
+const CoordsXY SceneryQuadrantOffsets[] = { { 7, 7 }, { 7, 23 }, { 23, 23 }, { 23, 7 } };
 
 void scenery_update_tile(int32_t x, int32_t y)
 {

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -278,7 +278,7 @@ extern int16_t gSceneryShiftPressZOffset;
 extern int16_t gSceneryCtrlPressed;
 extern int16_t gSceneryCtrlPressZ;
 
-extern const LocationXY8 ScenerySubTileOffsets[];
+extern const CoordsXY SceneryQuadrantOffsets[];
 
 extern money32 gClearSceneryCost;
 


### PR DESCRIPTION
This fully removes the last usage of sLocationXY8 which can then be removed.
LocationXY8 is also now confined to RCT1 / 2 headers and therefore not in use for any in memory code.