### PR TITLE
Add missing check for valid scenery type

### DIFF
--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -601,6 +601,7 @@ void ride_entry_set_invented(int32_t rideEntryIndex)
 
 bool scenery_is_invented(const ScenerySelection& sceneryItem)
 {
+    assert(sceneryItem.SceneryType < SCENERY_TYPE_COUNT);
     return _researchedSceneryItems[sceneryItem.SceneryType][sceneryItem.EntryIndex];
 }
 


### PR DESCRIPTION
Regression from #10922

[10922.sv6.gz](https://github.com/OpenRCT2/OpenRCT2/files/4389978/10922.sv6.gz)
