### PR TITLE
Fix #10740: Crash using benchspritegfx with a dimension not dividable by 32

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -952,7 +952,7 @@ void viewport_paint(
     if (recorded_sessions != nullptr)
     {
         const uint16_t columnSize = rightBorder - alignedX;
-        const uint16_t columnCount = (columnSize / 32);
+        const uint16_t columnCount = (columnSize + 31) / 32;
         recorded_sessions->resize(columnCount);
     }
 


### PR DESCRIPTION
Closes #10740