### PR TITLE
Fix Viewport.cpp copyright header

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2019 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md


### PR DESCRIPTION
GitHub Desktop actually shows that `clang-format` removes something:
![image](https://user-images.githubusercontent.com/6443427/75976422-29b65f80-5eb9-11ea-8099-04e4b6ea7765.png)
