### PR TITLE
Reduce direct usage of LOCATION_NULL

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -670,7 +670,7 @@ CoordsXY sub_68A15E(ScreenCoordsXY screenCoords)
 
     if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE)
     {
-        initialPos.x = LOCATION_NULL;
+        initialPos.setNull();
         return initialPos;
     }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1194,13 +1194,13 @@ static CoordsXYZD place_park_entrance_get_map_position(ScreenCoordsXY screenCoor
     CoordsXYZD parkEntranceMapPosition{ 0, 0, 0, INVALID_DIRECTION };
     const CoordsXY mapCoords = sub_68A15E(screenCoords);
     parkEntranceMapPosition = { mapCoords.x, mapCoords.y, 0, INVALID_DIRECTION };
-    if (parkEntranceMapPosition.x == LOCATION_NULL)
+    if (parkEntranceMapPosition.isNull())
         return parkEntranceMapPosition;
 
     auto surfaceElement = map_get_surface_element_at(mapCoords);
     if (surfaceElement == nullptr)
     {
-        parkEntranceMapPosition.x = LOCATION_NULL;
+        parkEntranceMapPosition.setNull();
         return parkEntranceMapPosition;
     }
 
@@ -1235,7 +1235,7 @@ static void window_map_place_park_entrance_tool_update(ScreenCoordsXY screenCoor
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     CoordsXYZD parkEntrancePosition = place_park_entrance_get_map_position(screenCoords);
-    if (parkEntrancePosition.x == LOCATION_NULL)
+    if (parkEntrancePosition.isNull())
     {
         park_entrance_remove_ghost();
         return;
@@ -1309,7 +1309,7 @@ static void window_map_place_park_entrance_tool_down(ScreenCoordsXY screenCoords
     park_entrance_remove_ghost();
 
     CoordsXYZD parkEntrancePosition = place_park_entrance_get_map_position(screenCoords);
-    if (parkEntrancePosition.x != LOCATION_NULL)
+    if (!parkEntrancePosition.isNull())
     {
         auto gameAction = PlaceParkEntranceAction(parkEntrancePosition);
         auto result = GameActions::Execute(&gameAction);

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -363,7 +363,7 @@ static void window_maze_construction_entrance_tooldown(ScreenCoordsXY screenCoor
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     CoordsXYZD entranceOrExitCoords = ride_get_entrance_or_exit_position_from_screen_position(screenCoords);
-    if (entranceOrExitCoords.x == LOCATION_NULL)
+    if (entranceOrExitCoords.isNull())
         return;
 
     if (gRideEntranceExitPlaceDirection == 0xFF)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2174,7 +2174,7 @@ static std::optional<CoordsXY> ride_get_place_position_from_screen_position(Scre
     if (!_trackPlaceCtrlState)
     {
         mapCoords = sub_68A15E(screenCoords);
-        if (mapCoords.x == LOCATION_NULL)
+        if (mapCoords.isNull())
             return std::nullopt;
 
         _trackPlaceZ = 0;
@@ -3578,6 +3578,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
                 break;
 
             _currentTrackBegin.z -= 8;
+            // FIXME: Unexpected & LOCATION_NULL. This will be hit on any negative value
             if (_currentTrackBegin.z & LOCATION_NULL)
                 break;
 
@@ -3605,6 +3606,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
             break;
 
         _currentTrackBegin.z -= 8;
+        // FIXME: Unexpected & LOCATION_NULL. This will be hit on any negative value
         if (_currentTrackBegin.z & LOCATION_NULL)
             break;
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3578,8 +3578,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
                 break;
 
             _currentTrackBegin.z -= 8;
-            // FIXME: Unexpected & LOCATION_NULL. This will be hit on any negative value
-            if (_currentTrackBegin.z & LOCATION_NULL)
+            if (_currentTrackBegin.z < 0)
                 break;
 
             if (bx >= 0)
@@ -3606,8 +3605,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
             break;
 
         _currentTrackBegin.z -= 8;
-        // FIXME: Unexpected & LOCATION_NULL. This will be hit on any negative value
-        if (_currentTrackBegin.z & LOCATION_NULL)
+        if (_currentTrackBegin.z < 0)
             break;
 
         if (bx >= 0)

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -344,7 +344,7 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
         TileElement* tileElement;
         CoordsXY footpathCoords;
         footpath_get_coordinates_from_pos(screenCoords, &footpathCoords.x, &footpathCoords.y, &direction, &tileElement);
-        if (footpathCoords.x == LOCATION_NULL)
+        if (footpathCoords.isNull())
             return;
 
         bool isPatrolAreaSet = staff_is_patrol_area_set(200 + selectedPeepType, footpathCoords.x, footpathCoords.y);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -273,7 +273,7 @@ static void window_track_place_toolupdate(rct_window* w, rct_widgetindex widgetI
 
     // Get the tool map position
     CoordsXY mapCoords = sub_68A15E(screenCoords);
-    if (mapCoords.x == LOCATION_NULL)
+    if (mapCoords.isNull())
     {
         window_track_place_clear_provisional();
         return;
@@ -343,7 +343,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     const CoordsXY mapCoords = sub_68A15E(screenCoords);
-    if (mapCoords.x == LOCATION_NULL)
+    if (mapCoords.isNull())
         return;
 
     // Try increasing Z until a feasible placement is found

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -768,7 +768,7 @@ namespace OpenRCT2
                 }
 
                 // Focus camera on event.
-                if (isPositionValid && result->Position.x != LOCATION_NULL)
+                if (isPositionValid && !result->Position.isNull())
                 {
                     auto* mainWindow = window_get_main();
                     if (mainWindow != nullptr)

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -431,7 +431,7 @@ namespace GameActions
                         network_add_player_money_spent(playerIndex, result->Cost);
                     }
 
-                    if (result->Position.x != LOCATION_NULL)
+                    if (!result->Position.isNull())
                     {
                         network_set_player_last_action_coord(playerId, result->Position);
                     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -110,7 +110,7 @@ std::optional<ScreenCoordsXY> centre_2d_coordinates(CoordsXYZ loc, rct_viewport*
     // If the start location was invalid
     // propagate the invalid location to the output.
     // This fixes a bug that caused the game to enter an infinite loop.
-    if (loc.x == LOCATION_NULL)
+    if (loc.isNull())
     {
         return std::nullopt;
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6184,7 +6184,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
     ride = get_ride(gRideEntranceExitPlaceRideIndex);
     if (ride == nullptr)
     {
-        entranceExitCoords.x = LOCATION_NULL;
+        entranceExitCoords.setNull();
         return entranceExitCoords;
     }
 
@@ -6193,7 +6193,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
     auto coords = screen_get_map_xy_with_z(screenCoords, stationHeight);
     if (!coords)
     {
-        entranceExitCoords.x = LOCATION_NULL;
+        entranceExitCoords.setNull();
         return entranceExitCoords;
     }
 
@@ -6204,14 +6204,14 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
 
     if (ride->type == RIDE_TYPE_NULL)
     {
-        entranceExitCoords.x = LOCATION_NULL;
+        entranceExitCoords.setNull();
         return entranceExitCoords;
     }
 
     auto stationStart = ride->stations[gRideEntranceExitPlaceStationIndex].Start;
     if (stationStart.isNull())
     {
-        entranceExitCoords.x = LOCATION_NULL;
+        entranceExitCoords.setNull();
         return entranceExitCoords;
     }
 
@@ -6280,7 +6280,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(ScreenCoordsX
         tileElement = ride_get_station_start_track_element(ride, gRideEntranceExitPlaceStationIndex);
         if (tileElement == nullptr)
         {
-            entranceExitCoords.x = LOCATION_NULL;
+            entranceExitCoords.setNull();
             return entranceExitCoords;
         }
         entranceExitCoords.direction = tileElement->GetDirection();

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -77,7 +77,7 @@ void rct_money_effect::CreateAt(money32 value, int32_t x, int32_t y, int32_t z, 
  */
 void rct_money_effect::Create(money32 value, CoordsXYZ loc)
 {
-    if (loc.x == LOCATION_NULL)
+    if (loc.isNull())
     {
         // If game actions return no valid location of the action we can not use the screen
         // coordinates as every client will have different ones.


### PR DESCRIPTION
Ideally we want to refactor a lot of these out to use std::optional as much as possible but for now move to using the standard interfaces.