### PR TITLE
11311 : Peep spawn locations can be placed elsewhere than on the edge of the map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.2.5+ (in development)
 ------------------------------------------------------------------------
+- Feature: [#11311] Peep spawn locations can now be placed elsewhere than on the edges of the map.
 - Feature: [#10925] Show hovered values on finance charts.
 - Feature: [#11013] Ctrl+C copies input dialog text to clipboard.
 - Feature: [#11272] Option for toggling notifications for 'Ride casualties' and 'Stuck or stalled vehicles'.

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -502,7 +502,8 @@ namespace Editor
         {
             int32_t direction = direction_reverse(parkEntrance.direction);
 
-            switch (footpath_is_connected_to_map_edge(parkEntrance, direction, 0))
+            //switch (footpath_is_connected_to_map_edge(parkEntrance, direction, 0))
+            switch (footpath_is_connected_to_map_peep_spawn_location(parkEntrance, direction, 0))
             {
                 case FOOTPATH_SEARCH_NOT_FOUND:
                     gGameCommandErrorText = STR_PARK_ENTRANCE_WRONG_DIRECTION_OR_NO_PATH;
@@ -513,7 +514,8 @@ namespace Editor
                     return false;
                 case FOOTPATH_SEARCH_SUCCESS:
                     // Run the search again and unown the path
-                    footpath_is_connected_to_map_edge(parkEntrance, direction, (1 << 5));
+                    //footpath_is_connected_to_map_edge(parkEntrance, direction, (1 << 5));
+                    footpath_is_connected_to_map_peep_spawn_location(parkEntrance, direction, (1 << 5));
                     break;
             }
         }

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -502,7 +502,6 @@ namespace Editor
         {
             int32_t direction = direction_reverse(parkEntrance.direction);
 
-            //switch (footpath_is_connected_to_map_edge(parkEntrance, direction, 0))
             switch (footpath_is_connected_to_map_peep_spawn_location(parkEntrance, direction, 0))
             {
                 case FOOTPATH_SEARCH_NOT_FOUND:
@@ -514,7 +513,6 @@ namespace Editor
                     return false;
                 case FOOTPATH_SEARCH_SUCCESS:
                     // Run the search again and unown the path
-                    //footpath_is_connected_to_map_edge(parkEntrance, direction, (1 << 5));
                     footpath_is_connected_to_map_peep_spawn_location(parkEntrance, direction, (1 << 5));
                     break;
             }

--- a/src/openrct2/actions/PlacePeepSpawnAction.hpp
+++ b/src/openrct2/actions/PlacePeepSpawnAction.hpp
@@ -62,12 +62,12 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::NO_FREE_ELEMENTS, STR_ERR_CANT_PLACE_PEEP_SPAWN_HERE, STR_NONE);
         }
 
-        if (_location.x <= 16 || _location.y <= 16 || _location.x >= (gMapSizeUnits - 16)
+        /*if (_location.x <= 16 || _location.y <= 16 || _location.x >= (gMapSizeUnits - 16)
             || _location.y >= (gMapSizeUnits - 16))
         {
             return std::make_unique<GameActionResult>(
                 GA_ERROR::INVALID_PARAMETERS, STR_ERR_CANT_PLACE_PEEP_SPAWN_HERE, STR_OFF_EDGE_OF_MAP);
-        }
+        }*/
 
         // Verify footpath exists at location, and retrieve coordinates
         auto pathElement = map_get_path_element_at(TileCoordsXYZ{ _location });

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -40,6 +40,7 @@
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
 #include "../peep/Staff.h"
+#include "../platform/platform.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../util/Util.h"
@@ -1317,6 +1318,40 @@ static int32_t cc_for_date([[maybe_unused]] InteractiveConsole& console, [[maybe
     return 1;
 }
 
+static int32_t cc_load_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
+{
+    if (argv.size() < 1)
+    {
+        console.WriteLine("Parameters required <filename>");
+        return 0;
+    }
+
+    char savePath[MAX_PATH];
+    if (String::IndexOf(argv[0].c_str(), '/') == SIZE_MAX && String::IndexOf(argv[0].c_str(), '\\') == SIZE_MAX)
+    {
+        // no / or \ was included. File should be in save dir.
+        platform_get_user_directory(savePath, "save", sizeof(savePath));
+        safe_strcat_path(savePath, argv[0].c_str(), sizeof(savePath));
+    }
+    else
+    {
+        safe_strcpy(savePath, argv[0].c_str(), sizeof(savePath));
+    }
+    if (!String::EndsWith(savePath, ".sv6", true) && !String::EndsWith(savePath, ".sc6", true))
+    {
+        path_append_extension(savePath, ".sv6", sizeof(savePath));
+    }
+    if (context_load_park_from_file(savePath))
+    {
+        console.WriteFormatLine("Park %s was loaded successfully", savePath);
+    }
+    else
+    {
+        console.WriteFormatLine("Loading Park %s failed", savePath);
+    }
+    return 1;
+}
+
 static int32_t cc_save_park([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     if (argv.size() < 1)
@@ -1727,6 +1762,7 @@ static constexpr const console_command console_command_table[] = {
                                     "Loading a scenery group will not load its associated objects.\n"
                                     "This is a safer method opposed to \"open object_selection\".",
                                     "load_object <objectfilenodat>" },
+    { "load_park", cc_load_park, "Load park from save directory or by absolute path", "load_park <filename>" },
     { "object_count", cc_object_count, "Shows the number of objects of each type in the scenario.", "object_count" },
     { "open", cc_open, "Opens the window with the give name.", "open <window>." },
     { "quit", cc_close, "Closes the console.", "quit" },

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3076,44 +3076,52 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
     }
 
     //check if peep is on peep spawn location
-    for (auto& elem : gPeepSpawns)
+    bool outside = false;
+    if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
+        // apply same old behaviour
+        outside = true;
+
+    else
     {
-        CoordsXYZ coord1, coord2;
-        coord1.x = elem.ToTileCentre().x;
-        coord1.y = elem.ToTileCentre().y;
-        coord1.z = elem.ToTileCentre().z;
-
-        CoordsXYZ tileCoord;
-        tileCoord.x = coord1.x / COORDS_XY_STEP;
-        tileCoord.y = coord1.y / COORDS_XY_STEP;
-        tileCoord.z = coord1.z;
-
-        //check if either peep is on the edge of the map or anywhere else
-        bool outside = false;
-        
-        if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits - 1) / COORDS_XY_STEP || tileCoord.y == 0
-            || tileCoord.y == (gMapSizeUnits - 1) / COORDS_XY_STEP)
+        for (auto& elem : gPeepSpawns)
         {
-            if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
-                // apply same old behaviour
+            CoordsXYZ coord1, coord2;
+            coord1.x = elem.ToTileCentre().x;
+            coord1.y = elem.ToTileCentre().y;
+            coord1.z = elem.ToTileCentre().z;
+
+            CoordsXYZ tileCoord;
+            tileCoord.x = coord1.x / COORDS_XY_STEP;
+            tileCoord.y = coord1.y / COORDS_XY_STEP;
+            tileCoord.z = coord1.z;
+
+            // check if either peep is on the edge of the map or anywhere else
+            if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits - 1) / COORDS_XY_STEP || tileCoord.y == 0
+                || tileCoord.y == (gMapSizeUnits - 1) / COORDS_XY_STEP)
+            {
+                //do nothing
+            }
+
+            else if (
+                newLoc.ToTileCentre().x == coord1.x && newLoc.ToTileCentre().y == coord1.y && height == coord1.z
+                && direction == elem.direction)
+            {
+                // the moment the peep enter the tile with the same direction, it disappears
                 outside = true;
+                break;
+            }
         }
-        
-        else if (newLoc.ToTileCentre().x == coord1.x && newLoc.ToTileCentre().y == coord1.y && height == coord1.z && direction == elem.direction)
-            //the moment the peep enter the tile with the same direction, it disappears
-            outside = true;
-
-        //calling the routine to make peep disappear
-        if (outside)
-        {
-            if (outside_of_park)
-                pathing_result |= PATHING_OUTSIDE_PARK;
-            peep_return_to_centre_of_tile(this);
-            return;
-        }
-        
-            
     }
+
+    // calling the routine to make peep disappear
+    if (outside)
+    {
+        if (outside_of_park)
+            pathing_result |= PATHING_OUTSIDE_PARK;
+        peep_return_to_centre_of_tile(this);
+        return;
+    }
+    
 
     TileElement* tileElement = map_get_first_element_at(newLoc);
     if (tileElement == nullptr)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3083,11 +3083,22 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         coord1.y = elem.ToTileCentre().y;
         coord1.z = elem.ToTileCentre().z;
 
+        CoordsXYZ tileCoord;
+        tileCoord.x = coord1.x / COORDS_XY_STEP;
+        tileCoord.y = coord1.y / COORDS_XY_STEP;
+        tileCoord.z = coord1.z;
+
         //check if either peep is on the edge of the map or anywhere else
         bool outside = false;
-        if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
-            //apply same old behaviour
-            outside = true;
+        
+        if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits - 1) / COORDS_XY_STEP || tileCoord.y == 0
+            || tileCoord.y == (gMapSizeUnits - 1) / COORDS_XY_STEP)
+        {
+            if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
+                // apply same old behaviour
+                outside = true;
+        }
+        
         else if (newLoc.ToTileCentre().x == coord1.x && newLoc.ToTileCentre().y == coord1.y && height == coord1.z && direction == elem.direction)
             //the moment the peep enter the tile with the same direction, it disappears
             outside = true;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3075,7 +3075,7 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         return;
     }
 
-    //check if peep is on peep spawn location
+
     bool outside = false;
     if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
         // apply same old behaviour
@@ -3083,17 +3083,11 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
 
     else
     {
+        //check if peep is on peep spawn location
         for (auto& peepSpawn : gPeepSpawns)
         {
-            CoordsXYZ coord1, coord2;
-            coord1.x = elem.ToTileCentre().x;
-            coord1.y = elem.ToTileCentre().y;
-            coord1.z = elem.ToTileCentre().z;
-
-            CoordsXYZ tileCoord;
-            tileCoord.x = coord1.x / COORDS_XY_STEP;
-            tileCoord.y = coord1.y / COORDS_XY_STEP;
-            tileCoord.z = coord1.z;
+            CoordsXYZ centeredPeepSpawn = peepSpawn.ToTileCentre();
+            auto tileCoord = TileCoordsXY(centeredPeepSpawn);
 
             // check if either peep is on the edge of the map or anywhere else
             if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits / COORDS_XY_STEP)-1 || tileCoord.y == 0
@@ -3103,8 +3097,9 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
             }
 
             else if (
-                newLoc.ToTileCentre().x == coord1.x && newLoc.ToTileCentre().y == coord1.y && height == coord1.z
-                && direction == elem.direction)
+                newLoc.ToTileCentre().x == centeredPeepSpawn.x && newLoc.ToTileCentre().y == centeredPeepSpawn.y
+                && height == centeredPeepSpawn.z
+                && direction == peepSpawn.direction)
             {
                 // the moment the peep enter the tile with the same direction, it disappears
                 outside = true;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3075,46 +3075,37 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         return;
     }
 
-
-    bool outside = false;
     if (newLoc.x <= 32 || newLoc.y <= 32 || newLoc.x >= gMapSizeUnits || newLoc.y >= gMapSizeUnits)
-        // apply same old behaviour
-        outside = true;
-
-    else
-    {
-        //check if peep is on peep spawn location
-        for (auto& peepSpawn : gPeepSpawns)
-        {
-            CoordsXYZ centeredPeepSpawn = peepSpawn.ToTileCentre();
-            auto tileCoord = TileCoordsXY(centeredPeepSpawn);
-
-            // check if either peep is on the edge of the map or anywhere else
-            if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits / COORDS_XY_STEP)-1 || tileCoord.y == 0
-                || tileCoord.y == (gMapSizeUnits / COORDS_XY_STEP)-1)
-            {
-                //do nothing
-            }
-
-            else if (
-                newLoc.ToTileCentre().x == centeredPeepSpawn.x && newLoc.ToTileCentre().y == centeredPeepSpawn.y
-                && height == centeredPeepSpawn.z
-                && direction == peepSpawn.direction)
-            {
-                // the moment the peep enter the tile with the same direction, it disappears
-                outside = true;
-                break;
-            }
-        }
-    }
-
-    // calling the routine to make peep disappear
-    if (outside)
     {
         if (outside_of_park)
             pathing_result |= PATHING_OUTSIDE_PARK;
         peep_return_to_centre_of_tile(this);
         return;
+    }
+    //check if peep is on peep spawn location
+    for (auto& peepSpawn : gPeepSpawns)
+    {
+        CoordsXYZ centeredPeepSpawn = peepSpawn.ToTileCentre();
+        auto tileCoord = TileCoordsXY(centeredPeepSpawn);
+
+        // check if either peep is on the edge of the map or anywhere else
+        if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits / COORDS_XY_STEP)-1 || tileCoord.y == 0
+            || tileCoord.y == (gMapSizeUnits / COORDS_XY_STEP)-1)
+        {
+            //do nothing
+        }
+
+        else if (
+            newLoc.ToTileCentre().x == centeredPeepSpawn.x && newLoc.ToTileCentre().y == centeredPeepSpawn.y
+            && height == centeredPeepSpawn.z
+            && direction == peepSpawn.direction)
+        {
+            // the moment the peep enter the tile with the same direction, it disappears
+            if (outside_of_park)
+                pathing_result |= PATHING_OUTSIDE_PARK;
+            peep_return_to_centre_of_tile(this);
+            return;
+        }
     }
     
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3083,7 +3083,7 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
 
     else
     {
-        for (auto& elem : gPeepSpawns)
+        for (auto& peepSpawn : gPeepSpawns)
         {
             CoordsXYZ coord1, coord2;
             coord1.x = elem.ToTileCentre().x;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3096,8 +3096,8 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
             tileCoord.z = coord1.z;
 
             // check if either peep is on the edge of the map or anywhere else
-            if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits - 1) / COORDS_XY_STEP || tileCoord.y == 0
-                || tileCoord.y == (gMapSizeUnits - 1) / COORDS_XY_STEP)
+            if (tileCoord.x == 0 || tileCoord.x == (gMapSizeUnits / COORDS_XY_STEP)-1 || tileCoord.y == 0
+                || tileCoord.y == (gMapSizeUnits / COORDS_XY_STEP)-1)
             {
                 //do nothing
             }

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -188,9 +188,10 @@ void footpath_chain_ride_queue(
     ride_id_t rideIndex, int32_t entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
 void footpath_update_path_wide_flags(const CoordsXY& footpathPos);
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
+void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);
 
 int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
-void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);
+int32_t footpath_is_connected_to_map_peep_spawn_location(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
 int32_t entrance_get_directions(const TileElement* tileElement);
 
 PathSurfaceEntry* get_path_surface_entry(PathSurfaceIndex entryIndex);


### PR DESCRIPTION
- In the scenario editor, it is now possible to place peep spawn locations elsewhere than on the edge of the map.
- The recursive routine that tracks the path from the entrance to the edge of the map has been adapted to check for peep spawn locations
- In game, if the peep is on the edge of the map, it exhibits the same behaviour as before, i.e. it quits the world on the edge of the tile.
- In game, if the peep is elsewhere, the moment it enters the tile with a spawn point with the same direction it quits the world.