### PR TITLE
Fix YaHei detection

### DIFF
--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -49,7 +49,7 @@ TTFFontSetDescriptor TTFFontHeiti = { {
 } };
 
 TTFFontSetDescriptor TTFFontSimSun = { {
-    {   "msyh.ttc",  "YaHei",  9, -1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
+    {   "msyh.ttc",  "Microsoft YaHei",  9, -1, -1,  9, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 11,  1, -1, 14, HINTING_THRESHOLD_MEDIUM, nullptr },
     { "simsun.ttc", "SimSun", 12,  1, -2, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };


### PR DESCRIPTION
On Linux at least, the old name caused both YaHei and SimSun to be regarded as "not present".

I would like someone on Windows to verify that this does not break anything. Perhaps @telk5093 could help?