### PR TITLE
Allow opening rides with unsuitable track when "Enable all drawable track pieces" is enabled.

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5224,7 +5224,7 @@ int32_t ride_is_valid_for_test(Ride* ride, int32_t status, bool isApplying)
         }
     }
 
-    if (ride->subtype != RIDE_ENTRY_INDEX_NULL)
+    if (ride->subtype != RIDE_ENTRY_INDEX_NULL && !gCheatsEnableAllDrawableTrackPieces)
     {
         rct_ride_entry* rideType = get_ride_entry(ride->subtype);
         if (rideType->flags & RIDE_ENTRY_FLAG_NO_INVERSIONS)


### PR DESCRIPTION
Currently, certain rides (most notably the hyper and hyper twister coasters) cannot be opened if the layout contains inversions and/or banked track. As far as I'm aware, there's currently no way to override this behaviour.

This PR disables that check when the "Enable all drawable track pieces" cheat is selected.

I am not sure if it might be better to disable it entirely, as I'm not sure there's any way you can actually see this error message if cheats are turned off - trains that can't run on inversions usually don't allow building them either. However, I'm not sure if there are exceptions, so I've left the default behaviour as it is.