### PR TITLE
Also change gClipSelectionA/B in TestPaint

### DIFF
--- a/test/testpaint/Compat.cpp
+++ b/test/testpaint/Compat.cpp
@@ -32,8 +32,8 @@ int16_t gMapBaseZ;
 bool gTrackDesignSaveMode = false;
 uint8_t gTrackDesignSaveRideIndex = RIDE_ID_NULL;
 uint8_t gClipHeight = 255;
-LocationXY8 gClipSelectionA = { 0, 0 };
-LocationXY8 gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
+TileCoordsXY gClipSelectionA = { 0, 0 };
+TileCoordsXY gClipSelectionB = { MAXIMUM_MAP_SIZE_TECHNICAL - 1, MAXIMUM_MAP_SIZE_TECHNICAL - 1 };
 uint32_t gScenarioTicks;
 uint8_t gCurrentRotation;
 


### PR DESCRIPTION
This change has already been applied in the regular project.
Cleans up another usage of LocationXY8.