### PR TITLE
Fix #10993: Guest Count Intent Not Listened To

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#10904] RCT1/LL-scenarios with red water won't open.
 - Fix: [#10941] The Clear Scenery tool gives refunds for ghost elements.
 - Fix: [#10963] Light effects are drawn off-centre in some rotations.
+- Fix: [#10993] Bottom toolbar not refreshing when a guest leaves the park.
 - Fix: [#11001] Rides list does not use natural sorting.
 - Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
 - Improved: [#10858] Added horizontal grid lines to finance charts.

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -413,6 +413,12 @@ public:
                 window_invalidate_by_class(WC_GUEST_LIST);
                 break;
 
+            case INTENT_ACTION_UPDATE_GUEST_COUNT:
+                gToolbarDirtyFlags |= BTM_TB_DIRTY_FLAG_PEEP_COUNT;
+                window_invalidate_by_class(WC_GUEST_LIST);
+                window_invalidate_by_class(WC_PARK_INFORMATION);
+                break;
+
             case INTENT_ACTION_UPDATE_PARK_RATING:
                 gToolbarDirtyFlags |= BTM_TB_DIRTY_FLAG_PARK_RATING;
                 window_invalidate_by_class(WC_PARK_INFORMATION);


### PR DESCRIPTION
This fixes the bug mentioned in #10993. 

`INTENT_ACTION_UPDATE_GUEST_COUNT` was not handled by `WindowManager.cpp`, causing the guest count not to redraw whenever a guest leaves. 

I just tested and the toolbar, guest list, and park information window all redraw correctly on guest leave. 