### PR TITLE
 Light Effects for rides reintegrated with less lag and option to turn off.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -137,6 +137,7 @@ The following people are not part of the development team, but have been contrib
 * Denis Khabenkov (kodmord)
 * Kevin Laframboise (klaframboise)
 * Tushar Sariya (TusharSariya)
+* (WantDiscussion)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3674,6 +3674,8 @@ STR_6357    :{SMALLFONT}{BLACK}Removes all ducks from the map
 STR_6358    :Page {UINT16}
 STR_6359    :{POP16}{POP16}Page {UINT16}
 STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
+STR_6361    :Enable lighting effects on rides (experimental)
+STR_6362    :{SMALLFONT}{BLACK} Rides will be lit up at night.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#10898] Banner text has an offset in tile inspector window.
 - Fix: [#10904] RCT1/LL-scenarios with red water won't open.
 - Fix: [#10941] The Clear Scenery tool gives refunds for ghost elements.
+- Fix: [#10963] Light effects are drawn off-centre in some rotations.
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Improved: [#10884] Added y-axes and labels to park window charts.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1778,9 +1778,9 @@ static void window_options_invalidate(rct_window* w)
                 w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
             }
 
-            widget_set_checkbox_value(w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
-            if (gConfigGeneral.day_night_cycle
-                && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
+            widget_set_checkbox_value(
+                w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
+            if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
                 && gConfigGeneral.enable_light_fx)
             {
                 w->disabled_widgets &= ~(1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -105,6 +105,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_EFFECTS_GROUP,
     WIDX_DAY_NIGHT_CHECKBOX,
     WIDX_ENABLE_LIGHT_FX_CHECKBOX,
+    WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX,
     WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
     WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
 
@@ -259,11 +260,12 @@ static rct_widget window_options_rendering_widgets[] = {
     { WWT_BUTTON,           1,  288,    298,    FRAME_RENDERING_START + 91,     FRAME_RENDERING_START + 100,    STR_DROPDOWN_GLYPH,             STR_VIRTUAL_FLOOR_STYLE_TIP },          // Virtual floor dropdown
 #undef FRAME_RENDERING_START
 #define FRAME_EFFECTS_START 163
-    { WWT_GROUPBOX,         1,  5,      304,    FRAME_EFFECTS_START + 0,        FRAME_EFFECTS_START + 78,       STR_EFFECTS_GROUP,              STR_NONE },                             // Rendering group
+    { WWT_GROUPBOX,         1,  5,      304,    FRAME_EFFECTS_START + 0,        FRAME_EFFECTS_START + 93,       STR_EFFECTS_GROUP,              STR_NONE },                             // Rendering group
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 15,       FRAME_EFFECTS_START + 26,       STR_CYCLE_DAY_NIGHT,            STR_CYCLE_DAY_NIGHT_TIP },              // Cycle day-night
     { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 30,       FRAME_EFFECTS_START + 41,       STR_ENABLE_LIGHTING_EFFECTS,    STR_ENABLE_LIGHTING_EFFECTS_TIP },      // Enable light fx
-    { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
-    { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 60,       FRAME_EFFECTS_START + 71,       STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
+    { WWT_CHECKBOX,         1,  30,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_ENABLE_LIGHTING_VEHICLES,   STR_ENABLE_LIGHTING_VEHICLES_TIP },     // Enable light fx for vehicles
+    { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 60,       FRAME_EFFECTS_START + 71,       STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
+    { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 75,       FRAME_EFFECTS_START + 86,       STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
 #undef FRAME_EFFECTS_START
     { WIDGETS_END },
 };
@@ -546,6 +548,7 @@ static uint64_t window_options_page_enabled_widgets[] = {
     (1 << WIDX_VIRTUAL_FLOOR_DROPDOWN) |
     (1 << WIDX_DAY_NIGHT_CHECKBOX) |
     (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX) |
+    (1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX) |
     (1 << WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX) |
     (1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX),
 
@@ -746,6 +749,11 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     break;
                 case WIDX_ENABLE_LIGHT_FX_CHECKBOX:
                     gConfigGeneral.enable_light_fx ^= 1;
+                    config_save_default();
+                    w->Invalidate();
+                    break;
+                case WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX:
+                    gConfigGeneral.enable_light_fx_for_vehicles ^= 1;
                     config_save_default();
                     w->Invalidate();
                     break;
@@ -1768,6 +1776,18 @@ static void window_options_invalidate(rct_window* w)
             else
             {
                 w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
+            }
+
+            widget_set_checkbox_value(w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
+            if (gConfigGeneral.day_night_cycle
+                && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
+                && gConfigGeneral.enable_light_fx)
+            {
+                w->disabled_widgets &= ~(1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
+            }
+            else
+            {
+                w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
             }
 
             widget_set_checkbox_value(

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -181,8 +181,8 @@ namespace Config
 
             // Default config setting is false until the games canvas can be separated from the effect
             model->day_night_cycle = reader->GetBoolean("day_night_cycle", false);
-
             model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
+            model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
             model->upper_case_banners = reader->GetBoolean("upper_case_banners", false);
             model->disable_lightning_effect = reader->GetBoolean("disable_lightning_effect", false);
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);
@@ -256,6 +256,7 @@ namespace Config
         writer->WriteBoolean("minimize_fullscreen_focus_loss", model->minimize_fullscreen_focus_loss);
         writer->WriteBoolean("day_night_cycle", model->day_night_cycle);
         writer->WriteBoolean("enable_light_fx", model->enable_light_fx);
+        writer->WriteBoolean("enable_light_fx_for_vehicles", model->enable_light_fx_for_vehicles);
         writer->WriteBoolean("upper_case_banners", model->upper_case_banners);
         writer->WriteBoolean("disable_lightning_effect", model->disable_lightning_effect);
         writer->WriteBoolean("allow_loading_with_incorrect_checksum", model->allow_loading_with_incorrect_checksum);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -41,6 +41,7 @@ struct GeneralConfiguration
     int32_t virtual_floor_style;
     bool day_night_cycle;
     bool enable_light_fx;
+    bool enable_light_fx_for_vehicles;
     bool upper_case_banners;
     bool render_weather_effects;
     bool render_weather_gloom;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -674,30 +674,30 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
 void lightfx_add_3d_light_magic_from_drawing_tile(
     const CoordsXY& mapPosition, int16_t offsetX, int16_t offsetY, int16_t offsetZ, uint8_t lightType)
 {
-    int16_t x = mapPosition.x + offsetX;
-    int16_t y = mapPosition.y + offsetY;
+    int16_t x = mapPosition.x + offsetX + 16;
+    int16_t y = mapPosition.y + offsetY + 16;
 
-    switch (get_current_rotation())
-    {
-        case 0:
-            x += 16;
-            y += 16;
-            break;
-        case 1:
-            x += 16;
-            y += 16;
-            break;
-        case 2:
-            x += 16;
-            y -= 16;
-            break;
-        case 3:
-            x += 16;
-            y -= 16;
-            break;
-        default:
-            return;
-    }
+    //switch (get_current_rotation())
+    //{
+    //    case 0:
+    //        x += 16;
+    //        y += 16;
+    //        break;
+    //    case 1:
+    //        x += 16;
+    //        y += 16;
+    //        break;
+    //    case 2:
+    //        x += 16;
+    //        y -= 16;
+    //        break;
+    //    case 3:
+    //        x += 16;
+    //        y -= 16;
+    //        break;
+    //    default:
+    //        return;
+    //}
 
     lightfx_add_3d_light((x << 16) | y, (offsetZ << 8) | LIGHTFX_LIGHT_QUALIFIER_MAP, x, y, offsetZ, lightType);
 }

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -677,28 +677,6 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
     int16_t x = mapPosition.x + offsetX + 16;
     int16_t y = mapPosition.y + offsetY + 16;
 
-    // switch (get_current_rotation())
-    //{
-    //    case 0:
-    //        x += 16;
-    //        y += 16;
-    //        break;
-    //    case 1:
-    //        x += 16;
-    //        y += 16;
-    //        break;
-    //    case 2:
-    //        x += 16;
-    //        y -= 16;
-    //        break;
-    //    case 3:
-    //        x += 16;
-    //        y -= 16;
-    //        break;
-    //    default:
-    //        return;
-    //}
-
     lightfx_add_3d_light((x << 16) | y, (offsetZ << 8) | LIGHTFX_LIGHT_QUALIFIER_MAP, x, y, offsetZ, lightType);
 }
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -128,6 +128,11 @@ bool lightfx_is_available()
     return _lightfxAvailable && gConfigGeneral.enable_light_fx != 0;
 }
 
+bool lightfx_for_vehicles_is_available()
+{
+    return lightfx_is_available() && gConfigGeneral.enable_light_fx_for_vehicles != 0;
+}
+
 void lightfx_init()
 {
     _LightListBack = _LightListA;
@@ -685,20 +690,16 @@ uint32_t lightfx_get_light_polution()
     return _lightPolution_front;
 }
 
-void lightfx_add_lights_magic_vehicles()
+void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex)
 {
-    uint16_t spriteIndex = gSpriteListHead[SPRITE_LIST_VEHICLE_HEAD];
-    while (spriteIndex != SPRITE_INDEX_NULL)
+    if (spriteIndex != SPRITE_INDEX_NULL)
     {
-        Vehicle* vehicle = &(get_sprite(spriteIndex)->vehicle);
         uint16_t vehicleID = spriteIndex;
-        spriteIndex = vehicle->next;
-
-        Vehicle* mother_vehicle = vehicle;
+        const Vehicle* mother_vehicle = vehicle;
 
         if (mother_vehicle->ride_subtype == RIDE_ENTRY_INDEX_NULL)
         {
-            continue;
+            return;
         }
 
         for (uint16_t q = vehicleID; q != SPRITE_INDEX_NULL;)

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -677,7 +677,7 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
     int16_t x = mapPosition.x + offsetX + 16;
     int16_t y = mapPosition.y + offsetY + 16;
 
-    //switch (get_current_rotation())
+    // switch (get_current_rotation())
     //{
     //    case 0:
     //        x += 16;

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -13,6 +13,7 @@
 #ifdef __ENABLE_LIGHTFX__
 
 #    include "../common.h"
+#    include "../ride/Ride.h"
 
 struct CoordsXY;
 struct rct_drawpixelinfo;
@@ -44,6 +45,7 @@ enum LIGHTFX_LIGHT_QUALIFIER
 
 void lightfx_set_available(bool available);
 bool lightfx_is_available();
+bool lightfx_for_vehicles_is_available();
 
 void lightfx_init();
 
@@ -62,7 +64,7 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
 void lightfx_add_3d_light_magic_from_drawing_tile(
     const CoordsXY& mapPosition, int16_t offsetX, int16_t offsetY, int16_t offsetZ, uint8_t lightType);
 
-void lightfx_add_lights_magic_vehicles();
+void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex);
 
 uint32_t lightfx_get_light_polution();
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3906,6 +3906,10 @@ enum
 
     STR_GRAPH_AXIS_LABEL = 6360,
 
+    STR_ENABLE_LIGHTING_VEHICLES = 6361,
+    STR_ENABLE_LIGHTING_VEHICLES_TIP = 6362,
+
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -17,6 +17,7 @@
 #include "../../ride/VehiclePaint.h"
 #include "../../world/Sprite.h"
 #include "../Paint.h"
+#include <openrct2\drawing\LightFX.h>
 
 /**
  * Paint Quadrant
@@ -111,6 +112,12 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         {
             case SPRITE_IDENTIFIER_VEHICLE:
                 vehicle_paint(session, (Vehicle*)spr, image_direction);
+                #ifdef __ENABLE_LIGHTFX__
+                                if (lightfx_for_vehicles_is_available())
+                                {
+                                    lightfx_add_lights_magic_vehicles((Vehicle*)spr, sprite_idx);
+                                }
+                #endif
                 break;
             case SPRITE_IDENTIFIER_PEEP:
                 peep_paint(session, (Peep*)spr, image_direction);


### PR DESCRIPTION
Light effects now only adds lights for vehicles on screen. Only minor lag when many vehicles are on screen. Added option to turn on/off ride lights.

Before:
![Annotation 2020-03-19 110021](https://user-images.githubusercontent.com/62322762/77018239-f6072980-69d0-11ea-990e-5e6a315b6141.jpg)

After:
![Annotation 2020-03-19 105916](https://user-images.githubusercontent.com/62322762/77018268-06b79f80-69d1-11ea-9fbb-f380c9a5d3fa.jpg)
