### PR TITLE
Fix #10587: Update last action coordinates on correct player

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#10489] Hosts last player action not being synchronized.
 - Fix: [#10543] Secondary shop item prices are not imported correctly from RCT1 saves.
 - Fix: [#10547] RCT1 parks have too many rides available.
+- Fix: [#10587] Update last action coordinates on correct player.
 - Fix: [#10694] The lift hill speed of the flying roller coaster cannot be changed (original bug).
 - Fix: [#10705] Apply multithreaded rendering to all viewports.
 - Fix: [#10739] Mountain tool overlay for even-numbered selections.

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -433,7 +433,7 @@ namespace GameActions
 
                     if (!result->Position.isNull())
                     {
-                        network_set_player_last_action_coord(playerId, result->Position);
+                        network_set_player_last_action_coord(playerIndex, result->Position);
                     }
                 }
                 else

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "18"
+#define NETWORK_STREAM_VERSION "19"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Amazing how this went unnoticed for quite some time.

Closes #10587 