### PR TITLE
Improve WinNT 5.1/MinGW support

### DIFF
--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -83,6 +83,8 @@ if (WIN32)
         else ()
             find_library(SDL2_LDFLAGS sdl2)
         endif ()
+        # Hardcode some of the libraries used by mingw builds
+        target_link_libraries(${PROJECT} imm32 winmm setupapi version)
     endif ()
 endif ()
 if (MSVC)

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -9,7 +9,7 @@
 
 #ifdef _WIN32
 
-#    ifdef __MINGW32__
+#    if defined(__MINGW32__) && !defined(WINVER) && !defined(_WIN32_WINNT)
 // 0x0600 == vista
 #        define WINVER 0x0600
 #        define _WIN32_WINNT 0x0600

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -13,7 +13,7 @@ if (APPLE)
     set_source_files_properties(${OPENRCT2_CORE_MM_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c++ -fmodules")
 endif ()
 
-add_library(${PROJECT_NAME} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${RCT2_SECTIONS})
+add_library(${PROJECT_NAME} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 SET_CHECK_CXX_FLAGS(${PROJECT_NAME})
 
@@ -132,6 +132,11 @@ else ()
                                      ${ZLIB_LIBRARIES}
                                      ${LIBZIP_LIBRARIES})
 endif ()
+
+if (MINGW)
+    # Hardcode libraries used by libzip on mingw
+    target_link_libraries(${PROJECT_NAME} crypto ws2_32)
+endif()
 
 if (UNIX AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
     # Include libdl for dlopen

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(WINVER) && !defined(_WIN32_WINNT)
 // 0x0600 == vista
 #    define WINVER 0x0600
 #    define _WIN32_WINNT 0x0600

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -22,7 +22,9 @@
 #        define __USE_SHGETKNOWNFOLDERPATH__
 #        define __USE_GETDATEFORMATEX__
 #    else
-#        define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#        ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#            define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#        endif
 #    endif
 
 #    include "../OpenRCT2.h"

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(WINVER) && !defined(_WIN32_WINNT)
 // 0x0600 == vista
 #    define WINVER 0x0600
 #    define _WIN32_WINNT 0x0600
@@ -49,6 +49,10 @@
 #    define SINGLE_INSTANCE_MUTEX_NAME "RollerCoaster Tycoon 2_GSKMUTEX"
 
 #    define OPENRCT2_DLL_MODULE_NAME "openrct2.dll"
+
+#    if _WIN32_WINNT < 0x600
+#        define swprintf_s(a, b, c, d, ...) swprintf(a, b, c, ##__VA_ARGS__)
+#    endif
 
 static HMODULE _dllModule = nullptr;
 


### PR DESCRIPTION
![openrct2](https://user-images.githubusercontent.com/550290/75927088-f8fc0900-5e6b-11ea-9f4b-9bc0077675f2.png)

`cmake .. -DCMAKE_TOOLCHAIN_FILE=/home/janisozaur/workspace/openrct2/CMakeLists_mingw.txt -G Ninja -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Wno-error=cast-function-type -DCURL_STATICLIB=1 -DZIP_STATIC=1 -D_WIN32_WINNT=0x501 -static" -DCMAKE_BUILD_TYPE=relwithdebinfo -DSTATIC=on -DDISABLE_NETWORK=on`

Fixes #10850 