### PR TITLE
Only use CoordsXY objects in world/Footpath.cpp

### DIFF
--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -788,15 +788,15 @@ static void window_footpath_set_provisional_path_at_point(ScreenCoordsXY screenC
  */
 static void window_footpath_set_selection_start_bridge_at_point(ScreenCoordsXY screenCoords)
 {
-    int32_t x, y, direction;
+    int32_t direction;
     TileElement* tileElement;
 
     map_invalidate_selection_rect();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
-    footpath_bridge_get_info_from_pos(screenCoords, &x, &y, &direction, &tileElement);
-    if (x == LOCATION_NULL)
+    auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+    if (mapCoords.isNull())
     {
         return;
     }
@@ -804,10 +804,8 @@ static void window_footpath_set_selection_start_bridge_at_point(ScreenCoordsXY s
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectType = MAP_SELECT_TYPE_FULL;
-    gMapSelectPositionA.x = x;
-    gMapSelectPositionB.x = x;
-    gMapSelectPositionA.y = y;
-    gMapSelectPositionB.y = y;
+    gMapSelectPositionA = mapCoords;
+    gMapSelectPositionB = mapCoords;
 
     int32_t z = tileElement->GetBaseZ();
 
@@ -822,7 +820,7 @@ static void window_footpath_set_selection_start_bridge_at_point(ScreenCoordsXY s
             z += PATH_HEIGHT_STEP; // Add another 2 for a steep slope
     }
 
-    gMapSelectArrowPosition = CoordsXYZ{ x, y, z };
+    gMapSelectArrowPosition = CoordsXYZ{ mapCoords, z };
     gMapSelectArrowDirection = direction;
 
     map_invalidate_selection_rect();
@@ -903,11 +901,11 @@ static void window_footpath_place_path_at_point(ScreenCoordsXY screenCoords)
  */
 static void window_footpath_start_bridge_at_point(ScreenCoordsXY screenCoords)
 {
-    int32_t x, y, z, direction;
+    int32_t z, direction;
     TileElement* tileElement;
 
-    footpath_bridge_get_info_from_pos(screenCoords, &x, &y, &direction, &tileElement);
-    if (x == LOCATION_NULL)
+    auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+    if (mapCoords.isNull())
     {
         return;
     }
@@ -945,9 +943,7 @@ static void window_footpath_start_bridge_at_point(ScreenCoordsXY screenCoords)
     }
 
     tool_cancel();
-    gFootpathConstructFromPosition.x = x;
-    gFootpathConstructFromPosition.y = y;
-    gFootpathConstructFromPosition.z = z;
+    gFootpathConstructFromPosition = { mapCoords, z };
     gFootpathConstructDirection = direction;
     gFootpathProvisionalFlags = 0;
     _window_footpath_provisional_path_arrow_timer = 0;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1230,16 +1230,13 @@ void window_guest_overview_tool_update(rct_window* w, rct_widgetindex widgetInde
 
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-    int32_t map_x, map_y;
-    footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, &map_x, &map_y, nullptr, nullptr);
-    if (map_x != LOCATION_NULL)
+    auto mapCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, nullptr);
+    if (!mapCoords.isNull())
     {
         gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
         gMapSelectType = MAP_SELECT_TYPE_FULL;
-        gMapSelectPositionA.x = map_x;
-        gMapSelectPositionB.x = map_x;
-        gMapSelectPositionA.y = map_y;
-        gMapSelectPositionB.y = map_y;
+        gMapSelectPositionA = mapCoords;
+        gMapSelectPositionB = mapCoords;
         map_invalidate_selection_rect();
     }
 
@@ -1281,15 +1278,14 @@ void window_guest_overview_tool_down(rct_window* w, rct_widgetindex widgetIndex,
     if (widgetIndex != WIDX_PICKUP)
         return;
 
-    int32_t dest_x, dest_y;
     TileElement* tileElement;
-    footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, &dest_x, &dest_y, nullptr, &tileElement);
+    auto destCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, &tileElement);
 
-    if (dest_x == LOCATION_NULL)
+    if (destCoords.isNull())
         return;
 
     PeepPickupAction pickupAction{
-        PeepPickupType::Place, w->number, { dest_x, dest_y, tileElement->base_height }, network_get_current_player_id()
+        PeepPickupType::Place, w->number, { destCoords, tileElement->base_height }, network_get_current_player_id()
     };
     pickupAction.SetCallback([](const GameAction* ga, const GameActionResult* result) {
         if (result->Error != GA_ERROR::OK)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1327,16 +1327,16 @@ static void window_map_place_park_entrance_tool_down(ScreenCoordsXY screenCoords
 static void window_map_set_peep_spawn_tool_down(ScreenCoordsXY screenCoords)
 {
     TileElement* tileElement;
-    int32_t mapX, mapY, mapZ, direction;
+    int32_t mapZ, direction;
 
     // Verify footpath exists at location, and retrieve coordinates
-    footpath_get_coordinates_from_pos(screenCoords, &mapX, &mapY, &direction, &tileElement);
-    if (mapX == LOCATION_NULL)
+    auto mapCoords = footpath_get_coordinates_from_pos(screenCoords, &direction, &tileElement);
+    if (mapCoords.isNull())
         return;
 
     mapZ = tileElement->GetBaseZ();
 
-    auto gameAction = PlacePeepSpawnAction({ mapX, mapY, mapZ, static_cast<Direction>(direction) });
+    auto gameAction = PlacePeepSpawnAction({ mapCoords, mapZ, static_cast<Direction>(direction) });
     auto result = GameActions::Execute(&gameAction);
     if (result->Error == GA_ERROR::OK)
     {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1269,14 +1269,14 @@ static void window_map_place_park_entrance_tool_update(ScreenCoordsXY screenCoor
  */
 static void window_map_set_peep_spawn_tool_update(ScreenCoordsXY screenCoords)
 {
-    int32_t mapX, mapY, mapZ, direction;
+    int32_t mapZ, direction;
     TileElement* tileElement;
 
     map_invalidate_selection_rect();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
-    footpath_bridge_get_info_from_pos(screenCoords, &mapX, &mapY, &direction, &tileElement);
-    if ((mapX & 0xFFFF) == 0x8000)
+    auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+    if (mapCoords.isNull())
         return;
 
     mapZ = tileElement->GetBaseZ();
@@ -1291,11 +1291,9 @@ static void window_map_set_peep_spawn_tool_update(ScreenCoordsXY screenCoords)
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_ARROW;
     gMapSelectType = MAP_SELECT_TYPE_FULL;
-    gMapSelectPositionA.x = mapX;
-    gMapSelectPositionA.y = mapY;
-    gMapSelectPositionB.x = mapX;
-    gMapSelectPositionB.y = mapY;
-    gMapSelectArrowPosition = CoordsXYZ{ mapX, mapY, mapZ };
+    gMapSelectPositionA = mapCoords;
+    gMapSelectPositionB = mapCoords;
+    gMapSelectArrowPosition = CoordsXYZ{ mapCoords, mapZ };
     gMapSelectArrowDirection = direction_reverse(direction);
     map_invalidate_selection_rect();
 }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -342,8 +342,7 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
 
         int32_t direction;
         TileElement* tileElement;
-        CoordsXY footpathCoords;
-        footpath_get_coordinates_from_pos(screenCoords, &footpathCoords.x, &footpathCoords.y, &direction, &tileElement);
+        auto footpathCoords = footpath_get_coordinates_from_pos(screenCoords, &direction, &tileElement);
         if (footpathCoords.isNull())
             return;
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1625,9 +1625,9 @@ void PathElement::SetShouldDrawPathOverSupports(bool on)
  *  clears the wide footpath flag for all footpaths
  *  at location
  */
-static void footpath_clear_wide(int32_t x, int32_t y)
+static void footpath_clear_wide(const CoordsXY& footpathPos)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
         return;
     do
@@ -1644,9 +1644,9 @@ static void footpath_clear_wide(int32_t x, int32_t y)
  *  returns footpath element if it can be made wide
  *  returns NULL if it can not be made wide
  */
-static TileElement* footpath_can_be_wide(int32_t x, int32_t y, uint8_t height)
+static TileElement* footpath_can_be_wide(const CoordsXY& footpathPos, uint8_t height)
 {
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -1669,18 +1669,12 @@ static TileElement* footpath_can_be_wide(int32_t x, int32_t y, uint8_t height)
  *
  *  rct2: 0x006A87BB
  */
-void footpath_update_path_wide_flags(int32_t x, int32_t y)
+void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
 {
-    if (x < 0x20)
-        return;
-    if (y < 0x20)
-        return;
-    if (x > 0x1FDF)
-        return;
-    if (y > 0x1FDF)
+    if (map_is_location_at_edge(footpathPos))
         return;
 
-    footpath_clear_wide(x, y);
+    footpath_clear_wide(footpathPos);
     /* Rather than clearing the wide flag of the following tiles and
      * checking the state of them later, leave them intact and assume
      * they were cleared. Consequently only the wide flag for this single
@@ -1699,7 +1693,7 @@ void footpath_update_path_wide_flags(int32_t x, int32_t y)
     // footpath_clear_wide(x, y);
     // y -= 0x20;
 
-    TileElement* tileElement = map_get_first_element_at({ x, y });
+    TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
         return;
     do
@@ -1722,24 +1716,24 @@ void footpath_update_path_wide_flags(int32_t x, int32_t y)
         // Spanned from 0x00F3EFA8 to 0x00F3EFC7 (8 elements) in the original
         TileElement* pathList[8];
 
-        x -= 0x20;
-        y -= 0x20;
-        pathList[0] = footpath_can_be_wide(x, y, height);
-        y += 0x20;
-        pathList[1] = footpath_can_be_wide(x, y, height);
-        y += 0x20;
-        pathList[2] = footpath_can_be_wide(x, y, height);
-        x += 0x20;
-        pathList[3] = footpath_can_be_wide(x, y, height);
-        x += 0x20;
-        pathList[4] = footpath_can_be_wide(x, y, height);
-        y -= 0x20;
-        pathList[5] = footpath_can_be_wide(x, y, height);
-        y -= 0x20;
-        pathList[6] = footpath_can_be_wide(x, y, height);
-        x -= 0x20;
-        pathList[7] = footpath_can_be_wide(x, y, height);
-        y += 0x20;
+        // TODO: Use DirectionDelta
+        auto pathPos = footpathPos - CoordsXY{ COORDS_XY_STEP, COORDS_XY_STEP };
+        pathList[0] = footpath_can_be_wide(pathPos, height);
+        pathPos.y += COORDS_XY_STEP;
+        pathList[1] = footpath_can_be_wide(pathPos, height);
+        pathPos.y += COORDS_XY_STEP;
+        pathList[2] = footpath_can_be_wide(pathPos, height);
+        pathPos.x += COORDS_XY_STEP;
+        pathList[3] = footpath_can_be_wide(pathPos, height);
+        pathPos.x += COORDS_XY_STEP;
+        pathList[4] = footpath_can_be_wide(pathPos, height);
+        pathPos.y -= COORDS_XY_STEP;
+        pathList[5] = footpath_can_be_wide(pathPos, height);
+        pathPos.y -= COORDS_XY_STEP;
+        pathList[6] = footpath_can_be_wide(pathPos, height);
+        pathPos.x -= COORDS_XY_STEP;
+        pathList[7] = footpath_can_be_wide(pathPos, height);
+        pathPos.y += COORDS_XY_STEP;
 
         uint8_t pathConnections = 0;
         if (tileElement->AsPath()->GetEdges() & EDGE_NW)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -244,8 +244,7 @@ void footpath_provisional_update()
  *      direction: ecx
  *      tileElement: edx
  */
-void footpath_get_coordinates_from_pos(
-    ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement)
+CoordsXY footpath_get_coordinates_from_pos(ScreenCoordsXY screenCoords, int32_t* direction, TileElement** tileElement)
 {
     int32_t z = 0, interactionType;
     TileElement* myTileElement;
@@ -262,9 +261,8 @@ void footpath_get_coordinates_from_pos(
             &myTileElement, &viewport);
         if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE)
         {
-            if (x != nullptr)
-                *x = LOCATION_NULL;
-            return;
+            position.setNull();
+            return position;
         }
     }
 
@@ -323,14 +321,12 @@ void footpath_get_coordinates_from_pos(
 
     position = position.ToTileStart();
 
-    if (x != nullptr)
-        *x = position.x;
-    if (y != nullptr)
-        *y = position.y;
     if (direction != nullptr)
         *direction = myDirection;
     if (tileElement != nullptr)
         *tileElement = myTileElement;
+
+    return position;
 }
 
 /**
@@ -390,7 +386,9 @@ void footpath_bridge_get_info_from_pos(
     }
 
     // We point at something else
-    footpath_get_coordinates_from_pos(screenCoords, x, y, direction, tileElement);
+    auto coords = footpath_get_coordinates_from_pos(screenCoords, direction, tileElement);
+    *x = coords.x;
+    *y = coords.y;
 }
 
 /**

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1227,16 +1227,16 @@ void footpath_update_queue_chains()
  *
  *  rct2: 0x0069ADBD
  */
-static void footpath_fix_ownership(int32_t x, int32_t y)
+static void footpath_fix_ownership(const CoordsXY& mapPos)
 {
-    const auto* surfaceElement = map_get_surface_element_at(CoordsXY{ x, y });
+    const auto* surfaceElement = map_get_surface_element_at(mapPos);
     uint16_t ownership;
 
     // Unlikely to be NULL unless deliberate.
     if (surfaceElement != nullptr)
     {
         // If the tile is not safe to own construction rights of, erase them.
-        if (check_max_allowable_land_rights_for_tile({ x, y, surfaceElement->base_height << 3 }) == OWNERSHIP_UNOWNED)
+        if (check_max_allowable_land_rights_for_tile({ mapPos, surfaceElement->base_height << 3 }) == OWNERSHIP_UNOWNED)
         {
             ownership = OWNERSHIP_UNOWNED;
         }
@@ -1256,7 +1256,7 @@ static void footpath_fix_ownership(int32_t x, int32_t y)
         ownership = OWNERSHIP_UNOWNED;
     }
 
-    auto landSetRightsAction = LandSetRightsAction({ x, y }, LandSetRightSetting::SetOwnershipWithChecks, ownership);
+    auto landSetRightsAction = LandSetRightsAction(mapPos, LandSetRightSetting::SetOwnershipWithChecks, ownership);
     landSetRightsAction.SetFlags(GAME_COMMAND_FLAG_NO_SPEND);
     GameActions::Execute(&landSetRightsAction);
 }
@@ -1325,7 +1325,7 @@ static int32_t footpath_is_connected_to_map_edge_recurse(
 
         if (flags & (1 << 5))
         {
-            footpath_fix_ownership(targetPos.x, targetPos.y);
+            footpath_fix_ownership(targetPos);
         }
         edges = tileElement->AsPath()->GetEdges();
         direction = direction_reverse(direction);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -339,8 +339,7 @@ CoordsXY footpath_get_coordinates_from_pos(ScreenCoordsXY screenCoords, int32_t*
  * direction: cl
  * tileElement: edx
  */
-void footpath_bridge_get_info_from_pos(
-    ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement)
+CoordsXY footpath_bridge_get_info_from_pos(ScreenCoordsXY screenCoords, int32_t* direction, TileElement** tileElement)
 {
     // First check if we point at an entrance or exit. In that case, we would want the path coming from the entrance/exit.
     int32_t interactionType;
@@ -349,8 +348,6 @@ void footpath_bridge_get_info_from_pos(
     CoordsXY map_pos = {};
     get_map_coordinates_from_pos(
         screenCoords, VIEWPORT_INTERACTION_MASK_RIDE, map_pos, &interactionType, tileElement, &viewport);
-    *x = map_pos.x;
-    *y = map_pos.y;
 
     if (interactionType == VIEWPORT_INTERACTION_ITEM_RIDE
         && viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
@@ -364,15 +361,13 @@ void footpath_bridge_get_info_from_pos(
             bx &= 3;
             if (direction != nullptr)
                 *direction = bx;
-            return;
+            return map_pos;
         }
     }
 
     get_map_coordinates_from_pos(
         screenCoords, VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN,
         map_pos, &interactionType, tileElement, &viewport);
-    *x = map_pos.x;
-    *y = map_pos.y;
     if (interactionType == VIEWPORT_INTERACTION_ITEM_RIDE && (*tileElement)->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
     {
         int32_t directions = entrance_get_directions(*tileElement);
@@ -381,14 +376,12 @@ void footpath_bridge_get_info_from_pos(
             int32_t bx = (*tileElement)->GetDirectionWithOffset(bitscanforward(directions));
             if (direction != nullptr)
                 *direction = bx;
-            return;
+            return map_pos;
         }
     }
 
     // We point at something else
-    auto coords = footpath_get_coordinates_from_pos(screenCoords, direction, tileElement);
-    *x = coords.x;
-    *y = coords.y;
+    return footpath_get_coordinates_from_pos(screenCoords, direction, tileElement);
 }
 
 /**

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2072,7 +2072,7 @@ bool tile_element_wants_path_connection_towards(TileCoordsXYZD coords, const Til
 }
 
 // fix up the corners around the given path element that gets removed
-static void footpath_fix_corners_around(int32_t x, int32_t y, TileElement* pathElement)
+static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileElement* pathElement)
 {
     // A mask for the paths' corners of each possible neighbour
     static constexpr uint8_t cornersTouchingTile[3][3] = {
@@ -2093,7 +2093,8 @@ static void footpath_fix_corners_around(int32_t x, int32_t y, TileElement* pathE
             if (xOffset == 0 && yOffset == 0)
                 continue;
 
-            TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x + xOffset, y + yOffset }.ToCoordsXY());
+            TileElement* tileElement = map_get_first_element_at(
+                TileCoordsXY{ footpathPos.x + xOffset, footpathPos.y + yOffset }.ToCoordsXY());
             if (tileElement == nullptr)
                 continue;
             do
@@ -2170,7 +2171,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
     if (fixCorners && tileElement->IsGhost())
     {
         auto tileFootpathPos = TileCoordsXY{ footpathPos };
-        footpath_fix_corners_around(tileFootpathPos.x, tileFootpathPos.y, tileElement);
+        footpath_fix_corners_around(tileFootpathPos, tileElement);
     }
 
     if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -183,8 +183,7 @@ money32 footpath_remove(CoordsXYZ footpathLoc, int32_t flags);
 money32 footpath_provisional_set(int32_t type, CoordsXYZ footpathLoc, int32_t slope);
 void footpath_provisional_remove();
 void footpath_provisional_update();
-void footpath_get_coordinates_from_pos(
-    ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
+CoordsXY footpath_get_coordinates_from_pos(ScreenCoordsXY screenCoords, int32_t* direction, TileElement** tileElement);
 void footpath_bridge_get_info_from_pos(
     ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
 void footpath_remove_litter(const CoordsXYZ& footpathPos);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -184,8 +184,7 @@ money32 footpath_provisional_set(int32_t type, CoordsXYZ footpathLoc, int32_t sl
 void footpath_provisional_remove();
 void footpath_provisional_update();
 CoordsXY footpath_get_coordinates_from_pos(ScreenCoordsXY screenCoords, int32_t* direction, TileElement** tileElement);
-void footpath_bridge_get_info_from_pos(
-    ScreenCoordsXY screenCoords, int32_t* x, int32_t* y, int32_t* direction, TileElement** tileElement);
+CoordsXY footpath_bridge_get_info_from_pos(ScreenCoordsXY screenCoords, int32_t* direction, TileElement** tileElement);
 void footpath_remove_litter(const CoordsXYZ& footpathPos);
 void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
 void footpath_update_queue_chains();

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -191,7 +191,7 @@ void footpath_update_queue_chains();
 bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);
 void footpath_chain_ride_queue(
     ride_id_t rideIndex, int32_t entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
-void footpath_update_path_wide_flags(int32_t x, int32_t y);
+void footpath_update_path_wide_flags(const CoordsXY& footpathPos);
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
 
 int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -625,7 +625,7 @@ void map_update_path_wide_flags()
     uint16_t y = gWidePathTileLoopY;
     for (int32_t i = 0; i < 128; i++)
     {
-        footpath_update_path_wide_flags(x, y);
+        footpath_update_path_wide_flags({ x, y });
 
         // Next x, y tile
         x += COORDS_XY_STEP;


### PR DESCRIPTION
I double check and it seems like this patch eliminates all the remaining `{x, y}` usages on footpath.