### PR TITLE
Remove peep sort

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -438,8 +438,6 @@ void game_fix_save_vars()
 
     gNumGuestsInPark = peepCount;
 
-    peep_sort();
-
     // Peeps to remove have to be cached here, as removing them from within the loop breaks iteration
     std::vector<Peep*> peepsToRemove;
 

--- a/src/openrct2/actions/GuestSetNameAction.hpp
+++ b/src/openrct2/actions/GuestSetNameAction.hpp
@@ -86,8 +86,6 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_CANT_NAME_GUEST, STR_NONE);
         }
 
-        peep_update_name_sort(peep);
-
         // Easter egg functions are for guests only
         Guest* guest = peep->AsGuest();
 

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -248,8 +248,6 @@ private:
             newPeep->energy_target = 0x60;
             newPeep->staff_mowing_timeout = 0;
 
-            peep_update_name_sort(newPeep);
-
             newPeep->staff_id = staffIndex;
 
             gStaffModes[staffIndex] = STAFF_MODE_WALK;

--- a/src/openrct2/actions/StaffSetNameAction.hpp
+++ b/src/openrct2/actions/StaffSetNameAction.hpp
@@ -90,8 +90,6 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::UNKNOWN, STR_CANT_NAME_GUEST, STR_NONE);
         }
 
-        peep_update_name_sort(peep);
-
         gfx_invalidate_screen();
 
         auto intent = Intent(INTENT_ACTION_REFRESH_STAFF_LIST);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -991,8 +991,6 @@ void peep_set_map_tooltip(Peep* peep);
 int32_t peep_compare(const void* sprite_index_a, const void* sprite_index_b);
 
 void SwitchToSpecialSprite(Peep* peep, uint8_t special_sprite_id);
-void peep_update_name_sort(Peep* peep);
-void peep_sort();
 void peep_update_names(bool realNames);
 
 void guest_set_name(uint16_t spriteIndex, const char* name);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1548,8 +1548,6 @@ private:
 
         dst->item_standard_flags = src->item_standard_flags;
 
-        peep_update_name_sort(dst);
-
         if (dst->type == PEEP_TYPE_GUEST)
         {
             if (dst->outside_of_park && dst->state != PEEP_STATE_LEAVING_PARK)


### PR DESCRIPTION
Peep Sort is no longer required after #11059 and #11014. Peeps are now only sorted in a temporary vector when the staff or guest list is open. This allows for simpler allocation of sprites for the new save format.

Also fixed the small graphical bug when you switch the guest real names whilst guest list is open.