### PR TITLE
Fix setting locale on linux

### DIFF
--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -13,6 +13,7 @@
 #    include "Platform2.h"
 #    include "platform.h"
 
+#    include <clocale>
 #    include <cstdlib>
 #    include <cstring>
 #    include <ctime>
@@ -72,6 +73,7 @@ namespace Platform
 
     std::string FormatShortDate(std::time_t timestamp)
     {
+        setlocale(LC_TIME, "");
         char date[20];
         std::strftime(date, sizeof(date), "%x", std::localtime(&timestamp));
         return std::string(date);
@@ -79,6 +81,7 @@ namespace Platform
 
     std::string FormatTime(std::time_t timestamp)
     {
+        setlocale(LC_TIME, "");
         char time[20];
         std::strftime(time, sizeof(time), "%X", std::localtime(&timestamp));
         return std::string(time);


### PR DESCRIPTION
Using the nl_NL.UTF8 locale, previously:

![afbeelding](https://user-images.githubusercontent.com/1478678/76805194-7580d700-67de-11ea-895b-0d860565a3f5.png)


Now:

![afbeelding](https://user-images.githubusercontent.com/1478678/76805178-6ef25f80-67de-11ea-9b4a-07916b14e5c0.png)
