### PR TITLE
Fix #10313: Path furniture can be placed on level crossings

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3666,6 +3666,8 @@ STR_6343    :Tile Inspector: Increase Y coordinate
 STR_6344    :Tile Inspector: Decrease Y coordinate
 STR_6345    :Tile Inspector: Increase element height
 STR_6346    :Tile Inspector: Decrease element height
+STR_6347    :Path additions cannot be placed on level crossings!
+STR_6348    :Remove level crossing first!
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
 - Fix: [#10228] Can't import RCT1 Deluxe from Steam.
+- Fix: [#10313] Path furniture can be placed on level crossings.
 - Fix: [#10325] Crash when banners have no text.
 - Fix: [#10420] Money effect causing false positive desync.
 - Fix: [#10477] Large Scenery cannot be placed higher using SHIFT.

--- a/src/openrct2/actions/FootpathSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathSceneryPlaceAction.hpp
@@ -81,6 +81,11 @@ public:
         }
 
         auto pathElement = tileElement->AsPath();
+        if (pathElement->IsLevelCrossing(_loc))
+        {
+            return MakeResult(
+                GA_ERROR::INVALID_PARAMETERS, STR_CANT_POSITION_THIS_HERE, STR_CANNOT_BUILD_PATH_ADDITIONS_ON_LEVEL_CROSSINGS);
+        }
 
         // No change
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && pathElement->GetAddition() == _pathItemType

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -105,6 +105,15 @@ public:
         if (surfaceElement == nullptr)
             return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
 
+        // We need to check if there is _currently_ a level crossing on the tile. For that, we need the old height,
+        // so we can't use the _height variable.
+        auto oldCoords = CoordsXYZ{ _coords, surfaceElement->GetBaseZ() };
+        auto* pathElement = map_get_footpath_element(oldCoords);
+        if (pathElement != nullptr && pathElement->AsPath()->IsLevelCrossing(oldCoords))
+        {
+            return MakeResult(GA_ERROR::DISALLOWED, STR_REMOVE_LEVEL_CROSSING_FIRST);
+        }
+
         TileElement* tileElement = CheckFloatingStructures(reinterpret_cast<TileElement*>(surfaceElement), _height);
         if (tileElement != nullptr)
         {

--- a/src/openrct2/actions/LandSetHeightAction.hpp
+++ b/src/openrct2/actions/LandSetHeightAction.hpp
@@ -105,8 +105,8 @@ public:
         if (surfaceElement == nullptr)
             return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_NONE);
 
-        // We need to check if there is _currently_ a level crossing on the tile. For that, we need the old height,
-        // so we can't use the _height variable.
+        // We need to check if there is _currently_ a level crossing on the tile.
+        // For that, we need the old height, so we can't use the _height variable.
         auto oldCoords = CoordsXYZ{ _coords, surfaceElement->GetBaseZ() };
         auto* pathElement = map_get_footpath_element(oldCoords);
         if (pathElement != nullptr && pathElement->AsPath()->IsLevelCrossing(oldCoords))

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -240,6 +240,16 @@ public:
                     GA_ERROR::NO_CLEARANCE, gGameCommandErrorText, gCommonFormatArgs);
             }
 
+            // When building a level crossing, remove any pre-existing path furniture.
+            if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH)
+            {
+                auto footpathElement = map_get_footpath_element(mapLoc);
+                if (footpathElement != nullptr && footpathElement->AsPath()->HasAddition())
+                {
+                    footpathElement->AsPath()->SetAddition(0);
+                }
+            }
+
             uint8_t mapGroundFlags = gMapGroundFlags & (ELEMENT_IS_ABOVE_GROUND | ELEMENT_IS_UNDERGROUND);
             if (res->GroundFlags != 0 && (res->GroundFlags & mapGroundFlags) == 0)
             {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3891,6 +3891,10 @@ enum
     STR_SHORTCUT_DECREASE_Y_COORD = 6344,
     STR_SHORTCUT_INCREASE_ELEM_HEIGHT = 6345,
     STR_SHORTCUT_DECREASE_ELEM_HEIGHT = 6346,
+
+    STR_CANNOT_BUILD_PATH_ADDITIONS_ON_LEVEL_CROSSINGS = 6347,
+    STR_REMOVE_LEVEL_CROSSING_FIRST = 6348,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2258,3 +2258,25 @@ void PathElement::SetEdgesAndCorners(uint8_t newEdgesAndCorners)
 {
     edges = newEdgesAndCorners;
 }
+
+bool PathElement::IsLevelCrossing(CoordsXY coords) const
+{
+    auto trackElement = map_get_track_element_at({ coords, GetBaseZ() });
+    if (trackElement == nullptr)
+    {
+        return false;
+    }
+
+    if (trackElement->GetTrackType() != TRACK_ELEM_FLAT)
+    {
+        return false;
+    }
+
+    auto ride = get_ride(trackElement->GetRideIndex());
+    if (ride == nullptr)
+    {
+        return false;
+    }
+
+    return (ride->type == RIDE_TYPE_MINIATURE_RAILWAY);
+}

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2130,12 +2130,11 @@ TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos)
     TileElement* tileElement = map_get_first_element_at(trackPos);
     if (tileElement == nullptr)
         return nullptr;
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->base_height != trackTilePos.z)
+        if (tileElement->GetBaseZ() != trackPos.z)
             continue;
 
         return tileElement->AsTrack();

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -254,6 +254,8 @@ public:
 
     bool ShouldDrawPathOverSupports();
     void SetShouldDrawPathOverSupports(bool on);
+
+    bool IsLevelCrossing(CoordsXY coords) const;
 };
 assert_struct_size(PathElement, 16);
 


### PR DESCRIPTION
Specifically, this changes the following things:

- Building path furniture on level crossings is no longer allowed
- When building a miniature railway track through a path to create a level crossing, it will automatically remove any path furniture
- Lowering the land on a level crossing (which will cause handrails to be built) is no longer allowed