### PR TITLE
Fix #10928: File browser's date column is too narrow

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#475] Water sides drawn incorrectly (original bug).
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).
 - Fix: [#7094] Back wall edge texture in water missing.
+- Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#11005] Company value overflows.
 - Fix: [#11027] Third color on walls becomes black when saving.
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -637,16 +637,16 @@ static void window_loadsave_textinput(rct_window* w, rct_widgetindex widgetIndex
 
 static void window_loadsave_compute_max_date_width()
 {
-    // Generate a time object for a relatively wide time: 2000-10-20 00:00:00
+    // Generate a time object for a relatively wide time: 2000-02-20 00:00:00
     std::tm tm;
     tm.tm_sec = 0;
     tm.tm_min = 0;
     tm.tm_hour = 0;
     tm.tm_mday = 20;
-    tm.tm_mon = 9;
+    tm.tm_mon = 2;
     tm.tm_year = 100;
     tm.tm_wday = 5;
-    tm.tm_yday = 294;
+    tm.tm_yday = 51;
     tm.tm_isdst = -1;
 
     std::time_t long_time = mktime(&tm);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -651,9 +651,20 @@ static void window_loadsave_compute_max_date_width()
 
     std::time_t long_time = mktime(&tm);
 
+    // Check how how this date is represented (e.g. 2000-02-20, or 00/02/20)
     std::string date = Platform::FormatShortDate(long_time);
     maxDateWidth = gfx_get_string_width(date.c_str());
 
+    // Some locales do not use leading zeros for months and days, so let's try October, too.
+    tm.tm_mon = 10;
+    tm.tm_yday = 294;
+    long_time = mktime(&tm);
+
+    // Again, check how how this date is represented (e.g. 2000-10-20, or 00/10/20)
+    date = Platform::FormatShortDate(long_time);
+    maxDateWidth = std::max(maxDateWidth, gfx_get_string_width(date.c_str()));
+
+    // Time appears to be universally represented with two digits for minutes, so 12:00 or 00:00 should be representable.
     std::string time = Platform::FormatTime(long_time);
     maxTimeWidth = gfx_get_string_width(time.c_str());
 }


### PR DESCRIPTION
The width of this column is font-dependent, and so I initially reasoned, at the time, that taking the width of the widest date I could think of would be most appropriate. However, I made a mistake by taking October (10) as the 'widest' month, as indeed February (02) or March (03) are both wider with their leading zeros. January (01) doesn't have this problem.

So, 2020 was a red herring. This comment illustrates the fix:

```diff
-    // Generate a time object for a relatively wide time: 2000-10-20 00:00:00
+    // Generate a time object for a relatively wide time: 2000-02-20 00:00:00
```

This assumes leading zeroes are included in the platform's locale, though, which isn't always the case. For Japanese, for example, I'd get 2020年３月17日. I have added an additional check that does use the date I originally coded in. The widest of the two widths is used.