### PR TITLE
Fix #11063: Reset scroll position when switching scenery tab

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -701,6 +701,11 @@ static void window_scenery_mousedown(rct_window* w, rct_widgetindex widgetIndex,
 
     if (widgetIndex >= WIDX_SCENERY_TAB_1 && widgetIndex <= WIDX_SCENERY_TAB_20)
     {
+        // Reset scroll position if moving to another tab
+        if (gWindowSceneryActiveTabIndex != widgetIndex - WIDX_SCENERY_TAB_1)
+        {
+            w->scrolls[0].v_top = 0;
+        }
         gWindowSceneryActiveTabIndex = widgetIndex - WIDX_SCENERY_TAB_1;
         w->Invalidate();
         gSceneryPlaceCost = MONEY32_UNDEFINED;


### PR DESCRIPTION
Corresponds to issue #11063 
Fixed the issue by resetting scroll position when another tab in the scenery window is clicked. I'm not sure if this is the correct/safe way to do this.

I'm unsure how the scroll struct works exactly. I found that all references to it in Scenery.cpp always use w->scrolls[0], even though the rct_window struct contains an array with 3 instances of the rct_scroll struct.
Resetting the scroll position by doing: `w->scrolls->v_top = 0` also worked.

I'm not that experienced with C++ so maybe I'm just not understanding something correctly.