### PR TITLE
Add format check and macOS to GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push, pull_request]
+env:
+  BUILD_SERVER: GitHub
+  OPENRCT2_ORG_TOKEN: ${{ secrets.OPENRCT2_ORG_TOKEN }}
+  OPENRCT2_VERSION: 0.2.4
 jobs:
   check-code-formatting:
     name: Check code formatting
@@ -10,6 +14,43 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run clang-format
         run: scripts/run-clang-format.py -r src test --exclude src/openrct2/thirdparty
+  osx:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+      - name: Build OpenRCT2
+        run: |
+          xcodebuild
+          mkdir -p artifacts
+          mv build/Release/OpenRCT2.app artifacts
+      - uses: actions/upload-artifact@master
+        name: Upload artifacts (CI)
+        with:
+          name: "OpenRCT2-macOS"
+          path: artifacts
+      - name: Upload artifacts (openrct2.org)
+        env:
+          GITHUB_SHA1: ${{ github.sha }}
+        run: |
+          if [[ "$OPENRCT2_ORG_TOKEN" != "" ]]; then
+              if [[ $GITHUB_REF == refs/tags/* ]]; then
+                  GITHUB_BRANCH=
+              else
+                  GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+                  GITHUB_BRANCH=push/testg
+                  if [[ ! "$GITHUB_BRANCH" =~ ^(develop|push/) ]]; then
+                      exit 0
+                  fi
+              fi
+
+              echo -e '\033[0;36mCompressing OpenRCT2.app...'
+              cd artifacts
+              zip -rq openrct2-macos.zip OpenRCT2.app
+
+              ../scripts/upload-build openrct2-macos.zip macos $OPENRCT2_VERSION $GITHUB_SHA1 $GITHUB_BRANCH
+          fi
   build-appimage:
     name: Linux (x64, AppImage)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,17 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
+  check-code-formatting:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    container:
+      image: openrct2/openrct2:format
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run clang-format
+        run: scripts/run-clang-format.py -r src test --exclude src/openrct2/thirdparty
   build-appimage:
-    name: Build AppImage
+    name: Linux (x64, AppImage)
     runs-on: ubuntu-latest
     container:
       image: openrct2/openrct2:ubuntu_amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
       fi
     - if [[ $TRAVIS_REPO_SLUG == "OpenRCT2/OpenRCT2" ]] && [[ $TRAVIS_PULL_REQUEST != "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then echo "Pull requests to master branch are not allowed!" ; exit 1 ; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/install.sh; export OPENRCT_MAKE_OPTS="-k 10 all openrct2-cli" ; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo gem install xcpretty-travis-formatter; fi
 
 install:
     - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
@@ -103,23 +102,6 @@ matrix:
           env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=docker64
           services:
             - docker
-        - os: osx
-          name: macOS Clang Xcode
-          if: type != cron
-          osx_image: xcode10.1
-          env:
-            - secure: "OXn/i72FxW/oh6RGlaN+gHSbkt1ToFe36etaiDOsJQznt6fe9CpFdnE8U1XBHlGokcEjbGNErRU7CFDKYHQuGrPZyHXwgqG2/0emIqFaFt5ti5ypyYKf5qH9x1LLLfdZxDyHkxXdlJ7Etxbp3G7qrV8CGRQiYRNHm1f98AmuufE="
-          after_success:
-            - cd build/Release
-            - zip -r openrct2-macos.zip OpenRCT2.app
-            - if [[ "z${TRAVIS_TAG}" != "z" ]] ; then
-              export PUSH_BRANCH=master ;
-              else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;
-              fi
-            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file openrct2-macos.zip https://transfer.sh/openrct2-macos.zip -o link && cat link && echo || echo "Failed transfer.sh upload"
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
-              curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-macos.zip" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=3" --form "file=@openrct2-macos.zip" "https://openrct2.org/altapi/?command=push-build";
-              fi
         - os: linux
           name: Android
           if: type = cron OR branch = master OR branch =~ ^android
@@ -203,7 +185,6 @@ script:
     # Android jobs are triggered from cron and overwrite `script` part
     - if [[ "$OPENRCT2_ANDROID" == "true" ]] ; then exit 0 ; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/build.sh ; fi
-    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then set -o pipefail && xcodebuild ; fi
 
 notifications:
     on_failure: change

--- a/scripts/upload-build
+++ b/scripts/upload-build
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+if [[ "$#" -ne 4 && "$#" -ne 5 ]]; then
+    echo 'Upload an OpenRCT2 build to openrct2.org.'
+    echo ''
+    echo 'Usage: upload-build <path> <flavour> <version> <sha1> [<branch>]'
+    echo 'Flavours: windows-portable-x86, windows-portable-x64'
+    echo '          windows-installer-x86, windows-installer-x64'
+    echo '          windows-symbols-x86, windows-symbols-x64'
+    echo '          macos'
+    echo '          linux-i686, linux-x86_64'
+    echo '          android-arm, android-x86'
+    echo ''
+    echo 'Environment variable ''OPENRCT2_ORG_TOKEN'' must be set.'
+    exit 1
+fi
+
+path=$1
+flavour=$2
+version=$3
+sha1=$4
+branch=$5
+
+case "$flavour" in
+    windows-portable-x86)
+        flavour=windows
+        flavourid=1
+        ;;
+    windows-portable-x64)
+        flavour=windows
+        flavourid=6
+        ;;
+    windows-installer-x86)
+        flavour=windows
+        flavourid=2
+        ;;
+    windows-installer-x64)
+        flavour=windows
+        flavourid=7
+        ;;
+    windows-symbols-x86)
+        flavour=windows
+        flavourid=5
+        ;;
+    windows-symbols-x64)
+        flavour=windows
+        flavourid=10
+        ;;
+    macos)
+        flavourid=3
+        ;;
+    linux-i686)
+        flavourid=4
+        ;;
+    linux-x86_64)
+        flavourid=9
+        ;;
+    android-arm)
+        flavourid=11
+        ;;
+    android-x86)
+        flavourid=12
+        ;;
+    *)
+        echo -e $"\033[0;31mUnknown flavour: $flavour"
+        exit 1
+esac
+
+if [ "$branch" != "" ]; then
+    versionextra=-$branch-${sha1:0:7}
+fi
+filename=OpenRCT2-$version$versionextra-$flavour.zip
+
+echo -e "\033[0;36mUploading to openrct2.org as '$filename'..."
+if [ "$OPENRCT2_ORG_TOKEN" == "" ]; then
+    echo -e "\033[0;31mOPENRCT2_ORG_TOKEN not set"
+    exit 1
+fi
+curl -m 300 --connect-timeout 5 -o - -v \
+    --form "key=$OPENRCT2_ORG_TOKEN" \
+    --form "fileName=$filename" \
+    --form "version=$version" \
+    --form "gitHash=$sha1" \
+    --form "gitBranch=$branch" \
+    --form "flavourId=$flavourid" \
+    --form "file=@$path" \
+    "https://openrct2.org/altapi/?command=push-build"


### PR DESCRIPTION
This moves the code format check and macOS CI to GitHub Actions. From my testing I have noticed that the macOS builds on GitHub Actions are quite fast (2 mins) which is a good sign and hopefully they will be a lot more reliable than Travis.

I am not able to test the macOS builds to see if they work or not, would someone be able to test one? You can download a macOS artefact from:

* The checks tabs on this PR
* [My fork]( https://github.com/IntelOrca/OpenRCT2/commit/a66560045f1b8db6a7de1f22a653a22a0bc0523c/checks?check_suite_id=392529655)