### PR TITLE
Fix secondary prices being imported incorrectly from SV4

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#10420] Money effect causing false positive desync.
 - Fix: [#10477] Large Scenery cannot be placed higher using SHIFT.
 - Fix: [#10489] Hosts last player action not being synchronized.
+- Fix: [#10543] Secondary shop item prices are not imported correctly from RCT1 saves.
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -187,7 +187,7 @@ struct rct1_ride
     uint8_t broken_vehicle;            // 0x141
     uint8_t broken_car;                // 0x142
     uint8_t breakdown_reason;          // 0x143
-    uint8_t unk_144[2];                // 0x144
+    money16 price_secondary;           // 0x144
     union
     {
         struct

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -984,6 +984,7 @@ private:
         // Finance / customers
         dst->upkeep_cost = src->upkeep_cost;
         dst->price = src->price;
+        dst->price_secondary = src->price_secondary;
         dst->income_per_hour = src->income_per_hour;
         dst->total_customers = src->total_customers;
         dst->profit = src->profit;


### PR DESCRIPTION
An oversight that has been present since the very first version of the SV4 import code.