### PR TITLE
Increase usage of ScreenCoordsXY on viewport functions and structs

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -794,10 +794,10 @@ private:
                 auto vp = original_w->viewport;
                 if (vp != nullptr)
                 {
-                    left = std::max<int16_t>(left, vp->x);
-                    right = std::min<int16_t>(right, vp->x + vp->width);
-                    top = std::max<int16_t>(top, vp->y);
-                    bottom = std::min<int16_t>(bottom, vp->y + vp->height);
+                    left = std::max<int16_t>(left, vp->pos.x);
+                    right = std::min<int16_t>(right, vp->pos.x + vp->width);
+                    top = std::max<int16_t>(top, vp->pos.y);
+                    bottom = std::min<int16_t>(bottom, vp->pos.y + vp->height);
                     if (left < right && top < bottom)
                     {
                         auto width = right - left;

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -809,7 +809,7 @@ private:
             }
 
             w = it->get();
-            if (right <= w->x || bottom <= w->y)
+            if (right <= w->windowPos.x || bottom <= w->windowPos.y)
             {
                 continue;
             }
@@ -819,14 +819,14 @@ private:
                 continue;
             }
 
-            if (left >= w->x)
+            if (left >= w->windowPos.x)
             {
                 break;
             }
 
-            DrawRainWindow(rainDrawer, original_w, left, w->x, top, bottom, drawFunc);
+            DrawRainWindow(rainDrawer, original_w, left, w->windowPos.x, top, bottom, drawFunc);
 
-            left = w->x;
+            left = w->windowPos.x;
             DrawRainWindow(rainDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }
@@ -841,11 +841,11 @@ private:
             return;
         }
 
-        if (top < w->y)
+        if (top < w->windowPos.y)
         {
-            DrawRainWindow(rainDrawer, original_w, left, right, top, w->y, drawFunc);
+            DrawRainWindow(rainDrawer, original_w, left, right, top, w->windowPos.y, drawFunc);
 
-            top = w->y;
+            top = w->windowPos.y;
             DrawRainWindow(rainDrawer, original_w, left, right, top, bottom, drawFunc);
             return;
         }

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -497,8 +497,7 @@ public:
             auto zoomDifference = zoom - viewport->zoom;
 
             mainWindow->viewport_target_sprite = SPRITE_INDEX_NULL;
-            mainWindow->saved_view_x = viewPos.x;
-            mainWindow->saved_view_y = viewPos.y;
+            mainWindow->savedViewPos = viewPos;
             viewport->zoom = zoom;
             gCurrentRotation = rotation;
 
@@ -507,8 +506,8 @@ public:
                 viewport->view_width <<= zoomDifference;
                 viewport->view_height <<= zoomDifference;
             }
-            mainWindow->saved_view_x -= viewport->view_width >> 1;
-            mainWindow->saved_view_y -= viewport->view_height >> 1;
+            mainWindow->savedViewPos.x -= viewport->view_width >> 1;
+            mainWindow->savedViewPos.y -= viewport->view_height >> 1;
 
             // Make sure the viewport has correct coordinates set.
             viewport_update_position(mainWindow);

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -242,10 +242,9 @@ void InGameConsole::Update()
             rct_viewport* mainViewport = window_get_viewport(mainWindow);
             if (mainViewport != nullptr)
             {
-                if (_lastMainViewportX != mainViewport->viewPos.x || _lastMainViewportY != mainViewport->viewPos.y)
+                if (_lastMainViewport != mainViewport->viewPos)
                 {
-                    _lastMainViewportX = mainViewport->viewPos.x;
-                    _lastMainViewportY = mainViewport->viewPos.y;
+                    _lastMainViewport = mainViewport->viewPos;
 
                     gfx_invalidate_screen();
                 }

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -242,10 +242,10 @@ void InGameConsole::Update()
             rct_viewport* mainViewport = window_get_viewport(mainWindow);
             if (mainViewport != nullptr)
             {
-                if (_lastMainViewportX != mainViewport->view_x || _lastMainViewportY != mainViewport->view_y)
+                if (_lastMainViewportX != mainViewport->viewPos.x || _lastMainViewportY != mainViewport->viewPos.y)
                 {
-                    _lastMainViewportX = mainViewport->view_x;
-                    _lastMainViewportY = mainViewport->view_y;
+                    _lastMainViewportX = mainViewport->viewPos.x;
+                    _lastMainViewportY = mainViewport->viewPos.y;
 
                     gfx_invalidate_screen();
                 }

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <openrct2/interface/InteractiveConsole.h>
+#include <openrct2/world/Location.hpp>
 
 namespace OpenRCT2::Ui
 {
@@ -25,7 +26,7 @@ namespace OpenRCT2::Ui
 
         bool _isOpen = false;
         int32_t _consoleLeft, _consoleTop, _consoleRight, _consoleBottom;
-        int32_t _lastMainViewportX, _lastMainViewportY;
+        ScreenCoordsXY _lastMainViewport;
         std::deque<std::string> _consoleLines;
         utf8 _consoleCurrentLine[CONSOLE_INPUT_SIZE] = {};
         int32_t _consoleCaretTicks;

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -83,8 +83,8 @@ void land_tool_show_surface_style_dropdown(rct_window* w, rct_widget* widget, ui
     auto surfaceCount = itemIndex;
 
     window_dropdown_show_image(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top, w->colours[2], 0, surfaceCount, 47, 36,
-        gAppropriateImageDropdownItemsPerRow[surfaceCount]);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top, w->colours[2], 0,
+        surfaceCount, 47, 36, gAppropriateImageDropdownItemsPerRow[surfaceCount]);
 
     gDropdownDefaultIndex = defaultIndex;
 }
@@ -112,8 +112,8 @@ void land_tool_show_edge_style_dropdown(rct_window* w, rct_widget* widget, uint8
     auto edgeCount = itemIndex;
 
     window_dropdown_show_image(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top, w->colours[2], 0, edgeCount, 47, 36,
-        gAppropriateImageDropdownItemsPerRow[edgeCount]);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top, w->colours[2], 0, edgeCount,
+        47, 36, gAppropriateImageDropdownItemsPerRow[edgeCount]);
 
     gDropdownDefaultIndex = defaultIndex;
 }

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -627,8 +627,8 @@ static Peep* viewport_interaction_get_closest_peep(ScreenCoordsXY screenCoords, 
     if (viewport == nullptr || viewport->zoom >= 2)
         return nullptr;
 
-    screenCoords.x = ((screenCoords.x - viewport->x) << viewport->zoom) + viewport->view_x;
-    screenCoords.y = ((screenCoords.y - viewport->y) << viewport->zoom) + viewport->view_y;
+    screenCoords.x = ((screenCoords.x - viewport->pos.x) << viewport->zoom) + viewport->viewPos.x;
+    screenCoords.y = ((screenCoords.y - viewport->pos.y) << viewport->zoom) + viewport->viewPos.y;
 
     closestPeep = nullptr;
     closestDistance = 0xFFFF;

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -116,10 +116,10 @@ static void widget_frame_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     //
     uint8_t press = ((w->flags & WF_10) ? INSET_RECT_FLAG_FILL_MID_LIGHT : 0);
@@ -137,8 +137,8 @@ static void widget_frame_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         return;
 
     // Draw the resize sprite at the bottom right corner
-    l = w->x + widget->right - 18;
-    t = w->y + widget->bottom - 18;
+    l = w->windowPos.x + widget->right - 18;
+    t = w->windowPos.y + widget->bottom - 18;
     gfx_draw_sprite(dpi, SPR_RESIZE | IMAGE_TYPE_REMAP | ((colour & 0x7F) << 19), l, t, 0);
 }
 
@@ -152,10 +152,10 @@ static void widget_resize_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -170,8 +170,8 @@ static void widget_resize_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
         return;
 
     // Draw the resize sprite at the bottom right corner
-    l = w->x + widget->right - 18;
-    t = w->y + widget->bottom - 18;
+    l = w->windowPos.x + widget->right - 18;
+    t = w->windowPos.y + widget->bottom - 18;
     gfx_draw_sprite(dpi, SPR_RESIZE | IMAGE_TYPE_REMAP | ((colour & 0x7F) << 19), l, t, 0);
 }
 
@@ -185,10 +185,10 @@ static void widget_button_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Check if the button is pressed down
     uint8_t press = widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET
@@ -240,8 +240,8 @@ static void widget_tab_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
     }
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
 
     // Get the colour and disabled image
     uint8_t colour = w->colours[widget->colour] & 0x7F;
@@ -267,10 +267,10 @@ static void widget_flat_button_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_w
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -303,10 +303,10 @@ static void widget_text_button(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -346,20 +346,20 @@ static void widget_text_centred(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t r = w->x + widget->right;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t r = w->windowPos.x + widget->right;
     int32_t t;
 
     if (widget->type == WWT_BUTTON || widget->type == WWT_TABLE_HEADER)
     {
         int32_t height = (widget->bottom - widget->top);
         if (height >= 10)
-            t = w->y + std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
+            t = w->windowPos.y + std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
         else
-            t = w->y + widget->top - 1;
+            t = w->windowPos.y + widget->top - 1;
     }
     else
-        t = w->y + widget->top;
+        t = w->windowPos.y + widget->top;
 
     gfx_draw_string_centred_clipped(
         dpi, widget->text, gCommonFormatArgs, colour, (l + r + 1) / 2 - 1, t, widget->right - widget->left - 2);
@@ -383,20 +383,20 @@ static void widget_text(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex w
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t r = w->x + widget->right;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t r = w->windowPos.x + widget->right;
     int32_t t;
 
     if (widget->type == WWT_BUTTON || widget->type == WWT_TABLE_HEADER)
     {
         int32_t height = (widget->bottom - widget->top);
         if (height >= 10)
-            t = w->y + std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
+            t = w->windowPos.y + std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
         else
-            t = w->y + widget->top - 1;
+            t = w->windowPos.y + widget->top - 1;
     }
     else
-        t = w->y + widget->top;
+        t = w->windowPos.y + widget->top;
 
     gfx_draw_string_left_clipped(dpi, widget->text, gCommonFormatArgs, colour, l + 1, t, r - l);
 }
@@ -411,10 +411,10 @@ static void widget_text_inset(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -433,10 +433,10 @@ static void widget_groupbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left + 5;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left + 5;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
     int32_t textRight = l;
 
     // Text
@@ -456,10 +456,10 @@ static void widget_groupbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
 
     // Border
     // Resolve the absolute ltrb
-    l = w->x + widget->left;
-    t = w->y + widget->top + 4;
-    r = w->x + widget->right;
-    b = w->y + widget->bottom;
+    l = w->windowPos.x + widget->left;
+    t = w->windowPos.y + widget->top + 4;
+    r = w->windowPos.x + widget->right;
+    b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour] & 0x7F;
@@ -495,10 +495,10 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -519,8 +519,8 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
     if (widget->text == STR_NONE)
         return;
 
-    l = widget->left + w->x + 2;
-    t = widget->top + w->y + 1;
+    l = widget->left + w->windowPos.x + 2;
+    t = widget->top + w->windowPos.y + 1;
     int32_t width = widget->right - widget->left - 4;
     if ((widget + 1)->type == WWT_CLOSEBOX)
     {
@@ -542,10 +542,10 @@ static void widget_closebox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Check if the button is pressed down
     uint8_t press = 0;
@@ -563,8 +563,8 @@ static void widget_closebox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (widget->text == STR_NONE)
         return;
 
-    l = w->x + (widget->left + widget->right) / 2 - 1;
-    t = w->y + std::max<int32_t>(widget->top, (widget->top + widget->bottom) / 2 - 5);
+    l = w->windowPos.x + (widget->left + widget->right) / 2 - 1;
+    t = w->windowPos.y + std::max<int32_t>(widget->top, (widget->top + widget->bottom) / 2 - 5);
 
     if (widget_is_disabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
@@ -582,9 +582,9 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t b = w->windowPos.y + widget->bottom;
     int32_t yMid = (b + t) / 2;
 
     // Get the colour
@@ -624,10 +624,10 @@ static void widget_scroll_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     rct_scroll* scroll = &w->scrolls[scrollIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -764,8 +764,8 @@ static void widget_draw_image(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         return;
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
 
     // Get the colour
     uint8_t colour = NOT_TRANSLUCENT(w->colours[widget->colour]);
@@ -881,12 +881,12 @@ void widget_scroll_get_part(
         }
     }
 
-    if ((w->scrolls[*scroll_id].flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w->y + widget->bottom - 11))
+    if ((w->scrolls[*scroll_id].flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w->windowPos.y + widget->bottom - 11))
     {
         // horizontal scrollbar
         int32_t rightOffset = 0;
-        int32_t iteratorLeft = widget->left + w->x + 10;
-        int32_t iteratorRight = widget->right + w->x - 10;
+        int32_t iteratorLeft = widget->left + w->windowPos.x + 10;
+        int32_t iteratorRight = widget->right + w->windowPos.x - 10;
         if (!(w->scrolls[*scroll_id].flags & VSCROLLBAR_VISIBLE))
         {
             rightOffset = 11;
@@ -904,11 +904,11 @@ void widget_scroll_get_part(
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT;
         }
-        else if (screenCoords.x < (widget->left + w->x + w->scrolls[*scroll_id].h_thumb_left))
+        else if (screenCoords.x < (widget->left + w->windowPos.x + w->scrolls[*scroll_id].h_thumb_left))
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_LEFT_TROUGH;
         }
-        else if (screenCoords.x > (widget->left + w->x + w->scrolls[*scroll_id].h_thumb_right))
+        else if (screenCoords.x > (widget->left + w->windowPos.x + w->scrolls[*scroll_id].h_thumb_right))
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH;
         }
@@ -917,12 +917,12 @@ void widget_scroll_get_part(
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_THUMB;
         }
     }
-    else if ((w->scrolls[*scroll_id].flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w->x + widget->right - 11))
+    else if ((w->scrolls[*scroll_id].flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w->windowPos.x + widget->right - 11))
     {
         // vertical scrollbar
         int32_t bottomOffset = 0;
-        int32_t iteratorTop = widget->top + w->y + 10;
-        int32_t iteratorBottom = widget->bottom + w->y;
+        int32_t iteratorTop = widget->top + w->windowPos.y + 10;
+        int32_t iteratorBottom = widget->bottom + w->windowPos.y;
         if (w->scrolls[*scroll_id].flags & HSCROLLBAR_VISIBLE)
         {
             bottomOffset = 11;
@@ -940,11 +940,11 @@ void widget_scroll_get_part(
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM;
         }
-        else if (screenCoords.y < (widget->top + w->y + w->scrolls[*scroll_id].v_thumb_top))
+        else if (screenCoords.y < (widget->top + w->windowPos.y + w->scrolls[*scroll_id].v_thumb_top))
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_TOP_TROUGH;
         }
-        else if (screenCoords.y > (widget->top + w->y + w->scrolls[*scroll_id].v_thumb_bottom))
+        else if (screenCoords.y > (widget->top + w->windowPos.y + w->scrolls[*scroll_id].v_thumb_bottom))
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH;
         }
@@ -959,8 +959,7 @@ void widget_scroll_get_part(
         *output_scroll_area = SCROLL_PART_VIEW;
         retScreenCoords.x = screenCoords.x - widget->left;
         retScreenCoords.y = screenCoords.y - widget->top;
-        retScreenCoords.x -= w->x;
-        retScreenCoords.y -= w->y;
+        retScreenCoords -= w->windowPos;
         if (retScreenCoords.x <= 0 || retScreenCoords.y <= 0)
         {
             *output_scroll_area = SCROLL_PART_NONE;
@@ -1005,10 +1004,10 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->x + widget->left;
-    int32_t t = w->y + widget->top;
-    int32_t r = w->x + widget->right;
-    int32_t b = w->y + widget->bottom;
+    int32_t l = w->windowPos.x + widget->left;
+    int32_t t = w->windowPos.y + widget->top;
+    int32_t r = w->windowPos.x + widget->right;
+    int32_t b = w->windowPos.y + widget->bottom;
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -38,13 +38,13 @@ static bool window_fits_between_others(int32_t x, int32_t y, int32_t width, int3
         if (w->flags & WF_STICK_TO_BACK)
             continue;
 
-        if (x + width <= w->x)
+        if (x + width <= w->windowPos.x)
             continue;
-        if (x >= w->x + w->width)
+        if (x >= w->windowPos.x + w->width)
             continue;
-        if (y + height <= w->y)
+        if (y + height <= w->windowPos.y)
             continue;
-        if (y >= w->y + w->height)
+        if (y >= w->windowPos.y + w->height)
             continue;
         return false;
     }
@@ -145,8 +145,7 @@ rct_window* window_create(
     }
 
     w->number = 0;
-    w->x = screenCoords.x;
-    w->y = screenCoords.y;
+    w->windowPos = screenCoords;
     w->width = width;
     w->height = height;
     w->viewport = nullptr;
@@ -227,43 +226,43 @@ rct_window* window_create_auto_pos(
         if (w->flags & WF_STICK_TO_BACK)
             continue;
 
-        x = w->x + w->width + 2;
-        y = w->y;
+        x = w->windowPos.x + w->width + 2;
+        y = w->windowPos.y;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x - w->width - 2;
-        y = w->y;
+        x = w->windowPos.x - w->width - 2;
+        y = w->windowPos.y;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x;
-        y = w->y + w->height + 2;
+        x = w->windowPos.x;
+        y = w->windowPos.y + w->height + 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x;
-        y = w->y - w->height - 2;
+        x = w->windowPos.x;
+        y = w->windowPos.y - w->height - 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x + w->width + 2;
-        y = w->y - w->height - 2;
+        x = w->windowPos.x + w->width + 2;
+        y = w->windowPos.y - w->height - 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x - w->width - 2;
-        y = w->y - w->height - 2;
+        x = w->windowPos.x - w->width - 2;
+        y = w->windowPos.y - w->height - 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x + w->width + 2;
-        y = w->y + w->height + 2;
+        x = w->windowPos.x + w->width + 2;
+        y = w->windowPos.y + w->height + 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
 
-        x = w->x - w->width - 2;
-        y = w->y + w->height + 2;
+        x = w->windowPos.x - w->width - 2;
+        y = w->windowPos.y + w->height + 2;
         if (window_fits_within_space(x, y, width, height))
             goto foundSpace;
     }
@@ -274,23 +273,23 @@ rct_window* window_create_auto_pos(
         if (w->flags & WF_STICK_TO_BACK)
             continue;
 
-        x = w->x + w->width + 2;
-        y = w->y;
+        x = w->windowPos.x + w->width + 2;
+        y = w->windowPos.y;
         if (window_fits_on_screen(x, y, width, height))
             goto foundSpace;
 
-        x = w->x - w->width - 2;
-        y = w->y;
+        x = w->windowPos.x - w->width - 2;
+        y = w->windowPos.y;
         if (window_fits_on_screen(x, y, width, height))
             goto foundSpace;
 
-        x = w->x;
-        y = w->y + w->height + 2;
+        x = w->windowPos.x;
+        y = w->windowPos.y + w->height + 2;
         if (window_fits_on_screen(x, y, width, height))
             goto foundSpace;
 
-        x = w->x;
-        y = w->y - w->height - 2;
+        x = w->windowPos.x;
+        y = w->windowPos.y - w->height - 2;
         if (window_fits_on_screen(x, y, width, height))
             goto foundSpace;
     }
@@ -300,7 +299,7 @@ rct_window* window_create_auto_pos(
     y = 30;
     for (auto& w : g_window_list)
     {
-        if (x == w->x && y == w->y)
+        if (x == w->windowPos.x && y == w->windowPos.y)
         {
             x += 5;
             y += 5;
@@ -639,7 +638,8 @@ void window_draw_widgets(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widgetindex widgetIndex;
 
     if ((w->flags & WF_TRANSPARENT) && !(w->flags & WF_NO_BACKGROUND))
-        gfx_filter_rect(dpi, w->x, w->y, w->x + w->width - 1, w->y + w->height - 1, PALETTE_51);
+        gfx_filter_rect(
+            dpi, w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y + w->height - 1, PALETTE_51);
 
     // todo: some code missing here? Between 006EB18C and 006EB260
 
@@ -647,8 +647,8 @@ void window_draw_widgets(rct_window* w, rct_drawpixelinfo* dpi)
     for (widget = w->widgets; widget->type != WWT_LAST; widget++)
     {
         // Check if widget is outside the draw region
-        if (w->x + widget->left < dpi->x + dpi->width && w->x + widget->right >= dpi->x)
-            if (w->y + widget->top < dpi->y + dpi->height && w->y + widget->bottom >= dpi->y)
+        if (w->windowPos.x + widget->left < dpi->x + dpi->width && w->windowPos.x + widget->right >= dpi->x)
+            if (w->windowPos.y + widget->top < dpi->y + dpi->height && w->windowPos.y + widget->bottom >= dpi->y)
                 widget_draw(dpi, w, widgetIndex);
 
         widgetIndex++;
@@ -659,7 +659,8 @@ void window_draw_widgets(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->flags & WF_WHITE_BORDER_MASK)
     {
         gfx_fill_rect_inset(
-            dpi, w->x, w->y, w->x + w->width - 1, w->y + w->height - 1, COLOUR_WHITE, INSET_RECT_FLAG_FILL_NONE);
+            dpi, w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y + w->height - 1, COLOUR_WHITE,
+            INSET_RECT_FLAG_FILL_NONE);
     }
 }
 
@@ -679,7 +680,7 @@ static void window_invalidate_pressed_image_buttons(rct_window* w)
             continue;
 
         if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex))
-            gfx_set_dirty_blocks(w->x, w->y, w->x + w->width, w->y + w->height);
+            gfx_set_dirty_blocks(w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width, w->windowPos.y + w->height);
     }
 }
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -133,8 +133,6 @@ rct_window* window_create(
 
     // Setup window
     w->classification = cls;
-    w->var_4B8 = -1;
-    w->var_4B9 = -1;
     w->flags = flags;
 
     // Play sounds and flash the window

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -204,9 +204,10 @@ static void window_about_openrct2_common_paint(rct_window* w, rct_drawpixelinfo*
 
     int32_t x1, x2, y;
 
-    x1 = w->x + (&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->left + 45;
-    x2 = w->x + (&w->widgets[WIDX_TAB_ABOUT_RCT2])->left + 45;
-    y = w->y + (((&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->top + (&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->bottom) / 2) - 3;
+    x1 = w->windowPos.x + (&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->left + 45;
+    x2 = w->windowPos.x + (&w->widgets[WIDX_TAB_ABOUT_RCT2])->left + 45;
+    y = w->windowPos.y + (((&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->top + (&w->widgets[WIDX_TAB_ABOUT_OPENRCT2])->bottom) / 2)
+        - 3;
 
     set_format_arg(0, rct_string_id, STR_TITLE_SEQUENCE_OPENRCT2);
     gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x1, y, 87, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_AQUAMARINE);
@@ -224,8 +225,8 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
-    x = w->x + (w->width / 2);
-    y = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight;
+    x = w->windowPos.x + (w->width / 2);
+    y = w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight;
     width = w->width - 20;
 
     y += gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, width, STR_ABOUT_OPENRCT2_DESCRIPTION, w->colours[2]) + lineHeight;
@@ -249,7 +250,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     utf8 buffer[256];
     utf8* ch = buffer;
     openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
-    gfx_draw_string_centred_wrapped(dpi, &ch, x, w->y + WH - 25, width, STR_STRING, w->colours[2]);
+    gfx_draw_string_centred_wrapped(dpi, &ch, x, w->windowPos.y + WH - 25, width, STR_STRING, w->colours[2]);
 }
 
 #pragma endregion OpenRCT2
@@ -287,9 +288,9 @@ static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     window_about_openrct2_common_paint(w, dpi);
 
-    yPage = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + 5;
+    yPage = w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + 5;
 
-    x = w->x + 200;
+    x = w->windowPos.x + 200;
     y = yPage + 5;
 
     int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
@@ -314,7 +315,7 @@ static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string_centred(dpi, STR_LICENSED_TO_INFOGRAMES_INTERACTIVE_INC, x, y, COLOUR_BLACK, nullptr);
 
     // Images
-    gfx_draw_sprite(dpi, SPR_CREDITS_CHRIS_SAWYER_SMALL, w->x + 92, yPage + 24, 0);
+    gfx_draw_sprite(dpi, SPR_CREDITS_CHRIS_SAWYER_SMALL, w->windowPos.x + 92, yPage + 24, 0);
 
     // Licence
 }

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -133,10 +133,9 @@ rct_window* window_banner_open(rct_windownumber number)
     window_init_scroll_widgets(w);
 
     auto banner = GetBanner(w->number);
-    int32_t view_x = banner->position.x << 5;
-    int32_t view_y = banner->position.y << 5;
+    auto bannerViewPos = banner->position.ToCoordsXY().ToTileCentre();
 
-    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
+    TileElement* tile_element = map_get_first_element_at(bannerViewPos);
     if (tile_element == nullptr)
         return nullptr;
     while (1)
@@ -152,14 +151,12 @@ rct_window* window_banner_open(rct_windownumber number)
     int32_t view_z = tile_element->GetBaseZ();
     w->frame_no = view_z;
 
-    view_x += 16;
-    view_y += 16;
-
     // Create viewport
     viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1, (viewportWidget->right - viewportWidget->left) - 2,
-        (viewportWidget->bottom - viewportWidget->top) - 2, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
+        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        (viewportWidget->right - viewportWidget->left) - 2, (viewportWidget->bottom - viewportWidget->top) - 2, 0,
+        { bannerViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
     w->Invalidate();
@@ -347,15 +344,14 @@ static void window_banner_viewport_rotate(rct_window* w)
 
     auto banner = GetBanner(w->number);
 
-    int32_t view_x = (banner->position.x << 5) + 16;
-    int32_t view_y = (banner->position.y << 5) + 16;
-    int32_t view_z = w->frame_no;
+    auto bannerViewPos = CoordsXYZ{ banner->position.ToCoordsXY().ToTileCentre(), w->frame_no };
 
     // Create viewport
     rct_widget* viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1, (viewportWidget->right - viewportWidget->left) - 1,
-        (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
+        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
+        bannerViewPos, 0, SPRITE_INDEX_NULL);
 
     if (w->viewport != nullptr)
         w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -154,7 +154,7 @@ rct_window* window_banner_open(rct_windownumber number)
     // Create viewport
     viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         (viewportWidget->right - viewportWidget->left) - 2, (viewportWidget->bottom - viewportWidget->top) - 2, 0,
         { bannerViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 
@@ -236,7 +236,7 @@ static void window_banner_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
             widget--;
 
             window_dropdown_show_text_custom_width(
-                widget->left + w->x, widget->top + w->y, widget->bottom - widget->top + 1, w->colours[1], 0,
+                widget->left + w->windowPos.x, widget->top + w->windowPos.y, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, 13, widget->right - widget->left - 3);
 
             dropdown_set_checked(banner->text_colour - 1, true);
@@ -349,7 +349,7 @@ static void window_banner_viewport_rotate(rct_window* w)
     // Create viewport
     rct_widget* viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
         bannerViewPos, 0, SPRITE_INDEX_NULL);
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -734,8 +734,9 @@ static void window_cheats_misc_mousedown(rct_window* w, rct_widgetindex widgetIn
                 gDropdownItemsArgs[i] = WeatherTypes[i];
             }
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 6, dropdownWidget->right - dropdownWidget->left - 3);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 6,
+                dropdownWidget->right - dropdownWidget->left - 3);
 
             currentWeather = gClimateCurrent.Weather;
             dropdown_set_checked(currentWeather, true);
@@ -754,8 +755,9 @@ static void window_cheats_misc_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 3, dropdownWidget->right - dropdownWidget->left - 3);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 3,
+                dropdownWidget->right - dropdownWidget->left - 3);
             dropdown_set_checked(_selectedStaffSpeed, true);
         }
     }
@@ -1190,36 +1192,56 @@ static void window_cheats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         }
         int32_t actual_month = _monthSpinnerValue - 1;
         gfx_draw_string_left(
-            dpi, STR_BOTTOM_TOOLBAR_CASH, gCommonFormatArgs, colour, w->x + XPL(0) + TXTO, w->y + YPL(2) + TXTO);
-        gfx_draw_string_left(dpi, STR_YEAR, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(7) + TXTO);
-        gfx_draw_string_left(dpi, STR_MONTH, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(8) + TXTO);
-        gfx_draw_string_left(dpi, STR_DAY, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(9) + TXTO);
+            dpi, STR_BOTTOM_TOOLBAR_CASH, gCommonFormatArgs, colour, w->windowPos.x + XPL(0) + TXTO,
+            w->windowPos.y + YPL(2) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_YEAR, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(7) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_MONTH, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(8) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_DAY, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(9) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_yearSpinnerValue, w->colours[1], w->x + WPL(1) - 34 - TXTO, w->y + YPL(7) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_yearSpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
+            w->windowPos.y + YPL(7) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_MONTH, &actual_month, w->colours[1], w->x + WPL(1) - 34 - TXTO, w->y + YPL(8) + TXTO);
+            dpi, STR_FORMAT_MONTH, &actual_month, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
+            w->windowPos.y + YPL(8) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_daySpinnerValue, w->colours[1], w->x + WPL(1) - 34 - TXTO, w->y + YPL(9) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_daySpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
+            w->windowPos.y + YPL(9) + TXTO);
     }
     else if (w->page == WINDOW_CHEATS_PAGE_MISC)
     {
-        gfx_draw_string_left(dpi, STR_CHEAT_STAFF_SPEED, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(17) + TXTO);
-        gfx_draw_string_left(dpi, STR_FORCE_WEATHER, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(10) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_STAFF_SPEED, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(17) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_FORCE_WEATHER, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(10) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_parkRatingSpinnerValue, w->colours[1], w->x + WPL(1) - 34 - TXTO, w->y + YPL(5) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_parkRatingSpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
+            w->windowPos.y + YPL(5) + TXTO);
     }
     else if (w->page == WINDOW_CHEATS_PAGE_GUESTS)
     {
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_HAPPINESS, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(1) + TXTO);
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_ENERGY, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(2) + TXTO);
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_HUNGER, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(3) + TXTO);
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_THIRST, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(4) + TXTO);
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_NAUSEA, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(5) + TXTO);
         gfx_draw_string_left(
-            dpi, STR_CHEAT_GUEST_NAUSEA_TOLERANCE, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(6) + TXTO);
-        gfx_draw_string_left(dpi, STR_CHEAT_GUEST_BATHROOM, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(7) + TXTO);
+            dpi, STR_CHEAT_GUEST_HAPPINESS, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO,
+            w->windowPos.y + YPL(1) + TXTO);
         gfx_draw_string_left(
-            dpi, STR_CHEAT_GUEST_PREFERRED_INTENSITY, nullptr, COLOUR_BLACK, w->x + XPL(0) + TXTO, w->y + YPL(8) + TXTO);
+            dpi, STR_CHEAT_GUEST_ENERGY, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(2) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_HUNGER, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(3) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_THIRST, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(4) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_NAUSEA, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(5) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_NAUSEA_TOLERANCE, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO,
+            w->windowPos.y + YPL(6) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_BATHROOM, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO,
+            w->windowPos.y + YPL(7) + TXTO);
+        gfx_draw_string_left(
+            dpi, STR_CHEAT_GUEST_PREFERRED_INTENSITY, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO,
+            w->windowPos.y + YPL(8) + TXTO);
     }
 }
 
@@ -1233,7 +1255,8 @@ static void window_cheats_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_FINANCES_SUMMARY_0;
         if (w->page == WINDOW_CHEATS_PAGE_MONEY)
             sprite_idx += (w->frame_no / 2) % 8;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_1].left, w->y + w->widgets[WIDX_TAB_1].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_1].left, w->windowPos.y + w->widgets[WIDX_TAB_1].top, 0);
     }
 
     // Guests tab
@@ -1242,14 +1265,16 @@ static void window_cheats_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_GUESTS_0;
         if (w->page == WINDOW_CHEATS_PAGE_GUESTS)
             sprite_idx += (w->frame_no / 3) % 8;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_2].left, w->y + w->widgets[WIDX_TAB_2].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_2].left, w->windowPos.y + w->widgets[WIDX_TAB_2].top, 0);
     }
 
     // Misc tab
     if (!(w->disabled_widgets & (1 << WIDX_TAB_3)))
     {
         sprite_idx = SPR_TAB_PARK;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_3].left, w->y + w->widgets[WIDX_TAB_3].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_3].left, w->windowPos.y + w->widgets[WIDX_TAB_3].top, 0);
     }
 
     // Rides tab
@@ -1258,7 +1283,8 @@ static void window_cheats_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_RIDE_0;
         if (w->page == WINDOW_CHEATS_PAGE_RIDES)
             sprite_idx += (w->frame_no / 4) % 16;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_4].left, w->y + w->widgets[WIDX_TAB_4].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_4].left, w->windowPos.y + w->widgets[WIDX_TAB_4].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -238,8 +238,10 @@ static void window_clear_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
 
     // Draw number for tool sizes bigger than 7
-    x = w->x + (window_clear_scenery_widgets[WIDX_PREVIEW].left + window_clear_scenery_widgets[WIDX_PREVIEW].right) / 2;
-    y = w->y + (window_clear_scenery_widgets[WIDX_PREVIEW].top + window_clear_scenery_widgets[WIDX_PREVIEW].bottom) / 2;
+    x = w->windowPos.x
+        + (window_clear_scenery_widgets[WIDX_PREVIEW].left + window_clear_scenery_widgets[WIDX_PREVIEW].right) / 2;
+    y = w->windowPos.y
+        + (window_clear_scenery_widgets[WIDX_PREVIEW].top + window_clear_scenery_widgets[WIDX_PREVIEW].bottom) / 2;
     if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
@@ -248,8 +250,9 @@ static void window_clear_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw cost amount
     if (gClearSceneryCost != MONEY32_UNDEFINED && gClearSceneryCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        x = (window_clear_scenery_widgets[WIDX_PREVIEW].left + window_clear_scenery_widgets[WIDX_PREVIEW].right) / 2 + w->x;
-        y = window_clear_scenery_widgets[WIDX_PREVIEW].bottom + w->y + 5 + 27;
+        x = (window_clear_scenery_widgets[WIDX_PREVIEW].left + window_clear_scenery_widgets[WIDX_PREVIEW].right) / 2
+            + w->windowPos.x;
+        y = window_clear_scenery_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 5 + 27;
         gfx_draw_string_centred(dpi, STR_COST_AMOUNT, x, y, COLOUR_BLACK, &gClearSceneryCost);
     }
 }

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -138,7 +138,7 @@ static void custom_currency_window_mousedown(rct_window* w, rct_widgetindex widg
             gDropdownItemsArgs[1] = STR_SUFFIX;
 
             window_dropdown_show_text_custom_width(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, 2, widget->right - widget->left - 3);
 
             if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CURRENCY_PREFIX)
@@ -237,8 +237,8 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     window_draw_widgets(w, dpi);
 
-    x = w->x + 10;
-    y = w->y + 30;
+    x = w->windowPos.x + 10;
+    y = w->windowPos.y + 30;
 
     gfx_draw_string_left(dpi, STR_RATE, nullptr, w->colours[1], x, y);
 
@@ -252,19 +252,19 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     gfx_draw_string(
         dpi, CurrencyDescriptors[CURRENCY_CUSTOM].symbol_unicode, w->colours[1],
-        w->x + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1,
-        w->y + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].top);
+        w->windowPos.x + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1,
+        w->windowPos.y + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].top);
 
     if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CURRENCY_PREFIX)
     {
         gfx_draw_string_left(
-            dpi, STR_PREFIX, w, w->colours[1], w->x + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
-            w->y + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top);
+            dpi, STR_PREFIX, w, w->colours[1], w->windowPos.x + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
+            w->windowPos.y + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top);
     }
     else
     {
         gfx_draw_string_left(
-            dpi, STR_SUFFIX, w, w->colours[1], w->x + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
-            w->y + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top);
+            dpi, STR_SUFFIX, w, w->colours[1], w->windowPos.x + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
+            w->windowPos.y + window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top);
     }
 }

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -127,7 +127,7 @@ rct_window* window_ride_demolish_prompt_open(Ride* ride)
     w = window_find_by_class(WC_DEMOLISH_RIDE_PROMPT);
     if (w != nullptr)
     {
-        auto windowPos = ScreenCoordsXY{ w->x, w->y };
+        auto windowPos = w->windowPos;
         window_close(w);
         w = window_create(windowPos, WW, WH, &window_ride_demolish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
@@ -152,7 +152,7 @@ rct_window* window_ride_refurbish_prompt_open(Ride* ride)
     w = window_find_by_class(WC_DEMOLISH_RIDE_PROMPT);
     if (w != nullptr)
     {
-        auto windowPos = ScreenCoordsXY{ w->x, w->y };
+        auto windowPos = w->windowPos;
         window_close(w);
         w = window_create(windowPos, WW, WH, &window_ride_refurbish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
@@ -223,8 +223,8 @@ static void window_ride_demolish_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs);
         set_format_arg(nameArgLen, money32, _demolishRideCost);
 
-        int32_t x = w->x + WW / 2;
-        int32_t y = w->y + (WH / 2) - 3;
+        int32_t x = w->windowPos.x + WW / 2;
+        int32_t y = w->windowPos.y + (WH / 2) - 3;
         gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, stringId, COLOUR_BLACK);
     }
 }
@@ -240,8 +240,8 @@ static void window_ride_refurbish_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs);
         set_format_arg(nameArgLen, money32, _demolishRideCost / 2);
 
-        int32_t x = w->x + WW / 2;
-        int32_t y = w->y + (WH / 2) - 3;
+        int32_t x = w->windowPos.x + WW / 2;
+        int32_t y = w->windowPos.y + (WH / 2) - 3;
         gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, stringId, COLOUR_BLACK);
     }
 }

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -331,8 +331,8 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         if (gDropdownItemsFormat[i] == DROPDOWN_SEPARATOR)
         {
-            l = w->x + 2 + (cell_x * _dropdown_item_width);
-            t = w->y + 2 + (cell_y * _dropdown_item_height);
+            l = w->windowPos.x + 2 + (cell_x * _dropdown_item_width);
+            t = w->windowPos.y + 2 + (cell_y * _dropdown_item_height);
             r = l + _dropdown_item_width - 1;
             t += (_dropdown_item_height / 2);
             b = t;
@@ -354,8 +354,8 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
             //
             if (i == highlightedIndex)
             {
-                l = w->x + 2 + (cell_x * _dropdown_item_width);
-                t = w->y + 2 + (cell_y * _dropdown_item_height);
+                l = w->windowPos.x + 2 + (cell_x * _dropdown_item_width);
+                t = w->windowPos.y + 2 + (cell_y * _dropdown_item_height);
                 r = l + _dropdown_item_width - 1;
                 b = t + _dropdown_item_height - 1;
                 gfx_filter_rect(dpi, l, t, r, b, PALETTE_DARKEN_3);
@@ -370,7 +370,8 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     image++;
 
                 gfx_draw_sprite(
-                    dpi, image, w->x + 2 + (cell_x * _dropdown_item_width), w->y + 2 + (cell_y * _dropdown_item_height), 0);
+                    dpi, image, w->windowPos.x + 2 + (cell_x * _dropdown_item_width),
+                    w->windowPos.y + 2 + (cell_y * _dropdown_item_height), 0);
             }
             else
             {
@@ -393,8 +394,8 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Draw item string
                 gfx_draw_string_left_clipped(
-                    dpi, item, (void*)(&gDropdownItemsArgs[i]), colour, w->x + 2 + (cell_x * _dropdown_item_width),
-                    w->y + 2 + (cell_y * _dropdown_item_height), w->width - 5);
+                    dpi, item, (void*)(&gDropdownItemsArgs[i]), colour, w->windowPos.x + 2 + (cell_x * _dropdown_item_width),
+                    w->windowPos.y + 2 + (cell_y * _dropdown_item_height), w->width - 5);
             }
         }
     }
@@ -406,11 +407,11 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 int32_t dropdown_index_from_point(int32_t x, int32_t y, rct_window* w)
 {
-    int32_t top = y - w->y - 2;
+    int32_t top = y - w->windowPos.y - 2;
     if (top < 0)
         return -1;
 
-    int32_t left = x - w->x;
+    int32_t left = x - w->windowPos.x;
     if (left >= w->width)
         return -1;
     left -= 2;
@@ -455,8 +456,8 @@ void window_dropdown_show_colour(rct_window* w, rct_widget* widget, uint8_t drop
 
     // Show dropdown
     window_dropdown_show_image(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, dropdownColour, DROPDOWN_FLAG_STAY_OPEN,
-        COLOUR_COUNT, 12, 12, gAppropriateImageDropdownItemsPerRow[COLOUR_COUNT]);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, dropdownColour,
+        DROPDOWN_FLAG_STAY_OPEN, COLOUR_COUNT, 12, 12, gAppropriateImageDropdownItemsPerRow[COLOUR_COUNT]);
 
     gDropdownIsColour = true;
     gDropdownLastColourHover = -1;

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -419,19 +419,19 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (drawPreviousButton)
         {
             gfx_filter_rect(
-                dpi, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + w->y,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].bottom + w->y, PALETTE_51);
+                dpi, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + w->windowPos.y,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].bottom + w->windowPos.y, PALETTE_51);
         }
 
         if ((drawPreviousButton || drawNextButton) && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         {
             gfx_filter_rect(
-                dpi, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + w->y,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].bottom + w->y, PALETTE_51);
+                dpi, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + w->windowPos.y,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].bottom + w->windowPos.y, PALETTE_51);
         }
     }
 
@@ -442,26 +442,28 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (drawPreviousButton)
         {
             gfx_fill_rect_inset(
-                dpi, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + 1 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 1 + w->y,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right - 1 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].bottom - 1 + w->y, w->colours[1], INSET_RECT_F_30);
+                dpi, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + 1 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 1 + w->windowPos.y,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right - 1 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].bottom - 1 + w->windowPos.y, w->colours[1],
+                INSET_RECT_F_30);
         }
 
         if ((drawPreviousButton || drawNextButton) && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         {
             gfx_fill_rect_inset(
-                dpi, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left + 1 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 1 + w->y,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right - 1 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].bottom - 1 + w->y, w->colours[1], INSET_RECT_F_30);
+                dpi, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left + 1 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 1 + w->windowPos.y,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right - 1 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].bottom - 1 + w->windowPos.y, w->colours[1],
+                INSET_RECT_F_30);
         }
 
         int16_t stateX = (window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right
                           + window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left)
                 / 2
-            + w->x;
-        int16_t stateY = w->height - 0x0C + w->y;
+            + w->windowPos.x;
+        int16_t stateY = w->height - 0x0C + w->windowPos.y;
         gfx_draw_string_centred(
             dpi, EditorStepNames[gS6Info.editor_step], stateX, stateY, NOT_TRANSLUCENT(w->colours[2]) | COLOUR_FLAG_OUTLINE,
             nullptr);
@@ -469,8 +471,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (drawPreviousButton)
         {
             gfx_draw_sprite(
-                dpi, SPR_PREVIOUS, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + 6 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 6 + w->y, 0);
+                dpi, SPR_PREVIOUS, window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + 6 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 6 + w->windowPos.y, 0);
 
             int32_t textColour = NOT_TRANSLUCENT(w->colours[1]);
             if (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR
@@ -482,8 +484,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int16_t textX = (window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].left + 30
                              + window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].right)
                     / 2
-                + w->x;
-            int16_t textY = window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 6 + w->y;
+                + w->windowPos.x;
+            int16_t textY = window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 6 + w->windowPos.y;
 
             rct_string_id stringId = EditorStepNames[gS6Info.editor_step - 1];
             if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
@@ -496,8 +498,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if ((drawPreviousButton || drawNextButton) && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         {
             gfx_draw_sprite(
-                dpi, SPR_NEXT, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right - 29 + w->x,
-                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 6 + w->y, 0);
+                dpi, SPR_NEXT, window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right - 29 + w->windowPos.x,
+                window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 6 + w->windowPos.y, 0);
 
             int32_t textColour = NOT_TRANSLUCENT(w->colours[1]);
 
@@ -509,8 +511,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int16_t textX = (window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left
                              + window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right - 30)
                     / 2
-                + w->x;
-            int16_t textY = window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 6 + w->y;
+                + w->windowPos.x;
+            int16_t textY = window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 6 + w->windowPos.y;
 
             rct_string_id stringId = EditorStepNames[gS6Info.editor_step + 1];
             if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -309,7 +309,6 @@ rct_window* window_editor_inventions_list_open()
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_RESIZE) | (1 << WIDX_TAB_1) | (1 << WIDX_RANDOM_SHUFFLE)
         | (1 << WIDX_MOVE_ITEMS_TO_BOTTOM) | (1 << WIDX_MOVE_ITEMS_TO_TOP);
     window_init_scroll_widgets(w);
-    w->var_4AE = 0;
     w->selected_tab = 0;
     w->research_item = nullptr;
     _editorInventionsListDraggedItem.rawValue = RESEARCH_ITEM_NULL;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -264,8 +264,8 @@ static ResearchItem* window_editor_inventions_list_get_item_from_scroll_y_includ
 static ResearchItem* get_research_item_at(const ScreenCoordsXY& screenCoords, int32_t* outScrollId)
 {
     rct_window* w = window_find_by_class(WC_EDITOR_INVENTION_LIST);
-    if (w != nullptr && w->x <= screenCoords.x && w->y < screenCoords.y && w->x + w->width > screenCoords.x
-        && w->y + w->height > screenCoords.y)
+    if (w != nullptr && w->windowPos.x <= screenCoords.x && w->windowPos.y < screenCoords.y
+        && w->windowPos.x + w->width > screenCoords.x && w->windowPos.y + w->height > screenCoords.y)
     {
         rct_widgetindex widgetIndex = window_find_widget_from_point(w, screenCoords);
         rct_widget* widget = &w->widgets[widgetIndex];
@@ -553,25 +553,25 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     window_draw_widgets(w, dpi);
 
     // Tab image
-    x = w->x + w->widgets[WIDX_TAB_1].left;
-    y = w->y + w->widgets[WIDX_TAB_1].top;
+    x = w->windowPos.x + w->widgets[WIDX_TAB_1].left;
+    y = w->windowPos.y + w->widgets[WIDX_TAB_1].top;
     gfx_draw_sprite(dpi, SPR_TAB_FINANCES_RESEARCH_0 + (w->frame_no / 2) % 8, x, y, 0);
 
     // Pre-researched items label
-    x = w->x + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].left;
-    y = w->y + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11;
+    x = w->windowPos.x + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].left;
+    y = w->windowPos.y + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11;
     gfx_draw_string_left(dpi, STR_INVENTION_PREINVENTED_ITEMS, nullptr, COLOUR_BLACK, x, y - 1);
 
     // Research order label
-    x = w->x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].left;
-    y = w->y + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11;
+    x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].left;
+    y = w->windowPos.y + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11;
     gfx_draw_string_left(dpi, STR_INVENTION_TO_BE_INVENTED_ITEMS, nullptr, COLOUR_BLACK, x, y - 1);
 
     // Preview background
     widget = &w->widgets[WIDX_PREVIEW];
     gfx_fill_rect(
-        dpi, w->x + widget->left + 1, w->y + widget->top + 1, w->x + widget->right - 1, w->y + widget->bottom - 1,
-        ColourMapA[w->colours[1]].darkest);
+        dpi, w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1, w->windowPos.x + widget->right - 1,
+        w->windowPos.y + widget->bottom - 1, ColourMapA[w->colours[1]].darkest);
 
     researchItem = &_editorInventionsListDraggedItem;
     if (researchItem->IsNull())
@@ -598,8 +598,8 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     if (object != nullptr)
     {
         rct_drawpixelinfo clipDPI;
-        x = w->x + widget->left + 1;
-        y = w->y + widget->top + 1;
+        x = w->windowPos.x + widget->left + 1;
+        y = w->windowPos.y + widget->top + 1;
         width = widget->right - widget->left - 1;
         int32_t height = widget->bottom - widget->top - 1;
         if (clip_drawpixelinfo(&clipDPI, dpi, x, y, width, height))
@@ -609,8 +609,8 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     }
 
     // Item name
-    x = w->x + ((widget->left + widget->right) / 2) + 1;
-    y = w->y + widget->bottom + 3;
+    x = w->windowPos.x + ((widget->left + widget->right) / 2) + 1;
+    y = w->windowPos.y + widget->bottom + 3;
     width = w->width - w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right - 6;
 
     rct_string_id drawString = window_editor_inventions_list_prepare_name(researchItem, false);
@@ -618,7 +618,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     y += 15;
 
     // Item category
-    x = w->x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
+    x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
     stringId = EditorInventionsResearchCategories[researchItem->category];
     gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, x, y);
 }
@@ -820,8 +820,8 @@ static void window_editor_inventions_list_drag_paint(rct_window* w, rct_drawpixe
     rct_string_id drawString;
     int32_t x, y;
 
-    x = w->x;
-    y = w->y + 2;
+    x = w->windowPos.x;
+    y = w->windowPos.y + 2;
     drawString = window_editor_inventions_list_prepare_name(&_editorInventionsListDraggedItem, true);
     gfx_draw_string_left(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK | COLOUR_FLAG_OUTLINE, x, y);
 }

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -66,7 +66,8 @@ rct_window* window_editor_main_open()
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);
     window->widgets = window_editor_main_widgets;
 
-    viewport_create(window, window->x, window->y, window->width, window->height, 0, 0x0FFF, 0x0FFF, 0, 0x1, SPRITE_INDEX_NULL);
+    viewport_create(
+        window, { window->x, window->y }, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
     window->viewport->flags |= 0x0400;
 
     gCurrentRotation = 0;

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -66,8 +66,7 @@ rct_window* window_editor_main_open()
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);
     window->widgets = window_editor_main_widgets;
 
-    viewport_create(
-        window, { window->x, window->y }, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
+    viewport_create(window, window->windowPos, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
     window->viewport->flags |= 0x0400;
 
     gCurrentRotation = 0;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -402,7 +402,6 @@ rct_window* window_editor_object_selection_open()
     }
     window_init_scroll_widgets(window);
 
-    window->var_4AE = 0;
     window->selected_tab = 0;
     window->selected_list_item = -1;
     window->object_entry = nullptr;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -613,8 +613,8 @@ void window_editor_object_selection_mousedown(rct_window* w, rct_widgetindex wid
             }
 
             window_dropdown_show_text(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[widget->colour],
-                DROPDOWN_FLAG_STAY_OPEN, _numSourceGameItems + numSelectionItems);
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                w->colours[widget->colour], DROPDOWN_FLAG_STAY_OPEN, _numSourceGameItems + numSelectionItems);
 
             for (int32_t i = 0; i < _numSourceGameItems; i++)
             {
@@ -967,8 +967,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         if (widget->type != WWT_EMPTY)
         {
             auto image = ObjectSelectionPages[i].Image;
-            x = w->x + widget->left;
-            y = w->y + widget->top;
+            x = w->windowPos.x + widget->left;
+            y = w->windowPos.y + widget->top;
             gfx_draw_sprite(dpi, image, x, y, 0);
         }
     }
@@ -996,8 +996,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
             }
             spriteIndex += (i == 4 ? ThrillRidesTabAnimationSequence[frame] : frame);
 
-            x = w->x + widget->left;
-            y = w->y + widget->top;
+            x = w->windowPos.x + widget->left;
+            y = w->windowPos.y + widget->top;
             gfx_draw_sprite(dpi, spriteIndex | (w->colours[1] << 19), x, y, 0);
         }
     }
@@ -1005,14 +1005,14 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     // Preview background
     widget = &w->widgets[WIDX_PREVIEW];
     gfx_fill_rect(
-        dpi, w->x + widget->left + 1, w->y + widget->top + 1, w->x + widget->right - 1, w->y + widget->bottom - 1,
-        ColourMapA[w->colours[1]].darkest);
+        dpi, w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1, w->windowPos.x + widget->right - 1,
+        w->windowPos.y + widget->bottom - 1, ColourMapA[w->colours[1]].darkest);
 
     // Draw number of selected items
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
-        x = w->x + 3;
-        y = w->y + w->height - 13;
+        x = w->windowPos.x + 3;
+        y = w->windowPos.y + w->height - 13;
 
         int32_t numSelected = _numSelectedObjectsForType[get_selected_object_type(w)];
         int32_t totalSelectable = object_entry_group_counts[get_selected_object_type(w)];
@@ -1031,8 +1031,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         stringId = _listSortType == RIDE_SORT_TYPE ? (rct_string_id)(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : (rct_string_id)STR_NONE;
         gfx_draw_string_left_clipped(
-            dpi, STR_OBJECTS_SORT_TYPE, &stringId, w->colours[1], w->x + widget->left + 1, w->y + widget->top + 1,
-            widget->right - widget->left);
+            dpi, STR_OBJECTS_SORT_TYPE, &stringId, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
     widget = &w->widgets[WIDX_LIST_SORT_RIDE];
     if (widget->type != WWT_EMPTY)
@@ -1040,8 +1040,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         stringId = _listSortType == RIDE_SORT_RIDE ? (rct_string_id)(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : (rct_string_id)STR_NONE;
         gfx_draw_string_left_clipped(
-            dpi, STR_OBJECTS_SORT_RIDE, &stringId, w->colours[1], w->x + widget->left + 1, w->y + widget->top + 1,
-            widget->right - widget->left);
+            dpi, STR_OBJECTS_SORT_RIDE, &stringId, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
 
     if (w->selected_list_item == -1 || _loadedObject == nullptr)
@@ -1053,8 +1053,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     widget = &w->widgets[WIDX_PREVIEW];
     {
         rct_drawpixelinfo clipDPI;
-        x = w->x + widget->left + 1;
-        y = w->y + widget->top + 1;
+        x = w->windowPos.x + widget->left + 1;
+        y = w->windowPos.y + widget->top + 1;
         width = widget->right - widget->left - 1;
         int32_t height = widget->bottom - widget->top - 1;
         if (clip_drawpixelinfo(&clipDPI, dpi, x, y, width, height))
@@ -1064,8 +1064,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     }
 
     // Draw name of object
-    x = w->x + (widget->left + widget->right) / 2 + 1;
-    y = w->y + widget->bottom + 3;
+    x = w->windowPos.x + (widget->left + widget->right) / 2 + 1;
+    y = w->windowPos.y + widget->bottom + 3;
     width = w->width - w->widgets[WIDX_LIST].right - 6;
     set_format_arg(0, rct_string_id, STR_STRING);
     set_format_arg(2, const char*, listItem->repositoryItem->Name.c_str());
@@ -1078,34 +1078,34 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         set_format_arg(0, rct_string_id, STR_STRING);
         set_format_arg(2, const char*, description.c_str());
 
-        x = w->x + w->widgets[WIDX_LIST].right + 4;
+        x = w->windowPos.x + w->widgets[WIDX_LIST].right + 4;
         y += 15;
-        width = w->x + w->width - x - 4;
+        width = w->windowPos.x + w->width - x - 4;
 
         gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y + 5, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
     }
 
-    y = w->y + w->height - (12 * 4);
+    y = w->windowPos.y + w->height - (12 * 4);
 
     // Draw ride type.
     if (get_selected_object_type(w) == OBJECT_TYPE_RIDE)
     {
         stringId = get_ride_type_string_id(listItem->repositoryItem);
-        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->x + w->width - 5, y);
+        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->windowPos.x + w->width - 5, y);
     }
 
     y += 12;
 
     // Draw object source
     stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->x + w->width - 5, y);
+    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->windowPos.x + w->width - 5, y);
     y += 12;
 
     // Draw object dat name
     const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
     set_format_arg(0, rct_string_id, STR_STRING);
     set_format_arg(2, const char*, path);
-    gfx_draw_string_right(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, w->x + w->width - 5, y);
+    gfx_draw_string_right(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 5, y);
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -263,7 +263,6 @@ rct_window* window_editor_objective_options_open()
     w->pressed_widgets = 0;
     w->hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];
     window_init_scroll_widgets(w);
-    w->var_4AE = 0;
     w->selected_tab = WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN;
     w->no_list_items = 0;
     w->selected_list_item = -1;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -303,7 +303,7 @@ static void window_editor_objective_options_draw_tab_images(rct_window* w, rct_d
     if (w->page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
         spriteIndex += (w->frame_no / 4) % 16;
 
-    gfx_draw_sprite(dpi, spriteIndex, w->x + widget->left, w->y + widget->top, 0);
+    gfx_draw_sprite(dpi, spriteIndex, w->windowPos.x + widget->left, w->windowPos.y + widget->top, 0);
 
     // Tab 2
     if (!(w->disabled_widgets & (1 << WIDX_TAB_2)))
@@ -313,7 +313,7 @@ static void window_editor_objective_options_draw_tab_images(rct_window* w, rct_d
         if (w->page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
             spriteIndex += (w->frame_no / 4) % 16;
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + widget->left, w->y + widget->top, 0);
+        gfx_draw_sprite(dpi, spriteIndex, w->windowPos.x + widget->left, w->windowPos.y + widget->top, 0);
     }
 }
 
@@ -485,8 +485,9 @@ static void window_editor_objective_options_show_objective_dropdown(rct_window* 
     numItems++;
 
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, dropdownWidget->right - dropdownWidget->left - 3);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
+        dropdownWidget->right - dropdownWidget->left - 3);
 
     objectiveType = gScenarioObjectiveType;
     for (int32_t j = 0; j < numItems; j++)
@@ -512,8 +513,9 @@ static void window_editor_objective_options_show_category_dropdown(rct_window* w
         gDropdownItemsArgs[i] = ScenarioCategoryStringIds[i];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 5, dropdownWidget->right - dropdownWidget->left - 3);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 5,
+        dropdownWidget->right - dropdownWidget->left - 3);
     dropdown_set_checked(gS6Info.category, true);
 }
 
@@ -863,21 +865,21 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     window_editor_objective_options_draw_tab_images(w, dpi);
 
     // Objective label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_OBJECTIVE].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE].top;
     gfx_draw_string_left(dpi, STR_OBJECTIVE_WINDOW, nullptr, COLOUR_BLACK, x, y);
 
     // Objective value
-    x = w->x + w->widgets[WIDX_OBJECTIVE].left + 1;
-    y = w->y + w->widgets[WIDX_OBJECTIVE].top;
+    x = w->windowPos.x + w->widgets[WIDX_OBJECTIVE].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE].top;
     stringId = ObjectiveDropdownOptionNames[gScenarioObjectiveType];
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, x, y);
 
     if (w->widgets[WIDX_OBJECTIVE_ARG_1].type != WWT_EMPTY)
     {
         // Objective argument 1 label
-        x = w->x + 28;
-        y = w->y + w->widgets[WIDX_OBJECTIVE_ARG_1].top;
+        x = w->windowPos.x + 28;
+        y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE_ARG_1].top;
         switch (gScenarioObjectiveType)
         {
             case OBJECTIVE_GUESTS_BY:
@@ -904,8 +906,8 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
         gfx_draw_string_left(dpi, stringId, nullptr, COLOUR_BLACK, x, y);
 
         // Objective argument 1 value
-        x = w->x + w->widgets[WIDX_OBJECTIVE_ARG_1].left + 1;
-        y = w->y + w->widgets[WIDX_OBJECTIVE_ARG_1].top;
+        x = w->windowPos.x + w->widgets[WIDX_OBJECTIVE_ARG_1].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE_ARG_1].top;
         switch (gScenarioObjectiveType)
         {
             case OBJECTIVE_GUESTS_BY:
@@ -935,20 +937,20 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     if (w->widgets[WIDX_OBJECTIVE_ARG_2].type != WWT_EMPTY)
     {
         // Objective argument 2 label
-        x = w->x + 28;
-        y = w->y + w->widgets[WIDX_OBJECTIVE_ARG_2].top;
+        x = w->windowPos.x + 28;
+        y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE_ARG_2].top;
         gfx_draw_string_left(dpi, STR_WINDOW_OBJECTIVE_DATE, nullptr, COLOUR_BLACK, x, y);
 
         // Objective argument 2 value
-        x = w->x + w->widgets[WIDX_OBJECTIVE_ARG_2].left + 1;
-        y = w->y + w->widgets[WIDX_OBJECTIVE_ARG_2].top;
+        x = w->windowPos.x + w->widgets[WIDX_OBJECTIVE_ARG_2].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_OBJECTIVE_ARG_2].top;
         arg = (gScenarioObjectiveYear * MONTH_COUNT) - 1;
         gfx_draw_string_left(dpi, STR_WINDOW_OBJECTIVE_VALUE_DATE, &arg, COLOUR_BLACK, x, y);
     }
 
     // Park name
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_PARK_NAME].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_PARK_NAME].top;
     width = w->widgets[WIDX_PARK_NAME].left - 16;
 
     {
@@ -961,8 +963,8 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     }
 
     // Scenario name
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_SCENARIO_NAME].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_SCENARIO_NAME].top;
     width = w->widgets[WIDX_SCENARIO_NAME].left - 16;
 
     set_format_arg(0, rct_string_id, STR_STRING);
@@ -971,13 +973,13 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     gfx_draw_string_left_clipped(dpi, STR_WINDOW_SCENARIO_NAME, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
 
     // Scenario details label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_DETAILS].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_DETAILS].top;
     gfx_draw_string_left(dpi, STR_WINDOW_PARK_DETAILS, nullptr, COLOUR_BLACK, x, y);
 
     // Scenario details value
-    x = w->x + 16;
-    y = w->y + w->widgets[WIDX_DETAILS].top + 10;
+    x = w->windowPos.x + 16;
+    y = w->windowPos.y + w->widgets[WIDX_DETAILS].top + 10;
     width = w->widgets[WIDX_DETAILS].left - 4;
 
     set_format_arg(0, rct_string_id, STR_STRING);
@@ -986,13 +988,13 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, width, STR_BLACK_STRING, COLOUR_BLACK);
 
     // Scenario category label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_CATEGORY].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_CATEGORY].top;
     gfx_draw_string_left(dpi, STR_WINDOW_SCENARIO_GROUP, nullptr, COLOUR_BLACK, x, y);
 
     // Scenario category value
-    x = w->x + w->widgets[WIDX_CATEGORY].left + 1;
-    y = w->y + w->widgets[WIDX_CATEGORY].top;
+    x = w->windowPos.x + w->widgets[WIDX_CATEGORY].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_CATEGORY].top;
     stringId = ScenarioCategoryStringIds[gS6Info.category];
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, x, y);
 }
@@ -1135,7 +1137,8 @@ static void window_editor_objective_options_rides_paint(rct_window* w, rct_drawp
     window_editor_objective_options_draw_tab_images(w, dpi);
 
     gfx_draw_string_left(
-        dpi, STR_WINDOW_PRESERVATION_ORDER, nullptr, COLOUR_BLACK, w->x + 6, w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + 3);
+        dpi, STR_WINDOW_PRESERVATION_ORDER, nullptr, COLOUR_BLACK, w->windowPos.x + 6,
+        w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + 3);
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -399,7 +399,6 @@ rct_window* window_editor_scenario_options_open()
     w->enabled_widgets = window_editor_scenario_options_page_enabled_widgets[0];
     w->hold_down_widgets = window_editor_scenario_options_page_hold_down_widgets[0];
     window_init_scroll_widgets(w);
-    w->var_4AE = 0;
     w->page = 0;
 
     return w;

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -439,7 +439,7 @@ static void window_editor_scenario_options_draw_tab_images(rct_window* w, rct_dr
     if (w->page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL)
         spriteIndex += (w->frame_no / 2) % 8;
 
-    gfx_draw_sprite(dpi, spriteIndex, w->x + widget->left, w->y + widget->top, 0);
+    gfx_draw_sprite(dpi, spriteIndex, w->windowPos.x + widget->left, w->windowPos.y + widget->top, 0);
 
     // Tab 2
     widget = &w->widgets[WIDX_TAB_2];
@@ -447,12 +447,12 @@ static void window_editor_scenario_options_draw_tab_images(rct_window* w, rct_dr
     if (w->page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS)
         spriteIndex += (w->frame_no / 4) % 8;
 
-    gfx_draw_sprite(dpi, spriteIndex, w->x + widget->left, w->y + widget->top, 0);
+    gfx_draw_sprite(dpi, spriteIndex, w->windowPos.x + widget->left, w->windowPos.y + widget->top, 0);
 
     // Tab 3
     widget = &w->widgets[WIDX_TAB_3];
     spriteIndex = SPR_TAB_PARK;
-    gfx_draw_sprite(dpi, spriteIndex, w->x + widget->left, w->y + widget->top, 0);
+    gfx_draw_sprite(dpi, spriteIndex, w->windowPos.x + widget->left, w->windowPos.y + widget->top, 0);
 }
 
 /**
@@ -547,8 +547,9 @@ static void window_editor_scenario_options_show_climate_dropdown(rct_window* w)
         gDropdownItemsArgs[i] = ClimateNames[i];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, CLIMATE_COUNT, dropdownWidget->right - dropdownWidget->left - 3);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, CLIMATE_COUNT,
+        dropdownWidget->right - dropdownWidget->left - 3);
     dropdown_set_checked(gClimate, true);
 }
 
@@ -747,45 +748,45 @@ static void window_editor_scenario_options_financial_paint(rct_window* w, rct_dr
 
     if (w->widgets[WIDX_INITIAL_CASH].type != WWT_EMPTY)
     {
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_INITIAL_CASH].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_INITIAL_CASH].top;
         gfx_draw_string_left(dpi, STR_INIT_CASH_LABEL, nullptr, COLOUR_BLACK, x, y);
 
-        x = w->x + w->widgets[WIDX_INITIAL_CASH].left + 1;
-        y = w->y + w->widgets[WIDX_INITIAL_CASH].top;
+        x = w->windowPos.x + w->widgets[WIDX_INITIAL_CASH].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_INITIAL_CASH].top;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gInitialCash, COLOUR_BLACK, x, y);
     }
 
     if (w->widgets[WIDX_INITIAL_LOAN].type != WWT_EMPTY)
     {
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_INITIAL_LOAN].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_INITIAL_LOAN].top;
         gfx_draw_string_left(dpi, STR_INIT_LOAN_LABEL, nullptr, COLOUR_BLACK, x, y);
 
-        x = w->x + w->widgets[WIDX_INITIAL_LOAN].left + 1;
-        y = w->y + w->widgets[WIDX_INITIAL_LOAN].top;
+        x = w->windowPos.x + w->widgets[WIDX_INITIAL_LOAN].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_INITIAL_LOAN].top;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gBankLoan, COLOUR_BLACK, x, y);
     }
 
     if (w->widgets[WIDX_MAXIMUM_LOAN].type != WWT_EMPTY)
     {
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_MAXIMUM_LOAN].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_MAXIMUM_LOAN].top;
         gfx_draw_string_left(dpi, STR_MAX_LOAN_LABEL, nullptr, COLOUR_BLACK, x, y);
 
-        x = w->x + w->widgets[WIDX_MAXIMUM_LOAN].left + 1;
-        y = w->y + w->widgets[WIDX_MAXIMUM_LOAN].top;
+        x = w->windowPos.x + w->widgets[WIDX_MAXIMUM_LOAN].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_MAXIMUM_LOAN].top;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gMaxBankLoan, COLOUR_BLACK, x, y);
     }
 
     if (w->widgets[WIDX_INTEREST_RATE].type != WWT_EMPTY)
     {
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_INTEREST_RATE].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_INTEREST_RATE].top;
         gfx_draw_string_left(dpi, STR_INTEREST_RATE_LABEL, nullptr, COLOUR_BLACK, x, y);
 
-        x = w->x + w->widgets[WIDX_INTEREST_RATE].left + 1;
-        y = w->y + w->widgets[WIDX_INTEREST_RATE].top;
+        x = w->windowPos.x + w->widgets[WIDX_INTEREST_RATE].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_INTEREST_RATE].top;
 
         int16_t interestRate = std::clamp<int16_t>((int16_t)gBankLoanInterestRate, INT16_MIN, INT16_MAX);
         gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &interestRate, COLOUR_BLACK, x, y);
@@ -1028,47 +1029,47 @@ static void window_editor_scenario_options_guests_paint(rct_window* w, rct_drawp
     if (w->widgets[WIDX_CASH_PER_GUEST].type != WWT_EMPTY)
     {
         // Cash per guest label
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_CASH_PER_GUEST].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_CASH_PER_GUEST].top;
         gfx_draw_string_left(dpi, STR_CASH_PER_GUEST_LABEL, nullptr, COLOUR_BLACK, x, y);
 
         // Cash per guest value
-        x = w->x + w->widgets[WIDX_CASH_PER_GUEST].left + 1;
-        y = w->y + w->widgets[WIDX_CASH_PER_GUEST].top;
+        x = w->windowPos.x + w->widgets[WIDX_CASH_PER_GUEST].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_CASH_PER_GUEST].top;
         arg = gGuestInitialCash;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
     }
 
     // Guest initial happiness label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top;
     gfx_draw_string_left(dpi, STR_GUEST_INIT_HAPPINESS, nullptr, COLOUR_BLACK, x, y);
 
     // Guest initial happiness value
-    x = w->x + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].left + 1;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top;
+    x = w->windowPos.x + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top;
     arg = (gGuestInitialHappiness * 100) / 255;
     gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
 
     // Guest initial hunger label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_HUNGER].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_HUNGER].top;
     gfx_draw_string_left(dpi, STR_GUEST_INIT_HUNGER, nullptr, COLOUR_BLACK, x, y);
 
     // Guest initial hunger value
-    x = w->x + w->widgets[WIDX_GUEST_INITIAL_HUNGER].left + 1;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_HUNGER].top;
+    x = w->windowPos.x + w->widgets[WIDX_GUEST_INITIAL_HUNGER].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_HUNGER].top;
     arg = ((255 - gGuestInitialHunger) * 100) / 255;
     gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
 
     // Guest initial thirst label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_THIRST].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_THIRST].top;
     gfx_draw_string_left(dpi, STR_GUEST_INIT_THIRST, nullptr, COLOUR_BLACK, x, y);
 
     // Guest initial thirst value
-    x = w->x + w->widgets[WIDX_GUEST_INITIAL_THIRST].left + 1;
-    y = w->y + w->widgets[WIDX_GUEST_INITIAL_THIRST].top;
+    x = w->windowPos.x + w->widgets[WIDX_GUEST_INITIAL_THIRST].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_GUEST_INITIAL_THIRST].top;
     arg = ((255 - gGuestInitialThirst) * 100) / 255;
     gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
 }
@@ -1245,8 +1246,9 @@ static void window_editor_scenario_options_park_mousedown(rct_window* w, rct_wid
             gDropdownItemsArgs[2] = STR_PAID_ENTRY_PAID_RIDES;
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top - 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 3, dropdownWidget->right - dropdownWidget->left - 3);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top - 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 3,
+                dropdownWidget->right - dropdownWidget->left - 3);
 
             if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                 dropdown_set_checked(2, true);
@@ -1392,13 +1394,13 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     if (w->widgets[WIDX_LAND_COST].type != WWT_EMPTY)
     {
         // Cost to buy land label
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_LAND_COST].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_LAND_COST].top;
         gfx_draw_string_left(dpi, STR_LAND_COST_LABEL, nullptr, COLOUR_BLACK, x, y);
 
         // Cost to buy land value
-        x = w->x + w->widgets[WIDX_LAND_COST].left + 1;
-        y = w->y + w->widgets[WIDX_LAND_COST].top;
+        x = w->windowPos.x + w->widgets[WIDX_LAND_COST].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_LAND_COST].top;
         arg = gLandPrice;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
     }
@@ -1406,13 +1408,13 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     if (w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].type != WWT_EMPTY)
     {
         // Cost to buy construction rights label
-        x = w->x + 8;
-        y = w->y + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top;
+        x = w->windowPos.x + 8;
+        y = w->windowPos.y + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top;
         gfx_draw_string_left(dpi, STR_RIGHTS_COST_LABEL, nullptr, COLOUR_BLACK, x, y);
 
         // Cost to buy construction rights value
-        x = w->x + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].left + 1;
-        y = w->y + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top;
+        x = w->windowPos.x + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top;
         arg = gConstructionRightsPrice;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
     }
@@ -1420,8 +1422,8 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     if (w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type != WWT_EMPTY)
     {
         // Pay for park or rides label
-        x = w->x + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].left + 1;
-        y = w->y + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].top;
+        x = w->windowPos.x + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].top;
         gfx_draw_string_left(dpi, STR_FREE_PARK_ENTER, nullptr, COLOUR_BLACK, x, y);
 
         // Pay for park and/or rides value
@@ -1438,25 +1440,25 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     if (w->widgets[WIDX_ENTRY_PRICE].type != WWT_EMPTY)
     {
         // Entry price label
-        x = w->x + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].right + 8;
-        y = w->y + w->widgets[WIDX_ENTRY_PRICE].top;
+        x = w->windowPos.x + w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].right + 8;
+        y = w->windowPos.y + w->widgets[WIDX_ENTRY_PRICE].top;
         gfx_draw_string_left(dpi, STR_ENTRY_PRICE_LABEL, nullptr, COLOUR_BLACK, x, y);
 
         // Entry price value
-        x = w->x + w->widgets[WIDX_ENTRY_PRICE].left + 1;
-        y = w->y + w->widgets[WIDX_ENTRY_PRICE].top;
+        x = w->windowPos.x + w->widgets[WIDX_ENTRY_PRICE].left + 1;
+        y = w->windowPos.y + w->widgets[WIDX_ENTRY_PRICE].top;
         arg = gParkEntranceFee;
         gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, x, y);
     }
 
     // Climate label
-    x = w->x + 8;
-    y = w->y + w->widgets[WIDX_CLIMATE].top;
+    x = w->windowPos.x + 8;
+    y = w->windowPos.y + w->widgets[WIDX_CLIMATE].top;
     gfx_draw_string_left(dpi, STR_CLIMATE_LABEL, nullptr, COLOUR_BLACK, x, y);
 
     // Climate value
-    x = w->x + w->widgets[WIDX_CLIMATE].left + 1;
-    y = w->y + w->widgets[WIDX_CLIMATE].top;
+    x = w->windowPos.x + w->widgets[WIDX_CLIMATE].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_CLIMATE].top;
     stringId = ClimateNames[gClimate];
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, x, y);
 }

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -141,7 +141,7 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message)
     w->error.var_480 = 0;
     if (!gDisableErrorWindowSound)
     {
-        audio_play_sound(SoundId::Error, 0, w->x + (w->width / 2));
+        audio_play_sound(SoundId::Error, 0, w->windowPos.x + (w->width / 2));
     }
 
     return w;
@@ -166,10 +166,10 @@ static void window_error_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t t, l, r, b;
 
-    l = w->x;
-    t = w->y;
-    r = w->x + w->width - 1;
-    b = w->y + w->height - 1;
+    l = w->windowPos.x;
+    t = w->windowPos.y;
+    r = w->windowPos.x + w->width - 1;
+    b = w->windowPos.y + w->height - 1;
 
     gfx_filter_rect(dpi, l + 1, t + 1, r - 1, b - 1, PALETTE_45);
     gfx_filter_rect(dpi, l, t, r, b, PALETTE_GLASS_SATURATED_RED);
@@ -184,7 +184,7 @@ static void window_error_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_filter_rect(dpi, l + 1, b - 1, l + 1, b - 1, PALETTE_DARKEN_3);
     gfx_filter_rect(dpi, r - 1, b - 1, r - 1, b - 1, PALETTE_DARKEN_3);
 
-    l = w->x + (w->width + 1) / 2 - 1;
-    t = w->y + 1;
+    l = w->windowPos.x + (w->width + 1) / 2 - 1;
+    t = w->windowPos.y + 1;
     draw_string_centred_raw(dpi, l, t, _window_error_num_lines, _window_error_text);
 }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -670,8 +670,8 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_finances_draw_tab_images(dpi, w);
 
-    int32_t x = w->x + 8;
-    int32_t y = w->y + 51;
+    int32_t x = w->windowPos.x + 8;
+    int32_t y = w->windowPos.y + 51;
 
     // Expenditure / Income heading
     draw_string_left_underline(dpi, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, nullptr, COLOUR_BLACK, x, y);
@@ -689,16 +689,19 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Horizontal rule below expenditure / income table
-    gfx_fill_rect_inset(dpi, w->x + 8, w->y + 272, w->x + 8 + 513, w->y + 272 + 1, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
+    gfx_fill_rect_inset(
+        dpi, w->windowPos.x + 8, w->windowPos.y + 272, w->windowPos.x + 8 + 513, w->windowPos.y + 272 + 1, w->colours[1],
+        INSET_RECT_FLAG_BORDER_INSET);
 
     // Loan and interest rate
-    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_LOAN, nullptr, COLOUR_BLACK, w->x + 8, w->y + 279);
+    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_LOAN, nullptr, COLOUR_BLACK, w->windowPos.x + 8, w->windowPos.y + 279);
     set_format_arg(0, uint16_t, gBankLoanInterestRate);
-    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, gCommonFormatArgs, COLOUR_BLACK, w->x + 167, w->y + 279);
+    gfx_draw_string_left(
+        dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 167, w->windowPos.y + 279);
 
     // Current cash
     rct_string_id stringId = gCash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
-    gfx_draw_string_left(dpi, stringId, &gCash, COLOUR_BLACK, w->x + 8, w->y + 294);
+    gfx_draw_string_left(dpi, stringId, &gCash, COLOUR_BLACK, w->windowPos.x + 8, w->windowPos.y + 294);
 
     // Objective related financial information
     if (gScenarioObjectiveType == OBJECTIVE_MONTHLY_FOOD_INCOME)
@@ -706,14 +709,15 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
         money32 lastMonthProfit = finance_get_last_month_shop_profit();
         set_format_arg(0, money32, lastMonthProfit);
         gfx_draw_string_left(
-            dpi, STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, gCommonFormatArgs, COLOUR_BLACK, w->x + 280,
-            w->y + 279);
+            dpi, STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, gCommonFormatArgs, COLOUR_BLACK,
+            w->windowPos.x + 280, w->windowPos.y + 279);
     }
     else
     {
         // Park value and company value
-        gfx_draw_string_left(dpi, STR_PARK_VALUE_LABEL, &gParkValue, COLOUR_BLACK, w->x + 280, w->y + 279);
-        gfx_draw_string_left(dpi, STR_COMPANY_VALUE_LABEL, &gCompanyValue, COLOUR_BLACK, w->x + 280, w->y + 294);
+        gfx_draw_string_left(dpi, STR_PARK_VALUE_LABEL, &gParkValue, COLOUR_BLACK, w->windowPos.x + 280, w->windowPos.y + 279);
+        gfx_draw_string_left(
+            dpi, STR_COMPANY_VALUE_LABEL, &gCompanyValue, COLOUR_BLACK, w->windowPos.x + 280, w->windowPos.y + 294);
     }
 }
 
@@ -837,10 +841,10 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
     window_finances_draw_tab_images(dpi, w);
 
     rct_widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
-    graphLeft = w->x + pageWidget->left + 4;
-    graphTop = w->y + pageWidget->top + 15;
-    graphRight = w->x + pageWidget->right - 4;
-    graphBottom = w->y + pageWidget->bottom - 4;
+    graphLeft = w->windowPos.x + pageWidget->left + 4;
+    graphTop = w->windowPos.y + pageWidget->top + 15;
+    graphRight = w->windowPos.x + pageWidget->right - 4;
+    graphBottom = w->windowPos.y + pageWidget->bottom - 4;
 
     // Cash (less loan)
     money32 cashLessLoan = gCash - gBankLoan;
@@ -944,10 +948,10 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
     window_finances_draw_tab_images(dpi, w);
 
     rct_widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
-    graphLeft = w->x + pageWidget->left + 4;
-    graphTop = w->y + pageWidget->top + 15;
-    graphRight = w->x + pageWidget->right - 4;
-    graphBottom = w->y + pageWidget->bottom - 4;
+    graphLeft = w->windowPos.x + pageWidget->left + 4;
+    graphTop = w->windowPos.y + pageWidget->top + 15;
+    graphRight = w->windowPos.x + pageWidget->right - 4;
+    graphBottom = w->windowPos.y + pageWidget->bottom - 4;
 
     // Park value
     money32 parkValue = gParkValue;
@@ -1046,10 +1050,10 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     window_finances_draw_tab_images(dpi, w);
 
     rct_widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
-    graphLeft = w->x + pageWidget->left + 4;
-    graphTop = w->y + pageWidget->top + 15;
-    graphRight = w->x + pageWidget->right - 4;
-    graphBottom = w->y + pageWidget->bottom - 4;
+    graphLeft = w->windowPos.x + pageWidget->left + 4;
+    graphTop = w->windowPos.y + pageWidget->top + 15;
+    graphRight = w->windowPos.x + pageWidget->right - 4;
+    graphBottom = w->windowPos.y + pageWidget->bottom - 4;
 
     // Weekly profit
     money32 weeklyPofit = gCurrentProfit;
@@ -1176,8 +1180,8 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
     window_draw_widgets(w, dpi);
     window_finances_draw_tab_images(dpi, w);
 
-    int32_t x = w->x + 8;
-    int32_t y = w->y + 62;
+    int32_t x = w->windowPos.x + 8;
+    int32_t y = w->windowPos.y + 62;
     int32_t noCampaignsActive = 1;
     for (int32_t i = 0; i < ADVERTISING_CAMPAIGN_COUNT; i++)
     {
@@ -1311,8 +1315,9 @@ static void window_finances_research_mousedown(rct_window* w, rct_widgetindex wi
         gDropdownItemsArgs[i] = ResearchFundingLevelNames[i];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4, dropdownWidget->right - dropdownWidget->left - 3);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4,
+        dropdownWidget->right - dropdownWidget->left - 3);
 
     int32_t currentResearchLevel = gResearchFundingLevel;
     dropdown_set_checked(currentResearchLevel, true);
@@ -1479,7 +1484,8 @@ static void window_finances_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w
             spriteIndex += frame;
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -616,19 +616,21 @@ static void window_footpath_paint(rct_window* w, rct_drawpixelinfo* dpi)
         image += pathType->image;
 
         // Draw construction image
-        int32_t x = w->x + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
-        int32_t y = w->y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 60;
+        int32_t x = w->windowPos.x
+            + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
+        int32_t y = w->windowPos.y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 60;
         gfx_draw_sprite(dpi, image, x, y, 0);
 
         // Draw build this... label
-        x = w->x + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
-        y = w->y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 23;
+        x = w->windowPos.x + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
+        y = w->windowPos.y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 23;
         gfx_draw_string_centred(dpi, STR_BUILD_THIS, x, y, COLOUR_BLACK, nullptr);
     }
 
     // Draw cost
-    int32_t x = w->x + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
-    int32_t y = w->y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 12;
+    int32_t x = w->windowPos.x
+        + (window_footpath_widgets[WIDX_CONSTRUCT].left + window_footpath_widgets[WIDX_CONSTRUCT].right) / 2;
+    int32_t y = w->windowPos.y + window_footpath_widgets[WIDX_CONSTRUCT].bottom - 12;
     if (_window_footpath_cost != MONEY32_UNDEFINED)
     {
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -676,8 +678,8 @@ static void window_footpath_show_footpath_types_dialog(rct_window* w, rct_widget
     }
 
     window_dropdown_show_image(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, numPathTypes, 47, 36,
-        gAppropriateImageDropdownItemsPerRow[numPathTypes]);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+        numPathTypes, 47, 36, gAppropriateImageDropdownItemsPerRow[numPathTypes]);
 }
 
 /**

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -244,7 +244,7 @@ static void window_game_bottom_toolbar_invalidate(rct_window* w)
 
     // Reset dimensions as appropriate -- in case we're switching languages.
     w->height = line_height * 2 + 12;
-    w->y = context_get_height() - w->height;
+    w->windowPos.y = context_get_height() - w->height;
 
     // Change height of widgets in accordance with line height.
     w->widgets[WIDX_LEFT_OUTSET].bottom = w->widgets[WIDX_MIDDLE_OUTSET].bottom = w->widgets[WIDX_RIGHT_OUTSET].bottom
@@ -370,24 +370,24 @@ static void window_game_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* d
 {
     // Draw panel grey backgrounds
     gfx_filter_rect(
-        dpi, w->x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].top,
-        w->x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom, PALETTE_51);
+        dpi, w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].top,
+        w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom, PALETTE_51);
     gfx_filter_rect(
-        dpi, w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top,
-        w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom, PALETTE_51);
+        dpi, w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top,
+        w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom, PALETTE_51);
 
     if (theme_get_flags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
     {
         // Draw grey background
         gfx_filter_rect(
-            dpi, w->x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].left,
-            w->y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].top,
-            w->x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].right,
-            w->y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].bottom, PALETTE_51);
+            dpi, w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].left,
+            w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].top,
+            w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].right,
+            w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET].bottom, PALETTE_51);
     }
 
     window_draw_widgets(w, dpi);
@@ -409,10 +409,10 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
 {
     // Draw green inset rectangle on panel
     gfx_fill_rect_inset(
-        dpi, w->x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left + 1,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].top + 1,
-        w->x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right - 1,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom - 1, w->colours[1], INSET_RECT_F_30);
+        dpi, w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left + 1,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].top + 1,
+        w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right - 1,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom - 1, w->colours[1], INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
@@ -421,8 +421,8 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
         rct_widget widget = window_game_bottom_toolbar_widgets[WIDX_MONEY];
-        int32_t x = w->x + (widget.left + widget.right) / 2;
-        int32_t y = w->y + (widget.top + widget.bottom) / 2 - (line_height == 10 ? 5 : 6);
+        int32_t x = w->windowPos.x + (widget.left + widget.right) / 2;
+        int32_t y = w->windowPos.y + (widget.top + widget.bottom) / 2 - (line_height == 10 ? 5 : 6);
 
         set_format_arg(0, money32, gCash);
         gfx_draw_string_centred(
@@ -448,8 +448,8 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
     // Draw guests
     {
         rct_widget widget = window_game_bottom_toolbar_widgets[WIDX_GUESTS];
-        int32_t x = w->x + (widget.left + widget.right) / 2;
-        int32_t y = w->y + (widget.top + widget.bottom) / 2 - 6;
+        int32_t x = w->windowPos.x + (widget.left + widget.right) / 2;
+        int32_t y = w->windowPos.y + (widget.top + widget.bottom) / 2 - 6;
 
         gfx_draw_string_centred(
             dpi,
@@ -464,8 +464,8 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
     // Draw park rating
     {
         rct_widget widget = window_game_bottom_toolbar_widgets[WIDX_PARK_RATING];
-        int32_t x = w->x + widget.left + 11;
-        int32_t y = w->y + (widget.top + widget.bottom) / 2 - 5;
+        int32_t x = w->windowPos.x + widget.left + 11;
+        int32_t y = w->windowPos.y + (widget.top + widget.bottom) / 2 - 5;
 
         window_game_bottom_toolbar_draw_park_rating(dpi, w, w->colours[3], x, y, std::max(10, ((gParkRating / 4) * 263) / 256));
     }
@@ -497,16 +497,16 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
 {
     // Draw green inset rectangle on panel
     gfx_fill_rect_inset(
-        dpi, w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 1,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + 1,
-        w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right - 1,
-        w->y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom - 1, w->colours[1], INSET_RECT_F_30);
+        dpi, w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 1,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + 1,
+        w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right - 1,
+        w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom - 1, w->colours[1], INSET_RECT_F_30);
 
     int32_t x = (window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left
                  + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right)
             / 2
-        + w->x;
-    int32_t y = window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + w->y + 2;
+        + w->windowPos.x;
+    int32_t y = window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + w->windowPos.y + 2;
 
     // Date
     int32_t year = date_get_year(gDateMonthsElapsed) + 1;
@@ -528,7 +528,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
     uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Temperature
-    x = w->x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 15;
+    x = w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 15;
     y += line_height + 1;
 
     int32_t temperature = gClimateCurrent.Temperature;
@@ -573,19 +573,20 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
 
     // Current news item
     gfx_fill_rect_inset(
-        dpi, w->x + middleOutsetWidget->left + 1, w->y + middleOutsetWidget->top + 1, w->x + middleOutsetWidget->right - 1,
-        w->y + middleOutsetWidget->bottom - 1, w->colours[2], INSET_RECT_F_30);
+        dpi, w->windowPos.x + middleOutsetWidget->left + 1, w->windowPos.y + middleOutsetWidget->top + 1,
+        w->windowPos.x + middleOutsetWidget->right - 1, w->windowPos.y + middleOutsetWidget->bottom - 1, w->colours[2],
+        INSET_RECT_F_30);
 
     // Text
     utf8* newsItemText = newsItem->Text;
-    x = w->x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
-    y = w->y + middleOutsetWidget->top + 11;
+    x = w->windowPos.x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
+    y = w->windowPos.y + middleOutsetWidget->top + 11;
     width = middleOutsetWidget->right - middleOutsetWidget->left - 62;
     gfx_draw_string_centred_wrapped_partial(
         dpi, x, y, width, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, &newsItemText, newsItem->Ticks);
 
-    x = w->x + window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].left;
-    y = w->y + window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].top;
+    x = w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].left;
+    y = w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].top;
     switch (newsItem->Type)
     {
         case NEWS_ITEM_RIDE:
@@ -666,14 +667,15 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo* dpi,
     rct_widget* middleOutsetWidget = &window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET];
 
     gfx_fill_rect_inset(
-        dpi, w->x + middleOutsetWidget->left + 1, w->y + middleOutsetWidget->top + 1, w->x + middleOutsetWidget->right - 1,
-        w->y + middleOutsetWidget->bottom - 1, w->colours[1], INSET_RECT_F_30);
+        dpi, w->windowPos.x + middleOutsetWidget->left + 1, w->windowPos.y + middleOutsetWidget->top + 1,
+        w->windowPos.x + middleOutsetWidget->right - 1, w->windowPos.y + middleOutsetWidget->bottom - 1, w->colours[1],
+        INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
-    int32_t x = w->x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
-    int32_t y = w->y + middleOutsetWidget->top + line_height + 1;
+    int32_t x = w->windowPos.x + (middleOutsetWidget->left + middleOutsetWidget->right) / 2;
+    int32_t y = w->windowPos.y + middleOutsetWidget->top + line_height + 1;
     int32_t width = middleOutsetWidget->right - middleOutsetWidget->left - 62;
 
     // Check if there is a map tooltip to draw

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -824,7 +824,7 @@ void window_guest_viewport_init(rct_window* w)
         if (peep->state != PEEP_STATE_PICKED && w->viewport == nullptr)
         {
             auto view_widget = &w->widgets[WIDX_VIEWPORT];
-            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
+            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->windowPos.x, view_widget->top + 1 + w->windowPos.y };
             int32_t width = view_widget->right - view_widget->left - 1;
             int32_t height = view_widget->bottom - view_widget->top - 1;
 
@@ -856,8 +856,8 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     rct_widget* widget = &w->widgets[WIDX_TAB_1];
     int32_t width = widget->right - widget->left - 1;
     int32_t height = widget->bottom - widget->top - 1;
-    int32_t x = widget->left + 1 + w->x;
-    int32_t y = widget->top + 1 + w->y;
+    int32_t x = widget->left + 1 + w->windowPos.x;
+    int32_t y = widget->top + 1 + w->windowPos.y;
     if (w->page == WINDOW_GUEST_OVERVIEW)
         height++;
 
@@ -924,8 +924,8 @@ static void window_guest_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_2];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     Peep* peep = GET_PEEP(w->number);
     int32_t image_id = get_peep_face_sprite_large(peep);
@@ -959,8 +959,8 @@ static void window_guest_rides_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_3];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_RIDE_0;
 
@@ -982,8 +982,8 @@ static void window_guest_finance_tab_paint(rct_window* w, rct_drawpixelinfo* dpi
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_4];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_FINANCES_SUMMARY_0;
 
@@ -1005,8 +1005,8 @@ static void window_guest_thoughts_tab_paint(rct_window* w, rct_drawpixelinfo* dp
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_5];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_THOUGHTS_0;
 
@@ -1028,8 +1028,8 @@ static void window_guest_inventory_tab_paint(rct_window* w, rct_drawpixelinfo* d
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_6];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_GUEST_INVENTORY;
 
@@ -1042,8 +1042,8 @@ static void window_guest_debug_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_7];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_GEARS_0;
     if (w->page == WINDOW_GUEST_DEBUG)
@@ -1076,7 +1076,7 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         rct_viewport* viewport = w->viewport;
         if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
         {
-            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->x + 2, w->y + 2, 0);
+            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->windowPos.x + 2, w->windowPos.y + 2, 0);
         }
     }
 
@@ -1084,16 +1084,16 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
     peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_ACTION_LBL];
-    int32_t x = (widget->left + widget->right) / 2 + w->x;
-    int32_t y = w->y + widget->top - 1;
+    int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
+    int32_t y = w->windowPos.y + widget->top - 1;
     int32_t width = widget->right - widget->left;
     gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
 
     // Draw the marquee thought
     widget = &w->widgets[WIDX_MARQUEE];
     width = widget->right - widget->left - 3;
-    int32_t left = widget->left + 2 + w->x;
-    int32_t top = widget->top + w->y;
+    int32_t left = widget->left + 2 + w->windowPos.x;
+    int32_t top = widget->top + w->windowPos.y;
     int32_t height = widget->bottom - widget->top;
     rct_drawpixelinfo dpi_marquee;
     if (!clip_drawpixelinfo(&dpi_marquee, dpi, left, top, width, height))
@@ -1396,9 +1396,9 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Not sure why this is not stats widgets
     // cx
-    int32_t x = w->x + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    int32_t x = w->windowPos.x + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     // dx
-    int32_t y = w->y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    int32_t y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     // Happiness
     gfx_draw_string_left(dpi, STR_GUEST_STAT_HAPPINESS_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -1688,13 +1688,13 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
 
     // cx
-    int32_t x = w->x + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].left + 2;
+    int32_t x = w->windowPos.x + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].left + 2;
     // dx
-    int32_t y = w->y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 2;
+    int32_t y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 2;
 
     gfx_draw_string_left(dpi, STR_GUEST_LABEL_RIDES_BEEN_ON, nullptr, COLOUR_BLACK, x, y);
 
-    y = w->y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
+    y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
     set_format_arg(0, rct_string_id, STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     if (peep->favourite_ride != RIDE_ID_NULL)
@@ -1771,9 +1771,9 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
 
     // cx
-    int32_t x = w->x + window_guest_finance_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    int32_t x = w->windowPos.x + window_guest_finance_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     // dx
-    int32_t y = w->y + window_guest_finance_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    int32_t y = w->windowPos.y + window_guest_finance_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     // Cash in pocket
     set_format_arg(0, money32, peep->cash_in_pocket);
@@ -1881,9 +1881,9 @@ void window_guest_thoughts_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
 
     // cx
-    int32_t x = w->x + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    int32_t x = w->windowPos.x + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     // dx
-    int32_t y = w->y + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    int32_t y = w->windowPos.y + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     gfx_draw_string_left(dpi, STR_GUEST_RECENT_THOUGHTS_LABEL, nullptr, COLOUR_BLACK, x, y);
 
@@ -1902,7 +1902,7 @@ void window_guest_thoughts_paint(rct_window* w, rct_drawpixelinfo* dpi)
         y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, width, STR_BLACK_STRING, COLOUR_BLACK);
 
         // If this is the last visible line end drawing.
-        if (y > w->y + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].bottom - 32)
+        if (y > w->windowPos.y + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].bottom - 32)
             return;
     }
 }
@@ -2024,11 +2024,11 @@ void window_guest_inventory_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (guest != nullptr)
     {
         rct_widget* pageBackgroundWidget = &window_guest_inventory_widgets[WIDX_PAGE_BACKGROUND];
-        int32_t x = w->x + pageBackgroundWidget->left + 4;
-        int32_t y = w->y + pageBackgroundWidget->top + 2;
+        int32_t x = w->windowPos.x + pageBackgroundWidget->left + 4;
+        int32_t y = w->windowPos.y + pageBackgroundWidget->top + 2;
         int32_t itemNameWidth = pageBackgroundWidget->right - pageBackgroundWidget->left - 8;
 
-        int32_t maxY = w->y + w->height - 22;
+        int32_t maxY = w->windowPos.y + w->height - 22;
         int32_t numItems = 0;
 
         gfx_draw_string_left(dpi, STR_CARRYING, nullptr, COLOUR_BLACK, x, y);
@@ -2078,8 +2078,8 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_guest_debug_tab_paint(w, dpi);
 
     auto peep = GET_PEEP(w->number);
-    auto x = w->x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    auto y = w->y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    auto x = w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    auto y = w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, x, y);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -875,42 +875,42 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_ENTERTAINER)
         y++;
 
-    int32_t ebx = g_peep_animation_entries[peep->sprite_type].sprite_animation->base_image + 1;
+    int32_t animationFrame = g_peep_animation_entries[peep->sprite_type].sprite_animation->base_image + 1;
 
-    int32_t eax = 0;
+    int32_t animationFrameOffset = 0;
 
     if (w->page == WINDOW_GUEST_OVERVIEW)
     {
-        eax = w->var_496;
-        eax &= 0xFFFC;
+        animationFrameOffset = w->var_496;
+        animationFrameOffset &= 0xFFFC;
     }
-    ebx += eax;
+    animationFrame += animationFrameOffset;
 
-    int32_t sprite_id = ebx | SPRITE_ID_PALETTE_COLOUR_2(peep->tshirt_colour, peep->trousers_colour);
+    int32_t sprite_id = animationFrame | SPRITE_ID_PALETTE_COLOUR_2(peep->tshirt_colour, peep->trousers_colour);
     gfx_draw_sprite(&clip_dpi, sprite_id, x, y, 0);
 
     // If holding a balloon
-    if (ebx >= 0x2A1D && ebx < 0x2A3D)
+    if (animationFrame >= 0x2A1D && animationFrame < 0x2A3D)
     {
-        ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour);
-        gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
+        animationFrame += 32;
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour);
+        gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 
     // If holding umbrella
-    if (ebx >= 0x2BBD && ebx < 0x2BDD)
+    if (animationFrame >= 0x2BBD && animationFrame < 0x2BDD)
     {
-        ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour);
-        gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
+        animationFrame += 32;
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour);
+        gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 
     // If wearing hat
-    if (ebx >= 0x29DD && ebx < 0x29FD)
+    if (animationFrame >= 0x29DD && animationFrame < 0x29FD)
     {
-        ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour);
-        gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
+        animationFrame += 32;
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour);
+        gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 }
 
@@ -1166,10 +1166,10 @@ void window_guest_overview_invalidate(rct_window* w)
  */
 void window_guest_overview_update(rct_window* w)
 {
-    int32_t var_496 = w->var_496;
-    var_496++;
-    var_496 %= 24;
-    w->var_496 = var_496;
+    int32_t newAnimationFrame = w->var_496;
+    newAnimationFrame++;
+    newAnimationFrame %= 24;
+    w->var_496 = newAnimationFrame;
 
     widget_invalidate(w, WIDX_TAB_1);
     widget_invalidate(w, WIDX_TAB_2);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -824,13 +824,13 @@ void window_guest_viewport_init(rct_window* w)
         if (peep->state != PEEP_STATE_PICKED && w->viewport == nullptr)
         {
             auto view_widget = &w->widgets[WIDX_VIEWPORT];
-            int32_t x = view_widget->left + 1 + w->x;
-            int32_t y = view_widget->top + 1 + w->y;
+            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
             int32_t width = view_widget->right - view_widget->left - 1;
             int32_t height = view_widget->bottom - view_widget->top - 1;
 
             viewport_create(
-                w, x, y, width, height, 0, focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK, focus.coordinate.z,
+                w, screenPos, width, height, 0,
+                { focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK, focus.coordinate.z },
                 focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
             if (w->viewport != nullptr && reCreateViewport)
             {

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -415,7 +415,7 @@ static void window_guest_list_mousedown(rct_window* w, rct_widgetindex widgetInd
             widget = &w->widgets[widgetIndex - 1];
 
             window_dropdown_show_text_custom_width(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, _window_guest_list_num_pages, widget->right - widget->left - 3);
 
             for (i = 0; i < _window_guest_list_num_pages; i++)
@@ -435,7 +435,7 @@ static void window_guest_list_mousedown(rct_window* w, rct_widgetindex widgetInd
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, 2, widget->right - widget->left - 3);
 
             dropdown_set_checked(_window_guest_list_selected_view, true);
@@ -679,18 +679,18 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     i += g_peep_animation_entries[PEEP_SPRITE_TYPE_NORMAL].sprite_animation->base_image + 1;
     i |= 0xA1600000;
     gfx_draw_sprite(
-        dpi, i, (window_guest_list_widgets[WIDX_TAB_1].left + window_guest_list_widgets[WIDX_TAB_1].right) / 2 + w->x,
-        window_guest_list_widgets[WIDX_TAB_1].bottom - 6 + w->y, 0);
+        dpi, i, (window_guest_list_widgets[WIDX_TAB_1].left + window_guest_list_widgets[WIDX_TAB_1].right) / 2 + w->windowPos.x,
+        window_guest_list_widgets[WIDX_TAB_1].bottom - 6 + w->windowPos.y, 0);
 
     // Tab 2 image
     i = (_window_guest_list_selected_tab == 1 ? w->list_information_type / 4 : 0);
     gfx_draw_sprite(
-        dpi, SPR_TAB_GUESTS_0 + i, window_guest_list_widgets[WIDX_TAB_2].left + w->x,
-        window_guest_list_widgets[WIDX_TAB_2].top + w->y, 0);
+        dpi, SPR_TAB_GUESTS_0 + i, window_guest_list_widgets[WIDX_TAB_2].left + w->windowPos.x,
+        window_guest_list_widgets[WIDX_TAB_2].top + w->windowPos.y, 0);
 
     // Filter description
-    x = w->x + 6;
-    y = w->y + window_guest_list_widgets[WIDX_TAB_CONTENT_PANEL].top + 3;
+    x = w->windowPos.x + 6;
+    y = w->windowPos.y + window_guest_list_widgets[WIDX_TAB_CONTENT_PANEL].top + 3;
     if (_window_guest_list_selected_tab == PAGE_INDIVIDUAL)
     {
         if (_window_guest_list_selected_filter != -1)
@@ -718,8 +718,8 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Number of guests (list items)
     if (_window_guest_list_selected_tab == PAGE_INDIVIDUAL)
     {
-        x = w->x + 4;
-        y = w->y + window_guest_list_widgets[WIDX_GUEST_LIST].bottom + 2;
+        x = w->windowPos.x + 4;
+        y = w->windowPos.y + window_guest_list_widgets[WIDX_GUEST_LIST].bottom + 2;
         set_format_arg(0, int16_t, w->var_492);
         gfx_draw_string_left(
             dpi, (w->var_492 == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL), gCommonFormatArgs,

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -226,8 +226,8 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Track preview
     rct_widget* widget = &window_install_track_widgets[WIDX_TRACK_PREVIEW];
-    int32_t x = w->x + widget->left + 1;
-    int32_t y = w->y + widget->top + 1;
+    int32_t x = w->windowPos.x + widget->left + 1;
+    int32_t y = w->windowPos.y + widget->top + 1;
     int32_t colour = ColourMapA[w->colours[0]].darkest;
     gfx_fill_rect(dpi, x, y, x + 369, y + 216, colour);
 
@@ -240,8 +240,8 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     drawing_engine_invalidate_image(SPR_TEMP);
     gfx_draw_sprite(dpi, SPR_TEMP, x, y, 0);
 
-    x = w->x + (widget->left + widget->right) / 2;
-    y = w->y + widget->bottom - 12;
+    x = w->windowPos.x + (widget->left + widget->right) / 2;
+    y = w->windowPos.y + widget->bottom - 12;
 
     // Warnings
     const TrackDesign* td6 = _trackDesign.get();
@@ -257,8 +257,8 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Information
-    x = w->x + widget->left + 1;
-    y = w->y + widget->bottom + 4;
+    x = w->windowPos.x + widget->left + 1;
+    y = w->windowPos.y + widget->bottom + 4;
     // 0x006D3CF1 -- 0x006d3d71 missing
 
     // Track design name & type

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -346,22 +346,22 @@ static void window_land_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw number for tool sizes bigger than 7
     if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
-        x = w->x + (previewWidget->left + previewWidget->right) / 2;
-        y = w->y + (previewWidget->top + previewWidget->bottom) / 2;
+        x = w->windowPos.x + (previewWidget->left + previewWidget->right) / 2;
+        y = w->windowPos.y + (previewWidget->top + previewWidget->bottom) / 2;
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gLandToolSize);
     }
     else if (gLandMountainMode)
     {
-        x = w->x + previewWidget->left;
-        y = w->y + previewWidget->top;
+        x = w->windowPos.x + previewWidget->left;
+        y = w->windowPos.y + previewWidget->top;
         int32_t sprite = gLandToolSize % 2 == 0 ? SPR_G2_MOUNTAIN_TOOL_EVEN : SPR_G2_MOUNTAIN_TOOL_ODD;
         gfx_draw_sprite(dpi, sprite, x, y, 0);
         widget_draw(dpi, w, WIDX_DECREMENT);
         widget_draw(dpi, w, WIDX_INCREMENT);
     }
 
-    x = w->x + (previewWidget->left + previewWidget->right) / 2;
-    y = w->y + previewWidget->bottom + 5;
+    x = w->windowPos.x + (previewWidget->left + previewWidget->right) / 2;
+    y = w->windowPos.y + previewWidget->bottom + 5;
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -271,8 +271,8 @@ static void window_land_rights_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t x, y;
 
-    x = w->x + (window_land_rights_widgets[WIDX_PREVIEW].left + window_land_rights_widgets[WIDX_PREVIEW].right) / 2;
-    y = w->y + (window_land_rights_widgets[WIDX_PREVIEW].top + window_land_rights_widgets[WIDX_PREVIEW].bottom) / 2;
+    x = w->windowPos.x + (window_land_rights_widgets[WIDX_PREVIEW].left + window_land_rights_widgets[WIDX_PREVIEW].right) / 2;
+    y = w->windowPos.y + (window_land_rights_widgets[WIDX_PREVIEW].top + window_land_rights_widgets[WIDX_PREVIEW].bottom) / 2;
 
     window_draw_widgets(w, dpi);
     // Draw number for tool sizes bigger than 7
@@ -284,8 +284,9 @@ static void window_land_rights_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw cost amount
     if (_landRightsCost != MONEY32_UNDEFINED && _landRightsCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        x = (window_land_rights_widgets[WIDX_PREVIEW].left + window_land_rights_widgets[WIDX_PREVIEW].right) / 2 + w->x;
-        y = window_land_rights_widgets[WIDX_PREVIEW].bottom + w->y + 32;
+        x = (window_land_rights_widgets[WIDX_PREVIEW].left + window_land_rights_widgets[WIDX_PREVIEW].right) / 2
+            + w->windowPos.x;
+        y = window_land_rights_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 32;
         gfx_draw_string_centred(dpi, STR_COST_AMOUNT, x, y, COLOUR_BLACK, &_landRightsCost);
     }
 }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -702,7 +702,8 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Draw path text
     set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(buffer));
-    gfx_draw_string_left_clipped(dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + 4, w->y + 20, w->width - 8);
+    gfx_draw_string_left_clipped(
+        dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 4, w->windowPos.y + 20, w->width - 8);
 
     // Name button text
     rct_string_id id = STR_NONE;
@@ -713,7 +714,9 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Draw name button indicator.
     rct_widget sort_name_widget = window_loadsave_widgets[WIDX_SORT_NAME];
-    gfx_draw_string_left(dpi, STR_NAME, &id, COLOUR_GREY, w->x + sort_name_widget.left + 11, w->y + sort_name_widget.top + 1);
+    gfx_draw_string_left(
+        dpi, STR_NAME, &id, COLOUR_GREY, w->windowPos.x + sort_name_widget.left + 11,
+        w->windowPos.y + sort_name_widget.top + 1);
 
     // Date button text
     if (gConfigGeneral.load_save_sort == SORT_DATE_ASCENDING)
@@ -724,7 +727,8 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
         id = STR_NONE;
 
     rct_widget sort_date_widget = window_loadsave_widgets[WIDX_SORT_DATE];
-    gfx_draw_string_left(dpi, STR_DATE, &id, COLOUR_GREY, w->x + sort_date_widget.left + 5, w->y + sort_date_widget.top + 1);
+    gfx_draw_string_left(
+        dpi, STR_DATE, &id, COLOUR_GREY, w->windowPos.x + sort_date_widget.left + 5, w->windowPos.y + sort_date_widget.top + 1);
 }
 
 static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
@@ -1221,8 +1225,8 @@ static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
     set_format_arg(0, rct_string_id, STR_STRING);
     set_format_arg(2, char*, _window_overwrite_prompt_name);
 
-    int32_t x = w->x + w->width / 2;
-    int32_t y = w->y + (w->height / 2) - 3;
+    int32_t x = w->windowPos.x + w->width / 2;
+    int32_t y = w->windowPos.y + (w->height / 2) - 3;
     gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
 }
 

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -68,7 +68,8 @@ rct_window* window_main_open()
         WF_STICK_TO_BACK);
     window->widgets = window_main_widgets;
 
-    viewport_create(window, window->x, window->y, window->width, window->height, 0, 0x0FFF, 0x0FFF, 0, 0x1, SPRITE_INDEX_NULL);
+    viewport_create(
+        window, { window->x, window->y }, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
     window->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
     gCurrentRotation = 0;
     gShowGridLinesRefCount = 0;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -68,8 +68,7 @@ rct_window* window_main_open()
         WF_STICK_TO_BACK);
     window->widgets = window_main_widgets;
 
-    viewport_create(
-        window, { window->x, window->y }, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
+    viewport_create(window, window->windowPos, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
     window->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
     gCurrentRotation = 0;
     gShowGridLinesRefCount = 0;

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -926,8 +926,8 @@ static void window_map_centre_on_view_point()
 
     // calculate centre view point of viewport and transform it to minimap coordinates
 
-    cx = ((w->viewport->view_width >> 1) + w->viewport->view_x) >> 5;
-    dx = ((w->viewport->view_height >> 1) + w->viewport->view_y) >> 4;
+    cx = ((w->viewport->view_width >> 1) + w->viewport->viewPos.x) >> 5;
+    dx = ((w->viewport->view_height >> 1) + w->viewport->viewPos.y) >> 4;
     cx += offset.x;
     dx += offset.y;
 
@@ -1132,10 +1132,10 @@ static void window_map_paint_hud_rectangle(rct_drawpixelinfo* dpi)
         return;
 
     auto offset = MiniMapOffsets[get_current_rotation()];
-    int16_t left = (viewport->view_x >> 5) + offset.x;
-    int16_t right = ((viewport->view_x + viewport->view_width) >> 5) + offset.x;
-    int16_t top = (viewport->view_y >> 4) + offset.y;
-    int16_t bottom = ((viewport->view_y + viewport->view_height) >> 4) + offset.y;
+    int16_t left = (viewport->viewPos.x >> 5) + offset.x;
+    int16_t right = ((viewport->viewPos.x + viewport->view_width) >> 5) + offset.x;
+    int16_t top = (viewport->viewPos.y >> 4) + offset.y;
+    int16_t bottom = ((viewport->viewPos.y + viewport->view_height) >> 4) + offset.y;
 
     // top horizontal lines
     gfx_fill_rect(dpi, left, top, left + 3, top, PALETTE_INDEX_56);

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -812,21 +812,21 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_map_draw_tab_images(w, dpi);
 
-    int32_t x = w->x + (window_map_widgets[WIDX_LAND_TOOL].left + window_map_widgets[WIDX_LAND_TOOL].right) / 2;
-    int32_t y = w->y + (window_map_widgets[WIDX_LAND_TOOL].top + window_map_widgets[WIDX_LAND_TOOL].bottom) / 2;
+    int32_t x = w->windowPos.x + (window_map_widgets[WIDX_LAND_TOOL].left + window_map_widgets[WIDX_LAND_TOOL].right) / 2;
+    int32_t y = w->windowPos.y + (window_map_widgets[WIDX_LAND_TOOL].top + window_map_widgets[WIDX_LAND_TOOL].bottom) / 2;
 
     // Draw land tool size
     if (widget_is_active_tool(w, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &_landRightsToolSize);
     }
-    y = w->y + window_map_widgets[WIDX_LAND_TOOL].bottom + 5;
+    y = w->windowPos.y + window_map_widgets[WIDX_LAND_TOOL].bottom + 5;
 
     // People starting position (scenario editor only)
     if (w->widgets[WIDX_PEOPLE_STARTING_POSITION].type != WWT_EMPTY)
     {
-        x = w->x + w->widgets[WIDX_PEOPLE_STARTING_POSITION].left + 12;
-        y = w->y + w->widgets[WIDX_PEOPLE_STARTING_POSITION].top + 18;
+        x = w->windowPos.x + w->widgets[WIDX_PEOPLE_STARTING_POSITION].left + 12;
+        y = w->windowPos.y + w->widgets[WIDX_PEOPLE_STARTING_POSITION].top + 18;
         gfx_draw_sprite(
             dpi, IMAGE_TYPE_REMAP | IMAGE_TYPE_REMAP_2_PLUS | (COLOUR_LIGHT_BROWN << 24) | (COLOUR_BRIGHT_RED << 19) | SPR_6410,
             x, y, 0);
@@ -837,8 +837,8 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
         // Render the map legend
         if (w->selected_tab == PAGE_RIDES)
         {
-            x = w->x + 4;
-            y = w->y + w->widgets[WIDX_MAP].bottom + 2;
+            x = w->windowPos.x + 4;
+            y = w->windowPos.y + w->widgets[WIDX_MAP].bottom + 2;
 
             static rct_string_id mapLabels[] = {
                 STR_MAP_RIDE,       STR_MAP_FOOD_STALL, STR_MAP_DRINK_STALL,  STR_MAP_SOUVENIR_STALL,
@@ -861,7 +861,8 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
     else if (!widget_is_active_tool(w, WIDX_SET_LAND_RIGHTS))
     {
         gfx_draw_string_left(
-            dpi, STR_MAP_SIZE, nullptr, w->colours[1], w->x + 4, w->y + w->widgets[WIDX_MAP_SIZE_SPINNER].top + 1);
+            dpi, STR_MAP_SIZE, nullptr, w->colours[1], w->windowPos.x + 4,
+            w->windowPos.y + w->widgets[WIDX_MAP_SIZE_SPINNER].top + 1);
     }
 }
 
@@ -999,14 +1000,16 @@ static void window_map_draw_tab_images(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->selected_tab == PAGE_PEEPS)
         image += w->list_information_type / 4;
 
-    gfx_draw_sprite(dpi, image, w->x + w->widgets[WIDX_PEOPLE_TAB].left, w->y + w->widgets[WIDX_PEOPLE_TAB].top, 0);
+    gfx_draw_sprite(
+        dpi, image, w->windowPos.x + w->widgets[WIDX_PEOPLE_TAB].left, w->windowPos.y + w->widgets[WIDX_PEOPLE_TAB].top, 0);
 
     // Ride/stall tab image (animated)
     image = SPR_TAB_RIDE_0;
     if (w->selected_tab == PAGE_RIDES)
         image += w->list_information_type / 4;
 
-    gfx_draw_sprite(dpi, image, w->x + w->widgets[WIDX_RIDES_TAB].left, w->y + w->widgets[WIDX_RIDES_TAB].top, 0);
+    gfx_draw_sprite(
+        dpi, image, w->windowPos.x + w->widgets[WIDX_RIDES_TAB].left, w->windowPos.y + w->widgets[WIDX_RIDES_TAB].top, 0);
 }
 
 /**

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -775,28 +775,33 @@ static void window_mapgen_base_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     const uint8_t textColour = w->colours[1];
 
-    gfx_draw_string_left(dpi, STR_MAP_SIZE, nullptr, textColour, w->x + 4, w->y + w->widgets[WIDX_MAP_SIZE].top + 1);
     gfx_draw_string_left(
-        dpi, STR_BASE_HEIGHT_LABEL, nullptr, textColour, w->x + 4, w->y + w->widgets[WIDX_BASE_HEIGHT].top + 1);
+        dpi, STR_MAP_SIZE, nullptr, textColour, w->windowPos.x + 4, w->windowPos.y + w->widgets[WIDX_MAP_SIZE].top + 1);
     gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour, w->x + 4, w->y + w->widgets[WIDX_WATER_LEVEL].top + 1);
-    gfx_draw_string_left(dpi, STR_TERRAIN_LABEL, nullptr, textColour, w->x + 4, w->y + w->widgets[WIDX_FLOOR_TEXTURE].top + 1);
+        dpi, STR_BASE_HEIGHT_LABEL, nullptr, textColour, w->windowPos.x + 4,
+        w->windowPos.y + w->widgets[WIDX_BASE_HEIGHT].top + 1);
+    gfx_draw_string_left(
+        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour, w->windowPos.x + 4,
+        w->windowPos.y + w->widgets[WIDX_WATER_LEVEL].top + 1);
+    gfx_draw_string_left(
+        dpi, STR_TERRAIN_LABEL, nullptr, textColour, w->windowPos.x + 4,
+        w->windowPos.y + w->widgets[WIDX_FLOOR_TEXTURE].top + 1);
 
     // The practical map size is 2 lower than the technical map size
     TileCoordsXY mapSizeArgs = { _mapSize - 2, _mapSize - 2 };
     gfx_draw_string_left(
-        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, w->colours[1], w->x + w->widgets[WIDX_MAP_SIZE].left + 1,
-        w->y + w->widgets[WIDX_MAP_SIZE].top + 1);
+        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, w->colours[1], w->windowPos.x + w->widgets[WIDX_MAP_SIZE].left + 1,
+        w->windowPos.y + w->widgets[WIDX_MAP_SIZE].top + 1);
 
     arg = (_baseHeight - 12) / 2;
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, w->colours[1], w->x + w->widgets[WIDX_BASE_HEIGHT].left + 1,
-        w->y + w->widgets[WIDX_BASE_HEIGHT].top + 1);
+        dpi, STR_COMMA16, &arg, w->colours[1], w->windowPos.x + w->widgets[WIDX_BASE_HEIGHT].left + 1,
+        w->windowPos.y + w->widgets[WIDX_BASE_HEIGHT].top + 1);
 
     arg = (_waterLevel - 12) / 2;
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, w->colours[1], w->x + w->widgets[WIDX_WATER_LEVEL].left + 1,
-        w->y + w->widgets[WIDX_WATER_LEVEL].top + 1);
+        dpi, STR_COMMA16, &arg, w->colours[1], w->windowPos.x + w->widgets[WIDX_WATER_LEVEL].left + 1,
+        w->windowPos.y + w->widgets[WIDX_WATER_LEVEL].top + 1);
 }
 
 #pragma endregion
@@ -1089,46 +1094,53 @@ static void window_mapgen_simplex_paint(rct_window* w, rct_drawpixelinfo* dpi)
     const uint8_t textColour = w->colours[1];
 
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_LOW].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_LOW].top + 1);
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_HIGH].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_HIGH].top + 1);
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, nullptr, textColour, w->x + 5,
-        w->y + w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1);
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1);
-    gfx_draw_string_left(dpi, STR_MAP_SIZE, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1);
     gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1);
+        dpi, STR_MAP_SIZE, nullptr, textColour, w->windowPos.x + 5, w->windowPos.y + w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1);
+    gfx_draw_string_left(
+        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1);
 
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_low, textColour, w->x + w->widgets[WIDX_SIMPLEX_LOW].left + 1,
-        w->y + w->widgets[WIDX_SIMPLEX_LOW].top + 1);
+        dpi, STR_COMMA16, &_simplex_low, textColour, w->windowPos.x + w->widgets[WIDX_SIMPLEX_LOW].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_LOW].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_high, textColour, w->x + w->widgets[WIDX_SIMPLEX_HIGH].left + 1,
-        w->y + w->widgets[WIDX_SIMPLEX_HIGH].top + 1);
+        dpi, STR_COMMA16, &_simplex_high, textColour, w->windowPos.x + w->widgets[WIDX_SIMPLEX_HIGH].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_HIGH].top + 1);
     gfx_draw_string_left(
         dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &_simplex_base_freq, textColour,
-        w->x + w->widgets[WIDX_SIMPLEX_BASE_FREQ].left + 1, w->y + w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1);
+        w->windowPos.x + w->widgets[WIDX_SIMPLEX_BASE_FREQ].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_octaves, textColour, w->x + w->widgets[WIDX_SIMPLEX_OCTAVES].left + 1,
-        w->y + w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1);
+        dpi, STR_COMMA16, &_simplex_octaves, textColour, w->windowPos.x + w->widgets[WIDX_SIMPLEX_OCTAVES].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1);
     gfx_draw_string_left(
-        dpi, STR_TERRAIN_LABEL, nullptr, textColour, w->x + 5, w->y + w->widgets[WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX].top + 1);
+        dpi, STR_TERRAIN_LABEL, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX].top + 1);
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_OPTION_PLACE_TREES, nullptr, textColour, w->x + 5,
-        w->y + w->widgets[WIDX_SIMPLEX_PLACE_TREES_CHECKBOX].top + 1);
+        dpi, STR_MAPGEN_OPTION_PLACE_TREES, nullptr, textColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_PLACE_TREES_CHECKBOX].top + 1);
 
     // The practical map size is 2 lower than the technical map size
     TileCoordsXY mapSizeArgs = { _mapSize - 2, _mapSize - 2 };
     gfx_draw_string_left(
-        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, textColour, w->x + w->widgets[WIDX_SIMPLEX_MAP_SIZE].left + 1,
-        w->y + w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1);
+        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, textColour, w->windowPos.x + w->widgets[WIDX_SIMPLEX_MAP_SIZE].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1);
 
     arg = (_waterLevel - 12) / 2;
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, textColour, w->x + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].left + 1,
-        w->y + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1);
+        dpi, STR_COMMA16, &arg, textColour, w->windowPos.x + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].left + 1,
+        w->windowPos.y + w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1);
 }
 
 #pragma endregion
@@ -1283,35 +1295,39 @@ static void window_mapgen_heightmap_paint(rct_window* w, rct_drawpixelinfo* dpi)
     const uint8_t strengthColour = _heightmapSmoothMap ? enabledColour : disabledColour;
     int16_t strength = _heightmapSmoothStrength;
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SMOOTH_STRENGTH, nullptr, strengthColour, w->x + 5, w->y + w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1);
+        dpi, STR_MAPGEN_SMOOTH_STRENGTH, nullptr, strengthColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &strength, strengthColour, w->x + w->widgets[WIDX_HEIGHTMAP_STRENGTH].left + 1,
-        w->y + w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1);
+        dpi, STR_COMMA16, &strength, strengthColour, w->windowPos.x + w->widgets[WIDX_HEIGHTMAP_STRENGTH].left + 1,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1);
 
     // Low label and value
     const uint8_t labelColour = _heightmapLoaded ? enabledColour : disabledColour;
     int16_t low = _heightmapLow;
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, labelColour, w->x + 5, w->y + w->widgets[WIDX_HEIGHTMAP_LOW].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, labelColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_LOW].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &low, labelColour, w->x + w->widgets[WIDX_HEIGHTMAP_LOW].left + 1,
-        w->y + w->widgets[WIDX_HEIGHTMAP_LOW].top + 1);
+        dpi, STR_COMMA16, &low, labelColour, w->windowPos.x + w->widgets[WIDX_HEIGHTMAP_LOW].left + 1,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_LOW].top + 1);
 
     // High label and value
     int16_t high = _heightmapHigh;
     gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, labelColour, w->x + 5, w->y + w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1);
+        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, labelColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &high, labelColour, w->x + w->widgets[WIDX_HEIGHTMAP_HIGH].left + 1,
-        w->y + w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1);
+        dpi, STR_COMMA16, &high, labelColour, w->windowPos.x + w->widgets[WIDX_HEIGHTMAP_HIGH].left + 1,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1);
 
     // Water level label and value
     int16_t waterLevel = _waterLevel;
     gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, labelColour, w->x + 5, w->y + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1);
+        dpi, STR_WATER_LEVEL_LABEL, nullptr, labelColour, w->windowPos.x + 5,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1);
     gfx_draw_string_left(
-        dpi, STR_COMMA16, &waterLevel, labelColour, w->x + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].left + 1,
-        w->y + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1);
+        dpi, STR_COMMA16, &waterLevel, labelColour, w->windowPos.x + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].left + 1,
+        w->windowPos.y + w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1);
 }
 
 #pragma endregion
@@ -1379,7 +1395,8 @@ static void window_mapgen_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w, 
             spriteIndex += (frame % TabAnimationFrames[w->page]);
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -129,8 +129,7 @@ static void window_map_tooltip_open()
     else
     {
         w->Invalidate();
-        w->x = pos.x;
-        w->y = pos.y;
+        w->windowPos = pos;
         w->width = width;
         w->height = height;
     }
@@ -159,6 +158,6 @@ static void window_map_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     gfx_draw_string_centred_wrapped(
-        dpi, gMapTooltipFormatArgs, w->x + (w->width / 2), w->y + (w->height / 2), w->width, STR_MAP_TOOLTIP_STRINGID,
-        COLOUR_BLACK);
+        dpi, gMapTooltipFormatArgs, w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2), w->width,
+        STR_MAP_TOOLTIP_STRINGID, COLOUR_BLACK);
 }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -367,8 +367,8 @@ static void window_multiplayer_groups_show_group_dropdown(rct_window* w, rct_wid
     numItems = network_get_num_groups();
 
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
     for (i = 0; i < network_get_num_groups(); i++)
     {
@@ -485,7 +485,7 @@ static void window_multiplayer_information_paint(rct_window* w, rct_drawpixelinf
     window_multiplayer_draw_tab_images(w, dpi);
 
     rct_drawpixelinfo clippedDPI;
-    if (clip_drawpixelinfo(&clippedDPI, dpi, w->x, w->y, w->width, w->height))
+    if (clip_drawpixelinfo(&clippedDPI, dpi, w->windowPos.x, w->windowPos.y, w->width, w->height))
     {
         dpi = &clippedDPI;
 
@@ -636,8 +636,8 @@ static void window_multiplayer_players_paint(rct_window* w, rct_drawpixelinfo* d
 
     // Number of players
     stringId = w->no_list_items == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;
-    x = w->x + 4;
-    y = w->y + w->widgets[WIDX_LIST].bottom + 2;
+    x = w->windowPos.x + 4;
+    y = w->windowPos.y + w->widgets[WIDX_LIST].bottom + 2;
     gfx_draw_string_left(dpi, stringId, &w->no_list_items, w->colours[2], x, y);
 }
 
@@ -907,12 +907,12 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
         set_format_arg(0, const char*, buffer);
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + (widget->left + widget->right - 11) / 2,
-            w->y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
+            w->windowPos.y + widget->top, widget->right - widget->left - 8);
     }
 
-    int32_t x = w->x + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4;
-    int32_t y = w->y + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4;
+    int32_t x = w->windowPos.x + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4;
+    int32_t y = w->windowPos.y + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4;
 
     gfx_draw_string_left(dpi, STR_DEFAULT_GROUP, nullptr, w->colours[2], x, y);
 
@@ -931,8 +931,8 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
         set_format_arg(0, const char*, buffer);
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + (widget->left + widget->right - 11) / 2,
-            w->y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
+            w->windowPos.y + widget->top, widget->right - widget->left - 8);
     }
 }
 
@@ -1062,7 +1062,8 @@ static void window_multiplayer_draw_tab_image(rct_window* w, rct_drawpixelinfo* 
             }
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -391,7 +391,7 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
     const int32_t graphHeight = (totalHeight - totalHeightText - heightTab) / 2;
 
     rct_drawpixelinfo clippedDPI;
-    if (clip_drawpixelinfo(&clippedDPI, dpi, w->x, w->y, w->width, w->height))
+    if (clip_drawpixelinfo(&clippedDPI, dpi, w->windowPos.x, w->windowPos.y, w->width, w->height))
     {
         dpi = &clippedDPI;
 
@@ -470,7 +470,8 @@ static void window_network_draw_tab_image(rct_window* w, rct_drawpixelinfo* dpi,
             }
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -182,8 +182,8 @@ static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
     lineCh = utf8_write_codepoint(lineCh, FORMAT_BLACK);
     safe_strcpy(lineCh, window_network_status_text, sizeof(buffer) - (lineCh - buffer));
     gfx_clip_string(buffer, w->widgets[WIDX_BACKGROUND].right - 50);
-    int32_t x = w->x + (w->width / 2);
-    int32_t y = w->y + (w->height / 2);
+    int32_t x = w->windowPos.x + (w->width / 2);
+    int32_t y = w->windowPos.y + (w->height / 2);
     x -= gfx_get_string_width(buffer) / 2;
     gfx_draw_string(dpi, buffer, COLOUR_BLACK, x, y);
 }

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -271,7 +271,7 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
                     }
 
                     window_dropdown_show_text_custom_width(
-                        w->x + dropdownWidget->left, w->y + dropdownWidget->top,
+                        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
                         dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
                         dropdownWidget->right - dropdownWidget->left - 3);
                 }
@@ -301,8 +301,9 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
                 }
 
                 window_dropdown_show_text_custom_width(
-                    w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                    w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, dropdownWidget->right - dropdownWidget->left - 3);
+                    w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                    dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
+                    dropdownWidget->right - dropdownWidget->left - 3);
             }
             break;
         // In RCT2, the maximum was 6 weeks
@@ -404,10 +405,10 @@ static void window_new_campaign_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widget* spinnerWidget = &window_new_campaign_widgets[WIDX_WEEKS_SPINNER];
     gfx_draw_string_left(
         dpi, w->campaign.no_weeks == 1 ? STR_MARKETING_1_WEEK : STR_X_WEEKS, &w->campaign.no_weeks, w->colours[0],
-        w->x + spinnerWidget->left + 1, w->y + spinnerWidget->top);
+        w->windowPos.x + spinnerWidget->left + 1, w->windowPos.y + spinnerWidget->top);
 
-    x = w->x + 14;
-    y = w->y + 60;
+    x = w->windowPos.x + 14;
+    y = w->windowPos.y + 60;
 
     // Price per week
     money32 pricePerWeek = AdvertisingCampaignPricePerWeek[w->campaign.campaign_type];

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -677,7 +677,8 @@ static void window_new_ride_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w
 
         spriteIndex |= w->colours[1] << 19;
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 
@@ -774,7 +775,7 @@ static void window_new_ride_scrollmousedown(rct_window* w, int32_t scrollIndex, 
     _windowNewRideHighlightedItem[_windowNewRideCurrentTab] = item;
     w->new_ride.selected_ride_id = item.ride_type_and_entry;
 
-    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
     w->new_ride.selected_ride_countdown = 8;
     w->Invalidate();
 }
@@ -840,7 +841,8 @@ static void window_new_ride_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ride_list_item item;
         item.ride_type_and_entry = static_cast<uint16_t>(w->new_ride.highlighted_ride_id);
         if (item.type != RIDE_TYPE_NULL || item.entry_index != RIDE_ENTRY_INDEX_NULL)
-            window_new_ride_paint_ride_information(w, dpi, item, w->x + 3, w->y + w->height - 64, w->width - 6);
+            window_new_ride_paint_ride_information(
+                w, dpi, item, w->windowPos.x + 3, w->windowPos.y + w->height - 64, w->width - 6);
     }
     else
     {

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -144,7 +144,7 @@ static void window_news_update(rct_window* w)
     }
 
     w->Invalidate();
-    audio_play_sound(SoundId::Click2, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click2, 0, w->windowPos.x + (w->width / 2));
 
     j = w->news.var_480;
     w->news.var_480 = -1;
@@ -240,7 +240,7 @@ static void window_news_scrollmousedown(rct_window* w, int32_t scrollIndex, cons
         w->news.var_482 = buttonIndex;
         w->news.var_484 = 4;
         w->Invalidate();
-        audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
+        audio_play_sound(SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
     }
 }
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -287,7 +287,8 @@ static void window_news_options_draw_tab_image(rct_window* w, rct_drawpixelinfo*
             }
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -560,12 +560,14 @@ static void window_object_load_error_paint(rct_window* w, rct_drawpixelinfo* dpi
 
     // Draw explanatory message
     set_format_arg(0, rct_string_id, STR_OBJECT_ERROR_WINDOW_EXPLANATION);
-    gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, w->x + 5, w->y + 18, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
+    gfx_draw_string_left_wrapped(
+        dpi, gCommonFormatArgs, w->windowPos.x + 5, w->windowPos.y + 18, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
 
     // Draw file name
     set_format_arg(0, rct_string_id, STR_OBJECT_ERROR_WINDOW_FILE);
     set_format_arg(2, utf8*, file_path.c_str());
-    gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + 5, w->y + 43, WW - 5);
+    gfx_draw_string_left_clipped(
+        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 5, w->windowPos.y + 43, WW - 5);
 }
 
 static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1286,8 +1286,8 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     }
 
                     window_dropdown_show_text_custom_width(
-                        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                        DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
+                        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
 
                     dropdown_set_checked((int32_t)theme_manager_get_active_available_theme_index(), true);
                     widget_invalidate(w, WIDX_THEMES_DROPDOWN);
@@ -1307,8 +1307,8 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     }
 
                     window_dropdown_show_text(
-                        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1],
-                        DROPDOWN_FLAG_STAY_OPEN, num_items);
+                        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                        w->colours[1], DROPDOWN_FLAG_STAY_OPEN, num_items);
 
                     dropdown_set_checked((int32_t)title_get_current_sequence(), true);
                     break;
@@ -1321,8 +1321,8 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     gDropdownItemsArgs[1] = STR_OPTIONS_SCENARIO_ORIGIN;
 
                     window_dropdown_show_text_custom_width(
-                        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                        DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
+                        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
 
                     dropdown_set_checked(gConfigGeneral.scenario_select_mode, true);
                     break;
@@ -2037,8 +2037,8 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
         case WINDOW_OPTIONS_PAGE_DISPLAY:
         {
             gfx_draw_string_left(
-                dpi, STR_FULLSCREEN_MODE, w, w->colours[1], w->x + 10,
-                w->y + window_options_display_widgets[WIDX_FULLSCREEN].top + 1);
+                dpi, STR_FULLSCREEN_MODE, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_display_widgets[WIDX_FULLSCREEN].top + 1);
 
             // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
             int32_t colour = w->colours[1];
@@ -2047,20 +2047,20 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 colour |= COLOUR_FLAG_INSET;
             }
             gfx_draw_string_left(
-                dpi, STR_DISPLAY_RESOLUTION, w, colour, w->x + 10 + 15,
-                w->y + window_options_display_widgets[WIDX_RESOLUTION].top + 1);
+                dpi, STR_DISPLAY_RESOLUTION, w, colour, w->windowPos.x + 10 + 15,
+                w->windowPos.y + window_options_display_widgets[WIDX_RESOLUTION].top + 1);
 
             gfx_draw_string_left(
-                dpi, STR_UI_SCALING_DESC, w, w->colours[1], w->x + 10,
-                w->y + window_options_display_widgets[WIDX_SCALE].top + 1);
+                dpi, STR_UI_SCALING_DESC, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_display_widgets[WIDX_SCALE].top + 1);
             gfx_draw_string_left(
-                dpi, STR_DRAWING_ENGINE, w, w->colours[1], w->x + 10,
-                w->y + window_options_display_widgets[WIDX_DRAWING_ENGINE].top + 1);
+                dpi, STR_DRAWING_ENGINE, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_display_widgets[WIDX_DRAWING_ENGINE].top + 1);
 
             int32_t scale = (int32_t)(gConfigGeneral.window_scale * 100);
             gfx_draw_string_left(
-                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &scale, w->colours[1], w->x + w->widgets[WIDX_SCALE].left + 1,
-                w->y + w->widgets[WIDX_SCALE].top + 1);
+                dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &scale, w->colours[1], w->windowPos.x + w->widgets[WIDX_SCALE].left + 1,
+                w->windowPos.y + w->widgets[WIDX_SCALE].top + 1);
 
             colour = w->colours[1];
             if (gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE
@@ -2069,72 +2069,74 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 colour |= COLOUR_FLAG_INSET;
             }
             gfx_draw_string_left(
-                dpi, STR_SCALING_QUALITY, w, colour, w->x + 25,
-                w->y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
+                dpi, STR_SCALING_QUALITY, w, colour, w->windowPos.x + 25,
+                w->windowPos.y + window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1);
             break;
         }
 
         case WINDOW_OPTIONS_PAGE_CULTURE:
             gfx_draw_string_left(
-                dpi, STR_OPTIONS_LANGUAGE, w, w->colours[1], w->x + 10,
-                w->y + window_options_culture_widgets[WIDX_LANGUAGE].top + 1);
+                dpi, STR_OPTIONS_LANGUAGE, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_LANGUAGE].top + 1);
             gfx_draw_string_left(
-                dpi, STR_CURRENCY, w, w->colours[1], w->x + 10, w->y + window_options_culture_widgets[WIDX_CURRENCY].top + 1);
+                dpi, STR_CURRENCY, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_CURRENCY].top + 1);
             gfx_draw_string_left(
-                dpi, STR_DISTANCE_AND_SPEED, w, w->colours[1], w->x + 10,
-                w->y + window_options_culture_widgets[WIDX_DISTANCE].top + 1);
+                dpi, STR_DISTANCE_AND_SPEED, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_DISTANCE].top + 1);
             gfx_draw_string_left(
-                dpi, STR_TEMPERATURE, w, w->colours[1], w->x + 10,
-                w->y + window_options_culture_widgets[WIDX_TEMPERATURE].top + 1);
+                dpi, STR_TEMPERATURE, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_TEMPERATURE].top + 1);
             gfx_draw_string_left(
-                dpi, STR_HEIGHT_LABELS, w, w->colours[1], w->x + 10,
-                w->y + window_options_culture_widgets[WIDX_HEIGHT_LABELS].top + 1);
+                dpi, STR_HEIGHT_LABELS, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_HEIGHT_LABELS].top + 1);
             gfx_draw_string_left(
-                dpi, STR_DATE_FORMAT, w, w->colours[1], w->x + 10,
-                w->y + window_options_culture_widgets[WIDX_DATE_FORMAT].top + 1);
+                dpi, STR_DATE_FORMAT, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_culture_widgets[WIDX_DATE_FORMAT].top + 1);
             break;
 
         case WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE:
         {
             gfx_draw_string_left(
-                dpi, STR_SHOW_TOOLBAR_BUTTONS_FOR, w, w->colours[1], w->x + 10,
-                w->y + window_options_controls_and_interface_widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15);
+                dpi, STR_SHOW_TOOLBAR_BUTTONS_FOR, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_controls_and_interface_widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15);
             gfx_draw_string_left(
-                dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1], w->x + 10,
-                w->y + window_options_controls_and_interface_widgets[WIDX_THEMES].top + 1);
+                dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_controls_and_interface_widgets[WIDX_THEMES].top + 1);
             break;
         }
 
         case WINDOW_OPTIONS_PAGE_MISC:
         {
             gfx_draw_string_left(
-                dpi, STR_TITLE_SEQUENCE, w, w->colours[1], w->x + 10,
-                w->y + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1);
+                dpi, STR_TITLE_SEQUENCE, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1);
             gfx_draw_string_left(
-                dpi, STR_OPTIONS_SCENARIO_GROUPING, nullptr, w->colours[1], w->x + 10,
-                w->y + window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top + 1);
+                dpi, STR_OPTIONS_SCENARIO_GROUPING, nullptr, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top + 1);
             gfx_draw_string_left(
-                dpi, STR_DEFAULT_INSPECTION_INTERVAL, w, w->colours[1], w->x + 10,
-                w->y + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1);
+                dpi, STR_DEFAULT_INSPECTION_INTERVAL, w, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1);
             break;
         }
 
         case WINDOW_OPTIONS_PAGE_ADVANCED:
         {
             gfx_draw_string_left(
-                dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->x + 24,
-                w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1);
+                dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1], w->windowPos.x + 24,
+                w->windowPos.y + window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1);
             gfx_draw_string_left(
                 dpi, window_options_autosave_names[gConfigGeneral.autosave_frequency], nullptr, w->colours[1],
-                w->x + window_options_advanced_widgets[WIDX_AUTOSAVE].left + 1,
-                w->y + window_options_advanced_widgets[WIDX_AUTOSAVE].top);
+                w->windowPos.x + window_options_advanced_widgets[WIDX_AUTOSAVE].left + 1,
+                w->windowPos.y + window_options_advanced_widgets[WIDX_AUTOSAVE].top);
             gfx_draw_string_left(
-                dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1], w->x + 24,
-                w->y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
+                dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1], w->windowPos.x + 24,
+                w->windowPos.y + window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
             int32_t autosavesToKeep = (int32_t)(gConfigGeneral.autosave_amount);
             gfx_draw_string_left(
                 dpi, STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, &autosavesToKeep, w->colours[1],
-                w->x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
+                w->windowPos.x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
+                w->windowPos.y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
             set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
 
@@ -2146,8 +2148,8 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
             uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
 
             gfx_draw_string_left_clipped(
-                dpi, STR_STRING, gCommonFormatArgs, w->colours[1], w->x + pathWidget.left + 1, w->y + pathWidget.top + padding,
-                277);
+                dpi, STR_STRING, gCommonFormatArgs, w->colours[1], w->windowPos.x + pathWidget.left + 1,
+                w->windowPos.y + pathWidget.top + padding, 277);
             break;
         }
     }
@@ -2157,8 +2159,8 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
 static void window_options_show_dropdown(rct_window* w, rct_widget* widget, int32_t num_items)
 {
     window_dropdown_show_text_custom_width(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN,
-        num_items, widget->right - widget->left - 3);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+        DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
 }
 
 static void window_options_update_height_markers()
@@ -2248,8 +2250,8 @@ static void window_options_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w,
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
     rct_widget* widget = &w->widgets[widgetIndex];
 
-    int16_t l = w->x + widget->left;
-    int16_t t = w->y + widget->top;
+    int16_t l = w->windowPos.x + widget->left;
+    int16_t t = w->windowPos.y + widget->top;
 
     if (!(w->disabled_widgets & (1LL << widgetIndex)))
     {

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -697,7 +697,7 @@ static void window_park_entrance_mousedown(rct_window* w, rct_widgetindex widget
         gDropdownItemsArgs[0] = STR_CLOSE_PARK;
         gDropdownItemsArgs[1] = STR_OPEN_PARK;
         window_dropdown_show_text(
-            w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, 2);
+            w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, 2);
 
         if (park_is_open())
         {
@@ -863,7 +863,7 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         window_draw_viewport(dpi, w);
         if (w->viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->x + 2, w->y + 2, 0);
+            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->windowPos.x + 2, w->windowPos.y + 2, 0);
     }
 
     // Draw park closed / open label
@@ -871,8 +871,8 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     labelWidget = &window_park_entrance_widgets[WIDX_STATUS];
     gfx_draw_string_centred_clipped(
-        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + (labelWidget->left + labelWidget->right) / 2,
-        w->y + labelWidget->top, labelWidget->right - labelWidget->left);
+        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (labelWidget->left + labelWidget->right) / 2,
+        w->windowPos.y + labelWidget->top, labelWidget->right - labelWidget->left);
 }
 
 /**
@@ -931,7 +931,7 @@ static void window_park_init_viewport(rct_window* w)
         {
             rct_widget* viewportWidget = &window_park_entrance_widgets[WIDX_VIEWPORT];
             viewport_create(
-                w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+                w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
                 (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
                 { x, y, z }, w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_MASK, SPRITE_INDEX_NULL);
             w->flags |= (1 << 2);
@@ -1046,8 +1046,8 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    x = w->x;
-    y = w->y;
+    x = w->windowPos.x;
+    y = w->windowPos.y;
     widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
@@ -1168,8 +1168,8 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    x = w->x;
-    y = w->y;
+    x = w->windowPos.x;
+    y = w->windowPos.y;
     widget = &window_park_guests_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
@@ -1302,14 +1302,14 @@ static void window_park_price_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    auto x = w->x + w->widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    auto y = w->y + w->widgets[WIDX_PAGE_BACKGROUND].top + 30;
+    auto x = w->windowPos.x + w->widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    auto y = w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + 30;
     gfx_draw_string_left(dpi, STR_INCOME_FROM_ADMISSIONS, &gTotalIncomeFromAdmissions, COLOUR_BLACK, x, y);
 
     money32 parkEntranceFee = park_get_entrance_fee();
     auto stringId = parkEntranceFee == 0 ? STR_FREE : STR_BOTTOM_TOOLBAR_CASH;
-    x = w->x + w->widgets[WIDX_PRICE].left + 1;
-    y = w->y + w->widgets[WIDX_PRICE].top + 1;
+    x = w->windowPos.x + w->widgets[WIDX_PRICE].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_PRICE].top + 1;
     gfx_draw_string_left(dpi, stringId, &parkEntranceFee, w->colours[1], x, y);
 }
 
@@ -1399,8 +1399,8 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    x = w->x + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    y = w->y + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    x = w->windowPos.x + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    y = w->windowPos.y + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     // Draw park size
     parkSize = gParkSize * 10;
@@ -1469,8 +1469,8 @@ rct_window* window_park_objective_open()
     window->hold_down_widgets = window_park_page_hold_down_widgets[WINDOW_PARK_PAGE_OBJECTIVE];
     window->event_handlers = &window_park_objective_events;
     window_init_scroll_widgets(window);
-    window->x = context_get_width() / 2 - 115;
-    window->y = context_get_height() / 2 - 87;
+    window->windowPos.x = context_get_width() / 2 - 115;
+    window->windowPos.y = context_get_height() / 2 - 87;
     window->Invalidate();
 
     return window;
@@ -1575,8 +1575,8 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_park_draw_tab_images(dpi, w);
 
     // Scenario description
-    x = w->x + window_park_objective_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    y = w->y + window_park_objective_widgets[WIDX_PAGE_BACKGROUND].top + 7;
+    x = w->windowPos.x + window_park_objective_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    y = w->windowPos.y + window_park_objective_widgets[WIDX_PAGE_BACKGROUND].top + 7;
     set_format_arg(0, rct_string_id, STR_STRING);
     set_format_arg(2, const char*, gScenarioDetails.c_str());
     y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, 222, STR_BLACK_STRING, COLOUR_BLACK);
@@ -1710,8 +1710,8 @@ static void window_park_awards_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    int32_t x = w->x + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    int32_t y = w->y + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    int32_t x = w->windowPos.x + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    int32_t y = w->windowPos.y + window_park_awards_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     int32_t count = 0;
     for (int32_t i = 0; i < MAX_AWARDS; i++)
     {
@@ -1800,7 +1800,9 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
 
     // Entrance tab
     if (!(w->disabled_widgets & (1 << WIDX_TAB_1)))
-        gfx_draw_sprite(dpi, SPR_TAB_PARK_ENTRANCE, w->x + w->widgets[WIDX_TAB_1].left, w->y + w->widgets[WIDX_TAB_1].top, 0);
+        gfx_draw_sprite(
+            dpi, SPR_TAB_PARK_ENTRANCE, w->windowPos.x + w->widgets[WIDX_TAB_1].left,
+            w->windowPos.y + w->widgets[WIDX_TAB_1].top, 0);
 
     // Rating tab
     if (!(w->disabled_widgets & (1 << WIDX_TAB_2)))
@@ -1808,10 +1810,14 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_GRAPH_0;
         if (w->page == WINDOW_PARK_PAGE_RATING)
             sprite_idx += (w->frame_no / 8) % 8;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_2].left, w->y + w->widgets[WIDX_TAB_2].top, 0);
-        gfx_draw_sprite(dpi, SPR_RATING_HIGH, w->x + w->widgets[WIDX_TAB_2].left + 7, w->y + w->widgets[WIDX_TAB_2].top + 1, 0);
         gfx_draw_sprite(
-            dpi, SPR_RATING_LOW, w->x + w->widgets[WIDX_TAB_2].left + 16, w->y + w->widgets[WIDX_TAB_2].top + 12, 0);
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_2].left, w->windowPos.y + w->widgets[WIDX_TAB_2].top, 0);
+        gfx_draw_sprite(
+            dpi, SPR_RATING_HIGH, w->windowPos.x + w->widgets[WIDX_TAB_2].left + 7,
+            w->windowPos.y + w->widgets[WIDX_TAB_2].top + 1, 0);
+        gfx_draw_sprite(
+            dpi, SPR_RATING_LOW, w->windowPos.x + w->widgets[WIDX_TAB_2].left + 16,
+            w->windowPos.y + w->widgets[WIDX_TAB_2].top + 12, 0);
     }
 
     // Guests tab
@@ -1820,7 +1826,8 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_GRAPH_0;
         if (w->page == WINDOW_PARK_PAGE_GUESTS)
             sprite_idx += (w->frame_no / 8) % 8;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_3].left, w->y + w->widgets[WIDX_TAB_3].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_3].left, w->windowPos.y + w->widgets[WIDX_TAB_3].top, 0);
 
         sprite_idx = g_peep_animation_entries[PEEP_SPRITE_TYPE_NORMAL].sprite_animation->base_image + 1;
         if (w->page == WINDOW_PARK_PAGE_GUESTS)
@@ -1828,8 +1835,8 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
 
         sprite_idx |= 0xA9E00000;
         gfx_draw_sprite(
-            dpi, sprite_idx, w->x + (w->widgets[WIDX_TAB_3].left + w->widgets[WIDX_TAB_3].right) / 2,
-            w->y + w->widgets[WIDX_TAB_3].bottom - 9, 0);
+            dpi, sprite_idx, w->windowPos.x + (w->widgets[WIDX_TAB_3].left + w->widgets[WIDX_TAB_3].right) / 2,
+            w->windowPos.y + w->widgets[WIDX_TAB_3].bottom - 9, 0);
     }
 
     // Price tab
@@ -1838,7 +1845,8 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_ADMISSION_0;
         if (w->page == WINDOW_PARK_PAGE_PRICE)
             sprite_idx += (w->frame_no / 2) % 8;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_4].left, w->y + w->widgets[WIDX_TAB_4].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_4].left, w->windowPos.y + w->widgets[WIDX_TAB_4].top, 0);
     }
 
     // Statistics tab
@@ -1847,7 +1855,8 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_STATS_0;
         if (w->page == WINDOW_PARK_PAGE_STATS)
             sprite_idx += (w->frame_no / 4) % 7;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_5].left, w->y + w->widgets[WIDX_TAB_5].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_5].left, w->windowPos.y + w->widgets[WIDX_TAB_5].top, 0);
     }
 
     // Objective tab
@@ -1856,12 +1865,14 @@ static void window_park_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         sprite_idx = SPR_TAB_OBJECTIVE_0;
         if (w->page == WINDOW_PARK_PAGE_OBJECTIVE)
             sprite_idx += (w->frame_no / 4) % 16;
-        gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_6].left, w->y + w->widgets[WIDX_TAB_6].top, 0);
+        gfx_draw_sprite(
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_6].left, w->windowPos.y + w->widgets[WIDX_TAB_6].top, 0);
     }
 
     // Awards tab
     if (!(w->disabled_widgets & (1 << WIDX_TAB_7)))
-        gfx_draw_sprite(dpi, SPR_TAB_AWARDS, w->x + w->widgets[WIDX_TAB_7].left, w->y + w->widgets[WIDX_TAB_7].top, 0);
+        gfx_draw_sprite(
+            dpi, SPR_TAB_AWARDS, w->windowPos.x + w->widgets[WIDX_TAB_7].left, w->windowPos.y + w->widgets[WIDX_TAB_7].top, 0);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -931,9 +931,9 @@ static void window_park_init_viewport(rct_window* w)
         {
             rct_widget* viewportWidget = &window_park_entrance_widgets[WIDX_VIEWPORT];
             viewport_create(
-                w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1,
-                (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0, x, y,
-                z, w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_MASK, SPRITE_INDEX_NULL);
+                w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+                (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
+                { x, y, z }, w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_MASK, SPRITE_INDEX_NULL);
             w->flags |= (1 << 2);
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -581,7 +581,8 @@ static void window_player_set_page(rct_window* w, int32_t page)
     {
         if (w->viewport == nullptr)
         {
-            viewport_create(w, w->x, w->y, w->width, w->height, 0, 128 * 32, 128 * 32, 0, 1, SPRITE_INDEX_NULL);
+            viewport_create(
+                w, { w->x, w->y }, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
             w->flags |= WF_NO_SCROLLING;
             window_event_invalidate_call(w);
             window_player_update_viewport(w, false);

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -456,8 +456,7 @@ void window_player_overview_invalidate(rct_window* w)
     {
         rct_widget* viewportWidget = &window_player_overview_widgets[WIDX_VIEWPORT];
 
-        viewport->x = w->x + viewportWidget->left;
-        viewport->y = w->y + viewportWidget->top;
+        viewport->pos = { w->x + viewportWidget->left, w->y + viewportWidget->top };
         viewport->width = viewportWidget->right - viewportWidget->left;
         viewport->height = viewportWidget->bottom - viewportWidget->top;
         viewport->view_width = viewport->width << viewport->zoom;
@@ -667,8 +666,7 @@ static void window_player_update_viewport(rct_window* w, bool scroll)
                 w->saved_view_y = centreLoc->y;
                 if (!scroll)
                 {
-                    w->viewport->view_x = centreLoc->x;
-                    w->viewport->view_y = centreLoc->y;
+                    w->viewport->viewPos = *centreLoc;
                 }
                 widget_invalidate(w, WIDX_VIEWPORT);
             }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -239,8 +239,8 @@ static void window_player_overview_show_group_dropdown(rct_window* w, rct_widget
     numItems = network_get_num_groups();
 
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
     for (i = 0; i < network_get_num_groups(); i++)
     {
@@ -377,13 +377,13 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         set_format_arg(0, const char*, buffer);
 
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + (widget->left + widget->right - 11) / 2,
-            w->y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
+            w->windowPos.y + widget->top, widget->right - widget->left - 8);
     }
 
     // Draw ping
-    int32_t x = w->x + 90;
-    int32_t y = w->y + 24;
+    int32_t x = w->windowPos.x + 90;
+    int32_t y = w->windowPos.y + 24;
 
     set_format_arg(0, rct_string_id, STR_PING);
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, x, y);
@@ -392,8 +392,8 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string(dpi, ping, w->colours[2], x + 30, y);
 
     // Draw last action
-    x = w->x + (w->width / 2);
-    y = w->y + w->height - 13;
+    x = w->windowPos.x + (w->width / 2);
+    y = w->windowPos.y + w->height - 13;
     int32_t width = w->width - 8;
     int32_t lastaction = network_get_player_last_action(player, 0);
     set_format_arg(0, rct_string_id, STR_ACTION_NA);
@@ -456,7 +456,7 @@ void window_player_overview_invalidate(rct_window* w)
     {
         rct_widget* viewportWidget = &window_player_overview_widgets[WIDX_VIEWPORT];
 
-        viewport->pos = { w->x + viewportWidget->left, w->y + viewportWidget->top };
+        viewport->pos = w->windowPos + ScreenCoordsXY{ viewportWidget->left, viewportWidget->top };
         viewport->width = viewportWidget->right - viewportWidget->left;
         viewport->height = viewportWidget->bottom - viewportWidget->top;
         viewport->view_width = viewport->width << viewport->zoom;
@@ -544,8 +544,8 @@ void window_player_statistics_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    int32_t x = w->x + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    int32_t y = w->y + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    int32_t x = w->windowPos.x + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    int32_t y = w->windowPos.y + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     set_format_arg(0, uint32_t, network_get_player_commands_ran(player));
     gfx_draw_string_left(dpi, STR_COMMANDS_RAN, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -581,7 +581,7 @@ static void window_player_set_page(rct_window* w, int32_t page)
         if (w->viewport == nullptr)
         {
             viewport_create(
-                w, { w->x, w->y }, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
+                w, w->windowPos, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
             w->flags |= WF_NO_SCROLLING;
             window_event_invalidate_call(w);
             window_player_update_viewport(w, false);
@@ -611,8 +611,8 @@ static void window_player_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
     if (!widget_is_disabled(w, WIDX_TAB_1))
     {
         widget = &w->widgets[WIDX_TAB_1];
-        x = widget->left + w->x;
-        y = widget->top + w->y;
+        x = widget->left + w->windowPos.x;
+        y = widget->top + w->windowPos.y;
         imageId = SPR_PEEP_LARGE_FACE_NORMAL;
         gfx_draw_sprite(dpi, imageId, x, y, 0);
     }
@@ -621,8 +621,8 @@ static void window_player_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
     if (!widget_is_disabled(w, WIDX_TAB_2))
     {
         widget = &w->widgets[WIDX_TAB_2];
-        x = widget->left + w->x;
-        y = widget->top + w->y;
+        x = widget->left + w->windowPos.x;
+        y = widget->top + w->windowPos.y;
         imageId = SPR_TAB_FINANCES_SUMMARY_0;
 
         if (w->page == WINDOW_PLAYER_PAGE_STATISTICS)
@@ -659,11 +659,10 @@ static void window_player_update_viewport(rct_window* w, bool scroll)
                 scroll = false;
             }
 
-            if (!scroll || w->saved_view_x != centreLoc->x || w->saved_view_y != centreLoc->y)
+            if (!scroll || w->savedViewPos != centreLoc)
             {
                 w->flags |= WF_SCROLLING_TO_LOCATION;
-                w->saved_view_x = centreLoc->x;
-                w->saved_view_y = centreLoc->y;
+                w->savedViewPos = *centreLoc;
                 if (!scroll)
                 {
                     w->viewport->viewPos = *centreLoc;

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -338,8 +338,8 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
 {
     baseWidgetIndex = baseWidgetIndex - WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP;
 
-    int32_t x = w->x + 10;
-    int32_t y = w->y + w->widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
+    int32_t x = w->windowPos.x + 10;
+    int32_t y = w->windowPos.y + w->widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
     rct_string_id stringId;
 
     if (gResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
@@ -393,8 +393,8 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     }
 
     // Last development
-    x = w->x + 10;
-    y = w->y + w->widgets[WIDX_LAST_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
+    x = w->windowPos.x + 10;
+    y = w->windowPos.y + w->widgets[WIDX_LAST_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
 
     rct_string_id lastDevelopmentFormat;
     if (gResearchLastItem.has_value())
@@ -463,8 +463,9 @@ static void window_research_funding_mousedown(rct_window* w, rct_widgetindex wid
         gDropdownItemsArgs[i] = ResearchFundingLevelNames[i];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4, dropdownWidget->right - dropdownWidget->left - 3);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4,
+        dropdownWidget->right - dropdownWidget->left - 3);
 
     int32_t currentResearchLevel = gResearchFundingLevel;
     dropdown_set_checked(currentResearchLevel, true);
@@ -570,7 +571,8 @@ void window_research_funding_page_paint(rct_window* w, rct_drawpixelinfo* dpi, r
 
     int32_t currentResearchLevel = gResearchFundingLevel;
     money32 currentResearchCostPerWeek = research_cost_table[currentResearchLevel];
-    gfx_draw_string_left(dpi, STR_RESEARCH_COST_PER_MONTH, &currentResearchCostPerWeek, COLOUR_BLACK, w->x + 10, w->y + 77);
+    gfx_draw_string_left(
+        dpi, STR_RESEARCH_COST_PER_MONTH, &currentResearchCostPerWeek, COLOUR_BLACK, w->windowPos.x + 10, w->windowPos.y + 77);
 }
 
 #pragma endregion
@@ -638,7 +640,8 @@ static void window_research_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w
             spriteIndex += frame;
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1255,7 +1255,8 @@ static void window_ride_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w, in
             spriteIndex += (frame % window_ride_tab_animation_frames[w->page]);
         }
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top, 0);
     }
 }
 
@@ -1290,7 +1291,9 @@ static void window_ride_draw_tab_main(rct_drawpixelinfo* dpi, rct_window* w)
                         spriteIndex += (w->frame_no / 4) % 8;
                     break;
             }
-            gfx_draw_sprite(dpi, spriteIndex, w->x + w->widgets[widgetIndex].left, w->y + w->widgets[widgetIndex].top, 0);
+            gfx_draw_sprite(
+                dpi, spriteIndex, w->windowPos.x + w->widgets[widgetIndex].left, w->windowPos.y + w->widgets[widgetIndex].top,
+                0);
         }
     }
 }
@@ -1313,8 +1316,8 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo* dpi, rct_window* w)
         if (w->page == WINDOW_RIDE_PAGE_VEHICLE)
             height += 4;
 
-        x += w->x;
-        y += w->y;
+        x += w->windowPos.x;
+        y += w->windowPos.y;
 
         rct_drawpixelinfo clipDPI;
         if (!clip_drawpixelinfo(&clipDPI, dpi, x, y, width, height))
@@ -1392,7 +1395,8 @@ static void window_ride_draw_tab_customer(rct_drawpixelinfo* dpi, rct_window* w)
         spriteIndex += 1;
         spriteIndex |= 0xA9E00000;
 
-        gfx_draw_sprite(dpi, spriteIndex, w->x + (widget->left + widget->right) / 2, w->y + widget->bottom - 6, 0);
+        gfx_draw_sprite(
+            dpi, spriteIndex, w->windowPos.x + (widget->left + widget->right) / 2, w->windowPos.y + widget->bottom - 6, 0);
     }
 }
 
@@ -1974,7 +1978,7 @@ static void window_ride_init_viewport(rct_window* w)
     {
         rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
 
-        auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ view_widget->left + 1, view_widget->top + 1 };
         int32_t width = view_widget->right - view_widget->left - 1;
         int32_t height = view_widget->bottom - view_widget->top - 1;
         viewport_create(
@@ -2139,8 +2143,8 @@ static void window_ride_show_view_dropdown(rct_window* w, rct_widget* widget)
     }
 
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
     // First item
     gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
@@ -2254,7 +2258,8 @@ static void window_ride_show_open_dropdown(rct_window* w, rct_widget* widget)
     window_ride_set_dropdown(info, RIDE_STATUS_TESTING, STR_TEST_RIDE);
     window_ride_set_dropdown(info, RIDE_STATUS_OPEN, STR_OPEN_RIDE);
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, info.NumItems);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+        info.NumItems);
     dropdown_set_checked(info.CheckedIndex, true);
     gDropdownDefaultIndex = info.DefaultIndex;
 }
@@ -2296,8 +2301,8 @@ static void window_ride_show_ride_type_dropdown(rct_window* w, rct_widget* widge
 
     rct_widget* dropdownWidget = widget - 1;
     window_dropdown_show_text(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], DROPDOWN_FLAG_STAY_OPEN, RIDE_TYPE_COUNT);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], DROPDOWN_FLAG_STAY_OPEN, RIDE_TYPE_COUNT);
 
     // Find the current ride type in the ordered list.
     uint8_t pos = 0;
@@ -2407,8 +2412,9 @@ static void window_ride_show_vehicle_type_dropdown(rct_window* w, rct_widget* wi
 
     rct_widget* dropdownWidget = widget - 1;
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
+        widget->right - dropdownWidget->left);
 
     // Find the current vehicle type in the ordered list.
     uint8_t pos = 0;
@@ -2890,7 +2896,7 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         window_draw_viewport(dpi, w);
         if (w->viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->x + 2, w->y + 2, 0);
+            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->windowPos.x + 2, w->windowPos.y + 2, 0);
     }
 
     // View dropdown
@@ -2916,15 +2922,15 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     widget = &window_ride_main_widgets[WIDX_VIEW];
     gfx_draw_string_centred(
-        dpi, STR_WINDOW_COLOUR_2_STRINGID, w->x + (widget->left + widget->right - 11) / 2, w->y + widget->top, COLOUR_BLACK,
-        gCommonFormatArgs);
+        dpi, STR_WINDOW_COLOUR_2_STRINGID, w->windowPos.x + (widget->left + widget->right - 11) / 2,
+        w->windowPos.y + widget->top, COLOUR_BLACK, gCommonFormatArgs);
 
     // Status
     widget = &window_ride_main_widgets[WIDX_STATUS];
     rct_string_id ride_status = window_ride_get_status(w, gCommonFormatArgs);
     gfx_draw_string_centred_clipped(
-        dpi, ride_status, gCommonFormatArgs, COLOUR_BLACK, w->x + (widget->left + widget->right) / 2, w->y + widget->top,
-        widget->right - widget->left);
+        dpi, ride_status, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right) / 2,
+        w->windowPos.y + widget->top, widget->right - widget->left);
 }
 
 #pragma endregion
@@ -3158,8 +3164,8 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (rideEntry == nullptr)
         return;
 
-    int32_t x = w->x + 8;
-    int32_t y = w->y + 64;
+    int32_t x = w->windowPos.x + 8;
+    int32_t y = w->windowPos.y + 64;
 
     // Description
     y += gfx_draw_string_left_wrapped(dpi, &rideEntry->naming.description, x, y, 300, STR_BLACK_STRING, COLOUR_BLACK);
@@ -3384,8 +3390,9 @@ static void window_ride_mode_dropdown(rct_window* w, rct_widget* widget)
         gDropdownItemsArgs[i] = RideModeNames[availableModes[i]];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numAvailableModes, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numAvailableModes,
+        widget->right - dropdownWidget->left);
 
     // Set checked item
     for (i = 0; i < numAvailableModes; i++)
@@ -3414,8 +3421,9 @@ static void window_ride_load_dropdown(rct_window* w, rct_widget* widget)
         gDropdownItemsArgs[i] = VehicleLoadNames[i];
     }
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 5, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 5,
+        widget->right - dropdownWidget->left);
 
     dropdown_set_checked(ride->depart_flags & RIDE_DEPART_WAIT_FOR_LOAD_MASK, true);
 }
@@ -3858,8 +3866,8 @@ static void window_ride_operating_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Horizontal rule between mode settings and depart settings
     gfx_fill_rect_inset(
-        dpi, w->x + window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].left + 4, w->y + 103,
-        w->x + window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].right - 5, w->y + 104, w->colours[1],
+        dpi, w->windowPos.x + window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].left + 4, w->windowPos.y + 103,
+        w->windowPos.x + window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].right - 5, w->windowPos.y + 104, w->colours[1],
         INSET_RECT_FLAG_BORDER_INSET);
 
     // Number of block sections
@@ -3867,8 +3875,8 @@ static void window_ride_operating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto blockSections = ride->num_block_brakes + ride->num_stations;
         gfx_draw_string_left(
-            dpi, STR_BLOCK_SECTIONS, &blockSections, COLOUR_BLACK, w->x + 21,
-            ride->mode == RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED ? w->y + 89 : w->y + 61);
+            dpi, STR_BLOCK_SECTIONS, &blockSections, COLOUR_BLACK, w->windowPos.x + 21,
+            ride->mode == RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED ? w->windowPos.y + 89 : w->windowPos.y + 61);
     }
 }
 
@@ -3993,8 +4001,9 @@ static void window_ride_maintenance_mousedown(rct_window* w, rct_widgetindex wid
                 gDropdownItemsArgs[i] = RideInspectionIntervalNames[i];
             }
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 7, widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 7,
+                widget->right - dropdownWidget->left);
 
             dropdown_set_checked(ride->inspection_interval, true);
             break;
@@ -4032,8 +4041,8 @@ static void window_ride_maintenance_mousedown(rct_window* w, rct_widgetindex wid
             else
             {
                 window_dropdown_show_text(
-                    w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                    w->colours[1], DROPDOWN_FLAG_STAY_OPEN, num_items);
+                    w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                    dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], DROPDOWN_FLAG_STAY_OPEN, num_items);
 
                 num_items = 1;
                 int32_t breakdownReason = ride->breakdown_reason_pending;
@@ -4254,20 +4263,20 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Locate mechanic button image
     rct_widget* widget = &window_ride_maintenance_widgets[WIDX_LOCATE_MECHANIC];
-    int32_t x = w->x + widget->left;
-    int32_t y = w->y + widget->top;
+    int32_t x = w->windowPos.x + widget->left;
+    int32_t y = w->windowPos.y + widget->top;
     gfx_draw_sprite(dpi, (gStaffMechanicColour << 24) | IMAGE_TYPE_REMAP | IMAGE_TYPE_REMAP_2_PLUS | SPR_MECHANIC, x, y, 0);
 
     // Inspection label
     widget = &window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL];
-    x = w->x + 4;
-    y = w->y + widget->top + 1;
+    x = w->windowPos.x + 4;
+    y = w->windowPos.y + widget->top + 1;
     gfx_draw_string_left(dpi, STR_INSPECTION, nullptr, COLOUR_BLACK, x, y);
 
     // Reliability
     widget = &window_ride_maintenance_widgets[WIDX_PAGE_BACKGROUND];
-    x = w->x + widget->left + 4;
-    y = w->y + widget->top + 4;
+    x = w->windowPos.x + widget->left + 4;
+    y = w->windowPos.y + widget->top + 4;
 
     uint16_t reliability = ride->reliability_percentage;
     gfx_draw_string_left(dpi, STR_RELIABILITY_LABEL_1757, &reliability, COLOUR_BLACK, x, y);
@@ -4508,8 +4517,9 @@ static void window_ride_colour_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4, widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4,
+                widget->right - dropdownWidget->left);
 
             dropdown_set_checked(colourSchemeIndex, true);
             break;
@@ -4530,8 +4540,9 @@ static void window_ride_colour_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4, widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 4,
+                widget->right - dropdownWidget->left);
 
             dropdown_set_checked(ride->track_colour[colourSchemeIndex].supports, true);
             break;
@@ -4555,8 +4566,9 @@ static void window_ride_colour_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, ddIndex, widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, ddIndex,
+                widget->right - dropdownWidget->left);
             break;
         }
         case WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN:
@@ -4568,9 +4580,9 @@ static void window_ride_colour_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, rideEntry->max_cars_in_train > 1 ? 3 : 2,
-                widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN,
+                rideEntry->max_cars_in_train > 1 ? 3 : 2, widget->right - dropdownWidget->left);
 
             dropdown_set_checked(ride->colour_scheme_type & 3, true);
             break;
@@ -4589,8 +4601,9 @@ static void window_ride_colour_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-                w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - dropdownWidget->left);
+                w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+                dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
+                widget->right - dropdownWidget->left);
 
             dropdown_set_checked(w->vehicleIndex, true);
             break;
@@ -4989,8 +5002,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     widget = &window_ride_colour_widgets[WIDX_TRACK_PREVIEW];
     if (widget->type != WWT_EMPTY)
         gfx_fill_rect(
-            dpi, w->x + widget->left + 1, w->y + widget->top + 1, w->x + widget->right - 1, w->y + widget->bottom - 1,
-            PALETTE_INDEX_12);
+            dpi, w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1, w->windowPos.x + widget->right - 1,
+            w->windowPos.y + widget->bottom - 1, PALETTE_INDEX_12);
 
     auto trackColour = ride_get_track_colour(ride, w->ride_colour);
 
@@ -4998,8 +5011,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr || rideEntry->shop_item == SHOP_ITEM_NONE)
     {
-        int32_t x = w->x + widget->left;
-        int32_t y = w->y + widget->top;
+        int32_t x = w->windowPos.x + widget->left;
+        int32_t y = w->windowPos.y + widget->top;
 
         // Track
         if (ride->type == RIDE_TYPE_MAZE)
@@ -5027,8 +5040,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     else
     {
-        int32_t x = w->x + (widget->left + widget->right) / 2 - 8;
-        int32_t y = w->y + (widget->bottom + widget->top) / 2 - 6;
+        int32_t x = w->windowPos.x + (widget->left + widget->right) / 2 - 8;
+        int32_t y = w->windowPos.y + (widget->bottom + widget->top) / 2 - 6;
 
         uint8_t shopItem = rideEntry->shop_item_secondary == SHOP_ITEM_NONE ? rideEntry->shop_item
                                                                             : rideEntry->shop_item_secondary;
@@ -5044,8 +5057,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (widget->type != WWT_EMPTY)
     {
         if (clip_drawpixelinfo(
-                &clippedDpi, dpi, w->x + widget->left + 1, w->y + widget->top + 1, widget->right - widget->left,
-                widget->bottom - widget->top))
+                &clippedDpi, dpi, w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1,
+                widget->right - widget->left, widget->bottom - widget->top))
         {
             gfx_clear(&clippedDpi, PALETTE_INDEX_12);
 
@@ -5073,7 +5086,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
             }
         }
 
-        gfx_draw_string_left_clipped(dpi, STR_STATION_STYLE, gCommonFormatArgs, COLOUR_BLACK, w->x + 3, w->y + 103, 97);
+        gfx_draw_string_left_clipped(
+            dpi, STR_STATION_STYLE, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 3, w->windowPos.y + 103, 97);
     }
 }
 
@@ -5225,8 +5239,9 @@ static void window_ride_music_mousedown(rct_window* w, rct_widgetindex widgetInd
     }
 
     window_dropdown_show_text_custom_width(
-        w->x + dropdownWidget->left, w->y + dropdownWidget->top, dropdownWidget->bottom - dropdownWidget->top + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - dropdownWidget->left);
+        w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top,
+        dropdownWidget->bottom - dropdownWidget->top + 1, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems,
+        widget->right - dropdownWidget->left);
 
     for (auto i = 0; i < numItems; i++)
     {
@@ -5524,7 +5539,8 @@ static void window_ride_measurements_mousedown(rct_window* w, rct_widgetindex wi
     gDropdownItemsFormat[1] = STR_SAVE_TRACK_DESIGN_WITH_SCENERY_ITEM;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], DROPDOWN_FLAG_STAY_OPEN, 2);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1],
+        DROPDOWN_FLAG_STAY_OPEN, 2);
     gDropdownDefaultIndex = 0;
     if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
     {
@@ -5697,13 +5713,13 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
     {
         rct_widget* widget = &window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND];
 
-        int32_t x = w->x + (widget->right - widget->left) / 2;
-        int32_t y = w->y + widget->top + 40;
+        int32_t x = w->windowPos.x + (widget->right - widget->left) / 2;
+        int32_t y = w->windowPos.y + widget->top + 40;
         gfx_draw_string_centred_wrapped(dpi, nullptr, x, y, w->width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, COLOUR_BLACK);
 
-        x = w->x + 4;
-        y = w->y + window_ride_measurements_widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
-        gfx_fill_rect_inset(dpi, x, y, w->x + 312, y + 1, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
+        x = w->windowPos.x + 4;
+        y = w->windowPos.y + window_ride_measurements_widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
+        gfx_fill_rect_inset(dpi, x, y, w->windowPos.x + 312, y + 1, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
     }
     else
     {
@@ -5711,8 +5727,8 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
         if (ride == nullptr)
             return;
 
-        int32_t x = w->x + window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-        int32_t y = w->y + window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+        int32_t x = w->windowPos.x + window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+        int32_t y = w->windowPos.y + window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
         {
@@ -6755,8 +6771,8 @@ static void window_ride_income_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (rideEntry == nullptr)
         return;
 
-    x = w->x + window_ride_income_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    y = w->y + window_ride_income_widgets[WIDX_PAGE_BACKGROUND].top + 33;
+    x = w->windowPos.x + window_ride_income_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    y = w->windowPos.y + window_ride_income_widgets[WIDX_PAGE_BACKGROUND].top + 33;
 
     // Primary item profit / loss per item sold
     primaryItem = rideEntry->shop_item;
@@ -6963,8 +6979,8 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride == nullptr)
         return;
 
-    x = w->x + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    y = w->y + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    x = w->windowPos.x + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    y = w->windowPos.y + window_ride_customer_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     // Customers currently on ride
     if (ride->IsRide())

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1974,13 +1974,13 @@ static void window_ride_init_viewport(rct_window* w)
     {
         rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
 
-        int32_t x = view_widget->left + 1 + w->x;
-        int32_t y = view_widget->top + 1 + w->y;
+        auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
         int32_t width = view_widget->right - view_widget->left - 1;
         int32_t height = view_widget->bottom - view_widget->top - 1;
         viewport_create(
-            w, x, y, width, height, focus.coordinate.zoom, focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK,
-            focus.coordinate.z, focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
+            w, screenPos, width, height, focus.coordinate.zoom,
+            { focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK, focus.coordinate.z },
+            focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
 
         w->flags |= WF_NO_SCROLLING;
         w->Invalidate();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1389,7 +1389,7 @@ static void window_ride_draw_tab_customer(rct_drawpixelinfo* dpi, rct_window* w)
         rct_widget* widget = &w->widgets[widgetIndex];
         int32_t spriteIndex = 0;
         if (w->page == WINDOW_RIDE_PAGE_CUSTOMER)
-            spriteIndex = w->var_492 & ~3;
+            spriteIndex = w->picked_peep_frame & ~3;
 
         spriteIndex += g_peep_animation_entries[PEEP_SPRITE_TYPE_NORMAL].sprite_animation->base_image;
         spriteIndex += 1;
@@ -1560,7 +1560,7 @@ static rct_window* window_ride_open(Ride* ride)
     w->vehicleIndex = 0;
     w->frame_no = 0;
     w->list_information_type = 0;
-    w->var_492 = 0;
+    w->picked_peep_frame = 0;
     w->ride_colour = 0;
     window_ride_disable_tabs(w);
     w->min_width = 316;
@@ -1801,7 +1801,7 @@ static void window_ride_set_page(rct_window* w, int32_t page)
 
     w->page = page;
     w->frame_no = 0;
-    w->var_492 = 0;
+    w->picked_peep_frame = 0;
 
     // There doesn't seem to be any need for this call, and it can sometimes modify the reported number of cars per train, so
     // I've removed it if (page == WINDOW_RIDE_PAGE_VEHICLE) { ride_update_max_vehicles(ride);
@@ -6908,9 +6908,9 @@ static void window_ride_customer_resize(rct_window* w)
  */
 static void window_ride_customer_update(rct_window* w)
 {
-    w->var_492++;
-    if (w->var_492 >= 24)
-        w->var_492 = 0;
+    w->picked_peep_frame++;
+    if (w->picked_peep_frame >= 24)
+        w->picked_peep_frame = 0;
 
     window_event_invalidate_call(w);
     widget_invalidate(w, WIDX_TAB_10);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2332,8 +2332,8 @@ static void window_ride_construction_paint(rct_window* w, rct_drawpixelinfo* dpi
         return;
 
     // Draw track piece
-    x = w->x + widget->left + 1;
-    y = w->y + widget->top + 1;
+    x = w->windowPos.x + widget->left + 1;
+    y = w->windowPos.y + widget->top + 1;
     width = widget->right - widget->left - 1;
     height = widget->bottom - widget->top - 1;
     if (clip_drawpixelinfo(&clipdpi, dpi, x, y, width, height))
@@ -2343,8 +2343,8 @@ static void window_ride_construction_paint(rct_window* w, rct_drawpixelinfo* dpi
     }
 
     // Draw cost
-    x = w->x + (widget->left + widget->right) / 2;
-    y = w->y + widget->bottom - 23;
+    x = w->windowPos.x + (widget->left + widget->right) / 2;
+    y = w->windowPos.y + widget->bottom - 23;
     if (_rideConstructionState != RIDE_CONSTRUCTION_STATE_PLACE)
         gfx_draw_string_centred(dpi, STR_BUILD_THIS, x, y, COLOUR_BLACK, w);
 
@@ -3387,7 +3387,7 @@ static void window_ride_construction_show_special_track_dropdown(rct_window* w, 
     }
 
     window_dropdown_show_text_custom_width(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, 0,
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0, 0,
         _numCurrentPossibleRideConfigurations, widget->right - widget->left);
 
     for (int32_t i = 0; i < 32; i++)

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -318,7 +318,8 @@ static void window_ride_list_mousedown(rct_window* w, rct_widgetindex widgetInde
     {
         gDropdownItemsFormat[0] = STR_CLOSE_ALL;
         gDropdownItemsFormat[1] = STR_OPEN_ALL;
-        window_dropdown_show_text(w->x + widget->left, w->y + widget->top, widget->bottom - widget->top, w->colours[1], 0, 2);
+        window_dropdown_show_text(
+            w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top, w->colours[1], 0, 2);
     }
     else if (widgetIndex == WIDX_INFORMATION_TYPE_DROPDOWN)
     {
@@ -353,8 +354,8 @@ static void window_ride_list_mousedown(rct_window* w, rct_widgetindex widgetInde
         }
 
         window_dropdown_show_text_custom_width(
-            w->x + widget->left, w->y + widget->top, widget->bottom - widget->top, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN,
-            numItems, widget->right - widget->left - 3);
+            w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top, w->colours[1], 0,
+            DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
         if (selectedIndex != -1)
         {
             dropdown_set_checked(selectedIndex, true);
@@ -569,8 +570,8 @@ static void window_ride_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Draw number of attractions on bottom
     gfx_draw_string_left(
-        dpi, ride_list_statusbar_count_strings[w->page], &w->no_list_items, COLOUR_BLACK, w->x + 4,
-        w->widgets[WIDX_LIST].bottom + w->y + 2);
+        dpi, ride_list_statusbar_count_strings[w->page], &w->no_list_items, COLOUR_BLACK, w->windowPos.x + 4,
+        w->widgets[WIDX_LIST].bottom + w->windowPos.y + 2);
 }
 
 /**
@@ -754,19 +755,22 @@ static void window_ride_list_draw_tab_images(rct_drawpixelinfo* dpi, rct_window*
     sprite_idx = SPR_TAB_RIDE_0;
     if (w->page == PAGE_RIDES)
         sprite_idx += w->frame_no / 4;
-    gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_1].left, w->y + w->widgets[WIDX_TAB_1].top, 0);
+    gfx_draw_sprite(
+        dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_1].left, w->windowPos.y + w->widgets[WIDX_TAB_1].top, 0);
 
     // Shops and stalls tab
     sprite_idx = SPR_TAB_SHOPS_AND_STALLS_0;
     if (w->page == PAGE_SHOPS_AND_STALLS)
         sprite_idx += w->frame_no / 4;
-    gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_2].left, w->y + w->widgets[WIDX_TAB_2].top, 0);
+    gfx_draw_sprite(
+        dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_2].left, w->windowPos.y + w->widgets[WIDX_TAB_2].top, 0);
 
     // Information kiosks and facilities tab
     sprite_idx = SPR_TAB_KIOSKS_AND_FACILITIES_0;
     if (w->page == PAGE_KIOSKS_AND_FACILITIES)
         sprite_idx += (w->frame_no / 4) % 8;
-    gfx_draw_sprite(dpi, sprite_idx, w->x + w->widgets[WIDX_TAB_3].left, w->y + w->widgets[WIDX_TAB_3].top, 0);
+    gfx_draw_sprite(
+        dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_TAB_3].left, w->windowPos.y + w->widgets[WIDX_TAB_3].top, 0);
 }
 
 /**

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -764,7 +764,7 @@ static void window_scenery_update(rct_window* w)
     rct_window* other = window_find_from_point(state->position);
     if (other == w)
     {
-        ScreenCoordsXY window = state->position - ScreenCoordsXY{ w->x - 26, w->y };
+        ScreenCoordsXY window = state->position - ScreenCoordsXY{ w->windowPos.x - 26, w->windowPos.y };
 
         if (window.y < 44 || window.x <= w->width)
         {
@@ -901,7 +901,7 @@ void window_scenery_scrollmousedown(rct_window* w, int32_t scrollIndex, const Sc
 
     gWindowSceneryPaintEnabled &= 0xFE;
     gWindowSceneryEyedropperEnabled = false;
-    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
     w->scenery.hover_counter = -16;
     gSceneryPlaceCost = MONEY32_UNDEFINED;
     w->Invalidate();
@@ -1128,8 +1128,8 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     uint32_t imageId = ((w->colours[1] << 19) | window_scenery_widgets[selectedWidgetId].image) + 1ul;
 
     gfx_draw_sprite(
-        dpi, imageId, w->x + window_scenery_widgets[selectedWidgetId].left, w->y + window_scenery_widgets[selectedWidgetId].top,
-        selectedWidgetId);
+        dpi, imageId, w->windowPos.x + window_scenery_widgets[selectedWidgetId].left,
+        w->windowPos.y + window_scenery_widgets[selectedWidgetId].top, selectedWidgetId);
 
     uint16_t selectedSceneryEntryId = w->scenery.selected_scenery_id;
     if (selectedSceneryEntryId == WINDOW_SCENERY_TAB_SELECTION_UNDEFINED)
@@ -1185,12 +1185,14 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         // -14
         gfx_draw_string_right(
-            dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK, w->x + w->width - 0x1A, w->y + w->height - 13);
+            dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 0x1A,
+            w->windowPos.y + w->height - 13);
     }
 
     set_format_arg(0, rct_string_id, sceneryEntry != nullptr ? sceneryEntry->name : (rct_string_id)STR_UNKNOWN_OBJECT_TYPE);
     gfx_draw_string_left_clipped(
-        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->x + 3, w->y + w->height - 13, w->width - 19);
+        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 3, w->windowPos.y + w->height - 13,
+        w->width - 19);
 }
 
 /**

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -236,8 +236,8 @@ static void window_scenery_scatter_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (gWindowSceneryScatterSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
         auto preview = window_scenery_scatter_widgets[WIDX_PREVIEW];
-        int32_t x = w->x + (preview.left + preview.right) / 2;
-        int32_t y = w->y + (preview.top + preview.bottom) / 2;
+        int32_t x = w->windowPos.x + (preview.left + preview.right) / 2;
+        int32_t y = w->windowPos.y + (preview.top + preview.bottom) / 2;
         gfx_draw_string_centred(dpi, STR_LAND_TOOL_SIZE_VALUE, x, y - 2, COLOUR_BLACK, &gWindowSceneryScatterSize);
     }
 }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -272,8 +272,8 @@ static void window_server_list_scroll_mousedown(rct_window* w, int32_t scrollInd
         const auto& server = _serverList.GetServer(serverIndex);
 
         auto listWidget = &w->widgets[WIDX_LIST];
-        int32_t ddx = w->x + listWidget->left + screenCoords.x + 2 - w->scrolls[0].h_left;
-        int32_t ddy = w->y + listWidget->top + screenCoords.y + 2 - w->scrolls[0].v_top;
+        int32_t ddx = w->windowPos.x + listWidget->left + screenCoords.x + 2 - w->scrolls[0].h_left;
+        int32_t ddy = w->windowPos.y + listWidget->top + screenCoords.y + 2 - w->scrolls[0].v_top;
 
         gDropdownItemsFormat[0] = STR_JOIN_GAME;
         if (server.favourite)
@@ -405,15 +405,19 @@ static void window_server_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    gfx_draw_string_left(dpi, STR_PLAYER_NAME, nullptr, COLOUR_WHITE, w->x + 6, w->y + w->widgets[WIDX_PLAYER_NAME_INPUT].top);
+    gfx_draw_string_left(
+        dpi, STR_PLAYER_NAME, nullptr, COLOUR_WHITE, w->windowPos.x + 6,
+        w->windowPos.y + w->widgets[WIDX_PLAYER_NAME_INPUT].top);
 
     // Draw version number
     std::string version = network_get_version();
     const char* versionCStr = version.c_str();
     gfx_draw_string_left(
-        dpi, STR_NETWORK_VERSION, (void*)&versionCStr, COLOUR_WHITE, w->x + 324, w->y + w->widgets[WIDX_START_SERVER].top + 1);
+        dpi, STR_NETWORK_VERSION, (void*)&versionCStr, COLOUR_WHITE, w->windowPos.x + 324,
+        w->windowPos.y + w->widgets[WIDX_START_SERVER].top + 1);
 
-    gfx_draw_string_left(dpi, _statusText, (void*)&_numPlayersOnline, COLOUR_WHITE, w->x + 8, w->y + w->height - 15);
+    gfx_draw_string_left(
+        dpi, _statusText, (void*)&_numPlayersOnline, COLOUR_WHITE, w->windowPos.x + 8, w->windowPos.y + w->height - 15);
 }
 
 static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -338,14 +338,20 @@ static void window_server_start_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    gfx_draw_string_left(dpi, STR_PORT, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_PORT_INPUT].top);
-    gfx_draw_string_left(dpi, STR_SERVER_NAME, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_NAME_INPUT].top);
     gfx_draw_string_left(
-        dpi, STR_SERVER_DESCRIPTION, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_DESCRIPTION_INPUT].top);
+        dpi, STR_PORT, nullptr, w->colours[1], w->windowPos.x + 6, w->windowPos.y + w->widgets[WIDX_PORT_INPUT].top);
     gfx_draw_string_left(
-        dpi, STR_SERVER_GREETING, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_GREETING_INPUT].top);
-    gfx_draw_string_left(dpi, STR_PASSWORD, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_PASSWORD_INPUT].top);
-    gfx_draw_string_left(dpi, STR_MAX_PLAYERS, nullptr, w->colours[1], w->x + 6, w->y + w->widgets[WIDX_MAXPLAYERS].top);
+        dpi, STR_SERVER_NAME, nullptr, w->colours[1], w->windowPos.x + 6, w->windowPos.y + w->widgets[WIDX_NAME_INPUT].top);
+    gfx_draw_string_left(
+        dpi, STR_SERVER_DESCRIPTION, nullptr, w->colours[1], w->windowPos.x + 6,
+        w->windowPos.y + w->widgets[WIDX_DESCRIPTION_INPUT].top);
+    gfx_draw_string_left(
+        dpi, STR_SERVER_GREETING, nullptr, w->colours[1], w->windowPos.x + 6,
+        w->windowPos.y + w->widgets[WIDX_GREETING_INPUT].top);
+    gfx_draw_string_left(
+        dpi, STR_PASSWORD, nullptr, w->colours[1], w->windowPos.x + 6, w->windowPos.y + w->widgets[WIDX_PASSWORD_INPUT].top);
+    gfx_draw_string_left(
+        dpi, STR_MAX_PLAYERS, nullptr, w->colours[1], w->windowPos.x + 6, w->windowPos.y + w->widgets[WIDX_MAXPLAYERS].top);
 }
 
 #endif

--- a/src/openrct2-ui/windows/ShortcutKeyChange.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeyChange.cpp
@@ -105,8 +105,8 @@ static void window_shortcut_change_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    int32_t x = w->x + 125;
-    int32_t y = w->y + 30;
+    int32_t x = w->windowPos.x + 125;
+    int32_t y = w->windowPos.y + 30;
 
     set_format_arg(0, rct_string_id, ShortcutStringIds[gKeyboardShortcutChangeId]);
     gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, 242, STR_SHORTCUT_CHANGE_PROMPT, COLOUR_BLACK);

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -188,7 +188,7 @@ rct_window* window_sign_open(rct_windownumber number)
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
         { signViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 
@@ -367,7 +367,7 @@ static void window_sign_viewport_rotate(rct_window* w)
     // Create viewport
     rct_widget* viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0, signViewPos,
         0, SPRITE_INDEX_NULL);
     if (w->viewport != nullptr)
@@ -431,7 +431,7 @@ rct_window* window_sign_small_open(rct_windownumber number)
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
         { signViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -156,10 +156,9 @@ rct_window* window_sign_open(rct_windownumber number)
     window_init_scroll_widgets(w);
 
     auto banner = GetBanner(w->number);
-    int32_t view_x = banner->position.x << 5;
-    int32_t view_y = banner->position.y << 5;
+    auto signViewPos = banner->position.ToCoordsXY().ToTileCentre();
 
-    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
+    TileElement* tile_element = map_get_first_element_at(signViewPos);
     if (tile_element == nullptr)
         return nullptr;
 
@@ -186,14 +185,12 @@ rct_window* window_sign_open(rct_windownumber number)
     w->var_492 = tile_element->AsLargeScenery()->GetSecondaryColour();
     w->var_48C = tile_element->AsLargeScenery()->GetEntryIndex();
 
-    view_x += 16;
-    view_y += 16;
-
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1, (viewportWidget->right - viewportWidget->left) - 1,
-        (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
+        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
+        { signViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
     w->Invalidate();
@@ -365,15 +362,14 @@ static void window_sign_viewport_rotate(rct_window* w)
 
     auto banner = GetBanner(w->number);
 
-    int32_t view_x = (banner->position.x << 5) + 16;
-    int32_t view_y = (banner->position.y << 5) + 16;
-    int32_t view_z = w->frame_no;
+    auto signViewPos = CoordsXYZ{ banner->position.ToCoordsXY().ToTileCentre(), w->frame_no };
 
     // Create viewport
     rct_widget* viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1, (viewportWidget->right - viewportWidget->left) - 1,
-        (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
+        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0, signViewPos,
+        0, SPRITE_INDEX_NULL);
     if (w->viewport != nullptr)
         w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
     w->Invalidate();
@@ -405,10 +401,9 @@ rct_window* window_sign_small_open(rct_windownumber number)
     w->colours[2] = COLOUR_DARK_BROWN;
 
     auto banner = GetBanner(w->number);
-    int32_t view_x = banner->position.x << 5;
-    int32_t view_y = banner->position.y << 5;
+    auto signViewPos = banner->position.ToCoordsXY().ToTileCentre();
 
-    TileElement* tile_element = map_get_first_element_at({ view_x, view_y });
+    TileElement* tile_element = map_get_first_element_at(signViewPos);
     if (tile_element == nullptr)
         return nullptr;
 
@@ -433,14 +428,12 @@ rct_window* window_sign_small_open(rct_windownumber number)
     w->var_492 = tile_element->AsWall()->GetSecondaryColour();
     w->var_48C = tile_element->AsWall()->GetEntryIndex();
 
-    view_x += 16;
-    view_y += 16;
-
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
     viewport_create(
-        w, w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1, (viewportWidget->right - viewportWidget->left) - 1,
-        (viewportWidget->bottom - viewportWidget->top) - 1, 0, view_x, view_y, view_z, 0, SPRITE_INDEX_NULL);
+        w, { w->x + viewportWidget->left + 1, w->y + viewportWidget->top + 1 },
+        (viewportWidget->right - viewportWidget->left) - 1, (viewportWidget->bottom - viewportWidget->top) - 1, 0,
+        { signViewPos, view_z }, 0, SPRITE_INDEX_NULL);
 
     w->viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
     w->flags |= WF_NO_SCROLLING;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -183,7 +183,7 @@ rct_window* window_sign_open(rct_windownumber number)
 
     w->list_information_type = tile_element->AsLargeScenery()->GetPrimaryColour();
     w->var_492 = tile_element->AsLargeScenery()->GetSecondaryColour();
-    w->var_48C = tile_element->AsLargeScenery()->GetEntryIndex();
+    w->SceneryEntry = tile_element->AsLargeScenery()->GetEntryIndex();
 
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
@@ -316,7 +316,7 @@ static void window_sign_invalidate(rct_window* w)
     rct_widget* main_colour_btn = &window_sign_widgets[WIDX_MAIN_COLOUR];
     rct_widget* text_colour_btn = &window_sign_widgets[WIDX_TEXT_COLOUR];
 
-    rct_scenery_entry* scenery_entry = get_large_scenery_entry(w->var_48C);
+    rct_scenery_entry* scenery_entry = get_large_scenery_entry(w->SceneryEntry);
 
     main_colour_btn->type = WWT_EMPTY;
     text_colour_btn->type = WWT_EMPTY;
@@ -426,7 +426,7 @@ rct_window* window_sign_small_open(rct_windownumber number)
 
     w->list_information_type = tile_element->AsWall()->GetPrimaryColour();
     w->var_492 = tile_element->AsWall()->GetSecondaryColour();
-    w->var_48C = tile_element->AsWall()->GetEntryIndex();
+    w->SceneryEntry = tile_element->AsWall()->GetEntryIndex();
 
     // Create viewport
     viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
@@ -527,7 +527,7 @@ static void window_sign_small_invalidate(rct_window* w)
     rct_widget* main_colour_btn = &window_sign_widgets[WIDX_MAIN_COLOUR];
     rct_widget* text_colour_btn = &window_sign_widgets[WIDX_TEXT_COLOUR];
 
-    rct_scenery_entry* scenery_entry = get_wall_entry(w->var_48C);
+    rct_scenery_entry* scenery_entry = get_wall_entry(w->SceneryEntry);
 
     main_colour_btn->type = WWT_EMPTY;
     text_colour_btn->type = WWT_EMPTY;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1380,12 +1380,12 @@ void window_staff_viewport_init(rct_window* w)
         {
             rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
 
-            int32_t x = view_widget->left + 1 + w->x;
-            int32_t y = view_widget->top + 1 + w->y;
+            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
             int32_t width = view_widget->right - view_widget->left - 1;
             int32_t height = view_widget->bottom - view_widget->top - 1;
 
-            viewport_create(w, x, y, width, height, 0, 0, 0, 0, focus.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite_id);
+            viewport_create(
+                w, screenPos, width, height, 0, { 0, 0, 0 }, focus.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite_id);
             w->flags |= WF_NO_SCROLLING;
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -567,8 +567,8 @@ void window_staff_overview_mousedown(rct_window* w, rct_widgetindex widgetIndex,
     gDropdownItemsFormat[0] = STR_SET_PATROL_AREA;
     gDropdownItemsFormat[1] = STR_CLEAR_PATROL_AREA;
 
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
     int32_t extray = widget->bottom - widget->top + 1;
     window_dropdown_show_text(x, y, extray, w->colours[1], 0, 2);
     gDropdownDefaultIndex = 0;
@@ -947,7 +947,7 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         rct_viewport* viewport = w->viewport;
         if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
         {
-            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->x + 2, w->y + 2, 0);
+            gfx_draw_sprite(dpi, SPR_HEARING_VIEWPORT, w->windowPos.x + 2, w->windowPos.y + 2, 0);
         }
     }
 
@@ -955,8 +955,8 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
     peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
-    int32_t x = (widget->left + widget->right) / 2 + w->x;
-    int32_t y = w->y + widget->top;
+    int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
+    int32_t y = w->windowPos.y + widget->top;
     int32_t width = widget->right - widget->left;
     gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
 }
@@ -971,8 +971,8 @@ void window_staff_options_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_2];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_STAFF_OPTIONS_0;
 
@@ -994,8 +994,8 @@ void window_staff_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
 
     rct_widget* widget = &w->widgets[WIDX_TAB_3];
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
 
     int32_t image_id = SPR_TAB_STATS_0;
 
@@ -1018,8 +1018,8 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widget* widget = &w->widgets[WIDX_TAB_1];
     int32_t width = widget->right - widget->left - 1;
     int32_t height = widget->bottom - widget->top - 1;
-    int32_t x = widget->left + 1 + w->x;
-    int32_t y = widget->top + 1 + w->y;
+    int32_t x = widget->left + 1 + w->windowPos.x;
+    int32_t y = widget->top + 1 + w->windowPos.y;
     if (w->page == WINDOW_STAFF_OVERVIEW)
         height++;
 
@@ -1101,8 +1101,8 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     Peep* peep = GET_PEEP(w->number);
 
-    int32_t x = w->x + window_staff_stats_widgets[WIDX_RESIZE].left + 4;
-    int32_t y = w->y + window_staff_stats_widgets[WIDX_RESIZE].top + 4;
+    int32_t x = w->windowPos.x + window_staff_stats_widgets[WIDX_RESIZE].left + 4;
+    int32_t y = w->windowPos.y + window_staff_stats_widgets[WIDX_RESIZE].top + 4;
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
@@ -1380,7 +1380,7 @@ void window_staff_viewport_init(rct_window* w)
         {
             rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
 
-            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->x, view_widget->top + 1 + w->y };
+            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->windowPos.x, view_widget->top + 1 + w->windowPos.y };
             int32_t width = view_widget->right - view_widget->left - 1;
             int32_t height = view_widget->bottom - view_widget->top - 1;
 
@@ -1427,8 +1427,8 @@ void window_staff_options_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
     // Get the dropdown box widget instead of button.
     widget--;
 
-    int32_t x = widget->left + w->x;
-    int32_t y = widget->top + w->y;
+    int32_t x = widget->left + w->windowPos.x;
+    int32_t y = widget->top + w->windowPos.y;
     int32_t extray = widget->bottom - widget->top + 1;
     int32_t width = widget->right - widget->left - 3;
     window_dropdown_show_text_custom_width(x, y, extray, w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numCostumes, width);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -623,13 +623,13 @@ void window_staff_overview_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
  */
 void window_staff_overview_update(rct_window* w)
 {
-    int32_t var_496 = w->var_496;
-    var_496++;
-    if (var_496 >= 24)
+    int32_t newAnimationFrame = w->var_496;
+    newAnimationFrame++;
+    if (newAnimationFrame >= 24)
     {
-        var_496 = 0;
+        newAnimationFrame = 0;
     }
-    w->var_496 = var_496;
+    w->var_496 = newAnimationFrame;
     widget_invalidate(w, WIDX_TAB_1);
 }
 

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -129,8 +129,8 @@ static void window_staff_fire_paint(rct_window *w, rct_drawpixelinfo *dpi)
 
     peep->FormatNameTo(gCommonFormatArgs);
 
-    int32_t x = w->x + WW / 2;
-    int32_t y = w->y + (WH / 2) - 3;
+    int32_t x = w->windowPos.x + WW / 2;
+    int32_t y = w->windowPos.y + (WH / 2) - 3;
 
     gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, x, y, WW - 4, STR_FIRE_STAFF_ID, COLOUR_BLACK);
 }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -569,8 +569,8 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         (window_staff_list_widgets[WIDX_STAFF_LIST_HANDYMEN_TAB].left
          + window_staff_list_widgets[WIDX_STAFF_LIST_HANDYMEN_TAB].right)
                 / 2
-            + w->x,
-        window_staff_list_widgets[WIDX_STAFF_LIST_HANDYMEN_TAB].bottom - 6 + w->y, 0);
+            + w->windowPos.x,
+        window_staff_list_widgets[WIDX_STAFF_LIST_HANDYMEN_TAB].bottom - 6 + w->windowPos.y, 0);
 
     // Mechanic tab image
     i = (selectedTab == 1 ? (w->list_information_type & ~3) : 0);
@@ -581,8 +581,8 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         (window_staff_list_widgets[WIDX_STAFF_LIST_MECHANICS_TAB].left
          + window_staff_list_widgets[WIDX_STAFF_LIST_MECHANICS_TAB].right)
                 / 2
-            + w->x,
-        window_staff_list_widgets[WIDX_STAFF_LIST_MECHANICS_TAB].bottom - 6 + w->y, 0);
+            + w->windowPos.x,
+        window_staff_list_widgets[WIDX_STAFF_LIST_MECHANICS_TAB].bottom - 6 + w->windowPos.y, 0);
 
     // Security tab image
     i = (selectedTab == 2 ? (w->list_information_type & ~3) : 0);
@@ -593,13 +593,13 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         (window_staff_list_widgets[WIDX_STAFF_LIST_SECURITY_TAB].left
          + window_staff_list_widgets[WIDX_STAFF_LIST_SECURITY_TAB].right)
                 / 2
-            + w->x,
-        window_staff_list_widgets[WIDX_STAFF_LIST_SECURITY_TAB].bottom - 6 + w->y, 0);
+            + w->windowPos.x,
+        window_staff_list_widgets[WIDX_STAFF_LIST_SECURITY_TAB].bottom - 6 + w->windowPos.y, 0);
 
     rct_drawpixelinfo sprite_dpi;
     if (clip_drawpixelinfo(
-            &sprite_dpi, dpi, window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].left + w->x + 1,
-            window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].top + w->y + 1,
+            &sprite_dpi, dpi, window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].left + w->windowPos.x + 1,
+            window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].top + w->windowPos.y + 1,
             window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].right
                 - window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].left - 1,
             window_staff_list_widgets[WIDX_STAFF_LIST_ENTERTAINERS_TAB].bottom
@@ -614,14 +614,15 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
         set_format_arg(0, money32, gStaffWageTable[selectedTab]);
-        gfx_draw_string_left(dpi, STR_COST_PER_MONTH, gCommonFormatArgs, COLOUR_BLACK, w->x + w->width - 155, w->y + 0x20);
+        gfx_draw_string_left(
+            dpi, STR_COST_PER_MONTH, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 155, w->windowPos.y + 0x20);
     }
 
     if (selectedTab < 3)
     {
         gfx_draw_string_left(
-            dpi, STR_UNIFORM_COLOUR, w, COLOUR_BLACK, w->x + 6,
-            window_staff_list_widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + w->y + 1);
+            dpi, STR_UNIFORM_COLOUR, w, COLOUR_BLACK, w->windowPos.x + 6,
+            window_staff_list_widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + w->windowPos.y + 1);
     }
 
     int32_t staffTypeStringId = StaffNamingConvention[selectedTab].plural;
@@ -635,8 +636,8 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     set_format_arg(2, rct_string_id, staffTypeStringId);
 
     gfx_draw_string_left(
-        dpi, STR_STAFF_LIST_COUNTER, gCommonFormatArgs, COLOUR_BLACK, w->x + 4,
-        window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + w->y + 2);
+        dpi, STR_STAFF_LIST_COUNTER, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 4,
+        window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + w->windowPos.y + 2);
 }
 
 /** rct2: 0x00992A08 */

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -192,12 +192,12 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    int32_t y = w->y + 25;
+    int32_t y = w->windowPos.y + 25;
 
     int32_t no_lines = 0;
     int32_t font_height = 0;
 
-    gfx_draw_string_centred(dpi, input_text_description, w->x + WW / 2, y, w->colours[1], &TextInputDescriptionArgs);
+    gfx_draw_string_centred(dpi, input_text_description, w->windowPos.x + WW / 2, y, w->colours[1], &TextInputDescriptionArgs);
 
     y += 25;
 
@@ -211,7 +211,8 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // +13 for cursor when max length.
     gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines, &font_height);
 
-    gfx_fill_rect_inset(dpi, w->x + 10, y, w->x + WW - 10, y + 10 * (no_lines + 1) + 3, w->colours[1], INSET_RECT_F_60);
+    gfx_fill_rect_inset(
+        dpi, w->windowPos.x + 10, y, w->windowPos.x + WW - 10, y + 10 * (no_lines + 1) + 3, w->colours[1], INSET_RECT_F_60);
 
     y += 1;
 
@@ -223,7 +224,7 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t cursorY = 0;
     for (int32_t line = 0; line <= no_lines; line++)
     {
-        gfx_draw_string(dpi, wrap_pointer, w->colours[1], w->x + 12, y);
+        gfx_draw_string(dpi, wrap_pointer, w->colours[1], w->windowPos.x + 12, y);
 
         size_t string_length = get_string_size(wrap_pointer) - 1;
 
@@ -232,7 +233,7 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
             // Make a copy of the string for measuring the width.
             char temp_string[TEXT_INPUT_SIZE] = { 0 };
             std::memcpy(temp_string, wrap_pointer, gTextInput->SelectionStart - char_count);
-            cursorX = w->x + 13 + gfx_get_string_width(temp_string);
+            cursorX = w->windowPos.x + 13 + gfx_get_string_width(temp_string);
             cursorY = y;
 
             int32_t width = 6;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -316,8 +316,8 @@ static void window_themes_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w)
         if (_selected_tab == i)
             sprite_idx += w->frame_no / window_themes_tab_animation_divisor[_selected_tab];
         gfx_draw_sprite(
-            dpi, sprite_idx, w->x + w->widgets[WIDX_THEMES_SETTINGS_TAB + i].left,
-            w->y + w->widgets[WIDX_THEMES_SETTINGS_TAB + i].top, 0);
+            dpi, sprite_idx, w->windowPos.x + w->widgets[WIDX_THEMES_SETTINGS_TAB + i].left,
+            w->windowPos.y + w->widgets[WIDX_THEMES_SETTINGS_TAB + i].top, 0);
     }
 }
 
@@ -523,7 +523,7 @@ static void window_themes_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, num_items, widget->right - widget->left - 3);
 
             dropdown_set_checked((int32_t)theme_manager_get_active_available_theme_index(), true);
@@ -838,13 +838,14 @@ void window_themes_paint(rct_window* w, rct_drawpixelinfo* dpi)
         const utf8* activeThemeName = theme_manager_get_available_theme_name(activeAvailableThemeIndex);
         set_format_arg(0, uintptr_t, (uintptr_t)activeThemeName);
         gfx_draw_string_left(
-            dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1], w->x + 10,
-            w->y + window_themes_widgets[WIDX_THEMES_PRESETS].top + 1);
+            dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1], w->windowPos.x + 10,
+            w->windowPos.y + window_themes_widgets[WIDX_THEMES_PRESETS].top + 1);
         gfx_draw_string_left_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, w->colours[1], w->x + window_themes_widgets[WIDX_THEMES_PRESETS].left + 1,
-            w->y + window_themes_widgets[WIDX_THEMES_PRESETS].top,
-            w->x + window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].left - window_themes_widgets[WIDX_THEMES_PRESETS].left
-                - 4);
+            dpi, STR_STRING, gCommonFormatArgs, w->colours[1],
+            w->windowPos.x + window_themes_widgets[WIDX_THEMES_PRESETS].left + 1,
+            w->windowPos.y + window_themes_widgets[WIDX_THEMES_PRESETS].top,
+            w->windowPos.x + window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].left
+                - window_themes_widgets[WIDX_THEMES_PRESETS].left - 4);
     }
 }
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1128,8 +1128,8 @@ static void window_tile_inspector_mousedown(rct_window* w, rct_widgetindex widge
                     gDropdownItemsArgs[1] = STR_TILE_INSPECTOR_WALL_SLOPED_LEFT;
                     gDropdownItemsArgs[2] = STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT;
                     window_dropdown_show_text_custom_width(
-                        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                        DROPDOWN_FLAG_STAY_OPEN, 3, widget->right - widget->left - 3);
+                        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, 3, widget->right - widget->left - 3);
 
                     // Set current value as checked
                     TileElement* const tileElement = window_tile_inspector_get_selected_element(w);
@@ -1723,54 +1723,54 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if ((widget = &w->widgets[WIDX_COLUMN_TYPE])->type != WWT_EMPTY)
     {
         gfx_draw_string_left_clipped(
-            dpi, STR_TILE_INSPECTOR_ELEMENT_TYPE, gCommonFormatArgs, w->colours[1], w->x + widget->left + 1,
-            w->y + widget->top + 1, widget->right - widget->left);
+            dpi, STR_TILE_INSPECTOR_ELEMENT_TYPE, gCommonFormatArgs, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_BASEHEIGHT])->type != WWT_EMPTY)
     {
         gfx_draw_string_left_clipped(
-            dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, gCommonFormatArgs, w->colours[1], w->x + widget->left + 1,
-            w->y + widget->top + 1, widget->right - widget->left);
+            dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, gCommonFormatArgs, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_CLEARANCEHEIGHT])->type != WWT_EMPTY)
     {
         gfx_draw_string_left_clipped(
-            dpi, STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, gCommonFormatArgs, w->colours[1], w->x + widget->left + 1,
-            w->y + widget->top + 1, widget->right - widget->left);
+            dpi, STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, gCommonFormatArgs, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_GHOSTFLAG])->type != WWT_EMPTY)
     {
         gfx_draw_string_left_clipped(
-            dpi, STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, gCommonFormatArgs, w->colours[1], w->x + widget->left + 1,
-            w->y + widget->top + 1, widget->right - widget->left);
+            dpi, STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, gCommonFormatArgs, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_LASTFLAG])->type != WWT_EMPTY)
     {
         gfx_draw_string_left_clipped(
-            dpi, STR_TILE_INSPECTOR_FLAG_LAST_SHORT, gCommonFormatArgs, w->colours[1], w->x + widget->left + 1,
-            w->y + widget->top + 1, widget->right - widget->left);
+            dpi, STR_TILE_INSPECTOR_FLAG_LAST_SHORT, gCommonFormatArgs, w->colours[1], w->windowPos.x + widget->left + 1,
+            w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
 
     // Draw coordinates
-    gfx_draw_string(dpi, (char*)"X:", COLOUR_WHITE, w->x + 5, w->y + 24);
-    gfx_draw_string(dpi, (char*)"Y:", COLOUR_WHITE, w->x + 74, w->y + 24);
+    gfx_draw_string(dpi, (char*)"X:", COLOUR_WHITE, w->windowPos.x + 5, w->windowPos.y + 24);
+    gfx_draw_string(dpi, (char*)"Y:", COLOUR_WHITE, w->windowPos.x + 74, w->windowPos.y + 24);
     if (windowTileInspectorTileSelected)
     {
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
-        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, w->x + 43, w->y + 24);
-        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, w->x + 113, w->y + 24);
+        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, w->windowPos.x + 43, w->windowPos.y + 24);
+        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, w->windowPos.x + 113, w->windowPos.y + 24);
     }
     else
     {
-        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->x + 43 - 7, w->y + 24);
-        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->x + 113 - 7, w->y + 24);
+        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->windowPos.x + 43 - 7, w->windowPos.y + 24);
+        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->windowPos.x + 113 - 7, w->windowPos.y + 24);
     }
 
     if (windowTileInspectorSelectedIndex != -1)
     {
         // X and Y of first element in detail box
-        int32_t x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-        int32_t y = w->y + w->widgets[WIDX_GROUPBOX_DETAILS].top + 14;
+        int32_t x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+        int32_t y = w->windowPos.y + w->widgets[WIDX_GROUPBOX_DETAILS].top + 14;
 
         // Get map element
         TileElement* const tileElement = window_tile_inspector_get_selected_element(w);
@@ -1812,18 +1812,18 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
 
                 // Raised corners
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_SURFACE_CHECK_CORNER_E].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_SURFACE_CHECK_CORNER_E].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SURFACE_CORNERS, nullptr, COLOUR_WHITE, x, y);
                 break;
             }
@@ -1849,18 +1849,18 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_PATH_SPINNER_HEIGHT].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_PATH_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_PATH_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_PATH_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
 
                 // Path connections
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_PATH_CHECK_EDGE_W].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_PATH_CHECK_EDGE_W].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, nullptr, COLOUR_WHITE, x, y);
                 break;
             }
@@ -1908,11 +1908,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                y = w->y + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
                 break;
@@ -1944,21 +1944,21 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / Lower
-                y = w->y + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
 
                 // Quarter tile
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_SCENERY_CHECK_QUARTER_E].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_SCENERY_CHECK_QUARTER_E].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, nullptr, COLOUR_WHITE, x, y);
 
                 // Collision
-                y = w->y + w->widgets[WIDX_SCENERY_CHECK_COLLISION_E].top;
+                y = w->windowPos.y + w->widgets[WIDX_SCENERY_CHECK_COLLISION_E].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_COLLISSION, nullptr, COLOUR_WHITE, x, y);
                 break;
             }
@@ -2015,11 +2015,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / Lower
-                y = w->y + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
                 break;
@@ -2051,17 +2051,17 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                y = w->y + w->widgets[WIDX_WALL_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_WALL_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_WALL_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_WALL_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
 
                 // Slope label
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                y = w->y + w->widgets[WIDX_WALL_DROPDOWN_SLOPE].top;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                y = w->windowPos.y + w->widgets[WIDX_WALL_DROPDOWN_SLOPE].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_WALL_SLOPE, nullptr, COLOUR_WHITE, x, y);
                 break;
             }
@@ -2097,11 +2097,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                y = w->y + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
                 break;
@@ -2121,17 +2121,17 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Properties
                 // Raise / lower label
-                y = w->y + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
 
                 // Blocked paths
                 y += 28;
-                x = w->x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
+                x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, nullptr, COLOUR_WHITE, x, y);
                 break;
             }
@@ -2140,11 +2140,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 // Properties
                 // Raise / lower label
-                y = w->y + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].top;
+                y = w->windowPos.y + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].top;
                 gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, x, y);
 
                 // Current base height
-                x = w->x + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].left + 3;
+                x = w->windowPos.x + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
                 gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, x, y);
                 break;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -249,8 +249,8 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
 
     rct_widget* const viewportWidget = &window_title_command_editor_widgets[WIDX_VIEWPORT];
     viewport_create(
-        window, window->x + viewportWidget->left + 1, window->y + viewportWidget->top + 1,
-        viewportWidget->right - viewportWidget->left - 1, viewportWidget->bottom - viewportWidget->top - 1, 0, 0, 0, 0, 0,
+        window, { window->x + viewportWidget->left + 1, window->y + viewportWidget->top + 1 },
+        viewportWidget->right - viewportWidget->left - 1, viewportWidget->bottom - viewportWidget->top - 1, 0, { 0, 0, 0 }, 0,
         SPRITE_INDEX_NULL);
 
     _window_title_command_editor_index = index;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -249,7 +249,7 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
 
     rct_widget* const viewportWidget = &window_title_command_editor_widgets[WIDX_VIEWPORT];
     viewport_create(
-        window, { window->x + viewportWidget->left + 1, window->y + viewportWidget->top + 1 },
+        window, window->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         viewportWidget->right - viewportWidget->left - 1, viewportWidget->bottom - viewportWidget->top - 1, 0, { 0, 0, 0 }, 0,
         SPRITE_INDEX_NULL);
 
@@ -394,7 +394,7 @@ static void window_title_command_editor_mousedown(rct_window* w, rct_widgetindex
             }
 
             window_dropdown_show_text_custom_width(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
 
             dropdown_set_checked(get_command_info_index(command.Type), true);
@@ -411,8 +411,8 @@ static void window_title_command_editor_mousedown(rct_window* w, rct_widgetindex
                 }
 
                 window_dropdown_show_text_custom_width(
-                    w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                    DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
+                    w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                    w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
 
                 dropdown_set_checked(command.Speed - 1, true);
             }
@@ -426,8 +426,8 @@ static void window_title_command_editor_mousedown(rct_window* w, rct_widgetindex
                 }
 
                 window_dropdown_show_text_custom_width(
-                    w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                    DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
+                    w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                    w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
 
                 dropdown_set_checked(command.SaveIndex, true);
             }
@@ -747,21 +747,25 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     TITLE_COMMAND_ORDER command_info = get_command_info(command.Type);
 
     // "Command:" label
-    gfx_draw_string_left(dpi, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, nullptr, w->colours[1], w->x + WS, w->y + BY - 14);
+    gfx_draw_string_left(
+        dpi, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, nullptr, w->colours[1], w->windowPos.x + WS, w->windowPos.y + BY - 14);
 
     // Command dropdown name
     gfx_draw_string_left_clipped(
-        dpi, command_info.nameStringId, nullptr, w->colours[1], w->x + w->widgets[WIDX_COMMAND].left + 1,
-        w->y + w->widgets[WIDX_COMMAND].top, w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4);
+        dpi, command_info.nameStringId, nullptr, w->colours[1], w->windowPos.x + w->widgets[WIDX_COMMAND].left + 1,
+        w->windowPos.y + w->widgets[WIDX_COMMAND].top,
+        w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4);
 
     // Label (e.g. "Location:")
-    gfx_draw_string_left(dpi, command_info.descStringId, nullptr, w->colours[1], w->x + WS, w->y + BY2 - 14);
+    gfx_draw_string_left(
+        dpi, command_info.descStringId, nullptr, w->colours[1], w->windowPos.x + WS, w->windowPos.y + BY2 - 14);
 
     if (command.Type == TITLE_SCRIPT_SPEED)
     {
         gfx_draw_string_left_clipped(
-            dpi, SpeedNames[command.Speed - 1], nullptr, w->colours[1], w->x + w->widgets[WIDX_INPUT].left + 1,
-            w->y + w->widgets[WIDX_INPUT].top, w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
+            dpi, SpeedNames[command.Speed - 1], nullptr, w->colours[1], w->windowPos.x + w->widgets[WIDX_INPUT].left + 1,
+            w->windowPos.y + w->widgets[WIDX_INPUT].top,
+            w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
     }
     if (command.Type == TITLE_SCRIPT_FOLLOW)
     {
@@ -779,26 +783,29 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         }
 
         gfx_set_dirty_blocks(
-            w->x + w->widgets[WIDX_VIEWPORT].left, w->y + w->widgets[WIDX_VIEWPORT].top, w->x + w->widgets[WIDX_VIEWPORT].right,
-            w->y + w->widgets[WIDX_VIEWPORT].bottom);
+            w->windowPos.x + w->widgets[WIDX_VIEWPORT].left, w->windowPos.y + w->widgets[WIDX_VIEWPORT].top,
+            w->windowPos.x + w->widgets[WIDX_VIEWPORT].right, w->windowPos.y + w->widgets[WIDX_VIEWPORT].bottom);
         gfx_draw_string_left_clipped(
-            dpi, spriteString, gCommonFormatArgs, colour, w->x + w->widgets[WIDX_VIEWPORT].left + 2,
-            w->y + w->widgets[WIDX_VIEWPORT].top + 1, w->widgets[WIDX_VIEWPORT].right - w->widgets[WIDX_VIEWPORT].left - 2);
+            dpi, spriteString, gCommonFormatArgs, colour, w->windowPos.x + w->widgets[WIDX_VIEWPORT].left + 2,
+            w->windowPos.y + w->widgets[WIDX_VIEWPORT].top + 1,
+            w->widgets[WIDX_VIEWPORT].right - w->widgets[WIDX_VIEWPORT].left - 2);
     }
     else if (command.Type == TITLE_SCRIPT_LOAD)
     {
         if (command.SaveIndex == SAVE_INDEX_INVALID)
         {
             gfx_draw_string_left_clipped(
-                dpi, STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, nullptr, w->colours[1], w->x + w->widgets[WIDX_INPUT].left + 1,
-                w->y + w->widgets[WIDX_INPUT].top, w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
+                dpi, STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, nullptr, w->colours[1],
+                w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top,
+                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
         }
         else
         {
             set_format_arg(0, uintptr_t, (uintptr_t)_sequence->Saves[command.SaveIndex]);
             gfx_draw_string_left_clipped(
-                dpi, STR_STRING, gCommonFormatArgs, w->colours[1], w->x + w->widgets[WIDX_INPUT].left + 1,
-                w->y + w->widgets[WIDX_INPUT].top, w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
+                dpi, STR_STRING, gCommonFormatArgs, w->colours[1], w->windowPos.x + w->widgets[WIDX_INPUT].left + 1,
+                w->windowPos.y + w->widgets[WIDX_INPUT].top,
+                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
         }
     }
     else if (command.Type == TITLE_SCRIPT_LOADSC)
@@ -807,7 +814,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         {
             gfx_draw_string_left_clipped(
                 dpi, STR_TITLE_COMMAND_EDITOR_NO_SCENARIO_SELECTED, nullptr, w->colours[1],
-                w->x + w->widgets[WIDX_INPUT].left + 1, w->y + w->widgets[WIDX_INPUT].top,
+                w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top,
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
         }
         else
@@ -825,8 +832,9 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             }
             set_format_arg(0, uintptr_t, name);
             gfx_draw_string_left_clipped(
-                dpi, nameString, gCommonFormatArgs, w->colours[1], w->x + w->widgets[WIDX_INPUT].left + 1,
-                w->y + w->widgets[WIDX_INPUT].top, w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
+                dpi, nameString, gCommonFormatArgs, w->colours[1], w->windowPos.x + w->widgets[WIDX_INPUT].left + 1,
+                w->windowPos.y + w->widgets[WIDX_INPUT].top,
+                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4);
         }
     }
 }

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -555,8 +555,8 @@ static void window_title_editor_mousedown(rct_window* w, rct_widgetindex widgetI
 
                 widget--;
                 window_dropdown_show_text_custom_width(
-                    w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1], 0,
-                    DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
+                    w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                    w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, numItems, widget->right - widget->left - 3);
                 dropdown_set_checked((int32_t)_selectedTitleSequence, true);
             }
             break;
@@ -827,13 +827,13 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
         case WINDOW_TITLE_EDITOR_TAB_PRESETS:
             set_format_arg(0, uintptr_t, _sequenceName);
             gfx_draw_string_left(
-                dpi, STR_TITLE_SEQUENCE, nullptr, w->colours[1], w->x + 10,
-                w->y + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1);
+                dpi, STR_TITLE_SEQUENCE, nullptr, w->colours[1], w->windowPos.x + 10,
+                w->windowPos.y + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1);
             gfx_draw_string_left_clipped(
                 dpi, STR_STRING, gCommonFormatArgs, w->colours[1],
-                w->x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left + 1,
-                w->y + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top,
-                w->x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS_DROPDOWN].left
+                w->windowPos.x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left + 1,
+                w->windowPos.y + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top,
+                w->windowPos.x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS_DROPDOWN].left
                     - window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left - 4);
             break;
         case WINDOW_TITLE_EDITOR_TAB_SAVES:
@@ -1049,8 +1049,8 @@ static void window_title_editor_draw_tab_images(rct_drawpixelinfo* dpi, rct_wind
             y = 1;
         }
         gfx_draw_sprite(
-            dpi, spriteId, w->x + w->widgets[WIDX_TITLE_EDITOR_PRESETS_TAB + i].left + x,
-            w->y + w->widgets[WIDX_TITLE_EDITOR_PRESETS_TAB + i].top + y, 0);
+            dpi, spriteId, w->windowPos.x + w->widgets[WIDX_TITLE_EDITOR_PRESETS_TAB + i].left + x,
+            w->windowPos.y + w->widgets[WIDX_TITLE_EDITOR_PRESETS_TAB + i].top + y, 0);
     }
 }
 

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -78,6 +78,6 @@ static void window_title_logo_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t x = 2;
     int32_t y = 2;
-    gfx_draw_sprite(dpi, SPR_G2_LOGO, w->x + x, w->y + y, 0);
-    gfx_draw_sprite(dpi, SPR_G2_TITLE, w->x + x + 104, w->y + y + 18, 0);
+    gfx_draw_sprite(dpi, SPR_G2_LOGO, w->windowPos.x + x, w->windowPos.y + y, 0);
+    gfx_draw_sprite(dpi, SPR_G2_TITLE, w->windowPos.x + x + 104, w->windowPos.y + y + 18, 0);
 }

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -113,7 +113,7 @@ rct_window* window_title_menu_open()
         i++;
     }
     window->width = x;
-    window->x = (context_get_width() - window->width) / 2;
+    window->windowPos.x = (context_get_width() - window->width) / 2;
 
     window_init_scroll_widgets(window);
 
@@ -184,8 +184,8 @@ static void window_title_menu_mousedown(rct_window* w, rct_widgetindex widgetInd
         gDropdownItemsFormat[3] = STR_TRACK_DESIGNS_MANAGER;
         gDropdownItemsFormat[4] = STR_OPEN_USER_CONTENT_FOLDER;
         window_dropdown_show_text(
-            w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, TRANSLUCENT(w->colours[0]),
-            DROPDOWN_FLAG_STAY_OPEN, 5);
+            w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+            TRANSLUCENT(w->colours[0]), DROPDOWN_FLAG_STAY_OPEN, 5);
     }
 }
 
@@ -225,6 +225,6 @@ static void window_title_menu_cursor(
 
 static void window_title_menu_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    gfx_filter_rect(dpi, w->x, w->y, w->x + w->width - 1, w->y + 82 - 1, PALETTE_51);
+    gfx_filter_rect(dpi, w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y + 82 - 1, PALETTE_51);
     window_draw_widgets(w, dpi);
 }

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -341,7 +341,7 @@ static void window_scenarioselect_scrollmousedown(rct_window* w, int32_t scrollI
                 mutableScreenCoords.y -= scenarioItemHeight;
                 if (mutableScreenCoords.y < 0 && !listItem.scenario.is_locked)
                 {
-                    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
+                    audio_play_sound(SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
                     gFirstTimeSaving = true;
                     _callback(listItem.scenario.scenario->path);
                     if (_titleEditor)
@@ -450,8 +450,8 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (widget->type == WWT_EMPTY)
             continue;
 
-        int32_t x = (widget->left + widget->right) / 2 + w->x;
-        int32_t y = (widget->top + widget->bottom) / 2 + w->y - 3;
+        int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
+        int32_t y = (widget->top + widget->bottom) / 2 + w->windowPos.y - 3;
 
         if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN || _titleEditor)
         {
@@ -471,8 +471,8 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (_showLockedInformation)
         {
             // Show locked information
-            int32_t x = w->x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
-            int32_t y = w->y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
+            int32_t x = w->windowPos.x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
+            int32_t y = w->windowPos.y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
             gfx_draw_string_centred_clipped(dpi, STR_SCENARIO_LOCKED, nullptr, COLOUR_BLACK, x + 85, y, 170);
             y += 15;
             y += gfx_draw_string_left_wrapped(dpi, nullptr, x, y, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK) + 5;
@@ -489,12 +489,13 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         shorten_path(path, sizeof(path), scenario->path, w->width - 6);
 
         const utf8* pathPtr = path;
-        gfx_draw_string_left(dpi, STR_STRING, (void*)&pathPtr, w->colours[1], w->x + 3, w->y + w->height - 3 - 11);
+        gfx_draw_string_left(
+            dpi, STR_STRING, (void*)&pathPtr, w->colours[1], w->windowPos.x + 3, w->windowPos.y + w->height - 3 - 11);
     }
 
     // Scenario name
-    int32_t x = w->x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
-    int32_t y = w->y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
+    int32_t x = w->windowPos.x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
+    int32_t y = w->windowPos.y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
     set_format_arg(0, rct_string_id, STR_STRING);
     set_format_arg(2, const char*, scenario->name);
     gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, x + 85, y, 170);

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -178,10 +178,10 @@ static void window_tooltip_update(rct_window* w)
  */
 static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t left = w->x;
-    int32_t top = w->y;
-    int32_t right = w->x + w->width - 1;
-    int32_t bottom = w->y + w->height - 1;
+    int32_t left = w->windowPos.x;
+    int32_t top = w->windowPos.y;
+    int32_t right = w->windowPos.x + w->width - 1;
+    int32_t bottom = w->windowPos.y + w->height - 1;
 
     // Background
     gfx_filter_rect(dpi, left + 1, top + 1, right - 1, bottom - 1, PALETTE_45);
@@ -200,7 +200,7 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_filter_pixel(dpi, right - 1, bottom - 1, PALETTE_DARKEN_3);
 
     // Text
-    left = w->x + ((w->width + 1) / 2) - 1;
-    top = w->y + 1;
+    left = w->windowPos.x + ((w->width + 1) / 2) - 1;
+    top = w->windowPos.y + 1;
     draw_string_centred_raw(dpi, left, top, _tooltipNumLines, _tooltipText);
 }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -503,8 +503,8 @@ static void window_top_toolbar_mousedown(rct_window* w, rct_widgetindex widgetIn
 #endif
             }
             window_dropdown_show_text(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80,
-                DROPDOWN_FLAG_STAY_OPEN, numItems);
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                w->colours[0] | 0x80, DROPDOWN_FLAG_STAY_OPEN, numItems);
 
 #ifndef DISABLE_TWITCH
             if (_menuDropdownIncludesTwitch && gTwitchEnable)
@@ -531,7 +531,8 @@ static void window_top_toolbar_mousedown(rct_window* w, rct_widgetindex widgetIn
             }
 
             window_dropdown_show_text(
-                w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1] | 0x80, 0, numItems);
+                w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1,
+                w->colours[1] | 0x80, 0, numItems);
             gDropdownDefaultIndex = DDIDX_SHOW_MAP;
             break;
         case WIDX_FASTFORWARD:
@@ -896,8 +897,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw staff button image (setting masks to the staff colours)
     if (window_top_toolbar_widgets[WIDX_STAFF].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_STAFF].left;
-        y = w->y + window_top_toolbar_widgets[WIDX_STAFF].top;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_STAFF].left;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_STAFF].top;
         imgId = SPR_TOOLBAR_STAFF;
         if (widget_is_pressed(w, WIDX_STAFF))
             imgId++;
@@ -908,8 +909,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw fast forward button
     if (window_top_toolbar_widgets[WIDX_FASTFORWARD].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0;
-        y = w->y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0;
         if (widget_is_pressed(w, WIDX_FASTFORWARD))
             y++;
         imgId = SPR_G2_FASTFORWARD;
@@ -928,8 +929,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw cheats button
     if (window_top_toolbar_widgets[WIDX_CHEATS].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_CHEATS].left - 1;
-        y = w->y + window_top_toolbar_widgets[WIDX_CHEATS].top - 1;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_CHEATS].left - 1;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_CHEATS].top - 1;
         if (widget_is_pressed(w, WIDX_CHEATS))
             y++;
         imgId = SPR_G2_SANDBOX;
@@ -939,8 +940,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw chat button
     if (window_top_toolbar_widgets[WIDX_CHAT].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_CHAT].left;
-        y = w->y + window_top_toolbar_widgets[WIDX_CHAT].top - 2;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_CHAT].left;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_CHAT].top - 2;
         if (widget_is_pressed(w, WIDX_CHAT))
             y++;
         imgId = SPR_G2_CHAT;
@@ -950,8 +951,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw debug button
     if (window_top_toolbar_widgets[WIDX_DEBUG].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_DEBUG].left;
-        y = w->y + window_top_toolbar_widgets[WIDX_DEBUG].top - 1;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_DEBUG].left;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_DEBUG].top - 1;
         if (widget_is_pressed(w, WIDX_DEBUG))
             y++;
         imgId = SPR_TAB_GEARS_0;
@@ -961,8 +962,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw research button
     if (window_top_toolbar_widgets[WIDX_RESEARCH].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_RESEARCH].left - 1;
-        y = w->y + window_top_toolbar_widgets[WIDX_RESEARCH].top;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_RESEARCH].left - 1;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_RESEARCH].top;
         if (widget_is_pressed(w, WIDX_RESEARCH))
             y++;
         imgId = SPR_TAB_FINANCES_RESEARCH_0;
@@ -972,8 +973,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw finances button
     if (window_top_toolbar_widgets[WIDX_FINANCES].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_FINANCES].left + 3;
-        y = w->y + window_top_toolbar_widgets[WIDX_FINANCES].top + 1;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_FINANCES].left + 3;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_FINANCES].top + 1;
         if (widget_is_pressed(w, WIDX_FINANCES))
             y++;
         imgId = SPR_FINANCE;
@@ -983,8 +984,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw news button
     if (window_top_toolbar_widgets[WIDX_NEWS].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_NEWS].left + 3;
-        y = w->y + window_top_toolbar_widgets[WIDX_NEWS].top + 0;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_NEWS].left + 3;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_NEWS].top + 0;
         if (widget_is_pressed(w, WIDX_NEWS))
             y++;
         imgId = SPR_G2_TAB_NEWS;
@@ -994,8 +995,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw network button
     if (window_top_toolbar_widgets[WIDX_NETWORK].type != WWT_EMPTY)
     {
-        x = w->x + window_top_toolbar_widgets[WIDX_NETWORK].left + 3;
-        y = w->y + window_top_toolbar_widgets[WIDX_NETWORK].top + 0;
+        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_NETWORK].left + 3;
+        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_NETWORK].top + 0;
         if (widget_is_pressed(w, WIDX_NETWORK))
             y++;
 
@@ -3244,7 +3245,8 @@ static void top_toolbar_init_fastforward_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsArgs[3] = STR_SPEED_TURBO;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0, num_items);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
+        num_items);
 
     // Set checkmarks
     if (gGameSpeed <= 4)
@@ -3291,7 +3293,8 @@ static void top_toolbar_init_rotate_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsFormat[1] = STR_ROTATE_ANTI_CLOCKWISE;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1] | 0x80, 0, 2);
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1] | 0x80, 0,
+        2);
 
     gDropdownDefaultIndex = DDIDX_ROTATE_CLOCKWISE;
 }
@@ -3343,7 +3346,7 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsArgs[DDIDX_DISABLE_SUPPORT_LIMITS] = STR_DISABLE_SUPPORT_LIMITS;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
         TOP_TOOLBAR_CHEATS_COUNT);
 
     // Disable items that are not yet available in multiplayer
@@ -3421,7 +3424,7 @@ static void top_toolbar_init_debug_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsArgs[DDIDX_DEBUG_PAINT] = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80,
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80,
         DROPDOWN_FLAG_STAY_OPEN, TOP_TOOLBAR_DEBUG_COUNT);
 
     dropdown_set_checked(DDIDX_DEBUG_PAINT, window_find_by_class(WC_DEBUG_PAINT) != nullptr);
@@ -3434,7 +3437,7 @@ static void top_toolbar_init_network_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsFormat[DDIDX_MULTIPLAYER_RECONNECT] = STR_MULTIPLAYER_RECONNECT;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[0] | 0x80, 0,
         TOP_TOOLBAR_NETWORK_COUNT);
 
     dropdown_set_disabled(DDIDX_MULTIPLAYER_RECONNECT, !network_is_desynchronised());
@@ -3527,7 +3530,7 @@ static void top_toolbar_init_view_menu(rct_window* w, rct_widget* widget)
     gDropdownItemsArgs[DDIDX_HIGHLIGHT_PATH_ISSUES] = STR_HIGHLIGHT_PATH_ISSUES_MENU;
 
     window_dropdown_show_text(
-        w->x + widget->left, w->y + widget->top, widget->bottom - widget->top + 1, w->colours[1] | 0x80, 0,
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, widget->bottom - widget->top + 1, w->colours[1] | 0x80, 0,
         TOP_TOOLBAR_VIEW_MENU_COUNT);
 
     // Set checkmarks

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -292,7 +292,7 @@ static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* d
     window_draw_widgets(w, dpi);
 
     gfx_draw_string_centred_wrapped(
-        dpi, &_trackDesignFileReference->name, w->x + 125, w->y + 28, 246,
+        dpi, &_trackDesignFileReference->name, w->windowPos.x + 125, w->windowPos.y + 28, 246,
         STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, COLOUR_BLACK);
 }
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -508,7 +508,7 @@ static void window_track_place_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Draw mini tile preview
     rct_drawpixelinfo clippedDpi;
-    if (clip_drawpixelinfo(&clippedDpi, dpi, w->x + 4, w->y + 18, 168, 78))
+    if (clip_drawpixelinfo(&clippedDpi, dpi, w->windowPos.x + 4, w->windowPos.y + 18, 168, 78))
     {
         rct_g1_element g1temp = {};
         g1temp.offset = _window_track_place_mini_preview.data();
@@ -521,7 +521,8 @@ static void window_track_place_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Price
     if (_window_track_place_last_cost != MONEY32_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        gfx_draw_string_centred(dpi, STR_COST_LABEL, w->x + 88, w->y + 94, COLOUR_BLACK, &_window_track_place_last_cost);
+        gfx_draw_string_centred(
+            dpi, STR_COST_LABEL, w->windowPos.x + 88, w->windowPos.y + 94, COLOUR_BLACK, &_window_track_place_last_cost);
     }
 }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -239,7 +239,7 @@ static void window_track_list_close(rct_window* w)
  */
 static void window_track_list_select(rct_window* w, int32_t listIndex)
 {
-    audio_play_sound(SoundId::Click1, 0, w->x + (w->width / 2));
+    audio_play_sound(SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         if (listIndex == 0)
@@ -514,8 +514,8 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Track preview
     int32_t x, y, colour;
     rct_widget* widget = &window_track_list_widgets[WIDX_TRACK_PREVIEW];
-    x = w->x + widget->left + 1;
-    y = w->y + widget->top + 1;
+    x = w->windowPos.x + widget->left + 1;
+    y = w->windowPos.y + widget->top + 1;
     colour = ColourMapA[w->colours[0]].darkest;
     gfx_fill_rect(dpi, x, y, x + 369, y + 216, colour);
 
@@ -538,8 +538,8 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     int32_t trackPreviewX = x, trackPreviewY = y;
-    x = w->x + (widget->left + widget->right) / 2;
-    y = w->y + (widget->top + widget->bottom) / 2;
+    x = w->windowPos.x + (widget->left + widget->right) / 2;
+    y = w->windowPos.y + (widget->top + widget->bottom) / 2;
 
     rct_g1_element g1temp = {};
     g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
@@ -550,7 +550,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     drawing_engine_invalidate_image(SPR_TEMP);
     gfx_draw_sprite(dpi, SPR_TEMP, trackPreviewX, trackPreviewY, 0);
 
-    y = w->y + widget->bottom - 12;
+    y = w->windowPos.y + widget->bottom - 12;
 
     // Warnings
     if ((_loadedTrackDesign->track_flags & TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE)
@@ -577,8 +577,8 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string_centred_clipped(dpi, STR_TRACK_PREVIEW_NAME_FORMAT, &trackName, COLOUR_BLACK, x, y, 368);
 
     // Information
-    x = w->x + widget->left + 1;
-    y = w->y + widget->bottom + 2;
+    x = w->windowPos.x + widget->left + 1;
+    y = w->windowPos.y + widget->bottom + 2;
 
     // Stats
     fixed32_2dp rating = _loadedTrackDesign->excitement * 10;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -396,12 +396,12 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
 
     // Clip height value
-    int32_t x = w->x + 8;
-    int32_t y = w->y + w->widgets[WIDX_CLIP_HEIGHT_VALUE].top;
+    int32_t x = w->windowPos.x + 8;
+    int32_t y = w->windowPos.y + w->widgets[WIDX_CLIP_HEIGHT_VALUE].top;
     gfx_draw_string_left(dpi, STR_VIEW_CLIPPING_HEIGHT_VALUE, nullptr, w->colours[0], x, y);
 
-    x = w->x + w->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1;
-    y = w->y + w->widgets[WIDX_CLIP_HEIGHT_VALUE].top;
+    x = w->windowPos.x + w->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1;
+    y = w->windowPos.y + w->widgets[WIDX_CLIP_HEIGHT_VALUE].top;
 
     fixed16_1dp clipHeightValueInUnits;
     fixed32_2dp clipHeightValueInMeters;

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -99,8 +99,8 @@ rct_window* window_viewport_open()
     if (mainWindow != nullptr)
     {
         rct_viewport* mainViewport = mainWindow->viewport;
-        int32_t x = mainViewport->view_x + (mainViewport->view_width / 2);
-        int32_t y = mainViewport->view_y + (mainViewport->view_height / 2);
+        int32_t x = mainViewport->viewPos.x + (mainViewport->view_width / 2);
+        int32_t y = mainViewport->viewPos.y + (mainViewport->view_height / 2);
         w->saved_view_x = x - (w->viewport->view_width / 2);
         w->saved_view_y = y - (w->viewport->view_height / 2);
     }
@@ -211,8 +211,7 @@ static void window_viewport_invalidate(rct_window* w)
     if (viewport->zoom >= 3)
         w->disabled_widgets |= 1 << WIDX_ZOOM_OUT;
 
-    viewport->x = w->x + viewportWidget->left;
-    viewport->y = w->y + viewportWidget->top;
+    viewport->pos = ScreenCoordsXY{ w->x + viewportWidget->left, w->y + viewportWidget->top };
     viewport->width = viewportWidget->right - viewportWidget->left;
     viewport->height = viewportWidget->bottom - viewportWidget->top;
     viewport->view_width = viewport->width << viewport->zoom;

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -94,15 +94,14 @@ rct_window* window_viewport_open()
     w->number = _viewportNumber++;
 
     // Create viewport
-    viewport_create(w, { w->x, w->y }, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
+    viewport_create(w, w->windowPos, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
     rct_window* mainWindow = window_get_main();
     if (mainWindow != nullptr)
     {
         rct_viewport* mainViewport = mainWindow->viewport;
         int32_t x = mainViewport->viewPos.x + (mainViewport->view_width / 2);
         int32_t y = mainViewport->viewPos.y + (mainViewport->view_height / 2);
-        w->saved_view_x = x - (w->viewport->view_width / 2);
-        w->saved_view_y = y - (w->viewport->view_height / 2);
+        w->savedViewPos = { x - (w->viewport->view_width / 2), y - (w->viewport->view_height / 2) };
     }
 
     w->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
@@ -150,8 +149,8 @@ static void window_viewport_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 CoordsXY mapCoords;
                 get_map_coordinates_from_pos(
-                    { w->x + (w->width / 2), w->y + (w->height / 2) }, VIEWPORT_INTERACTION_MASK_NONE, mapCoords, nullptr,
-                    nullptr, nullptr);
+                    { w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2) }, VIEWPORT_INTERACTION_MASK_NONE,
+                    mapCoords, nullptr, nullptr, nullptr);
                 window_scroll_to_location(mainWindow, mapCoords.x, mapCoords.y, tile_element_height(mapCoords));
             }
             break;
@@ -211,7 +210,7 @@ static void window_viewport_invalidate(rct_window* w)
     if (viewport->zoom >= 3)
         w->disabled_widgets |= 1 << WIDX_ZOOM_OUT;
 
-    viewport->pos = ScreenCoordsXY{ w->x + viewportWidget->left, w->y + viewportWidget->top };
+    viewport->pos = w->windowPos + ScreenCoordsXY{ viewportWidget->left, viewportWidget->top };
     viewport->width = viewportWidget->right - viewportWidget->left;
     viewport->height = viewportWidget->bottom - viewportWidget->top;
     viewport->view_width = viewport->width << viewport->zoom;

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -94,7 +94,7 @@ rct_window* window_viewport_open()
     w->number = _viewportNumber++;
 
     // Create viewport
-    viewport_create(w, w->x, w->y, w->width, w->height, 0, 128 * 32, 128 * 32, 0, 1, SPRITE_INDEX_NULL);
+    viewport_create(w, { w->x, w->y }, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
     rct_window* mainWindow = window_get_main();
     if (mainWindow != nullptr)
     {

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -211,8 +211,8 @@ static void window_water_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t x, y;
 
-    x = w->x + (window_water_widgets[WIDX_PREVIEW].left + window_water_widgets[WIDX_PREVIEW].right) / 2;
-    y = w->y + (window_water_widgets[WIDX_PREVIEW].top + window_water_widgets[WIDX_PREVIEW].bottom) / 2;
+    x = w->windowPos.x + (window_water_widgets[WIDX_PREVIEW].left + window_water_widgets[WIDX_PREVIEW].right) / 2;
+    y = w->windowPos.y + (window_water_widgets[WIDX_PREVIEW].top + window_water_widgets[WIDX_PREVIEW].bottom) / 2;
 
     window_draw_widgets(w, dpi);
     // Draw number for tool sizes bigger than 7
@@ -224,8 +224,8 @@ static void window_water_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
         // Draw raise cost amount
-        x = (window_water_widgets[WIDX_PREVIEW].left + window_water_widgets[WIDX_PREVIEW].right) / 2 + w->x;
-        y = window_water_widgets[WIDX_PREVIEW].bottom + w->y + 5;
+        x = (window_water_widgets[WIDX_PREVIEW].left + window_water_widgets[WIDX_PREVIEW].right) / 2 + w->windowPos.x;
+        y = window_water_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 5;
         if (gWaterToolRaiseCost != MONEY32_UNDEFINED && gWaterToolRaiseCost != 0)
             gfx_draw_string_centred(dpi, STR_RAISE_COST_AMOUNT, x, y, COLOUR_BLACK, &gWaterToolRaiseCost);
         y += 10;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -220,9 +220,9 @@ static AudioParams audio_get_params_from_location(SoundId soundId, const CoordsX
     {
         if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
         {
-            int16_t vy = pos2.y - viewport->view_y;
-            int16_t vx = pos2.x - viewport->view_x;
-            params.pan = viewport->x + (vx >> viewport->zoom);
+            int16_t vy = pos2.y - viewport->viewPos.x;
+            int16_t vx = pos2.x - viewport->viewPos.y;
+            params.pan = viewport->pos.x + (vx >> viewport->zoom);
             params.volume = SoundVolumeAdjust[static_cast<uint8_t>(soundId)]
                 + ((-1024 * viewport->zoom - 1) * (1 << volumeDown)) + 1;
 

--- a/src/openrct2/cmdline/BenchSpriteSort.cpp
+++ b/src/openrct2/cmdline/BenchSpriteSort.cpp
@@ -92,8 +92,7 @@ static std::vector<paint_session> extract_paint_session(const std::string parkFi
         resolutionHeight += 128;
 
         rct_viewport viewport;
-        viewport.x = 0;
-        viewport.y = 0;
+        viewport.pos = { 0, 0 };
         viewport.width = resolutionWidth;
         viewport.height = resolutionHeight;
         viewport.view_width = viewport.width;
@@ -109,8 +108,7 @@ static std::vector<paint_session> extract_paint_session(const std::string parkFi
         x = customY - customX;
         y = ((customX + customY) / 2) - z;
 
-        viewport.view_x = x - ((viewport.view_width) / 2);
-        viewport.view_y = y - ((viewport.view_height) / 2);
+        viewport.viewPos = { x - ((viewport.view_width) / 2), y - ((viewport.view_height) / 2) };
         viewport.zoom = 0;
         gCurrentRotation = 0;
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -441,8 +441,8 @@ void lightfx_update_viewport_settings()
     if (mainWindow)
     {
         rct_viewport* viewport = window_get_viewport(mainWindow);
-        _current_view_x_back = viewport->view_x;
-        _current_view_y_back = viewport->view_y;
+        _current_view_x_back = viewport->viewPos.x;
+        _current_view_y_back = viewport->viewPos.y;
         _current_view_rotation_back = get_current_rotation();
         _current_view_zoom_back = viewport->zoom;
     }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -367,8 +367,7 @@ static rct_viewport GetGiantViewport(int32_t mapSize, int32_t rotation, int32_t 
     int32_t bottom = translate_3d_to_2d_with_z(rotation, CoordsXYZ(bottomTileCoords, 0)).y;
 
     rct_viewport viewport{};
-    viewport.view_x = left;
-    viewport.view_y = top;
+    viewport.viewPos = { left, top };
     viewport.view_width = right - left;
     viewport.view_height = bottom - top;
     viewport.width = viewport.view_width >> zoom;
@@ -726,15 +725,15 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
 
                 auto coords2d = translate_3d_to_2d_with_z(customRotation, coords3d);
 
-                viewport.view_x = coords2d.x - ((viewport.view_width << customZoom) / 2);
-                viewport.view_y = coords2d.y - ((viewport.view_height << customZoom) / 2);
+                viewport.viewPos = { coords2d.x - ((viewport.view_width << customZoom) / 2),
+                                     coords2d.y - ((viewport.view_height << customZoom) / 2) };
                 viewport.zoom = customZoom;
                 gCurrentRotation = customRotation;
             }
             else
             {
-                viewport.view_x = gSavedView.x - (viewport.view_width / 2);
-                viewport.view_y = gSavedView.y - (viewport.view_height / 2);
+                viewport.viewPos = { gSavedView.x - (viewport.view_width / 2), gSavedView.y - (viewport.view_height / 2) };
+
                 viewport.zoom = gSavedViewZoom;
                 gCurrentRotation = gSavedViewRotation;
             }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -732,8 +732,7 @@ int32_t cmdline_for_screenshot(const char** argv, int32_t argc, ScreenshotOption
             }
             else
             {
-                viewport.viewPos = { gSavedView.x - (viewport.view_width / 2), gSavedView.y - (viewport.view_height / 2) };
-
+                viewport.viewPos = { gSavedView - ScreenCoordsXY{ (viewport.view_width / 2), (viewport.view_height / 2) } };
                 viewport.zoom = gSavedViewZoom;
                 gCurrentRotation = gSavedViewRotation;
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -154,8 +154,7 @@ void viewport_create(
         return;
     }
 
-    viewport->x = screenCoords.x;
-    viewport->y = screenCoords.y;
+    viewport->pos = screenCoords;
     viewport->width = width;
     viewport->height = height;
 
@@ -192,8 +191,7 @@ void viewport_create(
     }
     w->saved_view_x = centreLoc->x;
     w->saved_view_y = centreLoc->y;
-    viewport->view_x = centreLoc->x;
-    viewport->view_y = centreLoc->y;
+    viewport->viewPos = *centreLoc;
 }
 
 /**
@@ -237,9 +235,9 @@ static void viewport_redraw_after_shift(
     if (window != nullptr)
     {
         // skip current window and non-intersecting windows
-        if (viewport == window->viewport || viewport->x + viewport->width <= window->x
-            || viewport->x >= window->x + window->width || viewport->y + viewport->height <= window->y
-            || viewport->y >= window->y + window->height)
+        if (viewport == window->viewport || viewport->pos.x + viewport->width <= window->x
+            || viewport->pos.x >= window->x + window->width || viewport->pos.y + viewport->height <= window->y
+            || viewport->pos.y >= window->y + window->height)
         {
             auto itWindowPos = window_get_iterator(window);
             auto itNextWindow = itWindowPos != g_window_list.end() ? std::next(itWindowPos) : g_window_list.end();
@@ -252,50 +250,50 @@ static void viewport_redraw_after_shift(
         rct_viewport view_copy;
         std::memcpy(&view_copy, viewport, sizeof(rct_viewport));
 
-        if (viewport->x < window->x)
+        if (viewport->pos.x < window->x)
         {
-            viewport->width = window->x - viewport->x;
+            viewport->width = window->x - viewport->pos.x;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
 
-            viewport->x += viewport->width;
-            viewport->view_x += viewport->width << viewport->zoom;
+            viewport->pos.x += viewport->width;
+            viewport->viewPos.x += viewport->width << viewport->zoom;
             viewport->width = view_copy.width - viewport->width;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
         }
-        else if (viewport->x + viewport->width > window->x + window->width)
+        else if (viewport->pos.x + viewport->width > window->x + window->width)
         {
-            viewport->width = window->x + window->width - viewport->x;
+            viewport->width = window->x + window->width - viewport->pos.x;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
 
-            viewport->x += viewport->width;
-            viewport->view_x += viewport->width << viewport->zoom;
+            viewport->pos.x += viewport->width;
+            viewport->viewPos.x += viewport->width << viewport->zoom;
             viewport->width = view_copy.width - viewport->width;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
         }
-        else if (viewport->y < window->y)
+        else if (viewport->pos.y < window->y)
         {
-            viewport->height = window->y - viewport->y;
+            viewport->height = window->y - viewport->pos.y;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
 
-            viewport->y += viewport->height;
-            viewport->view_y += viewport->height << viewport->zoom;
+            viewport->pos.y += viewport->height;
+            viewport->viewPos.y += viewport->height << viewport->zoom;
             viewport->height = view_copy.height - viewport->height;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
         }
-        else if (viewport->y + viewport->height > window->y + window->height)
+        else if (viewport->pos.y + viewport->height > window->y + window->height)
         {
-            viewport->height = window->y + window->height - viewport->y;
+            viewport->height = window->y + window->height - viewport->pos.y;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
 
-            viewport->y += viewport->height;
-            viewport->view_y += viewport->height << viewport->zoom;
+            viewport->pos.y += viewport->height;
+            viewport->viewPos.y += viewport->height << viewport->zoom;
             viewport->height = view_copy.height - viewport->height;
             viewport->view_width = viewport->width << viewport->zoom;
             viewport_redraw_after_shift(dpi, window, viewport, x, y);
@@ -306,28 +304,28 @@ static void viewport_redraw_after_shift(
     }
     else
     {
-        int16_t left = viewport->x;
-        int16_t right = viewport->x + viewport->width;
-        int16_t top = viewport->y;
-        int16_t bottom = viewport->y + viewport->height;
+        int16_t left = viewport->pos.x;
+        int16_t right = viewport->pos.x + viewport->width;
+        int16_t top = viewport->pos.y;
+        int16_t bottom = viewport->pos.y + viewport->height;
 
         // if moved more than the viewport size
         if (abs(x) < viewport->width && abs(y) < viewport->height)
         {
             // update whole block ?
-            drawing_engine_copy_rect(viewport->x, viewport->y, viewport->width, viewport->height, x, y);
+            drawing_engine_copy_rect(viewport->pos.x, viewport->pos.y, viewport->width, viewport->height, x, y);
 
             if (x > 0)
             {
                 // draw left
-                int16_t _right = viewport->x + x;
+                int16_t _right = viewport->pos.x + x;
                 window_draw_all(dpi, left, top, _right, bottom);
                 left += x;
             }
             else if (x < 0)
             {
                 // draw right
-                int16_t _left = viewport->x + viewport->width + x;
+                int16_t _left = viewport->pos.x + viewport->width + x;
                 window_draw_all(dpi, _left, top, right, bottom);
                 right += x;
             }
@@ -335,13 +333,13 @@ static void viewport_redraw_after_shift(
             if (y > 0)
             {
                 // draw top
-                bottom = viewport->y + y;
+                bottom = viewport->pos.y + y;
                 window_draw_all(dpi, left, top, right, bottom);
             }
             else if (y < 0)
             {
                 // draw bottom
-                top = viewport->y + viewport->height + y;
+                top = viewport->pos.y + viewport->height + y;
                 window_draw_all(dpi, left, top, right, bottom);
             }
         }
@@ -365,14 +363,14 @@ static void viewport_shift_pixels(
         if (w->viewport == viewport)
             continue;
 
-        if (viewport->x + viewport->width <= w->x)
+        if (viewport->pos.x + viewport->width <= w->x)
             continue;
-        if (w->x + w->width <= viewport->x)
+        if (w->x + w->width <= viewport->pos.x)
             continue;
 
-        if (viewport->y + viewport->height <= w->y)
+        if (viewport->pos.y + viewport->height <= w->y)
             continue;
-        if (w->y + w->height <= viewport->y)
+        if (w->y + w->height <= viewport->pos.y)
             continue;
 
         auto left = w->x;
@@ -380,15 +378,15 @@ static void viewport_shift_pixels(
         auto top = w->y;
         auto bottom = w->y + w->height;
 
-        if (left < viewport->x)
-            left = viewport->x;
-        if (right > viewport->x + viewport->width)
-            right = viewport->x + viewport->width;
+        if (left < viewport->pos.x)
+            left = viewport->pos.x;
+        if (right > viewport->pos.x + viewport->width)
+            right = viewport->pos.x + viewport->width;
 
-        if (top < viewport->y)
-            top = viewport->y;
-        if (bottom > viewport->y + viewport->height)
-            bottom = viewport->y + viewport->height;
+        if (top < viewport->pos.y)
+            top = viewport->pos.y;
+        if (bottom > viewport->pos.y + viewport->height)
+            bottom = viewport->pos.y + viewport->height;
 
         if (left >= right)
             continue;
@@ -408,11 +406,10 @@ static void viewport_move(int16_t x, int16_t y, rct_window* w, rct_viewport* vie
     // Note: do not do the subtraction and then divide!
     // Note: Due to arithmetic shift != /zoom a shift will have to be used
     // hopefully when 0x006E7FF3 is finished this can be converted to /zoom.
-    int16_t x_diff = (viewport->view_x >> viewport->zoom) - (x >> viewport->zoom);
-    int16_t y_diff = (viewport->view_y >> viewport->zoom) - (y >> viewport->zoom);
+    int16_t x_diff = (viewport->viewPos.x >> viewport->zoom) - (x >> viewport->zoom);
+    int16_t y_diff = (viewport->viewPos.y >> viewport->zoom) - (y >> viewport->zoom);
 
-    viewport->view_x = x;
-    viewport->view_y = y;
+    viewport->viewPos = { x, y };
 
     // If no change in viewing area
     if ((!x_diff) && (!y_diff))
@@ -420,10 +417,10 @@ static void viewport_move(int16_t x, int16_t y, rct_window* w, rct_viewport* vie
 
     if (w->flags & WF_7)
     {
-        int32_t left = std::max<int32_t>(viewport->x, 0);
-        int32_t top = std::max<int32_t>(viewport->y, 0);
-        int32_t right = std::min<int32_t>(viewport->x + viewport->width, context_get_width());
-        int32_t bottom = std::min<int32_t>(viewport->y + viewport->height, context_get_height());
+        int32_t left = std::max<int32_t>(viewport->pos.x, 0);
+        int32_t top = std::max<int32_t>(viewport->pos.y, 0);
+        int32_t right = std::min<int32_t>(viewport->pos.x + viewport->width, context_get_width());
+        int32_t bottom = std::min<int32_t>(viewport->pos.y + viewport->height, context_get_height());
 
         if (left >= right)
             return;
@@ -441,15 +438,15 @@ static void viewport_move(int16_t x, int16_t y, rct_window* w, rct_viewport* vie
     rct_viewport view_copy;
     std::memcpy(&view_copy, viewport, sizeof(rct_viewport));
 
-    if (viewport->x < 0)
+    if (viewport->pos.x < 0)
     {
-        viewport->width += viewport->x;
-        viewport->view_width += viewport->x * zoom;
-        viewport->view_x -= viewport->x * zoom;
-        viewport->x = 0;
+        viewport->width += viewport->pos.x;
+        viewport->view_width += viewport->pos.x * zoom;
+        viewport->viewPos.x -= viewport->pos.x * zoom;
+        viewport->pos.x = 0;
     }
 
-    int32_t eax = viewport->x + viewport->width - context_get_width();
+    int32_t eax = viewport->pos.x + viewport->width - context_get_width();
     if (eax > 0)
     {
         viewport->width -= eax;
@@ -462,15 +459,15 @@ static void viewport_move(int16_t x, int16_t y, rct_window* w, rct_viewport* vie
         return;
     }
 
-    if (viewport->y < 0)
+    if (viewport->pos.y < 0)
     {
-        viewport->height += viewport->y;
-        viewport->view_height += viewport->y * zoom;
-        viewport->view_y -= viewport->y * zoom;
-        viewport->y = 0;
+        viewport->height += viewport->pos.y;
+        viewport->view_height += viewport->pos.y * zoom;
+        viewport->viewPos.y -= viewport->pos.y * zoom;
+        viewport->pos.y = 0;
     }
 
-    eax = viewport->y + viewport->height - context_get_height();
+    eax = viewport->pos.y + viewport->height - context_get_height();
     if (eax > 0)
     {
         viewport->height -= eax;
@@ -586,13 +583,13 @@ void viewport_update_position(rct_window* window)
     {
         // Moves the viewport if focusing in on an item
         uint8_t flags = 0;
-        x -= viewport->view_x;
+        x -= viewport->viewPos.x;
         if (x < 0)
         {
             x = -x;
             flags |= 1;
         }
-        y -= viewport->view_y;
+        y -= viewport->viewPos.y;
         if (y < 0)
         {
             y = -y;
@@ -614,8 +611,8 @@ void viewport_update_position(rct_window* window)
         {
             y = -y;
         }
-        x += viewport->view_x;
-        y += viewport->view_y;
+        x += viewport->viewPos.x;
+        y += viewport->viewPos.y;
     }
 
     viewport_move(x, y, window, viewport);
@@ -784,33 +781,33 @@ void viewport_render(
     rct_drawpixelinfo* dpi, const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,
     std::vector<paint_session>* sessions)
 {
-    if (right <= viewport->x)
+    if (right <= viewport->pos.x)
         return;
-    if (bottom <= viewport->y)
+    if (bottom <= viewport->pos.y)
         return;
-    if (left >= viewport->x + viewport->width)
+    if (left >= viewport->pos.x + viewport->width)
         return;
-    if (top >= viewport->y + viewport->height)
+    if (top >= viewport->pos.y + viewport->height)
         return;
 
 #ifdef DEBUG_SHOW_DIRTY_BOX
     int32_t l = left, t = top, r = right, b = bottom;
 #endif
 
-    left = std::max<int32_t>(left - viewport->x, 0);
-    right = std::min<int32_t>(right - viewport->x, viewport->width);
-    top = std::max<int32_t>(top - viewport->y, 0);
-    bottom = std::min<int32_t>(bottom - viewport->y, viewport->height);
+    left = std::max<int32_t>(left - viewport->pos.x, 0);
+    right = std::min<int32_t>(right - viewport->pos.x, viewport->width);
+    top = std::max<int32_t>(top - viewport->pos.y, 0);
+    bottom = std::min<int32_t>(bottom - viewport->pos.y, viewport->height);
 
     left <<= viewport->zoom;
     right <<= viewport->zoom;
     top <<= viewport->zoom;
     bottom <<= viewport->zoom;
 
-    left += viewport->view_x;
-    right += viewport->view_x;
-    top += viewport->view_y;
-    bottom += viewport->view_y;
+    left += viewport->viewPos.x;
+    right += viewport->viewPos.x;
+    top += viewport->viewPos.y;
+    bottom += viewport->viewPos.y;
 
     viewport_paint(viewport, dpi, left, top, right, bottom, sessions);
 
@@ -910,13 +907,13 @@ void viewport_paint(
     right = left + width;
     bottom = top + height;
 
-    int16_t x = (int16_t)(left - (int16_t)(viewport->view_x & bitmask));
+    int16_t x = (int16_t)(left - (int16_t)(viewport->viewPos.x & bitmask));
     x >>= viewport->zoom;
-    x += viewport->x;
+    x += viewport->pos.x;
 
-    int16_t y = (int16_t)(top - (int16_t)(viewport->view_y & bitmask));
+    int16_t y = (int16_t)(top - (int16_t)(viewport->viewPos.y & bitmask));
     y >>= viewport->zoom;
-    y += viewport->y;
+    y += viewport->pos.y;
 
     rct_drawpixelinfo dpi1 = *dpi;
     dpi1.bits = dpi->bits + (x - dpi->x) + ((y - dpi->y) * (dpi->width + dpi->pitch));
@@ -1062,8 +1059,8 @@ std::optional<CoordsXY> screen_pos_to_map_pos(const ScreenCoordsXY& screenCoords
 ScreenCoordsXY screen_coord_to_viewport_coord(rct_viewport* viewport, const ScreenCoordsXY& screenCoords)
 {
     ScreenCoordsXY ret;
-    ret.x = ((screenCoords.x - viewport->x) << viewport->zoom) + viewport->view_x;
-    ret.y = ((screenCoords.y - viewport->y) << viewport->zoom) + viewport->view_y;
+    ret.x = ((screenCoords.x - viewport->pos.x) << viewport->zoom) + viewport->viewPos.x;
+    ret.y = ((screenCoords.y - viewport->pos.y) << viewport->zoom) + viewport->viewPos.y;
     return ret;
 }
 
@@ -1651,15 +1648,13 @@ void get_map_coordinates_from_pos_window(
     if (window != nullptr && window->viewport != nullptr)
     {
         rct_viewport* myviewport = window->viewport;
-        screenCoords.x -= (int32_t)myviewport->x;
-        screenCoords.y -= (int32_t)myviewport->y;
+        screenCoords -= myviewport->pos;
         if (screenCoords.x >= 0 && screenCoords.x < (int32_t)myviewport->width && screenCoords.y >= 0
             && screenCoords.y < (int32_t)myviewport->height)
         {
             screenCoords.x <<= myviewport->zoom;
             screenCoords.y <<= myviewport->zoom;
-            screenCoords.x += (int32_t)myviewport->view_x;
-            screenCoords.y += (int32_t)myviewport->view_y;
+            screenCoords += myviewport->viewPos;
             screenCoords.x &= (0xFFFF << myviewport->zoom) & 0xFFFF;
             screenCoords.y &= (0xFFFF << myviewport->zoom) & 0xFFFF;
             rct_drawpixelinfo dpi;
@@ -1710,10 +1705,10 @@ void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int3
     if (viewport->visibility == VC_COVERED)
         return;
 
-    int32_t viewportLeft = viewport->view_x;
-    int32_t viewportTop = viewport->view_y;
-    int32_t viewportRight = viewport->view_x + viewport->view_width;
-    int32_t viewportBottom = viewport->view_y + viewport->view_height;
+    int32_t viewportLeft = viewport->viewPos.x;
+    int32_t viewportTop = viewport->viewPos.y;
+    int32_t viewportRight = viewport->viewPos.x + viewport->view_width;
+    int32_t viewportBottom = viewport->viewPos.y + viewport->view_height;
     if (right > viewportLeft && bottom > viewportTop)
     {
         left = std::max(left, viewportLeft);
@@ -1730,10 +1725,10 @@ void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int3
         top /= zoom;
         right /= zoom;
         bottom /= zoom;
-        left += viewport->x;
-        top += viewport->y;
-        right += viewport->x;
-        bottom += viewport->y;
+        left += viewport->pos.x;
+        top += viewport->pos.y;
+        right += viewport->pos.x;
+        bottom += viewport->pos.y;
         gfx_set_dirty_blocks(left, top, right, bottom);
     }
 }
@@ -1748,9 +1743,9 @@ static rct_viewport* viewport_find_from_point(const ScreenCoordsXY& screenCoords
     if (viewport == nullptr)
         return nullptr;
 
-    if (screenCoords.x < viewport->x || screenCoords.y < viewport->y)
+    if (screenCoords.x < viewport->pos.x || screenCoords.y < viewport->pos.y)
         return nullptr;
-    if (screenCoords.x >= viewport->x + viewport->width || screenCoords.y >= viewport->y + viewport->height)
+    if (screenCoords.x >= viewport->pos.x + viewport->width || screenCoords.y >= viewport->pos.y + viewport->height)
         return nullptr;
 
     return viewport;
@@ -1919,8 +1914,8 @@ void viewport_set_saved_view()
     {
         rct_viewport* viewport = w->viewport;
 
-        gSavedView = ScreenCoordsXY{ viewport->view_width / 2 + viewport->view_x,
-                                     viewport->view_height / 2 + viewport->view_y };
+        gSavedView = ScreenCoordsXY{ viewport->view_width / 2 + viewport->viewPos.x,
+                                     viewport->view_height / 2 + viewport->viewPos.y };
 
         gSavedViewZoom = viewport->zoom;
         gSavedViewRotation = get_current_rotation();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -136,8 +136,8 @@ std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, rct_vi
  *  w:      esi
  */
 void viewport_create(
-    rct_window* w, int32_t x, int32_t y, int32_t width, int32_t height, int32_t zoom, int32_t centre_x, int32_t centre_y,
-    int32_t centre_z, char flags, uint16_t sprite)
+    rct_window* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, int32_t zoom, CoordsXYZ centrePos,
+    char flags, uint16_t sprite)
 {
     rct_viewport* viewport = nullptr;
     for (int32_t i = 0; i < MAX_VIEWPORT_COUNT; i++)
@@ -154,8 +154,8 @@ void viewport_create(
         return;
     }
 
-    viewport->x = x;
-    viewport->y = y;
+    viewport->x = screenCoords.x;
+    viewport->y = screenCoords.y;
     viewport->width = width;
     viewport->height = height;
 
@@ -177,16 +177,14 @@ void viewport_create(
     {
         w->viewport_target_sprite = sprite;
         rct_sprite* centre_sprite = get_sprite(sprite);
-        centre_x = centre_sprite->generic.x;
-        centre_y = centre_sprite->generic.y;
-        centre_z = centre_sprite->generic.z;
+        centrePos = { centre_sprite->generic.x, centre_sprite->generic.y, centre_sprite->generic.z };
     }
     else
     {
         w->viewport_target_sprite = SPRITE_INDEX_NULL;
     }
 
-    auto centreLoc = centre_2d_coordinates({ centre_x, centre_y, centre_z }, viewport);
+    auto centreLoc = centre_2d_coordinates(centrePos, viewport);
     if (!centreLoc)
     {
         log_error("Invalid location for viewport.");

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2019 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1914,8 +1914,7 @@ void viewport_set_saved_view()
     {
         rct_viewport* viewport = w->viewport;
 
-        gSavedView = ScreenCoordsXY{ viewport->view_width / 2 + viewport->viewPos.x,
-                                     viewport->view_height / 2 + viewport->viewPos.y };
+        gSavedView = ScreenCoordsXY{ viewport->view_width / 2, viewport->view_height / 2 } + viewport->viewPos;
 
         gSavedViewZoom = viewport->zoom;
         gSavedViewRotation = get_current_rotation();

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -131,8 +131,8 @@ extern uint8_t gCurrentRotation;
 void viewport_init_all();
 std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, rct_viewport* viewport);
 void viewport_create(
-    rct_window* w, int32_t x, int32_t y, int32_t width, int32_t height, int32_t zoom, int32_t centre_x, int32_t centre_y,
-    int32_t centre_z, char flags, uint16_t sprite);
+    rct_window* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, int32_t zoom, CoordsXYZ centrePos,
+    char flags, uint16_t sprite);
 void viewport_update_position(rct_window* window);
 void viewport_update_sprite_follow(rct_window* window);
 void viewport_update_smart_sprite_follow(rct_window* window);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -401,8 +401,8 @@ rct_window* window_find_from_point(const ScreenCoordsXY& screenCoords)
     for (auto it = g_window_list.rbegin(); it != g_window_list.rend(); it++)
     {
         auto& w = *it;
-        if (screenCoords.x < w->x || screenCoords.x >= w->x + w->width || screenCoords.y < w->y
-            || screenCoords.y >= w->y + w->height)
+        if (screenCoords.x < w->windowPos.x || screenCoords.x >= w->windowPos.x + w->width || screenCoords.y < w->windowPos.y
+            || screenCoords.y >= w->windowPos.y + w->height)
             continue;
 
         if (w->flags & WF_NO_BACKGROUND)
@@ -442,8 +442,8 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsX
         }
         else if (widget->type != WWT_EMPTY)
         {
-            if (screenCoords.x >= w->x + widget->left && screenCoords.x <= w->x + widget->right
-                && screenCoords.y >= w->y + widget->top && screenCoords.y <= w->y + widget->bottom)
+            if (screenCoords.x >= w->windowPos.x + widget->left && screenCoords.x <= w->windowPos.x + widget->right
+                && screenCoords.y >= w->windowPos.y + widget->top && screenCoords.y <= w->windowPos.y + widget->bottom)
             {
                 widget_index = i;
             }
@@ -523,7 +523,9 @@ void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex)
     if (widget->left == -2)
         return;
 
-    gfx_set_dirty_blocks(w->x + widget->left, w->y + widget->top, w->x + widget->right + 1, w->y + widget->bottom + 1);
+    gfx_set_dirty_blocks(
+        w->windowPos.x + widget->left, w->windowPos.y + widget->top, w->windowPos.x + widget->right + 1,
+        w->windowPos.y + widget->bottom + 1);
 }
 
 template<typename _TPred> static void widget_invalidate_by_condition(_TPred pred)
@@ -661,10 +663,10 @@ rct_window* window_bring_to_front(rct_window* w)
             g_window_list.splice(itDestPos, g_window_list, itSourcePos);
             w->Invalidate();
 
-            if (w->x + w->width < 20)
+            if (w->windowPos.x + w->width < 20)
             {
-                int32_t i = 20 - w->x;
-                w->x += i;
+                int32_t i = 20 - w->windowPos.x;
+                w->windowPos.x += i;
                 if (w->viewport != nullptr)
                     w->viewport->pos.x += i;
                 w->Invalidate();
@@ -726,20 +728,20 @@ void window_push_others_right(rct_window* window)
             return;
         if (w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))
             return;
-        if (w->x >= window->x + window->width)
+        if (w->windowPos.x >= window->windowPos.x + window->width)
             return;
-        if (w->x + w->width <= window->x)
+        if (w->windowPos.x + w->width <= window->windowPos.x)
             return;
-        if (w->y >= window->y + window->height)
+        if (w->windowPos.y >= window->windowPos.y + window->height)
             return;
-        if (w->y + w->height <= window->y)
+        if (w->windowPos.y + w->height <= window->windowPos.y)
             return;
 
         w->Invalidate();
-        if (window->x + window->width + 13 >= context_get_width())
+        if (window->windowPos.x + window->width + 13 >= context_get_width())
             return;
-        uint16_t push_amount = window->x + window->width - w->x + 3;
-        w->x += push_amount;
+        uint16_t push_amount = window->windowPos.x + window->width - w->windowPos.x + 3;
+        w->windowPos.x += push_amount;
         w->Invalidate();
         if (w->viewport != nullptr)
             w->viewport->pos.x += push_amount;
@@ -760,20 +762,20 @@ void window_push_others_below(rct_window* w1)
         if (w2->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))
             return;
         // Check if w2 intersects with w1
-        if (w2->x > (w1->x + w1->width) || w2->x + w2->width < w1->x)
+        if (w2->windowPos.x > (w1->windowPos.x + w1->width) || w2->windowPos.x + w2->width < w1->windowPos.x)
             return;
-        if (w2->y > (w1->y + w1->height) || w2->y + w2->height < w1->y)
+        if (w2->windowPos.y > (w1->windowPos.y + w1->height) || w2->windowPos.y + w2->height < w1->windowPos.y)
             return;
 
         // Check if there is room to push it down
-        if (w1->y + w1->height + 80 >= context_get_height())
+        if (w1->windowPos.y + w1->height + 80 >= context_get_height())
             return;
 
         // Invalidate the window's current area
         w2->Invalidate();
 
-        int32_t push_amount = w1->y + w1->height - w2->y + 3;
-        w2->y += push_amount;
+        int32_t push_amount = w1->windowPos.y + w1->height - w2->windowPos.y + 3;
+        w2->windowPos.y += push_amount;
 
         // Invalidate the window's new area
         w2->Invalidate();
@@ -851,8 +853,8 @@ void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z)
                 for (; it != g_window_list.end(); it++)
                 {
                     auto w2 = (*it).get();
-                    int16_t x1 = w2->x - 10;
-                    int16_t y1 = w2->y - 10;
+                    int16_t x1 = w2->windowPos.x - 10;
+                    int16_t y1 = w2->windowPos.y - 10;
                     if (x2 >= x1 && x2 <= w2->width + x1 + 20)
                     {
                         if (y2 >= y1 && y2 <= w2->height + y1 + 20)
@@ -880,8 +882,9 @@ void window_scroll_to_location(rct_window* w, int32_t x, int32_t y, int32_t z)
         {
             if (!(w->flags & WF_NO_SCROLLING))
             {
-                w->saved_view_x = screenCoords.x - (int16_t)(w->viewport->view_width * window_scroll_locations[i][0]);
-                w->saved_view_y = screenCoords.y - (int16_t)(w->viewport->view_height * window_scroll_locations[i][1]);
+                w->savedViewPos = screenCoords
+                    - ScreenCoordsXY{ (int16_t)(w->viewport->view_width * window_scroll_locations[i][0]),
+                                      (int16_t)(w->viewport->view_height * window_scroll_locations[i][1]) };
                 w->flags |= WF_SCROLLING_TO_LOCATION;
             }
         }
@@ -938,8 +941,7 @@ void window_rotate_camera(rct_window* w, int32_t direction)
 
     if (centreLoc)
     {
-        w->saved_view_x = centreLoc->x;
-        w->saved_view_y = centreLoc->y;
+        w->savedViewPos = *centreLoc;
         viewport->viewPos = *centreLoc;
     }
 
@@ -976,8 +978,8 @@ void window_viewport_get_map_coords_by_cursor(
             rebased_y = ((w->height >> 1) - mouseCoords.y) * (1 << w->viewport->zoom);
 
     // Compute cursor offset relative to tile.
-    *offset_x = (w->saved_view_x - (centreLoc->x + rebased_x)) * (1 << w->viewport->zoom);
-    *offset_y = (w->saved_view_y - (centreLoc->y + rebased_y)) * (1 << w->viewport->zoom);
+    *offset_x = (w->savedViewPos.x - (centreLoc->x + rebased_x)) * (1 << w->viewport->zoom);
+    *offset_y = (w->savedViewPos.y - (centreLoc->y + rebased_y)) * (1 << w->viewport->zoom);
 }
 
 void window_viewport_centre_tile_around_cursor(rct_window* w, int16_t map_x, int16_t map_y, int16_t offset_x, int16_t offset_y)
@@ -1000,8 +1002,8 @@ void window_viewport_centre_tile_around_cursor(rct_window* w, int16_t map_x, int
             rebased_y = ((w->height >> 1) - mouseCoords.y) * (1 << w->viewport->zoom);
 
     // Apply offset to the viewport.
-    w->saved_view_x = centreLoc->x + rebased_x + (offset_x / (1 << w->viewport->zoom));
-    w->saved_view_y = centreLoc->y + rebased_y + (offset_y / (1 << w->viewport->zoom));
+    w->savedViewPos = { centreLoc->x + rebased_x + (offset_x / (1 << w->viewport->zoom)),
+                        centreLoc->y + rebased_y + (offset_y / (1 << w->viewport->zoom)) };
 }
 
 void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
@@ -1026,8 +1028,8 @@ void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
     while (v->zoom > zoomLevel)
     {
         v->zoom--;
-        w->saved_view_x += v->view_width / 4;
-        w->saved_view_y += v->view_height / 4;
+        w->savedViewPos.x += v->view_width / 4;
+        w->savedViewPos.y += v->view_height / 4;
         v->view_width /= 2;
         v->view_height /= 2;
     }
@@ -1036,8 +1038,8 @@ void window_zoom_set(rct_window* w, int32_t zoomLevel, bool atCursor)
     while (v->zoom < zoomLevel)
     {
         v->zoom++;
-        w->saved_view_x -= v->view_width / 2;
-        w->saved_view_y -= v->view_height / 2;
+        w->savedViewPos.x -= v->view_width / 2;
+        w->savedViewPos.y -= v->view_height / 2;
         v->view_width *= 2;
         v->view_height *= 2;
     }
@@ -1105,10 +1107,10 @@ void window_draw(rct_drawpixelinfo* dpi, rct_window* w, int32_t left, int32_t to
         return;
 
     // Clamp region
-    left = std::max<int32_t>(left, w->x);
-    top = std::max<int32_t>(top, w->y);
-    right = std::min<int32_t>(right, w->x + w->width);
-    bottom = std::min<int32_t>(bottom, w->y + w->height);
+    left = std::max<int32_t>(left, w->windowPos.x);
+    top = std::max<int32_t>(top, w->windowPos.y);
+    right = std::min<int32_t>(right, w->windowPos.x + w->width);
+    bottom = std::min<int32_t>(bottom, w->windowPos.y + w->height);
     if (left >= right)
         return;
     if (top >= bottom)
@@ -1139,37 +1141,37 @@ static int32_t window_draw_split(
     {
         // Check if this window overlaps w
         auto topwindow = it->get();
-        if (topwindow->x >= right || topwindow->y >= bottom)
+        if (topwindow->windowPos.x >= right || topwindow->windowPos.y >= bottom)
             continue;
-        if (topwindow->x + topwindow->width <= left || topwindow->y + topwindow->height <= top)
+        if (topwindow->windowPos.x + topwindow->width <= left || topwindow->windowPos.y + topwindow->height <= top)
             continue;
         if (topwindow->flags & WF_TRANSPARENT)
             continue;
 
         // A window overlaps w, split up the draw into two regions where the window starts to overlap
-        if (topwindow->x > left)
+        if (topwindow->windowPos.x > left)
         {
             // Split draw at topwindow.left
-            window_draw(dpi, w, left, top, topwindow->x, bottom);
-            window_draw(dpi, w, topwindow->x, top, right, bottom);
+            window_draw(dpi, w, left, top, topwindow->windowPos.x, bottom);
+            window_draw(dpi, w, topwindow->windowPos.x, top, right, bottom);
         }
-        else if (topwindow->x + topwindow->width < right)
+        else if (topwindow->windowPos.x + topwindow->width < right)
         {
             // Split draw at topwindow.right
-            window_draw(dpi, w, left, top, topwindow->x + topwindow->width, bottom);
-            window_draw(dpi, w, topwindow->x + topwindow->width, top, right, bottom);
+            window_draw(dpi, w, left, top, topwindow->windowPos.x + topwindow->width, bottom);
+            window_draw(dpi, w, topwindow->windowPos.x + topwindow->width, top, right, bottom);
         }
-        else if (topwindow->y > top)
+        else if (topwindow->windowPos.y > top)
         {
             // Split draw at topwindow.top
-            window_draw(dpi, w, left, top, right, topwindow->y);
-            window_draw(dpi, w, left, topwindow->y, right, bottom);
+            window_draw(dpi, w, left, top, right, topwindow->windowPos.y);
+            window_draw(dpi, w, left, topwindow->windowPos.y, right, bottom);
         }
-        else if (topwindow->y + topwindow->height < bottom)
+        else if (topwindow->windowPos.y + topwindow->height < bottom)
         {
             // Split draw at topwindow.bottom
-            window_draw(dpi, w, left, top, right, topwindow->y + topwindow->height);
-            window_draw(dpi, w, left, topwindow->y + topwindow->height, right, bottom);
+            window_draw(dpi, w, left, top, right, topwindow->windowPos.y + topwindow->height);
+            window_draw(dpi, w, left, topwindow->windowPos.y + topwindow->height, right, bottom);
         }
 
         // Drawing for this region should be done now, exit
@@ -1255,7 +1257,7 @@ void window_draw_viewport(rct_drawpixelinfo* dpi, rct_window* w)
 
 void window_set_position(rct_window* w, const ScreenCoordsXY& screenCoords)
 {
-    window_move_position(w, ScreenCoordsXY(screenCoords.x - w->x, screenCoords.y - w->y));
+    window_move_position(w, screenCoords - w->windowPos);
 }
 
 void window_move_position(rct_window* w, const ScreenCoordsXY& deltaCoords)
@@ -1267,12 +1269,10 @@ void window_move_position(rct_window* w, const ScreenCoordsXY& deltaCoords)
     w->Invalidate();
 
     // Translate window and viewport
-    w->x += deltaCoords.x;
-    w->y += deltaCoords.y;
+    w->windowPos += deltaCoords;
     if (w->viewport != nullptr)
     {
-        w->viewport->pos.x += deltaCoords.x;
-        w->viewport->pos.y += deltaCoords.y;
+        w->viewport->pos += deltaCoords;
     }
 
     // Invalidate new region
@@ -1588,26 +1588,24 @@ void window_relocate_windows(int32_t width, int32_t height)
     int32_t new_location = 8;
     window_visit_each([width, height, &new_location](rct_window* w) {
         // Work out if the window requires moving
-        if (w->x + 10 < width)
+        if (w->windowPos.x + 10 < width)
         {
             if (w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT))
             {
-                if (w->y - 22 < height)
+                if (w->windowPos.y - 22 < height)
                 {
                     return;
                 }
             }
-            if (w->y + 10 < height)
+            if (w->windowPos.y + 10 < height)
             {
                 return;
             }
         }
 
         // Calculate the new locations
-        int32_t x = w->x;
-        int32_t y = w->y;
-        w->x = new_location;
-        w->y = new_location + TOP_TOOLBAR_HEIGHT + 1;
+        auto newWinPos = w->windowPos;
+        w->windowPos = { new_location, new_location + TOP_TOOLBAR_HEIGHT + 1 };
 
         // Move the next new location so windows are not directly on top
         new_location += 8;
@@ -1615,8 +1613,7 @@ void window_relocate_windows(int32_t width, int32_t height)
         // Adjust the viewport if required.
         if (w->viewport != nullptr)
         {
-            w->viewport->pos.x -= x - w->x;
-            w->viewport->pos.y -= y - w->y;
+            w->viewport->pos -= newWinPos - w->windowPos;
         }
     });
 }
@@ -1633,21 +1630,21 @@ void window_resize_gui(int32_t width, int32_t height)
     rct_window* titleWind = window_find_by_class(WC_TITLE_MENU);
     if (titleWind != nullptr)
     {
-        titleWind->x = (width - titleWind->width) / 2;
-        titleWind->y = height - 154;
+        titleWind->windowPos.x = (width - titleWind->width) / 2;
+        titleWind->windowPos.y = height - 154;
     }
 
     rct_window* exitWind = window_find_by_class(WC_TITLE_EXIT);
     if (exitWind != nullptr)
     {
-        exitWind->x = width - 40;
-        exitWind->y = height - 64;
+        exitWind->windowPos.x = width - 40;
+        exitWind->windowPos.y = height - 64;
     }
 
     rct_window* optionsWind = window_find_by_class(WC_TITLE_OPTIONS);
     if (optionsWind != nullptr)
     {
-        optionsWind->x = width - 80;
+        optionsWind->windowPos.x = width - 80;
     }
 
     gfx_invalidate_screen();
@@ -1684,7 +1681,7 @@ void window_resize_gui_scenario_editor(int32_t width, int32_t height)
     rct_window* bottomWind = window_find_by_class(WC_BOTTOM_TOOLBAR);
     if (bottomWind != nullptr)
     {
-        bottomWind->y = height - 32;
+        bottomWind->windowPos.y = height - 32;
         bottomWind->width = std::max(640, width);
     }
 }
@@ -1756,18 +1753,18 @@ void window_update_viewport_ride_music()
 static void window_snap_left(rct_window* w, int32_t proximity)
 {
     auto mainWindow = window_get_main();
-    auto wBottom = w->y + w->height;
-    auto wLeftProximity = w->x - (proximity * 2);
-    auto wRightProximity = w->x + (proximity * 2);
+    auto wBottom = w->windowPos.y + w->height;
+    auto wLeftProximity = w->windowPos.x - (proximity * 2);
+    auto wRightProximity = w->windowPos.x + (proximity * 2);
     auto rightMost = INT32_MIN;
 
     window_visit_each([&](rct_window* w2) {
         if (w2 == w || w2 == mainWindow)
             return;
 
-        auto right = w2->x + w2->width;
+        auto right = w2->windowPos.x + w2->width;
 
-        if (wBottom < w2->y || w->y > w2->y + w2->height)
+        if (wBottom < w2->windowPos.y || w->windowPos.y > w2->windowPos.y + w2->height)
             return;
 
         if (right < wLeftProximity || right > wRightProximity)
@@ -1780,24 +1777,24 @@ static void window_snap_left(rct_window* w, int32_t proximity)
         rightMost = std::max(rightMost, 0);
 
     if (rightMost != INT32_MIN)
-        w->x = rightMost;
+        w->windowPos.x = rightMost;
 }
 
 static void window_snap_top(rct_window* w, int32_t proximity)
 {
     auto mainWindow = window_get_main();
-    auto wRight = w->x + w->width;
-    auto wTopProximity = w->y - (proximity * 2);
-    auto wBottomProximity = w->y + (proximity * 2);
+    auto wRight = w->windowPos.x + w->width;
+    auto wTopProximity = w->windowPos.y - (proximity * 2);
+    auto wBottomProximity = w->windowPos.y + (proximity * 2);
     auto bottomMost = INT32_MIN;
 
     window_visit_each([&](rct_window* w2) {
         if (w2 == w || w2 == mainWindow)
             return;
 
-        auto bottom = w2->y + w2->height;
+        auto bottom = w2->windowPos.y + w2->height;
 
-        if (wRight < w2->x || w->x > w2->x + w2->width)
+        if (wRight < w2->windowPos.x || w->windowPos.x > w2->windowPos.x + w2->width)
             return;
 
         if (bottom < wTopProximity || bottom > wBottomProximity)
@@ -1810,14 +1807,14 @@ static void window_snap_top(rct_window* w, int32_t proximity)
         bottomMost = std::max(bottomMost, 0);
 
     if (bottomMost != INT32_MIN)
-        w->y = bottomMost;
+        w->windowPos.y = bottomMost;
 }
 
 static void window_snap_right(rct_window* w, int32_t proximity)
 {
     auto mainWindow = window_get_main();
-    auto wRight = w->x + w->width;
-    auto wBottom = w->y + w->height;
+    auto wRight = w->windowPos.x + w->width;
+    auto wBottom = w->windowPos.y + w->height;
     auto wLeftProximity = wRight - (proximity * 2);
     auto wRightProximity = wRight + (proximity * 2);
     auto leftMost = INT32_MAX;
@@ -1826,13 +1823,13 @@ static void window_snap_right(rct_window* w, int32_t proximity)
         if (w2 == w || w2 == mainWindow)
             return;
 
-        if (wBottom < w2->y || w->y > w2->y + w2->height)
+        if (wBottom < w2->windowPos.y || w->windowPos.y > w2->windowPos.y + w2->height)
             return;
 
-        if (w2->x < wLeftProximity || w2->x > wRightProximity)
+        if (w2->windowPos.x < wLeftProximity || w2->windowPos.x > wRightProximity)
             return;
 
-        leftMost = std::min<int32_t>(leftMost, w2->x);
+        leftMost = std::min<int32_t>(leftMost, w2->windowPos.x);
     });
 
     auto screenWidth = context_get_width();
@@ -1840,14 +1837,14 @@ static void window_snap_right(rct_window* w, int32_t proximity)
         leftMost = std::min(leftMost, screenWidth);
 
     if (leftMost != INT32_MAX)
-        w->x = leftMost - w->width;
+        w->windowPos.x = leftMost - w->width;
 }
 
 static void window_snap_bottom(rct_window* w, int32_t proximity)
 {
     auto mainWindow = window_get_main();
-    auto wRight = w->x + w->width;
-    auto wBottom = w->y + w->height;
+    auto wRight = w->windowPos.x + w->width;
+    auto wBottom = w->windowPos.y + w->height;
     auto wTopProximity = wBottom - (proximity * 2);
     auto wBottomProximity = wBottom + (proximity * 2);
     auto topMost = INT32_MAX;
@@ -1856,13 +1853,13 @@ static void window_snap_bottom(rct_window* w, int32_t proximity)
         if (w2 == w || w2 == mainWindow)
             return;
 
-        if (wRight < w2->x || w->x > w2->x + w2->width)
+        if (wRight < w2->windowPos.x || w->windowPos.x > w2->windowPos.x + w2->width)
             return;
 
-        if (w2->y < wTopProximity || w2->y > wBottomProximity)
+        if (w2->windowPos.y < wTopProximity || w2->windowPos.y > wBottomProximity)
             return;
 
-        topMost = std::min<int32_t>(topMost, w2->y);
+        topMost = std::min<int32_t>(topMost, w2->windowPos.y);
     });
 
     auto screenHeight = context_get_height();
@@ -1870,34 +1867,30 @@ static void window_snap_bottom(rct_window* w, int32_t proximity)
         topMost = std::min(topMost, screenHeight);
 
     if (topMost != INT32_MAX)
-        w->y = topMost - w->height;
+        w->windowPos.y = topMost - w->height;
 }
 
 void window_move_and_snap(rct_window* w, ScreenCoordsXY newWindowCoords, int32_t snapProximity)
 {
-    int32_t originalX = w->x;
-    int32_t originalY = w->y;
+    auto originalPos = w->windowPos;
     int32_t minY = (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) ? 1 : TOP_TOOLBAR_HEIGHT + 2;
 
     newWindowCoords.y = std::clamp(newWindowCoords.y, minY, context_get_height() - 34);
 
     if (snapProximity > 0)
     {
-        w->x = newWindowCoords.x;
-        w->y = newWindowCoords.y;
+        w->windowPos = newWindowCoords;
 
         window_snap_right(w, snapProximity);
         window_snap_bottom(w, snapProximity);
         window_snap_left(w, snapProximity);
         window_snap_top(w, snapProximity);
 
-        if (w->x == originalX && w->y == originalY)
+        if (w->windowPos == originalPos)
             return;
 
-        newWindowCoords.x = w->x;
-        newWindowCoords.y = w->y;
-        w->x = originalX;
-        w->y = originalY;
+        newWindowCoords = w->windowPos;
+        w->windowPos = originalPos;
     }
 
     window_set_position(w, newWindowCoords);
@@ -2007,8 +2000,9 @@ bool window_is_visible(rct_window* w)
         auto& w_other = *(*it);
 
         // if covered by a higher window, no rendering needed
-        if (w_other.x <= w->x && w_other.y <= w->y && w_other.x + w_other.width >= w->x + w->width
-            && w_other.y + w_other.height >= w->y + w->height)
+        if (w_other.windowPos.x <= w->windowPos.x && w_other.windowPos.y <= w->windowPos.y
+            && w_other.windowPos.x + w_other.width >= w->windowPos.x + w->width
+            && w_other.windowPos.y + w_other.height >= w->windowPos.y + w->height)
         {
             w->visibility = VC_COVERED;
             w->viewport->visibility = VC_COVERED;
@@ -2044,9 +2038,9 @@ void window_draw_all(rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t 
     window_visit_each([&windowDPI, left, top, right, bottom](rct_window* w) {
         if (w->flags & WF_TRANSPARENT)
             return;
-        if (right <= w->x || bottom <= w->y)
+        if (right <= w->windowPos.x || bottom <= w->windowPos.y)
             return;
-        if (left >= w->x + w->width || top >= w->y + w->height)
+        if (left >= w->windowPos.x + w->width || top >= w->windowPos.y + w->height)
             return;
         window_draw(&windowDPI, w, left, top, right, bottom);
     });

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -89,16 +89,14 @@ struct rct_widget
  */
 struct rct_viewport
 {
-    int16_t width;       // 0x00
-    int16_t height;      // 0x02
-    int16_t x;           // 0x04
-    int16_t y;           // 0x06
-    int16_t view_x;      // 0x08
-    int16_t view_y;      // 0x0A
-    int16_t view_width;  // 0x0C
-    int16_t view_height; // 0x0E
-    uint32_t flags;      // 0x12
-    uint8_t zoom;        // 0x10
+    int16_t width;
+    int16_t height;
+    ScreenCoordsXY pos;
+    ScreenCoordsXY viewPos;
+    int16_t view_width;
+    int16_t view_height;
+    uint32_t flags;
+    uint8_t zoom;
     uint8_t var_11;
     uint8_t visibility; // VISIBILITY_CACHE
 };

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -260,8 +260,8 @@ struct error_variables
 
 struct rct_window;
 
-#define RCT_WINDOW_RIGHT(w) ((w)->x + (w)->width)
-#define RCT_WINDOW_BOTTOM(w) ((w)->y + (w)->height)
+#define RCT_WINDOW_RIGHT(w) ((w)->windowPos.x + (w)->width)
+#define RCT_WINDOW_BOTTOM(w) ((w)->windowPos.y + (w)->height)
 
 enum WINDOW_EVENTS
 {

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -38,5 +38,5 @@ void rct_window::ScrollToViewport()
 
 void rct_window::Invalidate()
 {
-    gfx_set_dirty_blocks(x, y, x + width, y + height);
+    gfx_set_dirty_blocks(windowPos.x, windowPos.y, windowPos.x + width, windowPos.y + height);
 }

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -62,6 +62,7 @@ struct rct_window
         int16_t picked_peep_old_x; // staff/guest window: peep x gets set to 0x8000 on pickup, this is the old value
         int16_t vehicleIndex;      // Ride window: selected car when setting vehicle colours
         int16_t numberOfStaff;     // Used in park window.
+        int16_t SceneryEntry;      // Used in sign window.
         int16_t var_48C;
     };
     uint16_t frame_no;              // updated every tic for motion in windows sprites
@@ -88,7 +89,7 @@ struct rct_window
     uint16_t viewport_target_sprite;
     ScreenCoordsXY savedViewPos;
     rct_windowclass classification;
-    uint8_t colours[6];
+    colour_t colours[6];
     uint8_t visibility;
     uint16_t viewport_smart_follow_sprite; // Handles setting viewport target sprite etc
 

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -80,18 +80,14 @@ struct rct_window
         const scenario_index_entry* highlighted_scenario;
         struct
         {
-            uint16_t var_494;
             uint16_t var_496;
         };
     };
-    uint8_t var_498[0x14];
     int16_t selected_tab;
     int16_t var_4AE;
     uint16_t viewport_target_sprite;
     ScreenCoordsXY savedViewPos;
     rct_windowclass classification;
-    int8_t var_4B8;
-    int8_t var_4B9;
     uint8_t colours[6];
     uint8_t visibility;
     uint16_t viewport_smart_follow_sprite; // Handles setting viewport target sprite etc

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -23,28 +23,27 @@ struct rct_object_entry;
  */
 struct rct_window
 {
-    rct_window_event_list* event_handlers; // 0x000
-    rct_viewport* viewport;                // 0x004
-    uint64_t enabled_widgets;              // 0x008
-    uint64_t disabled_widgets;             // 0x010
-    uint64_t pressed_widgets;              // 0x018
-    uint64_t hold_down_widgets;            // 0x020
-    rct_widget* widgets;                   // 0x028
-    int16_t x;                             // 0x02C
-    int16_t y;                             // 0x02E
-    int16_t width;                         // 0x030
-    int16_t height;                        // 0x032
-    int16_t min_width;                     // 0x034
-    int16_t max_width;                     // 0x036
-    int16_t min_height;                    // 0x038
-    int16_t max_height;                    // 0x03A
-    rct_windownumber number;               // 0x03C
-    uint16_t flags;                        // 0x03E
-    rct_scroll scrolls[3];                 // 0x040
-    uint8_t list_item_positions[1024];     // 0x076
-    uint16_t no_list_items;                // 0x476 0 for no items
+    rct_window_event_list* event_handlers;
+    rct_viewport* viewport;
+    uint64_t enabled_widgets;
+    uint64_t disabled_widgets;
+    uint64_t pressed_widgets;
+    uint64_t hold_down_widgets;
+    rct_widget* widgets;
+    ScreenCoordsXY windowPos;
+    int16_t width;
+    int16_t height;
+    int16_t min_width;
+    int16_t max_width;
+    int16_t min_height;
+    int16_t max_height;
+    rct_windownumber number;
+    uint16_t flags;
+    rct_scroll scrolls[3];
+    uint8_t list_item_positions[1024];
+    uint16_t no_list_items; // 0 for no items
     int16_t pad_478;
-    int16_t selected_list_item; // 0x47A -1 for none selected
+    int16_t selected_list_item; // -1 for none selected
     int16_t pad_47C;
     int16_t pad_47E;
     union
@@ -60,23 +59,23 @@ struct rct_window
         track_list_variables track_list;
         error_variables error;
     };
-    int16_t page; // 0x48A
+    int16_t page;
     union
     {
-        int16_t picked_peep_old_x; // 0x48C staff/guest window: peep x gets set to 0x8000 on pickup, this is the old value
-        int16_t vehicleIndex;      // 0x48C Ride window: selected car when setting vehicle colours
-        int16_t numberOfStaff;     // 0x48C Used in park window.
+        int16_t picked_peep_old_x; // staff/guest window: peep x gets set to 0x8000 on pickup, this is the old value
+        int16_t vehicleIndex;      // Ride window: selected car when setting vehicle colours
+        int16_t numberOfStaff;     // Used in park window.
         int16_t var_48C;
     };
-    uint16_t frame_no;              // 0x48E updated every tic for motion in windows sprites
-    uint16_t list_information_type; // 0x490 0 for none, Used as current position of marquee in window_peep
+    uint16_t frame_no;              // updated every tic for motion in windows sprites
+    uint16_t list_information_type; // 0 for none, Used as current position of marquee in window_peep
     union
     {
-        int16_t picked_peep_frame; // 0x492 Animation frame of picked peep in staff window and guest window
+        int16_t picked_peep_frame; // Animation frame of picked peep in staff window and guest window
         int16_t var_492;
     };
     union
-    { // 0x494
+    {
         uint32_t highlighted_item;
         uint16_t ride_colour;
         ResearchItem* research_item;
@@ -89,18 +88,17 @@ struct rct_window
         };
     };
     uint8_t var_498[0x14];
-    int16_t selected_tab; // 0x4AC
+    int16_t selected_tab;
     int16_t var_4AE;
-    uint16_t viewport_target_sprite; // 0x4B0 viewport target sprite
-    int16_t saved_view_x;            // 0x4B2
-    int16_t saved_view_y;            // 0x4B4
-    rct_windowclass classification;  // 0x4B6
+    uint16_t viewport_target_sprite;
+    ScreenCoordsXY savedViewPos;
+    rct_windowclass classification;
     uint8_t pad_4B7;
     int8_t var_4B8;
     int8_t var_4B9;
-    uint8_t colours[6];                    // 0x4BA
-    uint8_t visibility;                    // VISIBILITY_CACHE
-    uint16_t viewport_smart_follow_sprite; // Smart following of sprites. Handles setting viewport target sprite etc
+    uint8_t colours[6];
+    uint8_t visibility;
+    uint16_t viewport_smart_follow_sprite; // Handles setting viewport target sprite etc
 
     void SetLocation(int32_t x, int32_t y, int32_t z);
     void ScrollToViewport();

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -41,11 +41,8 @@ struct rct_window
     uint16_t flags;
     rct_scroll scrolls[3];
     uint8_t list_item_positions[1024];
-    uint16_t no_list_items; // 0 for no items
-    int16_t pad_478;
+    uint16_t no_list_items;     // 0 for no items
     int16_t selected_list_item; // -1 for none selected
-    int16_t pad_47C;
-    int16_t pad_47E;
     union
     {
         coordinate_focus viewport_focus_coordinates;
@@ -93,7 +90,6 @@ struct rct_window
     uint16_t viewport_target_sprite;
     ScreenCoordsXY savedViewPos;
     rct_windowclass classification;
-    uint8_t pad_4B7;
     int8_t var_4B8;
     int8_t var_4B9;
     uint8_t colours[6];

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1376,13 +1376,13 @@ void peep_update_crowd_noise()
     {
         if (peep->sprite_left == LOCATION_NULL)
             continue;
-        if (viewport->view_x > peep->sprite_right)
+        if (viewport->viewPos.x > peep->sprite_right)
             continue;
-        if (viewport->view_x + viewport->view_width < peep->sprite_left)
+        if (viewport->viewPos.x + viewport->view_width < peep->sprite_left)
             continue;
-        if (viewport->view_y > peep->sprite_bottom)
+        if (viewport->viewPos.y > peep->sprite_bottom)
             continue;
-        if (viewport->view_y + viewport->view_height < peep->sprite_top)
+        if (viewport->viewPos.y + viewport->view_height < peep->sprite_top)
             continue;
 
         visiblePeeps += peep->state == PEEP_STATE_QUEUING ? 1 : 2;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3549,8 +3549,8 @@ int32_t ride_music_params_update(
         rct_viewport* viewport = g_music_tracking_viewport;
         int16_t view_width = viewport->view_width;
         int16_t view_width2 = view_width * 2;
-        int16_t view_x = viewport->view_x - view_width2;
-        int16_t view_y = viewport->view_y - view_width;
+        int16_t view_x = viewport->viewPos.x - view_width2;
+        int16_t view_y = viewport->viewPos.y - view_width;
         int16_t view_x2 = view_width2 + view_width2 + viewport->view_width + view_x;
         int16_t view_y2 = view_width + view_width + viewport->view_height + view_y;
 
@@ -3559,7 +3559,7 @@ int32_t ride_music_params_update(
             return ride_music_params_update_label_58(position, tuneId);
         }
 
-        int32_t x2 = viewport->x + ((rotatedCoords.x - viewport->view_x) >> viewport->zoom);
+        int32_t x2 = viewport->pos.x + ((rotatedCoords.x - viewport->viewPos.x) >> viewport->zoom);
         x2 *= 0x10000;
         uint16_t screenwidth = context_get_width();
         if (screenwidth < 64)
@@ -3568,7 +3568,7 @@ int32_t ride_music_params_update(
         }
         int32_t pan_x = ((x2 / screenwidth) - 0x8000) >> 4;
 
-        int32_t y2 = viewport->y + ((rotatedCoords.y - viewport->view_y) >> viewport->zoom);
+        int32_t y2 = viewport->pos.y + ((rotatedCoords.y - viewport->viewPos.y) >> viewport->zoom);
         y2 *= 0x10000;
         uint16_t screenheight = context_get_height();
         if (screenheight < 64)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2017,8 +2017,7 @@ void track_design_draw_preview(TrackDesign* td6, uint8_t* pixels)
     view.height = 217;
     view.view_width = size_x;
     view.view_height = size_y;
-    view.x = 0;
-    view.y = 0;
+    view.pos = { 0, 0 };
     view.zoom = zoom_level;
     view.flags = VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_INVISIBLE_SPRITES;
 
@@ -2048,8 +2047,7 @@ void track_design_draw_preview(TrackDesign* td6, uint8_t* pixels)
         int32_t right = left + size_x;
         int32_t bottom = top + size_y;
 
-        view.view_x = left;
-        view.view_y = top;
+        view.viewPos = { left, top };
         viewport_paint(&view, &dpi, left, top, right, bottom);
 
         dpi.bits += TRACK_PREVIEW_IMAGE_SIZE;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -880,8 +880,8 @@ bool Vehicle::SoundCanPlay() const
     if (g_music_tracking_viewport == nullptr)
         return false;
 
-    int16_t left = g_music_tracking_viewport->view_x;
-    int16_t bottom = g_music_tracking_viewport->view_y;
+    int16_t left = g_music_tracking_viewport->viewPos.x;
+    int16_t bottom = g_music_tracking_viewport->viewPos.y;
     int16_t quarter_w = g_music_tracking_viewport->view_width / 4;
     int16_t quarter_h = g_music_tracking_viewport->view_height / 4;
 
@@ -937,9 +937,9 @@ rct_vehicle_sound_params Vehicle::CreateSoundParam(uint16_t priority) const
 {
     rct_vehicle_sound_params param;
     param.priority = priority;
-    int32_t panX = (sprite_left / 2) + (sprite_right / 2) - g_music_tracking_viewport->view_x;
+    int32_t panX = (sprite_left / 2) + (sprite_right / 2) - g_music_tracking_viewport->viewPos.x;
     panX >>= g_music_tracking_viewport->zoom;
-    panX += g_music_tracking_viewport->x;
+    panX += g_music_tracking_viewport->pos.x;
 
     uint16_t screenWidth = context_get_width();
     if (screenWidth < 64)
@@ -948,9 +948,9 @@ rct_vehicle_sound_params Vehicle::CreateSoundParam(uint16_t priority) const
     }
     param.pan_x = ((((panX * 65536) / screenWidth) - 0x8000) >> 4);
 
-    int32_t panY = (sprite_top / 2) + (sprite_bottom / 2) - g_music_tracking_viewport->view_y;
+    int32_t panY = (sprite_top / 2) + (sprite_bottom / 2) - g_music_tracking_viewport->viewPos.y;
     panY >>= g_music_tracking_viewport->zoom;
-    panY += g_music_tracking_viewport->y;
+    panY += g_music_tracking_viewport->pos.y;
 
     uint16_t screenHeight = context_get_height();
     if (screenHeight < 64)

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -72,6 +72,16 @@ struct ScreenCoordsXY
     {
         return { x + rhs.x, y + rhs.y };
     }
+
+    bool operator==(const ScreenCoordsXY& other) const
+    {
+        return x == other.x && y == other.y;
+    }
+
+    bool operator!=(const ScreenCoordsXY& other) const
+    {
+        return !(*this == other);
+    }
 };
 
 /**

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -53,6 +53,25 @@ struct ScreenCoordsXY
     {
         return { x - rhs.x, y - rhs.y };
     }
+
+    ScreenCoordsXY& operator+=(const ScreenCoordsXY& rhs)
+    {
+        x += rhs.x;
+        y += rhs.y;
+        return *this;
+    }
+
+    ScreenCoordsXY& operator-=(const ScreenCoordsXY& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        return *this;
+    }
+
+    const ScreenCoordsXY operator+(const ScreenCoordsXY& rhs) const
+    {
+        return { x + rhs.x, y + rhs.y };
+    }
 };
 
 /**

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -93,7 +93,7 @@ void MoneyEffect::Create(money32 value, CoordsXYZ loc)
 
         rct_viewport* mainViewport = window_get_viewport(mainWindow);
         auto mapPositionXY = screen_get_map_xy(
-            { mainViewport->x + (mainViewport->width / 2), mainViewport->y + (mainViewport->height / 2) }, nullptr);
+            { mainViewport->pos.x + (mainViewport->width / 2), mainViewport->pos.y + (mainViewport->height / 2) }, nullptr);
         if (!mapPositionXY)
             return;
 


### PR DESCRIPTION
I changed `rct_viewport` and `rct_window` to use `ScreenCoordsXY`, not sure if this is a problem, as they used to have comments on the size and paddings