### PR TITLE
Fix testing giga coaster with cable lift crashing the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#10489] Hosts last player action not being synchronized.
 - Fix: [#10543] Secondary shop item prices are not imported correctly from RCT1 saves.
 - Fix: [#10547] RCT1 parks have too many rides available.
+- Fix: [#10620] Testing/opening a giga coaster with a cable lift results in a crash.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,7 +17,6 @@
 - Fix: [#10489] Hosts last player action not being synchronized.
 - Fix: [#10543] Secondary shop item prices are not imported correctly from RCT1 saves.
 - Fix: [#10547] RCT1 parks have too many rides available.
-- Fix: [#10620] Testing/opening a giga coaster with a cable lift results in a crash.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -743,7 +743,7 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->num_circuits = src->num_circuits;
     dst->cable_lift_x = static_cast<int16_t>(src->CableLiftLoc.x);
     dst->cable_lift_y = static_cast<int16_t>(src->CableLiftLoc.y);
-    dst->cable_lift_z = static_cast<int16_t>(src->CableLiftLoc.z);
+    dst->cable_lift_z = static_cast<int16_t>(src->CableLiftLoc.z / COORDS_Z_STEP);
     // pad_1FD;
     dst->cable_lift = src->cable_lift;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -760,7 +760,7 @@ public:
         dst->total_air_time = src->total_air_time;
         dst->current_test_station = src->current_test_station;
         dst->num_circuits = src->num_circuits;
-        dst->CableLiftLoc = { src->cable_lift_x, src->cable_lift_y, src->cable_lift_z };
+        dst->CableLiftLoc = { src->cable_lift_x, src->cable_lift_y, src->cable_lift_z * COORDS_Z_STEP };
         // pad_1FD;
         dst->cable_lift = src->cable_lift;
 


### PR DESCRIPTION
Originally reported here: https://forums.openrct2.org/topic/4750-game-crashes-when-using-ghost-train