### PR TITLE
Replace cURL with WinHttp implementation on Windows

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		4C358E5221C445F700ADE6BC /* ReplayManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C358E5021C445F700ADE6BC /* ReplayManager.cpp */; };
 		4C3B4236205914F7000C5BB7 /* InGameConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B4234205914F7000C5BB7 /* InGameConsole.cpp */; };
 		4C724B2221F0AD790012ADD0 /* BenchSpriteSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C724B2121F0AD790012ADD0 /* BenchSpriteSort.cpp */; };
+		4C8A6FF323EB5326001A8255 /* Http.cURL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C8A6FF223EB5326001A8255 /* Http.cURL.cpp */; };
 		4C93F1AD1F8CD9F000A9330D /* Input.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C93F1AC1F8CD9F000A9330D /* Input.cpp */; };
 		4C93F1AF1F8CD9F600A9330D /* KeyboardShortcut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C93F1AE1F8CD9F600A9330D /* KeyboardShortcut.cpp */; };
 		4CB1375621C2E9F80029FCDA /* SimulateCommands.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CB1375521C2E9F80029FCDA /* SimulateCommands.cpp */; };
@@ -452,7 +453,6 @@
 		F76C85FF1EC4E88300FA49E2 /* Rain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83AB1EC4E7CC00FA49E2 /* Rain.cpp */; };
 		F76C86051EC4E88300FA49E2 /* Editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83B11EC4E7CC00FA49E2 /* Editor.cpp */; };
 		F76C86071EC4E88300FA49E2 /* FileClassifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83B31EC4E7CC00FA49E2 /* FileClassifier.cpp */; };
-		F76C86451EC4E88300FA49E2 /* Http.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83F61EC4E7CC00FA49E2 /* Http.cpp */; };
 		F76C86471EC4E88300FA49E2 /* Network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83F81EC4E7CC00FA49E2 /* Network.cpp */; };
 		F76C86491EC4E88300FA49E2 /* NetworkAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83FA1EC4E7CC00FA49E2 /* NetworkAction.cpp */; };
 		F76C864B1EC4E88300FA49E2 /* NetworkConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C83FC1EC4E7CC00FA49E2 /* NetworkConnection.cpp */; };
@@ -781,6 +781,8 @@
 		4C7B547E2010DFF700A52E21 /* Crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crash.h; sourceTree = "<group>"; };
 		4C8667801EEFDCDF0024AAB8 /* RideGroupManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RideGroupManager.cpp; sourceTree = "<group>"; };
 		4C8667811EEFDCDF0024AAB8 /* RideGroupManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RideGroupManager.h; sourceTree = "<group>"; };
+		4C8A6FF123EB5325001A8255 /* Http.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Http.h; sourceTree = "<group>"; };
+		4C8A6FF223EB5326001A8255 /* Http.cURL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Http.cURL.cpp; sourceTree = "<group>"; };
 		4C8B426E1EEB1ABD00F015CA /* X8DrawingEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = X8DrawingEngine.cpp; sourceTree = "<group>"; };
 		4C8B426F1EEB1ABD00F015CA /* X8DrawingEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = X8DrawingEngine.h; sourceTree = "<group>"; };
 		4C8B42711EEB1AE400F015CA /* HardwareDisplayDrawingEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HardwareDisplayDrawingEngine.cpp; sourceTree = "<group>"; };
@@ -1586,7 +1588,6 @@
 		F76C83871EC4E7CC00FA49E2 /* IStream.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = IStream.hpp; sourceTree = "<group>"; };
 		F76C83881EC4E7CC00FA49E2 /* Json.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Json.cpp; sourceTree = "<group>"; };
 		F76C83891EC4E7CC00FA49E2 /* Json.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Json.hpp; sourceTree = "<group>"; };
-		F76C838A1EC4E7CC00FA49E2 /* Math.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Math.hpp; sourceTree = "<group>"; };
 		F76C838B1EC4E7CC00FA49E2 /* Memory.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Memory.hpp; sourceTree = "<group>"; };
 		F76C838C1EC4E7CC00FA49E2 /* MemoryStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryStream.cpp; sourceTree = "<group>"; };
 		F76C838D1EC4E7CC00FA49E2 /* MemoryStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryStream.h; sourceTree = "<group>"; };
@@ -1615,8 +1616,6 @@
 		F76C83B31EC4E7CC00FA49E2 /* FileClassifier.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileClassifier.cpp; sourceTree = "<group>"; };
 		F76C83B41EC4E7CC00FA49E2 /* FileClassifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileClassifier.h; sourceTree = "<group>"; };
 		F76C83BA1EC4E7CC00FA49E2 /* input.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input.h; sourceTree = "<group>"; };
-		F76C83F61EC4E7CC00FA49E2 /* Http.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Http.cpp; sourceTree = "<group>"; };
-		F76C83F71EC4E7CC00FA49E2 /* http.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = http.h; sourceTree = "<group>"; };
 		F76C83F81EC4E7CC00FA49E2 /* Network.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Network.cpp; sourceTree = "<group>"; };
 		F76C83F91EC4E7CC00FA49E2 /* network.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = network.h; sourceTree = "<group>"; };
 		F76C83FA1EC4E7CC00FA49E2 /* NetworkAction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkAction.cpp; sourceTree = "<group>"; };
@@ -2662,11 +2661,12 @@
 				F76C83831EC4E7CC00FA49E2 /* FileStream.hpp */,
 				F76C83841EC4E7CC00FA49E2 /* Guard.cpp */,
 				F76C83851EC4E7CC00FA49E2 /* Guard.hpp */,
+				4C8A6FF223EB5326001A8255 /* Http.cURL.cpp */,
+				4C8A6FF123EB5325001A8255 /* Http.h */,
 				F76C83861EC4E7CC00FA49E2 /* IStream.cpp */,
 				F76C83871EC4E7CC00FA49E2 /* IStream.hpp */,
 				F76C83881EC4E7CC00FA49E2 /* Json.cpp */,
 				F76C83891EC4E7CC00FA49E2 /* Json.hpp */,
-				F76C838A1EC4E7CC00FA49E2 /* Math.hpp */,
 				F76C838B1EC4E7CC00FA49E2 /* Memory.hpp */,
 				F76C838C1EC4E7CC00FA49E2 /* MemoryStream.cpp */,
 				F76C838D1EC4E7CC00FA49E2 /* MemoryStream.h */,
@@ -2798,8 +2798,6 @@
 			children = (
 				2ADE2F3022441905002598AF /* DiscordService.cpp */,
 				2ADE2F2F22441905002598AF /* DiscordService.h */,
-				F76C83F61EC4E7CC00FA49E2 /* Http.cpp */,
-				F76C83F71EC4E7CC00FA49E2 /* http.h */,
 				F76C83F81EC4E7CC00FA49E2 /* Network.cpp */,
 				F76C83F91EC4E7CC00FA49E2 /* network.h */,
 				F76C83FA1EC4E7CC00FA49E2 /* NetworkAction.cpp */,
@@ -3904,6 +3902,7 @@
 				932A211E22D73CFA00C57EDB /* GameActionCompat.cpp in Sources */,
 				4C29DEB3218C6AE500E8707F /* RCT12.cpp in Sources */,
 				C6D2BEE81F9BAACE008B557C /* MazeConstruction.cpp in Sources */,
+				4C8A6FF323EB5326001A8255 /* Http.cURL.cpp in Sources */,
 				C666EE771F37ACB10061AA04 /* SavePrompt.cpp in Sources */,
 				C654DF391F69C0430040F43D /* TitleCommandEditor.cpp in Sources */,
 				C61FB2731FA3E25D0095FB9D /* TextInput.cpp in Sources */,
@@ -4069,7 +4068,6 @@
 				C688790020289B9B0084B384 /* ReverseFreefallCoaster.cpp in Sources */,
 				93F76EF620BFF76E00D4512C /* Paint.Sprite.cpp in Sources */,
 				C6607F481FE2B97E00D3FC0D /* Input.cpp in Sources */,
-				F76C86451EC4E88300FA49E2 /* Http.cpp in Sources */,
 				C688789F20289B200084B384 /* Language.cpp in Sources */,
 				C688791620289B9B0084B384 /* MiniGolf.cpp in Sources */,
 				F76C86471EC4E88300FA49E2 /* Network.cpp in Sources */,

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -53,7 +53,7 @@
              C4549: 'operator': operator before comma has no effect; did you intend 'operator'?
              C4555: expression has no effect; expected expression with side-effect
       -->
-      <PreprocessorDefinitions>__AVX2__;__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;CURL_STATICLIB;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__AVX2__;__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'!='true'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -61,7 +61,7 @@
       <AdditionalOptions>/utf-8 /std:c++17 /permissive- /Zc:externConstexpr</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -76,7 +76,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>benchmarkd.lib;libbreakpadd.lib;libbreakpad_clientd.lib;bz2d.lib;discord-rpc.lib;freetyped.lib;jansson_d.lib;libcurl-d.lib;libpng16d.lib;libspeexdsp.lib;SDL2d.lib;zip.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>benchmarkd.lib;libbreakpadd.lib;libbreakpad_clientd.lib;bz2d.lib;discord-rpc.lib;freetyped.lib;jansson_d.lib;libpng16d.lib;libspeexdsp.lib;SDL2d.lib;zip.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -94,7 +94,7 @@
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>benchmark.lib;libbreakpad.lib;libbreakpad_client.lib;bz2.lib;discord-rpc.lib;freetype.lib;jansson.lib;libcurl.lib;libpng16.lib;libspeexdsp.lib;SDL2.lib;zip.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>benchmark.lib;libbreakpad.lib;libbreakpad_client.lib;bz2.lib;discord-rpc.lib;freetype.lib;jansson.lib;libpng16.lib;libspeexdsp.lib;SDL2.lib;zip.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -11,10 +11,10 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
+#include <openrct2/core/Http.h>
 #include <openrct2/core/Json.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Localisation.h>
-#include <openrct2/network/Http.h>
 #include <openrct2/object/ObjectList.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/ObjectRepository.h>
@@ -151,7 +151,6 @@ private:
 
     void DownloadObject(const rct_object_entry& entry, const std::string name, const std::string url)
     {
-        using namespace OpenRCT2::Networking;
         try
         {
             std::printf("Downloading %s\n", url.c_str());
@@ -190,8 +189,6 @@ private:
 
     void NextDownload()
     {
-        using namespace OpenRCT2::Networking;
-
         if (!_downloadingObjects || _currentDownloadIndex >= _entries.size())
         {
             // Finished...

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -21,7 +21,6 @@
 #    include <openrct2/drawing/Drawing.h>
 #    include <openrct2/interface/Colour.h>
 #    include <openrct2/localisation/Localisation.h>
-#    include <openrct2/network/Http.h>
 #    include <openrct2/network/ServerList.h>
 #    include <openrct2/network/network.h>
 #    include <openrct2/platform/platform.h>

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -50,19 +50,18 @@ if (NOT DISABLE_NETWORK AND WIN32)
 endif ()
 
 if (NOT DISABLE_HTTP)
-    if (MSVC)
-        find_package(curl REQUIRED)
-        set(LIBCURL_LIBRARIES ${CURL_LIBRARIES})
+    if (WIN32)
+        target_link_libraries(${PROJECT_NAME} winhttp)
     else ()
         PKG_CHECK_MODULES(LIBCURL REQUIRED libcurl)
-    endif ()
-        
-    target_include_directories(${PROJECT_NAME} PRIVATE ${LIBCURL_INCLUDE_DIRS})
-        
-    if (STATIC)
-        target_link_libraries(${PROJECT_NAME} ${LIBCURL_STATIC_LIBRARIES})
-    else ()
-        target_link_libraries(${PROJECT_NAME} ${LIBCURL_LIBRARIES})
+
+        target_include_directories(${PROJECT_NAME} PRIVATE ${LIBCURL_INCLUDE_DIRS})
+
+        if (STATIC)
+            target_link_libraries(${PROJECT_NAME} ${LIBCURL_STATIC_LIBRARIES})
+        else ()
+            target_link_libraries(${PROJECT_NAME} ${LIBCURL_LIBRARIES})
+        endif ()
     endif ()
 endif ()
 

--- a/src/openrct2/core/Http.WinHttp.cpp
+++ b/src/openrct2/core/Http.WinHttp.cpp
@@ -1,0 +1,223 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#if !defined(DISABLE_HTTP) && defined(_WIN32)
+
+#    include "Http.h"
+
+#    include "../Version.h"
+#    include "String.hpp"
+
+#    include <cstdio>
+#    include <stdexcept>
+#    define WIN32_LEAN_AND_MEAN
+#    include <windows.h>
+#    include <winhttp.h>
+
+namespace Http
+{
+    static constexpr char OPENRCT2_USER_AGENT[] = "OpenRCT2/" OPENRCT2_VERSION;
+
+    static void ThrowWin32Exception(const char* methodName)
+    {
+        auto errorCode = GetLastError();
+        auto msg = String::StdFormat("%s failed, error: %d.", methodName, errorCode);
+        throw std::runtime_error(msg);
+    }
+
+    static const wchar_t* GetVerb(Method method)
+    {
+        switch (method)
+        {
+            case Method::GET:
+                return L"GET";
+            case Method::POST:
+                return L"POST";
+            case Method::PUT:
+                return L"PUT";
+            default:
+                throw std::runtime_error("Unsupported verb.");
+        }
+    }
+
+    static std::wstring ReadHeader(HINTERNET hRequest, DWORD infoLevel, const wchar_t* name)
+    {
+        wchar_t headerBuffer[256]{};
+        auto headerBufferLen = (DWORD)std::size(headerBuffer);
+        if (!WinHttpQueryHeaders(hRequest, infoLevel, name, headerBuffer, &headerBufferLen, WINHTTP_NO_HEADER_INDEX))
+            ThrowWin32Exception("WinHttpQueryHeaders");
+        return std::wstring(headerBuffer, headerBufferLen);
+    }
+
+    static int32_t ReadStatusCode(HINTERNET hRequest)
+    {
+        auto wStatusCode = ReadHeader(hRequest, WINHTTP_QUERY_STATUS_CODE, L"StatusCode");
+        return std::stoi(wStatusCode);
+    }
+
+    static std::map<std::string, std::string> ReadHeaders(HINTERNET hRequest)
+    {
+        DWORD dwSize{};
+        WinHttpQueryHeaders(
+            hRequest, WINHTTP_QUERY_RAW_HEADERS, WINHTTP_HEADER_NAME_BY_INDEX, NULL, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+        std::wstring buffer;
+        buffer.resize(dwSize);
+        if (!WinHttpQueryHeaders(
+                hRequest, WINHTTP_QUERY_RAW_HEADERS, WINHTTP_HEADER_NAME_BY_INDEX, buffer.data(), &dwSize,
+                WINHTTP_NO_HEADER_INDEX))
+            ThrowWin32Exception("WinHttpQueryHeaders");
+
+        std::map<std::string, std::string> headers;
+        std::wstring wKey, wValue;
+        int state = 0;
+        int index = 0;
+        for (auto c : buffer)
+        {
+            if (c == '\0')
+            {
+                state = 0;
+                if (index != 0 && wKey.size() != 0)
+                {
+                    auto key = String::ToUtf8(wKey);
+                    auto value = String::ToUtf8(wValue);
+                    headers[key] = value;
+                }
+                wKey.clear();
+                wValue.clear();
+                index++;
+                continue;
+            }
+            if (state == 0 && c == ':')
+            {
+                state = 1;
+            }
+            else if (state == 1 && c == ' ')
+            {
+                state = 2;
+            }
+            else if (state == 0)
+            {
+                wKey.push_back(c);
+            }
+            else
+            {
+                state = 2;
+                wValue.push_back(c);
+            }
+        }
+        return headers;
+    }
+
+    static std::string ReadBody(HINTERNET hRequest)
+    {
+        DWORD dwSize{};
+        std::string body;
+        do
+        {
+            // Check for available data.
+            if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
+                ThrowWin32Exception("WinHttpQueryDataAvailable");
+
+            // No more available data.
+            if (dwSize == 0)
+                break;
+
+            auto offset = body.size();
+            body.resize(offset + dwSize);
+            auto dst = (LPVOID)&body[offset];
+
+            DWORD dwDownloaded{};
+            if (!WinHttpReadData(hRequest, dst, dwSize, &dwDownloaded))
+                ThrowWin32Exception("WinHttpReadData");
+
+            // This condition should never be reached since WinHttpQueryDataAvailable
+            // reported that there are bits to read.
+            if (dwDownloaded == 0)
+                break;
+        } while (dwSize > 0);
+        return body;
+    }
+
+    Response Do(const Request& req)
+    {
+        HINTERNET hSession{}, hConnect{}, hRequest{};
+        try
+        {
+            URL_COMPONENTS url;
+            ZeroMemory(&url, sizeof(url));
+            url.dwStructSize = sizeof(url);
+            url.dwSchemeLength = (DWORD)-1;
+            url.dwHostNameLength = (DWORD)-1;
+            url.dwUrlPathLength = (DWORD)-1;
+            url.dwExtraInfoLength = (DWORD)-1;
+
+            auto wUrl = String::ToWideChar(req.url);
+            if (!WinHttpCrackUrl(wUrl.c_str(), 0, 0, &url))
+                throw std::invalid_argument("Unable to parse URI.");
+
+            auto userAgent = String::ToWideChar(OPENRCT2_USER_AGENT);
+            hSession = WinHttpOpen(
+                userAgent.c_str(), WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+            if (hSession == nullptr)
+                ThrowWin32Exception("WinHttpOpen");
+
+            auto wHostName = std::wstring(url.lpszHostName, url.dwHostNameLength);
+            hConnect = WinHttpConnect(hSession, wHostName.c_str(), url.nPort, 0);
+            if (hConnect == nullptr)
+                ThrowWin32Exception("WinHttpConnect");
+
+            auto wVerb = GetVerb(req.method);
+            auto wQuery = std::wstring(url.lpszUrlPath, url.dwUrlPathLength);
+            hRequest = WinHttpOpenRequest(
+                hConnect, wVerb, wQuery.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+            if (hRequest == nullptr)
+                ThrowWin32Exception("WinHttpOpenRequest");
+
+            for (auto header : req.header)
+            {
+                auto fullHeader = String::ToWideChar(header.first) + L": " + String::ToWideChar(header.second);
+                if (!WinHttpAddRequestHeaders(hRequest, fullHeader.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD))
+                    ThrowWin32Exception("WinHttpAddRequestHeaders");
+            }
+
+            auto reqBody = (LPVOID)req.body.data();
+            auto reqBodyLen = (DWORD)req.body.size();
+            if (!WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, reqBody, reqBodyLen, reqBodyLen, 0))
+                ThrowWin32Exception("WinHttpSendRequest");
+
+            if (!WinHttpReceiveResponse(hRequest, NULL))
+                ThrowWin32Exception("WinHttpReceiveResponse");
+
+            auto statusCode = ReadStatusCode(hRequest);
+            auto contentType = ReadHeader(hRequest, WINHTTP_QUERY_CONTENT_TYPE, L"Content-Type");
+            auto headers = ReadHeaders(hRequest);
+            auto body = ReadBody(hRequest);
+
+            Response response;
+            response.body = std::move(body);
+            response.status = (Status)statusCode;
+            response.content_type = String::ToUtf8(contentType);
+            response.header = headers;
+            return response;
+        }
+        catch ([[maybe_unused]] const std::exception& e)
+        {
+#    ifdef DEBUG
+            std::fprintf(stderr, "HTTP request failed: %s\n", e.what());
+#    endif
+            WinHttpCloseHandle(hSession);
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hRequest);
+            throw;
+        }
+    }
+} // namespace Http
+
+#endif

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -13,6 +13,7 @@
 
 #    include "../config/Config.h"
 #    include "../core/Console.hpp"
+#    include "../core/Http.h"
 #    include "../core/Json.hpp"
 #    include "../core/String.hpp"
 #    include "../localisation/Date.h"
@@ -23,7 +24,6 @@
 #    include "../util/Util.h"
 #    include "../world/Map.h"
 #    include "../world/Park.h"
-#    include "Http.h"
 #    include "Socket.h"
 #    include "network.h"
 
@@ -164,8 +164,6 @@ private:
 
     void SendRegistration(bool forceIPv4)
     {
-        using namespace OpenRCT2::Networking;
-
         _lastAdvertiseTime = platform_get_ticks();
 
         // Send the registration request
@@ -199,8 +197,6 @@ private:
 
     void SendHeartbeat()
     {
-        using namespace OpenRCT2::Networking;
-
         Http::Request request;
         request.url = GetMasterServerUrl();
         request.method = Http::Method::PUT;

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -15,11 +15,11 @@
 #    include "../PlatformEnvironment.h"
 #    include "../config/Config.h"
 #    include "../core/FileStream.hpp"
+#    include "../core/Http.h"
 #    include "../core/Json.hpp"
 #    include "../core/Memory.hpp"
 #    include "../core/Path.hpp"
 #    include "../core/String.hpp"
-#    include "../network/Http.h"
 #    include "../platform/platform.h"
 #    include "Socket.h"
 #    include "network.h"
@@ -331,7 +331,6 @@ std::future<std::vector<ServerListEntry>> ServerList::FetchOnlineServerListAsync
 #    ifdef DISABLE_HTTP
     return {};
 #    else
-    using namespace OpenRCT2::Networking;
 
     auto p = std::make_shared<std::promise<std::vector<ServerListEntry>>>();
     auto f = p->get_future();

--- a/src/openrct2/network/Twitch.cpp
+++ b/src/openrct2/network/Twitch.cpp
@@ -29,6 +29,7 @@ namespace Twitch
 #    include "../OpenRCT2.h"
 #    include "../actions/GuestSetFlagsAction.hpp"
 #    include "../config/Config.h"
+#    include "../core/Http.h"
 #    include "../core/Json.hpp"
 #    include "../core/String.hpp"
 #    include "../drawing/Drawing.h"
@@ -39,7 +40,6 @@ namespace Twitch
 #    include "../platform/platform.h"
 #    include "../util/Util.h"
 #    include "../world/Sprite.h"
-#    include "Http.h"
 #    include "Twitch.h"
 
 #    include <jansson.h>
@@ -47,7 +47,6 @@ namespace Twitch
 #    include <vector>
 
 using namespace OpenRCT2;
-using namespace OpenRCT2::Networking;
 
 bool gTwitchEnable = false;
 


### PR DESCRIPTION
This reduces the number of third party dependencies for Windows builds. WinHttp is quite a nice straight forward API so doesn't involve too much extra code.