### PR TITLE
Fix #11325: Space rings change colours and show incorrect sprites

### DIFF
--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -51,7 +51,7 @@ static void paint_space_rings_structure(paint_session* session, Ride* ride, uint
             session->InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;
             vehicle = GET_VEHICLE(ride->vehicles[vehicleIndex]);
             session->CurrentlyDrawnItem = vehicle;
-            frameNum += static_cast<int8_t>(vehicle->vehicle_sprite_type * 4);
+            frameNum += static_cast<int8_t>(vehicle->vehicle_sprite_type) * 4;
         }
 
         uint32_t imageColourFlags = session->TrackColours[SCHEME_MISC];


### PR DESCRIPTION
Mistake introduced by https://github.com/OpenRCT2/OpenRCT2/pull/11168.