### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/openrct2/thirdparty/filesystem.hpp
+++ b/src/openrct2/thirdparty/filesystem.hpp
@@ -45,6 +45,8 @@
 #define GHC_OS_MACOS
 #elif defined(__linux__)
 #define GHC_OS_LINUX
+#elif defined(__FreeBSD__)
+#define GHC_OS_FREEBSD
 #if defined(__ANDROID__)
 #define GHC_OS_ANDROID
 #endif


### PR DESCRIPTION
Otherwise build fails, this will be also the case for other systems where OpenRCT2 builds, like OpenBSD.