### PR TITLE
Enable Android builds with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,19 @@ jobs:
       - name: Build OpenRCT2
         shell: bash
         run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON -DDISABLE_HTTP_TWITCH=ON -DDISABLE_OPENGL=ON
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    container:
+      image: openrct2/openrct2-build:0.2.4-android
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build OpenRCT2
+        shell: bash
+        run: . scripts/setenv && cd src/openrct2-android && ./gradlew app:assemblePR
+      - name: Upload artifacts (CI)
+        uses: actions/upload-artifact@v1
+        with:
+          name: "OpenRCT2-Android"
+          path: src/openrct2-android/app/build/outputs/apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,15 @@ jobs:
         uses: actions/checkout@v1
       - name: Build OpenRCT2
         shell: bash
-        run: . scripts/setenv && cd src/openrct2-android && ./gradlew app:assemblePR
+        run: |
+          . scripts/setenv
+          pushd src/openrct2-android
+            ./gradlew app:assemblePR
+          popd
+          mkdir -p artifacts
+          mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2.apk
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v1
         with:
           name: "OpenRCT2-Android"
-          path: src/openrct2-android/app/build/outputs/apk
+          path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,18 @@ jobs:
             ./gradlew app:assemblePR
           popd
           mkdir -p artifacts
-          mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2.apk
+          mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v1
         with:
           name: "OpenRCT2-Android"
           path: artifacts
+      - name: Upload artifacts (openrct2.org)
+        shell: bash
+        run: |
+          . scripts/setenv -q
+          if [[ "$OPENRCT2_PUSH" == "true" ]]; then
+              upload-build artifacts/openrct2-arm.apk android-arm $OPENRCT2_VERSION $OPENRCT2_SHA1 $OPENRCT2_BRANCH
+          else
+              echo 'Not going to push build'
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: c
 
 before_install:
-    # Android jobs are triggered from cron and overwrite `before_script` part
-    - if [[ "$OPENRCT2_ANDROID" == "true" ]] ; then echo before_install not needed for Android jobs ; exit 0 ; fi
     - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
       echo "This build will get pushed!" ; echo "tag = ${TRAVIS_TAG}" ; echo "branch = ${TRAVIS_BRANCH}" ;
       fi
@@ -53,62 +51,6 @@ matrix:
           env: OPENRCT2_CMAKE_OPTS="-G Ninja -DDISABLE_OPENGL=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=OpenRCT2" TARGET=docker64
           services:
             - docker
-        - os: linux
-          name: Android
-          if: type = cron OR branch = master OR branch =~ ^android
-          language: android
-          before_install: []
-          env:
-            - secure: "S3u2VCE2Vy8KNXoeh+DhnzjCmgTX0r95uEZrXDU+IKANOOCKn7Dg4OFDZE3LY/i1y2/EUDpnR5yLC38Ks795EUP/sv/OoMl4tjQ20yERjqWh+gcIRrgx7SdVabuAh3t4aBdaLD4Pfnj5avxeCt6rL7yGnj0wdbrbJSBZPsgSnuQ="
-            - OPENRCT2_ANDROID="true"
-          addons:
-            apt:
-              sources:
-                - ubuntu-toolchain-r-test
-              packages:
-              - libstdc++6-4.7-dev
-          android:
-            components:
-              - build-tools-25.0.2
-          jdk: oraclejdk8
-          before_script:
-            # Only run Android jobs when triggered from cron or on tag, otherwise skip
-            - if [[ "$OPENRCT2_ANDROID" != "true" ]] && [[ "z${TRAVIS_TAG}" == "z" ]] ; then exit 0 ; fi
-            - pushd ~
-            - wget https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
-            - unzip -qo sdk-tools-linux-3859397.zip
-            - rm -Rf "$ANDROID_HOME/tools"
-            - mv tools "$ANDROID_HOME/tools"
-            - popd
-            - 'echo "count=0" >  ~/.android/repositories.cfg'
-            - '"$ANDROID_HOME/tools/bin/sdkmanager" --list'
-            - 'echo y | "$ANDROID_HOME/tools/bin/sdkmanager" platform-tools'
-            - 'echo y | "$ANDROID_HOME/tools/bin/sdkmanager" "platforms;android-25"'
-            - 'echo y | "$ANDROID_HOME/tools/bin/sdkmanager" "cmake;3.6.4111459"'
-            - '"$ANDROID_HOME/tools/bin/sdkmanager" ndk-bundle'
-            - '"$ANDROID_HOME/tools/bin/sdkmanager" --list'
-            - 'export ANDROID_NDK_HOME="$ANDROID_HOME/ndk-bundle"'
-            - 'cd src/openrct2-android'
-            - TERM=dumb # Makes Gradle use 'boring' output
-          script:
-            # Only run Android jobs when triggered from cron or on tag, otherwise skip
-            - if [[ "$OPENRCT2_ANDROID" != "true" ]] && [[ "z${TRAVIS_TAG}" == "z" ]] ; then exit 0 ; fi
-            - './gradlew app:assemblePR'
-          after_success:
-            # Only run Android jobs when triggered from cron or on tag, otherwise skip
-            - if [[ "$OPENRCT2_ANDROID" != "true" ]] && [[ "z${TRAVIS_TAG}" == "z" ]] ; then exit 0 ; fi
-            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/arm/pr/app-arm-pr.apk https://transfer.sh/openrct2-android-arm.apk -o link && cat link && echo|| if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
-            - curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT --upload-file app/build/outputs/apk/x86/pr/app-x86-pr.apk https://transfer.sh/openrct2-android-x86.apk -o link && cat link && echo || if [[ $? ]] ; then echo "Failed transfer.sh upload" ; fi;
-            - if [[ "z${TRAVIS_TAG}" != "z" ]] ; then
-              export PUSH_BRANCH=master ;
-              else export PUSH_BRANCH=$TRAVIS_BRANCH ; export FILENAME_PART=-${TRAVIS_BRANCH}-$(git rev-parse --short HEAD) ;
-              fi
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
-              curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-android-arm.apk" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=11" --form "file=@app/build/outputs/apk/arm/pr/app-arm-pr.apk" "https://openrct2.org/altapi/?command=push-build";
-              fi
-            - if [[ "z$OPENRCT2_ORG_TOKEN" != "z" && "$TRAVIS_PULL_REQUEST" == "false" && ("${TRAVIS_BRANCH}" =~ ^(develop|push/) || "z${TRAVIS_TAG}" != "z") ]] ; then
-              curl -m $CURL_MAX_TIME --connect-timeout $CURL_CONNECT_TIMEOUT -o - -v --form "key=$OPENRCT2_ORG_TOKEN" --form "fileName=OpenRCT2-${OPENRCT2_VERSION}${FILENAME_PART}-android-x86.apk" --form "version=${OPENRCT2_VERSION}" --form "gitHash=$TRAVIS_COMMIT" --form "gitBranch=$PUSH_BRANCH" --form "flavourId=12" --form "file=@app/build/outputs/apk/x86/pr/app-x86-pr.apk" "https://openrct2.org/altapi/?command=push-build";
-              fi
         # Following entries used to be included in testing, but they only proved useful while changing things in CMake setup.
         # They are meant to be used when there are changes to CMakeLists.txt
         # - os: linux
@@ -127,8 +69,6 @@ matrix:
         #   env: OPENRCT2_CMAKE_OPTS="-DDISABLE_HTTP_TWITCH=ON -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt" TARGET=windows
 
 script:
-    # Android jobs are triggered from cron and overwrite `script` part
-    - if [[ "$OPENRCT2_ANDROID" == "true" ]] ; then exit 0 ; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash scripts/linux/build.sh ; fi
 
 notifications:

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -50,11 +50,13 @@ android {
     }
 
     flavorDimensions "version"
+    /*
     productFlavors {
         full {
             dimension "version"
         }
     }
+    */
 
     externalNativeBuild {
         cmake {
@@ -63,21 +65,25 @@ android {
     }
 
     productFlavors {
+        /*
         arm7 {
             ndk {
                 abiFilters 'armeabi-v7a'
             }
         }
+        */
         arm {
             ndk {
                 abiFilters 'armeabi-v7a', 'arm64-v8a'
             }
         }
+        /*
         x86 {
             ndk {
                 abiFilters 'x86', 'x86_64'
             }
         }
+        */
     }
 }
 


### PR DESCRIPTION
Android builds building, working and uploading (both to CI and openrct2.org) again.

I have removed building of x86 and x86-64 builds for now as they double the CI time (+20 minutes) and I doubt they are that likely to be used.

Android builds can now be built every push and pull request in around 10 minutes, similar time to Windows.