### PR TITLE
Fix #10477. Fix upper max height limit being very low for large scenery

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 - Fix: [#10325] Crash when banners have no text.
 - Fix: [#10420] Money effect causing false positive desync.
-- Fix: [#10477] Multitile Scenery unable to be placed higher using shift.
+- Fix: [#10477] Large Scenery cannot be placed higher using SHIFT.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
 - Fix: [#10325] Crash when banners have no text.
 - Fix: [#10420] Money effect causing false positive desync.
+- Fix: [#10477] Multitile Scenery unable to be placed higher using shift.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1250,13 +1250,12 @@ static void sub_6E1F34(
         rct_scenery_entry* scenery_entry = get_large_scenery_entry(selected_scenery);
         if (scenery_entry)
         {
-            int16_t tileZ = 0;
+            int16_t maxClearZ = 0;
             for (int32_t i = 0; scenery_entry->large_scenery.tiles[i].x_offset != -1; ++i)
             {
-                assert(i < MAXIMUM_MAP_SIZE_TECHNICAL);
-                tileZ += scenery_entry->large_scenery.tiles[i].z_clearance;
+                maxClearZ = std::max(maxClearZ, static_cast<int16_t>(scenery_entry->large_scenery.tiles[i].z_clearance));
             }
-            maxPossibleHeight = std::max(0, maxPossibleHeight - tileZ);
+            maxPossibleHeight = std::max(0, maxPossibleHeight - maxClearZ);
         }
         can_raise_item = true;
     }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1253,7 +1253,7 @@ static void sub_6E1F34(
             int16_t maxClearZ = 0;
             for (int32_t i = 0; scenery_entry->large_scenery.tiles[i].x_offset != -1; ++i)
             {
-                maxClearZ = std::max(maxClearZ, static_cast<int16_t>(scenery_entry->large_scenery.tiles[i].z_clearance));
+                maxClearZ = std::max<int16_t>(maxClearZ, scenery_entry->large_scenery.tiles[i].z_clearance);
             }
             maxPossibleHeight = std::max(0, maxPossibleHeight - maxClearZ);
         }


### PR DESCRIPTION
Mistake made while improving mouse control when zoomed out caused the upper limit for multi tile scenery to be limited by the sum of all clearance z values instead of the greatest clearance z value.