### PR TITLE
Fix #11106 Crash on getting invalid vehicle index

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#11005] Company value overflows.
 - Fix: [#11027] Third color on walls becomes black when saving.
 - Fix: [#11063] Scrolling position persists when switching tabs in the scenery window.
+- Fix: [#11106] Crash on getting invalid vehicle index.
 - Fix: [#11126] Cannot place Frightmare track design.
 - Fix: [#11208] Cannot export parks with RCT2 DLC objects.
 - Fix: [#11230] Seat Rotation not imported correctly for hacked rides.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6224,6 +6224,8 @@ Vehicle* vehicle_get_head(const Vehicle* vehicle)
 
     for (;;)
     {
+        if (vehicle->prev_vehicle_on_ride > MAX_SPRITES)
+            return nullptr;
         prevVehicle = GET_VEHICLE(vehicle->prev_vehicle_on_ride);
         if (prevVehicle->next_vehicle_on_train == SPRITE_INDEX_NULL)
             break;


### PR DESCRIPTION
Fix crash on bad value for prev_vehicle_on_ride. This basically pushes the problem to the caller but for all of the parks that are suffering crashes on this (such as Thorpe Park) the caller handles nullptr correctly.

Ultimately I want to validate all of these values on load but that is something for the future.