### PR TITLE
Fix #11340: Sound bar only working when maxe out

### DIFF
--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -334,7 +334,7 @@ static void window_network_draw_graph(
         // std::sort(history.deltaBytesReceived.begin(), history.deltaBytesReceived.end(), std::greater<uint16_t>());
 
         // NOTE: Capacity is not a mistake, we always want the full length.
-        uint32_t curX = std::round((static_cast<float>(i) / static_cast<float>(_networkHistory.capacity()) * barWidth * width));
+        uint32_t curX = std::round((static_cast<float>(i) / static_cast<float>(_networkHistory.capacity())) * barWidth * width);
 
         float totalSum = 0.0f;
         for (int n = 1; n < NETWORK_STATISTICS_GROUP_MAX; n++)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2001,7 +2001,7 @@ static void window_options_invalidate(rct_window* w)
 static uint8_t get_scroll_percentage(rct_widget* widget, rct_scroll* scroll)
 {
     uint8_t width = widget->right - widget->left - 1;
-    return static_cast<float>(scroll->h_left / (scroll->h_right - width) * 100);
+    return static_cast<float>(scroll->h_left) / (scroll->h_right - width) * 100;
 }
 
 static void window_options_update(rct_window* w)

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -416,7 +416,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
                 if (w->selected_list_item != -1
                     && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumCommands))
                 {
-                    for (int32_t i = w->selected_list_item; i < static_cast<int16_t>(_editingTitleSequence->NumCommands - 1);
+                    for (int32_t i = w->selected_list_item; i < static_cast<int16_t>(_editingTitleSequence->NumCommands) - 1;
                          i++)
                     {
                         _editingTitleSequence->Commands[i] = _editingTitleSequence->Commands[i + 1];
@@ -446,7 +446,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
             if (window_title_editor_check_can_edit())
             {
                 if (w->selected_list_item != -1
-                    && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumCommands - 1))
+                    && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumCommands) - 1)
                 {
                     TitleCommand* a = &_editingTitleSequence->Commands[w->selected_list_item];
                     TitleCommand* b = &_editingTitleSequence->Commands[w->selected_list_item + 1];


### PR DESCRIPTION
The changesets replacing c-style casts with named casts mistakenly added some parentheses in the wrong place, changing the evauluation order.

The culprit was the change in Options, not sure if the others have side effects, but I checked the whole PR and found these mistakes, so I'm also fixing them.

(Regression from #11340)