### PR TITLE
Fix #10898: banner text has an offset in tile inspector window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#10739] Mountain tool overlay for even-numbered selections.
 - Fix: [#10752] Mute button state not correctly set at startup.
 - Fix: [#10822] Can place too many peep spawns.
+- Fix: [#10898] Banner text has an offset in tile inspector window.
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -2116,7 +2116,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     uint8_t args[32]{};
                     banner->FormatTextTo(args);
-                    gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, args, COLOUR_WHITE, x, y + 22);
+                    gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, args, COLOUR_WHITE, x, y);
                 }
 
                 // Properties


### PR DESCRIPTION
Interesting how this only gets reported now, it has been broken for 8 months already. It's likely a copy-paste error from 61d64ab8c53cd1efe0f1029498966c348de92648.