### PR TITLE
Extend object validation

### DIFF
--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -491,7 +491,14 @@ size_t ImageListGetMaximum();
 void FASTCALL gfx_bmp_sprite_to_buffer(
     const uint8_t* palette_pointer, uint8_t* source_pointer, uint8_t* dest_pointer, const rct_g1_element* source_image,
     rct_drawpixelinfo* dest_dpi, int32_t height, int32_t width, ImageId imageId);
+bool FASTCALL test_gfx_bmp_sprite_to_buffer(
+    const uint8_t* palette_pointer, uint8_t* source_pointer, uint8_t* dest_pointer, const rct_g1_element* source_image,
+    rct_drawpixelinfo* dest_dpi, int32_t height, int32_t width, ImageId imageId);
 void FASTCALL gfx_rle_sprite_to_buffer(
+    const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const uint8_t* RESTRICT palette_pointer,
+    const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,
+    int32_t width);
+bool FASTCALL test_gfx_rle_sprite_to_buffer(
     const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const uint8_t* RESTRICT palette_pointer,
     const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,
     int32_t width);
@@ -501,8 +508,11 @@ void FASTCALL gfx_draw_sprite_raw_masked(rct_drawpixelinfo* dpi, int32_t x, int3
 void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, int32_t image, int32_t x, int32_t y, uint8_t colour);
 
 void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, ImageId imageId, int32_t x, int32_t y);
+bool FASTCALL test_gfx_draw_sprite_software(rct_drawpixelinfo* dpi, ImageId imageId, int32_t x, int32_t y);
 const uint8_t* FASTCALL gfx_draw_sprite_get_palette(ImageId imageId);
 void FASTCALL gfx_draw_sprite_palette_set_software(
+    rct_drawpixelinfo* dpi, ImageId imageId, int32_t x, int32_t y, const uint8_t* palette_pointer);
+bool FASTCALL test_gfx_draw_sprite_palette_set_software(
     rct_drawpixelinfo* dpi, ImageId imageId, int32_t x, int32_t y, const uint8_t* palette_pointer);
 void FASTCALL
     gfx_draw_sprite_raw_masked_software(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t maskImage, int32_t colourImage);

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -214,6 +214,11 @@ public:
     {
     }
 
+    virtual bool ValidateObject() const
+    {
+        return true;
+    }
+
     virtual uint8_t GetObjectType() const final
     {
         return _objectEntry.flags & 0x0F;

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -39,6 +39,7 @@ public:
     void Unload() override;
 
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    bool ValidateObject() const override;
 
     std::string GetDescription() const;
     std::string GetCapacity() const;


### PR DESCRIPTION
In attempt to solve quite commonly seen https://github.com/OpenRCT2/OpenRCT2/issues/10702, I wanted to have some systematic method of rejecting the objects that could lead to such crashes, this is my draft solution. I would like to hear your opinion before I dig myself too deep in it.

I tried reusing as much current code as possible without impacting performance, I came up with the `if constexpr` approach and I quite like it, though I had to duplicate some functions because of the different return types. My initial approach was to use `auto` deduced type, but I ran into some problems when there is `void` in the mix.