### PR TITLE
Fix code formatting on macOS

### DIFF
--- a/scripts/check-code-formatting
+++ b/scripts/check-code-formatting
@@ -1,8 +1,18 @@
 #!/bin/sh
 set -e
 
+readlink_bin='readlink'
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if ! [ -x "$(command -v greadlink)" ]; then
+    echo 'Please install greadlink with Homebrew: brew install coreutils'
+    exit 1
+  fi
+  readlink_bin='greadlink'
+fi
+
 # Ensure we are in root directory
-basedir="$(readlink -f `dirname $0`/..)"
+basedir="$($readlink_bin -f `dirname $0`/..)"
 cd $basedir
 
 scripts/run-clang-format.py -r src test --exclude src/thirdparty


### PR DESCRIPTION
This command break by default because the `readlink` command on macOS does not support the `-f` flag. Recommend installing `greadlink` from Homebrew as a workaround.