### PR TITLE
Create Sprite Refactor

### DIFF
--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -158,8 +158,6 @@ private:
         }
         else
         {
-            move_sprite_to_list(newPeep, SPRITE_LIST_PEEP);
-
             newPeep->sprite_identifier = 1;
             newPeep->window_invalidate_flags = 0;
             newPeep->action = PEEP_ACTION_NONE_2;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6247,8 +6247,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if (!sprite->IsPeep() || (sprite->peep.state != PEEP_STATE_SITTING)
-            || (peep->z != sprite->peep.z))
+        if (!sprite->IsPeep() || (sprite->peep.state != PEEP_STATE_SITTING) || (peep->z != sprite->peep.z))
         {
             continue;
         }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5471,8 +5471,7 @@ void Guest::UpdateWalking()
     for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
-
-        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+        if (!sprite->IsPeep())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -6054,7 +6053,7 @@ bool Guest::UpdateWalkingFindBench()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+        if (!sprite->IsPeep())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6248,7 +6247,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if ((sprite->generic.linked_list_index != SPRITE_LIST_PEEP) || (sprite->peep.state != PEEP_STATE_SITTING)
+        if (!sprite->IsPeep() || (sprite->peep.state != PEEP_STATE_SITTING)
             || (peep->z != sprite->peep.z))
         {
             continue;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -418,18 +418,11 @@ void peep_update_all()
         peep = &(get_sprite(spriteIndex)->peep);
         spriteIndex = peep->next;
 
-        if ((uint32_t)(i & 0x7F) != (gCurrentTicks & 0x7F))
-        {
-            peep->Update();
-        }
-        else
+        if ((uint32_t)(i & 0x7F) == (gCurrentTicks & 0x7F))
         {
             peep_128_tick_update(peep, i);
-            if (peep->linked_list_index == SPRITE_LIST_PEEP)
-            {
-                peep->Update();
-            }
         }
+        peep->Update();
 
         i++;
     }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1815,7 +1815,7 @@ static int32_t peep_update_patrolling_find_sweeping(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_index != SPRITE_LIST_LITTER)
+        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_LITTER)
             continue;
 
         uint16_t z_diff = abs(peep->z - sprite->litter.z);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1100,7 +1100,7 @@ private:
         ImportPeeps();
         ImportLitter();
         ImportMiscSprites();
-        ResetFreeSpriteList();
+        ResetSpriteLists();
     }
 
     void ImportVehicles()

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1100,6 +1100,7 @@ private:
         ImportPeeps();
         ImportLitter();
         ImportMiscSprites();
+        ResetFreeSpriteList();
     }
 
     void ImportVehicles()

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1280,6 +1280,7 @@ public:
         }
         // This list contains the number of free slots. Increase it according to our own sprite limit.
         gSpriteListCount[SPRITE_LIST_FREE] += (MAX_SPRITES - RCT2_MAX_SPRITES);
+        ResetFreeSpriteList();
     }
 
     void ImportSprite(rct_sprite* dst, const RCT2Sprite* src)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1269,8 +1269,8 @@ public:
         for (int32_t i = 0; i < RCT2_MAX_SPRITES; i++)
         {
             auto src = &_s6.sprites[i];
-            auto dst = get_sprite(i);
-            ImportSprite(dst, src);
+            auto dst = CreateSpriteAt(i);
+            ImportSprite((rct_sprite*)dst, src);
         }
 
         for (int32_t i = 0; i < SPRITE_LIST_COUNT; i++)
@@ -1285,6 +1285,7 @@ public:
 
     void ImportSprite(rct_sprite* dst, const RCT2Sprite* src)
     {
+        // Todo: linked_list_index == FREE should be special cased to load a null
         std::memset(&dst->pad_00, 0, sizeof(rct_sprite));
         switch (src->unknown.sprite_identifier)
         {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1280,7 +1280,7 @@ public:
         }
         // This list contains the number of free slots. Increase it according to our own sprite limit.
         gSpriteListCount[SPRITE_LIST_FREE] += (MAX_SPRITES - RCT2_MAX_SPRITES);
-        ResetFreeSpriteList();
+        ResetSpriteLists();
     }
 
     void ImportSprite(rct_sprite* dst, const RCT2Sprite* src)

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -29,13 +29,12 @@ static void cable_lift_update_arriving(Vehicle* vehicle);
 Vehicle* cable_lift_segment_create(
     Ride& ride, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance, bool head)
 {
-    Vehicle* current = &(create_sprite(SPRITE_IDENTIFIER_VEHICLE)->vehicle);
+    Vehicle* current = reinterpret_cast<Vehicle*>(CreateSprite(head ? SPRITE_LIST_TRAIN_HEAD : SPRITE_LIST_VEHICLE));
     current->sprite_identifier = SPRITE_IDENTIFIER_VEHICLE;
     current->ride = ride.id;
     current->ride_subtype = RIDE_ENTRY_INDEX_NULL;
     if (head)
     {
-        move_sprite_to_list(current, SPRITE_LIST_TRAIN_HEAD);
         ride.cable_lift = current->sprite_index;
     }
     current->type = head ? VEHICLE_TYPE_HEAD : VEHICLE_TYPE_TAIL;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -324,8 +324,6 @@ void ride_update_favourited_stat()
 
     FOR_ALL_PEEPS (spriteIndex, peep)
     {
-        if (peep->linked_list_index != SPRITE_LIST_PEEP)
-            return;
         if (peep->favourite_ride != RIDE_ID_NULL)
         {
             auto ride = get_ride(peep->favourite_ride);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4317,7 +4317,7 @@ static Vehicle* vehicle_create_car(
         return nullptr;
 
     auto vehicleEntry = &rideEntry->vehicles[vehicleEntryIndex];
-    auto vehicle = &create_sprite(SPRITE_IDENTIFIER_VEHICLE)->vehicle;
+    auto vehicle = reinterpret_cast<Vehicle*>(CreateSprite(carIndex == 0 ? SPRITE_LIST_TRAIN_HEAD : SPRITE_LIST_VEHICLE));
     if (vehicle == nullptr)
         return nullptr;
 
@@ -4560,8 +4560,6 @@ static void vehicle_create_trains(ride_id_t rideIndex, int32_t x, int32_t y, int
         }
         lastTrain = train;
 
-        // Add train to ride vehicle list
-        move_sprite_to_list(train.head, SPRITE_LIST_TRAIN_HEAD);
         for (int32_t i = 0; i <= MAX_VEHICLES_PER_RIDE; i++)
         {
             if (ride->vehicles[i] == SPRITE_INDEX_NULL)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -393,15 +393,16 @@ void footpath_remove_litter(const CoordsXYZ& footpathPos)
     uint16_t spriteIndex = sprite_get_first_in_quadrant(footpathPos.x, footpathPos.y);
     while (spriteIndex != SPRITE_INDEX_NULL)
     {
-        Litter* sprite = &get_sprite(spriteIndex)->litter;
+        auto* sprite = &get_sprite(spriteIndex)->generic;
         uint16_t nextSpriteIndex = sprite->next_in_quadrant;
-        if (sprite->linked_list_index == SPRITE_LIST_LITTER)
+        if (sprite->sprite_identifier == SPRITE_IDENTIFIER_LITTER)
         {
-            int32_t distanceZ = abs(sprite->z - footpathPos.z);
+            Litter* litter = &get_sprite(spriteIndex)->litter;
+            int32_t distanceZ = abs(litter->z - footpathPos.z);
             if (distanceZ <= 32)
             {
-                invalidate_sprite_0(sprite);
-                sprite_remove(sprite);
+                invalidate_sprite_0(litter);
+                sprite_remove(litter);
             }
         }
         spriteIndex = nextSpriteIndex;
@@ -417,10 +418,11 @@ void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
     uint16_t spriteIndex = sprite_get_first_in_quadrant(footpathPos.x, footpathPos.y);
     while (spriteIndex != SPRITE_INDEX_NULL)
     {
-        Peep* peep = &get_sprite(spriteIndex)->peep;
-        uint16_t nextSpriteIndex = peep->next_in_quadrant;
-        if (peep->linked_list_index == SPRITE_LIST_PEEP)
+        auto* sprite = get_sprite(spriteIndex);
+        uint16_t nextSpriteIndex = sprite->generic.next_in_quadrant;
+        if (sprite->IsPeep())
         {
+            auto peep = &sprite->peep;
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)
             {
                 if (peep->z == footpathPos.z)

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -202,7 +202,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+                    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -369,31 +369,11 @@ void ResetFreeSpriteList()
     }
 }
 
-SpriteBase* CreateSpriteAt(SPRITE_IDENTIFIER spriteIdentifier, uint16_t spriteId)
+// Create a sprite without touching the linked lists
+// It is up to the caller to fix the linked lists
+SpriteBase* CreateSpriteAt(uint16_t spriteId)
 {
-    SPRITE_LIST linkedListIndex;
-    switch (spriteIdentifier)
-    {
-        case SPRITE_IDENTIFIER_VEHICLE:
-            linkedListIndex = SPRITE_LIST_VEHICLE;
-            break;
-        case SPRITE_IDENTIFIER_PEEP:
-            linkedListIndex = SPRITE_LIST_PEEP;
-            break;
-        case SPRITE_IDENTIFIER_MISC:
-            linkedListIndex = SPRITE_LIST_MISC;
-            break;
-        case SPRITE_IDENTIFIER_LITTER:
-            linkedListIndex = SPRITE_LIST_LITTER;
-            break;
-        default:
-            Guard::Assert(false, "Invalid sprite identifier: 0x%02X", spriteIdentifier);
-            return nullptr;
-    }
-
     SpriteBase* sprite = &(get_sprite(spriteId))->generic;
-
-    move_sprite_to_list(sprite, linkedListIndex);
 
     // Need to reset all sprite data, as the uninitialised values
     // may contain garbage and cause a desync later on.
@@ -433,8 +413,32 @@ rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier)
             return nullptr;
         }
     }
+
     _freeSprites.pop_back();
-    return (rct_sprite*)CreateSpriteAt(spriteIdentifier, gSpriteListHead[SPRITE_LIST_FREE]);
+    auto sprite = CreateSpriteAt(gSpriteListHead[SPRITE_LIST_FREE]);
+
+    SPRITE_LIST linkedListIndex;
+    switch (spriteIdentifier)
+    {
+        case SPRITE_IDENTIFIER_VEHICLE:
+            linkedListIndex = SPRITE_LIST_VEHICLE;
+            break;
+        case SPRITE_IDENTIFIER_PEEP:
+            linkedListIndex = SPRITE_LIST_PEEP;
+            break;
+        case SPRITE_IDENTIFIER_MISC:
+            linkedListIndex = SPRITE_LIST_MISC;
+            break;
+        case SPRITE_IDENTIFIER_LITTER:
+            linkedListIndex = SPRITE_LIST_LITTER;
+            break;
+        default:
+            Guard::Assert(false, "Invalid sprite identifier: 0x%02X", spriteIdentifier);
+            return nullptr;
+    }
+    move_sprite_to_list(sprite, linkedListIndex);
+
+    return (rct_sprite*)sprite;
 }
 
 /*

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -423,7 +423,7 @@ static void RemoveSpriteFromSpriteLists(SpriteBase* sprite)
         auto res = std::lower_bound(list.begin(), list.end(), sprite, [](const SpriteBase* a, SpriteBase* b) {
             return a->sprite_index < b->sprite_index;
         });
-        if (res != list.end())
+        if (res != list.end() && (*res)->sprite_index == sprite->sprite_index)
         {
             list.erase(res);
         }
@@ -799,6 +799,12 @@ void sprite_remove(SpriteBase* sprite)
         spriteIndex = &quadrantSprite->next_in_quadrant;
     }
     *spriteIndex = sprite->next_in_quadrant;
+
+    // Debug check
+    for (int i = 1; i < SPRITE_LIST_COUNT; ++i)
+    {
+        assert(gSpriteLists[i].size() == gSpriteListCount[i]);
+    }
 }
 
 static bool litter_can_be_at(int32_t x, int32_t y, int32_t z)
@@ -889,7 +895,7 @@ void litter_remove_at(int32_t x, int32_t y, int32_t z)
     {
         rct_sprite* sprite = get_sprite(spriteIndex);
         uint16_t nextSpriteIndex = sprite->generic.next_in_quadrant;
-        if (sprite->generic.linked_list_index == SPRITE_LIST_LITTER)
+        if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
         {
             Litter* litter = &sprite->litter;
 
@@ -946,11 +952,10 @@ uint16_t remove_floating_sprites()
  */
 static bool sprite_should_tween(rct_sprite* sprite)
 {
-    switch (sprite->generic.linked_list_index)
+    switch (sprite->generic.sprite_identifier)
     {
-        case SPRITE_LIST_PEEP:
-        case SPRITE_LIST_TRAIN_HEAD:
-        case SPRITE_LIST_VEHICLE:
+        case SPRITE_IDENTIFIER_PEEP:
+        case SPRITE_IDENTIFIER_VEHICLE:
             return true;
     }
     return false;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -204,10 +204,12 @@ extern uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
 extern const rct_string_id litterNames[12];
 
 rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier);
+SpriteBase* CreateSprite(SPRITE_LIST linkedListIndex);
 SpriteBase* CreateSpriteAt(uint16_t spriteId);
 void reset_sprite_list();
 void reset_sprite_spatial_index();
-void ResetFreeSpriteList();
+void ResetSpriteLists();
+const std::vector<SpriteBase*> GetSpriteList(SPRITE_LIST type);
 void sprite_clear_all_unused();
 void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newList);
 void sprite_misc_update_all();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -204,8 +204,10 @@ extern uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
 extern const rct_string_id litterNames[12];
 
 rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier);
+SpriteBase* CreateSpriteAt(SPRITE_IDENTIFIER spriteIdentifier, uint16_t spriteId);
 void reset_sprite_list();
 void reset_sprite_spatial_index();
+void ResetFreeSpriteList();
 void sprite_clear_all_unused();
 void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newList);
 void sprite_misc_update_all();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -204,7 +204,7 @@ extern uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
 extern const rct_string_id litterNames[12];
 
 rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier);
-SpriteBase* CreateSpriteAt(SPRITE_IDENTIFIER spriteIdentifier, uint16_t spriteId);
+SpriteBase* CreateSpriteAt(uint16_t spriteId);
 void reset_sprite_list();
 void reset_sprite_spatial_index();
 void ResetFreeSpriteList();


### PR DESCRIPTION
This refactor builds a vector based sprite list that is ultimately the same as the existing linked list sprite list. The idea is that code can be moved over to use the new sprite lists.

I am planning on allocating memory for each CreateSprite rather than a bulk lump of contiguous memory. As there would be no need to store anything for free sprite id's this refactor gets ready for this future and splits off free sprite id's to a separate vector.

The two structures (linked list and vector) hold the same data but the order will not be the same. The vector is guaranteed to be ordered by sprite_id. The linked list can be in any order. For this reason they cannot at this time be used interchangeably. The advantage of the vector being ordered is that there is no need to save the list as it can be easily rebuilt (see `ResetSpriteLists()`). 

Before killing off the existing sprite lists we will need a way to rebuild the linked list sprite list for S6 export. This may be added in this PR or in a later PR.

After killing off the linked lists the `next, previous, linked_list_index` will no longer be used within the sprite struct. You will also be able to iterate through a sprite list using a ranged for loop `for (auto &peep : GetSpriteList(SPRITE_LIST_PEEP))`.