### PR TITLE
Remove global variable for sound param list

### DIFF
--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -53,8 +53,6 @@ rct_ride_music_params gRideMusicParamsList[AUDIO_MAX_RIDE_MUSIC];
 rct_ride_music_params* gRideMusicParamsListEnd;
 
 rct_vehicle_sound gVehicleSoundList[AUDIO_MAX_VEHICLE_SOUNDS];
-rct_vehicle_sound_params gVehicleSoundParamsList[AUDIO_MAX_VEHICLE_SOUNDS];
-rct_vehicle_sound_params* gVehicleSoundParamsListEnd;
 
 // clang-format off
 static int32_t SoundVolumeAdjust[RCT2SoundCount] =

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -168,8 +168,6 @@ extern rct_ride_music_params gRideMusicParamsList[AUDIO_MAX_RIDE_MUSIC];
 extern rct_ride_music_params* gRideMusicParamsListEnd;
 
 extern rct_vehicle_sound gVehicleSoundList[AUDIO_MAX_VEHICLE_SOUNDS];
-extern rct_vehicle_sound_params gVehicleSoundParamsList[AUDIO_MAX_VEHICLE_SOUNDS];
-extern rct_vehicle_sound_params* gVehicleSoundParamsListEnd;
 
 /**
  * Deregisters the audio device.

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -302,9 +302,7 @@ struct Vehicle : SpriteBase
     void Invalidate();
     void SetState(VEHICLE_STATUS vehicleStatus, uint8_t subState = 0);
     bool IsGhost() const;
-    void UpdateSoundParams(
-        std::array<rct_vehicle_sound_params, AUDIO_MAX_VEHICLE_SOUNDS> vehicleSoundParamsList,
-        rct_vehicle_sound_params* vehicleSoundParamsListEnd) const;
+    void UpdateSoundParams(std::vector<rct_vehicle_sound_params>& vehicleSoundParamsList) const;
 
 private:
     bool SoundCanPlay() const;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -10,6 +10,7 @@
 #ifndef _VEHICLE_H_
 #define _VEHICLE_H_
 
+#include "../audio/audio.h"
 #include "../common.h"
 #include "../ride/RideTypes.h"
 #include "../world/Location.hpp"
@@ -301,7 +302,9 @@ struct Vehicle : SpriteBase
     void Invalidate();
     void SetState(VEHICLE_STATUS vehicleStatus, uint8_t subState = 0);
     bool IsGhost() const;
-    void UpdateSoundParams() const;
+    void UpdateSoundParams(
+        std::array<rct_vehicle_sound_params, AUDIO_MAX_VEHICLE_SOUNDS> vehicleSoundParamsList,
+        rct_vehicle_sound_params* vehicleSoundParamsListEnd) const;
 
 private:
     bool SoundCanPlay() const;


### PR DESCRIPTION
Closes #9113 
Continues #10070 

This took some heavy rebasing, as the functions had changed pretty heavily. @duncanspumpkin concern on the original PR was:
> Hmm this certainly works but I'm thinking std::array is horrible for this. std::vector isn't great either due to the memory allocations.

I don't think it's that big of a deal, as it's a small array, but I'm open to suggestions