### PR TITLE
Implement #10666: ShowMessageBox on Android

### DIFF
--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Ui
         {
             log_verbose(message.c_str());
 
-            STUB();
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "OpenRCT2", message.c_str(), window);
         }
 
         std::string ShowFileDialog(SDL_Window* window, const FileDialogDesc& desc) override


### PR DESCRIPTION
I have tested this on a Samsung G110H running Android 4.4. It properly shows an Android-style messagebox. (Tested by renaming g2.dat.)