### PR TITLE
Forward script parameters into tests

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -12,8 +12,8 @@ echo -e "\033[0;36mBuilding OpenRCT2 repository indexes...\033[0m"
 if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # Now run all the tests
     echo -e "\033[0;36mRunning OpenRCT2 tests...\033[0m"
-    ./tests --gtest_output=xml:../artifacts/test-results.xml
+    ./tests --gtest_output=xml:../artifacts/test-results.xml "$@"
 else
     echo -e "\033[0;36mRunning OpenRCT2 tests...\033[0m"
-    ctest --output-on-failure
+    ctest --output-on-failure "$@"
 fi


### PR DESCRIPTION
This patch forwards whatever parameter passed into run-tests to ctest or google test.
I'm using this to pass `--gtest_filter=TheInterestingTest` to run-tests