### PR TITLE
Fix #11111: Finance graph hover values are glitchy with software renderer

### DIFF
--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -811,7 +811,8 @@ static void window_finances_financial_graph_update(rct_window* w)
     // Tab animation
     if (++w->frame_no >= WindowFinancesTabAnimationLoops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_2);
+
+    w->Invalidate();
 }
 
 /**
@@ -918,7 +919,8 @@ static void window_finances_park_value_graph_update(rct_window* w)
     // Tab animation
     if (++w->frame_no >= WindowFinancesTabAnimationLoops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_2);
+
+    w->Invalidate();
 }
 
 /**


### PR DESCRIPTION
The new finance graph guides (#10925) did not invalidate the window, so they were rendered incompletely or not at all if no sprites were active behind the window.

The window already had update events for both graph tabs, but these were only updating the tab widgets for their animations. This changes it such that the entire window is invalidated. I'm not sure this is the best solution; this seems a little wasteful.

It would be better to only invalidate the window if mouse movement is detected, but to my knowledge, we don't support a `mouseover` event.