### PR TITLE
Fix ride fence drawing when stations are above each other

### DIFF
--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -221,14 +221,13 @@ bool track_paint_util_has_fence(
             break;
     }
 
-    int32_t entranceX = (position.x / 32) + offset.x;
-    int32_t entranceY = (position.y / 32) + offset.y;
+    TileCoordsXYZ testLocXYZ = { TileCoordsXY{ position } + offset, tileElement->base_height };
 
     int32_t entranceId = tileElement->AsTrack()->GetStationIndex();
     const TileCoordsXYZD entrance = ride_get_entrance_location(ride, entranceId);
     const TileCoordsXYZD exit = ride_get_exit_location(ride, entranceId);
 
-    return ((entrance.x != entranceX || entrance.y != entranceY) && (exit.x != entranceX || exit.y != entranceY));
+    return (entrance != testLocXYZ) && (exit != testLocXYZ);
 }
 
 void track_paint_util_paint_floor(


### PR DESCRIPTION
The code didn't check for the Z coordinate, and because of that, it would remove the fence on both lift platforms.