### PR TITLE
Fix #6530: Make land tools work consistently on park borders

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#11231] Change shortcut window list order to be more intuitive, and split it into logical sections.
 - Fix: [#11072] Land and water tools working out of bounds (original bug).
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.
+- Improved: [#6530] Allow water and land height changes on park borders.
 
 0.2.6 (2020-04-17)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -141,7 +141,7 @@ private:
         }
 
         if (!withinOwnership)
-        { 
+        {
             GameActionResult::Ptr ownerShipResult = std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, STR_LAND_NOT_OWNED_BY_PARK);
             ownerShipResult->ErrorTitle = STR_CANT_RAISE_LAND_HERE;
             return ownerShipResult;

--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -142,7 +142,8 @@ private:
 
         if (!withinOwnership)
         {
-            GameActionResult::Ptr ownerShipResult = std::make_unique<GameActionResult>(GA_ERROR::DISALLOWED, STR_LAND_NOT_OWNED_BY_PARK);
+            GameActionResult::Ptr ownerShipResult = std::make_unique<GameActionResult>(
+                GA_ERROR::DISALLOWED, STR_LAND_NOT_OWNED_BY_PARK);
             ownerShipResult->ErrorTitle = STR_CANT_RAISE_LAND_HERE;
             return ownerShipResult;
         }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -878,8 +878,17 @@ uint8_t map_get_lowest_land_height(const MapRange& range)
         for (int32_t xi = validRange.GetLeft(); xi <= validRange.GetRight(); xi += COORDS_XY_STEP)
         {
             auto* surfaceElement = map_get_surface_element_at(CoordsXY{ xi, yi });
+
             if (surfaceElement != nullptr && min_height > surfaceElement->base_height)
             {
+                if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
+                {
+                    if (!map_is_location_in_park(CoordsXY{ xi, yi }))
+                    {
+                        continue;
+                    }
+                }
+
                 min_height = surfaceElement->base_height;
             }
         }
@@ -901,6 +910,14 @@ uint8_t map_get_highest_land_height(const MapRange& range)
             auto* surfaceElement = map_get_surface_element_at(CoordsXY{ xi, yi });
             if (surfaceElement != nullptr)
             {
+                if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
+                {
+                    if (!map_is_location_in_park(CoordsXY{ xi, yi }))
+                    {
+                        continue;
+                    }
+                }
+
                 uint8_t base_height = surfaceElement->base_height;
                 if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
                     base_height += 2;


### PR DESCRIPTION
This PR makes it possible to adjust the water and land height inside of the park even when the area includes land that is not owned. The land that isn't owned is ignored, only when none of the land in the selected area is owned will the error message (Like: "Can't raise land here... Land not owned by park!") appear.

Fixes #6530.

![Ignore out of park messages when overlapping with the inside of the park](https://user-images.githubusercontent.com/2348094/78027765-32863e00-735e-11ea-9d95-a58eabd419f3.png)
