### PR TITLE
Use utf8_remove_format_codes to remove format codes from user strings

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#11225] Replay manager cannot handle track designs.
 - Fix: [#11246] Fix Various Import/Export issues with Boat locations, balloon frame number.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
+- Fix: [#11258] Properly remove format codes from imported strings.
 - Improved: [#11157] Slimmer virtual floor lines.
 
 0.2.5 (2020-03-24)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2945,8 +2945,9 @@ private:
     {
         const auto originalString = _s4.string_table[(stringId - USER_STRING_START) % 1024];
         std::string_view originalStringView(originalString, USER_STRING_MAX_LENGTH);
-        auto withoutFormatCodes = RCT12::RemoveFormatCodes(originalStringView);
-        return rct2_to_utf8(withoutFormatCodes, RCT2_LANGUAGE_ID_ENGLISH_UK);
+        auto asUtf8 = rct2_to_utf8(originalStringView, RCT2_LANGUAGE_ID_ENGLISH_UK);
+        utf8_remove_format_codes(asUtf8.data(), /*allow colour*/ false);
+        return asUtf8.data();
     }
 
     void FixLandOwnership()

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -482,44 +482,6 @@ bool is_user_string_id(rct_string_id stringId)
     return stringId >= 0x8000 && stringId < 0x9000;
 }
 
-std::string RCT12::RemoveFormatCodes(const std::string_view& s)
-{
-    constexpr auto RCT12_MULTIBYTE_PREFIX = (char)(uint8_t)0xFF;
-
-    std::string result;
-    result.reserve(s.size());
-
-    // Append each character that is not a format code
-    for (size_t i = 0; i < s.size(); i++)
-    {
-        auto c = s[i];
-        if (c == '\0')
-        {
-            break;
-        }
-        else if (c == RCT12_MULTIBYTE_PREFIX)
-        {
-            // Multi-byte, assume not a format code
-            result.push_back(c);
-            if (i + 1 < s.size())
-            {
-                result.push_back(s[i + 1]);
-            }
-            if (i + 2 < s.size())
-            {
-                result.push_back(s[i + 2]);
-            }
-            i += 2;
-        }
-        else if (!utf8_is_format_code(c))
-        {
-            result.push_back(c);
-        }
-    }
-
-    return result;
-}
-
 uint8_t RCT12TileElement::GetBannerIndex()
 {
     rct_scenery_entry* sceneryEntry;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -792,8 +792,3 @@ assert_struct_size(RCT12ResearchItem, 5);
 #pragma pack(pop)
 
 bool is_user_string_id(rct_string_id stringId);
-
-namespace RCT12
-{
-    std::string RemoveFormatCodes(const std::string_view& s);
-}

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1631,8 +1631,9 @@ public:
     {
         const auto originalString = _s6.custom_strings[(stringId - USER_STRING_START) % 1024];
         std::string_view originalStringView(originalString, USER_STRING_MAX_LENGTH);
-        auto withoutFormatCodes = RCT12::RemoveFormatCodes(originalStringView);
-        return rct2_to_utf8(withoutFormatCodes, RCT2_LANGUAGE_ID_ENGLISH_UK);
+        auto asUtf8 = rct2_to_utf8(originalStringView, RCT2_LANGUAGE_ID_ENGLISH_UK);
+        utf8_remove_format_codes(asUtf8.data(), /*allow colour*/ false);
+        return asUtf8.data();
     }
 
     std::vector<rct_object_entry> GetRequiredObjects()


### PR DESCRIPTION
The previous code used RCT12::RemoveFormatCodes to remove format codes from RCT strings. But that function uses utf8 methods to identify format codes. In this new version, rct2_to_utf8 is called first to obtain an utf8 string, and then utf8_remove_format_codes can be used.

Fixes  https://github.com/OpenRCT2/OpenRCT2/issues/11258.  With this patch saving and restoring a park will not erase banner names. Restoring the park in the game causes all blank banners to simply get the default value.

Important to notice that this change makes #11286 even worse. Now the tool tip doesn't get coloured even if you save/restore the map. However, the fix for that should probably be on the tooltip printing routine instead of the save routine, right?
The pull request https://github.com/OpenRCT2/OpenRCT2/pull/11291 shows this idea.