### PR TITLE
Fix: Object selector x button behaviour

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.
 - Fix: [#11005] Company value overflows.
+- Fix: [#11010] #6024 Object selector X button closes scenario and track editors.
 - Fix: [#11027] Third color on walls becomes black when saving.
 - Fix: [#11063] Scrolling position persists when switching tabs in the scenery window.
 - Fix: [#11106] Crash on getting invalid vehicle index.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,7 +32,6 @@
 - Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.
 - Fix: [#11005] Company value overflows.
-- Fix: [#11010] #6024 Object selector X button closes scenario and track editors.
 - Fix: [#11027] Third color on walls becomes black when saving.
 - Fix: [#11063] Scrolling position persists when switching tabs in the scenery window.
 - Fix: [#11106] Crash on getting invalid vehicle index.
@@ -44,6 +43,7 @@
 - Fix: [#11258] Properly remove format codes from imported strings.
 - Fix: [#11286] Fix banner tooltip colour.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
+- Improved: [#6024] The close button in the object selection now advances to the next step.
 - Improved: [#11157] Slimmer virtual floor lines.
 
 0.2.5 (2020-03-24)

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
+#include <openrct2/EditorObjectSelectionSession.h>
 #include <openrct2/Game.h>
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
@@ -225,21 +226,14 @@ void window_editor_bottom_toolbar_jump_forward_from_object_selection()
     if (!window_editor_bottom_toolbar_check_object_selection())
         return;
 
+    finish_object_selection();
     if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
     {
-        set_every_ride_type_invented();
-        set_every_ride_entry_invented();
         context_open_window(WC_CONSTRUCT_RIDE);
-        gS6Info.editor_step = EDITOR_STEP_ROLLERCOASTER_DESIGNER;
-        gfx_invalidate_screen();
     }
     else
     {
-        set_all_scenery_items_invented();
-        scenery_set_default_placement_configuration();
-        gS6Info.editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
         context_open_window(WC_MAP);
-        gfx_invalidate_screen();
     }
 }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -462,15 +462,10 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
+            window_close(w);
             if (gScreenFlags & SCREEN_FLAGS_EDITOR)
             {
-                window_close(w);
                 finish_object_selection();
-            }
-            else
-            {
-                // Used for in-game object selection cheat
-                window_close(w);
             }
             break;
         case WIDX_FILTER_RIDE_TAB_ALL:

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -464,8 +464,8 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
         case WIDX_CLOSE:
             if (gScreenFlags & SCREEN_FLAGS_EDITOR)
             {
-                auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt, PM_SAVE_BEFORE_QUIT);
-                GameActions::Execute(&loadOrQuitAction);
+                window_close(w);
+                finish_object_selection();
             }
             else
             {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -20,6 +20,7 @@
 #include "object/ObjectManager.h"
 #include "object/ObjectRepository.h"
 #include "ride/RideData.h"
+#include "scenario/Scenario.h"
 #include "windows/Intent.h"
 #include "world/Footpath.h"
 #include "world/LargeScenery.h"
@@ -372,6 +373,24 @@ void reset_selected_object_count_and_size()
         {
             _numSelectedObjectsForType[objectType]++;
         }
+    }
+}
+
+void finish_object_selection()
+{
+    if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
+    {
+        set_every_ride_type_invented();
+        set_every_ride_entry_invented();
+        gS6Info.editor_step = EDITOR_STEP_ROLLERCOASTER_DESIGNER;
+        gfx_invalidate_screen();
+    }
+    else
+    {
+        set_all_scenery_items_invented();
+        scenery_set_default_placement_configuration();
+        gS6Info.editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
+        gfx_invalidate_screen();
     }
 }
 

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-enum INPUT_FLAGS
+enum EDITOR_INPUT_FLAGS
 {
     INPUT_FLAG_EDITOR_OBJECT_1 = (1 << 1),
     INPUT_FLAG_EDITOR_OBJECT_2 = (1 << 2),

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "Editor.h"
 #include "common.h"
 #include "object/Object.h"
 
@@ -30,6 +31,7 @@ void editor_object_flags_free();
 void unload_unselected_objects();
 void sub_6AB211();
 void reset_selected_object_count_and_size();
+void finish_object_selection();
 int32_t window_editor_object_selection_select_object(uint8_t bh, int32_t flags, const rct_object_entry* entry);
 
 /**

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "Editor.h"
 #include "common.h"
 #include "object/Object.h"
 


### PR DESCRIPTION
Previously in scenario editor and track designer, the X button for the object selector would close the entire scenario editor and track designer, returning the user to the main menu. This is counter intuitive for the x button to close everything down instead of just the window it belongs to. Now it closes the object selector window and advance to the next stage of the scenario editor/track designer

The x button for the object selector in the cheat menu remains the same.