### PR TITLE
Fix #11147: incorrect saves in backtrace

### DIFF
--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -196,6 +196,8 @@ void S6Exporter::Export()
     _s6.scenario_srand_0 = state.s0;
     _s6.scenario_srand_1 = state.s1;
 
+    // Map elements must be reorganised prior to saving otherwise save may be invalid
+    map_reorganise_elements();
     ExportTileElements();
     ExportSprites();
     ExportParkName();


### PR DESCRIPTION
Fix #11147 

This is the source of the corrupted saves in backtrace. Backtrace does not call the normal scenario_save function and therefore never triggers the reorg function. Same goes for replays.