### PR TITLE
Rework StaffList to use a vector

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -362,11 +362,7 @@ public:
 
             case INTENT_ACTION_REFRESH_STAFF_LIST:
             {
-                auto w = window_find_by_class(WC_STAFF_LIST);
-                if (w != nullptr)
-                {
-                    w->no_list_items = 0;
-                }
+                WindowStaffListRefresh();
                 break;
             }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -188,9 +188,6 @@ void WindowStaffListRefresh()
     {
         return;
     }
-
-    w->no_list_items = 0;
-
     StaffList.clear();
     Peep* peep = nullptr;
     uint16_t spriteIndex;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -28,6 +28,7 @@
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Sprite.h>
+#include <vector>
 
 // clang-format off
 enum {
@@ -37,6 +38,7 @@ enum {
     WINDOW_STAFF_LIST_TAB_ENTERTAINERS
 };
 
+static std::vector<uint16_t> StaffList;
 static bool _quick_fire_mode = false;
 
 static void window_staff_list_close(rct_window *w);
@@ -125,7 +127,6 @@ static rct_widget window_staff_list_widgets[] = {
     { WIDGETS_END },
 };
 
-static uint16_t _window_staff_list_selected_type_count = 0;
 static int32_t _windowStaffListHighlightedIndex;
 static int32_t _windowStaffListSelectedTab = WINDOW_STAFF_LIST_TAB_HANDYMEN;
 
@@ -176,7 +177,34 @@ rct_window* window_staff_list_open()
     window->max_height = MAX_WH;
     _quick_fire_mode = false;
 
+    WindowStaffListRefresh();
     return window;
+}
+
+void WindowStaffListRefresh()
+{
+    auto w = window_find_by_class(WC_STAFF_LIST);
+    if (w == nullptr)
+    {
+        return;
+    }
+
+    w->no_list_items = 0;
+
+    StaffList.clear();
+    Peep* peep = nullptr;
+    uint16_t spriteIndex;
+    FOR_ALL_STAFF (spriteIndex, peep)
+    {
+        sprite_set_flashing(peep, false);
+        if (peep->staff_type != _windowStaffListSelectedTab)
+            continue;
+        sprite_set_flashing(peep, true);
+
+        StaffList.push_back(spriteIndex);
+    }
+
+    std::sort(StaffList.begin(), StaffList.end(), [](const uint16_t a, const uint16_t b) { return peep_compare(&a, &b) < 0; });
 }
 
 static void window_staff_list_cancel_tools(rct_window* w)
@@ -328,6 +356,10 @@ void window_staff_list_update(rct_window* w)
             }
         }
     }
+
+    // Note this may be slow if number of staff increases a large amount.
+    // See GuestList for fix (more intents) if required.
+    WindowStaffListRefresh();
 }
 
 /**
@@ -416,27 +448,15 @@ void window_staff_list_toolabort(rct_window* w, rct_widgetindex widgetIndex)
  */
 void window_staff_list_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    int32_t i, spriteIndex;
-    Peep* peep;
-
-    uint16_t staffCount = 0;
-    FOR_ALL_STAFF (spriteIndex, peep)
-    {
-        if (peep->staff_type == _windowStaffListSelectedTab)
-            staffCount++;
-    }
-
-    _window_staff_list_selected_type_count = staffCount;
-
     if (_windowStaffListHighlightedIndex != -1)
     {
         _windowStaffListHighlightedIndex = -1;
         w->Invalidate();
     }
 
-    *height = staffCount * SCROLLABLE_ROW_HEIGHT;
-    i = *height - window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + window_staff_list_widgets[WIDX_STAFF_LIST_LIST].top
-        + 21;
+    *height = static_cast<int16_t>(StaffList.size()) * SCROLLABLE_ROW_HEIGHT;
+    auto i = *height - window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom
+        + window_staff_list_widgets[WIDX_STAFF_LIST_LIST].top + 21;
     if (i < 0)
         i = 0;
     if (i < w->scrolls[0].v_top)
@@ -454,15 +474,9 @@ void window_staff_list_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t
  */
 void window_staff_list_scrollmousedown(rct_window* w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
 {
-    int32_t i, spriteIndex;
-    Peep* peep;
-
-    i = screenCoords.y / SCROLLABLE_ROW_HEIGHT;
-    FOR_ALL_STAFF (spriteIndex, peep)
+    int32_t i = screenCoords.y / SCROLLABLE_ROW_HEIGHT;
+    for (auto spriteIndex : StaffList)
     {
-        if (peep->staff_type != _windowStaffListSelectedTab)
-            continue;
-
         if (i == 0)
         {
             if (_quick_fire_mode)
@@ -472,6 +486,7 @@ void window_staff_list_scrollmousedown(rct_window* w, int32_t scrollIndex, const
             }
             else
             {
+                auto peep = GET_PEEP(spriteIndex);
                 auto intent = Intent(WC_PEEP);
                 intent.putExtra(INTENT_EXTRA_PEEP, peep);
                 context_open_intent(&intent);
@@ -627,12 +642,12 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     int32_t staffTypeStringId = StaffNamingConvention[selectedTab].plural;
     // If the number of staff for a given type is 1, we use the singular forms of the names
-    if (_window_staff_list_selected_type_count == 1)
+    if (StaffList.size() == 1)
     {
         staffTypeStringId = StaffNamingConvention[selectedTab].singular;
     }
 
-    set_format_arg(0, uint16_t, _window_staff_list_selected_type_count);
+    set_format_arg(0, uint16_t, static_cast<uint16_t>(StaffList.size()));
     set_format_arg(2, rct_string_id, staffTypeStringId);
 
     gfx_draw_string_left(

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -64,6 +64,7 @@ rct_window* window_shortcut_change_open(int32_t selected_key);
 rct_window* window_shortcut_keys_open();
 rct_window* window_staff_list_open();
 rct_window* window_staff_open(Peep* peep);
+void WindowStaffListRefresh();
 rct_window* window_themes_open();
 rct_window* window_title_exit_open();
 rct_window* window_title_logo_open();


### PR DESCRIPTION
This is a part of a reworking that removes the need for the peep list to be sorted by name/number order. Ultimately simplifying the sprite create code.

There will be a very minor performance impact of this new code as it is running every tick that the staff list is open. As the max number of staff is low this is not at present an issue. It would need looked at in the future to use intents to invalidate the list on fire/hire/death to handle this more efficient (like the guest list does).