### PR TITLE
Fix #11068: segfault when trying to clear empty list

### DIFF
--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -337,7 +337,10 @@ static void window_track_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
             // Keep the highlighted item selected
             if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
             {
-                w->selected_list_item = _filteredTrackIds[w->selected_list_item];
+                if (w->selected_list_item != -1 && _filteredTrackIds.size() > static_cast<size_t>(w->selected_list_item))
+                    w->selected_list_item = _filteredTrackIds[w->selected_list_item];
+                else
+                    w->selected_list_item = -1;
             }
             else
             {


### PR DESCRIPTION
The report in #11068 was using track designs manager with "Boat hire"
ride, for which there were no designs and selecting "Clear" button on
the list accessed empty vector in `_filteredTrackIds`.

![screenshot(8)](https://user-images.githubusercontent.com/550290/77701566-e8e0d080-6fb6-11ea-9280-76304b50ac94.png)
