### PR TITLE
Avoid fast-forwarding peep to ride as it may not have funds to pay

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2595,24 +2595,13 @@ bool Guest::FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array)
         vehicle = GET_VEHICLE(vehicle_id);
 
         uint8_t num_seats = vehicle->num_seats;
-        if (vehicle_is_used_in_pairs(vehicle))
-        {
-            num_seats &= VEHICLE_SEAT_NUM_MASK;
-            if (vehicle->next_free_seat & 1)
-            {
-                current_car = i;
-                peep_choose_seat_from_car(this, ride, vehicle);
-                GoToRideEntrance(ride);
-                return false;
-            }
-        }
         if (num_seats == vehicle->next_free_seat)
             continue;
 
         if (ride->mode == RIDE_MODE_FORWARD_ROTATION || ride->mode == RIDE_MODE_BACKWARD_ROTATION)
         {
             uint8_t position = (((~vehicle->vehicle_sprite_type + 1) >> 3) & 0xF) * 2;
-            if (vehicle->peep[position] != SPRITE_INDEX_NULL)
+            if (vehicle->peep[position + 1] != SPRITE_INDEX_NULL)
                 continue;
         }
         car_array.push_back(i);


### PR DESCRIPTION
The code being removed in the patch tries to fast forward a peep into the ride when it is the second peep for a vehicle that is used in pairs. Problem is that funds checking does not happen, so it happens that a peep may pay against its will.
Lets say a rich peep enters in line and a poor peep enters in line right after.
If the price of the ride is such that the rich peep can pay and the poor peep can't, it will be dragged into the ride because funds checking only happened for the first.
The second part of the patch just adjusts we consider the vehicle a full car if the second position is filled.
As a bonus, the function "Guest::FindVehicleToEnter" now really only *finds* a vehicle, and never actually enters.

(I just noticed I didn't branch off "develop" but added the commit on develop direcly. Sorry for that. Let me know if I have to fix that for this PR.)

I noticed this bug by inspecting the code and came up with this scenario:

[peep_pays_more_than_it_has.zip](https://github.com/OpenRCT2/OpenRCT2/files/4466492/peep_pays_more_than_it_has.zip)
In this scenario, two peeps are in queue. One is rich and the second has only 1 dolar. I raised the ride cost to 1.10 dolars.
![before](https://user-images.githubusercontent.com/7646859/79071302-63953580-7cb1-11ea-9525-6035ea2bee28.PNG)

Without the patch, the peep will pay 1.10 even though it doesn't have it.
![After](https://user-images.githubusercontent.com/7646859/79071314-6ee86100-7cb1-11ea-983d-8b6f23956ebb.PNG)

With the patch, the second peep turns around and leave, and the third peep goes into the ride.
Now added the third peep in line too.
![Before_fixed](https://user-images.githubusercontent.com/7646859/79071419-0948a480-7cb2-11ea-95cf-2b4c4624a5a5.PNG)
The poor peep goes back and leave the queue (in yellow shirt) and third one goes in.
![After_fixed](https://user-images.githubusercontent.com/7646859/79071425-0ea5ef00-7cb2-11ea-9088-2f194d3ba1c2.PNG)

This also happens in the original game. Thanks @tupaschoal for reproducing this in the original game for me :)

[OriginalSave_PeepOnVergeOverspending.zip](https://github.com/OpenRCT2/OpenRCT2/files/4466496/OriginalSave_PeepOnVergeOverspending.zip)
![before_original](https://user-images.githubusercontent.com/7646859/79071597-faaebd00-7cb2-11ea-8647-20c1f950a912.png)
![after_original](https://user-images.githubusercontent.com/7646859/79071602-ff737100-7cb2-11ea-92ea-43303eeb4ffc.png)


