### PR TITLE
Fix #10815: Vertical alignment of scatter tool area size label

### DIFF
--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -238,6 +238,6 @@ static void window_scenery_scatter_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto preview = window_scenery_scatter_widgets[WIDX_PREVIEW];
         int32_t x = w->x + (preview.left + preview.right) / 2;
         int32_t y = w->y + (preview.top + preview.bottom) / 2;
-        gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y, COLOUR_BLACK, &gWindowSceneryScatterSize);
+        gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gWindowSceneryScatterSize);
     }
 }


### PR DESCRIPTION
The `- 2` offset, as found in the land and water tools, was missing from the scatter tool.