### PR TITLE
Make casualty notifications optional

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3678,6 +3678,7 @@ STR_6361    :Enable lighting effects on rides (experimental)
 STR_6362    :{SMALLFONT}{BLACK}If enabled, vehicles for tracked rides will be lit up at night.
 STR_6363    :Copied text to clipboard
 STR_6464    :Ride casualties
+STR_6465    :Stuck or stalled vehicles
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3677,6 +3677,7 @@ STR_6360    :{SMALLFONT}{BLACK}{COMMA32}
 STR_6361    :Enable lighting effects on rides (experimental)
 STR_6362    :{SMALLFONT}{BLACK}If enabled, vehicles for tracked rides will be lit up at night.
 STR_6363    :Copied text to clipboard
+STR_6464    :Ride casualties
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#10925] Show hovered values on finance charts.
 - Feature: [#11013] Ctrl+C copies input dialog text to clipboard.
+- Feature: [#11272] Option for toggling notifications for 'Ride casualties' and 'Stuck or stalled vehicles'.
 - Feature: [#11300] Add powered launch and reverse incline launched shuttle mode to the Stand-Up Roller Coaster (for RCT1 parity).
 - Fix: [#475] Water sides drawn incorrectly (original bug).
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -39,6 +39,7 @@ static constexpr const notification_def NewsItemOptionDefinitions[] = {
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CASUALTIES,                   offsetof(NotificationConfiguration, ride_casualties)                    },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_WARNINGS,                     offsetof(NotificationConfiguration, ride_warnings)                      },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_RESEARCHED,                   offsetof(NotificationConfiguration, ride_researched)                    },
+    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_VEHICLE_STALLED,              offsetof(NotificationConfiguration, ride_stalled_vehicles)              },
     { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_WARNINGS,                    offsetof(NotificationConfiguration, guest_warnings)                     },
     { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LOST,                        offsetof(NotificationConfiguration, guest_lost)                         },
     { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_LEFT_PARK,                   offsetof(NotificationConfiguration, guest_left_park)                    },

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -36,6 +36,7 @@ static constexpr const notification_def NewsItemOptionDefinitions[] = {
     { NOTIFICATION_CATEGORY_PARK,   STR_NOTIFICATION_PARK_RATING_WARNINGS,              offsetof(NotificationConfiguration, park_rating_warnings)               },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_BROKEN_DOWN,                  offsetof(NotificationConfiguration, ride_broken_down)                   },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CRASHED,                      offsetof(NotificationConfiguration, ride_crashed)                       },
+    { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_CASUALTIES,                   offsetof(NotificationConfiguration, ride_casualties)                    },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_WARNINGS,                     offsetof(NotificationConfiguration, ride_warnings)                      },
     { NOTIFICATION_CATEGORY_RIDE,   STR_NOTIFICATION_RIDE_RESEARCHED,                   offsetof(NotificationConfiguration, ride_researched)                    },
     { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_WARNINGS,                    offsetof(NotificationConfiguration, guest_warnings)                     },

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -439,6 +439,7 @@ namespace Config
             model->ride_casualties = reader->GetBoolean("ride_casualties", true);
             model->ride_warnings = reader->GetBoolean("ride_warnings", true);
             model->ride_researched = reader->GetBoolean("ride_researched", true);
+            model->ride_stalled_vehicles = reader->GetBoolean("ride_stalled_vehicles", true);
             model->guest_warnings = reader->GetBoolean("guest_warnings", true);
             model->guest_lost = reader->GetBoolean("guest_lost", false);
             model->guest_left_park = reader->GetBoolean("guest_left_park", true);
@@ -464,6 +465,7 @@ namespace Config
         writer->WriteBoolean("ride_casualties", model->ride_casualties);
         writer->WriteBoolean("ride_warnings", model->ride_warnings);
         writer->WriteBoolean("ride_researched", model->ride_researched);
+        writer->WriteBoolean("ride_stalled_vehicles", model->ride_stalled_vehicles);
         writer->WriteBoolean("guest_warnings", model->guest_warnings);
         writer->WriteBoolean("guest_lost", model->guest_lost);
         writer->WriteBoolean("guest_left_park", model->guest_left_park);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -436,6 +436,7 @@ namespace Config
             model->park_rating_warnings = reader->GetBoolean("park_rating_warnings", true);
             model->ride_broken_down = reader->GetBoolean("ride_broken_down", true);
             model->ride_crashed = reader->GetBoolean("ride_crashed", true);
+            model->ride_casualties = reader->GetBoolean("ride_casualties", true);
             model->ride_warnings = reader->GetBoolean("ride_warnings", true);
             model->ride_researched = reader->GetBoolean("ride_researched", true);
             model->guest_warnings = reader->GetBoolean("guest_warnings", true);
@@ -460,6 +461,7 @@ namespace Config
         writer->WriteBoolean("park_rating_warnings", model->park_rating_warnings);
         writer->WriteBoolean("ride_broken_down", model->ride_broken_down);
         writer->WriteBoolean("ride_crashed", model->ride_crashed);
+        writer->WriteBoolean("ride_casualties", model->ride_casualties);
         writer->WriteBoolean("ride_warnings", model->ride_warnings);
         writer->WriteBoolean("ride_researched", model->ride_researched);
         writer->WriteBoolean("guest_warnings", model->guest_warnings);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -169,6 +169,7 @@ struct NotificationConfiguration
     bool park_rating_warnings;
     bool ride_broken_down;
     bool ride_crashed;
+    bool ride_casualties;
     bool ride_warnings;
     bool ride_researched;
     bool guest_warnings;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -172,6 +172,7 @@ struct NotificationConfiguration
     bool ride_casualties;
     bool ride_warnings;
     bool ride_researched;
+    bool ride_stalled_vehicles;
     bool guest_warnings;
     bool guest_lost;
     bool guest_left_park;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3911,6 +3911,8 @@ enum
 
     STR_COPY_INPUT_TO_CLIPBOARD = 6363,
 
+    STR_NOTIFICATION_RIDE_CASUALTIES = 6464,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3912,6 +3912,7 @@ enum
     STR_COPY_INPUT_TO_CLIPBOARD = 6363,
 
     STR_NOTIFICATION_RIDE_CASUALTIES = 6464,
+    STR_NOTIFICATION_RIDE_VEHICLE_STALLED = 6465,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     STR_COUNT = 32768

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5206,8 +5206,11 @@ static void vehicle_kill_all_passengers(Vehicle* vehicle)
 
     if (numFatalities != 0)
     {
-        ride->FormatNameTo(gCommonFormatArgs + 2);
-        news_item_add_to_queue(NEWS_ITEM_RIDE, STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
+        if (gConfigNotifications.ride_casualties)
+        {
+            ride->FormatNameTo(gCommonFormatArgs + 2);
+            news_item_add_to_queue(NEWS_ITEM_RIDE, STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
+        }
 
         if (gParkRatingCasualtyPenalty < 500)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3487,19 +3487,22 @@ static void vehicle_check_if_missing(Vehicle* vehicle)
 
     ride->lifecycle_flags |= RIDE_LIFECYCLE_HAS_STALLED_VEHICLE;
 
-    set_format_arg(0, rct_string_id, RideComponentNames[RideNameConvention[ride->type].vehicle].number);
+    if (gConfigNotifications.ride_stalled_vehicles)
+    {
+        set_format_arg(0, rct_string_id, RideComponentNames[RideNameConvention[ride->type].vehicle].number);
 
-    uint8_t vehicleIndex = 0;
-    for (; vehicleIndex < ride->num_vehicles; ++vehicleIndex)
-        if (ride->vehicles[vehicleIndex] == vehicle->sprite_index)
-            break;
+        uint8_t vehicleIndex = 0;
+        for (; vehicleIndex < ride->num_vehicles; ++vehicleIndex)
+            if (ride->vehicles[vehicleIndex] == vehicle->sprite_index)
+                break;
 
-    vehicleIndex++;
-    set_format_arg(2, uint16_t, vehicleIndex);
-    auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs + 4);
-    set_format_arg(4 + nameArgLen, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].singular);
+        vehicleIndex++;
+        set_format_arg(2, uint16_t, vehicleIndex);
+        auto nameArgLen = ride->FormatNameTo(gCommonFormatArgs + 4);
+        set_format_arg(4 + nameArgLen, rct_string_id, RideComponentNames[RideNameConvention[ride->type].station].singular);
 
-    news_item_add_to_queue(NEWS_ITEM_RIDE, STR_NEWS_VEHICLE_HAS_STALLED, vehicle->ride);
+        news_item_add_to_queue(NEWS_ITEM_RIDE, STR_NEWS_VEHICLE_HAS_STALLED, vehicle->ride);
+    }
 }
 
 static void vehicle_simulate_crash(Vehicle* vehicle)


### PR DESCRIPTION
This adds an option for toggling notifications for 'Ride casualties' and 'Stuck or stalled vehicles' to the Notification Settings window:

![Diamond Heights 2020-04-11 14-41-23](https://user-images.githubusercontent.com/604665/79043926-9cc29c80-7c02-11ea-8c7e-be5bbaf50a5d.png)

Fixes #11272