### PR TITLE
Axis labels and horizontal guides for park window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3673,7 +3673,7 @@ STR_6356    :{SMALLFONT}{BLACK}Spawns ducks if park contains water
 STR_6357    :{SMALLFONT}{BLACK}Removes all ducks from the map
 STR_6358    :Page {UINT16}
 STR_6359    :{POP16}{POP16}Page {UINT16}
-STR_6360    :{SMALLFONT}{BLACK}{UINT16}
+STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3673,6 +3673,7 @@ STR_6356    :{SMALLFONT}{BLACK}Spawns ducks if park contains water
 STR_6357    :{SMALLFONT}{BLACK}Removes all ducks from the map
 STR_6358    :Page {UINT16}
 STR_6359    :{POP16}{POP16}Page {UINT16}
+STR_6360    :{SMALLFONT}{BLACK}{UINT16}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Fix: [#10904] RCT1/LL-scenarios with red water won't open.
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
+- Improved: [#10884] Added y-axes and labels to park window charts.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1170,15 +1170,12 @@ static void window_park_guests_invalidate(rct_window* w)
  */
 static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t x, y;
-    rct_widget* widget;
-
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    x = w->windowPos.x;
-    y = w->windowPos.y;
-    widget = &window_park_guests_widgets[WIDX_PAGE_BACKGROUND];
+    int32_t x = w->windowPos.x;
+    int32_t y = w->windowPos.y;
+    rct_widget* widget = &window_park_guests_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
     gfx_draw_string_left(
@@ -1189,9 +1186,20 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
         dpi, x + widget->left + 4, y + widget->top + 15, x + widget->right - 4, y + widget->bottom - 4, w->colours[1],
         INSET_RECT_F_30);
 
+    // Y axis labels
+    x = x + widget->left + 23;
+    y = y + widget->top + 23;
+    for (int i = 5; i >= 0; i--)
+    {
+        uint16_t axisValue = i * 1000;
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
+        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 28, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
+        y += 20;
+    }
+
     // Graph
-    x += widget->left + 22;
-    y += widget->top + 26;
+    x = w->windowPos.x + widget->left + 47;
+    y = w->windowPos.y + widget->top + 26;
 
     graph_draw_uint8_t(dpi, gGuestsInParkHistory, 32, x, y);
 }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -74,21 +74,21 @@ enum WINDOW_PARK_WIDGET_IDX {
 
 #pragma region Widgets
 
-#define MAIN_PARK_WIDGETS \
-    { WWT_FRAME,            0,  0,      229,    0,      223,    0xFFFFFFFF,                     STR_NONE },                     /* panel / background */    \
-    { WWT_CAPTION,          0,  1,      228,    1,      14,     STR_STRINGID,                   STR_WINDOW_TITLE_TIP },         /* title bar          */    \
-    { WWT_CLOSEBOX,         0,  217,    227,    2,      13,     STR_CLOSE_X,                    STR_CLOSE_WINDOW_TIP },         /* close x button     */    \
-    { WWT_RESIZE,           1,  0,      229,    43,     173,    0xFFFFFFFF,                     STR_NONE },                     /* tab content panel  */    \
-    { WWT_TAB,              1,  3,      33,     17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_ENTRANCE_TAB_TIP },    /* tab 1              */    \
-    { WWT_TAB,              1,  34,     64,     17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_RATING_TAB_TIP },      /* tab 2              */    \
-    { WWT_TAB,              1,  65,     95,     17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_GUESTS_TAB_TIP },      /* tab 3              */    \
-    { WWT_TAB,              1,  96,     126,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_PRICE_TAB_TIP },       /* tab 4              */    \
-    { WWT_TAB,              1,  127,    157,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_STATS_TAB_TIP },       /* tab 5              */    \
-    { WWT_TAB,              1,  158,    188,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_OBJECTIVE_TAB_TIP },   /* tab 6              */    \
-    { WWT_TAB,              1,  189,    219,    17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_AWARDS_TAB_TIP }       /* tab 7              */
+#define MAIN_PARK_WIDGETS(WW) \
+    { WWT_FRAME,            0,  0,          WW - 1,      0,      223,    0xFFFFFFFF,                           STR_NONE },                     /* panel / background */    \
+    { WWT_CAPTION,          0,  1,          WW - 2,      1,      14,     STR_STRINGID,                         STR_WINDOW_TITLE_TIP },         /* title bar          */    \
+    { WWT_CLOSEBOX,         0,  WW - 13,    WW - 3,      2,      13,     STR_CLOSE_X,                          STR_CLOSE_WINDOW_TIP },         /* close x button     */    \
+    { WWT_RESIZE,           1,  0,          WW - 1,      43,     173,    0xFFFFFFFF,                           STR_NONE },                     /* tab content panel  */    \
+    { WWT_TAB,              1,  3,          33,          17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_ENTRANCE_TAB_TIP },    /* tab 1              */    \
+    { WWT_TAB,              1,  34,         64,          17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_RATING_TAB_TIP },      /* tab 2              */    \
+    { WWT_TAB,              1,  65,         95,          17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_GUESTS_TAB_TIP },      /* tab 3              */    \
+    { WWT_TAB,              1,  96,         126,         17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_PRICE_TAB_TIP },       /* tab 4              */    \
+    { WWT_TAB,              1,  127,        157,         17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_STATS_TAB_TIP },       /* tab 5              */    \
+    { WWT_TAB,              1,  158,        188,         17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_OBJECTIVE_TAB_TIP },   /* tab 6              */    \
+    { WWT_TAB,              1,  189,        219,         17,     43,     IMAGE_TYPE_REMAP | SPR_TAB,           STR_PARK_AWARDS_TAB_TIP }       /* tab 7              */
 
 static rct_widget window_park_entrance_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(230),
     { WWT_VIEWPORT,         1,  3,      204,    46,     160,    0xFFFFFFFF,                     STR_NONE },                         // viewport
     { WWT_LABEL_CENTRED,    1,  3,      204,    161,    171,    0xFFFFFFFF,                     STR_NONE },                         // status
     { WWT_FLATBTN,          1,  205,    228,    49,     72,     0xFFFFFFFF,                     STR_OPEN_OR_CLOSE_PARK_TIP },       // open / close
@@ -101,35 +101,35 @@ static rct_widget window_park_entrance_widgets[] = {
 };
 
 static rct_widget window_park_rating_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(255),
     { WIDGETS_END },
 };
 
 static rct_widget window_park_guests_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(255),
     { WIDGETS_END },
 };
 
 static rct_widget window_park_price_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(230),
     { WWT_LABEL,            1,  21,     146,    50,     61,     STR_ADMISSION_PRICE,            STR_NONE },                         //
       SPINNER_WIDGETS      (1,  147,    222,    50,     61,     STR_NONE,                       STR_NONE), // Price (3 widgets)
     { WIDGETS_END },
 };
 
 static rct_widget window_park_stats_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(230),
     { WIDGETS_END },
 };
 
 static rct_widget window_park_objective_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(230),
     { WWT_BUTTON,           1,  7,      222,    207,    220,    STR_ENTER_NAME_INTO_SCENARIO_CHART,         STR_NONE },             // enter name
     { WIDGETS_END },
 };
 
 static rct_widget window_park_awards_widgets[] = {
-    MAIN_PARK_WIDGETS,
+    MAIN_PARK_WIDGETS(230),
     { WIDGETS_END },
 };
 
@@ -999,7 +999,7 @@ static void window_park_rating_mouseup(rct_window* w, rct_widgetindex widgetInde
  */
 static void window_park_rating_resize(rct_window* w)
 {
-    window_set_resize(w, 230, 182, 230, 182);
+    window_set_resize(w, 255, 182, 255, 182);
 }
 
 /**
@@ -1120,7 +1120,7 @@ static void window_park_guests_mouseup(rct_window* w, rct_widgetindex widgetInde
  */
 static void window_park_guests_resize(rct_window* w)
 {
-    window_set_resize(w, 230, 182, 230, 182);
+    window_set_resize(w, 255, 182, 255, 182);
 }
 
 /**

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1056,13 +1056,13 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
         INSET_RECT_F_30);
 
     // Y axis labels
-    x = x + widget->left + 23;
+    x = x + widget->left + 27;
     y = y + widget->top + 23;
     for (int i = 5; i >= 0; i--)
     {
-        uint16_t axisValue = i * 200;
+        uint32_t axisValue = i * 200;
         gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
-        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 28, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
+        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 20;
     }
 
@@ -1187,13 +1187,13 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
         INSET_RECT_F_30);
 
     // Y axis labels
-    x = x + widget->left + 23;
+    x = x + widget->left + 27;
     y = y + widget->top + 23;
     for (int i = 5; i >= 0; i--)
     {
-        uint16_t axisValue = i * 1000;
+        uint32_t axisValue = i * 1000;
         gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
-        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 28, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
+        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 20;
     }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1040,15 +1040,12 @@ static void window_park_rating_invalidate(rct_window* w)
  */
 static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t x, y;
-    rct_widget* widget;
-
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    x = w->windowPos.x;
-    y = w->windowPos.y;
-    widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
+    int32_t x = w->windowPos.x;
+    int32_t y = w->windowPos.y;
+    rct_widget* widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
     gfx_draw_string_left(dpi, STR_PARK_RATING_LABEL, &gParkRating, COLOUR_BLACK, x + widget->left + 3, y + widget->top + 2);
@@ -1058,9 +1055,20 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
         dpi, x + widget->left + 4, y + widget->top + 15, x + widget->right - 4, y + widget->bottom - 4, w->colours[1],
         INSET_RECT_F_30);
 
+    // Y axis labels
+    x = x + widget->left + 23;
+    y = y + widget->top + 23;
+    for (int i = 5; i >= 0; i--)
+    {
+        uint16_t axisValue = i * 200;
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
+        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 28, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
+        y += 20;
+    }
+
     // Graph
-    x += widget->left + 22;
-    y += widget->top + 26;
+    x = w->windowPos.x + widget->left + 47;
+    y = w->windowPos.y + widget->top + 26;
 
     graph_draw_uint8_t(dpi, gParkRatingHistory, 32, x, y);
 }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3904,6 +3904,8 @@ enum
     STR_PAGE_X = 6358,
     STR_ARG_4_PAGE_X = 6359,
 
+    STR_GRAPH_AXIS_LABEL = 6360,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
This PR adds Y axis labels and horizontal guides to the park window, more specifically to the park rating and guests tabs.

Alignment isn't 100% perfect yet, in particularly for the guests tab. This needs a bit more tinkering.

![rating_800](https://user-images.githubusercontent.com/604665/76144129-a2661900-607d-11ea-81ec-8ee6146effb7.png)

![guests_2000](https://user-images.githubusercontent.com/604665/76144127-a1cd8280-607d-11ea-8f5f-0c462c6db52d.png)
