### PR TITLE
Fix #6766: Changelog window won't open

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
+- Fix: [#6766] Changelog window doesn't open on some platforms.
 - Fix: [#7784] Vehicle tab takes 1st car colour instead of tab_vehicle's colour.
 - Fix: [#7854] Cannot build a custom spiral roller coaster design.
 - Fix: [#7854] Empty entries in spiral roller coaster designs list.

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -159,7 +159,7 @@ namespace Platform
 
     std::string GetDocsPath()
     {
-        return std::string();
+        return GetInstallPath();
     }
 
     static SYSTEMTIME TimeToSystemTime(std::time_t timestamp)

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -159,7 +159,7 @@ namespace Platform
 
     std::string GetDocsPath()
     {
-        return GetInstallPath();
+        return GetCurrentExecutablePath();
     }
 
     static SYSTEMTIME TimeToSystemTime(std::time_t timestamp)

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -136,6 +136,13 @@ namespace Platform
         }
     }
 
+    static std::string GetCurrentExecutableDirectory()
+    {
+        auto exePath = GetCurrentExecutablePath();
+        auto exeDirectory = Path::GetDirectory(exePath);
+        return exeDirectory;
+    }
+
     std::string GetInstallPath()
     {
         auto path = std::string(gCustomOpenrctDataPath);
@@ -145,8 +152,7 @@ namespace Platform
         }
         else
         {
-            auto exePath = GetCurrentExecutablePath();
-            auto exeDirectory = Path::GetDirectory(exePath);
+            auto exeDirectory = GetCurrentExecutableDirectory();
             path = Path::Combine(exeDirectory, "data");
         }
         return path;
@@ -159,7 +165,7 @@ namespace Platform
 
     std::string GetDocsPath()
     {
-        return GetCurrentExecutablePath();
+        return GetCurrentExecutableDirectory();
     }
 
     static SYSTEMTIME TimeToSystemTime(std::time_t timestamp)

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -42,11 +42,6 @@ namespace Platform
         }
     }
 
-    std::string GetDocsPath()
-    {
-        return GetBundlePath();
-    }
-
     static std::string GetBundlePath()
     {
         @autoreleasepool {
@@ -61,6 +56,11 @@ namespace Platform
             }
             return std::string();
         }
+    }
+
+    std::string GetDocsPath()
+    {
+        return GetBundlePath();
     }
 
     std::string GetInstallPath()

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -44,7 +44,7 @@ namespace Platform
 
     std::string GetDocsPath()
     {
-        return std::string();
+        return GetBundlePath();
     }
 
     static std::string GetBundlePath()


### PR DESCRIPTION
The platform function `GetDocsPath` was only implemented for Linux; the others returned an empty string. For Windows, use the install path. For macOS, use the bundle (resources) path.

Fixes #6766 and #10160.