### PR TITLE
Prepare object indices for uint16_t (part 2)

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1293,7 +1293,7 @@ static void editor_load_selected_objects()
                 {
                     // Defaults selected items to researched (if in-game)
                     uint8_t objectType = entry->GetType();
-                    uint8_t entryIndex = object_manager_get_loaded_object_entry_index(loadedObject);
+                    auto entryIndex = object_manager_get_loaded_object_entry_index(loadedObject);
                     if (objectType == OBJECT_TYPE_RIDE)
                     {
                         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -272,7 +272,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     void* objectEntry = object_manager_load_object(&td6->vehicle_object);
     if (objectEntry != nullptr)
     {
-        int32_t groupIndex = object_manager_get_loaded_object_entry_index(objectEntry);
+        auto groupIndex = object_manager_get_loaded_object_entry_index(objectEntry);
         rideName = get_ride_naming(td6->type, get_ride_entry(groupIndex));
         friendlyTrackName = rideName.name;
     }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1652,7 +1652,7 @@ static void window_tile_inspector_invalidate(rct_window* w)
             w->widgets[WIDX_WALL_DROPDOWN_SLOPE].text = WallSlopeStringIds[tileElement->AsWall()->GetSlope()];
             w->widgets[WIDX_WALL_DROPDOWN_SLOPE_BUTTON].top = GBBT(propertiesAnchor, 1) + 4;
             w->widgets[WIDX_WALL_DROPDOWN_SLOPE_BUTTON].bottom = GBBB(propertiesAnchor, 1) - 4;
-            const uint8_t wallType = tileElement->AsWall()->GetEntryIndex();
+            const auto wallType = tileElement->AsWall()->GetEntryIndex();
             const rct_wall_scenery_entry wallEntry = get_wall_entry(wallType)->wall;
             const bool canBeSloped = !(wallEntry.flags & WALL_SCENERY_CANT_BUILD_ON_SLOPE);
             // Wall slope dropdown
@@ -1838,7 +1838,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Path addition
                 if (tileElement->AsPath()->HasAddition())
                 {
-                    const uint8_t pathAdditionType = tileElement->AsPath()->GetAdditionEntryIndex();
+                    const auto pathAdditionType = tileElement->AsPath()->GetAdditionEntryIndex();
                     const auto* sceneryElement = get_footpath_item_entry(pathAdditionType);
                     rct_string_id additionNameId = sceneryElement != nullptr ? sceneryElement->name
                                                                              : (rct_string_id)STR_UNKNOWN_OBJECT_TYPE;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1076,7 +1076,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
             console.WriteLineError("Unable to load object.");
             return 1;
         }
-        uint32_t groupIndex = object_manager_get_loaded_object_entry_index(loadedObject);
+        auto groupIndex = object_manager_get_loaded_object_entry_index(loadedObject);
 
         uint8_t objectType = entry->GetType();
         if (objectType == OBJECT_TYPE_RIDE)

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -67,7 +67,7 @@ void FootpathItemObject::Load()
     _legacyType.name = language_allocate_object_string(GetName());
     _legacyType.image = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
 
-    _legacyType.path_bit.scenery_tab_id = 0xFF;
+    _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
 }
 
 void FootpathItemObject::Unload()

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -31,7 +31,7 @@ void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, IStream* stream
     _legacyType.large_scenery.price = stream->ReadValue<int16_t>();
     _legacyType.large_scenery.removal_price = stream->ReadValue<int16_t>();
     stream->Seek(5, STREAM_SEEK_CURRENT);
-    _legacyType.large_scenery.scenery_tab_id = 0xFF;
+    _legacyType.large_scenery.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
     _legacyType.large_scenery.scrolling_mode = stream->ReadValue<uint8_t>();
     stream->Seek(4, STREAM_SEEK_CURRENT);
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -17,6 +17,8 @@
 #include <string_view>
 #include <vector>
 
+constexpr const uint16_t OBJECT_ENTRY_INDEX_NULL = 255;
+
 // First 0xF of rct_object_entry->flags
 enum OBJECT_TYPE
 {

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -116,7 +116,7 @@ bool find_object_in_entry_group(const rct_object_entry* entry, uint8_t* entry_ty
     return false;
 }
 
-void get_type_entry_index(size_t index, uint8_t* outObjectType, uint8_t* outEntryIndex)
+void get_type_entry_index(size_t index, uint8_t* outObjectType, uint16_t* outEntryIndex)
 {
     uint8_t objectType = OBJECT_TYPE_RIDE;
     for (size_t groupCount : object_entry_group_counts)
@@ -140,7 +140,8 @@ void get_type_entry_index(size_t index, uint8_t* outObjectType, uint8_t* outEntr
 
 const rct_object_entry* get_loaded_object_entry(size_t index)
 {
-    uint8_t objectType, entryIndex;
+    uint8_t objectType;
+    uint16_t entryIndex;
     get_type_entry_index(index, &objectType, &entryIndex);
 
     return object_entry_get_entry(objectType, entryIndex);
@@ -148,7 +149,8 @@ const rct_object_entry* get_loaded_object_entry(size_t index)
 
 void* get_loaded_object_chunk(size_t index)
 {
-    uint8_t objectType, entryIndex;
+    uint8_t objectType;
+    uint16_t entryIndex;
     get_type_entry_index(index, &objectType, &entryIndex);
     return object_entry_get_chunk(objectType, entryIndex);
 }

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -17,7 +17,7 @@
 #include "../world/Water.h"
 #include "ObjectLimits.h"
 
-void get_type_entry_index(size_t index, uint8_t* outObjectType, uint8_t* outEntryIndex);
+void get_type_entry_index(size_t index, uint8_t* outObjectType, uint16_t* outEntryIndex);
 const rct_object_entry* get_loaded_object_entry(size_t index);
 void* get_loaded_object_chunk(size_t index);
 uint8_t object_entry_get_type(const rct_object_entry* objectEntry);

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -85,9 +85,9 @@ public:
         return loadedObject;
     }
 
-    uint8_t GetLoadedObjectEntryIndex(const Object* object) override
+    uint16_t GetLoadedObjectEntryIndex(const Object* object) override
     {
-        uint8_t result = UINT8_MAX;
+        uint16_t result = OBJECT_ENTRY_INDEX_NULL;
         size_t index = GetLoadedObjectIndex(object);
         if (index != SIZE_MAX)
         {
@@ -439,13 +439,13 @@ private:
         window_close_by_class(WC_SCENERY);
     }
 
-    uint8_t GetPrimarySceneryGroupEntryIndex(Object* loadedObject)
+    uint16_t GetPrimarySceneryGroupEntryIndex(Object* loadedObject)
     {
         auto sceneryObject = dynamic_cast<SceneryObject*>(loadedObject);
         const rct_object_entry* primarySGEntry = sceneryObject->GetPrimarySceneryGroup();
         Object* sgObject = GetLoadedObject(primarySGEntry);
 
-        uint8_t entryIndex = 255;
+        auto entryIndex = OBJECT_ENTRY_INDEX_NULL;
         if (sgObject != nullptr)
         {
             entryIndex = GetLoadedObjectEntryIndex(sgObject);
@@ -690,11 +690,11 @@ void* object_manager_get_loaded_object(const rct_object_entry* entry)
     return (void*)loadedObject;
 }
 
-uint8_t object_manager_get_loaded_object_entry_index(const void* loadedObject)
+uint16_t object_manager_get_loaded_object_entry_index(const void* loadedObject)
 {
     auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
     const Object* object = static_cast<const Object*>(loadedObject);
-    uint8_t entryIndex = objectManager.GetLoadedObjectEntryIndex(object);
+    auto entryIndex = objectManager.GetLoadedObjectEntryIndex(object);
     return entryIndex;
 }
 

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -27,7 +27,7 @@ interface IObjectManager
     virtual Object* GetLoadedObject(size_t index) abstract;
     virtual Object* GetLoadedObject(int32_t objectType, size_t index) abstract;
     virtual Object* GetLoadedObject(const rct_object_entry* entry) abstract;
-    virtual uint8_t GetLoadedObjectEntryIndex(const Object* object) abstract;
+    virtual uint16_t GetLoadedObjectEntryIndex(const Object* object) abstract;
     virtual std::vector<rct_object_entry> GetInvalidObjects(const rct_object_entry* entries) abstract;
 
     virtual Object* LoadObject(const rct_object_entry* entry) abstract;
@@ -45,7 +45,7 @@ std::unique_ptr<IObjectManager> CreateObjectManager(IObjectRepository& objectRep
 
 void* object_manager_get_loaded_object_by_index(size_t index);
 void* object_manager_get_loaded_object(const rct_object_entry* entry);
-uint8_t object_manager_get_loaded_object_entry_index(const void* loadedObject);
+uint16_t object_manager_get_loaded_object_entry_index(const void* loadedObject);
 void* object_manager_load_object(const rct_object_entry* entry);
 void object_manager_unload_objects(const rct_object_entry* entries, size_t count);
 void object_manager_unload_all_objects();

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -82,8 +82,8 @@ void SceneryGroupObject::UpdateEntryIndexes()
         if (ori->LoadedObject == nullptr)
             continue;
 
-        uint16_t entryIndex = objectManager.GetLoadedObjectEntryIndex(ori->LoadedObject);
-        Guard::Assert(entryIndex != UINT8_MAX, GUARD_LINE);
+        auto entryIndex = objectManager.GetLoadedObjectEntryIndex(ori->LoadedObject);
+        Guard::Assert(entryIndex != OBJECT_ENTRY_INDEX_NULL, GUARD_LINE);
 
         auto sceneryType = ori->ObjectEntry.GetSceneryType();
         if (sceneryType != std::nullopt)

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -35,7 +35,7 @@ void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, IStream* stream
     _legacyType.small_scenery.animation_delay = stream->ReadValue<uint16_t>();
     _legacyType.small_scenery.animation_mask = stream->ReadValue<uint16_t>();
     _legacyType.small_scenery.num_frames = stream->ReadValue<uint16_t>();
-    _legacyType.small_scenery.scenery_tab_id = 0xFF;
+    _legacyType.small_scenery.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 
@@ -76,7 +76,7 @@ void SmallSceneryObject::Load()
     _legacyType.name = language_allocate_object_string(GetName());
     _legacyType.image = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
 
-    _legacyType.small_scenery.scenery_tab_id = 0xFF;
+    _legacyType.small_scenery.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
 
     if (scenery_small_entry_has_flag(&_legacyType, SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
     {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -560,7 +560,7 @@ private:
             const char* entryName = RCT1::GetRideTypeObject(rideType);
             if (!String::Equals(entryName, "        "))
             {
-                uint16_t entryIndex = _rideEntries.GetOrAddEntry(entryName);
+                auto entryIndex = _rideEntries.GetOrAddEntry(entryName);
                 _rideTypeToRideEntryMap[rideType] = entryIndex;
             }
         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -77,15 +77,15 @@ public:
         return _entries;
     }
 
-    size_t GetOrAddEntry(const char* entryName)
+    uint16_t GetOrAddEntry(const char* entryName)
     {
-        size_t entryIndex = Collections::IndexOf(_entries, entryName, true);
+        auto entryIndex = Collections::IndexOf(_entries, entryName, true);
         if (entryIndex == SIZE_MAX)
         {
             entryIndex = _entries.size();
             _entries.push_back(entryName);
         }
-        return entryIndex;
+        return static_cast<uint16_t>(entryIndex);
     }
 
     void AddRange(std::initializer_list<const char*> initializerList)
@@ -117,18 +117,18 @@ private:
     EntryList _waterEntry;
 
     // Lookup tables for converting from RCT1 hard coded types to the new dynamic object entries
-    uint8_t _rideTypeToRideEntryMap[RCT1_RIDE_TYPE_COUNT]{};
-    uint8_t _vehicleTypeToRideEntryMap[RCT1_VEHICLE_TYPE_COUNT]{};
-    uint8_t _smallSceneryTypeToEntryMap[256]{};
-    uint8_t _largeSceneryTypeToEntryMap[256]{};
-    uint8_t _wallTypeToEntryMap[256]{};
-    uint8_t _pathTypeToEntryMap[24]{};
-    uint8_t _pathAdditionTypeToEntryMap[16]{};
-    uint8_t _sceneryThemeTypeToEntryMap[24]{};
+    uint16_t _rideTypeToRideEntryMap[RCT1_RIDE_TYPE_COUNT]{};
+    uint16_t _vehicleTypeToRideEntryMap[RCT1_VEHICLE_TYPE_COUNT]{};
+    uint16_t _smallSceneryTypeToEntryMap[256]{};
+    uint16_t _largeSceneryTypeToEntryMap[256]{};
+    uint16_t _wallTypeToEntryMap[256]{};
+    uint16_t _pathTypeToEntryMap[24]{};
+    uint16_t _pathAdditionTypeToEntryMap[16]{};
+    uint16_t _sceneryThemeTypeToEntryMap[24]{};
 
     // Research
-    uint8_t _researchRideEntryUsed[MAX_RIDE_OBJECTS]{};
-    uint8_t _researchRideTypeUsed[RCT1_RIDE_TYPE_COUNT]{};
+    uint16_t _researchRideEntryUsed[MAX_RIDE_OBJECTS]{};
+    uint16_t _researchRideTypeUsed[RCT1_RIDE_TYPE_COUNT]{};
 
     // Scenario repository - used for determining scenario name
     IScenarioRepository* _scenarioRepository = GetScenarioRepository();
@@ -353,14 +353,14 @@ private:
 
     void InitialiseEntryMaps()
     {
-        std::fill(std::begin(_rideTypeToRideEntryMap), std::end(_rideTypeToRideEntryMap), 255);
-        std::fill(std::begin(_vehicleTypeToRideEntryMap), std::end(_vehicleTypeToRideEntryMap), 255);
-        std::fill(std::begin(_smallSceneryTypeToEntryMap), std::end(_smallSceneryTypeToEntryMap), 255);
-        std::fill(std::begin(_largeSceneryTypeToEntryMap), std::end(_largeSceneryTypeToEntryMap), 255);
-        std::fill(std::begin(_wallTypeToEntryMap), std::end(_wallTypeToEntryMap), 255);
-        std::fill(std::begin(_pathTypeToEntryMap), std::end(_pathTypeToEntryMap), 255);
-        std::fill(std::begin(_pathAdditionTypeToEntryMap), std::end(_pathAdditionTypeToEntryMap), 255);
-        std::fill(std::begin(_sceneryThemeTypeToEntryMap), std::end(_sceneryThemeTypeToEntryMap), 255);
+        std::fill(std::begin(_rideTypeToRideEntryMap), std::end(_rideTypeToRideEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_vehicleTypeToRideEntryMap), std::end(_vehicleTypeToRideEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_smallSceneryTypeToEntryMap), std::end(_smallSceneryTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_largeSceneryTypeToEntryMap), std::end(_largeSceneryTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_wallTypeToEntryMap), std::end(_wallTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_pathTypeToEntryMap), std::end(_pathTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_pathAdditionTypeToEntryMap), std::end(_pathAdditionTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
+        std::fill(std::begin(_sceneryThemeTypeToEntryMap), std::end(_sceneryThemeTypeToEntryMap), OBJECT_ENTRY_INDEX_NULL);
     }
 
     /**
@@ -503,7 +503,7 @@ private:
     {
         for (int32_t sceneryTheme = 0; sceneryTheme <= RCT1_SCENERY_THEME_PAGODA; sceneryTheme++)
         {
-            if (sceneryTheme != 0 && _sceneryThemeTypeToEntryMap[sceneryTheme] == 255)
+            if (sceneryTheme != 0 && _sceneryThemeTypeToEntryMap[sceneryTheme] == OBJECT_ENTRY_INDEX_NULL)
                 continue;
 
             std::vector<const char*> objects = RCT1::GetSceneryObjects(sceneryTheme);
@@ -560,8 +560,8 @@ private:
             const char* entryName = RCT1::GetRideTypeObject(rideType);
             if (!String::Equals(entryName, "        "))
             {
-                size_t entryIndex = _rideEntries.GetOrAddEntry(entryName);
-                _rideTypeToRideEntryMap[rideType] = (uint8_t)entryIndex;
+                uint16_t entryIndex = _rideEntries.GetOrAddEntry(entryName);
+                _rideTypeToRideEntryMap[rideType] = entryIndex;
             }
         }
     }
@@ -574,8 +574,8 @@ private:
             const char* entryName = RCT1::GetVehicleObject(vehicleType);
             if (!String::Equals(entryName, "        "))
             {
-                size_t entryIndex = _rideEntries.GetOrAddEntry(entryName);
-                _vehicleTypeToRideEntryMap[vehicleType] = (uint8_t)entryIndex;
+                auto entryIndex = _rideEntries.GetOrAddEntry(entryName);
+                _vehicleTypeToRideEntryMap[vehicleType] = entryIndex;
 
                 if (rideType != RIDE_TYPE_NULL)
                     AddEntryForRideType(rideType);
@@ -583,77 +583,77 @@ private:
         }
     }
 
-    void AddEntryForSmallScenery(uint8_t smallSceneryType)
+    void AddEntryForSmallScenery(uint16_t smallSceneryType)
     {
         assert(smallSceneryType < std::size(_smallSceneryTypeToEntryMap));
-        if (_smallSceneryTypeToEntryMap[smallSceneryType] == 255)
+        if (_smallSceneryTypeToEntryMap[smallSceneryType] == OBJECT_ENTRY_INDEX_NULL)
         {
             const char* entryName = RCT1::GetSmallSceneryObject(smallSceneryType);
-            size_t entryIndex = _smallSceneryEntries.GetOrAddEntry(entryName);
+            auto entryIndex = _smallSceneryEntries.GetOrAddEntry(entryName);
 
-            _smallSceneryTypeToEntryMap[smallSceneryType] = (uint8_t)entryIndex;
+            _smallSceneryTypeToEntryMap[smallSceneryType] = entryIndex;
         }
     }
 
-    void AddEntryForLargeScenery(uint8_t largeSceneryType)
+    void AddEntryForLargeScenery(uint16_t largeSceneryType)
     {
         assert(largeSceneryType < std::size(_largeSceneryTypeToEntryMap));
-        if (_largeSceneryTypeToEntryMap[largeSceneryType] == 255)
+        if (_largeSceneryTypeToEntryMap[largeSceneryType] == OBJECT_ENTRY_INDEX_NULL)
         {
             const char* entryName = RCT1::GetLargeSceneryObject(largeSceneryType);
-            size_t entryIndex = _largeSceneryEntries.GetOrAddEntry(entryName);
+            auto entryIndex = _largeSceneryEntries.GetOrAddEntry(entryName);
 
-            _largeSceneryTypeToEntryMap[largeSceneryType] = (uint8_t)entryIndex;
+            _largeSceneryTypeToEntryMap[largeSceneryType] = entryIndex;
         }
     }
 
-    void AddEntryForWall(uint8_t wallType)
+    void AddEntryForWall(uint16_t wallType)
     {
         assert(wallType < std::size(_wallTypeToEntryMap));
-        if (_wallTypeToEntryMap[wallType] == 255)
+        if (_wallTypeToEntryMap[wallType] == OBJECT_ENTRY_INDEX_NULL)
         {
             const char* entryName = RCT1::GetWallObject(wallType);
-            size_t entryIndex = _wallEntries.GetOrAddEntry(entryName);
+            auto entryIndex = _wallEntries.GetOrAddEntry(entryName);
 
-            _wallTypeToEntryMap[wallType] = (uint8_t)entryIndex;
+            _wallTypeToEntryMap[wallType] = entryIndex;
         }
     }
 
-    void AddEntryForPath(uint8_t pathType)
+    void AddEntryForPath(uint16_t pathType)
     {
         assert(pathType < std::size(_pathTypeToEntryMap));
-        if (_pathTypeToEntryMap[pathType] == 255)
+        if (_pathTypeToEntryMap[pathType] == OBJECT_ENTRY_INDEX_NULL)
         {
             const char* entryName = RCT1::GetPathObject(pathType);
             if (!String::Equals(entryName, "        "))
             {
-                size_t entryIndex = _pathEntries.GetOrAddEntry(entryName);
-                _pathTypeToEntryMap[pathType] = (uint8_t)entryIndex;
+                auto entryIndex = _pathEntries.GetOrAddEntry(entryName);
+                _pathTypeToEntryMap[pathType] = entryIndex;
             }
         }
     }
 
-    void AddEntryForPathAddition(uint8_t pathAdditionType)
+    void AddEntryForPathAddition(uint16_t pathAdditionType)
     {
         if (pathAdditionType == RCT1_PATH_ADDITION_NONE)
             return;
 
-        if (_pathAdditionTypeToEntryMap[pathAdditionType] == 255)
+        if (_pathAdditionTypeToEntryMap[pathAdditionType] == OBJECT_ENTRY_INDEX_NULL)
         {
             uint8_t normalisedPathAdditionType = RCT1::NormalisePathAddition(pathAdditionType);
-            if (_pathAdditionTypeToEntryMap[normalisedPathAdditionType] == 255)
+            if (_pathAdditionTypeToEntryMap[normalisedPathAdditionType] == OBJECT_ENTRY_INDEX_NULL)
             {
                 const char* entryName = RCT1::GetPathAddtionObject(normalisedPathAdditionType);
-                size_t entryIndex = _pathAdditionEntries.GetOrAddEntry(entryName);
+                auto entryIndex = _pathAdditionEntries.GetOrAddEntry(entryName);
 
-                _pathAdditionTypeToEntryMap[normalisedPathAdditionType] = (uint8_t)entryIndex;
+                _pathAdditionTypeToEntryMap[normalisedPathAdditionType] = entryIndex;
             }
 
             _pathAdditionTypeToEntryMap[pathAdditionType] = _pathAdditionTypeToEntryMap[normalisedPathAdditionType];
         }
     }
 
-    void AddEntriesForSceneryTheme(uint8_t sceneryThemeType)
+    void AddEntriesForSceneryTheme(uint16_t sceneryThemeType)
     {
         if (sceneryThemeType == RCT1_SCENERY_THEME_GENERAL || sceneryThemeType == RCT1_SCENERY_THEME_JUMPING_FOUNTAINS
             || sceneryThemeType == RCT1_SCENERY_THEME_GARDEN_CLOCK)
@@ -670,8 +670,8 @@ private:
             }
             else
             {
-                size_t entryIndex = _sceneryGroupEntries.GetOrAddEntry(entryName);
-                _sceneryThemeTypeToEntryMap[sceneryThemeType] = (uint8_t)entryIndex;
+                auto entryIndex = _sceneryGroupEntries.GetOrAddEntry(entryName);
+                _sceneryThemeTypeToEntryMap[sceneryThemeType] = entryIndex;
             }
         }
     }
@@ -2127,7 +2127,7 @@ private:
                 auto dst2 = dst->AsSmallScenery();
                 auto src2 = src->AsSmallScenery();
 
-                uint8_t entryIndex = _smallSceneryTypeToEntryMap[src2->GetEntryIndex()];
+                auto entryIndex = _smallSceneryTypeToEntryMap[src2->GetEntryIndex()];
                 dst2->SetEntryIndex(entryIndex);
                 dst2->SetAge(src2->GetAge());
                 dst2->SetSceneryQuadrant(src2->GetSceneryQuadrant());
@@ -2165,12 +2165,12 @@ private:
 
                 if (src2->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                 {
-                    uint8_t pathType = src2->GetPathType();
+                    auto pathType = src2->GetPathType();
                     if (pathType == 0)
                     {
                         pathType = RCT1_FOOTPATH_TYPE_TARMAC_GRAY;
                     }
-                    uint8_t entryIndex = _pathTypeToEntryMap[pathType];
+                    auto entryIndex = _pathTypeToEntryMap[pathType];
                     dst2->SetPathType(entryIndex & 0x7F);
                 }
 
@@ -2193,7 +2193,7 @@ private:
                 auto dst2 = dst->AsLargeScenery();
                 auto src2 = src->AsLargeScenery();
 
-                uint8_t type = src2->GetEntryIndex();
+                auto type = src2->GetEntryIndex();
                 dst2->SetEntryIndex(_largeSceneryTypeToEntryMap[type]);
                 dst2->SetSequenceIndex(src2->GetSequenceIndex());
                 dst2->SetPrimaryColour(RCT1::GetColour(src2->GetPrimaryColour()));
@@ -2206,7 +2206,7 @@ private:
                 auto dst2 = dst->AsBanner();
                 auto src2 = src->AsBanner();
 
-                uint8_t index = src2->GetIndex();
+                auto index = src2->GetIndex();
                 if (index != RCT12_BANNER_INDEX_NULL)
                     dst2->SetIndex(index);
                 else
@@ -2273,8 +2273,8 @@ private:
                 case RCT1_RESEARCH_TYPE_THEME:
                 {
                     uint8_t rct1SceneryTheme = researchItem->item;
-                    uint8_t sceneryGroupEntryIndex = _sceneryThemeTypeToEntryMap[rct1SceneryTheme];
-                    if (sceneryGroupEntryIndex != 254 && sceneryGroupEntryIndex != 255)
+                    auto sceneryGroupEntryIndex = _sceneryThemeTypeToEntryMap[rct1SceneryTheme];
+                    if (sceneryGroupEntryIndex != 254 && sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_NULL)
                     {
                         research_insert_scenery_group_entry(sceneryGroupEntryIndex, researched);
                     }
@@ -2458,7 +2458,7 @@ private:
     void InsertResearchVehicle(const rct1_research_item* researchItem, bool researched)
     {
         uint8_t vehicle = researchItem->item;
-        uint8_t rideEntryIndex = _vehicleTypeToRideEntryMap[vehicle];
+        auto rideEntryIndex = _vehicleTypeToRideEntryMap[vehicle];
 
         if (!_researchRideEntryUsed[rideEntryIndex])
         {
@@ -2580,7 +2580,7 @@ private:
         dst->rawValue = RESEARCH_ITEM_NULL;
         if (srcType == RCT1_RESEARCH_TYPE_RIDE)
         {
-            uint8_t entryIndex = _rideTypeToRideEntryMap[srcItem];
+            auto entryIndex = _rideTypeToRideEntryMap[srcItem];
 
             if (entryIndex != RIDE_ENTRY_INDEX_NULL)
             {
@@ -2598,7 +2598,7 @@ private:
         }
         else if (srcType == RCT1_RESEARCH_TYPE_VEHICLE)
         {
-            uint8_t entryIndex = _vehicleTypeToRideEntryMap[srcItem];
+            auto entryIndex = _vehicleTypeToRideEntryMap[srcItem];
 
             if (entryIndex != RIDE_ENTRY_INDEX_NULL)
             {
@@ -2616,9 +2616,9 @@ private:
         }
         else if (srcType == RCT1_RESEARCH_TYPE_THEME)
         {
-            uint8_t entryIndex = _sceneryThemeTypeToEntryMap[srcItem];
+            auto entryIndex = _sceneryThemeTypeToEntryMap[srcItem];
 
-            if (entryIndex != 254 && entryIndex != 255)
+            if (entryIndex != 254 && entryIndex != OBJECT_ENTRY_INDEX_NULL)
             {
                 dst->entryIndex = entryIndex;
                 dst->type = RESEARCH_ENTRY_TYPE_SCENERY;


### PR DESCRIPTION
This replaces more of the `uint8_t`s used for entry indices with `uint16_t`s, as well as replacing more occurrences of the "null" value with a constant.