### PR TITLE
Fix coloring of Banners on tooltip

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#11246] Fix Various Import/Export issues with Boat locations, balloon frame number.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
 - Fix: [#11258] Properly remove format codes from imported strings.
+- Fix: [#11286] Fix banner tooltip colour
 - Improved: [#11157] Slimmer virtual floor lines.
 
 0.2.5 (2020-03-24)

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -368,7 +368,7 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
             size_t argPos = 0;
             set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
             argPos += sizeof(rct_string_id);
-            argPos += banner->FormatTextTo(gMapTooltipFormatArgs + argPos);
+            argPos += banner->FormatTextTo(gMapTooltipFormatArgs + argPos, /*addColour*/ true);
             set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
             argPos += sizeof(rct_string_id);
             set_map_tooltip_format_arg(argPos, rct_string_id, sceneryEntry->name);

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -101,13 +101,7 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
 
     scrollingMode += direction;
 
-    // We need to get the text colour code into the beginning of the string, so use a temporary buffer
-    char colouredBannerText[32]{};
-    utf8_write_codepoint(colouredBannerText, FORMAT_COLOUR_CODE_START + banner->text_colour);
-
-    set_format_arg(0, rct_string_id, STR_STRING_STRINGID);
-    set_format_arg(2, const char*, &colouredBannerText);
-    banner->FormatTextTo(gCommonFormatArgs + 2 + sizeof(const char*));
+    banner->FormatTextTo(gCommonFormatArgs, /*addColour*/ true);
 
     if (gConfigGeneral.upper_case_banners)
     {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -39,6 +39,29 @@ std::string Banner::GetText() const
     return format_string(STR_STRINGID, args);
 }
 
+size_t Banner::FormatTextTo(void* argsV, bool addColour) const
+{
+    auto args = static_cast<uint8_t*>(argsV);
+
+    int numColourArgs = 0;
+    if (addColour)
+    {
+        textColourUtf8.resize(5); // one code point in utf8 takes at most 4 bytes
+        auto terminator = utf8_write_codepoint(textColourUtf8.data(), FORMAT_COLOUR_CODE_START + text_colour);
+        *terminator = '\0';
+
+        set_format_arg_on(args, numColourArgs, rct_string_id, STR_STRING_STRINGID);
+        numColourArgs += sizeof(rct_string_id);
+
+        set_format_arg_on(args, numColourArgs, const char*, textColourUtf8.data());
+        numColourArgs += sizeof(const char*);
+
+        args += numColourArgs;
+    }
+
+    return numColourArgs + FormatTextTo(args);
+}
+
 size_t Banner::FormatTextTo(void* argsV) const
 {
     auto args = (uint8_t*)argsV;

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -34,6 +34,7 @@ struct Banner
     uint8_t colour{};
     ride_id_t ride_index{};
     uint8_t text_colour{};
+    mutable std::string textColourUtf8;
     TileCoordsXY position;
 
     bool IsNull() const
@@ -42,6 +43,7 @@ struct Banner
     }
 
     std::string GetText() const;
+    size_t FormatTextTo(void* args, bool addColour) const;
     size_t FormatTextTo(void* args) const;
 };
 


### PR DESCRIPTION
This patch moves the function that adds coloring to the Buffer into the Buffer struct with a flag.
It also changes both Banner printing and Banner tooltip to use the colored version

I added a mutable buffer which is used for caching the string version of the formatting codepoint. Not sure if that is ideal.

This is a fix for #11286 