### PR TITLE
Translate SV6 object offsets to OpenRCT2 ones

### DIFF
--- a/src/openrct2/object/ObjectLimits.h
+++ b/src/openrct2/object/ObjectLimits.h
@@ -41,6 +41,5 @@ constexpr const uint16_t OBJECT_ENTRY_COUNT =
     MAX_WATER_OBJECTS +
     MAX_SCENARIO_TEXT_OBJECTS;
 // clang-format on
-static_assert(OBJECT_ENTRY_COUNT == 721);
 
 #define DAT_NAME_LENGTH 8

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -7,8 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifndef _RCT2_H_
-#define _RCT2_H_
+#pragma once
 
 #include "../common.h"
 #include "../object/Object.h"
@@ -34,7 +33,49 @@
 #define RCT2_MAX_RESEARCHED_SCENERY_ITEM_QUADS 56
 #define RCT2_MAX_RESEARCHED_SCENERY_ITEMS (RCT2_MAX_RESEARCHED_SCENERY_ITEM_QUADS * 32) // There are 32 bits per quad.
 
-constexpr const uint16_t RCT2_OBJECT_ENTRY_COUNT = 721;
+constexpr const uint8_t RCT2_MAX_RIDE_OBJECTS = 128;
+constexpr const uint8_t RCT2_MAX_SMALL_SCENERY_OBJECTS = 252;
+constexpr const uint8_t RCT2_MAX_LARGE_SCENERY_OBJECTS = 128;
+constexpr const uint8_t RCT2_MAX_WALL_SCENERY_OBJECTS = 128;
+constexpr const uint8_t RCT2_MAX_BANNER_OBJECTS = 32;
+constexpr const uint8_t RCT2_MAX_PATH_OBJECTS = 16;
+constexpr const uint8_t RCT2_MAX_PATH_ADDITION_OBJECTS = 15;
+constexpr const uint8_t RCT2_MAX_SCENERY_GROUP_OBJECTS = 19;
+constexpr const uint8_t RCT2_MAX_PARK_ENTRANCE_OBJECTS = 1;
+constexpr const uint8_t RCT2_MAX_WATER_OBJECTS = 1;
+constexpr const uint8_t RCT2_MAX_SCENARIO_TEXT_OBJECTS = 1;
+
+// clang-format off
+constexpr const uint16_t RCT2_OBJECT_ENTRY_COUNT =
+    RCT2_MAX_RIDE_OBJECTS +
+    RCT2_MAX_SMALL_SCENERY_OBJECTS +
+    RCT2_MAX_LARGE_SCENERY_OBJECTS +
+    RCT2_MAX_WALL_SCENERY_OBJECTS +
+    RCT2_MAX_BANNER_OBJECTS +
+    RCT2_MAX_PATH_OBJECTS +
+    RCT2_MAX_PATH_ADDITION_OBJECTS +
+    RCT2_MAX_SCENERY_GROUP_OBJECTS +
+    RCT2_MAX_PARK_ENTRANCE_OBJECTS +
+    RCT2_MAX_WATER_OBJECTS +
+    RCT2_MAX_SCENARIO_TEXT_OBJECTS;
+// clang-format on
+static_assert(RCT2_OBJECT_ENTRY_COUNT == 721);
+
+// clang-format off
+constexpr const int32_t rct2_object_entry_group_counts[] = {
+    RCT2_MAX_RIDE_OBJECTS,
+    RCT2_MAX_SMALL_SCENERY_OBJECTS,
+    RCT2_MAX_LARGE_SCENERY_OBJECTS,
+    RCT2_MAX_WALL_SCENERY_OBJECTS,
+    RCT2_MAX_BANNER_OBJECTS,
+    RCT2_MAX_PATH_OBJECTS,
+    RCT2_MAX_PATH_ADDITION_OBJECTS,
+    RCT2_MAX_SCENERY_GROUP_OBJECTS,
+    RCT2_MAX_PARK_ENTRANCE_OBJECTS,
+    RCT2_MAX_WATER_OBJECTS,
+    RCT2_MAX_SCENARIO_TEXT_OBJECTS,
+};
+// clang-format on
 
 struct rct2_install_info
 {
@@ -715,5 +756,3 @@ struct RCT2RideRatingCalculationData
 assert_struct_size(RCT2RideRatingCalculationData, 76);
 
 #pragma pack(pop)
-
-#endif

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -35,6 +35,7 @@
 #include "../peep/Staff.h"
 #include "../rct12/SawyerChunkReader.h"
 #include "../rct12/SawyerEncoding.h"
+#include "../rct2/RCT2.h"
 #include "../ride/Ride.h"
 #include "../ride/RideRatings.h"
 #include "../ride/ShopItem.h"
@@ -170,7 +171,7 @@ public:
 
         _s6Path = path;
 
-        return ParkLoadResult(std::vector<rct_object_entry>(std::begin(_s6.objects), std::end(_s6.objects)));
+        return ParkLoadResult(GetRequiredObjects());
     }
 
     bool GetDetails(scenario_index_entry* dst) override
@@ -1619,6 +1620,28 @@ public:
         std::string_view originalStringView(originalString, USER_STRING_MAX_LENGTH);
         auto withoutFormatCodes = RCT12::RemoveFormatCodes(originalStringView);
         return rct2_to_utf8(withoutFormatCodes, RCT2_LANGUAGE_ID_ENGLISH_UK);
+    }
+
+    std::vector<rct_object_entry> GetRequiredObjects()
+    {
+        std::vector<rct_object_entry> result;
+        rct_object_entry nullEntry = {};
+        std::memset(&nullEntry, 0xFF, sizeof(nullEntry));
+
+        int objectIt = 0;
+        for (int16_t objectType = OBJECT_TYPE_RIDE; objectType <= OBJECT_TYPE_WATER; objectType++)
+        {
+            for (int16_t i = 0; i < rct2_object_entry_group_counts[objectType]; i++, objectIt++)
+            {
+                result.push_back(_s6.objects[objectIt]);
+            }
+            for (int16_t i = rct2_object_entry_group_counts[objectType]; i < object_entry_group_counts[objectType]; i++)
+            {
+                result.push_back(nullEntry);
+            }
+        }
+
+        return result;
     }
 };
 


### PR DESCRIPTION
Previously, raising one of our own object limits (like 252 small scenery objects) resulted in a crash. This PR translates the object offsets between RCT2 and OpenRCT2, putting it "null objects" as necessary.