### PR TITLE
Refactor/16 bits for ride

### DIFF
--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -32,7 +32,7 @@ using namespace OpenRCT2;
 DEFINE_GAME_ACTION(RideDemolishAction, GAME_COMMAND_DEMOLISH_RIDE, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     uint8_t _modifyType = RIDE_MODIFY_DEMOLISH;
 
 public:

--- a/src/openrct2/actions/RideSetAppearanceAction.hpp
+++ b/src/openrct2/actions/RideSetAppearanceAction.hpp
@@ -38,7 +38,7 @@ enum class RideSetAppearanceType : uint8_t
 DEFINE_GAME_ACTION(RideSetAppearanceAction, GAME_COMMAND_SET_RIDE_APPEARANCE, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     uint8_t _type;
     uint8_t _value;
     uint32_t _index;

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -25,7 +25,7 @@
 DEFINE_GAME_ACTION(RideSetNameAction, GAME_COMMAND_SET_RIDE_NAME, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     std::string _name;
 
 public:

--- a/src/openrct2/actions/RideSetPriceAction.hpp
+++ b/src/openrct2/actions/RideSetPriceAction.hpp
@@ -26,7 +26,7 @@
 DEFINE_GAME_ACTION(RideSetPriceAction, GAME_COMMAND_SET_RIDE_PRICE, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     money16 _price = MONEY16_UNDEFINED;
     bool _primaryPrice = true;
 

--- a/src/openrct2/actions/RideSetSetting.hpp
+++ b/src/openrct2/actions/RideSetSetting.hpp
@@ -31,7 +31,7 @@ enum class RideSetSetting : uint8_t
 DEFINE_GAME_ACTION(RideSetSettingAction, GAME_COMMAND_SET_RIDE_SETTING, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     uint8_t _setting{ 0 };
     uint8_t _value{ 0 };
 

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -31,7 +31,7 @@ static rct_string_id _StatusErrorTitles[] = {
 DEFINE_GAME_ACTION(RideSetStatusAction, GAME_COMMAND_SET_RIDE_STATUS, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     uint8_t _status = RIDE_STATUS_CLOSED;
 
 public:

--- a/src/openrct2/actions/RideSetVehiclesAction.hpp
+++ b/src/openrct2/actions/RideSetVehiclesAction.hpp
@@ -33,7 +33,7 @@ enum class RideSetVehicleType : uint8_t
 DEFINE_GAME_ACTION(RideSetVehicleAction, GAME_COMMAND_SET_RIDE_VEHICLES, GameActionResult)
 {
 private:
-    NetworkRideId_t _rideIndex{ -1 };
+    NetworkRideId_t _rideIndex{ RideIdNewNull };
     uint8_t _type;
     uint8_t _value;
     uint8_t _colour;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../core/Endianness.h"
+#include "../ride/RideTypes.h"
 
 enum
 {
@@ -113,7 +114,7 @@ template<typename T, size_t _TypeID> struct NetworkObjectId_t
 // NOTE: When adding new types make sure to have no duplicate _TypeID's otherwise
 // there is no way to specialize templates if they have the exact symbol.
 using NetworkPlayerId_t = NetworkObjectId_t<int32_t, 0>;
-using NetworkRideId_t = NetworkObjectId_t<int32_t, 1>;
+using NetworkRideId_t = NetworkObjectId_t<ride_idnew_t, 1>;
 using NetworkCheatType_t = NetworkObjectId_t<int32_t, 2>;
 
 enum NetworkStatisticsGroup

--- a/src/openrct2/ride/RideTypes.h
+++ b/src/openrct2/ride/RideTypes.h
@@ -12,5 +12,7 @@
 #include <cstdint>
 
 typedef uint8_t ride_id_t;
-typedef uint32_t ride_idnew_t; // Temporary, old one can be removed after switching save format.
+typedef uint16_t ride_idnew_t; // Temporary, old one can be removed after switching save format.
 struct Ride;
+
+constexpr const ride_idnew_t RideIdNewNull = 0xFFFF;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -289,7 +289,7 @@ private:
     ride_idnew_t RideIndex;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-private-field"
-    uint8_t pad[1];
+    uint8_t pad[3];
 #pragma clang diagnostic pop
 
 public:
@@ -299,8 +299,8 @@ public:
     uint8_t GetSequenceIndex() const;
     void SetSequenceIndex(uint8_t newSequenceIndex);
 
-    uint32_t GetRideIndex() const;
-    void SetRideIndex(uint32_t newRideIndex);
+    ride_idnew_t GetRideIndex() const;
+    void SetRideIndex(ride_idnew_t newRideIndex);
 
     uint8_t GetColourScheme() const;
     void SetColourScheme(uint8_t newColourScheme);


### PR DESCRIPTION
When looking at the tile element refactor, it seemed to me that taking 32 bits for the ride id was quite a lot, especially in elements that are already jam-packed (like the Footpath element). 16 bits will still allow for 65535 rides, which only madmen like Marcel Vos will likely ever reach. It means we'll have 16 bits at our disposal to use for other things, like company IDs.