### PR TITLE
Fix line that causes build to fail on Mac

### DIFF
--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -108,7 +108,7 @@ namespace Platform
         @autoreleasepool {
             if (input == NULL)
             {
-                return NULL;
+                return 0;
             }
 
             NSString* inputDecomp = [NSString stringWithUTF8String:input];


### PR DESCRIPTION
When trying to build the game on Mac, I got the following error:

```
/Users/ec2618/Programming/RCT2/OpenRCT2/src/openrct2/platform/Platform.macOS.mm:111:24: error: implicit conversion of NULL constant to 'uintptr_t' (aka 'unsigned long') [-Werror,-Wnull-conversion]
                return NULL;
                ~~~~~~ ^~~~
                       0
1 error generated.
```
I asked about it on the Gitter and was told to submit a PR.