### PR TITLE
Fix #10705: Apply multithreaded rendering to all viewports

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#10489] Hosts last player action not being synchronized.
 - Fix: [#10543] Secondary shop item prices are not imported correctly from RCT1 saves.
 - Fix: [#10547] RCT1 parks have too many rides available.
+- Fix: [#10705] Apply multithreaded rendering to all viewports.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -934,8 +934,6 @@ void viewport_paint(
     // this as well as the [x += 32] in the loop causes signed integer overflow -> undefined behaviour.
     const int16_t rightBorder = dpi1.x + dpi1.width;
     const int16_t alignedX = floor2(dpi1.x, 32);
-    const uint16_t columSize = rightBorder - alignedX;
-    const uint16_t columnCount = (columSize / 32);
 
     std::vector<paint_session*> columns;
 
@@ -953,9 +951,9 @@ void viewport_paint(
     size_t index = 0;
     if (recorded_sessions != nullptr)
     {
-        const uint16_t colums = rightBorder - floor2(dpi1.x, 32);
-        const uint16_t column_count = (colums / 32) + (colums % 32 > 0 ? 1 : 0);
-        recorded_sessions->resize(column_count);
+        const uint16_t columnSize = rightBorder - alignedX;
+        const uint16_t columnCount = (columnSize / 32);
+        recorded_sessions->resize(columnCount);
     }
 
     // Splits the area into 32 pixel columns and renders them

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2019 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -932,14 +932,14 @@ void viewport_paint(
 
     // make sure, the compare operation is done in int16_t to avoid the loop becoming an infiniteloop.
     // this as well as the [x += 32] in the loop causes signed integer overflow -> undefined behaviour.
-    int16_t rightBorder = dpi1.x + dpi1.width;
+    const int16_t rightBorder = dpi1.x + dpi1.width;
+    const int16_t alignedX = floor2(dpi1.x, 32);
+    const uint16_t columSize = rightBorder - alignedX;
+    const uint16_t columnCount = (columSize / 32);
 
     std::vector<paint_session*> columns;
 
     bool useMultithreading = gConfigGeneral.multithreading;
-    if (window_get_main() != nullptr && viewport != window_get_main()->viewport)
-        useMultithreading = false;
-
     if (useMultithreading && _paintJobs == nullptr)
     {
         _paintJobs = std::make_unique<JobPool>();
@@ -953,12 +953,13 @@ void viewport_paint(
     size_t index = 0;
     if (recorded_sessions != nullptr)
     {
-        const uint16_t column_count = (rightBorder - floor2(dpi1.x, 32)) / 32 + 1;
+        const uint16_t colums = rightBorder - floor2(dpi1.x, 32);
+        const uint16_t column_count = (colums / 32) + (colums % 32 > 0 ? 1 : 0);
         recorded_sessions->resize(column_count);
     }
 
     // Splits the area into 32 pixel columns and renders them
-    for (x = floor2(dpi1.x, 32); x < rightBorder; x += 32, index++)
+    for (x = alignedX; x < rightBorder; x += 32, index++)
     {
         paint_session* session = paint_session_alloc(&dpi1, viewFlags);
         columns.push_back(session);


### PR DESCRIPTION
This fixes also the issue that it would reset the multithreading system every time any other viewport was rendered other than the main one which caused to always re-spawn threads every frame.