### PR TITLE
Fix #10372, #10509, #10806. Lift base sections did not export correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#6238] Invalid tile elem iteration in Guest::UpdateUsingBin
 - Fix: [#7094] Back wall edge texture in water missing.
 - Fix: [#9719] Hacked walls in RCT1 saves are imported incorrectly. 
+- Fix: [#10372, #10509, #10806] Lift base sections incorrectly exporting, causing various lift related bugs.
 - Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.
 - Fix: [#11005] Company value overflows.
@@ -16,7 +17,7 @@
 - Fix: [#11208] Cannot export parks with RCT2 DLC objects.
 - Fix: [#11230] Seat Rotation not imported correctly for hacked rides.
 - Fix: [#11225] Replay manager cannot handle track designs.
-- Fix: [#11246] Fix Various Import/Export issues
+- Fix: [#11246] Fix Various Import/Export issues with Boat locations, balloon frame number.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
 - Improved: [#11157] Slimmer virtual floor lines.
 

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -221,7 +221,8 @@ uint8_t RCT12TrackElement::GetColourScheme() const
 
 uint8_t RCT12TrackElement::GetStationIndex() const
 {
-    if (trackType == TRACK_ELEM_END_STATION || trackType == TRACK_ELEM_BEGIN_STATION || trackType == TRACK_ELEM_MIDDLE_STATION)
+    if (trackType == TRACK_ELEM_END_STATION || trackType == TRACK_ELEM_BEGIN_STATION || trackType == TRACK_ELEM_MIDDLE_STATION
+        || trackType == TRACK_ELEM_TOWER_BASE)
     {
         return (sequence & RCT12_TRACK_ELEMENT_SEQUENCE_STATION_INDEX_MASK) >> 4;
     }
@@ -790,7 +791,8 @@ void RCT12TrackElement::SetSequenceIndex(uint8_t newSequenceIndex)
 
 void RCT12TrackElement::SetStationIndex(uint8_t newStationIndex)
 {
-    if (trackType == TRACK_ELEM_END_STATION || trackType == TRACK_ELEM_BEGIN_STATION || trackType == TRACK_ELEM_MIDDLE_STATION)
+    if (trackType == TRACK_ELEM_END_STATION || trackType == TRACK_ELEM_BEGIN_STATION || trackType == TRACK_ELEM_MIDDLE_STATION
+        || trackType == TRACK_ELEM_TOWER_BASE)
     {
         sequence &= ~RCT12_TRACK_ELEMENT_SEQUENCE_STATION_INDEX_MASK;
         sequence |= (newStationIndex << 4);


### PR DESCRIPTION
Fix #10372, #10509, #10806. Lift base sections did not export correctly
Mistake made whilst refactoring that assumed that station indexes are set on only station pieces.