### PR TITLE
Android: target SDK 28, remove absolute path

### DIFF
--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 28
 
         versionCode 2
         versionName '0.2.5'

--- a/src/openrct2-android/app/src/main/java/io/openrct2/MainActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/MainActivity.java
@@ -11,6 +11,8 @@ import android.os.Bundle;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Environment;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -159,7 +161,9 @@ public class MainActivity extends AppCompatActivity {
     // When building, ensure OpenRCT2 assets are inside their own directory within the APK assets,
     // so that we do not attempt to copy files out of the standard Android asset folders - webkit, etc.
     private void copyAssets() {
-        File dataDir = new File("/sdcard/openrct2/");
+        File dataDir = new File(Environment.getExternalStorageDirectory().toString()
+            + File.separator + "openrct2" + File.separator);
+
         try {
             copyAsset(getAssets(), "openrct2", dataDir, "");
         } catch (IOException e) {


### PR DESCRIPTION
Android version: an absolute path was replaced with a call to the Environment class. The target SDK of 29 was decremented to a target SDK of 28 to fix an incompatibility with an SDK change. Game now builds; however a desktop version must be built first so that build artifacts are present in /bin.

SDK 29 doesn't like it when you write files directly to /sdcard, they're deprecating access to shared storage - which is insane, but out of our control. All of the code that touches the filesystem will have to be rewritten eventually to deal with this. In the meantime, builds compiled to SDK 28 or lower are still allowed to touch /sdcard.

Builds and runs fine (with deprecation warnings which I enabled in an earlier PR), tested working on a Pixel 2 XL on Android 10/Q. Again, a desktop version must be built prior to building the Android build at this time so that data is present in OpenRCT2/bin/data which is copied into the Android assets. This will be fixed eventually but for the time being I would like to focus on getting the game to a playable state without mouse/keyboard, if that's okay.