### PR TITLE
Make ParkLoadResult move friendly

### DIFF
--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -35,10 +35,10 @@ struct scenario_index_entry;
 struct ParkLoadResult final
 {
 public:
-    std::vector<rct_object_entry> const RequiredObjects;
+    std::vector<rct_object_entry> RequiredObjects;
 
     explicit ParkLoadResult(std::vector<rct_object_entry>&& requiredObjects)
-        : RequiredObjects(requiredObjects)
+        : RequiredObjects(std::move(requiredObjects))
     {
     }
 };


### PR DESCRIPTION
This patch changes the member of ParkLoadResult to not be const. Const members cannot be moved so trying to move ParkLoadResult actually causes a copy.
It also changes the constructor to move the parameter into the data member. Notice the constructor is currently copying the vector because of the missing std::move to initialize the member.

See: https://godbolt.org/z/L4Wakb