### PR TITLE
Fix #11343, 11344. Remove all peeps cheat causes a crash/hang

### DIFF
--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -685,9 +685,12 @@ private:
             }
         }
 
-        Peep* peep;
-        FOR_ALL_GUESTS (spriteIndex, peep)
+        // Do not use the FOR_ALL_PEEPS macro for this as next sprite index
+        // will be fetched on a delted peep.
+        for (spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP]; spriteIndex != SPRITE_INDEX_NULL;)
         {
+            auto peep = GET_PEEP(spriteIndex);
+            spriteIndex = peep->next;
             peep->Remove();
         }
 

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -686,7 +686,7 @@ private:
         }
 
         // Do not use the FOR_ALL_PEEPS macro for this as next sprite index
-        // will be fetched on a delted peep.
+        // will be fetched on a deleted peep.
         for (spriteIndex = gSpriteListHead[SPRITE_LIST_PEEP]; spriteIndex != SPRITE_INDEX_NULL;)
         {
             auto peep = GET_PEEP(spriteIndex);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -31,7 +31,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Caused by a refactor.