### PR TITLE
Clean up scenery window variables

### DIFF
--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -35,6 +35,8 @@
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 
+extern bool gWindowSceneryEyedropperEnabled;
+
 uint8_t gKeyboardShortcutChangeId;
 
 using shortcut_action = void (*)();

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -56,6 +56,16 @@ enum {
     WINDOW_SCENERY_TAB_20
 };
 
+uint16_t gWindowSceneryTabSelections[SCENERY_WINDOW_TABS];
+uint8_t gWindowSceneryActiveTabIndex;
+uint8_t gWindowSceneryClusterEnabled;
+uint8_t gWindowSceneryPaintEnabled;
+uint8_t gWindowSceneryRotation;
+colour_t gWindowSceneryPrimaryColour;
+colour_t gWindowScenerySecondaryColour;
+colour_t gWindowSceneryTertiaryColour;
+bool gWindowSceneryEyedropperEnabled = false;
+
 static void window_scenery_close(rct_window *w);
 static void window_scenery_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_scenery_resize(rct_window *w);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2526,9 +2526,6 @@ static money32 try_place_ghost_scenery(
                 gSceneryGhostPosition.x = map_tile.x;
                 gSceneryGhostPosition.y = map_tile.y;
                 gSceneryGhostPosition.z = (parameter_2 & 0xFF);
-                gSceneryPlacePathSlope = ((parameter_1 >> 8) & 0xFF);
-                gSceneryPlacePathType = ((parameter_2 >> 8) & 0xFF);
-                gSceneryGhostPathObjectType = parameter_3;
 
                 gSceneryGhostType |= SCENERY_GHOST_FLAG_1;
             });

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -20,6 +20,16 @@ struct Peep;
 struct TileElement;
 struct Vehicle;
 
+extern uint16_t gWindowSceneryTabSelections[];
+extern uint8_t gWindowSceneryActiveTabIndex;
+extern uint8_t gWindowSceneryClusterEnabled;
+extern uint8_t gWindowSceneryPaintEnabled;
+extern uint8_t gWindowSceneryRotation;
+extern colour_t gWindowSceneryPrimaryColour;
+extern colour_t gWindowScenerySecondaryColour;
+extern colour_t gWindowSceneryTertiaryColour;
+extern bool gWindowSceneryEyedropperEnabled;
+
 rct_window* window_about_open();
 rct_window* window_changelog_open();
 rct_window* window_cheats_open();

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -31,28 +31,15 @@
 #include "SmallScenery.h"
 #include "Wall.h"
 
-uint8_t gWindowSceneryActiveTabIndex;
-uint16_t gWindowSceneryTabSelections[20];
-uint8_t gWindowSceneryClusterEnabled;
-uint8_t gWindowSceneryPaintEnabled;
-uint8_t gWindowSceneryRotation;
-colour_t gWindowSceneryPrimaryColour;
-colour_t gWindowScenerySecondaryColour;
-colour_t gWindowSceneryTertiaryColour;
-bool gWindowSceneryEyedropperEnabled;
-
 uint8_t gSceneryQuadrant;
 
 money32 gSceneryPlaceCost;
 int16_t gSceneryPlaceObject;
 int16_t gSceneryPlaceZ;
-uint8_t gSceneryPlacePathType;
-uint8_t gSceneryPlacePathSlope;
 uint8_t gSceneryPlaceRotation;
 
 uint8_t gSceneryGhostType;
 LocationXYZ16 gSceneryGhostPosition;
-uint32_t gSceneryGhostPathObjectType;
 uint8_t gSceneryGhostWallRotation;
 
 int16_t gSceneryShiftPressed;

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -246,28 +246,15 @@ enum
 #define SCENERY_ENTRIES_BY_TAB 1024
 constexpr auto WINDOW_SCENERY_TAB_SELECTION_UNDEFINED = std::numeric_limits<uint16_t>::max();
 
-extern uint8_t gWindowSceneryActiveTabIndex;
-extern uint16_t gWindowSceneryTabSelections[20];
-extern uint8_t gWindowSceneryClusterEnabled;
-extern uint8_t gWindowSceneryPaintEnabled;
-extern uint8_t gWindowSceneryRotation;
-extern colour_t gWindowSceneryPrimaryColour;
-extern colour_t gWindowScenerySecondaryColour;
-extern colour_t gWindowSceneryTertiaryColour;
-extern bool gWindowSceneryEyedropperEnabled;
-
 extern uint8_t gSceneryQuadrant;
 
 extern money32 gSceneryPlaceCost;
 extern int16_t gSceneryPlaceObject;
 extern int16_t gSceneryPlaceZ;
-extern uint8_t gSceneryPlacePathType;
-extern uint8_t gSceneryPlacePathSlope;
 extern uint8_t gSceneryPlaceRotation;
 
 extern uint8_t gSceneryGhostType;
 extern LocationXYZ16 gSceneryGhostPosition;
-extern uint32_t gSceneryGhostPathObjectType;
 extern uint8_t gSceneryGhostWallRotation;
 
 extern int16_t gSceneryShiftPressed;


### PR DESCRIPTION
This moves many scenery window globals to the UI project and removes three globals that were never read, only assigned.