### PR TITLE
Rework GuestList to use a vector.

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -417,6 +417,7 @@ public:
                 gToolbarDirtyFlags |= BTM_TB_DIRTY_FLAG_PEEP_COUNT;
                 window_invalidate_by_class(WC_GUEST_LIST);
                 window_invalidate_by_class(WC_PARK_INFORMATION);
+                window_guest_list_refresh_list();
                 break;
 
             case INTENT_ACTION_UPDATE_PARK_RATING:

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -220,7 +220,6 @@ rct_window* window_guest_list_open()
     window_guest_list_widgets[WIDX_FILTER_BY_NAME].type = WWT_FLATBTN;
     window_guest_list_widgets[WIDX_PAGE_DROPDOWN].type = WWT_EMPTY;
     window_guest_list_widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WWT_EMPTY;
-    window->var_492 = 0;
     window->min_width = 350;
     window->min_height = 330;
     window->max_width = 500;
@@ -518,12 +517,11 @@ static void window_guest_list_update(rct_window* w)
  */
 static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    int32_t i, y;
+    int32_t y = 0;
     switch (_window_guest_list_selected_tab)
     {
         case PAGE_INDIVIDUAL:
             // Count the number of guests
-            w->var_492 = static_cast<int16_t>(GuestList.size());
             y = static_cast<int16_t>(GuestList.size()) * SCROLLABLE_ROW_HEIGHT;
             _window_guest_list_num_pages = 1 + (static_cast<int16_t>(GuestList.size()) - 1) / GUESTS_PER_PAGE;
             if (_window_guest_list_num_pages == 0)
@@ -534,7 +532,6 @@ static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, 
         case PAGE_SUMMARISED:
             // Find the groups
             window_guest_list_find_groups();
-            w->var_492 = _window_guest_list_num_groups;
             y = _window_guest_list_num_groups * SUMMARISED_GUEST_ROW_HEIGHT;
             break;
         default:
@@ -551,7 +548,7 @@ static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, 
         w->Invalidate();
     }
 
-    i = y - window_guest_list_widgets[WIDX_GUEST_LIST].bottom + window_guest_list_widgets[WIDX_GUEST_LIST].top + 21;
+    auto i = y - window_guest_list_widgets[WIDX_GUEST_LIST].bottom + window_guest_list_widgets[WIDX_GUEST_LIST].top + 21;
     if (i < 0)
         i = 0;
     if (i < w->scrolls[0].v_top)
@@ -570,7 +567,7 @@ static void window_guest_list_scrollgetsize(rct_window* w, int32_t scrollIndex, 
  */
 static void window_guest_list_scrollmousedown(rct_window* w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
 {
-    int32_t i;
+    int32_t i = 0;
 
     switch (_window_guest_list_selected_tab)
     {
@@ -721,11 +718,10 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         x = w->windowPos.x + 4;
         y = w->windowPos.y + window_guest_list_widgets[WIDX_GUEST_LIST].bottom + 2;
-        set_format_arg(0, int16_t, w->var_492);
+        set_format_arg(0, int16_t, static_cast<int16_t>(GuestList.size()));
         gfx_draw_string_left(
-            dpi, (w->var_492 == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL), gCommonFormatArgs,
+            dpi, (GuestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL), gCommonFormatArgs,
             COLOUR_BLACK, x, y);
-        assert(w->var_492 == static_cast<int16_t>(GuestList.size()));
     }
 }
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3241,7 +3241,7 @@ rct_string_id get_real_name_string_id_from_id(uint32_t id)
     return dx;
 }
 
-static int32_t peep_compare(const void* sprite_index_a, const void* sprite_index_b)
+int32_t peep_compare(const void* sprite_index_a, const void* sprite_index_b)
 {
     Peep const* peep_a = GET_PEEP(*(uint16_t*)sprite_index_a);
     Peep const* peep_b = GET_PEEP(*(uint16_t*)sprite_index_b);

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -988,6 +988,7 @@ void peep_window_state_update(Peep* peep);
 void peep_decrement_num_riders(Peep* peep);
 
 void peep_set_map_tooltip(Peep* peep);
+int32_t peep_compare(const void* sprite_index_a, const void* sprite_index_b);
 
 void SwitchToSpecialSprite(Peep* peep, uint8_t special_sprite_id);
 void peep_update_name_sort(Peep* peep);


### PR DESCRIPTION
This is part of a chain of refactors that will be used to rework peep order in the sprite list.
I basically want to change it so that peep order in the sprite list does not matter as that will make it easier to handle.

It has the added bonus of simplifying the code for the guest list.
Same change still needs to be made to the staff list before peep order can be changed.

~~Todo: Can remove assignments to `var_492` to simplify code as well.~~

There will be a small performance penalty with this new version of the code but its hard to tell if its any greater than the performance of the old code.