### PR TITLE
Fix #11005: Company value overflows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Fix: [#475] Water sides drawn incorrectly (original bug).
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).
 - Fix: [#7094] Back wall edge texture in water missing.
+- Fix: [#11005] Company value overflows.
 - Fix: [#11027] Third color on walls becomes black when saving.
 
 0.2.5 (2020-03-24)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -517,11 +517,10 @@ money32 Park::CalculateRideValue(const Ride* ride) const
 
 money32 Park::CalculateCompanyValue() const
 {
-    money32 result = finance_get_current_cash();
+    money32 result = gParkValue - gBankLoan;
 
-    // Clamp addition and substraction to prevent overflow
-    result = add_clamp_money32(result, -gBankLoan);
-    result = add_clamp_money32(result, gParkValue);
+    // Clamp addition to prevent overflow
+    result = add_clamp_money32(result, finance_get_current_cash());
 
     return result;
 }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -33,6 +33,7 @@
 #include "../ride/RideData.h"
 #include "../ride/ShopItem.h"
 #include "../scenario/Scenario.h"
+#include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "Entrance.h"
 #include "Map.h"
@@ -516,14 +517,13 @@ money32 Park::CalculateRideValue(const Ride* ride) const
 
 money32 Park::CalculateCompanyValue() const
 {
-    // Cast the sum to a 64-bit value
-    money64 result = (money64)finance_get_current_cash() + (money64)gParkValue - (money64)gBankLoan;
+    money32 result = finance_get_current_cash();
 
-    // Clamp the result to the range of a 32-bit value
-    result = result < INT32_MIN ? INT32_MIN : result;
-    result = result > INT32_MAX ? INT32_MAX : result;
+    // Clamp addition and substraction to prevent overflow
+    result = add_clamp_money32(result, -gBankLoan);
+    result = add_clamp_money32(result, gParkValue);
 
-    return (money32)result;
+    return result;
 }
 
 money16 Park::CalculateTotalRideValueForMoney() const

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -516,7 +516,14 @@ money32 Park::CalculateRideValue(const Ride* ride) const
 
 money32 Park::CalculateCompanyValue() const
 {
-    return finance_get_current_cash() + gParkValue - gBankLoan;
+    // Cast the sum to a 64-bit value
+    money64 result = (money64)finance_get_current_cash() + (money64)gParkValue - (money64)gBankLoan;
+
+    // Clamp the result to the range of a 32-bit value
+    result = result < INT32_MIN ? INT32_MIN : result;
+    result = result > INT32_MAX ? INT32_MAX : result;
+
+    return (money32)result;
 }
 
 money16 Park::CalculateTotalRideValueForMoney() const


### PR DESCRIPTION
In #11005, the company value overflows when the park cash is equal to `INT_MAX`, a ride is built and opened. This is fixed by clamping the company value between `INT_MIN` and `INT_MAX`. I just tested it and it works.

![fix11005](https://user-images.githubusercontent.com/40113382/77451844-8096c100-6df5-11ea-8312-23d0e0521f1c.gif)
