### PR TITLE
Fix #11208: Cannot export parks with RCT2 DLC objects

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#11027] Third color on walls becomes black when saving.
 - Fix: [#11063] Scrolling position persists when switching tabs in the scenery window.
 - Fix: [#11126] Cannot place Frightmare track design.
+- Fix: [#11208] Cannot export parks with RCT2 DLC objects.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
 - Improved: [#11157] Slimmer virtual floor lines.
 

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -26,11 +26,6 @@ Object::Object(const rct_object_entry& entry)
     char name[DAT_NAME_LENGTH + 1] = { 0 };
     std::copy_n(entry.name, DAT_NAME_LENGTH, name);
     _identifier = String::Duplicate(name);
-
-    if (IsOpenRCT2OfficialObject())
-    {
-        SetSourceGames({ OBJECT_SOURCE_OPENRCT2_OFFICIAL });
-    }
 }
 
 Object::~Object()
@@ -103,55 +98,6 @@ std::vector<uint8_t> Object::GetSourceGames()
 void Object::SetSourceGames(const std::vector<uint8_t>& sourceGames)
 {
     _sourceGames = sourceGames;
-}
-
-bool Object::IsOpenRCT2OfficialObject()
-{
-    static const char _openRCT2OfficialObjects[][9] = {
-        // Offical extended scenery set
-        "XXBBBR01",
-        "TTRFTL02",
-        "TTRFTL03",
-        "TTRFTL04",
-        "TTRFTL07",
-        "TTRFTL08",
-        "TTPIRF02",
-        "TTPIRF03",
-        "TTPIRF04",
-        "TTPIRF05",
-        "TTPIRF07",
-        "TTPIRF08",
-        "MG-PRAR ",
-        "TTRFWD01",
-        "TTRFWD02",
-        "TTRFWD03",
-        "TTRFWD04",
-        "TTRFWD05",
-        "TTRFWD06",
-        "TTRFWD07",
-        "TTRFWD08",
-        "TTRFGL01",
-        "TTRFGL02",
-        "TTRFGL03",
-        "ACWW33  ",
-        "ACWWF32 ",
-
-        // Official DLC
-        "BIGPANDA",
-        "LITTERPA",
-        "PANDAGR ",
-        "SCGPANDA",
-        "WTRPINK ",
-        "ZPANDA  ",
-    };
-
-    for (const auto entry : _openRCT2OfficialObjects)
-    {
-        if (String::Equals(_identifier, entry))
-            return true;
-    }
-
-    return false;
 }
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -195,8 +195,6 @@ protected:
     std::string GetString(uint8_t index) const;
     std::string GetString(int32_t language, uint8_t index) const;
 
-    bool IsOpenRCT2OfficialObject();
-
 public:
     explicit Object(const rct_object_entry& entry);
     virtual ~Object();

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -656,8 +656,16 @@ bool IsObjectCustom(const ObjectRepositoryItem* object)
         return false;
     }
 
-    // Validate the object is not one from base game or expansion pack
-    return !(object->ObjectEntry.flags & 0xF0);
+    switch (object->GetFirstSourceGame())
+    {
+        case OBJECT_SOURCE_RCT2:
+        case OBJECT_SOURCE_WACKY_WORLDS:
+        case OBJECT_SOURCE_TIME_TWISTER:
+        case OBJECT_SOURCE_OPENRCT2_OFFICIAL:
+            return false;
+        default:
+            return true;
+    }
 }
 
 const rct_object_entry* object_list_find(rct_object_entry* entry)


### PR DESCRIPTION
This will now stop OpenRCT2 from trying export official objects (which everyone has anyway). At the same time, this stops marking some custom objects as official, which was a hacky approach that dates from before the JSON objects.