### PR TITLE
Load_Park feature for headless server

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -39,6 +39,7 @@
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
 #include "../peep/Staff.h"
+#include "../platform/platform.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../util/Util.h"
@@ -1316,6 +1317,19 @@ static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe
     return 1;
 }
 
+static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+{
+    if (argv.size() > 0)
+    {
+        char savePath[MAX_PATH];
+        platform_get_user_directory(savePath, "save", sizeof(savePath));
+        safe_strcat_path(savePath, argv[0].c_str(), sizeof(savePath));
+        path_append_extension(savePath, ".sv6", sizeof(savePath));
+		context_load_park_from_file(savePath);
+    }
+    return 1;
+}
+
 static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
@@ -1687,6 +1701,8 @@ static constexpr const console_command console_command_table[] = {
                                     "Loading a scenery group will not load its associated objects.\n"
                                     "This is a safer method opposed to \"open object_selection\".",
                                     "load_object <objectfilenodat>" },
+	{ "load_park", cc_load_park, "Load park", "load_park [name]" },
+ 								
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "open", cc_open, "Opens the window with the give name.", "open <window>." },
     { "quit", cc_close, "Closes the console.", "quit" },

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1325,7 +1325,7 @@ static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[mayb
         platform_get_user_directory(savePath, "save", sizeof(savePath));
         safe_strcat_path(savePath, argv[0].c_str(), sizeof(savePath));
         path_append_extension(savePath, ".sv6", sizeof(savePath));
-		context_load_park_from_file(savePath);
+        context_load_park_from_file(savePath);
     }
     return 1;
 }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1701,8 +1701,7 @@ static constexpr const console_command console_command_table[] = {
                                     "Loading a scenery group will not load its associated objects.\n"
                                     "This is a safer method opposed to \"open object_selection\".",
                                     "load_object <objectfilenodat>" },
-	{ "load_park", cc_load_park, "Load park", "load_park [name]" },
- 								
+    { "load_park", cc_load_park, "Load park", "load_park [name]" },
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "open", cc_open, "Opens the window with the give name.", "open <window>." },
     { "quit", cc_close, "Closes the console.", "quit" },

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1319,14 +1319,28 @@ static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe
 
 static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
-    if (argv.size() > 0)
+    if (argv.size() < 1)
     {
-        char savePath[MAX_PATH];
+        console.WriteFormatLine("Parameters required <filename>");
+        return 0;
+    }
+
+    char savePath[MAX_PATH];
+    if (String::IndexOf(argv[0].c_str(), '/') == SIZE_MAX && String::IndexOf(argv[0].c_str(), '\\') == SIZE_MAX)
+    {
+        // no / or \ was included. File should be in save dir.
         platform_get_user_directory(savePath, "save", sizeof(savePath));
         safe_strcat_path(savePath, argv[0].c_str(), sizeof(savePath));
-        path_append_extension(savePath, ".sv6", sizeof(savePath));
-        context_load_park_from_file(savePath);
     }
+    else
+    {
+        safe_strcpy(savePath, argv[0].c_str(), sizeof(savePath));
+    }
+    if (!String::EndsWith(savePath, ".sv6", true) && !String::EndsWith(savePath, ".sc6", true))
+    {
+        path_append_extension(savePath, ".sv6", sizeof(savePath));
+    }
+    context_load_park_from_file(savePath);
     return 1;
 }
 
@@ -1701,7 +1715,7 @@ static constexpr const console_command console_command_table[] = {
                                     "Loading a scenery group will not load its associated objects.\n"
                                     "This is a safer method opposed to \"open object_selection\".",
                                     "load_object <objectfilenodat>" },
-    { "load_park", cc_load_park, "Load park from save directory with load_park parkname", "load_park <name>" },
+    { "load_park", cc_load_park, "Load park from save directory or by absolute path", "load_park <filename>" },
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "open", cc_open, "Opens the window with the give name.", "open <window>." },
     { "quit", cc_close, "Closes the console.", "quit" },

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1701,7 +1701,7 @@ static constexpr const console_command console_command_table[] = {
                                     "Loading a scenery group will not load its associated objects.\n"
                                     "This is a safer method opposed to \"open object_selection\".",
                                     "load_object <objectfilenodat>" },
-    { "load_park", cc_load_park, "Load park", "load_park [name]" },
+    { "load_park", cc_load_park, "Load park from save directory with load_park parkname", "load_park <name>" },
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "open", cc_open, "Opens the window with the give name.", "open <window>." },
     { "quit", cc_close, "Closes the console.", "quit" },

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1321,7 +1321,7 @@ static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[mayb
 {
     if (argv.size() < 1)
     {
-        console.WriteFormatLine("Parameters required <filename>");
+        console.WriteLine("Parameters required <filename>");
         return 0;
     }
 
@@ -1340,7 +1340,14 @@ static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[mayb
     {
         path_append_extension(savePath, ".sv6", sizeof(savePath));
     }
-    context_load_park_from_file(savePath);
+    if (context_load_park_from_file(savePath))
+    {
+        console.WriteFormatLine("Park %s was loaded successfully", savePath);
+    }
+    else
+    {
+        console.WriteFormatLine("Loading Park %s failed", savePath);
+    }
     return 1;
 }
 


### PR DESCRIPTION
New feature "load_park name" from "save" folder. Allows to load a new map while playing with headless server. Clients won't disconnect anymore as no server restart is needed. 
The save files need to be in the "save" directory to get detected by the server.