### PR TITLE
Fix #10713: Correctly encode network ride id over network

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -141,14 +141,15 @@ template<> struct DataSerializerTraits<NetworkPlayerId_t>
 {
     static void encode(IStream* stream, const NetworkPlayerId_t& val)
     {
-        uint32_t temp = ByteSwapBE(val.id);
+        uint32_t temp = static_cast<uint32_t>(val.id);
+        temp = ByteSwapBE(temp);
         stream->Write(&temp);
     }
     static void decode(IStream* stream, NetworkPlayerId_t& val)
     {
         uint32_t temp;
         stream->Read(&temp);
-        val.id = ByteSwapBE(temp);
+        val.id = static_cast<decltype(val.id)>(ByteSwapBE(temp));
     }
     static void log(IStream* stream, const NetworkPlayerId_t& val)
     {
@@ -175,14 +176,15 @@ template<> struct DataSerializerTraits<NetworkRideId_t>
 {
     static void encode(IStream* stream, const NetworkRideId_t& val)
     {
-        uint32_t temp = ByteSwapBE(val.id);
+        uint32_t temp = static_cast<uint32_t>(val.id);
+        temp = ByteSwapBE(temp);
         stream->Write(&temp);
     }
     static void decode(IStream* stream, NetworkRideId_t& val)
     {
         uint32_t temp;
         stream->Read(&temp);
-        val.id = ByteSwapBE(temp);
+        val.id = static_cast<decltype(val.id)>(ByteSwapBE(temp));
     }
     static void log(IStream* stream, const NetworkRideId_t& val)
     {

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
It byte swapped uint16_t and then during decode byte swapped it as uint32_t, now it always uses uint32_t for ride/player id. I could use the underlying type but that would require to re-create all replays again.

Closes #10713