### PR TITLE
Smoke position & animation speed

### DIFF
--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;
@@ -2726,7 +2726,6 @@ bool Network::LoadMap(IStream* stream)
         [[maybe_unused]] uint32_t checksum = stream->ReadValue<uint32_t>();
 
         // Read other data not in normal save files
-        stream->Read(gSpriteSpatialIndex, SPATIAL_INDEX_SIZE * sizeof(uint16_t));
         gGamePaused = stream->ReadValue<uint32_t>();
         _guestGenerationProbability = stream->ReadValue<uint32_t>();
         _suggestedGuestMaximum = stream->ReadValue<uint32_t>();
@@ -2775,7 +2774,6 @@ bool Network::SaveMap(IStream* stream, const std::vector<const ObjectRepositoryI
         s6exporter->SaveGame(stream);
 
         // Write other data not in normal save files
-        stream->Write(gSpriteSpatialIndex, SPATIAL_INDEX_SIZE * sizeof(uint16_t));
         stream->WriteValue<uint32_t>(gGamePaused);
         stream->WriteValue<uint32_t>(_guestGenerationProbability);
         stream->WriteValue<uint32_t>(_suggestedGuestMaximum);

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -165,6 +165,26 @@ namespace ObjectJsonHelpers
         return result;
     }
 
+    std::vector<double_t> GetJsonRealArray(const json_t* arr)
+    {
+        std::vector<double_t> result;
+        if (json_is_array(arr))
+        {
+            auto count = json_array_size(arr);
+            result.reserve(count);
+            for (size_t i = 0; i < count; i++)
+            {
+                auto element = json_real_value(json_array_get(arr, i));
+                result.push_back(element);
+            }
+        }
+        else if (json_is_number(arr))
+        {
+            result.push_back(json_real_value(arr));
+        }
+        return result;
+    }
+
     colour_t ParseColour(const std::string_view& s, colour_t defaultValue)
     {
         static const std::unordered_map<std::string_view, colour_t> LookupTable{

--- a/src/openrct2/object/ObjectJsonHelpers.cpp
+++ b/src/openrct2/object/ObjectJsonHelpers.cpp
@@ -165,22 +165,22 @@ namespace ObjectJsonHelpers
         return result;
     }
 
-    std::vector<double_t> GetJsonRealArray(const json_t* arr)
+    std::vector<float> GetJsonFloatArray(const json_t* arr)
     {
-        std::vector<double_t> result;
+        std::vector<float> result;
         if (json_is_array(arr))
         {
             auto count = json_array_size(arr);
             result.reserve(count);
             for (size_t i = 0; i < count; i++)
             {
-                auto element = json_real_value(json_array_get(arr, i));
+                auto element = json_number_value(json_array_get(arr, i));
                 result.push_back(element);
             }
         }
         else if (json_is_number(arr))
         {
-            result.push_back(json_real_value(arr));
+            result.push_back(json_number_value(arr));
         }
         return result;
     }

--- a/src/openrct2/object/ObjectJsonHelpers.h
+++ b/src/openrct2/object/ObjectJsonHelpers.h
@@ -31,6 +31,7 @@ namespace ObjectJsonHelpers
     float GetFloat(const json_t* obj, const std::string& name, const float& defaultValue = 0);
     std::vector<std::string> GetJsonStringArray(const json_t* arr);
     std::vector<int32_t> GetJsonIntegerArray(const json_t* arr);
+    std::vector<int32_t> GetJsonRealArray(const json_t* arr);
     colour_t ParseColour(const std::string_view& s, colour_t defaultValue = COLOUR_BLACK);
     uint8_t ParseCursor(const std::string& s, uint8_t defaultValue);
     rct_object_entry ParseObjectEntry(const std::string& s);

--- a/src/openrct2/object/ObjectJsonHelpers.h
+++ b/src/openrct2/object/ObjectJsonHelpers.h
@@ -31,7 +31,7 @@ namespace ObjectJsonHelpers
     float GetFloat(const json_t* obj, const std::string& name, const float& defaultValue = 0);
     std::vector<std::string> GetJsonStringArray(const json_t* arr);
     std::vector<int32_t> GetJsonIntegerArray(const json_t* arr);
-    std::vector<int32_t> GetJsonRealArray(const json_t* arr);
+    std::vector<float> GetJsonFloatArray(const json_t* arr);
     colour_t ParseColour(const std::string_view& s, colour_t defaultValue = COLOUR_BLACK);
     uint8_t ParseCursor(const std::string& s, uint8_t defaultValue);
     rct_object_entry ParseObjectEntry(const std::string& s);

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -453,7 +453,17 @@ void RideObject::ReadLegacyVehicle(
     vehicle->effect_visual = stream->ReadValue<uint8_t>();
     vehicle->draw_order = stream->ReadValue<uint8_t>();
     vehicle->num_vertical_frames_override = stream->ReadValue<uint8_t>();
-    stream->Seek(4, STREAM_SEEK_CURRENT);
+    stream->Seek(1, STREAM_SEEK_CURRENT);
+    vehicle->animation_speed_multiplier = stream->ReadValue<uint8_t>(); // for testing
+    if (vehicle->animation_speed_multiplier == 0) vehicle->animation_speed_multiplier = ANIMATION_SPEED_MULTIPLIER_COEFFICIENT; // for testing
+    vehicle->steam_effect_translation[0] = stream->ReadValue<int8_t>(); // for testing
+    if (vehicle->steam_effect_translation[0] == 0) vehicle->steam_effect_translation[0] = STEAM_EFFECT_TRANSLATION_COEFFICIENT; // for testing
+    vehicle->steam_effect_translation[1] = stream->ReadValue<int8_t>(); // for testing
+    if (vehicle->steam_effect_translation[1] == 0) vehicle->steam_effect_translation[1] = STEAM_EFFECT_TRANSLATION_COEFFICIENT; // for testing
+//    vehicle->animation_speed_modifier = ANIMATION_SPEED_MODIFIER_COEFFICIENT;
+//    vehicle->steam_effect_modifier[0] = STEAM_EFFECT_MODIFIER_COEFFICIENT;
+//    vehicle->steam_effect_modifier[1] = STEAM_EFFECT_MODIFIER_COEFFICIENT;
+//    stream->Seek(4, STREAM_SEEK_CURRENT);
 }
 
 uint8_t RideObject::CalculateNumVerticalFrames(const rct_ride_entry_vehicle* vehicleEntry)
@@ -774,6 +784,19 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(const json_t* jCar)
     car.effect_visual = ObjectJsonHelpers::GetInteger(jCar, "effectVisual", 1);
     car.draw_order = ObjectJsonHelpers::GetInteger(jCar, "drawOrder");
     car.num_vertical_frames_override = ObjectJsonHelpers::GetInteger(jCar, "numVerticalFramesOverride");
+
+    car.animation_speed_multiplier = Math::Clamp<uint8_t>(0, ObjectJsonHelpers::GetFloat(jCar, "animationSpeedModifier", 1)*ANIMATION_SPEED_MULTIPLIER_COEFFICIENT , UINT8_MAX);
+
+    auto jSteamEffect = ObjectJsonHelpers::GetJsonRealArray(json_object_get(jCar, "steamEffectModifier"));
+    if (jSteamEffect.size() == 2) {
+        car.steam_effect_translation[0] = Math::Clamp<int8_t>(INT8_MIN, jSteamEffect[0] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MAX);
+        car.steam_effect_translation[1] = Math::Clamp<int8_t>(INT8_MIN, jSteamEffect[1] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MAX);
+    }
+    else
+    {
+        car.steam_effect_translation[0] = STEAM_EFFECT_TRANSLATION_COEFFICIENT;
+        car.steam_effect_translation[1] = STEAM_EFFECT_TRANSLATION_COEFFICIENT;
+    }
 
     auto& peepLoadingPositions = car.peep_loading_positions;
     auto jLoadingPositions = json_object_get(jCar, "loadingPositions");

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -453,17 +453,10 @@ void RideObject::ReadLegacyVehicle(
     vehicle->effect_visual = stream->ReadValue<uint8_t>();
     vehicle->draw_order = stream->ReadValue<uint8_t>();
     vehicle->num_vertical_frames_override = stream->ReadValue<uint8_t>();
-    stream->Seek(1, STREAM_SEEK_CURRENT);
-    vehicle->animation_speed_multiplier = stream->ReadValue<uint8_t>(); // for testing
-    if (vehicle->animation_speed_multiplier == 0) vehicle->animation_speed_multiplier = ANIMATION_SPEED_MULTIPLIER_COEFFICIENT; // for testing
-    vehicle->steam_effect_translation[0] = stream->ReadValue<int8_t>(); // for testing
-    if (vehicle->steam_effect_translation[0] == 0) vehicle->steam_effect_translation[0] = STEAM_EFFECT_TRANSLATION_COEFFICIENT; // for testing
-    vehicle->steam_effect_translation[1] = stream->ReadValue<int8_t>(); // for testing
-    if (vehicle->steam_effect_translation[1] == 0) vehicle->steam_effect_translation[1] = STEAM_EFFECT_TRANSLATION_COEFFICIENT; // for testing
-//    vehicle->animation_speed_modifier = ANIMATION_SPEED_MODIFIER_COEFFICIENT;
-//    vehicle->steam_effect_modifier[0] = STEAM_EFFECT_MODIFIER_COEFFICIENT;
-//    vehicle->steam_effect_modifier[1] = STEAM_EFFECT_MODIFIER_COEFFICIENT;
-//    stream->Seek(4, STREAM_SEEK_CURRENT);
+    vehicle->animation_speed_multiplier = ANIMATION_SPEED_MULTIPLIER_COEFFICIENT;
+    vehicle->steam_effect_translation[0] = STEAM_EFFECT_TRANSLATION_COEFFICIENT;
+    vehicle->steam_effect_translation[1] = STEAM_EFFECT_TRANSLATION_COEFFICIENT;
+    stream->Seek(4, STREAM_SEEK_CURRENT);
 }
 
 uint8_t RideObject::CalculateNumVerticalFrames(const rct_ride_entry_vehicle* vehicleEntry)

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -785,12 +785,12 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(const json_t* jCar)
     car.draw_order = ObjectJsonHelpers::GetInteger(jCar, "drawOrder");
     car.num_vertical_frames_override = ObjectJsonHelpers::GetInteger(jCar, "numVerticalFramesOverride");
 
-    car.animation_speed_multiplier = Math::Clamp<uint8_t>(0, ObjectJsonHelpers::GetFloat(jCar, "animationSpeedModifier", 1)*ANIMATION_SPEED_MULTIPLIER_COEFFICIENT , UINT8_MAX);
+    car.animation_speed_multiplier = std::clamp<uint8_t>(ObjectJsonHelpers::GetFloat(jCar, "animationSpeedModifier", 1)*ANIMATION_SPEED_MULTIPLIER_COEFFICIENT, 0, UINT8_MAX);
 
-    auto jSteamEffect = ObjectJsonHelpers::GetJsonRealArray(json_object_get(jCar, "steamEffectModifier"));
+    auto jSteamEffect = ObjectJsonHelpers::GetJsonFloatArray(json_object_get(jCar, "steamEffectModifier"));
     if (jSteamEffect.size() == 2) {
-        car.steam_effect_translation[0] = Math::Clamp<int8_t>(INT8_MIN, jSteamEffect[0] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MAX);
-        car.steam_effect_translation[1] = Math::Clamp<int8_t>(INT8_MIN, jSteamEffect[1] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MAX);
+        car.steam_effect_translation[0] = std::clamp<int8_t>(jSteamEffect[0] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MIN, INT8_MAX);
+        car.steam_effect_translation[1] = std::clamp<int8_t>(jSteamEffect[1] * STEAM_EFFECT_TRANSLATION_COEFFICIENT, INT8_MIN, INT8_MAX);
     }
     else
     {

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -1512,7 +1512,9 @@ const rct_ride_entry_vehicle CableLiftVehicle = {
     /* .effect_visual = */ 1,
     /* .draw_order = */ 14,
     /* .num_vertical_frames_override = */ 0,
-    /* .peep_loading_positions = */ 0
+    /* .animation_speed_multiplier = */ ANIMATION_SPEED_MULTIPLIER_COEFFICIENT,
+    /* .steam_effect_translation = */ STEAM_EFFECT_TRANSLATION_COEFFICIENT,
+                                      STEAM_EFFECT_TRANSLATION_COEFFICIENT
 };
 
 /* rct2: 0x009A0AA0 */

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7242,7 +7242,7 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
     {
         case VEHICLE_ENTRY_ANIMATION_MINITURE_RAILWAY_LOCOMOTIVE: // loc_6D652B
             *var_C8 += _vehicleVelocityF64E08;
-            al = (*var_C8 >> 20) & 3;
+            al = ((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 20) & 3;
             if (vehicle->animation_frame != al)
             {
                 ah = al;
@@ -7274,7 +7274,9 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
                             }();
                             int32_t directionIndex = vehicle->sprite_direction >> 1;
                             auto offset = SteamParticleOffsets[typeIndex][directionIndex];
-                            steam_particle_create(vehicle->x + offset.x, vehicle->y + offset.y, vehicle->z + offset.z);
+                            steam_particle_create( vehicle->x + 0.5 + offset.x * vehicleEntry->steam_effect_translation[0] / STEAM_EFFECT_TRANSLATION_COEFFICIENT,
+                                vehicle->y + 0.5 + offset.y * vehicleEntry->steam_effect_translation[0] / STEAM_EFFECT_TRANSLATION_COEFFICIENT,
+                                vehicle->z + 0.5 + offset.z * vehicleEntry->steam_effect_translation[1] / STEAM_EFFECT_TRANSLATION_COEFFICIENT);
                         }
                     }
                 }
@@ -7283,7 +7285,7 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             break;
         case VEHICLE_ENTRY_ANIMATION_SWAN: // loc_6D6424
             *var_C8 += _vehicleVelocityF64E08;
-            al = (*var_C8 >> 18) & 2;
+            al = ((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 18) & 2;
             if (vehicle->animation_frame != al)
             {
                 vehicle->animation_frame = al;
@@ -7292,7 +7294,8 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             break;
         case VEHICLE_ENTRY_ANIMATION_CANOES: // loc_6D6482
             *var_C8 += _vehicleVelocityF64E08;
-            eax = ((*var_C8 >> 13) & 0xFF) * 6;
+            eax = (((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 13) & 0xFF)
+                * 6;
             ah = (eax >> 8) & 0xFF;
             if (vehicle->animation_frame != ah)
             {
@@ -7302,7 +7305,8 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             break;
         case VEHICLE_ENTRY_ANIMATION_ROW_BOATS: // loc_6D64F7
             *var_C8 += _vehicleVelocityF64E08;
-            eax = ((*var_C8 >> 13) & 0xFF) * 7;
+            eax = (((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 13) & 0xFF)
+                * 7;
             ah = (eax >> 8) & 0xFF;
             if (vehicle->animation_frame != ah)
             {
@@ -7312,7 +7316,7 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             break;
         case VEHICLE_ENTRY_ANIMATION_WATER_TRICYCLES: // loc_6D6453
             *var_C8 += _vehicleVelocityF64E08;
-            al = (*var_C8 >> 19) & 1;
+            al = ((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 19) & 1;
             if (vehicle->animation_frame != al)
             {
                 vehicle->animation_frame = al;
@@ -7334,7 +7338,7 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             break;
         case VEHICLE_ENTRY_ANIMATION_HELICARS: // loc_6D63F5
             *var_C8 += _vehicleVelocityF64E08;
-            al = (*var_C8 >> 18) & 3;
+            al = ((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 18) & 3;
             if (vehicle->animation_frame != al)
             {
                 vehicle->animation_frame = al;
@@ -7345,7 +7349,9 @@ static void vehicle_update_additional_animation(Vehicle* vehicle)
             if (vehicle->num_peeps != 0)
             {
                 *var_C8 += _vehicleVelocityF64E08;
-                eax = ((*var_C8 >> 13) & 0xFF) << 2;
+                eax = (((*var_C8 * vehicleEntry->animation_speed_multiplier / ANIMATION_SPEED_MULTIPLIER_COEFFICIENT) >> 13)
+                       & 0xFF)
+                    << 2;
                 ah = (eax >> 8) & 0xFF;
                 if (vehicle->animation_frame != ah)
                 {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -79,26 +79,25 @@ struct rct_ride_entry_vehicle
         uint32_t curved_lift_hill_image_id; // 0x4C , 0x66
         uint32_t corkscrew_image_id;        // 0x4C , 0x66
     };
-    uint32_t no_vehicle_images;              // 0x50 , 0x6A
-    uint8_t no_seating_rows;                 // 0x54 , 0x6E
-    uint8_t spinning_inertia;                // 0x55 , 0x6F
-    uint8_t spinning_friction;               // 0x56 , 0x70
-    SoundId friction_sound_id;               // 0x57 , 0x71
-    uint8_t log_flume_reverser_vehicle_type; // 0x58 , 0x72
-    uint8_t sound_range;                     // 0x59 , 0x73
-    uint8_t
-        double_sound_frequency;   // 0x5A , 0x74 (Doubles the velocity when working out the sound frequency {used on go karts})
-    uint8_t powered_acceleration; // 0x5B , 0x75
-    uint8_t powered_max_speed;    // 0x5C , 0x76
-    uint8_t car_visual;           // 0x5D , 0x77
-    uint8_t effect_visual;
-    uint8_t draw_order;
-    uint8_t num_vertical_frames_override;   // 0x60 , 0x7A, A custom number that can be used rather than letting RCT2 determine
-                                            // it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
-    uint8_t peep_loading_waypoint_segments; // 0x61 new
-    uint8_t pad_62[6] = {};                 // 0x62 , 0x7B
+    uint32_t no_vehicle_images;       // 0x50 , 0x6A
+    uint8_t no_seating_rows;          // 0x54 , 0x6E
+    uint8_t spinning_inertia;         // 0x55 , 0x6F
+    uint8_t spinning_friction;        // 0x56 , 0x70
+    uint8_t friction_sound_id;        // 0x57 , 0x71
+    uint8_t log_flume_reverser_vehicle_type;          // 0x58 , 0x72
+    uint8_t sound_range;              // 0x59 , 0x73
+    uint8_t double_sound_frequency;   // 0x5A , 0x74 (Doubles the velocity when working out the sound frequency {used on go karts})
+    uint8_t powered_acceleration;     // 0x5B , 0x75
+    uint8_t powered_max_speed;        // 0x5C , 0x76
+    uint8_t car_visual;               // 0x5D , 0x77
+    uint8_t effect_visual;            // 0x5E , 0x78
+    uint8_t draw_order;               // 0x5F , 0x79
+    uint8_t num_vertical_frames_override; // 0x60 , 0x7A, A custom number that can be used rather than letting RCT2 determine it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
+    uint8_t peep_loading_waypoint_segments; // 0x61, 0x7B new
+    uint8_t animation_speed_multiplier;  // 0x62 , 0x7C, A multiplier to change animation speed on most animation types
+    int8_t steam_effect_translation[2] = {}; // 0x63, 0x7D, A multiplier to change smoke particle effect positions in lateral and vertical directions
     std::vector<std::array<CoordsXY, 3>> peep_loading_waypoints = {};
-    std::vector<int8_t> peep_loading_positions = {}; // previously 0x61 , 0x7B
+    std::vector<int8_t> peep_loading_positions = {}; // previously 0x61
 };
 #ifdef __TESTPAINT__
 #    pragma pack(pop)
@@ -384,6 +383,42 @@ enum
     VEHICLE_ENTRY_ANIMATION_HELICARS,
     VEHICLE_ENTRY_ANIMATION_MONORAIL_CYCLES,
     VEHICLE_ENTRY_ANIMATION_MULTI_DIM_COASTER
+};
+constexpr const uint8_t ANIMATION_SPEED_MULTIPLIER_COEFFICIENT = 64;
+constexpr const uint8_t STEAM_EFFECT_TRANSLATION_COEFFICIENT = 32; 
+
+enum {
+    VEHICLE_STATUS_MOVING_TO_END_OF_STATION,
+    VEHICLE_STATUS_WAITING_FOR_PASSENGERS,
+    VEHICLE_STATUS_WAITING_TO_DEPART,
+    VEHICLE_STATUS_DEPARTING,
+    VEHICLE_STATUS_TRAVELLING,
+    VEHICLE_STATUS_ARRIVING,
+    VEHICLE_STATUS_UNLOADING_PASSENGERS,
+    VEHICLE_STATUS_TRAVELLING_BOAT,
+    VEHICLE_STATUS_CRASHING,
+    VEHICLE_STATUS_CRASHED,
+    VEHICLE_STATUS_TRAVELLING_DODGEMS,
+    VEHICLE_STATUS_SWINGING,
+    VEHICLE_STATUS_ROTATING,
+    VEHICLE_STATUS_FERRIS_WHEEL_ROTATING,
+    VEHICLE_STATUS_SIMULATOR_OPERATING,
+    VEHICLE_STATUS_SHOWING_FILM,
+    VEHICLE_STATUS_SPACE_RINGS_OPERATING,
+    VEHICLE_STATUS_TOP_SPIN_OPERATING,
+    VEHICLE_STATUS_HAUNTED_HOUSE_OPERATING,
+    VEHICLE_STATUS_DOING_CIRCUS_SHOW,
+    VEHICLE_STATUS_CROOKED_HOUSE_OPERATING,
+    VEHICLE_STATUS_WAITING_FOR_CABLE_LIFT,
+    VEHICLE_STATUS_TRAVELLING_CABLE_LIFT,
+    VEHICLE_STATUS_STOPPING,
+    VEHICLE_STATUS_WAITING_FOR_PASSENGERS_17,
+    VEHICLE_STATUS_WAITING_TO_START,
+    VEHICLE_STATUS_STARTING,
+    VEHICLE_STATUS_OPERATING_1A,
+    VEHICLE_STATUS_STOPPING_1B,
+    VEHICLE_STATUS_UNLOADING_PASSENGERS_1C,
+    VEHICLE_STATUS_STOPPED_BY_BLOCK_BRAKES
 };
 
 enum : uint32_t

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -76,26 +76,26 @@ struct rct_ride_entry_vehicle
     uint32_t flat_bank_to_gentle_slope_image_id;     // 0x48 , 0x62
     union
     {
-        uint32_t curved_lift_hill_image_id; // 0x4C , 0x66
-        uint32_t corkscrew_image_id;        // 0x4C , 0x66
+        uint32_t curved_lift_hill_image_id;          // 0x4C , 0x66
+        uint32_t corkscrew_image_id;                 // 0x4C , 0x66
     };
-    uint32_t no_vehicle_images;       // 0x50 , 0x6A
-    uint8_t no_seating_rows;          // 0x54 , 0x6E
-    uint8_t spinning_inertia;         // 0x55 , 0x6F
-    uint8_t spinning_friction;        // 0x56 , 0x70
-    uint8_t friction_sound_id;        // 0x57 , 0x71
-    uint8_t log_flume_reverser_vehicle_type;          // 0x58 , 0x72
-    uint8_t sound_range;              // 0x59 , 0x73
-    uint8_t double_sound_frequency;   // 0x5A , 0x74 (Doubles the velocity when working out the sound frequency {used on go karts})
-    uint8_t powered_acceleration;     // 0x5B , 0x75
-    uint8_t powered_max_speed;        // 0x5C , 0x76
-    uint8_t car_visual;               // 0x5D , 0x77
-    uint8_t effect_visual;            // 0x5E , 0x78
-    uint8_t draw_order;               // 0x5F , 0x79
-    uint8_t num_vertical_frames_override; // 0x60 , 0x7A, A custom number that can be used rather than letting RCT2 determine it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
-    uint8_t peep_loading_waypoint_segments; // 0x61, 0x7B new
-    uint8_t animation_speed_multiplier;  // 0x62 , 0x7C, A multiplier to change animation speed on most animation types
-    int8_t steam_effect_translation[2] = {}; // 0x63, 0x7D, A multiplier to change smoke particle effect positions in lateral and vertical directions
+    uint32_t no_vehicle_images;                      // 0x50 , 0x6A
+    uint8_t no_seating_rows;                         // 0x54 , 0x6E
+    uint8_t spinning_inertia;                        // 0x55 , 0x6F
+    uint8_t spinning_friction;                       // 0x56 , 0x70
+    SoundId friction_sound_id;                       // 0x57 , 0x71
+    uint8_t log_flume_reverser_vehicle_type;         // 0x58 , 0x72
+    uint8_t sound_range;                             // 0x59 , 0x73
+    uint8_t double_sound_frequency;                  // 0x5A , 0x74 (Doubles the velocity when working out the sound frequency {used on go karts})
+    uint8_t powered_acceleration;                    // 0x5B , 0x75
+    uint8_t powered_max_speed;                       // 0x5C , 0x76
+    uint8_t car_visual;                              // 0x5D , 0x77
+    uint8_t effect_visual;                           // 0x5E , 0x78
+    uint8_t draw_order;                              // 0x5F , 0x79
+    uint8_t num_vertical_frames_override;            // 0x60 , 0x7A, A custom number that can be used rather than letting RCT2 determine it. Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
+    uint8_t peep_loading_waypoint_segments;          // 0x61, 0x7B new
+    uint8_t animation_speed_multiplier;              // 0x62 , 0x7C, A multiplier to change animation speed on most animation types
+    int8_t steam_effect_translation[2] = {};         // 0x63, 0x7D, A multiplier to change smoke particle effect positions in lateral and vertical directions
     std::vector<std::array<CoordsXY, 3>> peep_loading_waypoints = {};
     std::vector<int8_t> peep_loading_positions = {}; // previously 0x61
 };
@@ -386,40 +386,6 @@ enum
 };
 constexpr const uint8_t ANIMATION_SPEED_MULTIPLIER_COEFFICIENT = 64;
 constexpr const uint8_t STEAM_EFFECT_TRANSLATION_COEFFICIENT = 32; 
-
-enum {
-    VEHICLE_STATUS_MOVING_TO_END_OF_STATION,
-    VEHICLE_STATUS_WAITING_FOR_PASSENGERS,
-    VEHICLE_STATUS_WAITING_TO_DEPART,
-    VEHICLE_STATUS_DEPARTING,
-    VEHICLE_STATUS_TRAVELLING,
-    VEHICLE_STATUS_ARRIVING,
-    VEHICLE_STATUS_UNLOADING_PASSENGERS,
-    VEHICLE_STATUS_TRAVELLING_BOAT,
-    VEHICLE_STATUS_CRASHING,
-    VEHICLE_STATUS_CRASHED,
-    VEHICLE_STATUS_TRAVELLING_DODGEMS,
-    VEHICLE_STATUS_SWINGING,
-    VEHICLE_STATUS_ROTATING,
-    VEHICLE_STATUS_FERRIS_WHEEL_ROTATING,
-    VEHICLE_STATUS_SIMULATOR_OPERATING,
-    VEHICLE_STATUS_SHOWING_FILM,
-    VEHICLE_STATUS_SPACE_RINGS_OPERATING,
-    VEHICLE_STATUS_TOP_SPIN_OPERATING,
-    VEHICLE_STATUS_HAUNTED_HOUSE_OPERATING,
-    VEHICLE_STATUS_DOING_CIRCUS_SHOW,
-    VEHICLE_STATUS_CROOKED_HOUSE_OPERATING,
-    VEHICLE_STATUS_WAITING_FOR_CABLE_LIFT,
-    VEHICLE_STATUS_TRAVELLING_CABLE_LIFT,
-    VEHICLE_STATUS_STOPPING,
-    VEHICLE_STATUS_WAITING_FOR_PASSENGERS_17,
-    VEHICLE_STATUS_WAITING_TO_START,
-    VEHICLE_STATUS_STARTING,
-    VEHICLE_STATUS_OPERATING_1A,
-    VEHICLE_STATUS_STOPPING_1B,
-    VEHICLE_STATUS_UNLOADING_PASSENGERS_1C,
-    VEHICLE_STATUS_STOPPED_BY_BLOCK_BRAKES
-};
 
 enum : uint32_t
 {


### PR DESCRIPTION
extending the abilities of objects slightly to move the steam effect of steam trains, and (hopefully) tune the speed that animations play at.

The attached object has properties set to utilize the features
[TESTDAT.zip](https://github.com/OpenRCT2/OpenRCT2/files/4455317/TESTDAT.zip)