### PR TITLE
Restore landscape door offsets

### DIFF
--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -47,7 +47,8 @@ void TerrainEdgeObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32
 
 void TerrainEdgeObject::ReadJson(IReadObjectContext* context, const json_t* root)
 {
-    // auto properties = json_object_get(root, "properties");
+    auto properties = json_object_get(root, "properties");
+    HasDoors = ObjectJsonHelpers::GetBoolean(properties, "hasDoors", false);
 
     ObjectJsonHelpers::LoadStrings(root, GetStringTable());
     ObjectJsonHelpers::LoadImages(context, root, GetImageTable());

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -19,6 +19,7 @@ public:
     uint32_t IconImageId{};
     uint32_t BaseImageId{};
     uint32_t NumImagesLoaded{};
+    bool HasDoors{};
 
     explicit TerrainEdgeObject(const rct_object_entry& entry)
         : Object(entry)

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -386,11 +386,22 @@ static uint32_t get_edge_image(uint8_t index, uint8_t type)
     return result;
 }
 
-static uint32_t get_tunnel_image(uint8_t index, uint8_t type)
+static uint32_t get_tunnel_image(ObjectEntryIndex index, uint8_t type)
 {
-    static constexpr uint32_t offsets[] = {
-        36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 36, 48, 60, 72,
-    };
+    static constexpr uint32_t offsets[TUNNEL_TYPE_COUNT] = { 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80,
+                                                             36, 48, 60, 72, 76, 80, 84, 88, 92, 96, 100 };
+
+    bool hasDoors = false;
+    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto obj = objMgr.GetLoadedObject(OBJECT_TYPE_TERRAIN_EDGE, index);
+    if (obj != nullptr)
+    {
+        auto tobj = static_cast<TerrainEdgeObject*>(obj);
+        hasDoors = tobj->HasDoors;
+    }
+
+    if (!hasDoors && type >= REGULAR_TUNNEL_TYPE_COUNT && type < std::size(offsets))
+        type = TUNNEL_0;
 
     uint32_t result = 0;
     if (type < std::size(offsets))

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -58,6 +58,8 @@ enum
     TUNNEL_13 = 0x0D,
     TUNNEL_14 = 0x0E,
     TUNNEL_15 = 0x0F,
+    REGULAR_TUNNEL_TYPE_COUNT,
+
     // Ghost train doors
     TUNNEL_DOORS_0 = 16,
     TUNNEL_DOORS_1 = 17,


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/7961 turned land edge types into objects. This broke landscape door drawing. This PR restores the ability.

(Note that while this re-enables the door drawing _capability_, it isn't used. To make them appear, work needs to be done to GhostTrain.cpp to use the proper tunnel type, and code needs to be added to open and close them properly. OTOH, if all you want is to make some RCT1 NE saves appear correctly, you can just replace all the tunnel constants in `GhostTrain.cpp` with TUNNEL_DOORS_2 and call it a day.)