### PR TITLE
Replacing set_format_arg_on macro in favor of a more C++zy solution

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -450,7 +450,7 @@ static void widget_groupbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
         utf8 buffer[512] = { 0 };
         uint8_t args[sizeof(uintptr_t)] = { 0 };
         format_string(buffer, sizeof(buffer), widget->text, gCommonFormatArgs);
-        set_format_arg_on(args, 0, uintptr_t, buffer);
+        Formatter(args).add<utf8*>(buffer);
         gfx_draw_string_left(dpi, STR_STRING, args, colour, l, t);
         textRight = l + gfx_get_string_width(buffer) + 1;
     }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -282,6 +282,8 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
     _window_guest_list_tracking_only = false;
     _window_guest_list_filter_arguments = {};
 
+    Formatter ft(_window_guest_list_filter_arguments.args);
+
     switch (type)
     {
         case GLFT_GUESTS_ON_RIDE:
@@ -289,10 +291,8 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
             auto ride = get_ride(index & 0xFF);
             if (ride != nullptr)
             {
-                set_format_arg_on(
-                    _window_guest_list_filter_arguments.args, 0, rct_string_id,
-                    ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_IN_RIDE : STR_ON_RIDE);
-                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
+                ft.add<rct_string_id>(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_IN_RIDE : STR_ON_RIDE);
+                ride->FormatNameTo(ft.buf());
 
                 _window_guest_list_selected_filter = 0;
                 _window_guest_list_highlighted_index = 0xFFFF;
@@ -306,8 +306,8 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
             auto ride = get_ride(index & 0xFF);
             if (ride != nullptr)
             {
-                set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_QUEUING_FOR);
-                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
+                ft.add<rct_string_id>(STR_QUEUING_FOR);
+                ride->FormatNameTo(ft.buf());
 
                 _window_guest_list_selected_filter = 0;
                 _window_guest_list_highlighted_index = 0xFFFF;
@@ -321,8 +321,8 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
             auto ride = get_ride(index & 0xFF);
             if (ride != nullptr)
             {
-                set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, STR_NONE);
-                ride->FormatNameTo(_window_guest_list_filter_arguments.args + 2);
+                ft.add<rct_string_id>(STR_NONE);
+                ride->FormatNameTo(ft.buf());
 
                 _window_guest_list_selected_filter = 1;
                 _window_guest_list_highlighted_index = 0xFFFF;
@@ -333,7 +333,7 @@ rct_window* window_guest_list_open_with_filter(int32_t type, int32_t index)
         }
         case GLFT_GUESTS_THINKING_X:
         {
-            set_format_arg_on(_window_guest_list_filter_arguments.args, 0, rct_string_id, PeepThoughts[index & 0xFF]);
+            ft.add<rct_string_id>(PeepThoughts[index & 0xFF]);
 
             _window_guest_list_selected_filter = 1;
             _window_guest_list_highlighted_index = 0xFFFF;
@@ -878,7 +878,7 @@ static int32_t window_guest_list_is_peep_in_filter(Peep* peep)
 
     if (_window_guest_list_filter_arguments.GetFirstStringId() == STR_NONE && _window_guest_list_selected_filter == 1)
     {
-        set_format_arg_on(peepArgs.args, 0, rct_string_id, STR_NONE);
+        Formatter(peepArgs.args).add<rct_string_id>(STR_NONE);
     }
 
     if (_window_guest_list_filter_arguments == peepArgs)

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -262,16 +262,15 @@ static void window_new_campaign_mousedown(rct_window* w, rct_widgetindex widgetI
                     {
                         // HACK until dropdown items have longer argument buffers
                         gDropdownItemsFormat[numItems] = STR_DROPDOWN_MENU_LABEL;
+                        Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItemsArgs[numItems]));
                         if (ride->custom_name.empty())
                         {
-                            ride->FormatNameTo(&gDropdownItemsArgs[numItems]);
+                            ride->FormatNameTo(ft.buf());
                         }
                         else
                         {
                             gDropdownItemsFormat[numItems] = STR_OPTIONS_DROPDOWN_ITEM;
-                            set_format_arg_on(
-                                reinterpret_cast<uint8_t*>(&gDropdownItemsArgs[numItems]), 0, const char*,
-                                ride->custom_name.c_str());
+                            ft.add<const char*>(ride->custom_name.c_str());
                         }
                         numItems++;
                     }

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -112,22 +112,20 @@ private:
             {
                 char str_downloading_objects[256]{};
                 uint8_t args[32]{};
+                Formatter ft(args);
                 if (_downloadStatusInfo.Source.empty())
                 {
-                    set_format_arg_on(args, 0, int16_t, static_cast<int16_t>(_downloadStatusInfo.Count));
-                    set_format_arg_on(args, 2, int16_t, static_cast<int16_t>(_downloadStatusInfo.Total));
-                    set_format_arg_on(args, 4, char*, _downloadStatusInfo.Name.c_str());
+                    ft.add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
+                    ft.add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
+                    ft.add<char*>(_downloadStatusInfo.Name.c_str());
                     format_string(str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS, args);
                 }
                 else
                 {
-                    set_format_arg_on(args, 0, char*, _downloadStatusInfo.Name.c_str());
-                    set_format_arg_on(args, sizeof(char*), char*, _downloadStatusInfo.Source.c_str());
-                    set_format_arg_on(
-                        args, sizeof(char*) + sizeof(char*), int16_t, static_cast<int16_t>(_downloadStatusInfo.Count));
-                    set_format_arg_on(
-                        args, sizeof(char*) + sizeof(char*) + sizeof(int16_t), int16_t,
-                        static_cast<int16_t>(_downloadStatusInfo.Total));
+                    ft.add<char*>(_downloadStatusInfo.Name.c_str());
+                    ft.add<char*>(_downloadStatusInfo.Source.c_str());
+                    ft.add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
+                    ft.add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
                     format_string(str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS_FROM, args);
                 }
 

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -272,7 +272,7 @@ namespace GameActions
             {
                 result->Error = GA_ERROR::INSUFFICIENT_FUNDS;
                 result->ErrorMessage = STR_NOT_ENOUGH_CASH_REQUIRES;
-                set_format_arg_on(result->ErrorMessageArgs.data(), 0, uint32_t, result->Cost);
+                Formatter(result->ErrorMessageArgs.data()).add<uint32_t>(result->Cost);
             }
         }
         return result;

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -98,13 +98,50 @@ template<typename T> void constexpr set_format_arg(uint8_t* args, size_t offset,
         set_format_arg_body(gCommonFormatArgs, offset, (uintptr_t)(value), sizeof(type));                                      \
     } while (false)
 
-#define set_format_arg_on(args, offset, type, value) set_format_arg_body(args, offset, (uintptr_t)(value), sizeof(type))
-
 #define set_map_tooltip_format_arg(offset, type, value)                                                                        \
     do                                                                                                                         \
     {                                                                                                                          \
         static_assert(sizeof(type) <= sizeof(uintptr_t), "Type too large");                                                    \
         set_format_arg_body(gMapTooltipFormatArgs, offset, (uintptr_t)(value), sizeof(type));                                  \
     } while (false)
+
+class Formatter
+{
+    const uint8_t* StartBuf;
+    uint8_t* CurrentBuf;
+
+public:
+    explicit Formatter(uint8_t* buf)
+        : StartBuf(buf)
+        , CurrentBuf(buf)
+    {
+    }
+
+    auto buf()
+    {
+        return CurrentBuf;
+    }
+
+    std::size_t bytes() const
+    {
+        return CurrentBuf - StartBuf;
+    }
+
+    template<typename TSpecified, typename TDeduced> Formatter& add(TDeduced value)
+    {
+        uintptr_t convertedValue;
+        if constexpr (std::is_integral_v<TSpecified>)
+        {
+            convertedValue = static_cast<uintptr_t>(value);
+        }
+        else
+        {
+            convertedValue = reinterpret_cast<uintptr_t>(value);
+        }
+        set_format_arg_body(CurrentBuf, 0, convertedValue, sizeof(TSpecified));
+        CurrentBuf += sizeof(TSpecified);
+        return *this;
+    }
+};
 
 #endif

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -2451,7 +2451,7 @@ void Network::Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPack
                 log_info("Wrote desync report to '%s'", outputFile.c_str());
 
                 uint8_t args[32]{};
-                set_format_arg_on(args, 0, char*, uniqueFileName);
+                Formatter(args).add<char*>(uniqueFileName);
 
                 char str_desync[1024];
                 format_string(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, args);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1786,14 +1786,14 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
 
 void Peep::FormatActionTo(void* argsV) const
 {
-    auto args = (uint8_t*)argsV;
+    Formatter ft((uint8_t*)argsV);
     switch (state)
     {
         case PEEP_STATE_FALLING:
-            set_format_arg_on(args, 0, rct_string_id, action == PEEP_ACTION_DROWNING ? STR_DROWNING : STR_WALKING);
+            ft.add<rct_string_id>(action == PEEP_ACTION_DROWNING ? STR_DROWNING : STR_WALKING);
             break;
         case PEEP_STATE_1:
-            set_format_arg_on(args, 0, rct_string_id, STR_WALKING);
+            ft.add<rct_string_id>(STR_WALKING);
             break;
         case PEEP_STATE_ON_RIDE:
         case PEEP_STATE_LEAVING_RIDE:
@@ -1802,28 +1802,26 @@ void Peep::FormatActionTo(void* argsV) const
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                set_format_arg_on(
-                    args, 0, rct_string_id, ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_IN_RIDE : STR_ON_RIDE);
-                ride->FormatNameTo(args + 2);
+                ft.add<rct_string_id>(ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_IN_RIDE) ? STR_IN_RIDE : STR_ON_RIDE);
+                ride->FormatNameTo(ft.buf());
             }
             else
             {
-                set_format_arg_on(args, 0, rct_string_id, STR_ON_RIDE);
-                set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                ft.add<rct_string_id>(STR_ON_RIDE).add<rct_string_id>(STR_NONE);
             }
             break;
         }
         case PEEP_STATE_BUYING:
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_AT_RIDE);
+            ft.add<rct_string_id>(STR_AT_RIDE);
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                ride->FormatNameTo(args + 2);
+                ride->FormatNameTo(ft.buf());
             }
             else
             {
-                set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                ft.add<rct_string_id>(STR_NONE);
             }
             break;
         }
@@ -1834,14 +1832,13 @@ void Peep::FormatActionTo(void* argsV) const
                 auto ride = get_ride(guest_heading_to_ride_id);
                 if (ride != nullptr)
                 {
-                    set_format_arg_on(args, 0, rct_string_id, STR_HEADING_FOR);
-                    ride->FormatNameTo(args + 2);
+                    ft.add<rct_string_id>(STR_HEADING_FOR);
+                    ride->FormatNameTo(ft.buf());
                 }
             }
             else
             {
-                set_format_arg_on(
-                    args, 0, rct_string_id, (peep_flags & PEEP_FLAGS_LEAVING_PARK) ? STR_LEAVING_PARK : STR_WALKING);
+                ft.add<rct_string_id>((peep_flags & PEEP_FLAGS_LEAVING_PARK) ? STR_LEAVING_PARK : STR_WALKING);
             }
             break;
         case PEEP_STATE_QUEUING_FRONT:
@@ -1850,13 +1847,13 @@ void Peep::FormatActionTo(void* argsV) const
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                set_format_arg_on(args, 0, rct_string_id, STR_QUEUING_FOR);
-                ride->FormatNameTo(args + 2);
+                ft.add<rct_string_id>(STR_QUEUING_FOR);
+                ride->FormatNameTo(ft.buf());
             }
             break;
         }
         case PEEP_STATE_SITTING:
-            set_format_arg_on(args, 0, rct_string_id, STR_SITTING);
+            ft.add<rct_string_id>(STR_SITTING);
             break;
         case PEEP_STATE_WATCHING:
             if (current_ride != RIDE_ID_NULL)
@@ -1864,100 +1861,97 @@ void Peep::FormatActionTo(void* argsV) const
                 auto ride = get_ride(current_ride);
                 if (ride != nullptr)
                 {
-                    set_format_arg_on(
-                        args, 0, rct_string_id, (current_seat & 0x1) ? STR_WATCHING_CONSTRUCTION_OF : STR_WATCHING_RIDE);
-                    ride->FormatNameTo(args + 2);
+                    ft.add<rct_string_id>((current_seat & 0x1) ? STR_WATCHING_CONSTRUCTION_OF : STR_WATCHING_RIDE);
+                    ride->FormatNameTo(ft.buf());
                 }
             }
             else
             {
-                set_format_arg_on(
-                    args, 0, rct_string_id,
-                    (current_seat & 0x1) ? STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED : STR_LOOKING_AT_SCENERY);
+                ft.add<rct_string_id>((current_seat & 0x1) ? STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED : STR_LOOKING_AT_SCENERY);
             }
             break;
         case PEEP_STATE_PICKED:
-            set_format_arg_on(args, 0, rct_string_id, STR_SELECT_LOCATION);
+            ft.add<rct_string_id>(STR_SELECT_LOCATION);
             break;
         case PEEP_STATE_PATROLLING:
         case PEEP_STATE_ENTERING_PARK:
         case PEEP_STATE_LEAVING_PARK:
-            set_format_arg_on(args, 0, rct_string_id, STR_WALKING);
+            ft.add<rct_string_id>(STR_WALKING);
             break;
         case PEEP_STATE_MOWING:
-            set_format_arg_on(args, 0, rct_string_id, STR_MOWING_GRASS);
+            ft.add<rct_string_id>(STR_MOWING_GRASS);
             break;
         case PEEP_STATE_SWEEPING:
-            set_format_arg_on(args, 0, rct_string_id, STR_SWEEPING_FOOTPATH);
+            ft.add<rct_string_id>(STR_SWEEPING_FOOTPATH);
             break;
         case PEEP_STATE_WATERING:
-            set_format_arg_on(args, 0, rct_string_id, STR_WATERING_GARDENS);
+            ft.add<rct_string_id>(STR_WATERING_GARDENS);
             break;
         case PEEP_STATE_EMPTYING_BIN:
-            set_format_arg_on(args, 0, rct_string_id, STR_EMPTYING_LITTER_BIN);
+            ft.add<rct_string_id>(STR_EMPTYING_LITTER_BIN);
             break;
         case PEEP_STATE_ANSWERING:
             if (sub_state == 0)
             {
-                set_format_arg_on(args, 0, rct_string_id, STR_WALKING);
+                ft.add<rct_string_id>(STR_WALKING);
             }
             else if (sub_state == 1)
             {
-                set_format_arg_on(args, 0, rct_string_id, STR_ANSWERING_RADIO_CALL);
+                ft.add<rct_string_id>(STR_ANSWERING_RADIO_CALL);
             }
             else
             {
-                set_format_arg_on(args, 0, rct_string_id, STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL);
+                ft.add<rct_string_id>(STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL);
                 auto ride = get_ride(current_ride);
                 if (ride != nullptr)
                 {
-                    ride->FormatNameTo(args + 2);
+                    ride->FormatNameTo(ft.buf());
                 }
                 else
                 {
-                    set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                    ft.add<rct_string_id>(STR_NONE);
                 }
             }
             break;
         case PEEP_STATE_FIXING:
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_FIXING_RIDE);
+            ft.add<rct_string_id>(STR_FIXING_RIDE);
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                ride->FormatNameTo(args + 2);
+                ride->FormatNameTo(ft.buf());
             }
             else
             {
-                set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                ft.add<rct_string_id>(STR_NONE);
             }
             break;
         }
         case PEEP_STATE_HEADING_TO_INSPECTION:
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_HEADING_TO_RIDE_FOR_INSPECTION);
+            ft.add<rct_string_id>(STR_HEADING_TO_RIDE_FOR_INSPECTION);
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                ride->FormatNameTo(args + 2);
+                ride->FormatNameTo(ft.buf());
             }
             else
             {
-                set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                ft.add<rct_string_id>(STR_NONE);
             }
             break;
         }
         case PEEP_STATE_INSPECTING:
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_INSPECTING_RIDE);
+            ft.add<rct_string_id>(STR_INSPECTING_RIDE);
             auto ride = get_ride(current_ride);
             if (ride != nullptr)
             {
-                ride->FormatNameTo(args + 2);
+                ride->FormatNameTo(ft.buf());
             }
             else
             {
-                set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+                ft.add<rct_string_id>(STR_NONE);
             }
             break;
         }
@@ -1966,7 +1960,7 @@ void Peep::FormatActionTo(void* argsV) const
 
 size_t Peep::FormatNameTo(void* argsV) const
 {
-    auto args = (uint8_t*)argsV;
+    Formatter ft((uint8_t*)argsV);
     if (name == nullptr)
     {
         if (type == PeepType::PEEP_TYPE_STAFF)
@@ -1984,28 +1978,23 @@ size_t Peep::FormatNameTo(void* argsV) const
                 staffNameIndex = 0;
             }
 
-            set_format_arg_on(args, 0, rct_string_id, staffNames[staffNameIndex]);
-            set_format_arg_on(args, 2, uint32_t, id);
-            return sizeof(rct_string_id) + sizeof(uint32_t);
+            ft.add<rct_string_id>(staffNames[staffNameIndex]);
+            ft.add<uint32_t>(id);
+            return ft.bytes();
         }
         else if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
             auto realNameStringId = get_real_name_string_id_from_id(id);
-            set_format_arg_on(args, 0, rct_string_id, realNameStringId);
-            return sizeof(rct_string_id);
+            return ft.add<rct_string_id>(realNameStringId).bytes();
         }
         else
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_GUEST_X);
-            set_format_arg_on(args, 2, uint32_t, id);
-            return sizeof(rct_string_id) + sizeof(uint32_t);
+            return ft.add<rct_string_id>(STR_GUEST_X).add<uint32_t>(id).bytes();
         }
     }
     else
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_STRING);
-        set_format_arg_on(args, 2, const char*, name);
-        return sizeof(rct_string_id) + sizeof(const char*);
+        return ft.add<rct_string_id>(STR_STRING).add<const char*>(name).bytes();
     }
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -753,35 +753,42 @@ int32_t ride_find_track_gap(const Ride* ride, CoordsXYE* input, CoordsXYE* outpu
 
 void Ride::FormatStatusTo(void* argsV) const
 {
-    auto args = static_cast<uint8_t*>(argsV);
+    Formatter ft(static_cast<uint8_t*>(argsV));
 
     if (lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_CRASHED);
+        ft.add<rct_string_id>(STR_CRASHED);
     }
     else if (lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_BROKEN_DOWN);
+        ft.add<rct_string_id>(STR_BROKEN_DOWN);
     }
     else if (status == RIDE_STATUS_CLOSED)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_CLOSED);
         if (!ride_type_has_flag(type, RIDE_TYPE_FLAG_IS_SHOP))
         {
             if (num_riders != 0)
             {
-                set_format_arg_on(args, 0, rct_string_id, num_riders == 1 ? STR_CLOSED_WITH_PERSON : STR_CLOSED_WITH_PEOPLE);
-                set_format_arg_on(args, 2, uint16_t, num_riders);
+                ft.add<rct_string_id>(num_riders == 1 ? STR_CLOSED_WITH_PERSON : STR_CLOSED_WITH_PEOPLE);
+                ft.add<uint16_t>(num_riders);
             }
+            else
+            {
+                ft.add<rct_string_id>(STR_CLOSED);
+            }
+        }
+        else
+        {
+            ft.add<rct_string_id>(STR_CLOSED);
         }
     }
     else if (status == RIDE_STATUS_SIMULATING)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_SIMULATING);
+        ft.add<rct_string_id>(STR_SIMULATING);
     }
     else if (status == RIDE_STATUS_TESTING)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_TEST_RUN);
+        ft.add<rct_string_id>(STR_TEST_RUN);
     }
     else if (
         mode == RIDE_MODE_RACE && !(lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
@@ -791,23 +798,23 @@ void Ride::FormatStatusTo(void* argsV) const
         if (sprite != nullptr && sprite->IsPeep())
         {
             auto peep = sprite->AsPeep();
-            set_format_arg_on(args, 0, rct_string_id, STR_RACE_WON_BY);
-            peep->FormatNameTo(args + 2);
+            ft.add<rct_string_id>(STR_RACE_WON_BY);
+            peep->FormatNameTo(ft.buf());
         }
         else
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_RACE_WON_BY);
-            set_format_arg_on(args, 2, rct_string_id, STR_NONE);
+            ft.add<rct_string_id>(STR_RACE_WON_BY);
+            ft.add<rct_string_id>(STR_NONE);
         }
     }
     else if (!ride_type_has_flag(type, RIDE_TYPE_FLAG_IS_SHOP))
     {
-        set_format_arg_on(args, 0, rct_string_id, num_riders == 1 ? STR_PERSON_ON_RIDE : STR_PEOPLE_ON_RIDE);
-        set_format_arg_on(args, 2, uint16_t, num_riders);
+        ft.add<rct_string_id>(num_riders == 1 ? STR_PERSON_ON_RIDE : STR_PEOPLE_ON_RIDE);
+        ft.add<uint16_t>(num_riders);
     }
     else
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_OPEN);
+        ft.add<rct_string_id>(STR_OPEN);
     }
 }
 
@@ -7777,13 +7784,13 @@ std::string Ride::GetName() const
 
 size_t Ride::FormatNameTo(void* argsV) const
 {
-    auto args = static_cast<uint8_t*>(argsV);
+    Formatter ft(static_cast<uint8_t*>(argsV));
     if (!custom_name.empty())
     {
         auto str = custom_name.c_str();
-        set_format_arg_on(args, 0, rct_string_id, STR_STRING);
-        set_format_arg_on(args, 2, void*, str);
-        return sizeof(rct_string_id) + sizeof(void*);
+        ft.add<rct_string_id>(STR_STRING);
+        ft.add<void*>(str);
+        return ft.bytes();
     }
     else
     {
@@ -7808,9 +7815,7 @@ size_t Ride::FormatNameTo(void* argsV) const
                 }
             }
         }
-        set_format_arg_on(args, 0, rct_string_id, 1);
-        set_format_arg_on(args, 2, rct_string_id, rideTypeName);
-        set_format_arg_on(args, 4, uint16_t, default_name_number);
-        return sizeof(rct_string_id) + sizeof(rct_string_id) + sizeof(uint16_t);
+        ft.add<rct_string_id>(1).add<rct_string_id>(rideTypeName).add<uint16_t>(default_name_number);
+        return ft.bytes();
     }
 }

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -66,54 +66,43 @@ std::string Banner::GetText() const
 
 size_t Banner::FormatTextTo(void* argsV, bool addColour) const
 {
-    auto args = static_cast<uint8_t*>(argsV);
+    Formatter ft(static_cast<uint8_t*>(argsV));
 
-    int numColourArgs = 0;
     if (addColour)
     {
-        set_format_arg_on(args, numColourArgs, rct_string_id, STR_STRING_STRINGID);
-        numColourArgs += sizeof(rct_string_id);
-
-        set_format_arg_on(args, numColourArgs, const char*, colourToUtf8(text_colour));
-        numColourArgs += sizeof(const char*);
-
-        args += numColourArgs;
+        ft.add<rct_string_id>(STR_STRING_STRINGID).add<const char*>(colourToUtf8(text_colour));
     }
 
-    return numColourArgs + FormatTextTo(args);
+    return ft.bytes() + FormatTextTo(ft.buf());
 }
 
 size_t Banner::FormatTextTo(void* argsV) const
 {
-    auto args = static_cast<uint8_t*>(argsV);
+    Formatter ft(static_cast<uint8_t*>(argsV));
+
     if (flags & BANNER_FLAG_NO_ENTRY)
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_NO_ENTRY);
-        return sizeof(rct_string_id);
+        return ft.add<rct_string_id>(STR_NO_ENTRY).bytes();
     }
     else if (flags & BANNER_FLAG_LINKED_TO_RIDE)
     {
         auto ride = get_ride(ride_index);
         if (ride != nullptr)
         {
-            return ride->FormatNameTo(args);
+            return ride->FormatNameTo(ft.buf());
         }
         else
         {
-            set_format_arg_on(args, 0, rct_string_id, STR_DEFAULT_SIGN);
-            return sizeof(rct_string_id);
+            return ft.add<rct_string_id>(STR_DEFAULT_SIGN).bytes();
         }
     }
     else if (text.empty())
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_DEFAULT_SIGN);
-        return sizeof(rct_string_id);
+        return ft.add<rct_string_id>(STR_DEFAULT_SIGN).bytes();
     }
     else
     {
-        set_format_arg_on(args, 0, rct_string_id, STR_STRING);
-        set_format_arg_on(args, 2, const char*, text.c_str());
-        return sizeof(rct_string_id) + sizeof(const char*);
+        return ft.add<rct_string_id>(STR_STRING).add<const char*>(text.c_str()).bytes();
     }
 }
 


### PR DESCRIPTION
This is a start to make the formatting infrastructure simpler. There are further changes that enables even more simplifications (like passing the Formatter to FormatTextTo functions).

Technically it should be possible to allow the template to deduce the type (so instead of writing `add<rct_string_id>(STR_NONE)` one would just write `add(STR_NONE)`) but I wanted to start with the more conservative version.