### PR TITLE
Add localisation merge workflow

### DIFF
--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -1,0 +1,44 @@
+name: Localisation Merge
+on:
+  schedule:
+    - cron:  '0 4 * * *'
+jobs:
+  merge-localisation:
+    name: Merge Localisation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Store private SSH
+        run: |
+          echo "Store private SSH deploy key..."
+          mkdir -p ~/.ssh
+          echo "${{ secrets.OPENRCT2_DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          chmod 700 ~/.ssh
+          chmod 600 ~/.ssh/id_rsa
+      - name: Clone repositories
+        run: |
+          echo "Cloning repositories..."
+          git clone -b master git@github.com:OpenRCT2/Localisation.git Localisation
+          git clone -b develop git@github.com:OpenRCT2/OpenRCT2.git OpenRCT2
+      - name: Copy over language files
+        run: |
+          echo "Copying language files..."
+          for f in ./Localisation/data/language/*
+          do
+              filename=$(basename $f)
+              cp $f "./OpenRCT2/data/language/$filename"
+          done
+      - name: Commit and push
+        run: |
+          pushd ./OpenRCT2
+          if [[ $(git status -s) ]]; then
+              echo "Committing and pushing..."
+              git add .
+              git config --global user.name "OpenRCT2 git bot"
+              git config --global user.email "gitbot@openrct2.org"
+              git commit -m "Merge Localisation/master into OpenRCT2/develop."
+              git push
+              echo "Complete"
+          else
+              echo "No changes to merge."
+          fi
+          popd


### PR DESCRIPTION
Previously the automated merges of the language files from https://github.com/OpenRCT2/Localisation into the develop branch were performed every day at 4am UTC on my own private server. This can now be done using GitHub actions.