### PR TITLE
Use a game action result for clear at function

### DIFF
--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -85,6 +85,12 @@ extern const rct_string_id DateGameShortMonthNames[MONTH_COUNT];
     std::memcpy(args + offset, &value, size);
 }
 
+template<typename T> void constexpr set_format_arg(uint8_t* args, size_t offset, uintptr_t value)
+{
+    static_assert(sizeof(T) <= sizeof(uintptr_t), "Type too large");
+    set_format_arg_body(args, offset, value, sizeof(T));
+}
+
 #define set_format_arg(offset, type, value)                                                                                    \
     do                                                                                                                         \
     {                                                                                                                          \


### PR DESCRIPTION
I've been meaning to do this for a while. 
The idea is to make it so that the error message args and ground flags are no longer passed around in global variables. Note this does not work at the moment as I need to modify the other callers of `map_obstruction_set_error_text`.