### PR TITLE
Light Effects for rides reintegrated with less lag and option to turn off.

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3675,7 +3675,7 @@ STR_6358    :Page {UINT16}
 STR_6359    :{POP16}{POP16}Page {UINT16}
 STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
 STR_6361    :Enable lighting effects on rides (experimental)
-STR_6362    :{SMALLFONT}{BLACK} Rides will be lit up at night.
+STR_6362    :{SMALLFONT}{BLACK}If enabled, vehicles for tracked rides will be lit up at night.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3674,6 +3674,8 @@ STR_6357    :{SMALLFONT}{BLACK}Removes all ducks from the map
 STR_6358    :Page {UINT16}
 STR_6359    :{POP16}{POP16}Page {UINT16}
 STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
+STR_6361    :Enable lighting effects on rides (experimental)
+STR_6362    :{SMALLFONT}{BLACK} Rides will be lit up at night.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,7 +41,7 @@
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Improved: [#10884] Added y-axes and labels to park window charts.
-- Improved: [#10970] Included vehicle light effect, added option to turn them on/off.
+- Improved: [#10970] Introduced optional light effects for vehicles at night.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,7 +41,7 @@
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Improved: [#10884] Added y-axes and labels to park window charts.
-- Improved: [#10970] Included vehicle light effect lag and option to turn on/off vehicle light effects.
+- Improved: [#10970] Included vehicle light effect, added option to turn them on/off.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Improved: [#10884] Added y-axes and labels to park window charts.
+- Improved: [#10970] Included vehicle light effect lag and option to turn on/off vehicle light effects.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -263,7 +263,7 @@ static rct_widget window_options_rendering_widgets[] = {
     { WWT_GROUPBOX,         1,  5,      304,    FRAME_EFFECTS_START + 0,        FRAME_EFFECTS_START + 93,       STR_EFFECTS_GROUP,              STR_NONE },                             // Rendering group
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 15,       FRAME_EFFECTS_START + 26,       STR_CYCLE_DAY_NIGHT,            STR_CYCLE_DAY_NIGHT_TIP },              // Cycle day-night
     { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 30,       FRAME_EFFECTS_START + 41,       STR_ENABLE_LIGHTING_EFFECTS,    STR_ENABLE_LIGHTING_EFFECTS_TIP },      // Enable light fx
-    { WWT_CHECKBOX,         1,  30,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_ENABLE_LIGHTING_VEHICLES,   STR_ENABLE_LIGHTING_VEHICLES_TIP },     // Enable light fx for vehicles
+    { WWT_CHECKBOX,         1,  40,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_ENABLE_LIGHTING_VEHICLES,   STR_ENABLE_LIGHTING_VEHICLES_TIP },     // Enable light fx for vehicles
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 60,       FRAME_EFFECTS_START + 71,       STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
     { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 75,       FRAME_EFFECTS_START + 86,       STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
 #undef FRAME_EFFECTS_START

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1778,9 +1778,9 @@ static void window_options_invalidate(rct_window* w)
                 w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
             }
 
-            widget_set_checkbox_value(w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
-            if (gConfigGeneral.day_night_cycle
-                && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
+            widget_set_checkbox_value(
+                w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
+            if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
                 && gConfigGeneral.enable_light_fx)
             {
                 w->disabled_widgets &= ~(1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -105,6 +105,7 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
     WIDX_EFFECTS_GROUP,
     WIDX_DAY_NIGHT_CHECKBOX,
     WIDX_ENABLE_LIGHT_FX_CHECKBOX,
+    WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX,
     WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
     WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX,
 
@@ -259,11 +260,12 @@ static rct_widget window_options_rendering_widgets[] = {
     { WWT_BUTTON,           1,  288,    298,    FRAME_RENDERING_START + 91,     FRAME_RENDERING_START + 100,    STR_DROPDOWN_GLYPH,             STR_VIRTUAL_FLOOR_STYLE_TIP },          // Virtual floor dropdown
 #undef FRAME_RENDERING_START
 #define FRAME_EFFECTS_START 163
-    { WWT_GROUPBOX,         1,  5,      304,    FRAME_EFFECTS_START + 0,        FRAME_EFFECTS_START + 78,       STR_EFFECTS_GROUP,              STR_NONE },                             // Rendering group
+    { WWT_GROUPBOX,         1,  5,      304,    FRAME_EFFECTS_START + 0,        FRAME_EFFECTS_START + 93,       STR_EFFECTS_GROUP,              STR_NONE },                             // Rendering group
     { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 15,       FRAME_EFFECTS_START + 26,       STR_CYCLE_DAY_NIGHT,            STR_CYCLE_DAY_NIGHT_TIP },              // Cycle day-night
     { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 30,       FRAME_EFFECTS_START + 41,       STR_ENABLE_LIGHTING_EFFECTS,    STR_ENABLE_LIGHTING_EFFECTS_TIP },      // Enable light fx
-    { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
-    { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 60,       FRAME_EFFECTS_START + 71,       STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
+    { WWT_CHECKBOX,         1,  30,     290,    FRAME_EFFECTS_START + 45,       FRAME_EFFECTS_START + 56,       STR_ENABLE_LIGHTING_VEHICLES,   STR_ENABLE_LIGHTING_VEHICLES_TIP },     // Enable light fx for vehicles
+    { WWT_CHECKBOX,         1,  10,     290,    FRAME_EFFECTS_START + 60,       FRAME_EFFECTS_START + 71,       STR_RENDER_WEATHER_EFFECTS,     STR_RENDER_WEATHER_EFFECTS_TIP },       // Render weather effects
+    { WWT_CHECKBOX,         1,  25,     290,    FRAME_EFFECTS_START + 75,       FRAME_EFFECTS_START + 86,       STR_DISABLE_LIGHTNING_EFFECT,   STR_DISABLE_LIGHTNING_EFFECT_TIP },     // Disable lightning effect
 #undef FRAME_EFFECTS_START
     { WIDGETS_END },
 };
@@ -546,6 +548,7 @@ static uint64_t window_options_page_enabled_widgets[] = {
     (1 << WIDX_VIRTUAL_FLOOR_DROPDOWN) |
     (1 << WIDX_DAY_NIGHT_CHECKBOX) |
     (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX) |
+    (1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX) |
     (1 << WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX) |
     (1 << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX),
 
@@ -746,6 +749,11 @@ static void window_options_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                     break;
                 case WIDX_ENABLE_LIGHT_FX_CHECKBOX:
                     gConfigGeneral.enable_light_fx ^= 1;
+                    config_save_default();
+                    w->Invalidate();
+                    break;
+                case WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX:
+                    gConfigGeneral.enable_light_fx_for_vehicles ^= 1;
                     config_save_default();
                     w->Invalidate();
                     break;
@@ -1768,6 +1776,18 @@ static void window_options_invalidate(rct_window* w)
             else
             {
                 w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
+            }
+
+            widget_set_checkbox_value(w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
+            if (gConfigGeneral.day_night_cycle
+                && gConfigGeneral.drawing_engine == DRAWING_ENGINE_SOFTWARE_WITH_HARDWARE_DISPLAY
+                && gConfigGeneral.enable_light_fx)
+            {
+                w->disabled_widgets &= ~(1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
+            }
+            else
+            {
+                w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
             }
 
             widget_set_checkbox_value(

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -181,8 +181,8 @@ namespace Config
 
             // Default config setting is false until the games canvas can be separated from the effect
             model->day_night_cycle = reader->GetBoolean("day_night_cycle", false);
-
             model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
+            model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
             model->upper_case_banners = reader->GetBoolean("upper_case_banners", false);
             model->disable_lightning_effect = reader->GetBoolean("disable_lightning_effect", false);
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);
@@ -256,6 +256,7 @@ namespace Config
         writer->WriteBoolean("minimize_fullscreen_focus_loss", model->minimize_fullscreen_focus_loss);
         writer->WriteBoolean("day_night_cycle", model->day_night_cycle);
         writer->WriteBoolean("enable_light_fx", model->enable_light_fx);
+        writer->WriteBoolean("enable_light_fx_for_vehicles", model->enable_light_fx_for_vehicles);
         writer->WriteBoolean("upper_case_banners", model->upper_case_banners);
         writer->WriteBoolean("disable_lightning_effect", model->disable_lightning_effect);
         writer->WriteBoolean("allow_loading_with_incorrect_checksum", model->allow_loading_with_incorrect_checksum);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -181,6 +181,7 @@ namespace Config
 
             // Default config setting is false until the games canvas can be separated from the effect
             model->day_night_cycle = reader->GetBoolean("day_night_cycle", false);
+
             model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
             model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
             model->upper_case_banners = reader->GetBoolean("upper_case_banners", false);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -41,6 +41,7 @@ struct GeneralConfiguration
     int32_t virtual_floor_style;
     bool day_night_cycle;
     bool enable_light_fx;
+    bool enable_light_fx_for_vehicles;
     bool upper_case_banners;
     bool render_weather_effects;
     bool render_weather_gloom;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -679,6 +679,7 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
 <<<<<<< HEAD
 =======
 
+<<<<<<< HEAD
     // switch (get_current_rotation())
     //{
     //    case 0:
@@ -702,6 +703,8 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
     //}
 >>>>>>> Update LightFX.cpp
 
+=======
+>>>>>>> Update LightFX.cpp
     lightfx_add_3d_light((x << 16) | y, (offsetZ << 8) | LIGHTFX_LIGHT_QUALIFIER_MAP, x, y, offsetZ, lightType);
 }
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -679,7 +679,7 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
 <<<<<<< HEAD
 =======
 
-    //switch (get_current_rotation())
+    // switch (get_current_rotation())
     //{
     //    case 0:
     //        x += 16;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -690,161 +690,136 @@ uint32_t lightfx_get_light_polution()
     return _lightPolution_front;
 }
 
-void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex)
+void lightfx_add_lights_magic_vehicle(const Vehicle* vehicle)
 {
-    if (spriteIndex != SPRITE_INDEX_NULL)
+    uint16_t vehicleID = vehicle->sprite_index;
+
+    int16_t place_x, place_y, place_z;
+
+    place_x = vehicle->x;
+    place_y = vehicle->y;
+    place_z = vehicle->z;
+
+    static constexpr const int16_t offsetLookup[] = {
+        10, 10, 9, 8, 7, 6, 4, 2, 0, -2, -4, -6, -7, -8, -9, -10, -10, -10, -9, -8, -7, -6, -4, -2, 0, 2, 4, 6, 7, 8, 9, 10,
+    };
+
+    auto ride = get_ride(vehicle->ride);
+
+    switch (ride->type)
     {
-        uint16_t vehicleID = spriteIndex;
-        const Vehicle* mother_vehicle = vehicle;
-
-        if (mother_vehicle->ride_subtype == RIDE_ENTRY_INDEX_NULL)
-        {
-            return;
-        }
-
-        for (uint16_t q = vehicleID; q != SPRITE_INDEX_NULL;)
-        {
-            vehicle = GET_VEHICLE(q);
-
-            vehicleID = q;
-            if (vehicle->next_vehicle_on_train == q)
-                break;
-            q = vehicle->next_vehicle_on_train;
-
-            int16_t place_x, place_y, place_z;
-
-            place_x = vehicle->x;
-            place_y = vehicle->y;
-            place_z = vehicle->z;
-
-            static constexpr const int16_t offsetLookup[] = {
-                10,  10,  9,  8,  7,  6,  4,  2,  0, -2, -4, -6, -7, -8, -9, -10,
-                -10, -10, -9, -8, -7, -6, -4, -2, 0, 2,  4,  6,  7,  8,  9,  10,
-            };
-
-            auto ride = get_ride(vehicle->ride);
-            if (ride == nullptr)
-                continue;
-
-            switch (ride->type)
+        case RIDE_TYPE_OBSERVATION_TOWER:
+            lightfx_add_3d_light(
+                vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y + 16, vehicle->z,
+                LIGHTFX_LIGHT_TYPE_SPOT_3);
+            lightfx_add_3d_light(
+                vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x + 16, vehicle->y, vehicle->z,
+                LIGHTFX_LIGHT_TYPE_SPOT_3);
+            lightfx_add_3d_light(
+                vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x - 16, vehicle->y, vehicle->z,
+                LIGHTFX_LIGHT_TYPE_SPOT_3);
+            lightfx_add_3d_light(
+                vehicleID, 0x0300 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y - 16, vehicle->z,
+                LIGHTFX_LIGHT_TYPE_SPOT_3);
+            break;
+        case RIDE_TYPE_MINE_TRAIN_COASTER:
+        case RIDE_TYPE_GHOST_TRAIN:
+            if (vehicle == vehicle_get_head(vehicle))
             {
-                case RIDE_TYPE_OBSERVATION_TOWER:
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y + 16, vehicle->z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_3);
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x + 16, vehicle->y, vehicle->z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_3);
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x - 16, vehicle->y, vehicle->z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_3);
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0300 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y - 16, vehicle->z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_3);
-                    break;
-                case RIDE_TYPE_MINE_TRAIN_COASTER:
-                case RIDE_TYPE_GHOST_TRAIN:
-                    if (vehicle == vehicle_get_head(vehicle))
-                    {
-                        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z,
-                            LIGHTFX_LIGHT_TYPE_SPOT_3);
-                    }
-                    break;
-                case RIDE_TYPE_CHAIRLIFT:
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z - 16,
-                        LIGHTFX_LIGHT_TYPE_LANTERN_2);
-                    break;
-                case RIDE_TYPE_BOAT_HIRE:
-                case RIDE_TYPE_CAR_RIDE:
-                case RIDE_TYPE_GO_KARTS:
-                case RIDE_TYPE_DODGEMS:
-                case RIDE_TYPE_MINI_HELICOPTERS:
-                case RIDE_TYPE_MONORAIL_CYCLES:
-                case RIDE_TYPE_SUBMARINE_RIDE:
-                case RIDE_TYPE_SPLASH_BOATS:
-                case RIDE_TYPE_WATER_COASTER:
-                {
-                    Vehicle* vehicle_draw = vehicle_get_head(vehicle);
-                    if (vehicle_draw->next_vehicle_on_train != SPRITE_INDEX_NULL)
-                    {
-                        vehicle_draw = GET_VEHICLE(vehicle_draw->next_vehicle_on_train);
-                    }
-                    place_x = vehicle_draw->x;
-                    place_y = vehicle_draw->y;
-                    place_z = vehicle_draw->z;
-                    place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
-                    place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_2);
-                    place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
-                    place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z,
-                        LIGHTFX_LIGHT_TYPE_SPOT_2);
-                    break;
-                }
-                case RIDE_TYPE_MONORAIL:
-                    lightfx_add_3d_light(
-                        vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y, vehicle->z + 12,
-                        LIGHTFX_LIGHT_TYPE_SPOT_2);
-                    if (vehicle == vehicle_get_head(vehicle))
-                    {
-                        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 3;
-                        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 3;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                    }
-                    if (vehicle == vehicle_get_tail(vehicle))
-                    {
-                        place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0300 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                        place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0400 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                    }
-                    break;
-                case RIDE_TYPE_MINIATURE_RAILWAY:
-                    if (vehicle == vehicle_get_head(vehicle))
-                    {
-                        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-                        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                    }
-                    else
-                    {
-                        lightfx_add_3d_light(
-                            vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
-                            LIGHTFX_LIGHT_TYPE_LANTERN_3);
-                    }
-                    break;
-                default:
-                    break;
-            };
+                place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z, LIGHTFX_LIGHT_TYPE_SPOT_3);
+            }
+            break;
+        case RIDE_TYPE_CHAIRLIFT:
+            lightfx_add_3d_light(
+                vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z - 16,
+                LIGHTFX_LIGHT_TYPE_LANTERN_2);
+            break;
+        case RIDE_TYPE_BOAT_HIRE:
+        case RIDE_TYPE_CAR_RIDE:
+        case RIDE_TYPE_GO_KARTS:
+        case RIDE_TYPE_DODGEMS:
+        case RIDE_TYPE_MINI_HELICOPTERS:
+        case RIDE_TYPE_MONORAIL_CYCLES:
+        case RIDE_TYPE_SUBMARINE_RIDE:
+        case RIDE_TYPE_SPLASH_BOATS:
+        case RIDE_TYPE_WATER_COASTER:
+        {
+            Vehicle* vehicle_draw = vehicle_get_head(vehicle);
+            if (vehicle_draw->next_vehicle_on_train != SPRITE_INDEX_NULL)
+            {
+                vehicle_draw = GET_VEHICLE(vehicle_draw->next_vehicle_on_train);
+            }
+            place_x = vehicle_draw->x;
+            place_y = vehicle_draw->y;
+            place_z = vehicle_draw->z;
+            place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
+            place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
+            lightfx_add_3d_light(
+                vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z, LIGHTFX_LIGHT_TYPE_SPOT_2);
+            place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
+            place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
+            lightfx_add_3d_light(
+                vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z, LIGHTFX_LIGHT_TYPE_SPOT_2);
+            break;
         }
-    }
+        case RIDE_TYPE_MONORAIL:
+            lightfx_add_3d_light(
+                vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, vehicle->x, vehicle->y, vehicle->z + 12,
+                LIGHTFX_LIGHT_TYPE_SPOT_2);
+            if (vehicle == vehicle_get_head(vehicle))
+            {
+                place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 3;
+                place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 3;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+            }
+            if (vehicle == vehicle_get_tail(vehicle))
+            {
+                place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0300 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0400 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+            }
+            break;
+        case RIDE_TYPE_MINIATURE_RAILWAY:
+            if (vehicle == vehicle_get_head(vehicle))
+            {
+                place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0100 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+                place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
+                place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+                lightfx_add_3d_light(
+                    vehicleID, 0x0200 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 2,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+            }
+            else
+            {
+                lightfx_add_3d_light(
+                    vehicleID, 0x0000 | LIGHTFX_LIGHT_QUALIFIER_SPRITE, place_x, place_y, place_z + 10,
+                    LIGHTFX_LIGHT_TYPE_LANTERN_3);
+            }
+            break;
+        default:
+            break;
+    };
 }
 
 void lightfx_apply_palette_filter(uint8_t i, uint8_t* r, uint8_t* g, uint8_t* b)

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -681,35 +681,7 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
 {
     int16_t x = mapPosition.x + offsetX + 16;
     int16_t y = mapPosition.y + offsetY + 16;
-<<<<<<< HEAD
-=======
 
-<<<<<<< HEAD
-    // switch (get_current_rotation())
-    //{
-    //    case 0:
-    //        x += 16;
-    //        y += 16;
-    //        break;
-    //    case 1:
-    //        x += 16;
-    //        y += 16;
-    //        break;
-    //    case 2:
-    //        x += 16;
-    //        y -= 16;
-    //        break;
-    //    case 3:
-    //        x += 16;
-    //        y -= 16;
-    //        break;
-    //    default:
-    //        return;
-    //}
->>>>>>> Update LightFX.cpp
-
-=======
->>>>>>> Update LightFX.cpp
     lightfx_add_3d_light((x << 16) | y, (offsetZ << 8) | LIGHTFX_LIGHT_QUALIFIER_MAP, x, y, offsetZ, lightType);
 }
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -676,6 +676,31 @@ void lightfx_add_3d_light_magic_from_drawing_tile(
 {
     int16_t x = mapPosition.x + offsetX + 16;
     int16_t y = mapPosition.y + offsetY + 16;
+<<<<<<< HEAD
+=======
+
+    //switch (get_current_rotation())
+    //{
+    //    case 0:
+    //        x += 16;
+    //        y += 16;
+    //        break;
+    //    case 1:
+    //        x += 16;
+    //        y += 16;
+    //        break;
+    //    case 2:
+    //        x += 16;
+    //        y -= 16;
+    //        break;
+    //    case 3:
+    //        x += 16;
+    //        y -= 16;
+    //        break;
+    //    default:
+    //        return;
+    //}
+>>>>>>> Update LightFX.cpp
 
     lightfx_add_3d_light((x << 16) | y, (offsetZ << 8) | LIGHTFX_LIGHT_QUALIFIER_MAP, x, y, offsetZ, lightType);
 }

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -128,6 +128,11 @@ bool lightfx_is_available()
     return _lightfxAvailable && gConfigGeneral.enable_light_fx != 0;
 }
 
+bool lightfx_for_vehicles_is_available()
+{
+    return lightfx_is_available() && gConfigGeneral.enable_light_fx_for_vehicles != 0;
+}
+
 void lightfx_init()
 {
     _LightListBack = _LightListA;
@@ -713,20 +718,16 @@ uint32_t lightfx_get_light_polution()
     return _lightPolution_front;
 }
 
-void lightfx_add_lights_magic_vehicles()
+void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex)
 {
-    uint16_t spriteIndex = gSpriteListHead[SPRITE_LIST_VEHICLE_HEAD];
-    while (spriteIndex != SPRITE_INDEX_NULL)
+    if (spriteIndex != SPRITE_INDEX_NULL)
     {
-        Vehicle* vehicle = &(get_sprite(spriteIndex)->vehicle);
         uint16_t vehicleID = spriteIndex;
-        spriteIndex = vehicle->next;
-
-        Vehicle* mother_vehicle = vehicle;
+        const Vehicle* mother_vehicle = vehicle;
 
         if (mother_vehicle->ride_subtype == RIDE_ENTRY_INDEX_NULL)
         {
-            continue;
+            return;
         }
 
         for (uint16_t q = vehicleID; q != SPRITE_INDEX_NULL;)

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -13,9 +13,9 @@
 #ifdef __ENABLE_LIGHTFX__
 
 #    include "../common.h"
-#    include "../ride/Ride.h"
 
 struct CoordsXY;
+struct Vehicle;
 struct rct_drawpixelinfo;
 struct rct_palette;
 

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -64,7 +64,7 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
 void lightfx_add_3d_light_magic_from_drawing_tile(
     const CoordsXY& mapPosition, int16_t offsetX, int16_t offsetY, int16_t offsetZ, uint8_t lightType);
 
-void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex);
+void lightfx_add_lights_magic_vehicle(const Vehicle* vehicle);
 
 uint32_t lightfx_get_light_polution();
 

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -13,6 +13,7 @@
 #ifdef __ENABLE_LIGHTFX__
 
 #    include "../common.h"
+#    include "../ride/Ride.h"
 
 struct CoordsXY;
 struct rct_drawpixelinfo;
@@ -44,6 +45,7 @@ enum LIGHTFX_LIGHT_QUALIFIER
 
 void lightfx_set_available(bool available);
 bool lightfx_is_available();
+bool lightfx_for_vehicles_is_available();
 
 void lightfx_init();
 
@@ -62,7 +64,7 @@ void lightfx_add_3d_light(uint32_t lightID, uint16_t lightIDqualifier, int16_t x
 void lightfx_add_3d_light_magic_from_drawing_tile(
     const CoordsXY& mapPosition, int16_t offsetX, int16_t offsetY, int16_t offsetZ, uint8_t lightType);
 
-void lightfx_add_lights_magic_vehicles();
+void lightfx_add_lights_magic_vehicles(const Vehicle* vehicle, uint16_t spriteIndex);
 
 uint32_t lightfx_get_light_polution();
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3906,6 +3906,10 @@ enum
 
     STR_GRAPH_AXIS_LABEL = 6360,
 
+    STR_ENABLE_LIGHTING_VEHICLES = 6361,
+    STR_ENABLE_LIGHTING_VEHICLES_TIP = 6362,
+
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3909,7 +3909,6 @@ enum
     STR_ENABLE_LIGHTING_VEHICLES = 6361,
     STR_ENABLE_LIGHTING_VEHICLES_TIP = 6362,
 
-
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -115,7 +115,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 #ifdef __ENABLE_LIGHTFX__
                 if (lightfx_for_vehicles_is_available())
                 {
-                    lightfx_add_lights_magic_vehicle(reinterpret_cast<Vehicle*>((const_cast<rct_sprite*>(spr))));
+                    lightfx_add_lights_magic_vehicle(reinterpret_cast<Vehicle*>(const_cast<rct_sprite*>(spr)));
                 }
 #endif
                 break;

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -115,7 +115,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 #ifdef __ENABLE_LIGHTFX__
                 if (lightfx_for_vehicles_is_available())
                 {
-                    lightfx_add_lights_magic_vehicles((Vehicle*)spr, sprite_idx);
+                    lightfx_add_lights_magic_vehicle((Vehicle*)spr);
                 }
 #endif
                 break;

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -115,7 +115,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 #ifdef __ENABLE_LIGHTFX__
                 if (lightfx_for_vehicles_is_available())
                 {
-                    lightfx_add_lights_magic_vehicle((Vehicle*)spr);
+                    lightfx_add_lights_magic_vehicle(reinterpret_cast<Vehicle*>((const_cast<rct_sprite*>(spr))));
                 }
 #endif
                 break;

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -10,6 +10,7 @@
 #include "Paint.Sprite.h"
 
 #include "../../drawing/Drawing.h"
+#include "../../drawing/LightFX.h"
 #include "../../interface/Viewport.h"
 #include "../../peep/Staff.h"
 #include "../../ride/RideData.h"
@@ -17,8 +18,6 @@
 #include "../../ride/VehiclePaint.h"
 #include "../../world/Sprite.h"
 #include "../Paint.h"
-
-#include <openrct2/drawing/LightFX.h>
 
 /**
  * Paint Quadrant

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -17,6 +17,7 @@
 #include "../../ride/VehiclePaint.h"
 #include "../../world/Sprite.h"
 #include "../Paint.h"
+
 #include <openrct2\drawing\LightFX.h>
 
 /**
@@ -112,12 +113,12 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         {
             case SPRITE_IDENTIFIER_VEHICLE:
                 vehicle_paint(session, (Vehicle*)spr, image_direction);
-                #ifdef __ENABLE_LIGHTFX__
-                                if (lightfx_for_vehicles_is_available())
-                                {
-                                    lightfx_add_lights_magic_vehicles((Vehicle*)spr, sprite_idx);
-                                }
-                #endif
+#ifdef __ENABLE_LIGHTFX__
+                if (lightfx_for_vehicles_is_available())
+                {
+                    lightfx_add_lights_magic_vehicles((Vehicle*)spr, sprite_idx);
+                }
+#endif
                 break;
             case SPRITE_IDENTIFIER_PEEP:
                 peep_paint(session, (Peep*)spr, image_direction);

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -17,6 +17,7 @@
 #include "../../ride/VehiclePaint.h"
 #include "../../world/Sprite.h"
 #include "../Paint.h"
+#include <openrct2\drawing\LightFX.h>
 
 /**
  * Paint Quadrant
@@ -111,6 +112,12 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
         {
             case SPRITE_IDENTIFIER_VEHICLE:
                 vehicle_paint(session, (Vehicle*)spr, image_direction);
+                #ifdef __ENABLE_LIGHTFX__
+                                if (lightfx_for_vehicles_is_available())
+                                {
+                                    lightfx_add_lights_magic_vehicles((Vehicle*)spr, sprite_idx);
+                                }
+                #endif
                 break;
             case SPRITE_IDENTIFIER_PEEP:
                 peep_paint(session, (Peep*)spr, image_direction);

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -18,7 +18,7 @@
 #include "../../world/Sprite.h"
 #include "../Paint.h"
 
-#include <openrct2\drawing\LightFX.h>
+#include <openrct2/drawing/LightFX.h>
 
 /**
  * Paint Quadrant


### PR DESCRIPTION
Light effects now only adds lights for vehicles on screen. Only minor lag when many vehicles are on screen. Added option to turn on/off ride lights.

Before:
![Annotation 2020-03-19 110021](https://user-images.githubusercontent.com/62322762/77018239-f6072980-69d0-11ea-990e-5e6a315b6141.jpg)

After:
![Annotation 2020-03-19 105916](https://user-images.githubusercontent.com/62322762/77018268-06b79f80-69d1-11ea-9fbb-f380c9a5d3fa.jpg)