### PR TITLE
Fix GCC10 warnings

### DIFF
--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1368,7 +1368,7 @@ Direction peep_pathfind_choose_direction(TileCoordsXYZ loc, Peep* peep)
             _peepPathFindNumJunctions = _peepPathFindMaxJunctions;
 
             // Initialise _peepPathFindHistory.
-            std::memset(_peepPathFindHistory, 0xFF, sizeof(_peepPathFindHistory));
+            std::memset(static_cast<void*>(_peepPathFindHistory), 0xFF, sizeof(_peepPathFindHistory));
 
             /* The pathfinding will only use elements
              * 1.._peepPathFindMaxJunctions, so the starting point

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -149,7 +149,7 @@ void invalidate_sprite_2(SpriteBase* sprite)
 void reset_sprite_list()
 {
     gSavedAge = 0;
-    std::memset(_spriteList, 0, sizeof(_spriteList));
+    std::memset(static_cast<void*>(_spriteList), 0, sizeof(_spriteList));
 
     for (int32_t i = 0; i < SPRITE_LIST_COUNT; i++)
     {


### PR DESCRIPTION
The warnings reported were:
```
../src/openrct2/peep/GuestPathfinding.cpp: In function ‘Direction peep_pathfind_choose_direction(TileCoordsXYZ, Peep*)’:
../src/openrct2/peep/GuestPathfinding.cpp:1371:81: error: ‘void* memset(void*, int, size_t)’ writing to an object of non-trivial type ‘struct<unnamed>’; use assignment instead [-Werror=class-memaccess]
 1371 |             std::memset(_peepPathFindHistory, 0xFF, sizeof(_peepPathFindHistory));
      |                                                                                 ^
../src/openrct2/peep/GuestPathfinding.cpp:35:1: note: ‘struct<unnamed>’ declared here
   35 | {
      | ^

../src/openrct2/world/Sprite.cpp: In function ‘void reset_sprite_list()’:
../src/openrct2/world/Sprite.cpp:152:52: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘union rct_sprite’; use assignment or value-initialization instead [-Werror=class-memaccess]
  152 |     std::memset(_spriteList, 0, sizeof(_spriteList));
      |                                                    ^
In file included from ../src/openrct2/world/Sprite.cpp:10:
../src/openrct2/world/Sprite.h:117:7: note: ‘union rct_sprite’ declared here
  117 | union rct_sprite
      |       ^~~~~~~~~~
```