### PR TITLE
Add drawing code for ō

### DIFF
--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -59,6 +59,7 @@ static const std::unordered_map<char32_t, int32_t> codepointOffsetMap = {
     { UnicodeChar::n_acute, CSChar::n_acute - CS_SPRITE_FONT_OFFSET },
     { UnicodeChar::n_caron_uc, SPR_G2_N_CARON_UPPER - SPR_CHAR_START },
     { UnicodeChar::n_caron, SPR_G2_N_CARON_LOWER - SPR_CHAR_START },
+    { UnicodeChar::o_macron, CSChar::o_circumflex - CS_SPRITE_FONT_OFFSET }, // No visual difference
     { UnicodeChar::o_double_acute_uc, SPR_G2_O_DOUBLE_ACUTE_UPPER - SPR_CHAR_START },
     { UnicodeChar::o_double_acute, SPR_G2_O_DOUBLE_ACUTE_LOWER - SPR_CHAR_START },
     { UnicodeChar::r_caron_uc, SPR_G2_R_CARON_UPPER - SPR_CHAR_START },

--- a/src/openrct2/localisation/FormatCodes.h
+++ b/src/openrct2/localisation/FormatCodes.h
@@ -134,6 +134,7 @@ namespace CSChar
     constexpr char32_t c_acute = 0xDE;
     constexpr char32_t e_ogonek = 0xE6;
     constexpr char32_t n_acute = 0xF0;
+    constexpr char32_t o_circumflex = 0xF4;
     constexpr char32_t l_stroke = 0xF7;
     constexpr char32_t s_acute = 0xF8;
     constexpr char32_t z_acute = 0xFE;
@@ -174,6 +175,7 @@ namespace UnicodeChar
     constexpr char32_t n_acute = 0x144;
     constexpr char32_t n_caron_uc = 0x147;
     constexpr char32_t n_caron = 0x148;
+    constexpr char32_t o_macron = 0x14D;
     constexpr char32_t o_double_acute_uc = 0x150;
     constexpr char32_t o_double_acute = 0x151;
     constexpr char32_t r_caron_uc = 0x158;


### PR DESCRIPTION
Put on the 0.2.6 milestone because the objects now use it. (For "shōji wall".)