### PR TITLE
Fix #8064 Ride construction errors shown as (undefined string)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -98,6 +98,7 @@
 - Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
 - Fix: [#7829] Rotated information kiosk can cause 'unreachable' messages.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
+- Fix: [#8064] Ride construction errors shown as (undefined string)
 - Fix: [#8219] Faulty folder recreation in "save" folder.
 - Fix: [#8480, #8535] Crash when mirroring track design.
 - Fix: [#8507] Incorrect change in vehicle rolling direction.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3550,7 +3550,6 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
     z -= bx;
 
     gMapSelectArrowPosition.z = z;
-    bx = 41;
     _currentTrackBegin.x = mapCoords->x;
     _currentTrackBegin.y = mapCoords->y;
     _currentTrackBegin.z = z;
@@ -3561,9 +3560,12 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
     }
 
     _previousTrackPiece = _currentTrackBegin;
+    // search for appropriate z value for ghost, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
+
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        for (;;)
+        for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
         {
             window_ride_construction_update_state(
                 &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords->x, &mapCoords->y, &z,
@@ -3573,16 +3575,11 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
             if (_currentTrackPrice != MONEY32_UNDEFINED)
                 break;
 
-            bx--;
-            if (bx == 0)
-                break;
-
             _currentTrackBegin.z -= 8;
             if (_currentTrackBegin.z < 0)
                 break;
 
-            if (bx >= 0)
-                _currentTrackBegin.z += 16;
+            _currentTrackBegin.z += 16;
         }
 
         auto intent = Intent(INTENT_ACTION_UPDATE_MAZE_CONSTRUCTION);
@@ -3591,8 +3588,6 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    // search for appropriate z value for ghost, up to max ride height
-    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
     for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
     {
         window_ride_construction_update_state(
@@ -3793,9 +3788,12 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
         z = _trackPlaceZ;
     }
 
+    // search for z value to build at, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
+
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        for (int32_t zAttempts = 41; zAttempts >= 0; zAttempts--)
+        for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
         {
             _rideConstructionState = RIDE_CONSTRUCTION_STATE_MAZE_BUILD;
             _currentTrackBegin.x = mapCoords.x;
@@ -3854,9 +3852,6 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
         }
         return;
     }
-
-    // search for z value to build at, up to max ride height
-    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
 
     for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
     {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3561,7 +3561,8 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
 
     _previousTrackPiece = _currentTrackBegin;
     // search for appropriate z value for ghost, up to max ride height
-    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
+    const auto smallZ = z / COORDS_Z_STEP;
+    int numAttempts = (smallZ <= MAX_TRACK_HEIGHT ? (MAX_TRACK_HEIGHT - smallZ + 1) : 2);
 
     if (ride->type == RIDE_TYPE_MAZE)
     {
@@ -3789,7 +3790,8 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
     }
 
     // search for z value to build at, up to max ride height
-    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
+    const auto smallZ = z / COORDS_Z_STEP;
+    int numAttempts = (smallZ <= MAX_TRACK_HEIGHT ? (MAX_TRACK_HEIGHT - smallZ + 1) : 2);
 
     if (ride->type == RIDE_TYPE_MAZE)
     {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3565,7 +3565,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
 
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        for (int zAttempts = 1; zAttempts < numAttempts; ++zAttempts)
+        for (int zAttempts = 0; zAttempts < numAttempts; ++zAttempts)
         {
             window_ride_construction_update_state(
                 &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords->x, &mapCoords->y, &z,
@@ -3588,7 +3588,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    for (int zAttempts = 1; zAttempts < numAttempts; ++zAttempts)
+    for (int zAttempts = 0; zAttempts < numAttempts; ++zAttempts)
     {
         window_ride_construction_update_state(
             &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords->x, &mapCoords->y, &z, nullptr);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3565,7 +3565,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
 
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
+        for (int zAttempts = 1; zAttempts < numAttempts; ++zAttempts)
         {
             window_ride_construction_update_state(
                 &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords->x, &mapCoords->y, &z,
@@ -3588,7 +3588,7 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
+    for (int zAttempts = 1; zAttempts < numAttempts; ++zAttempts)
     {
         window_ride_construction_update_state(
             &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords->x, &mapCoords->y, &z, nullptr);
@@ -3793,7 +3793,7 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
 
     if (ride->type == RIDE_TYPE_MAZE)
     {
-        for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
+        for (int32_t zAttempts = 0; zAttempts < numAttempts; ++zAttempts)
         {
             _rideConstructionState = RIDE_CONSTRUCTION_STATE_MAZE_BUILD;
             _currentTrackBegin.x = mapCoords.x;
@@ -3823,7 +3823,7 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
                 if (errorText == STR_NOT_ENOUGH_CASH_REQUIRES || errorText == STR_CAN_ONLY_BUILD_THIS_UNDERWATER
                     || errorText == STR_CAN_ONLY_BUILD_THIS_ON_WATER || errorText == STR_RIDE_CANT_BUILD_THIS_UNDERWATER
                     || errorText == STR_CAN_ONLY_BUILD_THIS_ABOVE_GROUND || errorText == STR_TOO_HIGH_FOR_SUPPORTS
-                    || zAttempts == 0 || z < 0)
+                    || zAttempts == (numAttempts - 1) || z < 0)
                 {
                     audio_play_sound(SoundId::Error, 0, state->position.x);
                     w = window_find_by_class(WC_RIDE_CONSTRUCTION);
@@ -3838,7 +3838,7 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
                     context_broadcast_intent(&intent2);
                     break;
                 }
-                else if (zAttempts >= 0)
+                else if (zAttempts < numAttempts)
                 {
                     z += 16;
                 }
@@ -3853,7 +3853,7 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
+    for (int32_t zAttempts = 0; zAttempts < numAttempts; ++zAttempts)
     {
         _rideConstructionState = RIDE_CONSTRUCTION_STATE_FRONT;
         _currentTrackBegin.x = mapCoords.x;
@@ -3877,7 +3877,8 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
             if (errorText == STR_NOT_ENOUGH_CASH_REQUIRES || errorText == STR_CAN_ONLY_BUILD_THIS_UNDERWATER
                 || errorText == STR_CAN_ONLY_BUILD_THIS_ON_WATER || errorText == STR_CAN_ONLY_BUILD_THIS_ABOVE_GROUND
                 || errorText == STR_TOO_HIGH_FOR_SUPPORTS || errorText == STR_TOO_HIGH
-                || errorText == STR_LOCAL_AUTHORITY_WONT_ALLOW_CONSTRUCTION_ABOVE_TREE_HEIGHT || zAttempts == 1 || z < 0)
+                || errorText == STR_LOCAL_AUTHORITY_WONT_ALLOW_CONSTRUCTION_ABOVE_TREE_HEIGHT || zAttempts == (numAttempts - 1)
+                || z < 0)
             {
                 int32_t saveTrackDirection = _currentTrackPieceDirection;
                 int32_t saveCurrentTrackCurve = _currentTrackCurve;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3838,10 +3838,7 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
                     context_broadcast_intent(&intent2);
                     break;
                 }
-                else if (zAttempts < numAttempts)
-                {
-                    z += 16;
-                }
+                z += 16;
             }
             else
             {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3591,8 +3591,8 @@ void ride_construction_toolupdate_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    // search for appropriate z value for ghost, up to max ride height (2^12 - 16)
-    int numAttempts = (z <= 2032 ? (2032 - z) / 8 + 1 : 2);
+    // search for appropriate z value for ghost, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
     for (int zAttempts = numAttempts; zAttempts > 1; zAttempts--)
     {
         window_ride_construction_update_state(
@@ -3855,8 +3855,8 @@ void ride_construction_tooldown_construct(ScreenCoordsXY screenCoords)
         return;
     }
 
-    // search for appropriate z value, up to max ride height (2^12 - 16)
-    int numAttempts = (z <= 2032 ? (2032 - z) / 8 + 1 : 2);
+    // search for z value to build at, up to max ride height
+    int numAttempts = (z <= (8 * MAX_TRACK_HEIGHT) ? MAX_TRACK_HEIGHT - (z / 8) + 1 : 2);
 
     for (int32_t zAttempts = numAttempts; zAttempts > 0; zAttempts--)
     {

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -224,7 +224,7 @@ public:
 
             clearanceZ = (clearanceZ / 8) + baseZ;
 
-            if (clearanceZ >= 255)
+            if (clearanceZ > MAX_TRACK_HEIGHT)
             {
                 return std::make_unique<TrackPlaceActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_TOO_HIGH);
             }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -78,6 +78,7 @@ enum
 };
 
 #define MAX_STATION_PLATFORM_LENGTH 32
+constexpr uint16_t const MAX_TRACK_HEIGHT = 254;
 
 enum
 {


### PR DESCRIPTION
I'm picking up on stale #9432 

I did apply the changes to the maze, as @duncanspumpkin suggested:
> If you are going to make this change make the change for mazes as well its just inconsistent as it is at present.
> As this is a complex equation it should really be a constexpr that is named.

I didn't convert it to a `constexpr` because I was unsure if @ZehMatt 's comment was applicable without changing other places or not:
https://github.com/OpenRCT2/OpenRCT2/pull/9432/files#r294541067