### PR TITLE
Feature: Add console command for removing all floating objects

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1202,7 +1202,7 @@ static int32_t cc_remove_floating_objects(InteractiveConsole& console, const arg
     uint16_t result = remove_floating_sprites();
     console.WriteFormatLine("Removed %d flying objects", result);
     return 0;
-} 
+}
 
 static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1197,6 +1197,13 @@ static int32_t cc_remove_unused_objects(InteractiveConsole& console, [[maybe_unu
     return 0;
 }
 
+static int32_t cc_remove_floating_objects(InteractiveConsole& console, const arguments_t& argv)
+{
+    uint16_t result = remove_floating_sprites();
+    console.WriteFormatLine("Removed %d flying objects", result);
+    return 0;
+} 
+
 static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     tile_element_iterator it;
@@ -1680,6 +1687,7 @@ static constexpr const console_command console_command_table[] = {
     { "quit", cc_close, "Closes the console.", "quit" },
     { "remove_park_fences", cc_remove_park_fences, "Removes all park fences from the surface", "remove_park_fences" },
     { "remove_unused_objects", cc_remove_unused_objects, "Removes all the unused objects from the object selection.", "remove_unused_objects" },
+    { "remove_floating_objects", cc_remove_floating_objects, "Removes floating objects", "remove_floating_objects"},
     { "rides", cc_rides, "Ride management.", "rides <subcommand>" },
     { "save_park", cc_save_park, "Save current state of park. If no name specified default path will be used.", "save_park [name]" },
     { "say", cc_say, "Say to other players.", "say <message>" },

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -94,6 +94,11 @@ void Duck::Invalidate()
     invalidate_sprite_1(this);
 }
 
+bool Duck::IsFlying()
+{
+    return this->state == DUCK_STATE::FLY_AWAY || this->state == DUCK_STATE::FLY_TO_WATER;
+}
+
 void Duck::Remove()
 {
     Invalidate();

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -815,6 +815,38 @@ void litter_remove_at(int32_t x, int32_t y, int32_t z)
 }
 
 /**
+ * Loops through all sprites, finds floating objects and removes them.
+ * Returns the amount of removed objects as feedback.
+ */
+uint16_t remove_floating_sprites()
+{
+    uint16_t removed = 0;
+    for (uint16_t i = 0; i < MAX_SPRITES; i++)
+    {
+        rct_sprite* rctSprite = get_sprite(i);
+        if (rctSprite->IsBalloon())
+        {
+            sprite_remove(rctSprite->AsBalloon());
+            removed++;
+        }
+        if (rctSprite->IsDuck())
+        {
+            if (rctSprite->AsDuck()->IsFlying())
+            {
+                rctSprite->duck.Remove();
+                removed++;
+            }
+        }
+        if (rctSprite->IsMoneyEffect())
+        {
+            sprite_remove(rctSprite->AsMoneyEffect());
+            removed++;
+        }
+    }
+    return removed;
+}
+
+/**
  * Determines whether it's worth tweening a sprite or not when frame smoothing is on.
  */
 static bool sprite_should_tween(rct_sprite* sprite)

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -827,6 +827,7 @@ uint16_t remove_floating_sprites()
         if (rctSprite->IsBalloon())
         {
             sprite_remove(rctSprite->AsBalloon());
+            sprite_misc_update(rctSprite);
             removed++;
         }
         if (rctSprite->IsDuck())
@@ -834,12 +835,14 @@ uint16_t remove_floating_sprites()
             if (rctSprite->AsDuck()->IsFlying())
             {
                 rctSprite->duck.Remove();
+                sprite_misc_update(rctSprite);
                 removed++;
             }
         }
         if (rctSprite->IsMoneyEffect())
         {
             sprite_remove(rctSprite->AsMoneyEffect());
+            sprite_misc_update(rctSprite);
             removed++;
         }
     }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -830,7 +830,7 @@ uint16_t remove_floating_sprites()
             sprite_misc_update(rctSprite);
             removed++;
         }
-        if (rctSprite->IsDuck())
+        else if (rctSprite->IsDuck())
         {
             if (rctSprite->AsDuck()->IsFlying())
             {
@@ -839,7 +839,7 @@ uint16_t remove_floating_sprites()
                 removed++;
             }
         }
-        if (rctSprite->IsMoneyEffect())
+        else if (rctSprite->IsMoneyEffect())
         {
             sprite_remove(rctSprite->AsMoneyEffect());
             sprite_misc_update(rctSprite);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -68,6 +68,7 @@ struct Duck : SpriteGeneric
     void UpdateFlyAway();
     uint32_t GetFrameImage(int32_t direction) const;
     void Invalidate();
+    bool IsFlying();
     void Remove();
     void MoveTo(const CoordsXYZ& destination);
 };
@@ -214,6 +215,7 @@ void invalidate_sprite_2(SpriteBase* sprite);
 void sprite_remove(SpriteBase* sprite);
 void litter_create(int32_t x, int32_t y, int32_t z, int32_t direction, int32_t type);
 void litter_remove_at(int32_t x, int32_t y, int32_t z);
+uint16_t remove_floating_sprites();
 void sprite_misc_explosion_cloud_create(int32_t x, int32_t y, int32_t z);
 void sprite_misc_explosion_flare_create(int32_t x, int32_t y, int32_t z);
 uint16_t sprite_get_first_in_quadrant(int32_t x, int32_t y);


### PR DESCRIPTION
Feature requested in issue #10637

Console command "remove_floating_objects" removes all balloon sprites, money effects and ducks with state FLY_AWAY or FLY_TO_WATER. It returns how many objects were removed.

