### PR TITLE
Fix #10602. Fix track scenery additions when far from station start

### DIFF
--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -529,8 +529,8 @@ rct_string_id TrackDesign::CreateTrackDesignScenery()
         }
 
         // Cast the value into a uint8_t as this value is not signed yet.
-        CoordsXY sceneryMapPos{ ((uint8_t)scenery.x) * 32 - gTrackPreviewOrigin.x,
-                                ((uint8_t)scenery.y) * 32 - gTrackPreviewOrigin.y };
+        auto sceneryPos = TileCoordsXY(static_cast<uint8_t>(scenery.x), static_cast<uint8_t>(scenery.y)).ToCoordsXY();
+        CoordsXY sceneryMapPos = sceneryPos - gTrackPreviewOrigin;
         CoordsXY rotatedSceneryMapPos = sceneryMapPos.Rotate(0 - _saveDirection);
         TileCoordsXY sceneryTilePos{ rotatedSceneryMapPos };
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -528,7 +528,9 @@ rct_string_id TrackDesign::CreateTrackDesignScenery()
             }
         }
 
-        CoordsXY sceneryMapPos{ scenery.x * 32 - gTrackPreviewOrigin.x, scenery.y * 32 - gTrackPreviewOrigin.y };
+        // Cast the value into a uint8_t as this value is not signed yet.
+        CoordsXY sceneryMapPos{ ((uint8_t)scenery.x) * 32 - gTrackPreviewOrigin.x,
+                                ((uint8_t)scenery.y) * 32 - gTrackPreviewOrigin.y };
         CoordsXY rotatedSceneryMapPos = sceneryMapPos.Rotate(0 - _saveDirection);
         TileCoordsXY sceneryTilePos{ rotatedSceneryMapPos };
 


### PR DESCRIPTION
Fix #10602. Fix track scenery additions when far from station start
Issue caused due to stuffing a temporary unsigned variable in a signed variable. This fix is not a permenant fix and this field in the future should be split up into two seperate fields: tile position and relative tile position.