### PR TITLE
Fixed #10464 error message showing wrong amount when placing track with not enough cash

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -137,6 +137,7 @@ The following people are not part of the development team, but have been contrib
 * Joseph Atkins-Turkish (Spacerat)
 * Tulio Paschoalin Leao (tupaschoal)
 * Denis Khabenkov (kodmord)
+* Kevin Laframboise (klaframboise)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -391,6 +391,7 @@ static void window_track_place_tooldown(rct_window* w, rct_widgetindex widgetInd
 
     // Unable to build track
     audio_play_sound_at_location(SoundId::Error, trackLoc);
+    std::copy(res->ErrorMessageArgs.begin(), res->ErrorMessageArgs.end(), gCommonFormatArgs);
     context_show_error(res->ErrorTitle, res->ErrorMessage);
 }
 


### PR DESCRIPTION
#10464 has been fixed. Added my name in contributors under bug fixes.