### PR TITLE
Warn to console if no autosave could be saved

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -792,7 +792,7 @@ void game_autosave()
     }
 
     if (!scenario_save(path, saveFlags))
-        std::fprintf(stderr, "Could not autosave the scenario. Is the save folder writeable?");
+        std::fprintf(stderr, "Could not autosave the scenario. Is the save folder writeable?\n");
 }
 
 static void game_load_or_quit_no_save_prompt_callback(int32_t result, const utf8* path)

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -65,6 +65,7 @@
 #include "world/Water.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <iterator>
 #include <memory>
 
@@ -791,7 +792,7 @@ void game_autosave()
     }
 
     if (!scenario_save(path, saveFlags))
-        log_error("Could not autosave the scenario. Is the save folder writeable?");
+        std::fprintf(stderr, "Could not autosave the scenario. Is the save folder writeable?");
 }
 
 static void game_load_or_quit_no_save_prompt_callback(int32_t result, const utf8* path)

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -790,7 +790,8 @@ void game_autosave()
         platform_file_copy(path, backupPath, true);
     }
 
-    scenario_save(path, saveFlags);
+    if (!scenario_save(path, saveFlags))
+        log_error("Could not autosave the scenario. Is the save folder writeable?");
 }
 
 static void game_load_or_quit_no_save_prompt_callback(int32_t result, const utf8* path)


### PR DESCRIPTION
From time to time, we get a question on Gitter or Discord as to why a server is not storing any autosaves. Usually, this is a permission problem. This PR provides a hint to console when the autosave function has failed, e.g.:

```
ERROR[../src/openrct2/rct2/S6Exporter.cpp:1722 (scenario_save)]: Unable to save park: 'Unable to open '/home/aaron/.config/OpenRCT2/save/autosave/autosave_2020-04-09_19-48-04.sv6''
ERROR[../src/openrct2/Game.cpp:794 (game_autosave)]: Could not autosave the scenario. Is the save folder writeable?
```