### PR TITLE
Finance charts horizontal lines

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -82,7 +82,7 @@ The following people are not part of the development team, but have been contrib
 * Kevin Strehl (bitman2049) - Tile inspector keybindings
 * Anton Scharnowski (scrapes) - Added Scenery Scatter Options Window.
 * Chad Ian Anderson (pizza2004) - Added New Game option, bug fixes, misc.
-* Peter Ryszkiewicz (pRizz) - Improved financial chart UX.
+* Peter Ryszkiewicz (pRizz) - Added horizontal grid lines to finance charts.
 
 ## Bug fixes
 * (halfbro)

--- a/contributors.md
+++ b/contributors.md
@@ -82,6 +82,7 @@ The following people are not part of the development team, but have been contrib
 * Kevin Strehl (bitman2049) - Tile inspector keybindings
 * Anton Scharnowski (scrapes) - Added Scenery Scatter Options Window.
 * Chad Ian Anderson (pizza2004) - Added New Game option, bug fixes, misc.
+* Peter Ryszkiewicz (pRizz) - Improved financial chart UX.
 
 ## Bug fixes
 * (halfbro)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,7 +7,6 @@
 - Feature: [#10305] Add two shortcuts for increasing and decreasing the scaling factor.
 - Feature: [#10189] Make Track Designs work in multiplayer.
 - Feature: [#10357] Added window for scenery scatter tool, allowing for area and density selection.
-- Feature: [#10858] Finance charts horizontal lines
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
@@ -32,6 +31,7 @@
 - Fix: [#10739] Mountain tool overlay for even-numbered selections.
 - Fix: [#10752] Mute button state not correctly set at startup.
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
+- Improved: [#10858] Added horizontal grid lines to finance charts.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#10305] Add two shortcuts for increasing and decreasing the scaling factor.
 - Feature: [#10189] Make Track Designs work in multiplayer.
 - Feature: [#10357] Added window for scenery scatter tool, allowing for area and density selection.
+- Feature: [#10858] Finance charts horizontal lines
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -879,6 +879,7 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
         y += 39;
     }
 
@@ -980,6 +981,7 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
         y += 39;
     }
 
@@ -1083,7 +1085,7 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
-        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);        
+        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
         y += 39;
     }
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -879,7 +879,7 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
-        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
+        gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
 
@@ -981,7 +981,7 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
-        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
+        gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
 
@@ -1085,7 +1085,7 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
-        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);
+        gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1083,6 +1083,7 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     {
         money32 axisValue = axisBase << yAxisScale;
         gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_line(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[0]);        
         y += 39;
     }
 


### PR DESCRIPTION
Fixes a pet peeve of mine where it is difficult to tell where along the graph the line is. This adds horizontal lines to make it easier to tell, for all the financial graphs.

Before:
<img width="532" alt="Screen Shot 2020-02-29 at 3 20 23 PM" src="https://user-images.githubusercontent.com/3519085/75615476-d2576e80-5b09-11ea-96a5-4746d26675f6.png">

After:
<img width="529" alt="Screen Shot 2020-02-29 at 3 19 47 PM" src="https://user-images.githubusercontent.com/3519085/75615477-d71c2280-5b09-11ea-9371-89597c9df158.png">
