### PR TITLE
Do not log element out of range as error

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -168,7 +168,7 @@ TileElement* map_get_first_element_at(const CoordsXY& elementPos)
 {
     if (!map_is_location_valid(elementPos))
     {
-        log_error("Trying to access element outside of range");
+        log_verbose("Trying to access element outside of range");
         return nullptr;
     }
     auto tileElementPos = TileCoordsXY{ elementPos };


### PR DESCRIPTION
Many routines will attempt to access tile elements outside the range of the map. This can happen for example when a routine is observing surrounding tiles of a piece of track that is near the edge of the map. Null is returned from the function which is handled by the routine, so not really an error and can reduce many bounds checking in callers.