### PR TITLE
Increase height of track save buttons

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -325,10 +325,10 @@ static rct_widget window_ride_music_widgets[] = {
 static rct_widget window_ride_measurements_widgets[] = {
     MAIN_RIDE_WIDGETS,
     { WWT_FLATBTN,          1,  288,    311,    194,    217,    SPR_FLOPPY,                     STR_SAVE_TRACK_DESIGN                       },
-    { WWT_BUTTON,           1,  4,      157,    128,    139,    STR_SELECT_NEARBY_SCENERY,      STR_NONE                                    },
-    { WWT_BUTTON,           1,  158,    311,    128,    139,    STR_RESET_SELECTION,            STR_NONE                                    },
-    { WWT_BUTTON,           1,  4,      157,    178,    189,    STR_DESIGN_SAVE,                STR_NONE                                    },
-    { WWT_BUTTON,           1,  158,    311,    178,    189,    STR_DESIGN_CANCEL,              STR_NONE                                    },
+    { WWT_BUTTON,           1,  4,      157,    127,    140,    STR_SELECT_NEARBY_SCENERY,      STR_NONE                                    },
+    { WWT_BUTTON,           1,  158,    311,    127,    140,    STR_RESET_SELECTION,            STR_NONE                                    },
+    { WWT_BUTTON,           1,  4,      157,    177,    190,    STR_DESIGN_SAVE,                STR_NONE                                    },
+    { WWT_BUTTON,           1,  158,    311,    177,    190,    STR_DESIGN_CANCEL,              STR_NONE                                    },
     { WIDGETS_END },
 };
 


### PR DESCRIPTION
This increases the height of the track save buttons in the ride window. While previous PRs have covered most of these, this will finally allow for CJK languages to fit the button captions with ease. For languages using the sprite font, it makes the window look less cramped as a fortunate side-effect.

Before:
![Forest Frontiers 2020-01-22 12-28-04](https://user-images.githubusercontent.com/604665/72891127-cfe84480-3d13-11ea-81d1-a2c440685782.png)

After:
![Forest Frontiers 2020-01-22 12-33-45](https://user-images.githubusercontent.com/604665/72891128-cfe84480-3d13-11ea-9b24-ae29db90138f.png)