### PR TITLE
Fix #11001: Rides list does not use natural sorting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#10904] RCT1/LL-scenarios with red water won't open.
 - Fix: [#10941] The Clear Scenery tool gives refunds for ghost elements.
 - Fix: [#10963] Light effects are drawn off-centre in some rotations.
+- Fix: [#11001] Rides list does not use natural sorting
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.
 - Improved: [#10884] Added y-axes and labels to park window charts.

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/network/network.h>
 #include <openrct2/sprites.h>
+#include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
 
@@ -805,7 +806,7 @@ void window_ride_list_refresh_list(rct_window* w)
                     if (otherRide != nullptr)
                     {
                         auto strB = otherRide->GetName();
-                        if (_strcmpi(strA.c_str(), strB.c_str()) >= 0)
+                        if (strlogicalcmp(strA.c_str(), strB.c_str()) >= 0)
                             break;
 
                         window_bubble_list_item(w, current_list_position);


### PR DESCRIPTION
Closes #11001 

~I'm adding a library called "[alphanum](http://www.davekoelle.com/files/alphanum.hpp)", it is described in detail on [davekoelle's page](http://www.davekoelle.com/alphanum.html), but is summarized as:~

~> People sort strings with numbers differently than software does. Most sorting algorithms compare ASCII values, which produces an ordering that is inconsistent with human logic. Here's how to fix it.~

~I've made just three changes to it:~
~- Use `#pragma once`~
~- Suppress "assignment within conditional expression" warning~
~- Remove a usage of `std::binary_function` which is deprecated in C++17~

![image](https://user-images.githubusercontent.com/6443427/77362693-2253da80-6d30-11ea-9315-03a496c71da8.png)
![image](https://user-images.githubusercontent.com/6443427/77362708-2aac1580-6d30-11ea-882a-7f90f569e994.png)
![image](https://user-images.githubusercontent.com/6443427/77362739-37306e00-6d30-11ea-9977-a58752fc1f6c.png)
