### PR TITLE
[WIP] Filter track designs by available scenery/vehicles

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3676,6 +3676,8 @@ STR_6359    :{POP16}{POP16}Page {UINT16}
 STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
 STR_6361    :Enable lighting effects on rides (experimental)
 STR_6362    :{SMALLFONT}{BLACK}If enabled, vehicles for tracked rides will be lit up at night.
+STR_6363    :Hide unavailable designs
+STR_6364    :{SMALLFONT}{BLACK}Hides track designs with unavailable scenery or vehicles
 
 #############
 # Scenarios #

--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -240,6 +240,8 @@ STR_6212    :Gray sandstone
 STR_6274    :Can't set color scheme...
 STR_6307    :Color scheme: {BLACK}{STRINGID}
 STR_6328    :{SMALLFONT}{BLACK}With this option enabled, giant screenshots will have a transparent background instead of the default black color.
+STR_6363    :Hide unavailable designs
+STR_6364    :{SMALLFONT}{BLACK}Hides track designs with unavailable scenery or vehicles
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3909,6 +3909,9 @@ enum
     STR_ENABLE_LIGHTING_VEHICLES = 6361,
     STR_ENABLE_LIGHTING_VEHICLES_TIP = 6362,
 
+    STR_FILTER_UNAVAILABLE = 6363,
+    STR_FILTER_UNAVAILABLE_TIP = 6364,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };


### PR DESCRIPTION
I am attempting to implement the feature that was requested in #10675, by adding a checkbox to the track list which allows the player to filter the designs based on the availability of scenery and vehicles.

![image](https://user-images.githubusercontent.com/40113382/77558521-51e31e00-6ebb-11ea-83af-7cf96f5a0940.png)

However, in its current state it is not functioning correctly. I filter the track list by looping through all track designs, loading each of them and attempting to read the `TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE` and `TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE` flags. If one of these flags is set for a design, it will not pass the filter.

Moreover, to make sure it works with filtering on the name, I have modified the string filter such that a track design passes through the two filters. First, it passes through the string filter and then it passes through the availability filter. If it manages to pass these filters, the track design gets added to the list of filtered track id's.

Right now, it appears as though the availability flags are both not set, even though they should be set for some rides, so no availibility filtering is actually happening. Perhaps I am forgetting something? I am not sure. Also, I get occasional crashes when filtering by name, this has only happened with my modified code, so it is not a bug in `develop`.

Any help would be appreciated, thanks.