### PR TITLE
Fix replay manager checksums

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.13/objects.zip")
 set(OBJECTS_SHA1 "86cfb7f33763078d9f5e8009bb1b5bf3c674a263")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.8/replays.zip")
-set(REPLAYS_SHA1 "3309db1a932709312150124b1e3bbe57c7fb45d0")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.9/replays.zip")
+set(REPLAYS_SHA1 "4A2CAE6C6DBD54E8C0A892AA6327540F6F5108B1")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.13/objects.zip</ObjectsUrl>
     <ObjectsSha1>86cfb7f33763078d9f5e8009bb1b5bf3c674a263</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.8/replays.zip</ReplaysUrl>
-    <ReplaysSha1>3309db1a932709312150124b1e3bbe57c7fb45d0</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.9/replays.zip</ReplaysUrl>
+    <ReplaysSha1>4A2CAE6C6DBD54E8C0A892AA6327540F6F5108B1</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -388,9 +388,9 @@ namespace OpenRCT2
             GameStateCompareData_t cmpData = snapshots->Compare(replaySnapshot, localSnapshot);
 
             // Find out if there are any differences between the two states
-            auto res = std::find_if(cmpData.spriteChanges.begin(), cmpData.spriteChanges.end(), [](const GameStateSpriteChange_t& diff) {
-                return diff.changeType != GameStateSpriteChange_t::EQUAL;
-            });
+            auto res = std::find_if(
+                cmpData.spriteChanges.begin(), cmpData.spriteChanges.end(),
+                [](const GameStateSpriteChange_t& diff) { return diff.changeType != GameStateSpriteChange_t::EQUAL; });
 
             // If there are difference write a log to the desyncs folder
             if (res != cmpData.spriteChanges.end())

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -81,7 +81,6 @@ namespace OpenRCT2
         uint16_t version;
         std::string networkId;
         MemoryStream parkData;
-        MemoryStream spriteSpatialData;
         MemoryStream parkParams;
         MemoryStream cheatData;
         std::string name;      // Name of play
@@ -239,7 +238,6 @@ namespace OpenRCT2
             s6exporter->Export();
             s6exporter->SaveGame(&replayData->parkData);
 
-            replayData->spriteSpatialData.Write(gSpriteSpatialIndex, sizeof(gSpriteSpatialIndex));
             replayData->timeRecorded = std::chrono::seconds(std::time(nullptr)).count();
 
             DataSerialiser parkParamsDs(true, replayData->parkParams);
@@ -505,12 +503,6 @@ namespace OpenRCT2
 
                 sprite_position_tween_reset();
 
-                Guard::Assert(sizeof(gSpriteSpatialIndex) >= data.spriteSpatialData.GetLength());
-
-                // In case the sprite limit will be increased we keep the unused fields cleared.
-                std::fill_n(gSpriteSpatialIndex, std::size(gSpriteSpatialIndex), SPRITE_INDEX_NULL);
-                std::memcpy(gSpriteSpatialIndex, data.spriteSpatialData.GetData(), data.spriteSpatialData.GetLength());
-
                 // Load all map global variables.
                 DataSerialiser parkParamsDs(false, data.parkParams);
                 SerialiseParkParameters(parkParamsDs);
@@ -625,7 +617,6 @@ namespace OpenRCT2
             data.parkData.SetPosition(0);
             data.parkParams.SetPosition(0);
             data.cheatData.SetPosition(0);
-            data.spriteSpatialData.SetPosition(0);
             data.gameStateSnapshot.SetPosition(0);
 
             return true;
@@ -721,7 +712,6 @@ namespace OpenRCT2
             serialiser << data.parkData;
             serialiser << data.parkParams;
             serialiser << data.cheatData;
-            serialiser << data.spriteSpatialData;
             serialiser << data.tickStart;
             serialiser << data.tickEnd;
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -734,9 +734,6 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
         void CheckState()
         {
-            if (_nextChecksumTick != gCurrentTicks)
-                return;
-
             uint32_t checksumIndex = _currentReplay->checksumIndex;
 
             if (checksumIndex >= _currentReplay->checksums.size())

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1511,6 +1511,14 @@ static int32_t cc_replay_normalise(InteractiveConsole& console, const arguments_
     std::string inputFile = argv[0];
     std::string outputFile = argv[1];
 
+    if (!String::EndsWith(outputFile, ".sv6r", true))
+    {
+        outputFile += ".sv6r";
+    }
+    std::string outPath = OpenRCT2::GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+        OpenRCT2::DIRBASE::USER, OpenRCT2::DIRID::REPLAY);
+    outputFile = Path::Combine(outPath, outputFile);
+
     auto* replayManager = OpenRCT2::GetContext()->GetReplayManager();
     if (replayManager->NormaliseReplay(inputFile, outputFile))
     {

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -71,6 +71,10 @@ protected:
 
 TEST_P(ReplayTests, RunReplay)
 {
+#ifdef PLATFORM_32BIT
+    log_warning("Replay Tests have not been performed. OpenRCT2/OpenRCT2#11279.");
+    return;
+#else
     gOpenRCT2Headless = true;
     gOpenRCT2NoGraphics = true;
     core_init();
@@ -96,6 +100,7 @@ TEST_P(ReplayTests, RunReplay)
         gs->UpdateLogic();
         ASSERT_TRUE(replayManager->IsPlaybackStateMismatching() == false);
     }
+#endif
 }
 
 static void PrintTo(const ReplayTestData& testData, std::ostream* os)


### PR DESCRIPTION
This will likely fail the CI's on some of the replays as we haven't been checking the checksums.

`_nextChecksumTick` is a variable only used when recording so it is never incremented and so `gCurrentTicks` is only equal on the very first tick.