### PR TITLE
Use CoordsXY* on world/Footpath.cpp

### DIFF
--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -500,12 +500,9 @@ namespace Editor
 
         for (const auto& parkEntrance : gParkEntrances)
         {
-            int32_t x = parkEntrance.x;
-            int32_t y = parkEntrance.y;
-            int32_t z = parkEntrance.z / 8;
             int32_t direction = direction_reverse(parkEntrance.direction);
 
-            switch (footpath_is_connected_to_map_edge(x, y, z, direction, 0))
+            switch (footpath_is_connected_to_map_edge(parkEntrance, direction, 0))
             {
                 case FOOTPATH_SEARCH_NOT_FOUND:
                     gGameCommandErrorText = STR_PARK_ENTRANCE_WRONG_DIRECTION_OR_NO_PATH;
@@ -516,7 +513,7 @@ namespace Editor
                     return false;
                 case FOOTPATH_SEARCH_SUCCESS:
                     // Run the search again and unown the path
-                    footpath_is_connected_to_map_edge(x, y, z, direction, (1 << 5));
+                    footpath_is_connected_to_map_edge(parkEntrance, direction, (1 << 5));
                     break;
             }
         }

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -426,7 +426,7 @@ private:
         }
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_PATH_SCENERY))
-            footpath_connect_edges(_loc.x, _loc.y, (TileElement*)pathElement, GetFlags());
+            footpath_connect_edges(_loc, reinterpret_cast<TileElement*>(pathElement), GetFlags());
 
         footpath_update_queue_chains();
         map_invalidate_tile_full(_loc);

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -182,7 +182,7 @@ private:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_PATH_SCENERY))
         {
-            footpath_remove_edges_at(_loc.x, _loc.y, (TileElement*)pathElement);
+            footpath_remove_edges_at(_loc, reinterpret_cast<TileElement*>(pathElement));
         }
 
         pathElement->SetPathEntryIndex(_type);
@@ -358,7 +358,7 @@ private:
 
             if (!(GetFlags() & GAME_COMMAND_FLAG_PATH_SCENERY))
             {
-                footpath_remove_edges_at(_loc.x, _loc.y, tileElement);
+                footpath_remove_edges_at(_loc, tileElement);
             }
             if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -117,7 +117,7 @@ public:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_interrupt_peeps(_loc.x, _loc.y, _loc.z);
+            footpath_interrupt_peeps(_loc);
         }
 
         gFootpathGroundFlags = 0;

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -272,7 +272,7 @@ private:
 
         if (!(GetFlags() & (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST)))
         {
-            footpath_remove_litter(_loc.x, _loc.y, _loc.z);
+            footpath_remove_litter(_loc);
         }
 
         res->Cost = MONEY(12, 00);

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -95,7 +95,7 @@ public:
         }
 
         footpath_provisional_remove();
-        auto tileElement = map_get_footpath_element_slope((_loc.x / 32), (_loc.y / 32), _loc.z / 8, _slope);
+        auto tileElement = map_get_footpath_element_slope(_loc, _slope);
         if (tileElement == nullptr)
         {
             return ElementInsertQuery(std::move(res));
@@ -141,7 +141,7 @@ public:
             }
         }
 
-        auto tileElement = map_get_footpath_element_slope((_loc.x / 32), (_loc.y / 32), _loc.z / 8, _slope);
+        auto tileElement = map_get_footpath_element_slope(_loc, _slope);
         if (tileElement == nullptr)
         {
             return ElementInsertExecute(std::move(res));
@@ -432,17 +432,17 @@ private:
         map_invalidate_tile_full(_loc);
     }
 
-    PathElement* map_get_footpath_element_slope(int32_t x, int32_t y, int32_t z, int32_t slope) const
+    PathElement* map_get_footpath_element_slope(const CoordsXYZ& footpathPos, int32_t slope) const
     {
         TileElement* tileElement;
         bool isSloped = slope & FOOTPATH_PROPERTIES_FLAG_IS_SLOPED;
 
-        tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+        tileElement = map_get_first_element_at(footpathPos);
         do
         {
             if (tileElement == nullptr)
                 break;
-            if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH && tileElement->base_height == z
+            if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH && tileElement->GetBaseZ() == footpathPos.z
                 && (tileElement->AsPath()->IsSloped() == isSloped)
                 && (tileElement->AsPath()->GetSlopeDirection() == (slope & FOOTPATH_PROPERTIES_SLOPE_DIRECTION_MASK)))
             {

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
@@ -98,7 +98,7 @@ public:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_interrupt_peeps(_loc.x, _loc.y, _loc.z);
+            footpath_interrupt_peeps(_loc);
         }
 
         gFootpathGroundFlags = 0;

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.hpp
@@ -184,7 +184,7 @@ private:
 
         if (!(GetFlags() & (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST)))
         {
-            footpath_remove_litter(_loc.x, _loc.y, _loc.z);
+            footpath_remove_litter(_loc);
         }
 
         res->Cost = MONEY(12, 00);

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -91,7 +91,7 @@ public:
             {
                 res->Cost += bannerRes->Cost;
             }
-            footpath_remove_edges_at(_loc.x, _loc.y, footpathElement);
+            footpath_remove_edges_at(_loc, footpathElement);
             map_invalidate_tile_full(_loc);
             tile_element_remove(footpathElement);
             footpath_update_queue_chains();

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -79,7 +79,7 @@ public:
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
             footpath_interrupt_peeps(_loc);
-            footpath_remove_litter(_loc.x, _loc.y, _loc.z);
+            footpath_remove_litter(_loc);
         }
 
         TileElement* footpathElement = GetFootpathElement();

--- a/src/openrct2/actions/FootpathRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathRemoveAction.hpp
@@ -78,7 +78,7 @@ public:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_interrupt_peeps(_loc.x, _loc.y, _loc.z);
+            footpath_interrupt_peeps(_loc);
             footpath_remove_litter(_loc.x, _loc.y, _loc.z);
         }
 

--- a/src/openrct2/actions/FootpathSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathSceneryPlaceAction.hpp
@@ -176,7 +176,7 @@ public:
         }
         else
         {
-            footpath_interrupt_peeps(_loc.x, _loc.y, _loc.z);
+            footpath_interrupt_peeps(_loc);
         }
 
         if ((_pathItemType != 0 && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))

--- a/src/openrct2/actions/FootpathSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/FootpathSceneryRemoveAction.hpp
@@ -99,7 +99,7 @@ public:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_interrupt_peeps(_loc.x, _loc.y, _loc.z);
+            footpath_interrupt_peeps(_loc);
         }
 
         if (pathElement == nullptr)

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -148,7 +148,7 @@ public:
     {
         money32 cost = MONEY(0, 0);
         auto surfaceHeight = tile_element_height(_coords);
-        footpath_remove_litter(_coords.x, _coords.y, surfaceHeight);
+        footpath_remove_litter({ _coords, surfaceHeight });
 
         if (!gCheatsDisableClearanceChecks)
         {

--- a/src/openrct2/actions/LargeSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.hpp
@@ -304,7 +304,7 @@ public:
 
             if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {
-                footpath_remove_litter(curTile.x, curTile.y, zLow * 8);
+                footpath_remove_litter({ curTile, zLow * COORDS_Z_STEP });
                 if (!gCheatsDisableClearanceChecks)
                 {
                     wall_remove_at({ curTile, zLow * 8, zHigh * 8 });

--- a/src/openrct2/actions/MazePlaceTrackAction.hpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.hpp
@@ -150,7 +150,7 @@ public:
         uint32_t flags = GetFlags();
         if (!(flags & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_remove_litter(_loc.x, _loc.y, _loc.z);
+            footpath_remove_litter(_loc);
             wall_remove_at({ _loc.ToTileStart(), _loc.z, _loc.z + 32 });
         }
 

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -195,7 +195,7 @@ public:
         uint32_t flags = GetFlags();
         if (!(flags & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_remove_litter(_loc.x, _loc.y, _loc.z);
+            footpath_remove_litter(_loc);
             wall_remove_at({ _loc.ToTileStart(), _loc.z, _loc.z + 32 });
         }
 

--- a/src/openrct2/actions/PlaceParkEntranceAction.hpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.hpp
@@ -171,7 +171,7 @@ public:
 
             if (!(flags & GAME_COMMAND_FLAG_GHOST))
             {
-                footpath_connect_edges(entranceLoc.x, entranceLoc.y, newElement, 1);
+                footpath_connect_edges(entranceLoc, newElement, GAME_COMMAND_FLAG_APPLY);
             }
 
             update_park_fences(entranceLoc);

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -224,7 +224,7 @@ public:
             maze_entrance_hedge_removal(_loc.x, _loc.y, tileElement);
         }
 
-        footpath_connect_edges(_loc.x, _loc.y, tileElement, GetFlags());
+        footpath_connect_edges(_loc, tileElement, GetFlags());
         footpath_update_queue_chains();
 
         map_invalidate_tile_full(_loc);

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -169,7 +169,7 @@ public:
         auto z = ride->stations[_stationNum].GetBaseZ();
         if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_remove_litter(_loc.x, _loc.y, z);
+            footpath_remove_litter({ _loc, z });
             wall_remove_at_z({ _loc, z });
         }
 

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
@@ -172,7 +172,7 @@ public:
 
         footpath_queue_chain_reset();
         maze_entrance_hedge_replacement(_loc.x, _loc.y, tileElement);
-        footpath_remove_edges_at(_loc.x, _loc.y, tileElement);
+        footpath_remove_edges_at(_loc, tileElement);
 
         tile_element_remove(tileElement);
 

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -370,7 +370,7 @@ public:
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_remove_litter(_loc.x, _loc.y, targetHeight);
+            footpath_remove_litter({ _loc, targetHeight });
             if (!gCheatsDisableClearanceChecks && (scenery_small_entry_has_flag(sceneryEntry, SMALL_SCENERY_FLAG_NO_WALLS)))
             {
                 wall_remove_at({ _loc, targetHeight, targetHeight + sceneryEntry->small_scenery.height });

--- a/src/openrct2/actions/SurfaceSetStyleAction.hpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.hpp
@@ -219,7 +219,7 @@ public:
                             surfaceElement->SetSurfaceStyle(_surfaceStyle);
 
                             map_invalidate_tile_full(coords);
-                            footpath_remove_litter(coords.x, coords.y, tile_element_height(coords));
+                            footpath_remove_litter({ coords, tile_element_height(coords) });
                         }
                     }
                 }

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -468,7 +468,7 @@ public:
 
             if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks)
             {
-                footpath_remove_litter(mapLoc.x, mapLoc.y, mapLoc.z);
+                footpath_remove_litter(mapLoc);
                 if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_NO_WALLS)
                 {
                     wall_remove_at({ mapLoc, baseZ * 8, clearanceZ * 8 });

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -676,7 +676,7 @@ public:
 
             if (!gCheatsDisableClearanceChecks || !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {
-                footpath_connect_edges(mapLoc.x, mapLoc.y, tileElement, GetFlags());
+                footpath_connect_edges(mapLoc, tileElement, GetFlags());
             }
             map_invalidate_tile_full(mapLoc);
         }

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -434,7 +434,7 @@ public:
             footpath_queue_chain_reset();
             if (!gCheatsDisableClearanceChecks || !(tileElement->IsGhost()))
             {
-                footpath_remove_edges_at(mapLoc.x, mapLoc.y, tileElement);
+                footpath_remove_edges_at(mapLoc, tileElement);
             }
             tile_element_remove(tileElement);
             sub_6CB945(ride);

--- a/src/openrct2/actions/WaterSetHeightAction.hpp
+++ b/src/openrct2/actions/WaterSetHeightAction.hpp
@@ -114,7 +114,7 @@ public:
         res->Position.z = _height * 8;
 
         int32_t surfaceHeight = tile_element_height(_coords);
-        footpath_remove_litter(_coords.x, _coords.y, surfaceHeight);
+        footpath_remove_litter({ _coords, surfaceHeight });
         if (!gCheatsDisableClearanceChecks)
             wall_remove_at_z({ _coords, surfaceHeight });
 

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -137,20 +137,19 @@ static int32_t peep_move_one_tile(Direction direction, Peep* peep)
  */
 static int32_t guest_surface_path_finding(Peep* peep)
 {
-    int16_t x = peep->next_x;
-    int16_t y = peep->next_y;
-    int16_t z = peep->next_z;
+    auto pathPos = CoordsXYRangedZ{ peep->next_x, peep->next_y, peep->next_z * COORDS_Z_STEP,
+                                    (peep->next_z * COORDS_Z_STEP) + PATH_HEIGHT };
     Direction randDirection = scenario_rand() & 3;
 
-    if (!fence_in_the_way(x, y, z, z + 4, randDirection))
+    if (!fence_in_the_way(pathPos, randDirection))
     {
-        x += CoordsDirectionDelta[randDirection].x;
-        y += CoordsDirectionDelta[randDirection].y;
+        pathPos.x += CoordsDirectionDelta[randDirection].x;
+        pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(x, y, z, z + 4, backwardsDirection))
+        if (!fence_in_the_way(pathPos, backwardsDirection))
         {
-            if (!map_surface_is_blocked({ x, y }))
+            if (!map_surface_is_blocked(pathPos))
             {
                 return peep_move_one_tile(randDirection, peep);
             }
@@ -165,17 +164,17 @@ static int32_t guest_surface_path_finding(Peep* peep)
     }
     randDirection &= 3;
 
-    x = peep->next_x;
-    y = peep->next_y;
-    if (!fence_in_the_way(x, y, z, z + 4, randDirection))
+    pathPos.x = peep->next_x;
+    pathPos.y = peep->next_y;
+    if (!fence_in_the_way(pathPos, randDirection))
     {
-        x += CoordsDirectionDelta[randDirection].x;
-        y += CoordsDirectionDelta[randDirection].y;
+        pathPos.x += CoordsDirectionDelta[randDirection].x;
+        pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(x, y, z, z + 4, backwardsDirection))
+        if (!fence_in_the_way(pathPos, backwardsDirection))
         {
-            if (!map_surface_is_blocked({ x, y }))
+            if (!map_surface_is_blocked(pathPos))
             {
                 return peep_move_one_tile(randDirection, peep);
             }
@@ -185,17 +184,17 @@ static int32_t guest_surface_path_finding(Peep* peep)
     randDirection -= 2;
     randDirection &= 3;
 
-    x = peep->next_x;
-    y = peep->next_y;
-    if (!fence_in_the_way(x, y, z, z + 4, randDirection))
+    pathPos.x = peep->next_x;
+    pathPos.y = peep->next_y;
+    if (!fence_in_the_way(pathPos, randDirection))
     {
-        x += CoordsDirectionDelta[randDirection].x;
-        y += CoordsDirectionDelta[randDirection].y;
+        pathPos.x += CoordsDirectionDelta[randDirection].x;
+        pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(x, y, z, z + 4, backwardsDirection))
+        if (!fence_in_the_way(pathPos, backwardsDirection))
         {
-            if (!map_surface_is_blocked({ x, y }))
+            if (!map_surface_is_blocked(pathPos))
             {
                 return peep_move_one_tile(randDirection, peep);
             }

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -42,6 +42,8 @@
 #define PEEP_MAX_NAUSEA 255
 #define PEEP_MAX_THIRST 255
 
+constexpr auto PEEP_CLEARANCE_HEIGHT = 4 * COORDS_Z_STEP;
+
 struct TileElement;
 struct Ride;
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -727,10 +727,16 @@ static uint8_t staff_direction_surface(Peep* peep, uint8_t initialDirection)
 
         direction &= 3;
 
-        if (fence_in_the_way(peep->next_x, peep->next_y, peep->next_z, peep->next_z + 4, direction))
+        if (fence_in_the_way(
+                { peep->next_x, peep->next_y, peep->next_z * COORDS_Z_STEP,
+                  (peep->next_z * COORDS_Z_STEP) + PEEP_CLEARANCE_HEIGHT },
+                direction))
             continue;
 
-        if (fence_in_the_way(peep->next_x, peep->next_y, peep->next_z, peep->next_z + 4, direction_reverse(direction)))
+        if (fence_in_the_way(
+                { peep->next_x, peep->next_y, peep->next_z * COORDS_Z_STEP,
+                  (peep->next_z * COORDS_Z_STEP) + PEEP_CLEARANCE_HEIGHT },
+                direction_reverse(direction)))
             continue;
 
         CoordsXY chosenTile = { peep->next_x + CoordsDirectionDelta[direction].x,

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -3001,7 +3001,7 @@ private:
                 // Trigger footpath update
                 footpath_queue_chain_reset();
                 footpath_connect_edges(
-                    entranceCoords.x * 32, (entranceCoords.y) * 32, (TileElement*)entranceElement,
+                    entranceCoords.ToCoordsXY(), reinterpret_cast<TileElement*>(entranceElement),
                     GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
                 footpath_update_queue_chains();
             }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3931,9 +3931,7 @@ static void sub_6B5952(Ride* ride)
         if (location.isNull())
             continue;
 
-        int32_t x = location.x * 32;
-        int32_t y = location.y * 32;
-        int32_t z = location.z;
+        auto mapLocation = location.ToCoordsXYZ();
 
         // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to
         // the ride or not.
@@ -3944,11 +3942,11 @@ static void sub_6B5952(Ride* ride)
             {
                 if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
                     continue;
-                if (tileElement->base_height != z)
+                if (tileElement->GetBaseZ() != mapLocation.z)
                     continue;
 
                 int32_t direction = tileElement->GetDirection();
-                footpath_chain_ride_queue(ride->id, i, x, y, tileElement, direction_reverse(direction));
+                footpath_chain_ride_queue(ride->id, i, mapLocation, tileElement, direction_reverse(direction));
             } while (!(tileElement++)->IsLastForTile());
         }
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7089,7 +7089,7 @@ void sub_6CB945(Ride* ride)
             {
                 footpath_queue_chain_reset();
                 maze_entrance_hedge_replacement(location.x, location.y, tileElement);
-                footpath_remove_edges_at(location.x, location.y, tileElement);
+                footpath_remove_edges_at(location, tileElement);
                 footpath_update_queue_chains();
                 map_invalidate_tile_full(location);
                 tile_element_remove(tileElement);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1192,7 +1192,7 @@ static bool TrackDesignPlaceSceneryElement(
                     }
 
                     footpath_queue_chain_reset();
-                    footpath_remove_edges_at(mapCoord.x, mapCoord.y, reinterpret_cast<TileElement*>(pathElement));
+                    footpath_remove_edges_at(mapCoord, reinterpret_cast<TileElement*>(pathElement));
 
                     flags = GAME_COMMAND_FLAG_APPLY;
                     if (_trackDesignPlaceOperation == PTD_OPERATION_PLACE_TRACK_PREVIEW)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1205,7 +1205,7 @@ static bool TrackDesignPlaceSceneryElement(
                             | GAME_COMMAND_FLAG_GHOST;
                     }
 
-                    footpath_connect_edges(mapCoord.x, mapCoord.y, reinterpret_cast<TileElement*>(pathElement), flags);
+                    footpath_connect_edges(mapCoord, reinterpret_cast<TileElement*>(pathElement), flags);
                     footpath_update_queue_chains();
                     return true;
                 }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -421,9 +421,9 @@ void footpath_remove_litter(int32_t x, int32_t y, int32_t z)
  *
  *  rct2: 0x0069A48B
  */
-void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z)
+void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
 {
-    uint16_t spriteIndex = sprite_get_first_in_quadrant(x, y);
+    uint16_t spriteIndex = sprite_get_first_in_quadrant(footpathPos.x, footpathPos.y);
     while (spriteIndex != SPRITE_INDEX_NULL)
     {
         Peep* peep = &get_sprite(spriteIndex)->peep;
@@ -432,7 +432,7 @@ void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z)
         {
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)
             {
-                if (peep->z == z)
+                if (peep->z == footpathPos.z)
                 {
                     peep->SetState(PEEP_STATE_WALKING);
                     peep->destination_x = (peep->x & 0xFFE0) + 16;
@@ -917,7 +917,7 @@ static void loc_6A6D7E(
         }
         if (!(flags & (GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED)))
         {
-            footpath_interrupt_peeps(targetPos.x, targetPos.y, tileElement->GetBaseZ());
+            footpath_interrupt_peeps({ targetPos, tileElement->GetBaseZ() });
         }
         map_invalidate_element(targetPos, tileElement);
     }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1418,10 +1418,12 @@ searchFromFootpath:
     }
 }
 
-int32_t footpath_is_connected_to_map_edge(int32_t x, int32_t y, int32_t z, int32_t direction, int32_t flags)
+// TODO: Use GAME_COMMAND_FLAGS
+int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags)
 {
     flags |= (1 << 0);
-    return footpath_is_connected_to_map_edge_recurse(x, y, z, direction, flags, 0, 0, 16);
+    return footpath_is_connected_to_map_edge_recurse(
+        footpathPos.x, footpathPos.y, footpathPos.z / COORDS_Z_STEP, direction, flags, 0, 0, 16);
 }
 
 bool PathElement::IsSloped() const

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -741,7 +741,7 @@ static bool footpath_reconnect_queue_to_path(int32_t x, int32_t y, TileElement* 
     return false;
 }
 
-static bool footpath_disconnect_queue_from_path(int32_t x, int32_t y, TileElement* tileElement, int32_t action)
+static bool footpath_disconnect_queue_from_path(const CoordsXY& footpathPos, TileElement* tileElement, int32_t action)
 {
     if (!tileElement->AsPath()->IsQueue())
         return false;
@@ -756,7 +756,7 @@ static bool footpath_disconnect_queue_from_path(int32_t x, int32_t y, TileElemen
     if (action < 0)
     {
         uint8_t direction = tileElement->AsPath()->GetSlopeDirection();
-        if (footpath_reconnect_queue_to_path(x, y, tileElement, action, direction))
+        if (footpath_reconnect_queue_to_path(footpathPos.x, footpathPos.y, tileElement, action, direction))
             return true;
     }
 
@@ -764,7 +764,7 @@ static bool footpath_disconnect_queue_from_path(int32_t x, int32_t y, TileElemen
     {
         if ((action < 0) && (direction == tileElement->AsPath()->GetSlopeDirection()))
             continue;
-        if (footpath_reconnect_queue_to_path(x, y, tileElement, action, direction))
+        if (footpath_reconnect_queue_to_path(footpathPos.x, footpathPos.y, tileElement, action, direction))
             return true;
     }
 
@@ -892,7 +892,7 @@ static void loc_6A6D7E(
                 {
                     if ((initialTileElement)->GetType() == TILE_ELEMENT_TYPE_PATH && initialTileElement->AsPath()->IsQueue())
                     {
-                        if (footpath_disconnect_queue_from_path(targetPos.x, targetPos.y, tileElement, 0))
+                        if (footpath_disconnect_queue_from_path(targetPos, tileElement, 0))
                         {
                             neighbour_list_push(
                                 neighbourList, 3, direction, tileElement->AsPath()->GetRideIndex(),
@@ -908,7 +908,7 @@ static void loc_6A6D7E(
         }
         else
         {
-            footpath_disconnect_queue_from_path(targetPos.x, targetPos.y, tileElement, 1 + ((flags >> 6) & 1));
+            footpath_disconnect_queue_from_path(targetPos, tileElement, 1 + ((flags >> 6) & 1));
             tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << direction_reverse(direction)));
             if (tileElement->AsPath()->IsQueue())
             {
@@ -1937,7 +1937,7 @@ static void footpath_remove_edges_towards_here(
     map_invalidate_tile({ x, y, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
 
     if (isQueue)
-        footpath_disconnect_queue_from_path(x, y, tileElement, -1);
+        footpath_disconnect_queue_from_path({ x, y }, tileElement, -1);
 
     direction = (direction + 1) & 3;
     x += CoordsDirectionDelta[direction].x;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -397,16 +397,16 @@ void footpath_bridge_get_info_from_pos(
  *
  *  rct2: 0x00673883
  */
-void footpath_remove_litter(int32_t x, int32_t y, int32_t z)
+void footpath_remove_litter(const CoordsXYZ& footpathPos)
 {
-    uint16_t spriteIndex = sprite_get_first_in_quadrant(x, y);
+    uint16_t spriteIndex = sprite_get_first_in_quadrant(footpathPos.x, footpathPos.y);
     while (spriteIndex != SPRITE_INDEX_NULL)
     {
         rct_litter* sprite = &get_sprite(spriteIndex)->litter;
         uint16_t nextSpriteIndex = sprite->next_in_quadrant;
         if (sprite->linked_list_index == SPRITE_LIST_LITTER)
         {
-            int32_t distanceZ = abs(sprite->z - z);
+            int32_t distanceZ = abs(sprite->z - footpathPos.z);
             if (distanceZ <= 32)
             {
                 invalidate_sprite_0((rct_sprite*)sprite);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -454,11 +454,11 @@ void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z)
  *
  *  rct2: 0x006E59DC
  */
-bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t direction)
+bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction)
 {
     TileElement* tileElement;
 
-    tileElement = map_get_first_element_at({ x, y });
+    tileElement = map_get_first_element_at(fencePos);
     if (tileElement == nullptr)
         return false;
     do
@@ -467,9 +467,9 @@ bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t dire
             continue;
         if (tileElement->IsGhost())
             continue;
-        if (z0 >= tileElement->clearance_height)
+        if (fencePos.baseZ >= tileElement->GetClearanceZ())
             continue;
-        if (z1 <= tileElement->base_height)
+        if (fencePos.clearanceZ <= tileElement->GetBaseZ())
             continue;
         if ((tileElement->GetDirection()) != direction)
             continue;
@@ -710,10 +710,10 @@ static bool footpath_reconnect_queue_to_path(int32_t x, int32_t y, TileElement* 
 
     if (action < 0)
     {
-        if (fence_in_the_way(x, y, tileElement->base_height, tileElement->clearance_height, direction))
+        if (fence_in_the_way({ x, y, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction))
             return false;
 
-        if (fence_in_the_way(x1, y1, tileElement->base_height, tileElement->clearance_height, direction_reverse(direction)))
+        if (fence_in_the_way({ x1, y1, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction_reverse(direction)))
             return false;
     }
 
@@ -876,8 +876,7 @@ static void loc_6A6D7E(
         if (query)
         {
             if (fence_in_the_way(
-                    targetPos.x, targetPos.y, tileElement->base_height, tileElement->clearance_height,
-                    direction_reverse(direction)))
+                    { targetPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction_reverse(direction)))
             {
                 return;
             }
@@ -941,8 +940,7 @@ static void loc_6A6C85(
 {
     if (query
         && fence_in_the_way(
-            tileElementPos.x, tileElementPos.y, tileElementPos.element->base_height, tileElementPos.element->clearance_height,
-            direction))
+            { tileElementPos, tileElementPos.element->GetBaseZ(), tileElementPos.element->GetClearanceZ() }, direction))
         return;
 
     if (tileElementPos.element->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2130,7 +2130,7 @@ static void footpath_fix_corners_around(int32_t x, int32_t y, TileElement* pathE
  * @param x x-coordinate in units (not tiles)
  * @param y y-coordinate in units (not tiles)
  */
-void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
+void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement)
 {
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
     {
@@ -2140,7 +2140,7 @@ void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
             return;
     }
 
-    footpath_update_queue_entrance_banner({ x, y }, tileElement);
+    footpath_update_queue_entrance_banner(footpathPos, tileElement);
 
     bool fixCorners = false;
     for (uint8_t direction = 0; direction < 4; direction++)
@@ -2163,12 +2163,13 @@ void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
         // When clearance checks were disabled a neighbouring path can be connected to both the path-ghost and to something
         // else, so before removing edges from neighbouring paths we have to make sure there is nothing else they are connected
         // to.
-        if (!tile_element_wants_path_connection_towards({ x / 32, y / 32, z1, direction }, tileElement))
+        if (!tile_element_wants_path_connection_towards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
         {
             bool isQueue = tileElement->GetType() == TILE_ELEMENT_TYPE_PATH ? tileElement->AsPath()->IsQueue() : false;
             int32_t z0 = z1 - 2;
             footpath_remove_edges_towards(
-                x + CoordsDirectionDelta[direction].x, y + CoordsDirectionDelta[direction].y, z0, z1, direction, isQueue);
+                footpathPos.x + CoordsDirectionDelta[direction].x, footpathPos.y + CoordsDirectionDelta[direction].y, z0, z1,
+                direction, isQueue);
         }
         else
         {
@@ -2180,7 +2181,8 @@ void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
     // Only fix corners when needed, to avoid changing corners that have been set for its looks.
     if (fixCorners && tileElement->IsGhost())
     {
-        footpath_fix_corners_around(x / 32, y / 32, tileElement);
+        auto tileFootpathPos = TileCoordsXY{ footpathPos };
+        footpath_fix_corners_around(tileFootpathPos.x, tileFootpathPos.y, tileElement);
     }
 
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -35,7 +35,7 @@
 #include <algorithm>
 #include <iterator>
 
-void footpath_update_queue_entrance_banner(int32_t x, int32_t y, TileElement* tileElement);
+void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement);
 
 uint8_t gFootpathProvisionalFlags;
 CoordsXYZ gFootpathProvisionalPosition;
@@ -1001,7 +1001,7 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
 
     neighbour_list_init(&neighbourList);
 
-    footpath_update_queue_entrance_banner(footpathPos.x, footpathPos.y, tileElement);
+    footpath_update_queue_entrance_banner(footpathPos, tileElement);
     for (Direction direction : ALL_DIRECTIONS)
     {
         loc_6A6C85({ footpathPos, tileElement }, direction, flags, true, &neighbourList);
@@ -1884,7 +1884,7 @@ bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
  *
  *  rct2: 0x006A7642
  */
-void footpath_update_queue_entrance_banner(int32_t x, int32_t y, TileElement* tileElement)
+void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement)
 {
     int32_t elementType = tileElement->GetType();
     switch (elementType)
@@ -1897,7 +1897,7 @@ void footpath_update_queue_entrance_banner(int32_t x, int32_t y, TileElement* ti
                 {
                     if (tileElement->AsPath()->GetEdges() & (1 << direction))
                     {
-                        footpath_chain_ride_queue(255, 0, x, y, tileElement, direction);
+                        footpath_chain_ride_queue(255, 0, footpathPos.x, footpathPos.y, tileElement, direction);
                     }
                 }
                 tileElement->AsPath()->SetRideIndex(RIDE_ID_NULL);
@@ -1907,7 +1907,8 @@ void footpath_update_queue_entrance_banner(int32_t x, int32_t y, TileElement* ti
             if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
             {
                 footpath_queue_chain_push(tileElement->AsEntrance()->GetRideIndex());
-                footpath_chain_ride_queue(255, 0, x, y, tileElement, direction_reverse(tileElement->GetDirection()));
+                footpath_chain_ride_queue(
+                    255, 0, footpathPos.x, footpathPos.y, tileElement, direction_reverse(tileElement->GetDirection()));
             }
             break;
     }
@@ -2137,7 +2138,7 @@ void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement)
             return;
     }
 
-    footpath_update_queue_entrance_banner(x, y, tileElement);
+    footpath_update_queue_entrance_banner({ x, y }, tileElement);
 
     bool fixCorners = false;
     for (uint8_t direction = 0; direction < 4; direction++)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -987,7 +987,7 @@ static void loc_6A6C85(
  *
  *  rct2: 0x006A6C66
  */
-void footpath_connect_edges(int32_t x, int32_t y, TileElement* tileElement, int32_t flags)
+void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags)
 {
     rct_neighbour_list neighbourList;
     rct_neighbour neighbour;
@@ -996,10 +996,10 @@ void footpath_connect_edges(int32_t x, int32_t y, TileElement* tileElement, int3
 
     neighbour_list_init(&neighbourList);
 
-    footpath_update_queue_entrance_banner(x, y, tileElement);
+    footpath_update_queue_entrance_banner(footpathPos.x, footpathPos.y, tileElement);
     for (Direction direction : ALL_DIRECTIONS)
     {
-        loc_6A6C85(x, y, direction, tileElement, flags, true, &neighbourList);
+        loc_6A6C85(footpathPos.x, footpathPos.y, direction, tileElement, flags, true, &neighbourList);
     }
 
     neighbour_list_sort(&neighbourList);
@@ -1035,12 +1035,12 @@ void footpath_connect_edges(int32_t x, int32_t y, TileElement* tileElement, int3
 
     while (neighbour_list_pop(&neighbourList, &neighbour))
     {
-        loc_6A6C85(x, y, neighbour.direction, tileElement, flags, false, nullptr);
+        loc_6A6C85(footpathPos.x, footpathPos.y, neighbour.direction, tileElement, flags, false, nullptr);
     }
 
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)
     {
-        footpath_connect_corners(x, y, tileElement);
+        footpath_connect_corners(footpathPos.x, footpathPos.y, tileElement);
     }
 }
 

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -178,7 +178,7 @@ extern const LocationXY16 BenchUseOffsets[NumOrthogonalDirections * 2];
 TileElement* map_get_footpath_element(CoordsXYZ coords);
 struct PathElement;
 PathElement* map_get_footpath_element_slope(int32_t x, int32_t y, int32_t z, int32_t slope);
-void footpath_interrupt_peeps(int32_t x, int32_t y, int32_t z);
+void footpath_interrupt_peeps(const CoordsXYZ& footpathPos);
 money32 footpath_remove(CoordsXYZ footpathLoc, int32_t flags);
 money32 footpath_provisional_set(int32_t type, CoordsXYZ footpathLoc, int32_t slope);
 void footpath_provisional_remove();

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -24,6 +24,7 @@ enum
 constexpr auto FootpathMaxHeight = 248;
 constexpr auto FootpathMinHeight = 2;
 constexpr auto PATH_HEIGHT_STEP = 2 * COORDS_Z_STEP;
+constexpr auto PATH_HEIGHT = 4 * COORDS_Z_STEP;
 
 #define FOOTPATH_ELEMENT_INSERT_QUEUE 0x80
 
@@ -189,7 +190,7 @@ void footpath_bridge_get_info_from_pos(
 void footpath_remove_litter(int32_t x, int32_t y, int32_t z);
 void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
 void footpath_update_queue_chains();
-bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t direction);
+bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);
 void footpath_chain_ride_queue(
     ride_id_t rideIndex, int32_t entranceIndex, int32_t x, int32_t y, TileElement* tileElement, int32_t direction);
 void footpath_update_path_wide_flags(int32_t x, int32_t y);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -192,7 +192,7 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
 void footpath_update_queue_chains();
 bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);
 void footpath_chain_ride_queue(
-    ride_id_t rideIndex, int32_t entranceIndex, int32_t x, int32_t y, TileElement* tileElement, int32_t direction);
+    ride_id_t rideIndex, int32_t entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
 void footpath_update_path_wide_flags(int32_t x, int32_t y);
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
 

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -196,7 +196,7 @@ void footpath_chain_ride_queue(
 void footpath_update_path_wide_flags(int32_t x, int32_t y);
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
 
-int32_t footpath_is_connected_to_map_edge(int32_t x, int32_t y, int32_t z, int32_t direction, int32_t flags);
+int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
 void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);
 int32_t entrance_get_directions(const TileElement* tileElement);
 

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -197,7 +197,7 @@ void footpath_update_path_wide_flags(int32_t x, int32_t y);
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
 
 int32_t footpath_is_connected_to_map_edge(int32_t x, int32_t y, int32_t z, int32_t direction, int32_t flags);
-void footpath_remove_edges_at(int32_t x, int32_t y, TileElement* tileElement);
+void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);
 int32_t entrance_get_directions(const TileElement* tileElement);
 
 PathSurfaceEntry* get_path_surface_entry(int32_t entryIndex);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -177,7 +177,7 @@ extern const LocationXY16 BenchUseOffsets[NumOrthogonalDirections * 2];
 
 TileElement* map_get_footpath_element(CoordsXYZ coords);
 struct PathElement;
-PathElement* map_get_footpath_element_slope(int32_t x, int32_t y, int32_t z, int32_t slope);
+PathElement* map_get_footpath_element_slope(const CoordsXYZ& footpathPos, int32_t slope);
 void footpath_interrupt_peeps(const CoordsXYZ& footpathPos);
 money32 footpath_remove(CoordsXYZ footpathLoc, int32_t flags);
 money32 footpath_provisional_set(int32_t type, CoordsXYZ footpathLoc, int32_t slope);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -187,7 +187,7 @@ void footpath_get_coordinates_from_pos(
     ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
 void footpath_bridge_get_info_from_pos(
     ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
-void footpath_remove_litter(int32_t x, int32_t y, int32_t z);
+void footpath_remove_litter(const CoordsXYZ& footpathPos);
 void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
 void footpath_update_queue_chains();
 bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -187,7 +187,7 @@ void footpath_get_coordinates_from_pos(
 void footpath_bridge_get_info_from_pos(
     ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
 void footpath_remove_litter(int32_t x, int32_t y, int32_t z);
-void footpath_connect_edges(int32_t x, int32_t y, TileElement* tileElement, int32_t flags);
+void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
 void footpath_update_queue_chains();
 bool fence_in_the_way(int32_t x, int32_t y, int32_t z0, int32_t z1, int32_t direction);
 void footpath_chain_ride_queue(

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -475,6 +475,12 @@ struct TileCoordsXYZD : public TileCoordsXYZ
     {
     }
 
+    TileCoordsXYZD(TileCoordsXY t_, int32_t z_, Direction d_)
+        : TileCoordsXYZ(t_, z_)
+        , direction(d_)
+    {
+    }
+
     TileCoordsXYZD(CoordsXY c_, int32_t z_, Direction d_)
         : TileCoordsXYZ(c_, z_)
         , direction(d_)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -964,7 +964,7 @@ void map_remove_all_rides()
                 [[fallthrough]];
             case TILE_ELEMENT_TYPE_TRACK:
                 footpath_queue_chain_reset();
-                footpath_remove_edges_at(it.x * 32, it.y * 32, it.element);
+                footpath_remove_edges_at(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
                 tile_element_remove(it.element);
                 tile_element_iterator_restart_for_tile(&it);
                 break;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -43,9 +43,20 @@ constexpr const int32_t LAND_HEIGHT_STEP = 2 * COORDS_Z_STEP;
 
 typedef CoordsXYZD PeepSpawn;
 
-struct CoordsXYE
+struct CoordsXYE : public CoordsXY
 {
-    int32_t x, y;
+    CoordsXYE() = default;
+    constexpr CoordsXYE(int32_t _x, int32_t _y, TileElement* _e)
+        : CoordsXY(_x, _y)
+        , element(_e)
+    {
+    }
+
+    constexpr CoordsXYE(CoordsXY c, TileElement* _e)
+        : CoordsXY(c)
+        , element(_e)
+    {
+    }
     TileElement* element;
 };
 


### PR DESCRIPTION
I'm trying to get rid of non coords usage in Footpath. Some notes:

- Some places seemed like they could use a `CoordsXYRangedZD` with the `Direction`, but I was not sure if this should be done.
- Some other places could benefit from Map's `CoordsXYE`, would that be ok?
- The only left are `footpath_update_path_wide_flags(int32_t x, int32_t y);` which I couldn't tell for sure are `CoordsXY` and `footpath_get_coordinates_from_pos` + `footpath_bridge_get_info_from_pos` which would involve changing from altering parameter to returning coords. 