### PR TITLE
Fix #1148: Research funding dropdown not shown in finances window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,8 @@
 - Feature: [#9029] Open doors with the tile inspector.
 - Feature: [#11231] Change shortcut window list order to be more intuitive, and split it into logical sections.
 - Feature: [#11306] Path additions are now kept when replacing the path.
-- Fix: [#6119]: Advertising campaign for ride window not updated properly (original bug).
+- Fix: [#1148] Research funding dropdown not shown in finances window.
+- Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).
 - Fix: [#11072] Land and water tools working out of bounds (original bug).
 - Fix: [#11259] Custom JSON object breaks saves.
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1368,6 +1368,11 @@ static void window_finances_research_invalidate(rct_window* w)
         _windowFinancesResearchWidgets[WIDX_RESEARCH_FUNDING].type = WWT_EMPTY;
         _windowFinancesResearchWidgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON].type = WWT_EMPTY;
     }
+    else
+    {
+        _windowFinancesResearchWidgets[WIDX_RESEARCH_FUNDING].type = WWT_DROPDOWN;
+        _windowFinancesResearchWidgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON].type = WWT_BUTTON;
+    }
     int32_t currentResearchLevel = gResearchFundingLevel;
 
     // Current funding


### PR DESCRIPTION
@rctdude2 Could you test this?